### PR TITLE
Show Autosave Status in Sidebar

### DIFF
--- a/src/hooks/useAutoSave.ts
+++ b/src/hooks/useAutoSave.ts
@@ -1,7 +1,14 @@
 import equal from "fast-deep-equal";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { deepClone } from "@/utils/deepClone";
+
+const AUTOSAVE_LOADING_DURATION_MS = 1000; // Minimum duration to show "Saving..." status
+export interface AutoSaveStatus {
+  isSaving: boolean;
+  lastSavedAt: Date | null;
+  isDirty: boolean;
+}
 
 export const useAutoSave = <T>(
   saveFunction: (data: T) => Promise<void> | void,
@@ -11,10 +18,14 @@ export const useAutoSave = <T>(
 ) => {
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
   const lastSavedDataRef = useRef<T>(deepClone(data));
+  const [isSaving, setIsSaving] = useState(false);
+  const [lastSavedAt, setLastSavedAt] = useState<Date | null>(null);
 
   const isDirty = !equal(data, lastSavedDataRef.current);
 
   useEffect(() => {
+    let isCancelled = false;
+
     if (timeoutRef.current) {
       clearTimeout(timeoutRef.current);
     }
@@ -26,19 +37,43 @@ export const useAutoSave = <T>(
 
     if (shouldSave && isDirty) {
       timeoutRef.current = setTimeout(async () => {
-        try {
-          await saveFunction(data);
-          lastSavedDataRef.current = deepClone(data);
-        } catch (error) {
-          console.error("Auto-save failed:", error);
-        }
+        if (isCancelled) return;
+
+        setIsSaving(true);
+
+        const savePromise = (async () => {
+          try {
+            await saveFunction(data);
+            if (!isCancelled) {
+              lastSavedDataRef.current = deepClone(data);
+              setLastSavedAt(new Date());
+            }
+          } catch (error) {
+            console.error("Auto-save failed:", error);
+          }
+        })();
+
+        const minDisplayPromise = new Promise((resolve) =>
+          setTimeout(resolve, AUTOSAVE_LOADING_DURATION_MS),
+        );
+
+        await Promise.all([savePromise, minDisplayPromise]);
+
+        setIsSaving(false);
       }, debounceMs);
     }
 
     return () => {
+      isCancelled = true;
       if (timeoutRef.current) {
         clearTimeout(timeoutRef.current);
       }
     };
   }, [data, isDirty, saveFunction, debounceMs, shouldSave]);
+
+  return {
+    isSaving,
+    lastSavedAt,
+    isDirty,
+  };
 };

--- a/src/providers/ComponentSpecProvider.tsx
+++ b/src/providers/ComponentSpecProvider.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode, useCallback, useMemo, useRef, useState } from "react";
 
-import { useAutoSave } from "@/hooks/useAutoSave";
+import { type AutoSaveStatus, useAutoSave } from "@/hooks/useAutoSave";
 import { type UndoRedo, useUndoRedo } from "@/hooks/useUndoRedo";
 import { loadPipelineByName } from "@/services/pipelineService";
 import {
@@ -41,6 +41,7 @@ interface ComponentSpecContextType {
   taskStatusMap: Map<string, string>;
   setTaskStatusMap: (taskStatusMap: Map<string, string>) => void;
   undoRedo: UndoRedo;
+  autoSaveStatus: AutoSaveStatus;
 }
 
 const ComponentSpecContext = createRequiredContext<ComponentSpecContextType>(
@@ -161,7 +162,7 @@ export const ComponentSpecProvider = ({
   const shouldAutoSave =
     !isLoading && !readOnly && componentSpec && !!componentSpec.name;
 
-  useAutoSave(
+  const autoSaveStatus = useAutoSave(
     async (spec) => {
       if (isInitialLoad) {
         setIsInitialLoad(false);
@@ -183,6 +184,7 @@ export const ComponentSpecProvider = ({
       componentSpec,
       graphSpec,
       taskStatusMap,
+      autoSaveStatus,
       isLoading,
       refetch,
       setComponentSpec,
@@ -196,6 +198,7 @@ export const ComponentSpecProvider = ({
       componentSpec,
       graphSpec,
       taskStatusMap,
+      autoSaveStatus,
       isLoading,
       refetch,
       setComponentSpec,

--- a/src/services/pipelineService.ts
+++ b/src/services/pipelineService.ts
@@ -295,3 +295,7 @@ export async function importPipelineFromFile(
     };
   }
 }
+
+export function getPipelineFile(pipelineName: string) {
+  return getComponentFileFromList(USER_PIPELINES_LIST_NAME, pipelineName);
+}

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -47,3 +47,41 @@ export const formatDuration = (startTime: string, endTime: string): string => {
     return `${seconds}s`;
   }
 };
+
+/**
+ * Format relative time between a past date and now
+ * @param date - past timestamp string
+ * @returns Formatted relative string (e.g., "9:43am", "yesterday", "3 days ago")
+ */
+export const formatRelativeTime = (date: Date | null) => {
+  if (!date) return null;
+  const now = new Date();
+  const past = new Date(date);
+
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const yesterday = new Date(today);
+  yesterday.setDate(today.getDate() - 1);
+
+  const pastDate = new Date(
+    past.getFullYear(),
+    past.getMonth(),
+    past.getDate(),
+  );
+
+  const isSameDay = pastDate.getTime() === today.getTime();
+  const isYesterday = pastDate.getTime() === yesterday.getTime();
+
+  if (isSameDay) {
+    return past.toLocaleTimeString([], {
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  } else if (isYesterday) {
+    return "yesterday";
+  } else {
+    const diffDays = Math.floor(
+      (now.getTime() - past.getTime()) / (1000 * 60 * 60 * 24),
+    );
+    return `${diffDays} days ago`;
+  }
+};


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Adds an indicator to the sidebar's Pipeline Actions section to show whether an autosave operation is being completed and when the last autosave was completed. Since the autosave method is generally very quick, a 1s "loading" timeout is added to emulate nice UX where the user can visually see that a save is occurring.

When loading a pipeline it will read the pipeline file `modificationDate` to show when it was last saved. This will then update when the first autosave succeeds. A similar system is used for the manual `save` action.

This is only a basic first-implementation.

Known issues that are resolved in future PR's:
- autosave spinner appears when first loading a pipeline
- autosave spinner and time can appear even if the autosave is ultimately skipped

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->
Closes https://github.com/Shopify/oasis-frontend/issues/205

## Type of Change

<!-- Please delete options that are not relevant -->

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

![image.png](https://app.graphite.dev/user-attachments/assets/a28602c7-db71-4973-a914-ec42f942002d.png)

![image.png](https://app.graphite.dev/user-attachments/assets/beacce31-b46b-4008-bc98-3b2e12016d9e.png)

![image.png](https://app.graphite.dev/user-attachments/assets/d8b9b4aa-d843-43ef-a36d-719995e3dcb9.png)

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->
1. Open a pipeline. In the top left it will tell you how long ago it was last saved
2. Make an edit. After 2s the autosave will trigger. Observe the Spinner
3. The "last saved" date is now the current time
4. Refresh the page; the "last saved" date is now updated
5. Click the "Save" button. The save will complete and the time will update again.
6. Confirm all other autosave functionality works as expected.

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
