### PR TITLE
Fix broken text wrap in Code Viewer

### DIFF
--- a/src/components/shared/CodeViewer.tsx
+++ b/src/components/shared/CodeViewer.tsx
@@ -205,7 +205,6 @@ const CodeSyntaxHighlighter = ({
       fontFamily:
         'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
     }}
-    wrapLongLines={true}
     showLineNumbers={true}
     lineNumberStyle={{
       minWidth: "2.5em",


### PR DESCRIPTION
Fixes instances where text in the codeviewer was wrapping vertically 
Fixes: https://github.com/Cloud-Pipelines/pipeline-studio-app/issues/324

Before:
<img width="487" alt="image" src="https://github.com/user-attachments/assets/64b13adb-4ca4-473e-acde-bcef8260d99f" />

After:
<img width="468" alt="image" src="https://github.com/user-attachments/assets/7d408c6c-5f35-459f-8782-c0eafb712933" />

