### PR TITLE
replace legacy library with separate classes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
+        "dexie": "^4.0.11",
         "eslint-plugin-simple-import-sort": "^12.1.1",
         "fast-deep-equal": "^3.1.3",
         "gh-pages": "^6.3.0",
@@ -5845,6 +5846,12 @@
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
       "license": "MIT"
+    },
+    "node_modules/dexie": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/dexie/-/dexie-4.0.11.tgz",
+      "integrity": "sha512-SOKO002EqlvBYYKQSew3iymBoN2EQ4BDw/3yprjh7kAfFzjBYkaMNa/pZvcA7HSWlcKSQb9XhPe3wKyQ0x4A8A==",
+      "license": "Apache-2.0"
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
+    "dexie": "^4.0.11",
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "fast-deep-equal": "^3.1.3",
     "gh-pages": "^6.3.0",

--- a/src/betaFlags.ts
+++ b/src/betaFlags.ts
@@ -14,6 +14,13 @@ export const ExistingBetaFlags = {
     default: false,
   } as BetaFlag,
 
+  ["component-library-v2"]: {
+    name: "Component Library V2",
+    description:
+      "Enable the Component Library V2. All lib folders will be based on new components",
+    default: false,
+  } as BetaFlag,
+
   ["redirect-on-new-pipeline-run"]: {
     name: "Redirect on new pipeline run",
     description: "Automatically open a new tab after starting a new execution.",

--- a/src/components/shared/FavoriteComponentToggle.tsx
+++ b/src/components/shared/FavoriteComponentToggle.tsx
@@ -1,14 +1,19 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
 import { PackagePlus, Star } from "lucide-react";
 import type { MouseEvent, PropsWithChildren } from "react";
 import { useCallback, useMemo, useState } from "react";
 
 import { ConfirmationDialog } from "@/components/shared/Dialogs";
 import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
 import { Icon } from "@/components/ui/icon";
 import { cn } from "@/lib/utils";
 import { useComponentLibrary } from "@/providers/ComponentLibraryProvider";
+import { FAVORITE_COMPONENTS_LIBRARY_ID } from "@/providers/ComponentLibraryProvider/libraries/migrateLegacyFavoriteFolder";
 import type { ComponentReference } from "@/utils/componentSpec";
 import { getComponentName } from "@/utils/getComponentName";
+
+import { withSuspenseWrapper } from "./SuspenseWrapper";
 
 interface ComponentFavoriteToggleProps {
   component: ComponentReference;
@@ -83,101 +88,117 @@ const DeleteFromLibraryButton = ({ active, onClick }: StateButtonProps) => {
   );
 };
 
-export const ComponentFavoriteToggle = ({
-  component,
-  hideDelete = false,
-}: ComponentFavoriteToggleProps) => {
-  const {
-    addToComponentLibrary,
-    removeFromComponentLibrary,
-    checkIfFavorited,
-    checkIfUserComponent,
-    checkLibraryContainsComponent,
-    setComponentFavorite,
-  } = useComponentLibrary();
-
-  const [isOpen, setIsOpen] = useState(false);
-
-  const { spec, url } = component;
-
-  const isFavorited = useMemo(
-    () => checkIfFavorited(component),
-    [component, checkIfFavorited],
-  );
-
-  const isUserComponent = useMemo(
-    () => checkIfUserComponent(component),
-    [component, checkIfUserComponent],
-  );
-
-  const isInLibrary = useMemo(
-    () => checkLibraryContainsComponent(component),
-    [component, checkLibraryContainsComponent],
-  );
-
-  const displayName = useMemo(
-    () => getComponentName({ spec, url }),
-    [spec, url],
-  );
-
-  const onFavorite = useCallback(() => {
-    setComponentFavorite(component, !isFavorited);
-  }, [isFavorited, setComponentFavorite]);
-
-  // Delete User Components
-  const handleDelete = useCallback(async () => {
-    removeFromComponentLibrary(component);
-  }, [removeFromComponentLibrary]);
-
-  /* Confirmation Dialog handlers */
-  const openConfirmationDialog = useCallback(() => {
-    setIsOpen(true);
-  }, []);
-
-  const handleCancel = useCallback(() => {
-    setIsOpen(false);
-  }, []);
-
-  const handleConfirm = useCallback(() => {
-    setIsOpen(false);
-
-    if (!isInLibrary) {
-      addToComponentLibrary(component);
-      return;
-    }
-
-    handleDelete();
-  }, [component, isInLibrary, addToComponentLibrary, handleDelete]);
-
-  const showDeleteButton = isInLibrary && isUserComponent && !hideDelete;
-
-  return (
-    <>
-      {!isInLibrary && <AddToLibraryButton onClick={openConfirmationDialog} />}
-
-      {isInLibrary && !isUserComponent && (
-        <FavoriteStarButton active={isFavorited} onClick={onFavorite} />
-      )}
-
-      {showDeleteButton && (
-        <DeleteFromLibraryButton onClick={openConfirmationDialog} />
-      )}
-
-      <ConfirmationDialog
-        isOpen={isOpen}
-        title={
-          !isInLibrary
-            ? "Add to Component Library?"
-            : "Delete custom component?"
-        }
-        description={
-          !isInLibrary
-            ? `This will add "${displayName}" to your Component Library for use in your pipelines.`
-            : `"${displayName}" is a custom user component. Unstarring it will remove it from your library. This action cannot be undone.`
-        }
-        onConfirm={handleConfirm}
-        onCancel={handleCancel}
-      />
-    </>
-  );
+const ComponentFavoriteToggleSkeleton = () => {
+  return <Spinner size={10} />;
 };
+
+/**
+ * TODO: hide changes behind the beta flag
+ */
+export const ComponentFavoriteToggle = withSuspenseWrapper(
+  ({ component, hideDelete = false }: ComponentFavoriteToggleProps) => {
+    const {
+      // this methods will be removed in the future, replaced by the new library
+      addToComponentLibrary,
+      removeFromComponentLibrary,
+      checkIfUserComponent,
+      checkLibraryContainsComponent,
+      getComponentLibrary,
+    } = useComponentLibrary();
+
+    const [isOpen, setIsOpen] = useState(false);
+
+    const favoriteLibrary = getComponentLibrary(FAVORITE_COMPONENTS_LIBRARY_ID);
+
+    const { spec, url } = component;
+
+    const { data: isFavorited, refetch: refetchFavorited } = useSuspenseQuery({
+      queryKey: ["is-favorite-component", component.digest],
+      queryFn: () => favoriteLibrary.hasComponent(component),
+    });
+
+    const isUserComponent = useMemo(
+      () => checkIfUserComponent(component),
+      [component, checkIfUserComponent],
+    );
+
+    const isInLibrary = useMemo(
+      () => checkLibraryContainsComponent(component),
+      [component, checkLibraryContainsComponent],
+    );
+
+    const displayName = useMemo(
+      () => getComponentName({ spec, url }),
+      [spec, url],
+    );
+
+    const onFavorite = useCallback(async () => {
+      if (isFavorited) {
+        await favoriteLibrary.removeComponent(component);
+      } else {
+        await favoriteLibrary.addComponent(component);
+      }
+      refetchFavorited();
+    }, [isFavorited, refetchFavorited, favoriteLibrary, component]);
+
+    // Delete User Components
+    const handleDelete = useCallback(async () => {
+      removeFromComponentLibrary(component);
+    }, [removeFromComponentLibrary]);
+
+    /* Confirmation Dialog handlers */
+    const openConfirmationDialog = useCallback(() => {
+      setIsOpen(true);
+    }, []);
+
+    const handleCancel = useCallback(() => {
+      setIsOpen(false);
+    }, []);
+
+    const handleConfirm = useCallback(() => {
+      setIsOpen(false);
+
+      if (!isInLibrary) {
+        addToComponentLibrary(component);
+        return;
+      }
+
+      handleDelete();
+    }, [component, isInLibrary, addToComponentLibrary, handleDelete]);
+
+    const showDeleteButton = isInLibrary && isUserComponent && !hideDelete;
+
+    return (
+      <>
+        {!isInLibrary && (
+          <AddToLibraryButton onClick={openConfirmationDialog} />
+        )}
+
+        {isInLibrary && !isUserComponent && (
+          <FavoriteStarButton active={isFavorited} onClick={onFavorite} />
+        )}
+
+        {showDeleteButton && (
+          <DeleteFromLibraryButton onClick={openConfirmationDialog} />
+        )}
+
+        <ConfirmationDialog
+          isOpen={isOpen}
+          title={
+            !isInLibrary
+              ? "Add to Component Library?"
+              : "Delete custom component?"
+          }
+          description={
+            !isInLibrary
+              ? `This will add "${displayName}" to your Component Library for use in your pipelines.`
+              : `"${displayName}" is a custom user component. Unstarring it will remove it from your library. This action cannot be undone.`
+          }
+          onConfirm={handleConfirm}
+          onCancel={handleCancel}
+        />
+      </>
+    );
+  },
+  ComponentFavoriteToggleSkeleton,
+);

--- a/src/components/shared/ReactFlow/FlowSidebar/components/FolderItem.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/components/FolderItem.tsx
@@ -6,9 +6,14 @@ import {
   useState,
 } from "react";
 
+import { withSuspenseWrapper } from "@/components/shared/SuspenseWrapper";
 import { Icon } from "@/components/ui/icon";
 import { InlineStack } from "@/components/ui/layout";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Spinner } from "@/components/ui/spinner";
 import { cn } from "@/lib/utils";
+import type { Library } from "@/providers/ComponentLibraryProvider/libraries/types";
+import { useLibraryComponents } from "@/providers/ComponentLibraryProvider/useLibraryComponents";
 import type { UIComponentFolder } from "@/types/componentLibrary";
 
 import { ComponentItemFromUrl, ComponentMarkup } from "./ComponentItem";
@@ -86,5 +91,40 @@ const FolderItem = ({ folder, icon }: FolderItemProps) => {
     </div>
   );
 };
