### PR TITLE
Fixed IONode type detection

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/IONode/IONode.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/IONode/IONode.tsx
@@ -115,7 +115,9 @@ const IONode = ({ type, data, selected = false }: IONodeProps) => {
         {/* type */}
         <div className="text-xs text-slate-700 font-mono truncate max-w-[250px]">
           <span className="font-bold text-slate-700">Type:</span>{" "}
-          {outputConnectedType || data.type || "Any"}
+          {type === "input"
+            ? input?.type?.toString() || "Any"
+            : outputConnectedType || output?.type?.toString() || "Any"}
         </div>
 
         <span className="font-bold text-slate-700">


### PR DESCRIPTION
## Description

This PR fixes the type display in IONode components. For input nodes, it now shows the input type if available, and for output nodes, it shows either the connected output type or the output's own type. This ensures more accurate type information is displayed to users.

## Related Issue and Pull requests

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Screenshots (if applicable)

### Before

![image.png](https://app.graphite.dev/user-attachments/assets/9e9b96e4-5641-4e2a-9024-88403be7b0d2.png)

### After

![image.png](https://app.graphite.dev/user-attachments/assets/d1eaedc6-fddb-4b0c-b146-4b90ff72a3b8.png)

## Test Instructions

1. Create a flow with input and output nodes
2. Verify that input nodes correctly display their type information
3. Verify that output nodes show either the connected output type or their own type

## Additional Comments