### PR TITLE
Move Recent Executions into a Popover

### DIFF
--- a/src/components/Editor/PipelineDetails.tsx
+++ b/src/components/Editor/PipelineDetails.tsx
@@ -17,7 +17,6 @@ import { USER_PIPELINES_LIST_NAME } from "@/utils/constants";
 import { deselectAllNodes } from "@/utils/flowUtils";
 
 import { TaskImplementation } from "../shared/TaskDetails";
-import RecentExecutions from "./components/RecentExecutions";
 import { InputValueEditor } from "./InputValueEditor/InputValueEditor";
 import { OutputNameEditor } from "./OutputNameEditor";
 import RenamePipeline from "./RenamePipeline";
@@ -285,9 +284,6 @@ const PipelineDetails = () => {
           </div>
         </div>
       </div>
-
-      {/* Recent Executions */}
-      <RecentExecutions />
 
       {/* Pipeline YAML */}
       <div className="flex flex-col h-full">

--- a/src/components/shared/ReactFlow/FlowSidebar/components/RecentExecutions.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/components/RecentExecutions.tsx
@@ -4,10 +4,11 @@ import { InfoBox } from "@/components/shared/InfoBox";
 import RunOverview from "@/components/shared/RunOverview";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Spinner } from "@/components/ui/spinner";
+import { cn } from "@/lib/utils";
 import { useBackend } from "@/providers/BackendProvider";
 import { usePipelineRuns } from "@/providers/PipelineRunsProvider";
 
-const RecentExecutions = () => {
+const RecentExecutions = ({ pipelineName }: { pipelineName?: string }) => {
   const { backendUrl, configured, available } = useBackend();
   const { runs, recentRuns, isLoading, error, refetch } = usePipelineRuns();
 
@@ -18,15 +19,9 @@ const RecentExecutions = () => {
           <RunOverview
             run={run}
             config={{
-              showStatus: true,
               showName: false,
-              showExecutionId: true,
-              showCreatedAt: true,
-              showTaskStatusBar: false,
-              showStatusCounts: "full",
-              showAuthor: true,
             }}
-            className="rounded-sm"
+            className="rounded-sm hover:bg-gray-100"
           />
         </a>
       )),
@@ -39,11 +34,19 @@ const RecentExecutions = () => {
     refetch();
   }, [backendUrl, refetch]);
 
