### PR TITLE
Resizable Sheets

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfigurationSheet/TaskConfigurationSheet.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfigurationSheet/TaskConfigurationSheet.tsx
@@ -81,12 +81,14 @@ const TaskConfigurationSheet = ({
       <SheetTrigger asChild>{trigger}</SheetTrigger>
       <SheetContent
         side="right"
-        className="!w-[512px] !max-w-[512px] shadow-none"
+        className="shadow-none"
         style={{
           top: TOP_NAV_HEIGHT + "px",
           height: sheetHeight + "px",
         }}
         overlay={false}
+        defaultSize={512}
+        resizable
       >
         <SheetHeader className="pb-0">
           <SheetTitle className="flex items-center gap-2">

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -47,31 +47,130 @@ function SheetContent({
   children,
   side = "right",
   overlay = true,
+  resizable = false,
+  defaultSize = null,
+  style,
   ...props
 }: React.ComponentProps<typeof SheetPrimitive.Content> & {
   side?: "top" | "right" | "bottom" | "left";
   overlay?: boolean;
+  resizable?: boolean;
+  defaultSize?: number | null;
 }) {
+  const [size, setSize] = React.useState<number | null>(defaultSize);
+  const [isResizing, setIsResizing] = React.useState(false);
+  const contentRef = React.useRef<HTMLDivElement>(null);
+
+  const handleMouseDown = React.useCallback(
+    (e: React.MouseEvent) => {
+      if (!resizable) return;
+
+      e.preventDefault();
+      setIsResizing(true);
+
+      const startPos =
+        side === "left" || side === "right" ? e.clientX : e.clientY;
+      const startSize =
+        size ||
+        (side === "left" || side === "right"
+          ? contentRef.current?.offsetWidth
+          : contentRef.current?.offsetHeight) ||
+        0;
+
+      const handleMouseMove = (e: MouseEvent) => {
+        let newSize: number;
+
+        if (side === "right") {
+          newSize = startSize + (startPos - e.clientX);
+        } else if (side === "left") {
+          newSize = startSize + (e.clientX - startPos);
+        } else if (side === "bottom") {
+          newSize = startSize + (startPos - e.clientY);
+        } else {
+          newSize = startSize + (e.clientY - startPos);
+        }
+
+        const minSize = 256;
+        const maxSize =
+          side === "left" || side === "right"
+            ? window.innerWidth * 0.8
+            : window.innerHeight * 0.8;
+
+        newSize = Math.max(minSize, Math.min(maxSize, newSize));
+
+        setSize(newSize);
+      };
+
+      const handleMouseUp = () => {
+        setIsResizing(false);
+        document.removeEventListener("mousemove", handleMouseMove);
+        document.removeEventListener("mouseup", handleMouseUp);
+      };
+
+      document.addEventListener("mousemove", handleMouseMove);
+      document.addEventListener("mouseup", handleMouseUp);
+    },
+    [resizable, side, size],
+  );
+
+  const resizeHandleClasses = cn(
+    "absolute bg-transparent hover:bg-blue-500/20 transition-colors",
+    {
+      "top-0 bottom-0 w-1 cursor-col-resize":
+        side === "left" || side === "right",
+      "left-0 right-0 h-1 cursor-row-resize":
+        side === "top" || side === "bottom",
+      "right-0": side === "left",
+      "left-0": side === "right",
+      "bottom-0": side === "top",
+      "top-0": side === "bottom",
+    },
+  );
+
+  const sizeStyles = React.useMemo(() => {
+    if (size === null) return {};
+
+    if (side === "left" || side === "right") {
+      return { width: `${size}px` };
+    } else {
+      return { height: `${size}px` };
+    }
+  }, [size, side]);
+
   return (
     <SheetPortal>
-      {/* The optional overlay is a custom modification to the standard Shadcn Sheet component */}
       {overlay && <SheetOverlay />}
       <SheetPrimitive.Content
+        ref={contentRef}
         data-slot="sheet-content"
         className={cn(
           "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
           side === "right" &&
-            "data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm",
+            "data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full border-l" +
+              (resizable || defaultSize ? "" : " w-3/4 sm:max-w-sm"),
           side === "left" &&
-            "data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left inset-y-0 left-0 h-full w-3/4 border-r sm:max-w-sm",
+            "data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left inset-y-0 left-0 h-full border-r" +
+              (resizable || defaultSize ? "" : " w-3/4 sm:max-w-sm"),
           side === "top" &&
-            "data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-0 h-auto border-b",
+            "data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-0 border-b" +
+              (resizable || defaultSize ? "" : " h-auto"),
           side === "bottom" &&
-            "data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom inset-x-0 bottom-0 h-auto border-t",
+            "data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom inset-x-0 bottom-0 border-t" +
+              (resizable || defaultSize ? "" : " h-auto"),
+          resizable && "select-none",
+          isResizing && "cursor-col-resize",
           className,
         )}
+        style={{ ...sizeStyles, ...style }}
         {...props}
       >
+        {resizable && (
+          <div
+            className={resizeHandleClasses}
+            onMouseDown={handleMouseDown}
+            style={{ zIndex: 1000 }}
+          />
+        )}
         {children}
         <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
           <XIcon className="size-4" />


### PR DESCRIPTION
## Description

Adds an optional prop to the Sheet UI component that activates the ability to resize the panel by clicking and dragging on the free edge. In conjunction with this it also adds the ability to define the initial size of the sheet.

## Related Issue and Pull requests

Closes https://github.com/Cloud-Pipelines/pipeline-studio-app/issues/267

## Type of Change

<!-- Please delete options that are not relevant -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

![image](https://github.com/user-attachments/assets/ef415eea-1fc0-4e93-a53d-f4ea0da3114c)

## Additional Comments

This will likely be superseded or integrated into the upcoming work on moving the sheet into a permanent side panel.
