### PR TITLE
Remove Close Button from IO Value Editors

### DIFF
--- a/src/components/Editor/IOEditor/InputValueEditor/InputValueEditor.tsx
+++ b/src/components/Editor/IOEditor/InputValueEditor/InputValueEditor.tsx
@@ -2,8 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { updateInputNameOnComponentSpec } from "@/components/Editor/utils/updateInputNameOnComponentSpec";
 import { InfoBox } from "@/components/shared/InfoBox";
-import { Button } from "@/components/ui/button";
-import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { BlockStack } from "@/components/ui/layout";
 import { Heading, Paragraph } from "@/components/ui/typography";
 import { useNodeSelectionTransfer } from "@/hooks/useNodeSelectionTransfer";
 import useToastNotification from "@/hooks/useToastNotification";
@@ -23,13 +22,11 @@ import { checkNameCollision } from "./FormFields/utils";
 interface InputValueEditorProps {
   input: InputSpec;
   disabled?: boolean;
-  onClose?: () => void;
 }
 
 export const InputValueEditor = ({
   input,
   disabled = false,
-  onClose,
 }: InputValueEditorProps) => {
   const notify = useToastNotification();
   const { transferSelection } = useNodeSelectionTransfer(inputNameToNodeId);
@@ -163,11 +160,6 @@ export const InputValueEditor = ({
     saveChanges();
   }, [saveChanges]);
 
-  const handleClose = useCallback(() => {
-    saveChanges();
-    onClose?.();
-  }, [saveChanges, onClose]);
-
   const handleCopyValue = useCallback(() => {
     if (inputValue) {
       void navigator.clipboard.writeText(inputValue);
@@ -243,12 +235,6 @@ export const InputValueEditor = ({
         inputValue={effectiveOptionalValue}
         disabled={isOptionalDisabled}
       />
-
-      <InlineStack align="end" className="w-full">
-        <Button variant="outline" onClick={handleClose}>
-          Close
-        </Button>
-      </InlineStack>
     </BlockStack>
   );
 };

--- a/src/components/Editor/IOEditor/OutputNameEditor/OutputNameEditor.tsx
+++ b/src/components/Editor/IOEditor/OutputNameEditor/OutputNameEditor.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
 
-import { Button } from "@/components/ui/button";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Heading, Paragraph } from "@/components/ui/typography";
 import { useNodeSelectionTransfer } from "@/hooks/useNodeSelectionTransfer";
@@ -17,14 +16,12 @@ interface OutputNameEditorProps {
   output: OutputSpec;
   disabled?: boolean;
   connectedDetails: OutputConnectedDetails;
-  onClose?: () => void;
 }
 
 export const OutputNameEditor = ({
   output,
   disabled,
   connectedDetails,
-  onClose,
 }: OutputNameEditorProps) => {
   const { transferSelection } = useNodeSelectionTransfer(outputNameToNodeId);
   const { setComponentSpec, componentSpec } = useComponentSpec();
@@ -91,11 +88,6 @@ export const OutputNameEditor = ({
     [componentSpec, output.name],
   );
 
-  const handleClose = useCallback(() => {
-    saveChanges();
-    onClose?.();
-  }, [saveChanges, onClose]);
-
   useEffect(() => {
     setOutputName(output.name);
   }, [output.name]);
@@ -129,11 +121,6 @@ export const OutputNameEditor = ({
             inputName={output.name}
           />
         </div>
-      </InlineStack>
-      <InlineStack align="end" className="w-full">
-        <Button variant="outline" onClick={handleClose}>
-          Close
-        </Button>
       </InlineStack>
     </BlockStack>
   );

--- a/src/components/Editor/PipelineDetails.tsx
+++ b/src/components/Editor/PipelineDetails.tsx
@@ -1,6 +1,5 @@
-import { useReactFlow } from "@xyflow/react";
 import { Frown, Network } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -21,7 +20,6 @@ import {
 } from "@/utils/componentSpec";
 import { getComponentFileFromList } from "@/utils/componentStore";
 import { USER_PIPELINES_LIST_NAME } from "@/utils/constants";
-import { deselectAllNodes } from "@/utils/flowUtils";
 
 import { InfoBox } from "../shared/InfoBox";
 import { TaskImplementation } from "../shared/TaskDetails";
@@ -31,9 +29,7 @@ import RenamePipeline from "./RenamePipeline";
 import { getOutputConnectedDetails } from "./utils/getOutputConnectedDetails";
 
 const PipelineDetails = () => {
-  const { setNodes } = useReactFlow();
-
-  const { setContent, clearContent } = useContextPanel();
+  const { setContent } = useContextPanel();
   const { componentSpec, graphSpec, isValid, errors } = useComponentSpec();
 
   const notify = useToastNotification();
@@ -51,10 +47,6 @@ const PipelineDetails = () => {
     return JSON.stringify(typeSpec);
   };
 
-  const handleCancel = () => {
-    deselectNode();
-  };
-
   // State for file metadata
   const [fileMeta, setFileMeta] = useState<{
     creationTime?: Date;
@@ -62,11 +54,6 @@ const PipelineDetails = () => {
     createdBy?: string;
     digest?: string;
   }>({});
-
-  const deselectNode = useCallback(() => {
-    setNodes(deselectAllNodes);
-    clearContent();
-  }, [setNodes]);
 
   // Fetch file metadata on mount or when componentSpec.name changes
   useEffect(() => {
@@ -91,13 +78,7 @@ const PipelineDetails = () => {
   }, [componentSpec?.name]);
 
   const handleInputEdit = (input: InputSpec) => {
-    setContent(
-      <InputValueEditor
-        key={input.name}
-        input={input}
-        onClose={handleCancel}
-      />,
-    );
+    setContent(<InputValueEditor key={input.name} input={input} />);
   };
 
   const handleOutputEdit = (output: OutputSpec) => {
@@ -110,7 +91,6 @@ const PipelineDetails = () => {
         connectedDetails={outputConnectedDetails}
         key={output.name}
         output={output}
-        onClose={handleCancel}
       />,
     );
   };

--- a/src/components/shared/ReactFlow/FlowCanvas/IONode/IONode.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/IONode/IONode.tsx
@@ -1,6 +1,6 @@
 import { useLocation } from "@tanstack/react-router";
-import { Handle, Position, useReactFlow } from "@xyflow/react";
-import { memo, useCallback, useEffect, useMemo } from "react";
+import { Handle, Position } from "@xyflow/react";
+import { memo, useEffect, useMemo } from "react";
 
 import { InputValueEditor } from "@/components/Editor/IOEditor/InputValueEditor";
 import { OutputNameEditor } from "@/components/Editor/IOEditor/OutputNameEditor";
@@ -9,7 +9,6 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 import { useContextPanel } from "@/providers/ContextPanelProvider";
-import { deselectAllNodes } from "@/utils/flowUtils";
 
 interface IONodeProps {
   type: "input" | "output";
@@ -24,10 +23,9 @@ interface IONodeProps {
 }
 
 const IONode = ({ type, data, selected = false }: IONodeProps) => {
-  const { setNodes } = useReactFlow();
   const location = useLocation();
   const { graphSpec, componentSpec } = useComponentSpec();
-  const { setContent, clearContent } = useContextPanel();
+  const { setContent } = useContextPanel();
 
   const isPipelineEditor = location.pathname.includes("/editor");
 
@@ -54,11 +52,6 @@ const IONode = ({ type, data, selected = false }: IONodeProps) => {
     [componentSpec.outputs, data.label],
   );
 
-  const deselectNode = useCallback(() => {
-    setNodes(deselectAllNodes);
-    clearContent();
-  }, [setNodes]);
-
   useEffect(() => {
     if (selected) {
       if (input && isInput) {
@@ -67,7 +60,6 @@ const IONode = ({ type, data, selected = false }: IONodeProps) => {
             input={input}
             key={input.name}
             disabled={!isPipelineEditor}
-            onClose={deselectNode}
           />,
         );
       }
@@ -83,7 +75,6 @@ const IONode = ({ type, data, selected = false }: IONodeProps) => {
             connectedDetails={outputConnectedDetails}
             key={output.name}
             disabled={!isPipelineEditor}
-            onClose={deselectNode}
           />,
         );
       }


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

Remove the "Close" button from IO Node value editors. The button is redundant because: values save on blur, and the panel can be closed by clicking on the canvas or something else.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->
Closes https://github.com/Shopify/oasis-frontend/issues/239

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
