### PR TITLE
New Sidebar Icons and show Toolbar in Run View

### DIFF
--- a/src/components/Editor/PipelineEditor.tsx
+++ b/src/components/Editor/PipelineEditor.tsx
@@ -28,6 +28,7 @@ const PipelineEditor = () => {
     snapToGrid: true,
     panOnDrag: true,
     selectionOnDrag: false,
+    nodesDraggable: true,
   });
 
   const updateFlowConfig = useCallback(
@@ -58,6 +59,7 @@ const PipelineEditor = () => {
           <FlowControls
             style={{ marginLeft: "224px", marginBottom: "24px" }}
             updateConfig={updateFlowConfig}
+            showInteractive
           />
           <Background gap={GRID_SIZE} className="bg-slate-50!" />
         </FlowCanvas>

--- a/src/components/PipelineRun/PipelineRunPage.tsx
+++ b/src/components/PipelineRun/PipelineRunPage.tsx
@@ -34,6 +34,7 @@ const PipelineRunPage = () => {
           <FlowControls
             style={{ marginLeft: "224px", marginBottom: "24px" }}
             updateConfig={updateFlowConfig}
+            showInteractive={false}
           />
           <Background gap={GRID_SIZE} className="bg-slate-50!" />
         </FlowCanvas>

--- a/src/components/shared/ReactFlow/FlowCanvas/SelectionToolbar.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/SelectionToolbar.tsx
@@ -1,16 +1,18 @@
-import { CircleFadingArrowUp, Copy, Trash } from "lucide-react";
+import { CircleFadingArrowUp, ClipboardPlus, Copy, Trash } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 
 interface SelectionToolbarProps {
-  onDuplicate: () => void;
-  onDelete: () => void;
-  onUpgrade: () => void;
+  onCopy?: () => void;
+  onDuplicate?: () => void;
+  onDelete?: () => void;
+  onUpgrade?: () => void;
 }
 
 const SelectionToolbar = ({
-  onDelete,
+  onCopy,
   onDuplicate,
+  onDelete,
   onUpgrade,
 }: SelectionToolbarProps) => {
   return (
@@ -20,30 +22,46 @@ const SelectionToolbar = ({
         border: "1px solid rgba(0, 89, 220, 0.4)",
       }}
     >
-      <Button
-        className="h-full aspect-square w-min rounded-sm p-1"
-        variant="ghost"
-        onClick={onUpgrade}
-        size="icon"
-      >
-        <CircleFadingArrowUp className="p-0.5" />
-      </Button>
-      <Button
-        className="cursor-pointer h-full aspect-square w-min rounded-sm p-1"
-        variant="ghost"
-        onClick={onDuplicate}
-        size="icon"
-      >
-        <Copy className="p-0.5" />
-      </Button>
-      <Button
-        className="h-full aspect-square w-min rounded-sm text-destructive hover:text-destructive p-1"
-        variant="ghost"
-        onClick={onDelete}
-        size="icon"
-      >
-        <Trash className="p-0.5" />
-      </Button>
+      {onUpgrade && (
+        <Button
+          className="h-full aspect-square w-min rounded-sm p-1"
+          variant="ghost"
+          onClick={onUpgrade}
+          size="icon"
+        >
+          <CircleFadingArrowUp className="p-0.5" />
+        </Button>
+      )}
+      {onDuplicate && (
+        <Button
+          className="cursor-pointer h-full aspect-square w-min rounded-sm p-1"
+          variant="ghost"
+          onClick={onDuplicate}
+          size="icon"
+        >
+          <Copy className="p-0.5" />
+        </Button>
+      )}
+      {onCopy && (
+        <Button
+          className="cursor-pointer h-full aspect-square w-min rounded-sm p-1"
+          variant="ghost"
+          onClick={onCopy}
+          size="icon"
+        >
+          <ClipboardPlus className="p-0.5" />
+        </Button>
+      )}
+      {onDelete && (
+        <Button
+          className="h-full aspect-square w-min rounded-sm text-destructive hover:text-destructive p-1"
+          variant="ghost"
+          onClick={onDelete}
+          size="icon"
+        >
+          <Trash className="p-0.5" />
+        </Button>
+      )}
     </div>
   );
 };

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNode.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNode.tsx
@@ -9,7 +9,7 @@ import type { TaskNodeData } from "@/types/taskNode";
 import { StatusIndicator } from "./StatusIndicator";
 import { TaskNodeCard } from "./TaskNodeCard";
 
-const ComponentTaskNode = ({ data, selected }: NodeProps) => {
+const TaskNode = ({ data, selected }: NodeProps) => {
   const { taskStatusMap } = useComponentSpec();
 
   const typedData = useMemo(() => data as TaskNodeData, [data]);
@@ -30,4 +30,4 @@ const ComponentTaskNode = ({ data, selected }: NodeProps) => {
   );
 };
 
-export default memo(ComponentTaskNode);
+export default memo(TaskNode);

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeInputs.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeInputs.tsx
@@ -27,7 +27,7 @@ export function TaskNodeInputs({
   onBackgroundClick,
   handleIOClicked,
 }: TaskNodeInputsProps) {
-  const { inputs, taskSpec } = useTaskNode();
+  const { inputs, taskSpec, state } = useTaskNode();
   const {
     setSearchTerm,
     setSearchFilters,
@@ -91,10 +91,12 @@ export function TaskNodeInputs({
 
   const handleSelectionChange = useCallback(
     (inputName: string, selected: boolean) => {
+      if (state.readOnly) return;
+
       const input = inputs.find((i) => i.name === inputName);
       toggleHighlightRelatedHandles(selected, input);
     },
-    [inputs, toggleHighlightRelatedHandles],
+    [inputs, state, toggleHighlightRelatedHandles],
   );
 
   const checkHighlight = useCallback(

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeOutputs.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeOutputs.tsx
@@ -24,7 +24,7 @@ export function TaskNodeOutputs({
   onBackgroundClick,
   handleIOClicked,
 }: TaskNodeOutputsProps) {
-  const { nodeId, outputs } = useTaskNode();
+  const { nodeId, outputs, state } = useTaskNode();
   const {
     setSearchTerm,
     setSearchFilters,
@@ -85,10 +85,12 @@ export function TaskNodeOutputs({
 
   const handleSelectionChange = useCallback(
     (outputName: string, selected: boolean) => {
+      if (state.readOnly) return;
+
       const output = outputs.find((o) => o.name === outputName);
       toggleHighlightRelatedHandles(selected, output);
     },
-    [outputs, toggleHighlightRelatedHandles],
+    [outputs, state, toggleHighlightRelatedHandles],
   );
 
   const checkHighlight = useCallback(

--- a/src/components/shared/ReactFlow/FlowControls/FlowControls.tsx
+++ b/src/components/shared/ReactFlow/FlowControls/FlowControls.tsx
@@ -4,7 +4,11 @@ import {
   Controls,
   type ReactFlowProps,
 } from "@xyflow/react";
-import { SquareDashedMousePointerIcon } from "lucide-react";
+import {
+  LockKeyhole,
+  LockKeyholeOpen,
+  SquareDashedMousePointerIcon,
+} from "lucide-react";
 import { useCallback, useState } from "react";
 
 import { cn } from "@/lib/utils";
@@ -18,6 +22,7 @@ export default function FlowControls({
   ...props
 }: FlowControlsProps) {
   const [multiSelectActive, setMultiSelectActive] = useState(false);
+  const [lockActive, setLockActive] = useState(true);
 
   const onClickMultiSelect = useCallback(() => {
     updateConfig({
@@ -27,13 +32,32 @@ export default function FlowControls({
     setMultiSelectActive(!multiSelectActive);
   }, [multiSelectActive, updateConfig]);
 
+  const handleLockChange = useCallback(() => {
+    updateConfig({
+      nodesDraggable: lockActive,
+    });
+    setLockActive(!lockActive);
+  }, [lockActive, updateConfig]);
+
   return (
     <Controls {...props}>
+      {!props.showInteractive && (
+        <ControlButton
+          onClick={handleLockChange}
+          className={cn(lockActive && "bg-gray-100!")}
+        >
+          {lockActive ? (
+            <LockKeyhole className="fill-none! -scale-x-120 scale-y-120" />
+          ) : (
+            <LockKeyholeOpen className="fill-none! -scale-x-120 scale-y-120" />
+          )}
+        </ControlButton>
+      )}
       <ControlButton
         onClick={onClickMultiSelect}
         className={cn(multiSelectActive && "bg-gray-100!")}
       >
-        <SquareDashedMousePointerIcon />
+        <SquareDashedMousePointerIcon className="scale-120" />
       </ControlButton>
     </Controls>
   );

--- a/src/components/shared/ReactFlow/FlowSidebar/components/ImportComponent.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/components/ImportComponent.tsx
@@ -1,4 +1,4 @@
-import { Component, X } from "lucide-react";
+import { PackagePlus, X } from "lucide-react";
 import { Upload } from "lucide-react";
 import { type ChangeEvent, useRef, useState } from "react";
 
@@ -15,7 +15,6 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { SidebarMenuButton, SidebarMenuItem } from "@/components/ui/sidebar";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import useImportComponent from "@/hooks/useImportComponent";
 import useToastNotification from "@/hooks/useToastNotification";
@@ -118,16 +117,11 @@ const ImportComponent = () => {
 
   return (
     <Dialog open={isOpen} onOpenChange={handleOpenChange}>
-      <SidebarMenuItem>
-        <DialogTrigger asChild>
-          <div className="w-full">
-            <SidebarMenuButton className="cursor-pointer w-full">
-              <Component />
-              <span className="font-normal text-xs">Import Component</span>
-            </SidebarMenuButton>
-          </div>
-        </DialogTrigger>
-      </SidebarMenuItem>
+      <DialogTrigger asChild>
+        <Button className="w-fit" variant="ghost">
+          <PackagePlus className="w-4 h-4" />
+        </Button>
+      </DialogTrigger>
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Import Component</DialogTitle>

--- a/src/components/shared/ReactFlow/FlowSidebar/sections/GraphComponents.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/sections/GraphComponents.tsx
@@ -6,12 +6,18 @@ import {
   SidebarGroupContent,
   SidebarGroupLabel,
 } from "@/components/ui/sidebar";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { useComponentLibrary } from "@/providers/ComponentLibraryProvider";
 
 import {
   EmptyState,
   ErrorState,
   FolderItem,
+  ImportComponent,
   LoadingState,
   SearchInput,
   SearchResults,
@@ -102,8 +108,16 @@ const GraphComponents = () => {
   return (
     <SidebarGroup>
       <SidebarGroupLabel asChild>
-        <div className="flex items-center">
+        <div className="flex items-center justify-between gap-2">
           <span className="font-medium text-sm">Components</span>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span>
+                <ImportComponent />
+              </span>
+            </TooltipTrigger>
+            <TooltipContent side="top">Add component</TooltipContent>
+          </Tooltip>
         </div>
       </SidebarGroupLabel>
       <SidebarGroupContent className="[&_li]:marker:hidden [&_li]:before:content-none [&_li]:list-none">
@@ -113,6 +127,7 @@ const GraphComponents = () => {
           onChange={handleSearchChange}
           onFiltersChange={handleFiltersChange}
         />
+
         {memoizedContent}
       </SidebarGroupContent>
     </SidebarGroup>

--- a/src/components/shared/ReactFlow/FlowSidebar/sections/SettingsAndActions.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/sections/SettingsAndActions.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from "@tanstack/react-router";
 import { useStore } from "@xyflow/react";
-import { FileDown, Import, Save, SaveAll } from "lucide-react";
+import { CloudUpload, FolderDown, Save, SaveAll } from "lucide-react";
 import { useEffect, useMemo, useRef } from "react";
 
 import { PipelineNameDialog } from "@/components/shared/Dialogs";
@@ -14,14 +14,17 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@/components/ui/sidebar";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import useToastNotification from "@/hooks/useToastNotification";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 import { EDITOR_PATH } from "@/routes/router";
 import { useSavePipeline } from "@/services/pipelineService";
 import { componentSpecToYaml } from "@/utils/componentStore";
 import { updateComponentSpecFromNodes } from "@/utils/nodes/updateComponentSpecFromNodes";
-
-import { ImportComponent } from "../components";
 
 const SettingsAndActions = () => {
   const { componentSpec } = useComponentSpec();
@@ -90,25 +93,35 @@ const SettingsAndActions = () => {
     <SidebarGroup className="pb-0">
       <SidebarGroupLabel asChild>
         <div className="flex items-center">
-          <span className="font-medium text-sm">Settings & Actions</span>
+          <span className="font-medium text-sm">Pipeline Actions</span>
         </div>
       </SidebarGroupLabel>
       <SidebarGroupContent>
-        <SidebarMenu>
+        <SidebarMenu className="flex-row gap-2 text-foreground/75">
           <SidebarMenuItem>
-            <SidebarMenuButton
-              onClick={handleSavePipeline}
-              className="cursor-pointer"
-            >
-              <Save />
-              <span className="font-normal text-xs">Save</span>
-            </SidebarMenuButton>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <SidebarMenuButton
+                  onClick={handleSavePipeline}
+                  className="cursor-pointer"
+                >
+                  <Save className="w-5! h-5!" strokeWidth={1.5} />
+                </SidebarMenuButton>
+              </TooltipTrigger>
+              <TooltipContent side="top">Save Pipeline</TooltipContent>
+            </Tooltip>
+          </SidebarMenuItem>
+          <SidebarMenuItem>
             <PipelineNameDialog
               trigger={
-                <SidebarMenuButton className="cursor-pointer">
-                  <SaveAll />
-                  <span className="font-normal text-xs">Save as</span>
-                </SidebarMenuButton>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <SidebarMenuButton className="cursor-pointer">
+                      <SaveAll className="w-5! h-5!" strokeWidth={1.5} />
+                    </SidebarMenuButton>
+                  </TooltipTrigger>
+                  <TooltipContent side="top">Save-as Pipeline</TooltipContent>
+                </Tooltip>
               }
               title="Save Pipeline As"
               description="Enter a name for your pipeline"
@@ -119,34 +132,40 @@ const SettingsAndActions = () => {
             />
           </SidebarMenuItem>
           <SidebarMenuItem>
-            <SidebarMenuButton asChild className="cursor-pointer">
-              <a
-                href={URL.createObjectURL(componentTextBlob)}
-                download={filename}
-              >
-                <FileDown />
-                <span className="font-normal text-xs">Export Pipeline</span>
-              </a>
-            </SidebarMenuButton>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <SidebarMenuButton asChild className="cursor-pointer">
+                  <a
+                    href={URL.createObjectURL(componentTextBlob)}
+                    download={filename}
+                  >
+                    <CloudUpload className="w-5! h-5!" strokeWidth={1.5} />
+                  </a>
+                </SidebarMenuButton>
+              </TooltipTrigger>
+              <TooltipContent side="top">Export Pipeline</TooltipContent>
+            </Tooltip>
           </SidebarMenuItem>
           <SidebarMenuItem>
             <ImportPipeline
               triggerComponent={
-                <SidebarMenuButton asChild>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    className="w-full justify-start px-2!"
-                  >
-                    <Import />
-                    <span className="font-normal text-xs">Import Pipeline</span>
-                  </Button>
-                </SidebarMenuButton>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <SidebarMenuButton asChild>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        className="w-full justify-start px-2!"
+                      >
+                        <FolderDown className="w-5! h-5!" strokeWidth={1.5} />
+                      </Button>
+                    </SidebarMenuButton>
+                  </TooltipTrigger>
+                  <TooltipContent side="top">Import Pipeline</TooltipContent>
+                </Tooltip>
               }
             />
           </SidebarMenuItem>
-
-          <ImportComponent />
         </SidebarMenu>
       </SidebarGroupContent>
     </SidebarGroup>


### PR DESCRIPTION
Implements a variety of small miscellaneous changes discussed in a couple of Slack threads that popped up this afternoon.

- Node Toolbar will now appear when selecting multiple nodes in run view
- In run view the Node Toolbar has one action available: copy components to clipboard
- Nodes are now draggable in run view when the canvas is unlocked (see the lock icon next to the minimap)
- "Settings & Actions" Sidebar Group now renamed to "Pipeline Actions"
- Icons updated in the Sidebar
- Import Component moved to Component Library section header
- Remaining actions in "Pipeline Actions" have been collapsed into icons and stacked horizontally
- Related Handles are no longer highlighted in run view when clicking on an I/O Handle

![image](https://github.com/user-attachments/assets/6242e7c1-5aef-4628-be5c-de6d686cd476)

![image](https://github.com/user-attachments/assets/d1e339b9-b7a1-440c-917e-0a7072291bb5)

Sidebar Before
![image](https://github.com/user-attachments/assets/8c83f8e4-cebd-4e0c-bf51-63bfb735410b)

Sidebar After
![image](https://github.com/user-attachments/assets/c1c62415-6046-4d07-8342-b402fc669ba4)
