### PR TITLE
Add Dimension Annotation to manually control node size

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNode.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNode.tsx
@@ -1,4 +1,4 @@
-import type { NodeProps } from "@xyflow/react";
+import { type NodeProps } from "@xyflow/react";
 import { CircleFadingArrowUp, CopyIcon } from "lucide-react";
 import { memo, useMemo, useRef, useState } from "react";
 
@@ -110,6 +110,8 @@ const ComponentTaskNode = ({ data, selected }: NodeProps) => {
 
       <TaskNodeCard
         componentSpec={componentSpec}
+        taskSpec={taskSpec}
+        taskId={taskId}
         inputs={inputs}
         outputs={outputs}
         invalidArguments={invalidArguments}

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/Handles.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/Handles.tsx
@@ -27,42 +27,52 @@ export const InputHandle = ({
   const hasDefault = input.default !== undefined && input.default !== "";
 
   return (
-    <div
-      className="flex flex-row items-center hover:bg-gray-300 rounded-md cursor-pointer"
-      key={input.name}
-      onClick={handleClick}
-    >
-      <Handle
-        type="target"
-        id={`input_${input.name}`}
-        position={Position.Left}
-        isConnectable={true}
+    <div className="relative w-full h-fit" key={input.name}>
+      <div className="absolute -translate-x-6 flex items-center h-3 w-3">
+        <Handle
+          type="target"
+          id={`input_${input.name}`}
+          position={Position.Left}
+          isConnectable={true}
+          className={cn("border-0! h-full! w-full! transform-none!", missing)}
+        />
+      </div>
+      <div
         className={cn(
-          "relative! border-0! !w-[12px] !h-[12px] transform-none! -translate-x-6 ",
-          missing,
+          "flex flex-row items-center rounded-md cursor-pointer relative",
+          onClick && "hover:bg-gray-300",
         )}
-      />
-      <div className="flex flex-row w-[250px] gap-0.5 items-center justify-between">
-        <div
-          className={cn(
-            "-translate-x-3 min-w-0 inline-block",
-            !value ? "max-w-full" : "max-w-3/4",
-          )}
-        >
-          <div className="text-xs text-gray-800! bg-gray-200 rounded-md px-2 py-1 hover:bg-gray-300 truncate">
-            {input.name.replace(/_/g, " ")}
-          </div>
-        </div>
-        {(hasValue || hasDefault) && (
+        onClick={handleClick}
+      >
+        <div className="flex flex-row w-full gap-0.5 items-center justify-between">
           <div
             className={cn(
-              "max-w-1/2 min-w-0 text-xs text-gray-800! truncate inline-block text-right pr-2",
-              !hasValue && "text-gray-500!",
+              "flex w-fit min-w-0",
+              !value ? "max-w-full" : "max-w-3/4",
             )}
           >
-            {hasValue ? value : input.default}
+            <div
+              className={cn(
+                "text-xs text-gray-800! bg-gray-200 rounded-md px-2 py-1 truncate",
+                onClick && "hover:bg-gray-300",
+              )}
+            >
+              {input.name.replace(/_/g, " ")}
+            </div>
           </div>
-        )}
+          {(hasValue || hasDefault) && (
+            <div className="flex w-fit max-w-1/2 min-w-0">
+              <div
+                className={cn(
+                  "text-xs text-gray-800! truncate inline-block text-right pr-2",
+                  !hasValue && "text-gray-500!",
+                )}
+              >
+                {hasValue ? value : input.default}
+              </div>
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );
@@ -70,16 +80,41 @@ export const InputHandle = ({
 
 type OutputHandleProps = {
   output: OutputSpec;
+  value?: string;
   onClick?: (e: MouseEvent<HTMLDivElement>) => void;
 };
 
-export const OutputHandle = ({ output, onClick }: OutputHandleProps) => {
+export const OutputHandle = ({ output, value, onClick }: OutputHandleProps) => {
+  const hasValue = value !== undefined && value !== "" && value !== null;
+
   const handleClick = (e: MouseEvent<HTMLDivElement>) => {
     onClick?.(e);
   };
 
   return (
-    <div className="flex flex-row-reverse items-center" key={output.name}>
+    <div className="flex items-center justify-end w-full" key={output.name}>
+      <div className="flex flex-row-reverse w-full gap-0.5 items-center justify-between">
+        <div
+          className={cn(
+            "translate-x-3 min-w-0 inline-block",
+            !value ? "max-w-full" : "max-w-3/4",
+          )}
+        >
+          <div
+            className={cn(
+              "text-xs text-gray-800! bg-gray-200 rounded-md px-2 py-1 truncate",
+              onClick && "hover:bg-gray-300",
+            )}
+          >
+            {output.name.replace(/_/g, " ")}
+          </div>
+        </div>
+        {hasValue && (
+          <div className="max-w-1/2 min-w-0 text-xs text-gray-800! truncate inline-block text-left pr-2">
+            {value}
+          </div>
+        )}
+      </div>
       <Handle
         type="source"
         id={`output_${output.name}`}
@@ -97,12 +132,6 @@ export const OutputHandle = ({ output, onClick }: OutputHandleProps) => {
           bg-gray-500!
           `}
       />
-      <div
-        className="text-xs text-gray-800! max-w-[250px] truncate bg-gray-200 cursor-pointer rounded-md px-2 py-1 translate-x-3 hover:bg-gray-300"
-        onClick={handleClick}
-      >
-        {output.name.replace(/_/g, " ")}
-      </div>
     </div>
   );
 };

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeCard.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeCard.tsx
@@ -1,4 +1,11 @@
-import { type MouseEvent, type RefObject } from "react";
+import {
+  type MouseEvent,
+  type RefObject,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
@@ -7,13 +14,16 @@ import type {
   ComponentSpec,
   InputSpec,
   OutputSpec,
+  TaskSpec,
 } from "@/utils/componentSpec";
-import { getValue } from "@/utils/string";
 
-import { InputHandle, OutputHandle } from "./Handles";
+import { TaskNodeInputs } from "./TaskNodeInputs";
+import { TaskNodeOutputs } from "./TaskNodeOutputs";
 
 type TaskNodeCardProps = {
   componentSpec: ComponentSpec;
+  taskSpec: TaskSpec;
+  taskId?: string;
   inputs: InputSpec[];
   outputs: OutputSpec[];
   values?: Record<string, ArgumentType>;
@@ -25,8 +35,27 @@ type TaskNodeCardProps = {
   onIOClick: () => void;
 };
 
+const DEFAULT_DIMENSIONS = {
+  w: 300,
+  h: undefined,
+};
+
+const MIN_WIDTH = 150;
+const MIN_HEIGHT = 100;
+
+type EditorPosition = {
+  x?: string;
+  y?: string;
+  width?: string;
+  height?: string;
+  w?: string;
+  h?: string;
+};
+
 const TaskNodeCard = ({
   componentSpec,
+  taskSpec,
+  taskId = "",
   inputs = [],
   outputs = [],
   values,
@@ -37,6 +66,12 @@ const TaskNodeCard = ({
   onClick,
   onIOClick,
 }: TaskNodeCardProps) => {
+  const [scrollHeight, setScrollHeight] = useState(0);
+  const [condensed, setCondensed] = useState(false);
+  const [expandedInputs, setExpandedInputs] = useState(false);
+  const [expandedOutputs, setExpandedOutputs] = useState(false);
+
+  const contentRef = useRef<HTMLDivElement>(null);
   const handleIOClicked = (e: MouseEvent<HTMLDivElement>) => {
     e.stopPropagation();
     e.preventDefault();
@@ -44,46 +79,111 @@ const TaskNodeCard = ({
     onIOClick();
   };
 
+  let annotatedDimensions;
+  try {
+    const parsed = JSON.parse(
+      taskSpec.annotations?.["editor.position"] as string,
+    ) as EditorPosition | undefined;
+
+    if (parsed) {
+      const width = parsed.width ?? parsed.w;
+      const height = parsed.height ?? parsed.h;
+
+      annotatedDimensions = {
+        x: !isNaN(Number(parsed.x)) ? parsed.x : undefined,
+        y: !isNaN(Number(parsed.y)) ? parsed.y : undefined,
+        width: !isNaN(Number(width)) ? width : undefined,
+        height: !isNaN(Number(height)) ? height : undefined,
+      };
+    } else {
+      annotatedDimensions = undefined;
+    }
+  } catch {
+    annotatedDimensions = undefined;
+  }
+
+  const dimensions = annotatedDimensions
+    ? {
+        w: Math.max(
+          parseInt(annotatedDimensions.width ?? "") || DEFAULT_DIMENSIONS.w,
+          MIN_WIDTH,
+        ),
+        h:
+          Math.max(parseInt(annotatedDimensions.height ?? ""), MIN_HEIGHT) ||
+          DEFAULT_DIMENSIONS.h,
+      }
+    : DEFAULT_DIMENSIONS;
+
+  const handleInputSectionClick = useCallback(() => {
+    setExpandedInputs((prev) => !prev);
+  }, []);
+
+  const handleOutputSectionClick = useCallback(() => {
+    setExpandedOutputs((prev) => !prev);
+  }, []);
+
+  useEffect(() => {
+    if (nodeRef.current) {
+      setScrollHeight(nodeRef.current.scrollHeight);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (contentRef.current && scrollHeight > 0 && dimensions.h) {
+      setCondensed(scrollHeight > dimensions.h);
+    }
+  }, [scrollHeight, dimensions.h]);
+
   return (
     <Card
       className={cn(
-        "rounded-2xl border-gray-200 border-2 max-w-[300px] min-w-[300px] break-words p-0 drop-shadow-none gap-2",
+        "rounded-2xl border-gray-200 border-2 break-words p-0 drop-shadow-none gap-2",
         selected ? "border-gray-500" : "hover:border-slate-200",
         highlighted && "border-orange-500",
       )}
+      style={{
+        width: dimensions.w + "px",
+        height: condensed || !dimensions.h ? "auto" : dimensions.h + "px",
+        transition: "height 0.2s",
+      }}
       ref={nodeRef}
       onClick={onClick}
     >
       <CardHeader className="border-b border-slate-200 px-2 py-2.5">
-        <CardTitle className="max-w-[300px] break-words text-left text-xs text-slate-900">
+        <CardTitle className="break-words text-left text-xs text-slate-900">
           {componentSpec.name}
         </CardTitle>
       </CardHeader>
       <CardContent className="p-2 flex flex-col gap-2">
-        {inputs.length > 0 && (
-          <div className="flex flex-col gap-3 p-2 bg-gray-100 border-1 border-gray-200 rounded-lg">
-            {inputs.map((input) => (
-              <InputHandle
-                key={input.name}
-                input={input}
-                invalid={invalidArguments.includes(input.name)}
-                onClick={handleIOClicked}
-                value={getValue(values?.[input.name])}
-              />
-            ))}
-          </div>
-        )}
-        {outputs.length > 0 && (
-          <div className="flex flex-col gap-3 p-2 bg-gray-100 border-1 border-gray-200 rounded-lg">
-            {outputs.map((output) => (
-              <OutputHandle
-                key={output.name}
-                output={output}
-                onClick={handleIOClicked}
-              />
-            ))}
-          </div>
-        )}
+        <div
+          className="flex flex-col gap-2"
+          style={{
+            maxHeight:
+              dimensions.h && !(expandedInputs || expandedOutputs)
+                ? `${dimensions.h}px`
+                : "100%",
+          }}
+          ref={contentRef}
+        >
+          <TaskNodeInputs
+            inputs={inputs}
+            invalidArguments={invalidArguments}
+            values={values}
+            condensed={condensed}
+            expanded={expandedInputs}
+            onBackgroundClick={handleInputSectionClick}
+            handleIOClicked={handleIOClicked}
+          />
+
+          <TaskNodeOutputs
+            outputs={outputs}
+            taskId={taskId}
+            condensed={condensed}
+            expanded={expandedOutputs}
+            onBackgroundClick={handleOutputSectionClick}
+            handleIOClicked={handleIOClicked}
+          />
+        </div>
       </CardContent>
     </Card>
   );

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeInputs.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeInputs.tsx
@@ -1,0 +1,104 @@
+import { AlertCircle } from "lucide-react";
+import { type MouseEvent } from "react";
+
+import { cn } from "@/lib/utils";
+import type { ArgumentType, InputSpec } from "@/utils/componentSpec";
+import { getValue } from "@/utils/string";
+
+import { InputHandle } from "./Handles";
+
+interface TaskNodeInputsProps {
+  inputs: InputSpec[];
+  invalidArguments: string[];
+  values?: Record<string, ArgumentType>;
+  condensed: boolean;
+  expanded: boolean;
+  onBackgroundClick?: () => void;
+  handleIOClicked: (e: MouseEvent<HTMLDivElement>) => void;
+}
+
+export function TaskNodeInputs({
+  inputs,
+  invalidArguments,
+  values,
+  condensed,
+  expanded,
+  onBackgroundClick,
+  handleIOClicked,
+}: TaskNodeInputsProps) {
+  const inputsWithTaskOutput = inputs.filter(
+    (input) =>
+      values?.[input.name] &&
+      typeof values[input.name] === "object" &&
+      values[input.name] !== null &&
+      "taskOutput" in (values[input.name] as object),
+  );
+
+  if (inputsWithTaskOutput.length === 0) {
+    inputsWithTaskOutput.push(inputs[0]);
+  }
+
+  if (!inputs.length) return null;
+
+  const hiddenInputs = inputs.length - inputsWithTaskOutput.length;
+
+  const hiddenInvalidArguments = invalidArguments.filter(
+    (invalidArgument) =>
+      !inputsWithTaskOutput.some((input) => input.name === invalidArgument),
+  );
+
+  return (
+    <div
+      className={cn(
+        "flex flex-col items-center gap-3 p-2 bg-gray-100 border-1 border-gray-200 rounded-lg hover:bg-gray-200/70",
+        condensed && onBackgroundClick && "hover:bg-gray-200/70 cursor-pointer",
+      )}
+      onClick={(e) => {
+        if (condensed && onBackgroundClick) {
+          e.stopPropagation();
+          onBackgroundClick();
+        }
+      }}
+    >
+      {condensed && !expanded ? (
+        <>
+          {inputsWithTaskOutput.map((input, i) => (
+            <InputHandle
+              key={input.name}
+              input={input}
+              invalid={invalidArguments.includes(input.name)}
+              value={
+                inputs.length > 1 && i === 0
+                  ? `+${hiddenInputs} more input${hiddenInputs > 1 ? "s" : ""}`
+                  : " "
+              }
+            />
+          ))}
+          {hiddenInvalidArguments.length > 0 && (
+            <div className="flex text-xs text-destructive-foreground mt-1 items-center">
+              <AlertCircle className="h-4 w-4 inline-block mr-1" />
+              <span>{`${hiddenInvalidArguments.length} hidden input${hiddenInvalidArguments.length > 1 ? "s have" : " has"} invalid arguments`}</span>
+            </div>
+          )}
+        </>
+      ) : (
+        <>
+          {inputs.map((input) => (
+            <InputHandle
+              key={input.name}
+              input={input}
+              invalid={invalidArguments.includes(input.name)}
+              onClick={handleIOClicked}
+              value={getValue(values?.[input.name])}
+            />
+          ))}
+          {condensed && (
+            <span className="text-xs text-gray-400 mt-1">
+              (Click to collapse)
+            </span>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeOutputs.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeOutputs.tsx
@@ -1,0 +1,94 @@
+import { useEdges } from "@xyflow/react";
+import { type MouseEvent, useCallback } from "react";
+
+import { cn } from "@/lib/utils";
+import type { OutputSpec } from "@/utils/componentSpec";
+import { taskIdToNodeId } from "@/utils/nodes/nodeIdUtils";
+
+import { OutputHandle } from "./Handles";
+
+type TaskNodeOutputsProps = {
+  outputs: OutputSpec[];
+  taskId: string;
+  condensed: boolean;
+  expanded: boolean;
+  onBackgroundClick?: () => void;
+  handleIOClicked: (e: MouseEvent<HTMLDivElement>) => void;
+};
+
+export function TaskNodeOutputs({
+  outputs,
+  taskId,
+  condensed,
+  expanded,
+  onBackgroundClick,
+  handleIOClicked,
+}: TaskNodeOutputsProps) {
+  const edges = useEdges();
+
+  const nodeId = taskIdToNodeId(taskId);
+
+  const outputsWithTaskInput = outputs.filter((output) =>
+    edges.some(
+      (edge) =>
+        edge.source === nodeId && edge.sourceHandle === `output_${output.name}`,
+    ),
+  );
+
+  if (outputsWithTaskInput.length === 0) {
+    outputsWithTaskInput.push(outputs[0]);
+  }
+
+  const handleBackgroundClick = useCallback(
+    (e: MouseEvent) => {
+      if (condensed && onBackgroundClick) {
+        e.stopPropagation();
+        onBackgroundClick();
+      }
+    },
+    [condensed, onBackgroundClick],
+  );
+
+  if (!outputs.length) return null;
+
+  const hiddenOutputs = outputs.length - outputsWithTaskInput.length;
+
+  return (
+    <div
+      className={cn(
+        "flex flex-col justify-end items-center gap-3 p-2 bg-gray-100 border-1 border-gray-200 rounded-lg",
+        condensed && onBackgroundClick && "hover:bg-gray-200/70 cursor-pointer",
+      )}
+      onClick={handleBackgroundClick}
+    >
+      {condensed && !expanded ? (
+        outputsWithTaskInput.map((output, i) => (
+          <OutputHandle
+            key={output.name}
+            output={output}
+            value={
+              outputs.length > 1 && i === 0
+                ? `+${hiddenOutputs} more output${hiddenOutputs > 1 ? "s" : ""}`
+                : " "
+            }
+          />
+        ))
+      ) : (
+        <>
+          {outputs.map((output) => (
+            <OutputHandle
+              key={output.name}
+              output={output}
+              onClick={handleIOClicked}
+            />
+          ))}
+          {condensed && (
+            <span className="text-xs text-gray-400 mt-1">
+              (Click to collapse)
+            </span>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/shared/ReactFlow/FlowCanvas/utils/updateNodePosition.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/utils/updateNodePosition.ts
@@ -17,10 +17,10 @@ export const updateNodePositions = (
   }
 
   for (const node of updatedNodes) {
-    const positionAnnotation = JSON.stringify({
+    const newPosition = {
       x: node.position.x,
       y: node.position.y,
-    });
+    };
 
     if (!("graph" in newComponentSpec.implementation)) {
       throw new Error("Implementation does not contain a graph");
@@ -33,9 +33,19 @@ export const updateNodePositions = (
       if (graphSpec.tasks[taskId]) {
         const taskSpec = { ...graphSpec.tasks[taskId] };
 
+        const currentPosition = JSON.parse(
+          (taskSpec.annotations?.["editor.position"] as string) || "{}",
+        );
+        const updatedPosition = {
+          ...currentPosition,
+          ...newPosition,
+        };
+
+        const updatedPositionAnnotation = JSON.stringify(updatedPosition);
+
         taskSpec.annotations = {
           ...taskSpec.annotations,
-          "editor.position": positionAnnotation,
+          "editor.position": updatedPositionAnnotation,
         };
 
         const newGraphSpec = {
@@ -54,11 +64,22 @@ export const updateNodePositions = (
       const inputIndex = inputs.findIndex((input) => input.name === inputName);
 
       if (inputIndex >= 0) {
+        const currentPosition = JSON.parse(
+          (inputs[inputIndex].annotations?.["editor.position"] as string) ||
+            "{}",
+        );
+        const updatedPosition = {
+          ...currentPosition,
+          ...newPosition,
+        };
+
+        const updatedPositionAnnotation = JSON.stringify(updatedPosition);
+
         inputs[inputIndex] = {
           ...inputs[inputIndex],
           annotations: {
             ...inputs[inputIndex].annotations,
-            "editor.position": positionAnnotation,
+            "editor.position": updatedPositionAnnotation,
           },
         };
         newComponentSpec.inputs = inputs;
@@ -71,11 +92,22 @@ export const updateNodePositions = (
       );
 
       if (outputIndex >= 0) {
+        const currentPosition = JSON.parse(
+          (outputs[outputIndex].annotations?.["editor.position"] as string) ||
+            "{}",
+        );
+        const updatedPosition = {
+          ...currentPosition,
+          ...newPosition,
+        };
+
+        const updatedPositionAnnotation = JSON.stringify(updatedPosition);
+
         outputs[outputIndex] = {
           ...outputs[outputIndex],
           annotations: {
             ...outputs[outputIndex].annotations,
-            "editor.position": positionAnnotation,
+            "editor.position": updatedPositionAnnotation,
           },
         };
         newComponentSpec.outputs = outputs;


### PR DESCRIPTION
Closes https://github.com/Cloud-Pipelines/pipeline-studio-app/issues/29

Allow TaskNode dimensions to be overridden using a `dimension` task annotation.

Using the AnnotationEditor the user can customize the size of a node on the canvas by extending the `editor.position` annotation with `{width: int, height: int}` where int is the dimension size in pixels.

Also adds UX for input/outputs on nodes to be collapsed and expanded (by clicking on the collapsed field) if the annotated height is too small to contain all the node content. When condensed only the inputs/outputs with connections to other nodes will be shown. When expanded all will be shown.

![image](https://github.com/user-attachments/assets/ad4cc355-eb7a-4bc7-8f41-b695b0c323ad)

![image](https://github.com/user-attachments/assets/c0b39003-ab5d-4e73-aeef-d0b83e49044d)

![image](https://github.com/user-attachments/assets/f5c7770b-80e9-49c0-8915-87340848dcff)

![image](https://github.com/user-attachments/assets/3851404f-476b-4dbe-9af4-9c1aafefb497)

![image](https://github.com/user-attachments/assets/ddd8e5d9-afd3-47e7-bd15-0aa266b44ec8)

![image](https://github.com/user-attachments/assets/c4a57ece-473e-4da5-945e-076f77f705fe)


In future I would like to follow-up this PR by refining the logic and combining `expanded` and `condensed` props into one and applying the collapse ability to all nodes (not just ones that overflow). Then the actual card sizing can be properly revised to reflect the user's input annotation (rather than just shrink down to the condensed version if it is too big).
