### PR TITLE
Validate Pipeline on Submission

### DIFF
--- a/src/components/shared/Submitters/Oasis/OasisSubmitter.tsx
+++ b/src/components/shared/Submitters/Oasis/OasisSubmitter.tsx
@@ -13,6 +13,7 @@ import { usePipelineRuns } from "@/providers/PipelineRunsProvider";
 import { APP_ROUTES } from "@/routes/router";
 import type { PipelineRun } from "@/types/pipelineRun";
 import type { ComponentSpec } from "@/utils/componentSpec";
+import { checkComponentSpecValidity } from "@/utils/validations";
 
 interface OasisSubmitterProps {
   componentSpec?: ComponentSpec;
@@ -105,6 +106,13 @@ const OasisSubmitter = ({
   const handleSubmit = useCallback(async () => {
     if (!componentSpec) {
       handleError("No pipeline to submit");
+      return;
+    }
+
+    const { isValid, errors } = checkComponentSpecValidity(componentSpec);
+
+    if (!isValid) {
+      handleError(`Pipeline validation failed: ${errors[0]}`);
       return;
     }
 

--- a/src/utils/validations.test.ts
+++ b/src/utils/validations.test.ts
@@ -1,0 +1,501 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { type ComponentSpec } from "./componentSpec";
+import { checkComponentSpecValidity } from "./validations";
+
+// Mock the componentSpec module
+vi.mock("./componentSpec", () => ({
+  isGraphImplementation: vi.fn(),
+}));
+
+const { isGraphImplementation } = await import("./componentSpec");
+
+describe("checkComponentSpecValidity", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("Basic Component Spec Validation", () => {
+    it("should return error for null component spec", () => {
+      const result = checkComponentSpecValidity(null as any);
+
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContain("Component spec is null or undefined");
+    });
+
+    it("should return error for undefined component spec", () => {
+      const result = checkComponentSpecValidity(undefined as any);
+
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContain("Component spec is null or undefined");
+    });
+
+    it("should return error for empty component name", () => {
+      const componentSpec: ComponentSpec = {
+        name: "",
+        implementation: { container: { image: "test-image" } },
+      };
+
+      const result = checkComponentSpecValidity(componentSpec);
+
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContain(
+        "Component name is required and cannot be empty",
+      );
+    });
+
+    it("should return error for missing implementation", () => {
+      const componentSpec: ComponentSpec = {
+        name: "test-component",
+        implementation: null as any,
+      };
+
+      const result = checkComponentSpecValidity(componentSpec);
+
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContain("Component implementation is required");
+    });
+  });
+
+  describe("Input/Output Validation", () => {
+    it("should return error for input without name", () => {
+      const componentSpec: ComponentSpec = {
+        name: "test-component",
+        implementation: { container: { image: "test-image" } },
+        inputs: [{ name: "", type: "string", value: "test-value" }],
+      };
+
+      const result = checkComponentSpecValidity(componentSpec);
+
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContain(
+        'Input with value "test-value" must have a valid name',
+      );
+    });
+
+    it("should return error for duplicate input names", () => {
+      const componentSpec: ComponentSpec = {
+        name: "test-component",
+        implementation: { container: { image: "test-image" } },
+        inputs: [
+          { name: "duplicate", type: "string", value: "value1" },
+          { name: "duplicate", type: "string", value: "value2" },
+        ],
+      };
+
+      const result = checkComponentSpecValidity(componentSpec);
+
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContain(
+        'Duplicate input name found: "duplicate"',
+      );
+    });
+
+    it("should return error for output without name", () => {
+      const componentSpec: ComponentSpec = {
+        name: "test-component",
+        implementation: { container: { image: "test-image" } },
+        outputs: [{ name: "", type: "string" }],
+      };
+
+      const result = checkComponentSpecValidity(componentSpec);
+
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContain(
+        'Output with type "string" must have a valid name',
+      );
+    });
+
+    it("should return error for duplicate output names", () => {
+      const componentSpec: ComponentSpec = {
+        name: "test-component",
+        implementation: { container: { image: "test-image" } },
+        outputs: [
+          { name: "duplicate", type: "string" },
+          { name: "duplicate", type: "number" },
+        ],
+      };
+
+      const result = checkComponentSpecValidity(componentSpec);
+
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContain(
+        'Duplicate output name found: "duplicate"',
+      );
+    });
+  });
+
+  describe("Non-Graph Implementation", () => {
+    it("should skip graph validations for container implementations", () => {
+      vi.mocked(isGraphImplementation).mockReturnValue(false);
+
+      const componentSpec: ComponentSpec = {
+        name: "test-component",
+        implementation: { container: { image: "test-image" } },
+      };
+
+      const result = checkComponentSpecValidity(componentSpec);
+
+      expect(result.isValid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+  });
+
+  describe("Graph Implementation Validation", () => {
+    beforeEach(() => {
+      vi.mocked(isGraphImplementation).mockReturnValue(true);
+    });
+
+    it("should return error for graph without tasks", () => {
+      const componentSpec: ComponentSpec = {
+        name: "test-component",
+        implementation: {
+          graph: {
+            tasks: {},
+          },
+        },
+      };
+
+      const result = checkComponentSpecValidity(componentSpec);
+
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContain(
+        "Pipeline must contain at least one task",
+      );
+    });
+
+    it("should return error for task without componentRef", () => {
+      const componentSpec: ComponentSpec = {
+        name: "test-component",
+        implementation: {
+          graph: {
+            tasks: {
+              task1: {} as any,
+            },
+          },
+        },
+      };
+
+      const result = checkComponentSpecValidity(componentSpec);
+
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContain('Task "task1" must have a componentRef');
+    });
+
+    it("should validate graph input references", () => {
+      const componentSpec: ComponentSpec = {
+        name: "test-component",
+        inputs: [{ name: "validInput", type: "string" }],
+        implementation: {
+          graph: {
+            tasks: {
+              task1: {
+                componentRef: {
+                  name: "child-component",
+                  spec: {
+                    name: "child-component",
+                    implementation: { container: { image: "child-image" } },
+                  },
+                },
+                arguments: {
+                  arg1: {
+                    graphInput: { inputName: "invalidInput" },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const result = checkComponentSpecValidity(componentSpec);
+
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContain(
+        'Task "task1" argument "arg1" references non-existent graph input: "invalidInput"',
+      );
+    });
+
+    it("should validate task output references", () => {
+      const componentSpec: ComponentSpec = {
+        name: "test-component",
+        implementation: {
+          graph: {
+            tasks: {
+              task1: {
+                componentRef: {
+                  name: "child-component",
+                  spec: {
+                    name: "child-component",
+                    implementation: { container: { image: "child-image" } },
+                  },
+                },
+                arguments: {
+                  arg1: {
+                    taskOutput: {
+                      taskId: "nonExistentTask",
+                      outputName: "output1",
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const result = checkComponentSpecValidity(componentSpec);
+
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContain(
+        'Task "task1" argument "arg1" references non-existent task: "nonExistentTask"',
+      );
+    });
+
+    it("should validate required task inputs", () => {
+      const componentSpec: ComponentSpec = {
+        name: "test-component",
+        implementation: {
+          graph: {
+            tasks: {
+              task1: {
+                componentRef: {
+                  name: "child-component",
+                  spec: {
+                    name: "child-component",
+                    implementation: { container: { image: "child-image" } },
+                    inputs: [
+                      {
+                        name: "requiredInput",
+                        type: "string",
+                        optional: false,
+                      },
+                    ],
+                  },
+                },
+                arguments: {},
+              },
+            },
+          },
+        },
+      };
+
+      const result = checkComponentSpecValidity(componentSpec);
+
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContain(
+        'Task "task1" is missing required argument for input: "requiredInput"',
+      );
+    });
+
+    it("should validate graph outputs", () => {
+      const componentSpec: ComponentSpec = {
+        name: "test-component",
+        outputs: [{ name: "validOutput", type: "string" }],
+        implementation: {
+          graph: {
+            tasks: {
+              task1: {
+                componentRef: {
+                  name: "child-component",
+                  spec: {
+                    name: "child-component",
+                    implementation: { container: { image: "child-image" } },
+                  },
+                },
+              },
+            },
+            outputValues: {
+              invalidOutput: {
+                taskOutput: { taskId: "task1", outputName: "output1" },
+              },
+            },
+          },
+        },
+      };
+
+      const result = checkComponentSpecValidity(componentSpec);
+
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContain(
+        'Graph output "invalidOutput" is not defined in component outputs',
+      );
+    });
+
+    it("should validate input-output connections", () => {
+      const componentSpec: ComponentSpec = {
+        name: "test-component",
+        inputs: [{ name: "requiredInput", type: "string", optional: false }],
+        outputs: [{ name: "requiredOutput", type: "string" }],
+        implementation: {
+          graph: {
+            tasks: {
+              task1: {
+                componentRef: {
+                  name: "child-component",
+                  spec: {
+                    name: "child-component",
+                    implementation: { container: { image: "child-image" } },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const result = checkComponentSpecValidity(componentSpec);
+
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContain(
+        'Pipeline input "requiredInput" is required and does not have a value',
+      );
+      expect(result.errors).toContain(
+        'Pipeline output "requiredOutput" is not connected to any tasks',
+      );
+    });
+
+    it("should detect circular dependencies", () => {
+      const componentSpec: ComponentSpec = {
+        name: "test-component",
+        implementation: {
+          graph: {
+            tasks: {
+              task1: {
+                componentRef: {
+                  name: "child-component-1",
+                  spec: {
+                    name: "child-component-1",
+                    implementation: { container: { image: "child-image-1" } },
+                  },
+                },
+                arguments: {
+                  arg1: {
+                    taskOutput: { taskId: "task2", outputName: "output1" },
+                  },
+                },
+              },
+              task2: {
+                componentRef: {
+                  name: "child-component-2",
+                  spec: {
+                    name: "child-component-2",
+                    implementation: { container: { image: "child-image-2" } },
+                  },
+                },
+                arguments: {
+                  arg1: {
+                    taskOutput: { taskId: "task1", outputName: "output1" },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const result = checkComponentSpecValidity(componentSpec);
+
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContain(
+        "Circular dependency detected in pipeline at task: task1",
+      );
+    });
+  });
+
+  describe("Valid Component Spec", () => {
+    it("should return valid for a complete valid graph component spec", () => {
+      vi.mocked(isGraphImplementation).mockReturnValue(true);
+
+      const componentSpec: ComponentSpec = {
+        name: "valid-component",
+        inputs: [{ name: "input1", type: "string", optional: false }],
+        outputs: [{ name: "output1", type: "string" }],
+        implementation: {
+          graph: {
+            tasks: {
+              task1: {
+                componentRef: {
+                  name: "child-component",
+                  spec: {
+                    name: "child-component",
+                    implementation: { container: { image: "child-image" } },
+                    inputs: [
+                      { name: "taskInput", type: "string", optional: false },
+                    ],
+                    outputs: [{ name: "taskOutput", type: "string" }],
+                  },
+                },
+                arguments: {
+                  taskInput: {
+                    graphInput: { inputName: "input1" },
+                  },
+                },
+              },
+            },
+            outputValues: {
+              output1: {
+                taskOutput: { taskId: "task1", outputName: "taskOutput" },
+              },
+            },
+          },
+        },
+      };
+
+      const result = checkComponentSpecValidity(componentSpec);
+
+      expect(result.isValid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it("should return valid for container implementation", () => {
+      vi.mocked(isGraphImplementation).mockReturnValue(false);
+
+      const componentSpec: ComponentSpec = {
+        name: "function-component",
+        inputs: [{ name: "input1", type: "string", default: "default-value" }],
+        outputs: [{ name: "output1", type: "string" }],
+        implementation: {
+          container: {
+            image: "my-function-image",
+            command: ["python", "script.py"],
+            args: ["--input", { inputValue: "input1" }],
+          },
+        },
+      };
+
+      const result = checkComponentSpecValidity(componentSpec);
+
+      expect(result.isValid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it("should handle optional inputs correctly", () => {
+      vi.mocked(isGraphImplementation).mockReturnValue(false);
+
+      const componentSpec: ComponentSpec = {
+        name: "component-with-optional-input",
+        inputs: [
+          { name: "requiredInput", type: "string", optional: false },
+          { name: "optionalInput", type: "string", optional: true },
+          {
+            name: "inputWithDefault",
+            type: "string",
+            default: "default-value",
+          },
+        ],
+        outputs: [{ name: "output1", type: "string" }],
+        implementation: {
+          container: {
+            image: "test-image",
+          },
+        },
+      };
+
+      const result = checkComponentSpecValidity(componentSpec);
+
+      expect(result.isValid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+  });
+});

--- a/src/utils/validations.ts
+++ b/src/utils/validations.ts
@@ -1,0 +1,435 @@
+import {
+  type ArgumentType,
+  type ComponentSpec,
+  type GraphInputArgument,
+  type GraphSpec,
+  type InputSpec,
+  isGraphImplementation,
+  type TaskOutputArgument,
+  type TaskSpec,
+} from "./componentSpec";
+
+export const checkComponentSpecValidity = (
+  componentSpec: ComponentSpec,
+): { isValid: boolean; errors: string[] } => {
+  const errors: string[] = [];
+
+  // Basic validation
+  const basicErrors = validateBasicComponentSpec(componentSpec);
+  errors.push(...basicErrors);
+
+  if (
+    basicErrors.length > 0 &&
+    basicErrors.some((e) => e.includes("null") || e.includes("implementation"))
+  ) {
+    return { isValid: false, errors };
+  }
+
+  // Validate inputs and outputs
+  errors.push(...validateInputsAndOutputs(componentSpec));
+
+  // Skip further validation for non-graph implementations
+  if (!isGraphImplementation(componentSpec.implementation)) {
+    console.warn(
+      "Component implementation is not a graph. Skipping graph-specific validations.",
+    );
+    return { isValid: errors.length === 0, errors };
+  }
+
+  // Graph-specific validations
+  const graphSpec = componentSpec.implementation.graph;
+  errors.push(...validateGraphTasks(graphSpec, componentSpec));
+  errors.push(...validateGraphOutputs(graphSpec, componentSpec));
+  errors.push(...validateInputOutputConnections(graphSpec, componentSpec));
+  errors.push(...validateCircularDependencies(graphSpec));
+
+  return { isValid: errors.length === 0, errors };
+};
+
+const validateBasicComponentSpec = (componentSpec: ComponentSpec): string[] => {
+  const errors: string[] = [];
+
+  // Basic null/undefined check
+  if (!componentSpec) {
+    errors.push("Component spec is null or undefined");
+    return errors;
+  }
+
+  // Validate component name
+  if (!componentSpec.name || componentSpec.name.trim() === "") {
+    errors.push("Component name is required and cannot be empty");
+  }
+
+  // Validate implementation exists
+  if (!componentSpec.implementation) {
+    errors.push("Component implementation is required");
+  }
+
+  return errors;
+};
+
+const validateInputsAndOutputs = (componentSpec: ComponentSpec): string[] => {
+  const errors: string[] = [];
+
+  // Validate inputs array structure
+  if (componentSpec.inputs) {
+    const inputNames = new Set<string>();
+    componentSpec.inputs.forEach((input) => {
+      // Check input name is required
+      if (!input.name || input.name.trim() === "") {
+        errors.push(`Input with value "${input.value}" must have a valid name`);
+      } else {
+        // Check for duplicate input names
+        if (inputNames.has(input.name)) {
+          errors.push(`Duplicate input name found: "${input.name}"`);
+        }
+        inputNames.add(input.name);
+      }
+    });
+  }
+
+  // Validate outputs array structure
+  if (componentSpec.outputs) {
+    const outputNames = new Set<string>();
+    componentSpec.outputs.forEach((output) => {
+      // Check output name is required
+      if (!output.name || output.name.trim() === "") {
+        errors.push(`Output with type "${output.type}" must have a valid name`);
+      } else {
+        // Check for duplicate output names
+        if (outputNames.has(output.name)) {
+          errors.push(`Duplicate output name found: "${output.name}"`);
+        }
+        outputNames.add(output.name);
+      }
+    });
+  }
+
+  return errors;
+};
+
+const validateGraphTasks = (
+  graphSpec: GraphSpec,
+  componentSpec: ComponentSpec,
+): string[] => {
+  const errors: string[] = [];
+
+  // Validate graph tasks exist
+  if (!graphSpec.tasks || Object.keys(graphSpec.tasks).length === 0) {
+    errors.push("Pipeline must contain at least one task");
+    return errors;
+  }
+
+  // Validate task structure and names
+  Object.entries(graphSpec.tasks).forEach(
+    ([taskId, task]: [string, TaskSpec]) => {
+      errors.push(
+        ...validateSingleTask(taskId, task, graphSpec, componentSpec),
+      );
+    },
+  );
+
+  return errors;
+};
+
+const validateSingleTask = (
+  taskId: string,
+  task: TaskSpec,
+  graphSpec: GraphSpec,
+  componentSpec: ComponentSpec,
+): string[] => {
+  const errors: string[] = [];
+
+  // Check task ID is valid
+  if (!taskId || taskId.trim() === "") {
+    errors.push("Task ID cannot be empty");
+  }
+
+  // Validate task has component reference
+  if (!task.componentRef) {
+    errors.push(`Task "${taskId}" must have a componentRef`);
+  }
+
+  // Validate task arguments
+  errors.push(...validateTaskArguments(taskId, task, graphSpec, componentSpec));
+
+  // Validate required inputs
+  errors.push(...validateTaskRequiredInputs(taskId, task));
+
+  return errors;
+};
+
+const validateTaskArguments = (
+  taskId: string,
+  task: TaskSpec,
+  graphSpec: GraphSpec,
+  componentSpec: ComponentSpec,
+): string[] => {
+  const errors: string[] = [];
+
+  if (!task.arguments) return errors;
+
+  Object.entries(task.arguments).forEach(
+    ([argName, argValue]: [string, ArgumentType]) => {
+      if (typeof argValue === "object" && argValue !== null) {
+        // Check graphInput references
+        if ("graphInput" in argValue) {
+          errors.push(
+            ...validateGraphInputReference(
+              taskId,
+              argName,
+              argValue,
+              componentSpec,
+            ),
+          );
+        }
+
+        // Check taskOutput references
+        if ("taskOutput" in argValue) {
+          errors.push(
+            ...validateTaskOutputReference(
+              taskId,
+              argName,
+              argValue,
+              graphSpec,
+            ),
+          );
+        }
+      }
+    },
+  );
+
+  return errors;
+};
+
+const validateGraphInputReference = (
+  taskId: string,
+  argName: string,
+  argValue: GraphInputArgument,
+  componentSpec: ComponentSpec,
+): string[] => {
+  const errors: string[] = [];
+  const inputName = argValue.graphInput.inputName;
+  const componentInput = componentSpec.inputs?.find(
+    (i) => i.name === inputName,
+  );
+
+  if (!componentInput) {
+    errors.push(
+      `Task "${taskId}" argument "${argName}" references non-existent graph input: "${inputName}"`,
+    );
+  }
+
+  return errors;
+};
+
+const validateTaskOutputReference = (
+  taskId: string,
+  argName: string,
+  argValue: TaskOutputArgument,
+  graphSpec: GraphSpec,
+): string[] => {
+  const errors: string[] = [];
+  const referencedTaskId = argValue.taskOutput.taskId;
+  const referencedOutput = argValue.taskOutput.outputName;
+
+  if (!graphSpec.tasks[referencedTaskId]) {
+    errors.push(
+      `Task "${taskId}" argument "${argName}" references non-existent task: "${referencedTaskId}"`,
+    );
+  } else {
+    // Validate that the referenced output exists in the referenced task's component
+    const referencedTask = graphSpec.tasks[referencedTaskId];
+    if (referencedTask.componentRef && referencedTask.componentRef.spec) {
+      const referencedTaskSpec = referencedTask.componentRef.spec;
+      const outputExists = referencedTaskSpec.outputs?.some(
+        (output: any) => output.name === referencedOutput,
+      );
+
+      if (!outputExists) {
+        errors.push(
+          `Task "${taskId}" argument "${argName}" references non-existent output "${referencedOutput}" from task "${referencedTaskId}"`,
+        );
+      }
+    } else {
+      console.warn(
+        `Cannot validate output "${referencedOutput}" for task "${referencedTaskId}" - component spec not loaded`,
+      );
+    }
+  }
+
+  return errors;
+};
+
+const validateTaskRequiredInputs = (
+  taskId: string,
+  task: TaskSpec,
+): string[] => {
+  const errors: string[] = [];
+
+  if (!task.componentRef || !task.componentRef.spec) {
+    console.warn(
+      `Cannot validate required inputs for task "${taskId}" - component spec not loaded`,
+    );
+    return errors;
+  }
+
+  const taskComponentSpec = task.componentRef.spec;
+
+  if (taskComponentSpec.inputs) {
+    taskComponentSpec.inputs.forEach((input: InputSpec) => {
+      // Check if this input is required (not optional and no default value)
+      const isRequired = !input.optional && !input.default;
+
+      if (isRequired) {
+        // Check if this required input has a value in task arguments
+        const hasArgument =
+          task.arguments &&
+          Object.prototype.hasOwnProperty.call(task.arguments, input.name);
+
+        if (!hasArgument) {
+          errors.push(
+            `Task "${taskId}" is missing required argument for input: "${input.name}"`,
+          );
+        }
+      }
+    });
+  }
+
+  return errors;
+};
+
+const validateGraphOutputs = (
+  graphSpec: GraphSpec,
+  componentSpec: ComponentSpec,
+): string[] => {
+  const errors: string[] = [];
+
+  if (!graphSpec.outputValues) return errors;
+
+  Object.entries(graphSpec.outputValues).forEach(
+    ([outputName, outputValue]: [string, TaskOutputArgument]) => {
+      // Check if output is defined in component outputs
+      const componentOutput = componentSpec.outputs?.find(
+        (o) => o.name === outputName,
+      );
+      if (!componentOutput) {
+        errors.push(
+          `Graph output "${outputName}" is not defined in component outputs`,
+        );
+      }
+
+      // Check if referenced task exists
+      const referencedTaskId = outputValue.taskOutput.taskId;
+      if (!graphSpec.tasks[referencedTaskId]) {
+        errors.push(
+          `Graph output "${outputName}" references non-existent task: "${referencedTaskId}"`,
+        );
+      }
+    },
+  );
+
+  return errors;
+};
+
+const validateInputOutputConnections = (
+  graphSpec: GraphSpec,
+  componentSpec: ComponentSpec,
+): string[] => {
+  const errors: string[] = [];
+
+  // Validate all required component inputs have corresponding graph inputs or default values
+  if (componentSpec.inputs) {
+    componentSpec.inputs.forEach((input) => {
+      if (!input.optional && !input.default) {
+        // Check if this required input is used in any task arguments
+        const isInputUsed = Object.values(graphSpec.tasks).some(
+          (task: TaskSpec) =>
+            task.arguments &&
+            Object.values(task.arguments).some(
+              (arg: ArgumentType) =>
+                typeof arg === "object" &&
+                arg !== null &&
+                "graphInput" in arg &&
+                arg.graphInput.inputName === input.name,
+            ),
+        );
+
+        if (!isInputUsed) {
+          errors.push(
+            `Pipeline input "${input.name}" is required and does not have a value`,
+          );
+        }
+      }
+    });
+  }
+
+  // Validate all component outputs are provided by graph outputs
+  if (componentSpec.outputs) {
+    componentSpec.outputs.forEach((output) => {
+      const hasGraphOutput =
+        graphSpec.outputValues &&
+        Object.prototype.hasOwnProperty.call(
+          graphSpec.outputValues,
+          output.name,
+        );
+
+      if (!hasGraphOutput) {
+        errors.push(
+          `Pipeline output "${output.name}" is not connected to any tasks`,
+        );
+      }
+    });
+  }
+
+  return errors;
+};
+
+const validateCircularDependencies = (graphSpec: GraphSpec): string[] => {
+  const errors: string[] = [];
+  const visited = new Set<string>();
+  const recursionStack = new Set<string>();
+
+  const hasCycle = (taskId: string): boolean => {
+    if (recursionStack.has(taskId)) {
+      return true; // Found cycle
+    }
+    if (visited.has(taskId)) {
+      return false; // Already processed
+    }
+
+    visited.add(taskId);
+    recursionStack.add(taskId);
+
+    const task = graphSpec.tasks[taskId];
+    if (task?.arguments) {
+      for (const argValue of Object.values(task.arguments)) {
+        if (
+          typeof argValue === "object" &&
+          argValue !== null &&
+          "taskOutput" in argValue
+        ) {
+          const dependentTaskId = (argValue as any).taskOutput.taskId;
+          if (hasCycle(dependentTaskId)) {
+            return true;
+          }
+        }
+      }
+    }
+
+    recursionStack.delete(taskId);
+    return false;
+  };
+
+  // Check for cycles starting from each task
+  for (const taskId of Object.keys(graphSpec.tasks)) {
+    if (!visited.has(taskId) && hasCycle(taskId)) {
+      errors.push(
+        "Circular dependency detected in pipeline at task: " + taskId,
+      );
+      break;
+    }
+  }
+
+  return errors;
+};


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

Runs a general validation on `ComponentSpec` when the pipeline is submitted and displays the first error in a toast. If an error is detected the pipeline will not submit.

Covers common stuff like:
- missing or malformed spec
- unconnected outputs
- required inputs without values
- circular references

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

Enables solutions to https://github.com/Shopify/oasis-frontend/issues/232 and https://github.com/Shopify/oasis-frontend/issues/233

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

![image.png](https://app.graphite.dev/user-attachments/assets/4b2703bb-def3-481b-9119-68a684d9516a.png)

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->

Validation algorithm with mostly generated by AI based on the component spec structure. we are free to alter it as we see fit.
