### PR TITLE
fix virtualized codeviewer in prod build

### DIFF
--- a/src/components/shared/CodeViewer/CodeSyntaxHighlighter.test.tsx
+++ b/src/components/shared/CodeViewer/CodeSyntaxHighlighter.test.tsx
@@ -58,8 +58,9 @@ describe("<CodeSyntaxHighlighter />", () => {
 
   describe("virtualized mode", () => {
     const batchSize = 100;
+    const lineNumber = 1000;
     const largeCode = Array.from(
-      { length: 1000 },
+      { length: lineNumber },
       (_, i) => `const line${i} = ${i};`,
     ).join("\n");
 
@@ -114,11 +115,7 @@ describe("<CodeSyntaxHighlighter />", () => {
       expect(virtualizedDivs.length).toBeGreaterThan(0);
     });
 
-    /**
-     * This test skipped, due to unknown failure. Not sure what changed in the between the last time it was run and now.
-     * Given, that entire code viewer is going to be replaced, may not be worth fixing.
-     */
-    test.skip("virtualized mode renders large code efficiently in batches", async () => {
+    test("virtualized mode renders large code efficiently in batches", async () => {
       render(
         <div
           data-testid="scroll-container"
@@ -146,7 +143,7 @@ describe("<CodeSyntaxHighlighter />", () => {
         virtualizedContainer!.querySelectorAll("div[data-index]");
 
       expect(batchContainerDivs[0].childElementCount).toBe(batchSize);
-      expect(batchContainerDivs.length).toBe(2);
+      expect(batchContainerDivs.length).toBe(Math.ceil(lineNumber / batchSize));
     });
   });
 });


### PR DESCRIPTION
## Description

Added a version state to force re-rendering when the scroll element changes - a double-render of dev mode hid the problem. Tested in production build: `yarn build` + `yarn serve`.

Fixed and re-enabled the previously skipped test for virtualized code rendering in `CodeSyntaxHighlighter`. The PR extracts the line number into a constant variable for better maintainability and updates the batch container calculation to use this constant. Also added proper `displayName` properties to memo components for better debugging. 

Bug screen:

<img width="433" height="923" alt="image" src="https://github.com/user-attachments/assets/d0b10479-7a50-4cbd-80de-1ff7ba9c9524" />


## Type of Change

- [x] Bug fix

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

Run the test suite for the CodeSyntaxHighlighter component to verify that the previously skipped test now passes. The test verifies that virtualized mode correctly renders large code efficiently in batches.