### PR TITLE
Toggle Description on Argument Input

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfigurationSheet/OutputsList.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfigurationSheet/OutputsList.tsx
@@ -10,16 +10,24 @@ const OutputsList = ({ taskSpec }: OutputsListProps) => {
   const outputs = componentSpec?.outputs;
 
   const outputsMarkup = outputs?.map((output) => (
-    <div key={output.name} className="flex items-center justify-between p-2">
-      <span className="text-sm">{output.name}</span>
-      <span className="text-xs max-w-3/4 truncate" title={output.description}>
-        {output.description}
+    <div key={output.name} className="flex items-center p-2">
+      <span className="text-sm">
+        {output.name}
+        {output.type && (
+          <span className="text-xs text-muted-foreground italic">
+            {" "}
+            ({output.type as string})
+          </span>
+        )}
+        {output.description && (
+          <span
+            className="text-xs max-w-3/4 truncate"
+            title={output.description}
+          >
+            : {output.description}
+          </span>
+        )}
       </span>
-      {output.type && (
-        <span className="text-xs text-muted-foreground italic">
-          {output.type as string}
-        </span>
-      )}
     </div>
   ));
 


### PR DESCRIPTION
Makes the Argument Input row clickable. When clicked it will show/hide the description for the input.
Also a small layout change for the outputs list.

![image](https://github.com/user-attachments/assets/71aae337-3cda-4d09-8e6d-c90dde729873)

![image](https://github.com/user-attachments/assets/998d3a78-107d-4977-860e-8ce004018e32)

![image](https://github.com/user-attachments/assets/dd0be2ea-6d80-4021-90d6-b965c5052ae4)

