### PR TITLE
Add Multiline Argument Input via Dialog

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/ArgumentInputDialog.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/ArgumentInputDialog.tsx
@@ -1,0 +1,95 @@
+import { useCallback, useEffect, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Textarea } from "@/components/ui/textarea";
+import type { ArgumentInput } from "@/types/arguments";
+
+import { getInputValue, typeSpecToString } from "./utils";
+
+export const ArgumentInputDialog = ({
+  argument,
+  placeholder,
+  lastSubmittedValue,
+  open,
+  onCancel,
+  onConfirm,
+}: {
+  argument: ArgumentInput;
+  placeholder?: string;
+  lastSubmittedValue?: string;
+  open: boolean;
+  onCancel: () => void;
+  onConfirm: (value: string) => void;
+}) => {
+  const [value, setValue] = useState("");
+
+  const handleConfirm = useCallback(() => {
+    onConfirm(value);
+  }, [value, onConfirm]);
+
+  const handleCancel = useCallback(() => {
+    setValue(getArgumentDisplayValue(argument, lastSubmittedValue));
+    onCancel();
+  }, [argument, onCancel]);
+
+  useEffect(() => {
+    setValue(getArgumentDisplayValue(argument, lastSubmittedValue));
+  }, [argument]);
+
+  const setCursorToEnd = useCallback(
+    (ref: HTMLTextAreaElement | null) => {
+      if (ref && open) {
+        ref.focus();
+        ref.setSelectionRange(ref.value.length, ref.value.length);
+      }
+    },
+    [open],
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={onCancel}>
+      <DialogContent>
+        <DialogTitle>
+          {argument.key}{" "}
+          <span className="text-muted-foreground text-xs font-normal ml-1">
+            ({typeSpecToString(argument.inputSpec.type)}
+            {!argument.inputSpec.optional ? "*" : ""})
+          </span>
+        </DialogTitle>
+        <DialogDescription>
+          {argument.inputSpec.description ||
+            "Enter the value for this argument."}
+        </DialogDescription>
+        <Textarea
+          ref={setCursorToEnd}
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          placeholder={placeholder}
+        />
+        <DialogFooter>
+          <Button variant="outline" onClick={handleCancel}>
+            Cancel
+          </Button>
+          <Button onClick={handleConfirm}>Confirm</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+function getArgumentDisplayValue(
+  argument: ArgumentInput,
+  lastSubmittedValue?: string,
+): string {
+  if (argument.isRemoved) {
+    return lastSubmittedValue || getInputValue(argument) || "";
+  }
+  return getInputValue(argument) || "";
+}

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/ArgumentInputField.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/ArgumentInputField.tsx
@@ -11,6 +11,7 @@ import {
   HelpCircle,
   Info,
   ListRestart,
+  Maximize2,
   PlusSquare,
 } from "lucide-react";
 import {
@@ -31,7 +32,14 @@ import {
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import type { ArgumentInput } from "@/types/arguments";
-import type { ArgumentType, TypeSpecType } from "@/utils/componentSpec";
+
+import { ArgumentInputDialog } from "./ArgumentInputDialog";
+import {
+  getDefaultValue,
+  getInputValue,
+  getPlaceholder,
+  typeSpecToString,
+} from "./utils";
 
 export const ArgumentInputField = ({
   argument,
@@ -48,6 +56,8 @@ export const ArgumentInputField = ({
     getInputValue(argument) ?? "",
   );
 
+  const [isTextareaDialogOpen, setIsTextareaDialogOpen] = useState(false);
+
   const undoValue = useMemo(() => argument, []);
   const hint = argument.inputSpec.annotations?.hint as string | undefined;
 
@@ -58,16 +68,24 @@ export const ArgumentInputField = ({
 
   const handleBlur = () => {
     const value = inputValue.trim();
-
-    const updatedArgument = {
-      ...argument,
-      value,
-      isRemoved: value === lastSubmittedValue ? argument.isRemoved : false,
-    };
-
-    onSave(updatedArgument);
-    setLastSubmittedValue(value);
+    handleSubmit(value);
   };
+
+  const handleSubmit = useCallback(
+    (value: string) => {
+      if (value === lastSubmittedValue) return;
+
+      const updatedArgument = {
+        ...argument,
+        value,
+        isRemoved: false,
+      };
+
+      onSave(updatedArgument);
+      setLastSubmittedValue(value);
+    },
+    [inputValue, lastSubmittedValue, argument, onSave],
+  );
 
   const handleRemove = () => {
     const updatedArgument = {
@@ -117,6 +135,26 @@ export const ArgumentInputField = ({
     setShowDescription((prev) => !prev);
   }, []);
 
+  const handleExpand = useCallback(() => {
+    if (disabled) return;
+
+    setIsTextareaDialogOpen(true);
+  }, [disabled]);
+
+  const handleDialogConfirm = useCallback(
+    (value: string) => {
+      setInputValue(value);
+      setIsTextareaDialogOpen(false);
+
+      handleSubmit(value);
+    },
+    [handleSubmit],
+  );
+
+  const handleDialogCancel = useCallback(() => {
+    setIsTextareaDialogOpen(false);
+  }, []);
+
   const canUndo = useMemo(
     () => JSON.stringify(argument) !== JSON.stringify(undoValue),
     [argument, undoValue],
@@ -135,186 +173,166 @@ export const ArgumentInputField = ({
   }, [argument]);
 
   return (
-    <div className="relative w-full flex-col gap-2">
-      <div
-        className="flex w-full items-center justify-between gap-2 py-1 rounded-md hover:bg-secondary/70 cursor-pointer"
-        onClick={handleBackgroundClick}
-      >
-        <div className="flex items-center gap-2 justify-between w-40 pr-2">
-          <div className="flex items-center gap-2">
+    <>
+      <div className="relative w-full flex-col gap-2">
+        <div
+          className="flex w-full items-center justify-between gap-2 py-1 rounded-md hover:bg-secondary/70 cursor-pointer"
+          onClick={handleBackgroundClick}
+        >
+          <div className="flex items-center gap-2 justify-between w-40 pr-2">
+            <div className="flex items-center gap-2">
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <div
+                    className={cn(
+                      "bg-success rounded-full h-2 w-2 cursor-pointer",
+                      !canUndo && "invisible",
+                      disabled && "opacity-50",
+                    )}
+                    onClick={handleUndo}
+                  />
+                </TooltipTrigger>
+                <TooltipContent className="z-9999">
+                  Recently changed
+                </TooltipContent>
+              </Tooltip>
+              <div
+                className={cn(
+                  "flex flex-col",
+                  argument.isRemoved && "opacity-50",
+                )}
+              >
+                <Label
+                  htmlFor={argument.inputSpec.name}
+                  className="text-sm break-words"
+                >
+                  {argument.inputSpec.name.replace(/_/g, " ")}
+                </Label>
+                <span
+                  className="text-xs text-muted-foreground truncate"
+                  title={typeSpecToString(argument.inputSpec.type)}
+                >
+                  ({typeSpecToString(argument.inputSpec.type)}
+                  {!argument.inputSpec.optional ? "*" : ""})
+                </span>
+              </div>
+            </div>
+            {!!hint && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <HelpCircle className="w-4 h-4" />
+                </TooltipTrigger>
+                <TooltipContent className="z-9999">{hint}</TooltipContent>
+              </Tooltip>
+            )}
+          </div>
+
+          <div className="relative min-w-24 grow group">
             <Tooltip>
               <TooltipTrigger asChild>
-                <div
+                <Input
+                  id={argument.inputSpec.name}
+                  value={inputValue}
+                  onChange={handleInputChange}
+                  onBlur={handleBlur}
+                  placeholder={placeholder}
+                  required={!argument.inputSpec.optional}
                   className={cn(
-                    "bg-success rounded-full h-2 w-2 cursor-pointer",
-                    !canUndo && "invisible",
-                    disabled && "opacity-50",
+                    "flex-1 group-hover:pr-8",
+                    argument.isRemoved &&
+                      !argument.inputSpec.optional &&
+                      "border-red-200",
+                    argument.isRemoved &&
+                      argument.inputSpec.optional &&
+                      "border-gray-100 text-muted-foreground",
+                    argument.isRemoved && "opacity-50 focus:opacity-100",
                   )}
-                  onClick={handleUndo}
+                  disabled={disabled}
                 />
               </TooltipTrigger>
-              <TooltipContent className="z-9999">
-                Recently changed
-              </TooltipContent>
-            </Tooltip>
-            <div
-              className={cn(
-                "flex flex-col",
-                argument.isRemoved && "opacity-50",
+              {placeholder && !inputValue && (
+                <TooltipContent className="z-9999">
+                  {placeholder}
+                </TooltipContent>
               )}
+            </Tooltip>
+            <Button
+              className={cn(
+                "absolute right-0 top-1/2 -translate-y-1/2 hover:bg-transparent hover:text-blue-500 hidden group-hover:flex",
+              )}
+              onClick={handleExpand}
+              disabled={disabled}
+              variant="ghost"
             >
-              <Label
-                htmlFor={argument.inputSpec.name}
-                className="text-sm break-words"
-              >
-                {argument.inputSpec.name.replace(/_/g, " ")}
-              </Label>
-              <span
-                className="text-xs text-muted-foreground truncate"
-                title={typeSpecToString(argument.inputSpec.type)}
-              >
-                ({typeSpecToString(argument.inputSpec.type)}
-                {!argument.inputSpec.optional ? "*" : ""})
-              </span>
-            </div>
+              <Maximize2 />
+            </Button>
           </div>
-          {!!hint && (
+
+          <div className="flex gap-1 items-center w-24 justify-end">
             <Tooltip>
               <TooltipTrigger asChild>
-                <HelpCircle className="w-4 h-4" />
+                <Button
+                  type="button"
+                  onClick={handleRemove}
+                  disabled={disabled}
+                  variant="ghost"
+                  size="icon"
+                >
+                  {argument.isRemoved ? (
+                    <PlusSquare className="h-4 w-4" />
+                  ) : (
+                    <Delete className="h-4 w-4" />
+                  )}
+                </Button>
               </TooltipTrigger>
-              <TooltipContent className="z-9999">{hint}</TooltipContent>
+              <TooltipContent className="z-9999">
+                {argument.isRemoved ? "Include Argument" : "Exclude Argument"}
+              </TooltipContent>
             </Tooltip>
-          )}
-        </div>
 
-        <div className="relative min-w-24 grow">
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Input
-                id={argument.inputSpec.name}
-                value={inputValue}
-                onChange={handleInputChange}
-                onBlur={handleBlur}
-                placeholder={placeholder}
-                required={!argument.inputSpec.optional}
-                className={cn(
-                  "flex-1",
-                  canUndo && "pr-10",
-                  argument.isRemoved &&
-                    !argument.inputSpec.optional &&
-                    "border-red-200",
-                  argument.isRemoved &&
-                    argument.inputSpec.optional &&
-                    "border-gray-100 text-muted-foreground",
-                  argument.isRemoved && "opacity-50 focus:opacity-100",
-                )}
-                disabled={disabled}
-              />
-            </TooltipTrigger>
-            {placeholder && !inputValue && (
-              <TooltipContent className="z-9999">{placeholder}</TooltipContent>
-            )}
-          </Tooltip>
-        </div>
-
-        <div className="flex gap-1 items-center w-24 justify-end">
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                type="button"
-                onClick={handleRemove}
-                disabled={disabled}
-                variant="ghost"
-                size="icon"
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  onClick={handleReset}
+                  className={cn(argument.isRemoved ? "invisible" : "")}
+                  disabled={
+                    disabled ||
+                    argument.isRemoved ||
+                    argument.value === getDefaultValue(argument)
+                  }
+                  variant="ghost"
+                  size="icon"
+                >
+                  <ListRestart className="h-4 w-4" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent
+                className={cn("z-9999", argument.isRemoved ? "invisible" : "")}
               >
-                {argument.isRemoved ? (
-                  <PlusSquare className="h-4 w-4" />
-                ) : (
-                  <Delete className="h-4 w-4" />
-                )}
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent className="z-9999">
-              {argument.isRemoved ? "Include Argument" : "Exclude Argument"}
-            </TooltipContent>
-          </Tooltip>
-
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                type="button"
-                onClick={handleReset}
-                className={cn(argument.isRemoved ? "invisible" : "")}
-                disabled={
-                  disabled ||
-                  argument.isRemoved ||
-                  argument.value === getDefaultValue(argument)
-                }
-                variant="ghost"
-                size="icon"
-              >
-                <ListRestart className="h-4 w-4" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent
-              className={cn("z-9999", argument.isRemoved ? "invisible" : "")}
-            >
-              Reset to Default
-            </TooltipContent>
-          </Tooltip>
+                Reset to Default
+              </TooltipContent>
+            </Tooltip>
+          </div>
         </div>
+        {showDescription && (
+          <div className="z-50 bg-gray-50 text-secondary-foreground p-2 rounded-md w-full mb-2">
+            <p className="text-sm">
+              <Info className="h-4 w-4 inline-block mr-2" />
+              {argument.inputSpec.description ?? "No description provided."}
+            </p>
+          </div>
+        )}
       </div>
-      {showDescription && (
-        <div className="z-50 bg-gray-50 text-secondary-foreground p-2 rounded-md w-full mb-2">
-          <p className="text-sm">
-            <Info className="h-4 w-4 inline-block mr-2" />
-            {argument.inputSpec.description ?? "No description provided."}
-          </p>
-        </div>
-      )}
-    </div>
+
+      <ArgumentInputDialog
+        argument={argument}
+        placeholder={placeholder}
+        lastSubmittedValue={lastSubmittedValue}
+        open={isTextareaDialogOpen}
+        onCancel={handleDialogCancel}
+        onConfirm={handleDialogConfirm}
+      />
+    </>
   );
-};
-
-const typeSpecToString = (typeSpec?: TypeSpecType): string => {
-  if (typeSpec === undefined) {
-    return "Any";
-  }
-  if (typeof typeSpec === "string") {
-    return typeSpec;
-  }
-  return JSON.stringify(typeSpec);
-};
-
-const getPlaceholder = (argument: ArgumentType) => {
-  if (typeof argument === "string" || !argument) {
-    return "";
-  }
-
-  if (argument && "taskOutput" in argument) {
-    return `<from task ${argument.taskOutput.taskId} / ${argument.taskOutput.outputName}>`;
-  }
-  if (argument && "graphInput" in argument) {
-    return `<from graph input ${argument.graphInput.inputName}>`;
-  }
-  return "<reference>";
-};
-
-const getInputValue = (argumentInput: ArgumentInput) => {
-  const argument = argumentInput.value;
-
-  if (argument === undefined) {
-    return argumentInput.inputSpec.default;
-  }
-
-  if (typeof argument === "string") {
-    return argument;
-  }
-
-  return "";
-};
-
-const getDefaultValue = (argumentInput: ArgumentInput) => {
-  return argumentInput.inputSpec.default ?? "";
 };

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/utils.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/utils.ts
@@ -1,5 +1,9 @@
 import type { ArgumentInput } from "@/types/arguments";
-import type { TaskSpec } from "@/utils/componentSpec";
+import type {
+  ArgumentType,
+  TaskSpec,
+  TypeSpecType,
+} from "@/utils/componentSpec";
 
 export const getArgumentInputs = (taskSpec: TaskSpec) => {
   const componentSpec = taskSpec.componentRef.spec;
@@ -34,4 +38,46 @@ export const getArgumentInputs = (taskSpec: TaskSpec) => {
     }) ?? [];
 
   return argumentInputs;
+};
+
+export const typeSpecToString = (typeSpec?: TypeSpecType): string => {
+  if (typeSpec === undefined) {
+    return "Any";
+  }
+  if (typeof typeSpec === "string") {
+    return typeSpec;
+  }
+  return JSON.stringify(typeSpec);
+};
+
+export const getPlaceholder = (argument: ArgumentType) => {
+  if (typeof argument === "string" || !argument) {
+    return "";
+  }
+
+  if (argument && "taskOutput" in argument) {
+    return `<from task ${argument.taskOutput.taskId} / ${argument.taskOutput.outputName}>`;
+  }
+  if (argument && "graphInput" in argument) {
+    return `<from graph input ${argument.graphInput.inputName}>`;
+  }
+  return "<reference>";
+};
+
+export const getInputValue = (argumentInput: ArgumentInput) => {
+  const argument = argumentInput.value;
+
+  if (argument === undefined) {
+    return argumentInput.inputSpec.default;
+  }
+
+  if (typeof argument === "string") {
+    return argument;
+  }
+
+  return "";
+};
+
+export const getDefaultValue = (argumentInput: ArgumentInput) => {
+  return argumentInput.inputSpec.default ?? "";
 };


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

Adds a dialog with a multiline textarea that users can opt to use for entering argument values instead of the single-line input.

The dialog is accessible via the `expand` button.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

n/a - verbally requested

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->
<img width="539" height="416" alt="image" src="https://github.com/user-attachments/assets/22bdb769-5e46-44c0-8b8e-83f07752b437" />
<img width="654" height="411" alt="image" src="https://github.com/user-attachments/assets/d0a7845b-55be-41ac-a7ce-5a73ab1cc2e6" />
<img width="750" height="549" alt="image" src="https://github.com/user-attachments/assets/d80a7e10-8bc8-4053-85a6-e60b3809cf39" />
<img width="539" height="422" alt="image" src="https://github.com/user-attachments/assets/0068a904-2e83-4d47-9392-f0507fde7329" />


## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->
Click the new expand button in an argument's input box to see the new dialog with multiline textarea.

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
