### PR TITLE
Fix Shortcuts in Dialogs acting on nodes in the background

### DIFF
--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -50,10 +50,32 @@ function DialogContent({
   className,
   children,
   showCloseButton = true,
+  preventKeyboardPropagation = true,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
   showCloseButton?: boolean;
+  preventKeyboardPropagation?: boolean;
 }) {
+  const handleKeyDown = React.useCallback(
+    (e: React.KeyboardEvent) => {
+      if (!preventKeyboardPropagation) return;
+
+      // Stop propagation for common keyboard shortcuts that might interfere with canvas
+      const shouldStopPropagation =
+        (e.key === "a" && (e.metaKey || e.ctrlKey)) ||
+        (e.key === "c" && (e.metaKey || e.ctrlKey)) ||
+        (e.key === "v" && (e.metaKey || e.ctrlKey)) ||
+        e.key === "Tab" ||
+        e.key === "Enter" ||
+        e.key === "Escape";
+
+      if (shouldStopPropagation) {
+        e.stopPropagation();
+      }
+    },
+    [preventKeyboardPropagation],
+  );
+
   return (
     <DialogPortal data-slot="dialog-portal">
       <DialogOverlay />
@@ -63,6 +85,7 @@ function DialogContent({
           "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
           className,
         )}
+        onKeyDown={handleKeyDown}
         {...props}
       >
         {children}


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

Fixes an issue where using common shortcuts e.g. `cmd + A` or  `cmd + C` to select text inside a dialog would result in the dialog closing and actions being taken on the canvas.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

User reported

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->
1. Open Backend Configuration, turn off env setting, enter text in the box and `cmd + A` to select all of the text
2. Open Rename Pipeline, enter text in the box and `cmd + A` to select all of the text
3. Drag an existing component definition to the canvas, in the resulting component replace dialog enter text in the box and `cmd + A` to select all of the text
4. Open the multiline text editor via annotations or arguments, enter text in the box and `cmd + A` to select all of the text
5. Confirm that in the above scenarios the dialog does not close when pressing `cmd + A`
6. Do the same for  copy + paste, escape and enter

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
