### PR TITLE
fix ui bug in io node

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfiguration/ioCell.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfiguration/ioCell.tsx
@@ -93,8 +93,8 @@ const IoCell = ({ io, artifacts }: IoCellProps) => {
   return (
     <Collapsible key={io.name}>
       <div className="flex flex-col gap-3 py-3 border rounded-md relative z-10 bg-white">
-        <div className="flex justify-between px-3 gap-2">
-          <div className="flex-1 min-w-auto flex-shrink-0">
+        <div className="flex justify-between px-3 gap-2 flex-wrap">
+          <div className="min-w-auto flex-shrink-0">
             <Tooltip
               delayDuration={300}
               open={isTooltipOpen}


### PR DESCRIPTION
## Description

Adjusted the flex layout in the IoCell component to improve responsiveness. Changed the parent div to use `flex-wrap` and removed the `flex-1` class from the child div to prevent unwanted stretching.

## Type of Change

- [x] Improvement
- [x] Bug fix

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Test Instructions

Verify that the IoCell component renders correctly with proper wrapping behavior when the container width is constrained.

[Screen Recording 2025-09-12 at 2.00.00 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/user-attachments/thumbnails/1bf983c2-d110-4d06-b6a0-14b467aa65de.mov" />](https://app.graphite.dev/user-attachments/video/1bf983c2-d110-4d06-b6a0-14b467aa65de.mov)