+
+const FolderSkeleton = () => {
+  return (
+    <div className="w-full">
+      <div className="flex items-center px-4 py-1 cursor-pointer hover:bg-gray-100">
+        <Spinner />
+        <span className="truncate text-sm font-medium pl-1">
+          <Skeleton size="lg" color="dark" />
+        </span>
+        <div className="ml-auto">
+          <ChevronRight className="h-4 w-4 text-gray-400 flex-shrink-0" />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const LibraryFolderItem = withSuspenseWrapper(
+  ({
+    library,
+    ...rest
+  }: Omit<FolderItemProps, "folder"> & { library: Library }) => {
+    const folder = useLibraryComponents(library);
+
+    if (
+      (!folder.components || folder.components.length === 0) &&
+      (!folder.folders || folder.folders.length === 0)
+    ) {
+      return null;
+    }
+
+    return <FolderItem {...rest} folder={folder} />;
+  },
+  FolderSkeleton,
+);
 
 export default FolderItem;

--- a/src/components/shared/ReactFlow/FlowSidebar/sections/GraphComponents.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/sections/GraphComponents.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/ui/tooltip";
 import { useComponentLibrary } from "@/providers/ComponentLibraryProvider";
 import { useForcedSearchContext } from "@/providers/ComponentLibraryProvider/ForcedSearchProvider";
+import { FAVORITE_COMPONENTS_LIBRARY_ID } from "@/providers/ComponentLibraryProvider/libraries/migrateLegacyFavoriteFolder";
 import type { UIComponentFolder } from "@/types/componentLibrary";
 
 import {
@@ -29,6 +30,7 @@ import {
   SearchResults,
 } from "../components";
 import { IONodeSidebarItem } from "../components/ComponentItem";
+import { LibraryFolderItem } from "../components/FolderItem";
 import PublishedComponentsSearch from "../components/PublishedComponentsSearch";
 import { UpgradeAvailableAlertBox } from "../components/UpgradeAvailableAlertBox";
 
@@ -36,6 +38,14 @@ const GraphComponents = ({ isOpen }: { isOpen: boolean }) => {
   const remoteComponentLibrarySearchEnabled = useBetaFlagValue(
     "remote-component-library-search",
   );
+  const componentLibraryV2Enabled = useBetaFlagValue("component-library-v2");
+
+  const { getComponentLibrary } = useComponentLibrary();
+  const favoriteComponentsLibrary = getComponentLibrary(
+    FAVORITE_COMPONENTS_LIBRARY_ID,
+  );
+  const standardComponentsLibrary = getComponentLibrary("standard_components");
+  const usedComponentsLibrary = getComponentLibrary("used_components");
 
   const { updateSearchFilter, currentSearchFilter } = useForcedSearchContext();
   const {
@@ -80,11 +90,14 @@ const GraphComponents = ({ isOpen }: { isOpen: boolean }) => {
 
     // Otherwise show the regular folder structure
     const hasUsedComponents =
+      !componentLibraryV2Enabled &&
       usedComponentsFolder?.components &&
       usedComponentsFolder.components.length > 0;
 
     const hasFavouriteComponents =
-      favoritesFolder?.components && favoritesFolder.components.length > 0;
+      !componentLibraryV2Enabled &&
+      favoritesFolder?.components &&
+      favoritesFolder.components.length > 0;
 
     const hasUserComponents =
       userComponentsFolder?.components &&
@@ -102,6 +115,13 @@ const GraphComponents = ({ isOpen }: { isOpen: boolean }) => {
               icon="LayoutGrid"
             />
           )}
+          {componentLibraryV2Enabled ? (
+            <LibraryFolderItem
+              key="used-components-folder-v2"
+              library={usedComponentsLibrary}
+              icon="LayoutGrid"
+            />
+          ) : null}
           {hasFavouriteComponents && (
             <FolderItem
               key="favorite-components-folder"
@@ -109,6 +129,14 @@ const GraphComponents = ({ isOpen }: { isOpen: boolean }) => {
               icon="Star"
             />
           )}
+          {componentLibraryV2Enabled ? (
+            <LibraryFolderItem
+              key="favorite-components-folder-v2"
+              library={favoriteComponentsLibrary}
+              icon="Star"
+            />
+          ) : null}
+
           {hasUserComponents && (
             <FolderItem
               key="my-components-folder"
@@ -132,17 +160,26 @@ const GraphComponents = ({ isOpen }: { isOpen: boolean }) => {
             icon="Cable"
           />
           <Separator />
-          <FolderItem
-            key="standard-library-folder"
-            folder={
-              {
-                name: "Standard library",
-                components: [],
-                folders: componentLibrary.folders,
-              } as UIComponentFolder
-            }
-            icon="Folder"
-          />
+          {componentLibraryV2Enabled ? null : (
+            <FolderItem
+              key="standard-library-folder"
+              folder={
+                {
+                  name: "Standard library",
+                  components: [],
+                  folders: componentLibrary.folders,
+                } as UIComponentFolder
+              }
+              icon="Folder"
+            />
+          )}
+          {componentLibraryV2Enabled ? (
+            <LibraryFolderItem
+              key="standard-library-folder-v2"
+              library={standardComponentsLibrary}
+              icon="Folder"
+            />
+          ) : null}
         </BlockStack>
       </BlockStack>
     );
@@ -151,10 +188,15 @@ const GraphComponents = ({ isOpen }: { isOpen: boolean }) => {
     usedComponentsFolder,
     userComponentsFolder,
     favoritesFolder,
+    componentLibraryV2Enabled,
     isLoading,
     error,
     searchResult,
     remoteComponentLibrarySearchEnabled,
+    handleFiltersChange,
+    favoriteComponentsLibrary,
+    standardComponentsLibrary,
+    usedComponentsLibrary,
   ]);
 
   if (!isOpen) {

--- a/src/providers/ComponentLibraryProvider/libraries/browserPersistedLibrary.ts
+++ b/src/providers/ComponentLibraryProvider/libraries/browserPersistedLibrary.ts
@@ -1,0 +1,144 @@
+import { hydrateComponentReference } from "@/services/componentService";
+import type { ComponentFolder } from "@/types/componentLibrary";
+import {
+  type ComponentReference,
+  isDiscoverableComponentReference,
+} from "@/utils/componentSpec";
+
+import { isValidFilterRequest, type LibraryFilterRequest } from "../types";
+import { LibraryDB, type StoredLibrary } from "./storage";
+import {
+  DuplicateComponentError,
+  InvalidComponentReferenceError,
+  type Library,
+} from "./types";
+import { dispatchLibraryChangeEvent } from "./utils";
+
+class LibraryNotFoundError extends Error {
+  name = "LibraryNotFoundError";
+  constructor(message: string) {
+    super(message);
+  }
+}
+
+export class BrowserPersistedLibrary implements Library {
+  #loading: Promise<void>;
+  #components = new Map<string, ComponentReference>();
+  #eventEmitter: EventTarget = new EventTarget();
+
+  constructor(
+    private readonly libId: string,
+    private readonly createLibrary: () => Promise<StoredLibrary | undefined>,
+  ) {
+    this.#loading = this.#loadLibrary();
+  }
+
+  get eventEmitter() {
+    return this.#eventEmitter;
+  }
+
+  async #loadLibrary() {
+    const library =
+      (await LibraryDB.component_libraries.get(this.libId)) ??
+      (await this.createLibrary());
+
+    if (!library) {
+      throw new LibraryNotFoundError(`Library ${this.libId} not found`);
+    }
+
+    const components = library.components ?? [];
+
+    const hydratedComponents = (
+      await Promise.all(
+        components.map(async (component) => {
+          return await hydrateComponentReference(component);
+        }),
+        // todo: handle per-component errors
+      )
+    ).filter((c) => isDiscoverableComponentReference(c));
+
+    hydratedComponents.forEach((component) => {
+      this.#components.set(component.digest, component);
+    });
+  }
+
+  async hasComponent(component: ComponentReference): Promise<boolean> {
+    await this.#loading;
+
+    if (!isDiscoverableComponentReference(component)) {
+      return false;
+    }
+
+    return this.#components.has(component.digest);
+  }
+
+  async addComponent(component: ComponentReference): Promise<void> {
+    await this.#loading;
+
+    const hydratedComponent = await hydrateComponentReference(component);
+
+    if (!hydratedComponent) {
+      throw new InvalidComponentReferenceError(component);
+    }
+
+    if (this.#components.has(hydratedComponent.digest)) {
+      throw new DuplicateComponentError(component);
+    }
+
+    await LibraryDB.component_libraries
+      .where("id")
+      .equals(this.libId)
+      .modify((lib) => {
+        lib.knownDigests = Array.from(
+          new Set([...(lib.knownDigests ?? []), hydratedComponent.digest]),
+        );
+        lib.components = [...(lib.components ?? []), hydratedComponent];
+      });
+
+    this.#components.set(hydratedComponent.digest, hydratedComponent);
+
+    dispatchLibraryChangeEvent(this, "add", hydratedComponent);
+  }
+
+  async removeComponent(component: ComponentReference): Promise<void> {
+    await this.#loading;
+
+    if (!isDiscoverableComponentReference(component)) {
+      throw new InvalidComponentReferenceError(component);
+    }
+
+    // todo: handle options like what library/storage
+    await LibraryDB.component_libraries
+      .where("id")
+      .equals(this.libId)
+      .modify((lib) => {
+        lib.components = lib.components?.filter(
+          (c) => c.digest !== component.digest,
+        );
+        lib.knownDigests = lib.knownDigests?.filter(
+          (digest) => digest !== component.digest,
+        );
+      });
+
+    this.#components.delete(component.digest);
+
+    dispatchLibraryChangeEvent(this, "remove", component);
+  }
+
+  async getComponents(filter?: LibraryFilterRequest): Promise<ComponentFolder> {
+    await this.#loading;
+
+    if (isValidFilterRequest(filter)) {
+      // todo: filter components
+    }
+
+    const library = await LibraryDB.component_libraries.get(this.libId);
+
+    return {
+      name: library?.name ?? this.libId,
+      components: Array.from(this.#components.values()),
+      // todo: support folders
+      folders: [],
+    };
+  }
+}

--- a/src/providers/ComponentLibraryProvider/libraries/graphSpecReadonlyLibrary.ts
+++ b/src/providers/ComponentLibraryProvider/libraries/graphSpecReadonlyLibrary.ts
@@ -1,0 +1,112 @@
+import { hydrateComponentReference } from "@/services/componentService";
+import type { ComponentFolder } from "@/types/componentLibrary";
+import {
+  type ComponentReference,
+  type GraphSpec,
+  isDiscoverableComponentReference,
+} from "@/utils/componentSpec";
+
+import { isValidFilterRequest, type LibraryFilterRequest } from "../types";
+import { type Library, ReadOnlyLibraryError } from "./types";
+import { dispatchLibraryChangeEvent } from "./utils";
+
+export class GraphSpecReadonlyLibrary implements Library {
+  #graphSpec: GraphSpec | undefined;
+  #components: Map<string, ComponentReference> = new Map();
+  #eventEmitter: EventTarget = new EventTarget();
+
+  constructor(
+    private readonly name: string,
+    graphSpec: GraphSpec | undefined,
+  ) {
+    void this.setGraphSpec(graphSpec);
+  }
+
+  get eventEmitter() {
+    return this.#eventEmitter;
+  }
+
+  async setGraphSpec(graphSpec: GraphSpec | undefined) {
+    this.#graphSpec = graphSpec;
+    void this.#refresh();
+  }
+
+  async getComponents(filter?: LibraryFilterRequest): Promise<ComponentFolder> {
+    if (isValidFilterRequest(filter)) {
+      const components = Array.from(this.#components.values()).filter(
+        (component) => {
+          // todo: search by some other fields from
+          return component.name
+            ?.toLowerCase()
+            .includes(filter.searchTerm.toLowerCase());
+        },
+      );
+
+      return {
+        name: this.name,
+        components,
+        folders: [],
+      };
+    }
+
+    return {
+      name: this.name,
+      components: Array.from(this.#components.values()),
+      folders: [],
+    };
+  }
+
+  async hasComponent(component: ComponentReference): Promise<boolean> {
+    await this.#refresh();
+
+    if (!isDiscoverableComponentReference(component)) {
+      return false;
+    }
+
+    return this.#components.has(component.digest);
+  }
+
+  async addComponent(): Promise<void> {
+    throw new ReadOnlyLibraryError("This library is read-only.");
+  }
+
+  async removeComponent(): Promise<void> {
+    throw new ReadOnlyLibraryError("This library is read-only.");
+  }
+
+  async #refresh() {
+    this.#components.clear();
+
+    if (!this.#graphSpec) {
+      dispatchLibraryChangeEvent(this, "refresh");
+      return;
+    }
+
+    if (
+      !this.#graphSpec ||
+      !this.#graphSpec.tasks ||
+      typeof this.#graphSpec.tasks !== "object"
+    ) {
+      dispatchLibraryChangeEvent(this, "refresh");
+      return;
+    }
+
+    for (const task of Object.values(this.#graphSpec.tasks)) {
+      const key = task.componentRef.digest;
+      if (key) {
+        const hydratedComponent = await hydrateComponentReference(
+          task.componentRef,
+        );
+
+        if (!hydratedComponent) {
+          // todo: how to handle individual components that are failed to load?
+          return;
+        }
+
+        this.#components.set(key, hydratedComponent);
+      }
+    }
+
+    dispatchLibraryChangeEvent(this, "refresh");
+  }
+}

--- a/src/providers/ComponentLibraryProvider/libraries/migrateLegacyFavoriteFolder.ts
+++ b/src/providers/ComponentLibraryProvider/libraries/migrateLegacyFavoriteFolder.ts
@@ -1,0 +1,49 @@
+import { COMPONENT_LIBRARY_URL } from "@/services/componentService";
+
+import { LibraryDB, type StoredLibraryItem } from "./storage";
+import { YamlFileLibrary } from "./yamlFileLibrary";
+
+export const FAVORITE_COMPONENTS_LIBRARY_ID = "favorite_components";
+
+export async function migrateLegacyFavoriteFolder() {
+  /**
+   * Migrate the favorite components to the new database
+   */
+  const yamlLibrary = new YamlFileLibrary(
+    "Standard Components",
+    COMPONENT_LIBRARY_URL,
+  );
+
+  const searchResult = await yamlLibrary.getComponents({
+    filters: ["all"],
+    searchTerm: "*",
+  });
+
+  const favoriteComponents =
+    searchResult.components
+      ?.filter((component) => component.favorited)
+      .map(
+        (component) =>
+          ({
+            digest: component.digest,
+            name: component.name,
+            url: component.url,
+          }) as StoredLibraryItem,
+      ) ?? [];
+
+  await LibraryDB.component_libraries.put({
+    id: FAVORITE_COMPONENTS_LIBRARY_ID,
+    name: "Favorite Components",
+    icon: "star",
+    type: "indexdb",
+    knownDigests: favoriteComponents.map((component) => component.digest),
+    configuration: {
+      migrated_at: new Date().toISOString(),
+    },
+    components: favoriteComponents,
+  });
+
+  return await LibraryDB.component_libraries.get(
+    FAVORITE_COMPONENTS_LIBRARY_ID,
+  );
+}

--- a/src/providers/ComponentLibraryProvider/libraries/storage.ts
+++ b/src/providers/ComponentLibraryProvider/libraries/storage.ts
@@ -1,0 +1,44 @@
+import Dexie, { type EntityTable } from "dexie";
+
+const DB_NAME = "oasis-app";
+const DEXIE_EPOCH = 0;
+
+export interface StoredLibraryItem {
+  digest: string;
+  name: string;
+  url?: string;
+}
+
+interface StoredLibraryFolder {
+  name: string;
+  folders?: StoredLibraryFolder[];
+  components?: StoredLibraryItem[];
+}
+
+export interface StoredLibrary extends StoredLibraryFolder {
+  id: string;
+  icon?: string;
+  /**
+   * yaml - a yaml file that contains the components
+   * indexdb - a local database that contains the components. filled only by the Oasis App
+   * pinned - a pinned libraries from the Backend API
+   * github - a github repository that contains the components
+   */
+  type: "yaml" | "indexdb" | "pinned" | "github";
+
+  configuration?: Record<string, unknown>;
+  knownDigests: string[];
+}
+
+export const LibraryDB = new Dexie(DB_NAME) as Dexie & {
+  component_libraries: EntityTable<StoredLibrary, "id">;
+};
+
+/**
+ * Initialize the database with the favorite components
+ * Each version should be declared in DEXIE_EPOCH + {number}, starting from 1
+ */
+LibraryDB.version(DEXIE_EPOCH + 1).stores({
+  // id - primary key; name is unique index
+  component_libraries: "id, &name",
+});

--- a/src/providers/ComponentLibraryProvider/libraries/types.ts
+++ b/src/providers/ComponentLibraryProvider/libraries/types.ts
@@ -23,6 +23,8 @@ export interface Library {
   ): Promise<void>;
 
   getComponents(filter?: LibraryFilterRequest): Promise<ComponentFolder>;
+
+  eventEmitter?: EventTarget;
 }
 
 export class InvalidComponentReferenceError extends Error {
@@ -42,5 +44,13 @@ export class DuplicateComponentError extends Error {
     super(
       `Component already exists in library: ${component.digest ?? component.url ?? ""}`,
     );
+  }
+}
+
+export class ReadOnlyLibraryError extends Error {
+  name = "ReadOnlyLibraryError";
+
+  constructor(message: string) {
+    super(message);
   }
 }

--- a/src/providers/ComponentLibraryProvider/libraries/utils.ts
+++ b/src/providers/ComponentLibraryProvider/libraries/utils.ts
@@ -1,0 +1,46 @@
+import type { ComponentReference } from "@/utils/componentSpec";
+
+import type { Library } from "./types";
+
+const CACHE_NAME = "component-library";
+
+/**
+ * Fetch a resource from the network, and cache the response.
+ * @param url - The URL to fetch.
+ * @returns The response from the network.
+ */
+export async function fetchWithCache(url: string): Promise<Response> {
+  const cache = await caches.open(CACHE_NAME);
+  const cacheResponse = await cache.match(url);
+  if (cacheResponse) {
+    return cacheResponse;
+  }
+
+  const response = await fetch(url);
+  if (response.ok) {
+    await cache.put(url, response.clone());
+  }
+
+  return response;
+}
+
+/**
+ * Dispatch a change event to the library's event emitter.
+ * @param library - The library to dispatch the event to.
+ * @param type - The type of change to dispatch.
+ * @param component - The component that was added or removed.
+ */
+export function dispatchLibraryChangeEvent(
+  library: Library,
+  type: "add" | "remove" | "refresh",
+  component?: ComponentReference,
+) {
+  library.eventEmitter?.dispatchEvent(
+    new CustomEvent("change", {
+      detail: {
+        type,
+        component,
+      },
+    }),
+  );
+}

--- a/src/providers/ComponentLibraryProvider/libraries/yamlFileLibrary.ts
+++ b/src/providers/ComponentLibraryProvider/libraries/yamlFileLibrary.ts
@@ -1,0 +1,157 @@
+import { hydrateComponentReference } from "@/services/componentService";
+import {
+  type ComponentFolder,
+  isValidComponentLibrary,
+} from "@/types/componentLibrary";
+import { loadObjectFromYamlData } from "@/utils/cache";
+import {
+  type ComponentReference,
+  isDiscoverableComponentReference,
+} from "@/utils/componentSpec";
+
+import { isValidFilterRequest, type LibraryFilterRequest } from "../types";
+import {
+  InvalidComponentReferenceError,
+  type Library,
+  ReadOnlyLibraryError,
+} from "./types";
+import { fetchWithCache } from "./utils";
+
+class YamlFileLibraryError extends Error {
+  name = "YamlFileLibraryError";
+
+  constructor(message: string) {
+    super(message);
+  }
+}
+
+export class YamlFileLibrary implements Library {
+  #components: Map<string, ComponentReference> = new Map();
+  #rootFolder: ComponentFolder;
+  #loading: Promise<void>;
+
+  constructor(
+    name: string,
+    private readonly yamlFilePath: string,
+  ) {
+    this.#rootFolder = {
+      name,
+      folders: [],
+      components: [],
+    };
+
+    this.#loading = this.#loadLibrary();
+  }
+
+  async hasComponent(component: ComponentReference): Promise<boolean> {
+    await this.#loading;
+
+    if (!isDiscoverableComponentReference(component)) {
+      throw new InvalidComponentReferenceError(component);
+    }
+
+    return this.#components.has(component.digest);
+  }
+
+  async addComponent(): Promise<void> {
+    throw new ReadOnlyLibraryError("This library is read-only");
+  }
+
+  async removeComponent(): Promise<void> {
+    throw new ReadOnlyLibraryError("This library is read-only");
+  }
+
+  async getComponents(filter?: LibraryFilterRequest): Promise<ComponentFolder> {
+    await this.#loading;
+
+    if (isValidFilterRequest(filter)) {
+      return {
+        name: this.#rootFolder.name,
+        // TODO: implement contentful filter
+        components: Array.from(this.#components.values()),
+      };
+    }
+
+    return {
+      name: this.#rootFolder.name,
+      components: this.#rootFolder.components ?? [],
+      folders: this.#rootFolder.folders ?? [],
+    };
+  }
+
+  async #loadLibrary() {
+    const response = await fetchWithCache(this.yamlFilePath);
+
+    if (!response.ok) {
+      throw new YamlFileLibraryError(
+        `Failed to fetch ${this.yamlFilePath}: ${response.status}`,
+      );
+    }
+
+    const data = await response.arrayBuffer();
+
+    const yamlData = loadObjectFromYamlData(data);
+
+    if (!isValidComponentLibrary(yamlData)) {
+      throw new YamlFileLibraryError(
+        `Invalid component library: ${this.yamlFilePath}`,
+      );
+    }
+
+    // visit all components and folders in the library
+    const queue = [
+      ...yamlData.folders.map((folder) => ({
+        folder,
+        parent: this.#rootFolder,
+      })),
+    ];
+
+    // BFS to process folders and components
+    while (queue.length > 0) {
+      const queuedFolder = queue.shift();
+      if (!queuedFolder) {
+        continue;
+      }
+
+      const { folder, parent } = queuedFolder;
+
+      const currentFolder: ComponentFolder = {
+        name: folder.name,
+        components: [],
+        folders: [],
+      };
+
+      for (const componentRef of folder.components ?? []) {
+        // todo: we can skip hydration if the component has at least digest, url and name
+        const hydratedComponentRef =
+          await hydrateComponentReference(componentRef);
+
+        if (!hydratedComponentRef) {
+          // todo: track component failure
+          console.warn(
+            `Failed to hydrate component: ${componentRef.url ?? componentRef.digest}`,
+            componentRef,
+          );
+          continue;
+        }
+
+        this.#components.set(hydratedComponentRef.digest, hydratedComponentRef);
+        currentFolder.components = [
+          ...(folder.components ?? []),
+          hydratedComponentRef,
+        ];
+      }
+
+      parent.folders = [...(parent.folders ?? []), currentFolder];
+
+      queue.push(
+        ...(folder.folders?.map((subfolder) => ({
+          folder: subfolder,
+          parent: currentFolder,
+        })) ?? []),
+      );
+    }
+
+    console.log("Loaded library", this.#rootFolder);
+  }
+}

--- a/src/providers/ComponentLibraryProvider/useLibraryComponents.ts
+++ b/src/providers/ComponentLibraryProvider/useLibraryComponents.ts
@@ -1,0 +1,36 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { useEffect } from "react";
+
+import type { Library } from "./libraries/types";
+import type { LibraryFilterRequest } from "./types";
+
+const globalLibraryIdMap = new Map<Library, string>();
+
+function libraryId(library: Library) {
+  if (!globalLibraryIdMap.has(library)) {
+    globalLibraryIdMap.set(library, crypto.randomUUID());
+  }
+
+  return globalLibraryIdMap.get(library)!;
+}
+
+export function useLibraryComponents(
+  library: Library,
+  filter?: LibraryFilterRequest,
+) {
+  const { data: folder, refetch } = useSuspenseQuery({
+    queryKey: ["component-library", libraryId(library)],
+    queryFn: () => library.getComponents(filter),
+  });
+
+  useEffect(() => {
+    const handleChange = () => refetch();
+
+    library.eventEmitter?.addEventListener("change", handleChange);
+    return () => {
+      library.eventEmitter?.removeEventListener("change", handleChange);
+    };
+  }, [library, refetch]);
+
+  return folder;
+}

--- a/src/services/componentService.ts
+++ b/src/services/componentService.ts
@@ -41,7 +41,7 @@ export interface ExistingAndNewComponent {
   newComponent: ComponentSpec | undefined;
 }
 
-const COMPONENT_LIBRARY_URL = getAppSettings().componentLibraryUrl;
+export const COMPONENT_LIBRARY_URL = getAppSettings().componentLibraryUrl;
 
 /**
  * Generate a digest for a component


### PR DESCRIPTION
## Description

This PR adds a new beta flag `component-library-v2` and implements the foundation for a new component library system. The implementation includes:

- Added Dexie.js as a dependency for IndexedDB storage
- Created browser-persisted library for favorite components
- Added GraphSpec-based readonly library for used components
- Implemented YAML file library for standard components
- Added migration utility for legacy favorite components
- Updated FavoriteComponentToggle to use the new library system
- Modified FlowSidebar to conditionally render components based on the beta flag

## Related Issue and Pull requests

## Type of Change

- [x] New feature
- [x] Improvement
- [x] Cleanup/Refactor

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

1. Enable the `component-library-v2` beta flag
2. Verify that the component library sidebar displays components correctly
3. Test favoriting components to ensure they are properly stored and displayed
4. Check that used components are correctly shown in the sidebar

## Additional Comments

This implementation maintains backward compatibility by keeping the old system functional when the beta flag is disabled. The new system provides better performance and maintainability through proper data storage and separation of concerns.