### PR TITLE
Add Button to Copy Argument Values

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/ArgumentsEditor.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/ArgumentsEditor.tsx
@@ -44,7 +44,7 @@ export const ArgumentsEditor = ({
   };
 
   return (
-    <div className="h-auto flex flex-col gap-2 max-h-[60vh] overflow-y-auto pr-4">
+    <div className="h-auto flex flex-col gap-2 max-h-[60vh] overflow-y-auto">
       {argumentInputs.map((argument) => (
         <ArgumentInputField
           key={argument.key}

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/ArgumentsSection.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/ArgumentsSection.tsx
@@ -14,7 +14,7 @@ const ArgumentsSection = ({
   disabled = false,
 }: ArgumentsSectionProps) => {
   return (
-    <div className="flex-1 overflow-y-auto p-2">
+    <div className="flex-1 overflow-y-auto py-2">
       <p className="text-sm text-muted-foreground mb-3">
         Configure the arguments for this task node.
       </p>


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

Adds a button to the argument editor that copies the argument value to clipboard.

Button will be hidden if the argument is unset, and will be disabled if no value is entered.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

User requested

## Type of Change

<!-- Please delete options that are not relevant -->

- [ ] Bug fix
- [x] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->
<img width="480" height="359" alt="image" src="https://github.com/user-attachments/assets/3f081dc7-0a73-4958-ba03-fd08ac19ab0f" />


## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->
1. Go to the argument editor.
2. Enter a value on an argument
3. Click the button to copy the value to clipboard

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
