### PR TITLE
retire virtual codeviewer beta flag

### DIFF
--- a/src/betaFlags.ts
+++ b/src/betaFlags.ts
@@ -1,7 +1,1 @@
-export const ExistingBetaFlags = {
-  codeViewer: {
-    name: "Code Viewer virtualization",
-    description: "Enable the code viewer virtualization.",
-    default: false,
-  },
-};
+export const ExistingBetaFlags = {};

--- a/src/components/shared/CodeViewer/CodeViewer.tsx
+++ b/src/components/shared/CodeViewer/CodeViewer.tsx
@@ -4,7 +4,6 @@ import { useCallback, useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 
 import { FullscreenElement } from "../FullscreenElement";
-import { useBetaFlagValue } from "../Settings/useBetaFlags";
 import CodeSyntaxHighlighter from "./CodeSyntaxHighlighter";
 
 interface CodeViewerProps {
@@ -21,8 +20,6 @@ const CodeViewer = ({
   language = "yaml",
   filename = "",
 }: CodeViewerProps) => {
-  const isVirtualized = useBetaFlagValue("codeViewer");
-
   const [isFullscreen, setIsFullscreen] = useState(false);
 
   const handleEnterFullscreen = useCallback(() => {
@@ -76,7 +73,7 @@ const CodeViewer = ({
               language={language}
               height="calc(100% - 48px)"
               fontSize="0.75rem"
-              virtualized={isVirtualized}
+              virtualized
             />
           </div>
         </div>


### PR DESCRIPTION
## Description

Removed the beta flag for the code viewer virtualization feature, making it always enabled. This change eliminates the dependency on `useBetaFlagValue` for the code viewer component and sets the `virtualized` property to always be `true` instead of being conditionally set based on the beta flag.

## Related Issue and Pull requests

## Type of Change

- [x] Improvement
- [x] Cleanup/Refactor

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

Verify that the code viewer component works correctly with virtualization permanently enabled.