### PR TITLE
Moves component spec provider

### DIFF
--- a/src/components/layout/AppMenu.tsx
+++ b/src/components/layout/AppMenu.tsx
@@ -1,6 +1,7 @@
 import { Link } from "@tanstack/react-router";
 
 import ImportPipeline from "@/components/shared/ImportPipeline";
+import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 import { TOP_NAV_HEIGHT } from "@/utils/constants";
 
 import BackendStatus from "../shared/BackendStatus";
@@ -8,6 +9,8 @@ import NewPipelineButton from "../shared/NewPipelineButton";
 import { PersonalPreferences } from "../shared/Settings/PersonalPreferences";
 
 const AppMenu = () => {
+  const { componentSpec } = useComponentSpec();
+  const title = componentSpec?.name;
   return (
     <div
       className="w-full bg-stone-900 p-2"
@@ -22,6 +25,7 @@ const AppMenu = () => {
               className="w-10 h-10 filter invert cursor-pointer"
             />
           </Link>
+          <span className="text-white text-sm font-bold">{title}</span>
         </div>
         <div className="flex flex-row gap-32 items-center">
           <div className="flex flex-row gap-2 items-center">

--- a/src/components/layout/RootLayout.tsx
+++ b/src/components/layout/RootLayout.tsx
@@ -5,6 +5,7 @@ import { ToastContainer } from "react-toastify";
 import { SidebarProvider } from "@/components/ui/sidebar";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 import { BackendProvider } from "@/providers/BackendProvider";
+import { ComponentSpecProvider } from "@/providers/ComponentSpecProvider";
 
 import AppFooter from "./AppFooter";
 import AppMenu from "./AppMenu";
@@ -13,23 +14,26 @@ const RootLayout = () => {
   useDocumentTitle();
 
   return (
+
     <BackendProvider>
       <SidebarProvider>
-        <ToastContainer />
+        <ComponentSpecProvider>
+          <ToastContainer />
 
-        <div className="App flex flex-col min-h-screen w-full">
-          <AppMenu />
+          <div className="App flex flex-col min-h-screen w-full">
+            <AppMenu />
 
-          <main className="flex-1 grid">
-            <Outlet />
-          </main>
+            <main className="flex-1 grid">
+              <Outlet />
+            </main>
 
-          <AppFooter />
+            <AppFooter />
 
-          {import.meta.env.VITE_ENABLE_ROUTER_DEVTOOLS === "true" && (
-            <TanStackRouterDevtools />
-          )}
-        </div>
+            {import.meta.env.VITE_ENABLE_ROUTER_DEVTOOLS === "true" && (
+              <TanStackRouterDevtools />
+            )}
+          </div>
+        </ComponentSpecProvider>
       </SidebarProvider>
     </BackendProvider>
   );

--- a/src/routes/Editor/Editor.tsx
+++ b/src/routes/Editor/Editor.tsx
@@ -2,26 +2,36 @@ import "@/styles/editor.css";
 
 import { DndContext } from "@dnd-kit/core";
 import { ReactFlowProvider } from "@xyflow/react";
+import { useEffect } from "react";
 
 import PipelineEditor from "@/components/Editor/PipelineEditor";
 import { useLoadComponentSpecFromPath } from "@/hooks/useLoadComponentSpecFromPath";
 import { useBackend } from "@/providers/BackendProvider";
-import { ComponentSpecProvider } from "@/providers/ComponentSpecProvider";
+import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 
 const Editor = () => {
   const { backendUrl } = useBackend();
   const { componentSpec } = useLoadComponentSpecFromPath(backendUrl);
+  const { setComponentSpec } = useComponentSpec();
+
+  useEffect(() => {
+    if (componentSpec) {
+      setComponentSpec(componentSpec);
+    }
+  }, [componentSpec, setComponentSpec]);
+
+  if (!componentSpec) {
+    return <div>Loading...</div>;
+  }
 
   return (
-    <ComponentSpecProvider spec={componentSpec}>
-      <div className="dndflow">
-        <DndContext>
-          <ReactFlowProvider>
-            <PipelineEditor />
-          </ReactFlowProvider>
-        </DndContext>
-      </div>
-    </ComponentSpecProvider>
+    <div className="dndflow">
+      <DndContext>
+        <ReactFlowProvider>
+          <PipelineEditor />
+        </ReactFlowProvider>
+      </DndContext>
+    </div>
   );
 };
 


### PR DESCRIPTION
## Description

partly resolves: <https://github.com/Shopify/oasis-frontend/issues/171>

Added a component title to the app menu by refactoring the ComponentSpecProvider to be a global provider. This allows the component name to be displayed in the app header, improving navigation context for users.

## Type of Change

- [x] Improvement
- [x] Refactor

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Test Instructions

1. Open a pipeline in the editor and verify the component name appears in the app menu
2. Run a pipeline and verify the component name appears in the app menu
3. Navigate between different views to ensure the component name updates correctly