### PR TITLE
Add Beta Flag for Automatic Redirects on New Pipeline Runs

### DIFF
--- a/src/betaFlags.ts
+++ b/src/betaFlags.ts
@@ -1,3 +1,10 @@
 import type { BetaFlag } from "@/types/betaFlags";
 
-export const ExistingBetaFlags: Record<string, BetaFlag> = {};
+export const ExistingBetaFlags: Record<string, BetaFlag> = {
+  ["redirect-on-new-pipeline-run"]: {
+    name: "Redirect on new pipeline run",
+    description:
+      "Automatically redirect from the editor to the pipeline run page after starting a new execution.",
+    default: false,
+  },
+};

--- a/src/components/shared/Submitters/Oasis/OasisSubmitter.tsx
+++ b/src/components/shared/Submitters/Oasis/OasisSubmitter.tsx
@@ -2,6 +2,7 @@ import { useNavigate } from "@tanstack/react-router";
 import { AlertCircle, CheckCircle, Loader2, SendHorizonal } from "lucide-react";
 import { useCallback, useState } from "react";
 
+import { useBetaFlagValue } from "@/components/shared/Settings/useBetaFlags";
 import { Button } from "@/components/ui/button";
 import { SidebarMenuButton } from "@/components/ui/sidebar";
 import useCooldownTimer from "@/hooks/useCooldownTimer";
@@ -24,6 +25,7 @@ const OasisSubmitter = ({
 }: OasisSubmitterProps) => {
   const { configured, available } = useBackend();
   const { submit, isSubmitting } = usePipelineRuns();
+  const isAutoRedirect = useBetaFlagValue("redirect-on-new-pipeline-run");
 
   const [submitSuccess, setSubmitSuccess] = useState<boolean | null>(null);
   const { cooldownTime, setCooldownTime } = useCooldownTimer(0);
@@ -55,9 +57,11 @@ const OasisSubmitter = ({
               Pipeline successfully submitted
             </span>
           </div>
-          <Button onClick={() => handleViewRun(runId)} className="w-full">
-            View Run
-          </Button>
+          {!isAutoRedirect && (
+            <Button onClick={() => handleViewRun(runId)} className="w-full">
+              View Run
+            </Button>
+          )}
         </div>
       );
       notify(<SuccessComponent />, "success");
@@ -71,8 +75,18 @@ const OasisSubmitter = ({
       setCooldownTime(3);
       onSubmitComplete?.();
       showSuccessNotification(response.root_execution_id);
+
+      if (isAutoRedirect) {
+        handleViewRun(response.root_execution_id);
+      }
     },
-    [setCooldownTime, onSubmitComplete, showSuccessNotification],
+    [
+      setCooldownTime,
+      onSubmitComplete,
+      showSuccessNotification,
+      isAutoRedirect,
+      handleViewRun,
+    ],
   );
 
   const onError = useCallback(


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Adds an opt-in beta flag for users to automatically redirect to the run page when they submit a new pipeline run from the editor.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->
Closes https://github.com/Shopify/oasis-frontend/issues/214

## Type of Change

<!-- Please delete options that are not relevant -->

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->
<img width="568" height="333" alt="image" src="https://github.com/user-attachments/assets/a6479092-1e92-4c0d-8424-9b2112c42972" />


## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->
1. Turn beta flag on
2. submit a pipeline run & get automatically redirected
3. Turn beta flag off
4. submit a pipeline run & do not get automatically redirected (existing behaviour)

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
