### PR TITLE
Fix Initial Autosave on Load

### DIFF
--- a/src/hooks/useLoadComponentSpecFromPath.ts
+++ b/src/hooks/useLoadComponentSpecFromPath.ts
@@ -12,17 +12,19 @@ import { getIdOrTitleFromPath } from "@/utils/URL";
 export const useLoadComponentSpecFromPath = (backendUrl: string) => {
   const location = useLocation();
 
-  const pathname = useMemo(() => location.pathname, [location.pathname]);
-  const isRunPath = pathname.includes(RUNS_BASE_PATH);
   const { setComponentSpec, clearComponentSpec, componentSpec } =
     useComponentSpec();
+
+  const [isLoadingPipeline, setIsLoadingPipeline] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const pathname = useMemo(() => location.pathname, [location.pathname]);
+  const isRunPath = pathname.includes(RUNS_BASE_PATH);
 
   const { title, id } = useMemo(
     () => getIdOrTitleFromPath(pathname),
     [pathname],
   );
-  const [isLoadingPipeline, setIsLoadingPipeline] = useState(false);
-  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     const loadPipelineFromStorage = async () => {


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

Addresses some tech debt where pipelines would try to autosave when loaded. We had a spaghetti-workaround in place, but with new autosave features being introduced these were no longer viable.

This now means that pipelines won't autosave when loaded; nor will the autosave spinner show (even if the save operation is ultimately skipped)

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [x] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
