### PR TITLE
fix fullscreen mode scroll

### DIFF
--- a/src/components/shared/FullscreenElement/FullscreenElement.test.tsx
+++ b/src/components/shared/FullscreenElement/FullscreenElement.test.tsx
@@ -71,6 +71,7 @@ describe("FullscreenElement", () => {
     expect(fullscreenContainer.parentElement).toBe(document.body);
     expect(fullscreenContainer).toHaveClass("fixed");
     expect(fullscreenContainer).toHaveClass("z-[2147483647]");
+    expect(fullscreenContainer).toHaveClass("pointer-events-auto");
   });
 
   test("switches from fullscreen to normal mode", () => {

--- a/src/components/shared/FullscreenElement/FullscreenElement.tsx
+++ b/src/components/shared/FullscreenElement/FullscreenElement.tsx
@@ -35,6 +35,7 @@ function FullscreenElementPortal({
         "w-full",
         "h-full",
         "overflow-hidden",
+        "pointer-events-auto",
       );
       document.body.appendChild(containerElementRef.current);
     } else {


### PR DESCRIPTION
## Description

Added `pointer-events-auto` class to the `FullscreenElement` component to ensure it properly captures mouse events when in fullscreen mode. This fixes an issue where click events might pass through the fullscreen container.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

1. Verify that the fullscreen container properly captures mouse events
2. Confirm that the existing test now checks for the `pointer-events-auto` class
3. Ensure that all existing functionality of the FullscreenElement component works as expected