### PR TITLE
When a node is deleted, remove arguments from other nodes

### DIFF
--- a/src/components/shared/ReactFlow/FlowGraph/TaskNode/ArgumentsEditor/ArgumentsEditorDialog.tsx
+++ b/src/components/shared/ReactFlow/FlowGraph/TaskNode/ArgumentsEditor/ArgumentsEditorDialog.tsx
@@ -18,9 +18,9 @@ import { ArgumentsEditor } from "./ArgumentsEditor";
 interface ArgumentsEditorDialogProps {
   initialPosition?: { x: number; y: number };
   taskSpec: TaskSpec;
-  disabled?: boolean;
   closeEditor: () => void;
   setArguments?: (args: Record<string, ArgumentType>) => void;
+  disabled?: boolean;
   handleDelete: () => void;
 }
 
@@ -43,7 +43,7 @@ const ArgumentsEditorDialog = ({
         * [initialValue] - This is the initial value of the argument when the Editor is opened. Immutable. It is used to determine if the argument has been changed during the current editing session.
         * [inputSpec] - These are some general constants for the argument. Immutable. It is used to display the argument name and type in the UI.
         * [isRemoved] - This is used to remove unwanted arguments from the Task Spec, as specified by the user. This is essentially used in place of an "undefined" input, since React requires an empty string for controlled components.
-        
+
         * Note that "undefined" and "empty string" are treated differently in the task spec, but we can only use "empty string" in the UI due to React's rules around controlled components.
         * The difference is best seen in a required argument with a linked node:
         *   - The connection will disappear and the connection point turn red when the node is removed, since it is required. This is what the "Remove" button is for.


### PR DESCRIPTION
When a node or edge is deleted, the connection still remains on the existing nodes arguments. This PR resolves that by "cleaning" the tasks and re-adding them to the graph.  This will work for both the delete button and they delete keystroke.




https://github.com/user-attachments/assets/9d92cc58-3ceb-461d-b6ea-a95033e61bb3

