### PR TITLE
Fix default search filter, missing confirmation dialog and other items

### DIFF
--- a/src/components/shared/Dialogs/ComponentDetailsDialog.tsx
+++ b/src/components/shared/Dialogs/ComponentDetailsDialog.tsx
@@ -14,6 +14,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import type { ComponentReference } from "@/utils/componentSpec";
 
 import InfoIconButton from "../Buttons/InfoIconButton";
+import { ComponentFavoriteToggle } from "../FavoriteComponentToggle";
 import { TaskDetails, TaskImplementation, TaskIO } from "../TaskDetails";
 
 interface ComponentDetailsProps {
@@ -67,8 +68,9 @@ const ComponentDetails = ({
         aria-label={`${displayName} component details`}
       >
         <DialogHeader>
-          <DialogTitle className="flex items-center justify-between mr-5">
+          <DialogTitle className="flex items-center gap-2 mr-5">
             <span>{displayName}</span>
+            <ComponentFavoriteToggle component={component} />
           </DialogTitle>
         </DialogHeader>
 

--- a/src/components/shared/FavoriteComponentToggle.tsx
+++ b/src/components/shared/FavoriteComponentToggle.tsx
@@ -1,0 +1,91 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { useCallback, useMemo, useState } from "react";
+
+import { ConfirmationDialog } from "@/components/shared/Dialogs";
+import { FavoriteStar } from "@/components/shared/FavoriteStar";
+import { useComponentLibrary } from "@/providers/ComponentLibraryProvider";
+import type { ComponentReference } from "@/utils/componentSpec";
+import { deleteComponentFileFromList } from "@/utils/componentStore";
+import { USER_COMPONENTS_LIST_NAME } from "@/utils/constants";
+import { getComponentName } from "@/utils/getComponentName";
+
+interface ComponentFavoriteToggleProps {
+  component: ComponentReference;
+}
+
+export const ComponentFavoriteToggle = ({
+  component,
+}: ComponentFavoriteToggleProps) => {
+  const { checkIfFavorited, checkIfUserComponent, setComponentFavorite } =
+    useComponentLibrary();
+  const queryClient = useQueryClient();
+
+  const [isOpen, setIsOpen] = useState(false);
+
+  const { name: fileName, spec, url } = component;
+
+  const isFavorited = useMemo(
+    () =>
+      component.favorited !== undefined
+        ? component.favorited
+        : checkIfFavorited(component),
+    [component, checkIfFavorited],
+  );
+
+  const isUserComponent = useMemo(
+    () => checkIfUserComponent(component),
+    [component, checkIfUserComponent],
+  );
+
+  const displayName = useMemo(
+    () => getComponentName({ spec, url }),
+    [spec, url],
+  );
+
+  const onFavorite = useCallback(() => {
+    setComponentFavorite(component, !isFavorited);
+  }, [isFavorited, setComponentFavorite]);
+
+  // Delete User Components
+  const handleDelete = useCallback(async () => {
+    try {
+      await deleteComponentFileFromList(
+        USER_COMPONENTS_LIST_NAME,
+        fileName ?? "",
+      );
+      queryClient.invalidateQueries({ queryKey: ["userComponents"] });
+    } catch (error) {
+      console.error("Error deleting component:", error);
+    }
+  }, [fileName, queryClient]);
+
+  /* Confirmation Dialog handlers */
+  const openConfirmationDialog = useCallback(() => {
+    setIsOpen(true);
+  }, []);
+
+  const handleCancel = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  const handleConfirm = useCallback(() => {
+    handleDelete();
+    setIsOpen(false);
+  }, [handleDelete]);
+
+  return (
+    <>
+      <FavoriteStar
+        active={isFavorited}
+        onClick={isUserComponent ? openConfirmationDialog : onFavorite}
+      />
+      <ConfirmationDialog
+        isOpen={isOpen}
+        title="Delete custom component?"
+        description={`"${displayName}" is a custom user component. Unstarring it will remove it from your library. This action cannot be undone.`}
+        onConfirm={handleConfirm}
+        onCancel={handleCancel}
+      />
+    </>
+  );
+};

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfigurationSheet/TaskConfigurationSheet.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfigurationSheet/TaskConfigurationSheet.tsx
@@ -7,7 +7,7 @@ import {
 } from "lucide-react";
 import { type ReactNode } from "react";
 
-import { FavoriteStar } from "@/components/shared/FavoriteStar";
+import { ComponentFavoriteToggle } from "@/components/shared/FavoriteComponentToggle";
 import {
   TaskDetails,
   TaskImplementation,
@@ -27,7 +27,6 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { useComponentLibrary } from "@/providers/ComponentLibraryProvider";
 import { useTaskNode } from "@/providers/TaskNodeProvider";
 import { TOP_NAV_HEIGHT } from "@/utils/constants";
 
@@ -56,7 +55,6 @@ const TaskConfigurationSheet = ({
   focusedIo,
 }: TaskConfigurationSheetProps) => {
   const { name, taskSpec, taskId, state, callbacks } = useTaskNode();
-  const { checkIfFavorited, setComponentFavorite } = useComponentLibrary();
 
   const { readOnly, runStatus } = state;
   const disabled = !!runStatus;
@@ -67,21 +65,6 @@ const TaskConfigurationSheet = ({
     if (isFullscreen) {
       onOpenChange(false);
     }
-  };
-
-  const handleFavorite = () => {
-    if (!taskSpec.componentRef) {
-      console.error(
-        "TaskConfigurationSheet called with missing taskSpec.componentRef",
-      );
-      return;
-    }
-
-    // Note: the taskSpec componentRef does not have knowledge of favourited state, so we use the checkIfFavorited utility to directly check the component library instead
-    setComponentFavorite(
-      taskSpec.componentRef,
-      !checkIfFavorited(taskSpec.componentRef),
-    );
   };
 
   const componentSpec = taskSpec.componentRef.spec;
@@ -107,11 +90,7 @@ const TaskConfigurationSheet = ({
       >
         <SheetHeader className="pb-0">
           <SheetTitle className="flex items-center gap-2">
-            {name}{" "}
-            <FavoriteStar
-              active={checkIfFavorited(taskSpec.componentRef)}
-              onClick={handleFavorite}
-            />
+            {name} <ComponentFavoriteToggle component={taskSpec.componentRef} />
           </SheetTitle>
           <SheetDescription className="hidden">
             {name} configuration sheet

--- a/src/components/shared/ReactFlow/FlowSidebar/components/FolderItem.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/components/FolderItem.tsx
@@ -4,22 +4,13 @@ import {
   Folder,
   type LucideProps,
 } from "lucide-react";
-import {
-  type JSXElementConstructor,
-  type MouseEvent,
-  useCallback,
-  useState,
-} from "react";
+import { type JSXElementConstructor, type MouseEvent, useState } from "react";
 
-import { useComponentLibrary } from "@/providers/ComponentLibraryProvider";
 import { type FolderItemProps } from "@/types/componentLibrary";
-import type { ComponentReference } from "@/utils/componentSpec";
 
 import { ComponentItemFromUrl, ComponentMarkup } from "./ComponentItem";
 
 const FolderItem = ({ folder, icon }: FolderItemProps) => {
-  const { setComponentFavorite } = useComponentLibrary();
-
   const [isOpen, setIsOpen] = useState(false);
 
   const hasComponents = folder.components && folder.components.length > 0;
@@ -32,13 +23,6 @@ const FolderItem = ({ folder, icon }: FolderItemProps) => {
 
   const Icon = icon as JSXElementConstructor<LucideProps>;
   const chevronStyles = "h-4 w-4 text-gray-400 flex-shrink-0";
-
-  const handleFavorite = useCallback(
-    (component: ComponentReference) => {
-      setComponentFavorite(component, !component.favorited);
-    },
-    [setComponentFavorite],
-  );
 
   return (
     <div className="w-full">
@@ -72,22 +56,10 @@ const FolderItem = ({ folder, icon }: FolderItemProps) => {
                 const key = `${folder.name}-component-${component.name || component?.spec?.name || component.url}`;
                 // If the component has a spec render the component, otherwise, render using URL
                 if (component.spec) {
-                  return (
-                    <ComponentMarkup
-                      key={key}
-                      component={component}
-                      onFavorite={() => handleFavorite(component)}
-                    />
-                  );
+                  return <ComponentMarkup key={key} component={component} />;
                 }
 
-                return (
-                  <ComponentItemFromUrl
-                    key={key}
-                    url={component.url}
-                    onFavorite={() => handleFavorite(component)}
-                  />
-                );
+                return <ComponentItemFromUrl key={key} url={component.url} />;
               })}
             </div>
           )}

--- a/src/components/shared/ReactFlow/FlowSidebar/components/SearchResults.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/components/SearchResults.tsx
@@ -3,7 +3,6 @@ import { useCallback } from "react";
 import { Button } from "@/components/ui/button";
 import { useComponentLibrary } from "@/providers/ComponentLibraryProvider";
 import type { SearchResult } from "@/types/componentLibrary";
-import type { ComponentReference } from "@/utils/componentSpec";
 import { ComponentSearchFilter } from "@/utils/constants";
 
 import { ComponentMarkup } from "./ComponentItem";
@@ -17,8 +16,7 @@ const SearchResults = ({
   searchResult,
   onFiltersChange,
 }: SearchResultsProps) => {
-  const { searchTerm, searchFilters, setComponentFavorite } =
-    useComponentLibrary();
+  const { searchTerm, searchFilters } = useComponentLibrary();
 
   const matchedComponents = searchResult.components.standard;
 
@@ -29,13 +27,6 @@ const SearchResults = ({
       onFiltersChange([...searchFilters, ComponentSearchFilter.NAME]);
     }
   }, [searchFilters, onFiltersChange]);
-
-  const handleFavorite = useCallback(
-    (component: ComponentReference) => {
-      setComponentFavorite(component, !component.favorited);
-    },
-    [setComponentFavorite],
-  );
 
   const filtersWithoutExactMatch = searchFilters.filter(
     (f) => f !== ComponentSearchFilter.EXACTMATCH,
@@ -91,11 +82,7 @@ const SearchResults = ({
             )}
             {/* User component results */}
             {matchedUserComponents.map((component, index) => (
-              <ComponentMarkup
-                key={`user-${index}`}
-                component={component}
-                onFavorite={() => handleFavorite(component)}
-              />
+              <ComponentMarkup key={`user-${index}`} component={component} />
             ))}
           </>
         )}
@@ -110,11 +97,7 @@ const SearchResults = ({
             )}
             {/* Library component results */}
             {matchedComponents.map((component, index) => (
-              <ComponentMarkup
-                key={`lib-${index}`}
-                component={component}
-                onFavorite={() => handleFavorite(component)}
-              />
+              <ComponentMarkup key={`lib-${index}`} component={component} />
             ))}
           </>
         )}

--- a/src/providers/ComponentLibraryProvider.tsx
+++ b/src/providers/ComponentLibraryProvider.tsx
@@ -289,7 +289,7 @@ export const ComponentLibraryProvider = ({
     if (searchTerm.trim() === "") {
       setSearchFilters(DEFAULT_FILTERS);
     }
-  }, [searchTerm]);
+  }, [searchTerm, searchFilters]);
 
   useEffect(() => {
     if (!rawComponentLibrary) {
@@ -328,8 +328,8 @@ export const ComponentLibraryProvider = ({
       highlightSearchResults,
       refetchLibrary,
       refetchUserComponents,
-      setSearchTerm: setSearchTerm,
-      setSearchFilters: setSearchFilters,
+      setSearchTerm,
+      setSearchFilters,
       setHighlightSearchResults,
       setComponentFavorite,
       checkIfFavorited,

--- a/src/types/componentLibrary.ts
+++ b/src/types/componentLibrary.ts
@@ -6,7 +6,6 @@ import type { ComponentReference, ComponentSpec } from "@/utils/componentSpec";
 export type ComponentItemFromUrlProps = {
   url?: string;
   componentRef?: ComponentReference;
-  onFavorite?: () => void;
 };
 
 export type ComponentLibrary = {


### PR DESCRIPTION
Some quick fixes and changes noticed during today's demo:

- Adds tooltips to the component library so the full component name can be viewed
- Fixes a bug where new searches were defaulting to empty state rather than the "name" filter
- Allows components to be "starred" from their details dialog
- Confirmation dialog will now correctly trigger when "unstarring" a user component via the task config sheet
- Adds the FavoriteComponentToggle component to bring together the frontend "star" logic and confirmation dialog into one place


![image](https://github.com/user-attachments/assets/a348b630-a3d2-436f-8e41-c0e8c7ddb48c)
![image](https://github.com/user-attachments/assets/f71d06dd-5bbc-4d6b-87e4-983c4ec2fa78)
![image](https://github.com/user-attachments/assets/61e05db6-ead8-4a81-bb9e-c037e3f6ed6a)


