### PR TITLE
Users can upload to canvas

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
@@ -15,6 +15,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { ConfirmationDialog } from "@/components/shared/Dialogs";
 import useComponentSpecToEdges from "@/hooks/useComponentSpecToEdges";
+import useComponentUploader from "@/hooks/useComponentUploader";
 import useConfirmationDialog from "@/hooks/useConfirmationDialog";
 import { useCopyPaste } from "@/hooks/useCopyPaste";
 import useToastNotification from "@/hooks/useToastNotification";
@@ -281,10 +282,20 @@ const FlowCanvas = ({
     [graphSpec, handleConnection, updateGraphSpec],
   );
 
-  /* New Tasks from the Sidebar */
+  const { handleDrop } = useComponentUploader({
+    onImportSuccess: () => {}, // TODO: Implement adding the component to the canvas
+  });
+
   const onDragOver = useCallback(
-    (event: DragEvent) => {
+    (event: DragEvent<HTMLDivElement>) => {
       event.preventDefault();
+
+      // Check if we're dragging files
+      const hasFiles = event.dataTransfer.types.includes("Files");
+      if (hasFiles) {
+        return;
+      }
+
       event.dataTransfer.dropEffect = "move";
 
       const cursorPosition = reactFlowInstance?.screenToFlowPosition({
@@ -306,8 +317,14 @@ const FlowCanvas = ({
   );
 
   const onDrop = useCallback(
-    async (event: DragEvent) => {
+    async (event: DragEvent<HTMLDivElement>) => {
       event.preventDefault();
+
+      // Handle file drops
+      if (event.dataTransfer.files.length > 0) {
+        handleDrop(event);
+        return;
+      }
 
       const { taskSpec: droppedTask, taskType } = getTaskFromEvent(event);
 
@@ -374,6 +391,7 @@ const FlowCanvas = ({
       setComponentSpec,
       updateGraphSpec,
       triggerConfirmation,
+      handleDrop,
     ],
   );
 

--- a/src/hooks/useComponentUploader.tsx
+++ b/src/hooks/useComponentUploader.tsx
@@ -1,0 +1,62 @@
+import { type DragEvent } from "react";
+
+import useImportComponent from "@/hooks/useImportComponent";
+import useToastNotification from "@/hooks/useToastNotification";
+
+interface useComponentUploaderProps {
+  onImportSuccess?: (content: string) => void;
+}
+
+const useComponentUploader = ({
+  onImportSuccess,
+}: useComponentUploaderProps) => {
+  const notify = useToastNotification();
+
+  const { onImportFromFile } = useImportComponent({
+    successCallback: () => {
+      notify("Component imported successfully", "success");
+    },
+    errorCallback: (error: Error) => {
+      notify(error.message, "error");
+    },
+  });
+
+  const handleFileUpload = async (file: File) => {
+    if (!file.name.endsWith(".yaml")) {
+      notify("Only YAML files are supported", "error");
+      return;
+    }
+
+    const reader = new FileReader();
+    reader.onload = async (e) => {
+      const content = e.target?.result;
+      if (!content) {
+        notify("Failed to read file", "error");
+        return;
+      }
+
+      try {
+        await onImportFromFile(content as string);
+        onImportSuccess?.(content as string);
+      } catch (error) {
+        notify((error as Error).message, "error");
+      }
+    };
+
+    reader.readAsText(file);
+  };
+
+  const handleDrop = (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    const files = event.dataTransfer?.files;
+    if (files && files.length > 0) {
+      handleFileUpload(files[0]);
+    }
+  };
+
+  return {
+    handleDrop,
+  };
+};
+
+export default useComponentUploader;


### PR DESCRIPTION
If a user drags a component.yaml, we upload it to the user components.

This does NOT add the component to the canvas (this will come in a later PR)
This does NOT allow a user to drag onto the component library (that will come later)


If a user does not drag a .yaml, it will show an error.