### PR TITLE
Clears component spec when navigating away from editors

### DIFF
--- a/src/components/layout/AppMenu.tsx
+++ b/src/components/layout/AppMenu.tsx
@@ -5,11 +5,13 @@ import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 import { TOP_NAV_HEIGHT } from "@/utils/constants";
 
 import BackendStatus from "../shared/BackendStatus";
+import CloneRunButton from "../shared/CloneRunButton";
 import NewPipelineButton from "../shared/NewPipelineButton";
 import { PersonalPreferences } from "../shared/Settings/PersonalPreferences";
 
 const AppMenu = () => {
   const { componentSpec } = useComponentSpec();
+
   const title = componentSpec?.name;
   return (
     <div
@@ -29,6 +31,7 @@ const AppMenu = () => {
         </div>
         <div className="flex flex-row gap-32 items-center">
           <div className="flex flex-row gap-2 items-center">
+            <CloneRunButton />
             <ImportPipeline />
             <NewPipelineButton />
           </div>

--- a/src/components/shared/CloneRunButton.tsx
+++ b/src/components/shared/CloneRunButton.tsx
@@ -2,6 +2,7 @@ import { useLocation, useNavigate } from "@tanstack/react-router";
 import { Loader2 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 import { RUNS_BASE_PATH } from "@/routes/router";
 import { copyRunToPipeline } from "@/services/pipelineRunService";
 import type { ComponentSpec } from "@/utils/componentSpec";
@@ -51,15 +52,16 @@ const CloneRunButtonInner = ({
   );
 };
 
-const CloneRunButton = ({ spec }: { spec?: ComponentSpec }) => {
+const CloneRunButton = () => {
   const location = useLocation();
+  const { componentSpec } = useComponentSpec();
 
   const isRunDetailRoute = location.pathname.includes(RUNS_BASE_PATH);
 
   if (!isRunDetailRoute) {
     return null;
   }
-  return <CloneRunButtonInner componentSpec={spec} />;
+  return <CloneRunButtonInner componentSpec={componentSpec} />;
 };
 
 export default CloneRunButton;

--- a/src/providers/ComponentSpecProvider.tsx
+++ b/src/providers/ComponentSpecProvider.tsx
@@ -41,6 +41,7 @@ export const EMPTY_GRAPH_COMPONENT_SPEC: ComponentSpec = {
 interface ComponentSpecContextType {
   componentSpec: ComponentSpec;
   setComponentSpec: (spec: ComponentSpec) => void;
+  clearComponentSpec: () => void;
   graphSpec: GraphSpec;
   isLoading: boolean;
   refetch: () => void;
@@ -67,12 +68,20 @@ export const ComponentSpecProvider = ({
   const [componentSpec, setComponentSpec] = useState<ComponentSpec>(
     spec ?? EMPTY_GRAPH_COMPONENT_SPEC,
   );
+
   const [taskStatusMap, setTaskStatusMap] = useState<Map<string, string>>(
     new Map(),
   );
 
   const [isLoading, setIsLoading] = useState(!!spec);
   const [hasInitiallyLoaded, setHasInitiallyLoaded] = useState(false);
+
+  const clearComponentSpec = useCallback(() => {
+    setComponentSpec(EMPTY_GRAPH_COMPONENT_SPEC);
+    setTaskStatusMap(new Map());
+    setIsLoading(false);
+    setHasInitiallyLoaded(false);
+  }, []);
 
   const graphSpec = useMemo(() => {
     if (
@@ -186,6 +195,7 @@ export const ComponentSpecProvider = ({
       isLoading,
       refetch,
       setComponentSpec,
+      clearComponentSpec,
       saveComponentSpec,
       updateGraphSpec,
       setTaskStatusMap,
@@ -198,6 +208,7 @@ export const ComponentSpecProvider = ({
       isLoading,
       refetch,
       setComponentSpec,
+      clearComponentSpec,
       saveComponentSpec,
       updateGraphSpec,
       setTaskStatusMap,

--- a/src/routes/Editor/Editor.tsx
+++ b/src/routes/Editor/Editor.tsx
@@ -12,13 +12,16 @@ import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 const Editor = () => {
   const { backendUrl } = useBackend();
   const { componentSpec } = useLoadComponentSpecFromPath(backendUrl);
-  const { setComponentSpec } = useComponentSpec();
+  const { setComponentSpec, clearComponentSpec } = useComponentSpec();
 
   useEffect(() => {
     if (componentSpec) {
       setComponentSpec(componentSpec);
     }
-  }, [componentSpec, setComponentSpec]);
+    return () => {
+      clearComponentSpec();
+    };
+  }, [componentSpec, setComponentSpec, clearComponentSpec]);
 
   if (!componentSpec) {
     return <div>Loading...</div>;

--- a/src/routes/PipelineRun/PipelineRun.tsx
+++ b/src/routes/PipelineRun/PipelineRun.tsx
@@ -18,7 +18,7 @@ import { getBackendStatusString } from "@/utils/backend";
 import type { ComponentSpec } from "@/utils/componentSpec";
 
 const PipelineRun = () => {
-  const { setComponentSpec } = useComponentSpec();
+  const { setComponentSpec, clearComponentSpec } = useComponentSpec();
   const { backendUrl, configured, available } = useBackend();
   const { id: rootExecutionId } = runDetailRoute.useParams() as RunDetailParams;
 
@@ -41,7 +41,10 @@ const PipelineRun = () => {
 
       setComponentSpec(componentSpecWithExecutionIds);
     }
-  }, [componentSpec, setComponentSpec]);
+    return () => {
+      clearComponentSpec();
+    };
+  }, [componentSpec, setComponentSpec, clearComponentSpec]);
 
   useDocumentTitle({
     "/runs/$id": (params) =>


### PR DESCRIPTION
## Description

partly resolves: <https://github.com/Shopify/oasis-frontend/issues/171>

Added a `clearComponentSpec` function to the ComponentSpecProvider to reset the component spec to the empty state. This function is now called in the cleanup phase of the useEffect hooks in both the Editor and PipelineRun components to prevent stale component specs from persisting between navigation.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Test Instructions

1. Navigate between different pipeline runs and verify that the component spec is properly reset
2. Navigate from the editor to other pages and back, ensuring no stale component specs remain