### PR TITLE
hot-fix: load components from published library

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
@@ -489,6 +489,12 @@ const FlowCanvas = ({
 
         if (hydratedComponentRef) {
           droppedTask.componentRef = hydratedComponentRef;
+        } else {
+          notify(
+            "Failed to add component to canvas. Please, try again.",
+            "error",
+          );
+          return;
         }
       }
 

--- a/src/services/hydrateComponentReference.test.ts
+++ b/src/services/hydrateComponentReference.test.ts
@@ -410,6 +410,31 @@ describe("hydrateComponentReference()", () => {
         expect(result).toBeNull();
         expect(localforage.saveComponent).not.toHaveBeenCalled();
       });
+
+      it("should handle relative URL", async () => {
+        // Arrange
+        const testUrl = "/remote-component.yaml";
+        const { text: componentText, spec: componentSpec } =
+          prepareComponentContent("RemoteComponent", "remote:v2");
+
+        mockGetComponentByUrl(null); // Not cached
+        mockFetchResponse(componentText);
+
+        const loadableRef = { url: testUrl };
+
+        // Act
+        const result = await hydrateComponentReference(loadableRef);
+
+        // Assert
+        expect(localforage.getComponentByUrl).toHaveBeenCalledWith(testUrl);
+        expect(global.fetch).toHaveBeenCalledWith(testUrl);
+        expect(result).not.toBeNull();
+        expect(result?.digest).toBeDefined();
+        expect(result?.name).toBe("RemoteComponent");
+        expect(result?.spec).toEqual(componentSpec);
+        expect(result?.text).toBe(componentText);
+        expect(localforage.saveComponent).toHaveBeenCalled();
+      });
     });
 
     describe("when remote component text is invalid", () => {

--- a/src/utils/componentSpec.ts
+++ b/src/utils/componentSpec.ts
@@ -248,9 +248,7 @@ export function isLoadableComponentReference(
     componentReference &&
       typeof componentReference === "object" &&
       componentReference.url !== undefined &&
-      componentReference.url.length > 0 &&
-      // simple URL validation
-      /^(https?|ftp):\/\/[^\s/$.?#].[^\s]*$/i.test(componentReference.url),
+      componentReference.url.length > 0,
   );
 }
 


### PR DESCRIPTION
## Description

This PR adds error handling when a component fails to be added to the canvas and simplifies the URL validation in component references.

1. Added an error notification when a component fails to be added to the canvas, providing feedback to the user and preventing silent failures
2. Removed the URL regex validation from `isLoadableComponentReference` to simplify the validation logic

## Type of Change

- [x] Bug fix
- [x] Improvement

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Test Instructions

1. Try to add a component to the canvas that would fail to hydrate
2. Verify that an error notification appears
3. Test that component references with various URL formats still load correctly