### PR TITLE
Move Pipeline YAML into a Collapsible

### DIFF
--- a/src/components/Editor/PipelineDetails.tsx
+++ b/src/components/Editor/PipelineDetails.tsx
@@ -4,6 +4,11 @@ import { useCallback, useEffect, useState } from "react";
 
 import { getOutputConnectedDetails } from "@/components/shared/ReactFlow/FlowCanvas/utils/getOutputConnectedDetails";
 import { Button } from "@/components/ui/button";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
 import { Icon } from "@/components/ui/icon";
 import { InlineStack } from "@/components/ui/layout";
 import useToastNotification from "@/hooks/useToastNotification";
@@ -30,6 +35,8 @@ const PipelineDetails = () => {
   const { componentSpec, graphSpec } = useComponentSpec();
 
   const notify = useToastNotification();
+
+  const [isYamlOpen, setIsYamlOpen] = useState(false);
 
   // Utility function to convert TypeSpecType to string
   const typeSpecToString = (typeSpec?: TypeSpecType): string => {
@@ -321,17 +328,28 @@ const PipelineDetails = () => {
       </div>
 
       {/* Pipeline YAML */}
-      <div className="flex flex-col h-full">
-        <div className="font-medium text-md flex items-center gap-1 cursor-pointer">
-          Pipeline YAML
-        </div>
-        <div className="mt-1 h-full min-h-0 flex-1">
+      <Collapsible
+        open={isYamlOpen}
+        onOpenChange={setIsYamlOpen}
+        className="h-full"
+      >
+        <CollapsibleTrigger asChild>
+          <InlineStack
+            gap="1"
+            blockAlign="center"
+            className="font-medium text-md cursor-pointer"
+          >
+            <Icon name={isYamlOpen ? "ChevronDown" : "ChevronRight"} />
+            Pipeline YAML
+          </InlineStack>
+        </CollapsibleTrigger>
+        <CollapsibleContent className="mt-1 h-9/10 flex-1 min-h-0">
           <TaskImplementation
             displayName={componentSpec.name ?? "Pipeline"}
             componentSpec={componentSpec}
           />
-        </div>
-      </div>
+        </CollapsibleContent>
+      </Collapsible>
     </div>
   );
 };


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

Move Pipeline YAML section into a collapsible to free up space in the details panel and remove the codeviewer from active view.

Intended to make space for pipeline validations to be displayed on the details panel

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

![image.png](https://app.graphite.dev/user-attachments/assets/2f912726-6fad-48b8-9047-278a6eb6f025.png)

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
