### PR TITLE
OutputNode Save-on-Blur

### DIFF
--- a/src/components/Editor/PipelineDetails.tsx
+++ b/src/components/Editor/PipelineDetails.tsx
@@ -110,8 +110,7 @@ const PipelineDetails = () => {
         connectedDetails={outputConnectedDetails}
         key={output.name}
         output={output}
-        onSave={deselectNode}
-        onCancel={handleCancel}
+        onClose={handleCancel}
       />,
     );
   };

--- a/src/components/shared/ReactFlow/FlowCanvas/IONode/IONode.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/IONode/IONode.tsx
@@ -82,14 +82,13 @@ const IONode = ({ type, data, selected = false }: IONodeProps) => {
             output={output}
             connectedDetails={outputConnectedDetails}
             key={output.name}
-            onSave={deselectNode}
             disabled={!isPipelineEditor}
-            onCancel={deselectNode}
+            onClose={deselectNode}
           />,
         );
       }
     }
-  }, [input, selected]);
+  }, [input, output, selected]);
 
   const {
     outputName: outputConnectedValue,


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

Converts OutputNameEditor to save-on-blur functionality. Removes the "Save" button; fields will now save when blurred. Renamed "Cancel" to "Close"

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

Progresses https://github.com/Shopify/oasis-frontend/issues/239

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

![image.png](https://app.graphite.dev/user-attachments/assets/7f0caa9c-9f54-4c0a-9f1c-51fa74c0dcdb.png)

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
