### PR TITLE
Added pipeline_run_id-based redirects

### DIFF
--- a/src/components/Home/RunSection/RunRow.tsx
+++ b/src/components/Home/RunSection/RunRow.tsx
@@ -16,6 +16,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import useToastNotification from "@/hooks/useToastNotification";
+import { useBackend } from "@/providers/BackendProvider";
 import { APP_ROUTES } from "@/routes/router";
 import {
   countTaskStatuses,
@@ -27,12 +28,14 @@ import { convertUTCToLocalTime, formatDate } from "@/utils/date";
 const RunRow = ({ run }: { run: PipelineRunResponse }) => {
   const navigate = useNavigate();
   const notify = useToastNotification();
+  const { backendUrl } = useBackend();
 
   const executionId = `${run.root_execution_id}`;
 
   const { data, isLoading, error } = useFetchExecutionInfo(
     executionId,
-    false, // poll
+    backendUrl,
+    false,
   );
   const { details, state } = data;
 

--- a/src/components/PipelineRun/RootExecutionStatusProvider.test.tsx
+++ b/src/components/PipelineRun/RootExecutionStatusProvider.test.tsx
@@ -239,7 +239,8 @@ describe("<RootExecutionStatusProvider />", () => {
       // Verify polling is initially enabled
       expect(mockUseFetchExecutionInfo).toHaveBeenCalledWith(
         "test-execution-id",
-        true, // poll
+        "http://localhost:8000",
+        true,
       );
     });
 
@@ -506,7 +507,8 @@ describe("<RootExecutionStatusProvider />", () => {
 
       expect(mockUseFetchExecutionInfo).toHaveBeenCalledWith(
         "test-execution-id",
-        true, // poll
+        "http://localhost:8000",
+        true,
       );
     });
 
@@ -544,7 +546,8 @@ describe("<RootExecutionStatusProvider />", () => {
 
       expect(mockUseFetchExecutionInfo).toHaveBeenCalledWith(
         "test-execution-id",
-        true, // poll
+        customBackendUrl,
+        true,
       );
     });
   });

--- a/src/components/PipelineRun/RootExecutionStatusProvider.tsx
+++ b/src/components/PipelineRun/RootExecutionStatusProvider.tsx
@@ -11,6 +11,7 @@ import type {
   GetExecutionInfoResponse,
   GetGraphExecutionStateResponse,
 } from "@/api/types.gen";
+import { useBackend } from "@/providers/BackendProvider";
 import {
   countTaskStatuses,
   getRunStatus,
@@ -32,10 +33,13 @@ export function RootExecutionStatusProvider({
   rootExecutionId,
   children,
 }: PropsWithChildren<{ rootExecutionId: string }>) {
+  const { backendUrl } = useBackend();
+
   const [isPolling, setIsPolling] = useState(true);
 
   const { data, isLoading, error } = useFetchExecutionInfo(
     rootExecutionId,
+    backendUrl,
     isPolling,
   );
   const { details, state } = data;

--- a/src/routes/PipelineRun/PipelineRun.tsx
+++ b/src/routes/PipelineRun/PipelineRun.tsx
@@ -39,11 +39,7 @@ const PipelineRun = () => {
     error: executionError,
     refetch: refetchExecution,
     enabled,
-  } = useFetchExecutionInfo(
-    rootExecutionId,
-    false, // poll
-    !triedAsRunId, // enabled - disable if we've already tried as run_id
-  );
+  } = useFetchExecutionInfo(rootExecutionId, backendUrl, false, !triedAsRunId);
 
   // If fetching as root_execution_id fails, try as run_id
   const shouldFetchAsRunId = !!executionError && !triedAsRunId && enabled;
@@ -51,10 +47,7 @@ const PipelineRun = () => {
     data: pipelineRunData,
     isLoading: isPipelineRunLoading,
     error: pipelineRunError,
-  } = useFetchPipelineRun(
-    id,
-    shouldFetchAsRunId, // enabled
-  );
+  } = useFetchPipelineRun(id, backendUrl, shouldFetchAsRunId);
 
   // Update rootExecutionId when we get pipeline run data
   useEffect(() => {

--- a/src/services/executionService.ts
+++ b/src/services/executionService.ts
@@ -8,7 +8,6 @@ import type {
   GetGraphExecutionStateResponse,
   PipelineRunResponse,
 } from "@/api/types.gen";
-import { useBackend } from "@/providers/BackendProvider";
 import type { TaskStatusCounts } from "@/types/pipelineRun";
 import { fetchWithErrorHandling } from "@/utils/fetchWithErrorHandling";
 
@@ -59,26 +58,25 @@ export const useFetchContainerExecutionState = (
   });
 };
 
-export const useFetchPipelineRun = (runId: string, enabled: boolean = true) => {
-  const { backendUrl, configured, available } = useBackend();
-
+export const useFetchPipelineRun = (
+  runId: string,
+  backendUrl: string,
+  enabled: boolean = true,
+) => {
   return useQuery<PipelineRunResponse>({
     queryKey: ["pipeline-run", runId],
     queryFn: () => fetchPipelineRun(runId, backendUrl),
-    enabled: enabled && configured && available,
+    enabled,
     refetchOnWindowFocus: false,
   });
 };
 
 export const useFetchExecutionInfo = (
   executionId: string,
+  backendUrl: string,
   poll: boolean = false,
   enabled: boolean = true,
 ) => {
-  const { backendUrl, configured, available } = useBackend();
-
-  const queryEnabled = enabled && configured && available;
-
   const {
     data: details,
     isLoading: isDetailsLoading,
@@ -90,7 +88,7 @@ export const useFetchExecutionInfo = (
     refetchOnWindowFocus: false,
     queryFn: () => fetchExecutionDetails(executionId, backendUrl),
     refetchInterval: poll ? 5000 : false,
-    enabled: queryEnabled,
+    enabled,
   });
 
   const {
@@ -104,7 +102,7 @@ export const useFetchExecutionInfo = (
     refetchOnWindowFocus: false,
     queryFn: () => fetchExecutionState(executionId, backendUrl),
     refetchInterval: poll ? 5000 : false,
-    enabled: queryEnabled,
+    enabled,
   });
 
   const isLoading = isDetailsLoading || isStateLoading;
@@ -117,7 +115,7 @@ export const useFetchExecutionInfo = (
     refetchState();
   }, [refetchDetails, refetchState]);
 
-  return { data, isLoading, isFetching, error, refetch, enabled: queryEnabled };
+  return { data, isLoading, isFetching, error, refetch, enabled };
 };
 
 export const fetchExecutionStatus = async (


### PR DESCRIPTION
## Description

Enhanced the PipelineRun component to support both execution IDs and run IDs. The component now first attempts to fetch data using the provided ID as a root_execution_id, and if that fails, it tries again treating it as a run_id. This allows users to access pipeline run details using either identifier type.

## Type of Change

- [x] New feature
- [x] Improvement

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

1. Configure a backend
2. Navigate to a pipeline run using either:
   - `/runs/{root_execution_id}` (existing path)
   - `/runs/{run_id}` (now supported)
3. Verify the correct execution details are displayed in both cases
4. Test error states by using invalid IDs

## Additional Comments

This implementation adds a new `useFetchPipelineRun` hook that retrieves pipeline run data by run ID. The PipelineRun component now intelligently handles both ID types, making the UI more flexible and user-friendly.