### PR TITLE
Integrate Configurable Backend with RunSection

### DIFF
--- a/src/components/shared/BackendStatus.tsx
+++ b/src/components/shared/BackendStatus.tsx
@@ -13,7 +13,8 @@ import { useBackend } from "@/providers/BackendProvider";
 import BackendConfigurationDialog from "./Dialogs/BackendConfigurationDialog";
 
 const BackendStatus = () => {
-  const { available, backendUrl } = useBackend();
+  const { available, backendUrl, isConfiguredFromEnv, configured } =
+    useBackend();
 
   const [open, setOpen] = useState(false);
 
@@ -21,10 +22,15 @@ const BackendStatus = () => {
     setOpen(true);
   }, []);
 
-  const hideBackendUrl = backendUrl === import.meta.env.VITE_BACKEND_API_URL;
-  const backendAvailableString = hideBackendUrl
+  const backendAvailableString = isConfiguredFromEnv
     ? "Backend available"
     : `Connected to ${backendUrl}`;
+  const backendNotAvailableString = configured
+    ? "Backend unavailable"
+    : "Backend not configured";
+
+  const configuredStatusColor = available ? "bg-green-500" : "bg-red-500";
+  const notConfiguredStatusColor = "bg-yellow-500";
 
   return (
     <>
@@ -40,14 +46,14 @@ const BackendStatus = () => {
               <span
                 className={cn(
                   "absolute -bottom-0.25 -right-0.25 w-2 h-2 rounded-full border-1 border-slate-900",
-                  available ? "bg-green-500" : "bg-red-500",
+                  configured ? configuredStatusColor : notConfiguredStatusColor,
                 )}
               />
             </div>
           </Button>
         </TooltipTrigger>
         <TooltipContent>
-          {available ? backendAvailableString : "Backend unavailable"}
+          {available ? backendAvailableString : backendNotAvailableString}
         </TooltipContent>
       </Tooltip>
 

--- a/src/components/shared/Dialogs/BackendConfigurationDialog.tsx
+++ b/src/components/shared/Dialogs/BackendConfigurationDialog.tsx
@@ -71,6 +71,7 @@ const BackendConfigurationDialog = ({
   const handleConfirm = useCallback(() => {
     setEnvConfig(isEnvConfig);
     setBackendUrl(inputBackendUrl);
+    setInputBackendUrl(inputBackendUrl.trim());
     setInputBackendTestResult(null);
     setOpen(false);
   }, [isEnvConfig, inputBackendUrl, setEnvConfig, setBackendUrl, setOpen]);
@@ -91,7 +92,7 @@ const BackendConfigurationDialog = ({
   }, [isConfiguredFromEnv, backendUrl, setInputBackendUrl]);
 
   const hasBackendConfigured =
-    !!inputBackendUrl || (isEnvConfig && hasEnvConfig);
+    !!inputBackendUrl.trim() || (isEnvConfig && hasEnvConfig);
   const confirmButtonText = hasBackendConfigured
     ? "Confirm"
     : "Continue without backend";
@@ -206,7 +207,7 @@ const BackendConfigurationDialog = ({
                   </Button>
                 </div>
               </div>
-              {!inputBackendUrl && (
+              {!inputBackendUrl.trim() && (
                 <div className="flex items-center gap-2">
                   <AlertCircle className="inline-block text-red-500 h-4 w-4" />
                   <p className="text-red-500 text-sm">

--- a/src/components/shared/InfoBox.tsx
+++ b/src/components/shared/InfoBox.tsx
@@ -1,16 +1,49 @@
 import type { ReactNode } from "react";
 
+import { cn } from "@/lib/utils";
+
 interface InfoBoxProps {
   title: string;
   className?: string;
   children: ReactNode;
+  variant?: "info" | "error" | "warning" | "success";
 }
 
-export const InfoBox = ({ title, className, children }: InfoBoxProps) => {
+const variantStyles: Record<
+  NonNullable<InfoBoxProps["variant"]>,
+  { container: string; title: string }
+> = {
+  info: {
+    container: "border-blue-200 bg-blue-50",
+    title: "text-blue-800",
+  },
+  error: {
+    container: "border-red-200 bg-red-50",
+    title: "text-red-800",
+  },
+  warning: {
+    container: "border-yellow-200 bg-yellow-50",
+    title: "text-yellow-800",
+  },
+  success: {
+    container: "border-green-200 bg-green-50",
+    title: "text-green-800",
+  },
+};
+
+export const InfoBox = ({
+  title,
+  className,
+  children,
+  variant = "info",
+}: InfoBoxProps) => {
+  const styles = variantStyles[variant];
   return (
-    <div className="border border-blue-200 bg-blue-50 rounded-md p-2">
-      <div className="text-sm font-semibold text-gray-800 mb-1">{title}</div>
-      <div className={className}>{children}</div>
+    <div className={`border rounded-md p-2 ${styles.container}`}>
+      <div className={`text-sm font-semibold mb-1 ${styles.title}`}>
+        {title}
+      </div>
+      <div className={cn("text-sm", className)}>{children}</div>
     </div>
   );
 };

--- a/src/providers/BackendProvider.tsx
+++ b/src/providers/BackendProvider.tsx
@@ -19,6 +19,7 @@ import { getBackendUrlFromEnv } from "@/utils/URL";
 import { normalizeUrl } from "@/utils/URL";
 
 type BackendContextType = {
+  configured: boolean;
   available: boolean;
   backendUrl: string;
   isConfiguredFromEnv: boolean;
@@ -43,6 +44,8 @@ export const BackendProvider = ({ children }: { children: ReactNode }) => {
   const [available, setAvailable] = useState(false);
 
   const backendUrl = useEnv ? backendUrlFromEnv : userBackendUrl;
+
+  const configured = !!backendUrl.trim();
 
   const setBackendUrl = useCallback(async (url: string) => {
     const normalized = normalizeUrl(url);
@@ -96,7 +99,7 @@ export const BackendProvider = ({ children }: { children: ReactNode }) => {
   useEffect(() => {
     const getSettings = async () => {
       const url = await getUserBackendUrl();
-      setUserBackendUrl(url || "");
+      setUserBackendUrl(url);
 
       const flag = await getUseEnv();
       setUseEnv(flag === true);
@@ -106,6 +109,7 @@ export const BackendProvider = ({ children }: { children: ReactNode }) => {
 
   const contextValue = useMemo(
     () => ({
+      configured,
       available,
       backendUrl,
       isConfiguredFromEnv: useEnv,
@@ -113,7 +117,15 @@ export const BackendProvider = ({ children }: { children: ReactNode }) => {
       setBackendUrl,
       ping,
     }),
-    [available, backendUrl, useEnv, setEnvConfig, setBackendUrl, ping],
+    [
+      configured,
+      available,
+      backendUrl,
+      useEnv,
+      setEnvConfig,
+      setBackendUrl,
+      ping,
+    ],
   );
 
   return (


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
In RunSection: Replaces static API_URL with backendUrl from BackendProvider.

Implements the configurable backend into RunSection, so that pipeline runs on the homepage are now fetched from the configured backend. Will display an appropriate error or info message if a backend is unavailable or not configured.

To facilitate this the PR also includes some supporting changes, such as colour variants for the InfoBox component and a new `configured` value from the backend provider. Also includes a few minor bugfixes.

The implementation into RunSection is **intended to be a blueprint for future implementations** in other sections. As such, only the run section is done in this PR. Once this flow has been approved I will propagate to all other instances of API_URL in another PR.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->
Follows #527 and progresses https://github.com/Shopify/oasis-frontend/issues/133

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] New feature

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->
<img width="845" height="277" alt="image" src="https://github.com/user-attachments/assets/87a5b2e6-bc20-4259-a6f6-4b8176b7e441" />

<img width="845" height="262" alt="image" src="https://github.com/user-attachments/assets/2eee8e8b-51bd-450e-a869-e4b67b2f3d92" />

<img width="823" height="845" alt="image" src="https://github.com/user-attachments/assets/1cac3ab0-2a18-4f5c-8fab-784264b5a99a" />


## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

- Open the app with a running backend on localhost
- Load runs section
- In config dialog tinker with the settings and see how the runs section responds.
- Continuing with no backend should give the yellow "no backend config" message
- Continuing with an invalid backend should give the red "backend config unavailable" message

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