+  const titleMarkup = (
+    <h3 className={cn("text-md mb-1", { "font-medium": !pipelineName })}>
+      {pipelineName ? <span className="font-bold">{pipelineName}</span> : null}
+      {pipelineName ? " - " : ""}
+      Recent Pipeline Runs
+    </h3>
+  );
+
   if (isLoading) {
     return (
       <div>
-        <h3 className="text-md font-medium mb-1">Recent Pipeline Runs</h3>
-        <div className="h-48 bg-gray-100 border border-gray-300 rounded p-2 flex items-center justify-center">
+        {titleMarkup}
+        <div className="h-48 rounded p-2 flex items-center justify-center">
           <Spinner className="mr-2" />
           <p className="text-secondary-foreground">
             Loading recent pipeline runs...
@@ -56,8 +59,8 @@ const RecentExecutions = () => {
   if (error) {
     return (
       <div>
-        <h3 className="text-md font-medium mb-1">Recent Pipeline Runs</h3>
-        <div className="h-48 bg-gray-100 border border-gray-300 rounded p-2 flex items-center justify-center">
+        {titleMarkup}
+        <div className="h-48 rounded p-2 flex items-center justify-center">
           <p className="text-destructive">{error}</p>
         </div>
       </div>
@@ -67,7 +70,7 @@ const RecentExecutions = () => {
   if (!configured) {
     return (
       <div>
-        <h3 className="text-md font-medium mb-1">Recent Pipeline Runs</h3>
+        {titleMarkup}
         <InfoBox title="Backend not configured" variant="warning">
           Configure a backend to view recent pipeline runs.
         </InfoBox>
@@ -78,7 +81,7 @@ const RecentExecutions = () => {
   if (!available) {
     return (
       <div>
-        <h3 className="text-md font-medium mb-1">Recent Pipeline Runs</h3>
+        {titleMarkup}
         <InfoBox title="Backend not available" variant="error">
           The configured backend is unavailable.
         </InfoBox>
@@ -88,11 +91,11 @@ const RecentExecutions = () => {
 
   return (
     <div>
-      <h3 className="text-md font-medium mb-1">Recent Pipeline Runs</h3>
+      {titleMarkup}
       {recentRuns.length === 0 ? (
         <div className="text-xs text-muted-foreground">No runs yet.</div>
       ) : (
-        <ScrollArea className="h-fit bg-gray-100 border border-gray-300 rounded p-2">
+        <ScrollArea className="h-fit rounded">
           {runOverviews}
           {remainingRuns > 0 && (
             <div className="mt-2 text-xs text-muted-foreground w.full text-center">

--- a/src/components/shared/ReactFlow/FlowSidebar/components/RecentExecutionsButton.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/components/RecentExecutionsButton.tsx
@@ -1,0 +1,40 @@
+import { List } from "lucide-react";
+
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { SidebarMenuButton } from "@/components/ui/sidebar";
+import { useComponentSpec } from "@/providers/ComponentSpecProvider";
+import { usePipelineRuns } from "@/providers/PipelineRunsProvider";
+
+import RecentExecutions from "./RecentExecutions";
+
+export const RecentExecutionsButton = ({
+  tooltipPosition = "top",
+}: {
+  tooltipPosition?: "top" | "right";
+}) => {
+  const { runs } = usePipelineRuns();
+  const { componentSpec } = useComponentSpec();
+
+  return (
+    <Popover>
+      <PopoverTrigger data-popover-trigger>
+        <SidebarMenuButton
+          asChild
+          tooltip={`Recent Pipeline Runs (${runs.length})`}
+          forceTooltip
+          tooltipPosition={tooltipPosition}
+          className="text-black/80 rounded-md font-medium transition hover:bg-accent hover:text-accent-foreground focus-visible:ring-ring cursor-pointer py-2 px-3"
+        >
+          <List className="w-4 h-4" />
+        </SidebarMenuButton>
+      </PopoverTrigger>
+      <PopoverContent className="w-[500px]">
+        <RecentExecutions pipelineName={componentSpec.name} />
+      </PopoverContent>
+    </Popover>
+  );
+};

--- a/src/components/shared/ReactFlow/FlowSidebar/sections/RunsAndSubmission.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/sections/RunsAndSubmission.tsx
@@ -10,6 +10,8 @@ import {
 import { cn } from "@/lib/utils";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 
+import { RecentExecutionsButton } from "../components/RecentExecutionsButton";
+
 const RunsAndSubmission = ({ isOpen }: { isOpen: boolean }) => {
   const { componentSpec } = useComponentSpec();
 
@@ -30,6 +32,9 @@ const RunsAndSubmission = ({ isOpen }: { isOpen: boolean }) => {
                 <GoogleCloudSubmissionDialog componentSpec={componentSpec} />
               </SidebarMenuItem>
             )}
+            <SidebarMenuItem>
+              <RecentExecutionsButton tooltipPosition="right" />
+            </SidebarMenuItem>
           </SidebarMenu>
         </SidebarGroupContent>
       </>
@@ -38,7 +43,12 @@ const RunsAndSubmission = ({ isOpen }: { isOpen: boolean }) => {
 
   return (
     <SidebarGroup>
-      <SidebarGroupLabel>Runs & Submissions</SidebarGroupLabel>
+      <SidebarGroupLabel>
+        <div className="flex items-center justify-between gap-2 w-full">
+          <div>Runs & Submissions</div>
+          <RecentExecutionsButton />
+        </div>
+      </SidebarGroupLabel>
       <SidebarGroupContent>
         <SidebarMenu>
           <SidebarMenuItem>

--- a/src/components/shared/RunOverview.tsx
+++ b/src/components/shared/RunOverview.tsx
@@ -30,12 +30,13 @@ const defaultConfig = {
   showAuthor: false,
 };
 
-const RunOverview = ({
-  run,
-  config = defaultConfig,
-  className = "",
-}: RunOverviewProps) => {
+const RunOverview = ({ run, config, className = "" }: RunOverviewProps) => {
   const navigate = useNavigate();
+
+  const combinedConfig = {
+    ...defaultConfig,
+    ...config,
+  };
 
   return (
     <div
@@ -50,20 +51,20 @@ const RunOverview = ({
     >
       <div className="flex items-center justify-between mb-1">
         <div className="flex items-center gap-2">
-          {config?.showName && <span>{run.pipeline_name}</span>}
+          {combinedConfig?.showName && <span>{run.pipeline_name}</span>}
           <div className="flex items-center gap-3">
-            {config?.showStatus && <StatusIcon status={run.status} />}
-            {config?.showExecutionId && (
+            {combinedConfig?.showStatus && <StatusIcon status={run.status} />}
+            {combinedConfig?.showExecutionId && (
               <div className="text-xs">{`#${run.root_execution_id}`}</div>
             )}
           </div>
-          {config?.showCreatedAt && run.created_at && (
+          {combinedConfig?.showCreatedAt && run.created_at && (
             <div className="flex items-center gap-2">
               <span>•</span>
               <span className="text-gray-500 text-xs">{`${formatDate(run.created_at || "")}`}</span>
             </div>
           )}
-          {config?.showAuthor && run.created_by && (
+          {combinedConfig?.showAuthor && run.created_by && (
             <div className="flex items-center gap-1">
               <span className="mr-1">•</span>
               <span className="text-xs">Initiated by</span>
@@ -73,20 +74,20 @@ const RunOverview = ({
             </div>
           )}
         </div>
-        {config?.showStatusCounts &&
-          config.showStatusCounts !== "none" &&
+        {combinedConfig?.showStatusCounts &&
+          combinedConfig.showStatusCounts !== "none" &&
           run.statusCounts && (
             <StatusText
               statusCounts={run.statusCounts}
               shorthand={
-                config.showStatusCounts === "shorthand" ||
-                (config.showAuthor && !!run.created_by)
+                combinedConfig.showStatusCounts === "shorthand" ||
+                (combinedConfig.showAuthor && !!run.created_by)
               }
             />
           )}
       </div>
 
-      {config?.showTaskStatusBar && (
+      {combinedConfig?.showTaskStatusBar && (
         <StatusBar statusCounts={run.statusCounts} />
       )}
     </div>


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Discussed on Slack.

The Pipeline Details Recent Executions sections takes up more space than the value it provides. This PR moves it into a popover button, similar to how it works in the Pipeline List

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->
Closes https://github.com/Shopify/oasis-frontend/issues/174

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->
<img width="600" height="714" alt="image" src="https://github.com/user-attachments/assets/824f2273-ffef-478d-8101-27b32252b522" />
<img width="812" height="659" alt="image" src="https://github.com/user-attachments/assets/c8f4c164-d5ba-45d8-b368-e21e2ba0afb2" />


## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
