### PR TITLE
Added logs auto-scroll

### DIFF
--- a/src/components/shared/CodeViewer/CodeSyntaxHighlighter.test.tsx
+++ b/src/components/shared/CodeViewer/CodeSyntaxHighlighter.test.tsx
@@ -3,8 +3,8 @@ import { describe, expect, test, vi } from "vitest";
 
 // Mock Monaco to render plain text so we can assert on content
 vi.mock("@monaco-editor/react", () => ({
-  default: ({ defaultValue }: { defaultValue: string }) => (
-    <pre data-testid="monaco-mock">{defaultValue}</pre>
+  default: ({ value }: { value: string }) => (
+    <pre data-testid="monaco-mock">{value}</pre>
   ),
 }));
 

--- a/src/components/shared/CodeViewer/CodeSyntaxHighlighter.tsx
+++ b/src/components/shared/CodeViewer/CodeSyntaxHighlighter.tsx
@@ -1,21 +1,99 @@
 import MonacoEditor from "@monaco-editor/react";
-import { memo } from "react";
+import type { editor } from "monaco-editor";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 interface CodeSyntaxHighlighterProps {
   code: string;
   language: string;
+  isFullscreen?: boolean;
 }
 
-const CodeSyntaxHighlighter = memo(function CodeSyntaxHighlighter({
+const CodeSyntaxHighlighter = ({
   code,
   language,
-}: CodeSyntaxHighlighterProps) {
+  isFullscreen = false,
+}: CodeSyntaxHighlighterProps) => {
+  const editorInstance = useRef<editor.IStandaloneCodeEditor | null>(null);
+  const [autoScrollEnabled, setAutoScrollEnabled] = useState(true);
+  const autoScrollEnabledRef = useRef(true);
+
+  // Keep ref in sync with state
+  useEffect(() => {
+    autoScrollEnabledRef.current = autoScrollEnabled;
+  }, [autoScrollEnabled]);
+
+  const scrollToBottom = useCallback(() => {
+    if (editorInstance.current) {
+      const model = editorInstance.current.getModel();
+      if (model) {
+        const lineCount = model.getLineCount();
+        editorInstance.current.revealLine(lineCount);
+      }
+    }
+  }, []);
+
+  const isAtBottom = useCallback((): boolean => {
+    if (!editorInstance.current) return false;
+
+    const scrollTop = editorInstance.current.getScrollTop();
+    const scrollHeight = editorInstance.current.getScrollHeight();
+    const layoutInfo = editorInstance.current.getLayoutInfo();
+    const visibleHeight = layoutInfo.height;
+
+    // Consider "at bottom" if we're within 50 pixels of the bottom
+
+    const threshold = 50;
+    const distanceFromBottom = Math.max(
+      0,
+      scrollHeight - scrollTop - visibleHeight,
+    );
+
+    return distanceFromBottom <= threshold;
+  }, []);
+
+  // Auto-scroll when code changes if enabled
+  useEffect(() => {
+    if (autoScrollEnabled) {
+      scrollToBottom();
+    }
+  }, [code, autoScrollEnabled, scrollToBottom]);
+
+  // Re-scroll when transitioning from fullscreen
+  useEffect(() => {
+    if (!isFullscreen && autoScrollEnabled) {
+      const timer = setTimeout(scrollToBottom, 100);
+      return () => clearTimeout(timer);
+    }
+  }, [isFullscreen, autoScrollEnabled, scrollToBottom]);
+
+  const handleEditorDidMount = useCallback(
+    (editor: editor.IStandaloneCodeEditor) => {
+      editorInstance.current = editor;
+
+      // Initially scroll to bottom
+      scrollToBottom();
+
+      // Listen for scroll events to enable/disable auto-scroll
+      editor.onDidScrollChange(() => {
+        const atBottom = isAtBottom();
+
+        // Simple logic: if at bottom, enable auto-scroll; if not, disable it
+        if (atBottom && !autoScrollEnabledRef.current) {
+          setAutoScrollEnabled(true);
+        } else if (!atBottom && autoScrollEnabledRef.current) {
+          setAutoScrollEnabled(false);
+        }
+      });
+    },
+    [isAtBottom, scrollToBottom],
+  );
+
   return (
     <MonacoEditor
-      key={code} // force re-render when code changes
       defaultLanguage={language}
       theme="vs-dark"
-      defaultValue={code}
+      value={code}
+      onMount={handleEditorDidMount}
       options={{
         readOnly: true,
         minimap: {
@@ -28,6 +106,6 @@ const CodeSyntaxHighlighter = memo(function CodeSyntaxHighlighter({
       }}
     />
   );
-});
+};
 
 export default CodeSyntaxHighlighter;

--- a/src/components/shared/CodeViewer/CodeViewer.tsx
+++ b/src/components/shared/CodeViewer/CodeViewer.tsx
@@ -68,7 +68,11 @@ const CodeViewer = ({
             className="absolute inset-0 overflow-y-auto bg-slate-900"
             style={{ willChange: "transform", minHeight: DEFAULT_HEIGHT }}
           >
-            <CodeSyntaxHighlighter code={code} language={language} />
+            <CodeSyntaxHighlighter
+              code={code}
+              language={language}
+              isFullscreen={isFullscreen}
+            />
           </div>
         </div>
       </div>

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfiguration/TaskConfiguration.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfiguration/TaskConfiguration.tsx
@@ -151,7 +151,7 @@ const TaskConfiguration = ({ taskNode, actions }: TaskConfigurationProps) => {
           {readOnly && (
             <TabsContent value="logs" className="h-full">
               {!!executionId && (
-                <div className="flex w-full justify-end pr-4">
+                <div className="flex w-full justify-end items-center pr-4 mb-2">
                   <OpenLogsInNewWindowLink
                     executionId={executionId}
                     status={runStatus}

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfiguration/logs.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfiguration/logs.tsx
@@ -113,6 +113,7 @@ const Logs = ({
     log_text?: string;
     system_error_exception_full?: string;
   }>();
+
   const { data, isLoading, error, refetch } = useQuery({
     queryKey: ["logs", executionId],
     queryFn: () => getLogs(String(executionId), backendUrl),


### PR DESCRIPTION
## Description

Added an auto-scroll feature to task logs in the ReactFlow TaskConfiguration component. This enhancement allows users to toggle automatic scrolling to the bottom of logs as new content arrives, improving the user experience when monitoring task execution in real-time.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

![image.png](https://app.graphite.dev/user-attachments/assets/7348ea1e-0ea0-439a-8697-d97b05e95719.png)

## Test Instructions

1. Open an ongoing run
2. Click on a currently executing task
3. Select "Logs", then click "Auto-scroll to bottom"
4. Check that the code viewer scrolls down automatically as the logs are arriving
5. Open the logs in fullscreen mode
6. Check that the code viewer scrolls down automatically as the logs are arriving

## Additional Comments

The auto-scroll feature uses a setTimeout to ensure the Monaco editor has fully rendered the logs before attempting to scroll to the bottom.