### PR TITLE
Add Component Source URL to components

### DIFF
--- a/src/DragNDrop/DraggableComponent.tsx
+++ b/src/DragNDrop/DraggableComponent.tsx
@@ -70,7 +70,28 @@ const DraggableComponent = ({
       title={title}
       {...props}
     >
-      {componentReference.spec?.name ?? "Component"}
+      <div className="flex flex-col items-center">
+        <p>{componentReference.spec?.name ?? "Component"}</p>
+        {componentReference.url && (
+          <p className="text-[0.5625rem]">
+            <a className="text-gray-500" href={componentReference.url}>
+              {new URL(componentReference.url).hostname}
+            </a>
+            {componentReference.url.includes("raw.githubusercontent.com") && (
+              <a
+                className="text-blue-500 ml-2"
+                href={componentReference.url
+                  .replace("raw.githubusercontent.com", "github.com")
+                  .replace(/\/([^/]+)\/([^/]+)\/([^/]+)\//, "/$1/$2/$3/tree/")}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                View Repo
+              </a>
+            )}
+          </p>
+        )}
+      </div>
     </div>
   );
 };

--- a/src/DragNDrop/UserComponentLibrary.tsx
+++ b/src/DragNDrop/UserComponentLibrary.tsx
@@ -148,7 +148,16 @@ const UserComponentLibrary = () => {
       <Button onClick={() => setIsImportComponentDialogOpen(true)}>
         Import from URL
       </Button>
-      <div {...getRootProps()}>
+      <div
+        {...getRootProps({
+          onClick: (event) => {
+            // Prevent triggering file input if clicking on a DraggableComponent
+            if ((event.target as HTMLElement).closest(".draggable-component")) {
+              event.stopPropagation();
+            }
+          },
+        })}
+      >
         <Input {...getInputProps()} />
         <div className="border border-black p-4 min-h-12">
           {isDragActive
@@ -156,20 +165,17 @@ const UserComponentLibrary = () => {
             : errorMessage ||
               "Drag and drop component.yaml files or click to select files"}
           {Array.from(componentFiles.entries()).map(([fileName, fileEntry]) => (
-            <>
-              <DraggableComponent
-                key={fileName}
-                componentReference={fileEntry.componentRef}
-              />
+            <div key={fileName} className="draggable-component">
+              <DraggableComponent componentReference={fileEntry.componentRef} />
               <Button onClick={handleDelete(fileName)}>Delete</Button>
-            </>
+            </div>
           ))}
         </div>
       </div>
       <ImportComponentFromUrlDialog
         isOpen={isImportComponentDialogOpen}
         onCancel={() => setIsImportComponentDialogOpen(false)}
-        initialValue={"https://raw.githubusercontent.com/.../component.yaml"}
+        placeholder={"https://raw.githubusercontent.com/.../component.yaml"}
         onImport={onImportFromUrl}
       />
     </div>
@@ -182,7 +188,8 @@ interface SaveAsDialogProps {
   isOpen: boolean;
   onImport: (name: string) => void;
   onCancel: () => void;
-  initialValue: string | undefined;
+  initialValue?: string;
+  placeholder?: string;
 }
 
 const ImportComponentFromUrlDialog = ({
@@ -190,6 +197,7 @@ const ImportComponentFromUrlDialog = ({
   onImport,
   onCancel,
   initialValue,
+  placeholder,
 }: SaveAsDialogProps) => {
   const [url, setUrl] = useState(initialValue);
 
@@ -214,7 +222,7 @@ const ImportComponentFromUrlDialog = ({
         <Input
           id="name"
           type="text"
-          placeholder={initialValue}
+          placeholder={placeholder}
           required
           autoFocus
           value={url}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,12 @@
 module.exports = {
   content: ["./src/**/*.{js,jsx,ts,tsx}"],
   theme: {
-    extend: {},
+    extend: {
+      fontSize: {
+        "2xs": "0.625rem", // 10px
+        "3xs": "0.5rem", // 8px
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
Closes https://github.com/Cloud-Pipelines/pipeline-studio-app/issues/112

If a component has a source URL, display it on the DraggableCard.
If the url is a github url, link to the file in the repo tree.

Also fixes an issue with the Drop Zone triggering a file upload dialog when clicking on a component.