### PR TITLE
Rename Task "RunStatus" to "Status"

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/GhostNode/GhostNode.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/GhostNode/GhostNode.tsx
@@ -45,11 +45,7 @@ const GhostNode = memo(({ data }: NodeProps) => {
           p-1
         "
       >
-        <TaskNodeProvider
-          data={ghostTaskData}
-          selected={false}
-          runStatus={undefined}
-        >
+        <TaskNodeProvider data={ghostTaskData} selected={false}>
           <TaskNodeCard />
         </TaskNodeProvider>
       </div>

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/StatusIndicator.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/StatusIndicator.tsx
@@ -12,7 +12,7 @@ import { QuickTooltip } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 
 type StatusIndicatorProps = {
-  status?: ContainerExecutionStatus;
+  status: ContainerExecutionStatus;
   disabledCache?: boolean;
 };
 
@@ -20,9 +20,7 @@ export const StatusIndicator = ({
   status,
   disabledCache = false,
 }: StatusIndicatorProps) => {
-  if (!status) return null;
-
-  const { style, text, icon } = getRunStatus(status);
+  const { style, text, icon } = getStatusMetadata(status);
 
   return (
     <div className="absolute -z-1 -top-5 left-0 flex items-start">
@@ -47,7 +45,7 @@ export const StatusIndicator = ({
   );
 };
 
-const getRunStatus = (status: ContainerExecutionStatus) => {
+const getStatusMetadata = (status: ContainerExecutionStatus) => {
   switch (status) {
     case "SUCCEEDED":
       return {

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNode.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNode.tsx
@@ -15,19 +15,17 @@ const TaskNode = ({ data, selected }: NodeProps) => {
 
   const typedData = useMemo(() => data as TaskNodeData, [data]);
 
-  const runStatus = taskStatusMap.get(
+  const status = taskStatusMap.get(
     typedData.taskId ?? "",
   ) as ContainerExecutionStatus;
 
   const disabledCache = isCacheDisabled(typedData.taskSpec);
 
   return (
-    <TaskNodeProvider
-      data={typedData}
-      selected={selected}
-      runStatus={runStatus}
-    >
-      <StatusIndicator status={runStatus} disabledCache={disabledCache} />
+    <TaskNodeProvider data={typedData} selected={selected} status={status}>
+      {!!status && (
+        <StatusIndicator status={status} disabledCache={disabledCache} />
+      )}
       <TaskNodeCard />
     </TaskNodeProvider>
   );

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/TaskOverview.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/TaskOverview.tsx
@@ -39,8 +39,8 @@ const TaskOverview = ({ taskNode, actions }: TaskOverviewProps) => {
   const executionData = useExecutionDataOptional();
   const details = executionData?.details;
 
-  const { readOnly, runStatus } = state;
-  const disabled = !!runStatus;
+  const { readOnly, status } = state;
+  const disabled = !!status;
 
   if (!taskSpec || !taskId) {
     return null;
@@ -69,7 +69,7 @@ const TaskOverview = ({ taskNode, actions }: TaskOverviewProps) => {
           displayName={name}
           component={taskSpec.componentRef}
         />
-        {!!runStatus && <StatusIcon status={runStatus} tooltip label="task" />}
+        {readOnly && <StatusIcon status={status} tooltip label="task" />}
       </InlineStack>
 
       <div className="px-4 overflow-y-auto pb-4 h-full w-full">
@@ -110,7 +110,7 @@ const TaskOverview = ({ taskNode, actions }: TaskOverviewProps) => {
               componentDigest={taskSpec.componentRef.digest}
               url={taskSpec.componentRef.url}
               onDelete={callbacks.onDelete}
-              runStatus={runStatus}
+              status={status}
               hasDeletionConfirmation={false}
               readOnly={readOnly}
               additionalSection={[
@@ -159,11 +159,11 @@ const TaskOverview = ({ taskNode, actions }: TaskOverviewProps) => {
                 <div className="flex w-full justify-end pr-4">
                   <OpenLogsInNewWindowLink
                     executionId={executionId}
-                    status={runStatus}
+                    status={status}
                   />
                 </div>
               )}
-              <Logs executionId={executionId} status={runStatus} />
+              <Logs executionId={executionId} status={status} />
             </TabsContent>
           )}
           {!readOnly && (

--- a/src/components/shared/TaskDetails/Details.tsx
+++ b/src/components/shared/TaskDetails/Details.tsx
@@ -42,7 +42,7 @@ interface TaskDetailsProps {
   actions?: ReactNode[];
   onDelete?: () => void;
   hasDeletionConfirmation?: boolean;
-  runStatus?: string;
+  status?: string;
   readOnly?: boolean;
   additionalSection?: {
     title: string;
@@ -61,7 +61,7 @@ const TaskDetails = ({
   actions = [],
   onDelete,
   hasDeletionConfirmation = true,
-  runStatus,
+  status,
   readOnly = false,
   additionalSection = [],
 }: TaskDetailsProps) => {
@@ -154,13 +154,13 @@ const TaskDetails = ({
             </div>
           </div>
         )}
-        {runStatus && (
+        {status && (
           <div className="flex flex-col px-3 py-2">
             <div className="flex-shrink-0 font-medium text-sm text-gray-700 mb-1">
               Run Status
             </div>
             <div className="text-xs text-gray-600 break-words whitespace-pre-wrap">
-              {runStatus}
+              {status}
             </div>
           </div>
         )}

--- a/src/providers/TaskNodeProvider.tsx
+++ b/src/providers/TaskNodeProvider.tsx
@@ -27,7 +27,7 @@ type TaskNodeState = Readonly<{
   readOnly: boolean;
   disabled: boolean;
   connectable: boolean;
-  runStatus?: ContainerExecutionStatus;
+  status?: ContainerExecutionStatus;
   isCustomComponent: boolean;
   dimensions: TaskNodeDimensions;
 }>;
@@ -45,7 +45,7 @@ type TaskNodeProviderProps = {
   children: ReactNode;
   data: TaskNodeData;
   selected: boolean;
-  runStatus?: ContainerExecutionStatus;
+  status?: ContainerExecutionStatus;
 };
 
 export type TaskNodeContextType = {
@@ -67,7 +67,7 @@ export const TaskNodeProvider = ({
   children,
   data,
   selected,
-  runStatus,
+  status,
 }: TaskNodeProviderProps) => {
   const notify = useToastNotification();
   const reactFlowInstance = useReactFlow();
@@ -144,7 +144,7 @@ export const TaskNodeProvider = ({
       highlighted: !!data.highlighted && !data.isGhost,
       readOnly: !!data.readOnly || !!data.isGhost,
       connectable: !!data.connectable,
-      runStatus: data.isGhost ? undefined : runStatus,
+      status: data.isGhost ? undefined : status,
       disabled: data.isGhost ?? false,
       isCustomComponent,
       dimensions,
@@ -154,7 +154,7 @@ export const TaskNodeProvider = ({
       data.highlighted,
       data.readOnly,
       data.isGhost,
-      runStatus,
+      status,
       isCustomComponent,
       dimensions,
     ],


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
A simple rename to clarify some terminology internal to Task Nodes. 
Arguably `run status` is referring to the pipeline run, so having this variable being used in reference to task status could be confusing; hence the motivation for a rename.

Note this applies only within Task Nodes. Outside of task nodes the `status` naming is unchanged.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Cleanup/Refactor

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
