### PR TITLE
Uses code syntax highlighter for new components

### DIFF
--- a/src/components/shared/CodeViewer/CodeSyntaxHighlighter.tsx
+++ b/src/components/shared/CodeViewer/CodeSyntaxHighlighter.tsx
@@ -4,11 +4,13 @@ import { memo } from "react";
 interface CodeSyntaxHighlighterProps {
   code: string;
   language: string;
+  readOnly?: boolean;
 }
 
 const CodeSyntaxHighlighter = memo(function CodeSyntaxHighlighter({
   code,
   language,
+  readOnly = true,
 }: CodeSyntaxHighlighterProps) {
   return (
     <MonacoEditor
@@ -17,7 +19,7 @@ const CodeSyntaxHighlighter = memo(function CodeSyntaxHighlighter({
       theme="vs-dark"
       defaultValue={code}
       options={{
-        readOnly: true,
+        readOnly: readOnly,
         minimap: {
           enabled: false,
         },

--- a/src/components/shared/ComponentEditor/ComponentEditorDialog.tsx
+++ b/src/components/shared/ComponentEditor/ComponentEditorDialog.tsx
@@ -1,4 +1,3 @@
-import MonacoEditor from "@monaco-editor/react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { Button } from "@/components/ui/button";
@@ -11,6 +10,7 @@ import { hydrateComponentReference } from "@/services/componentService";
 import type { TaskNodeData } from "@/types/taskNode";
 import type { ComponentReference, TaskSpec } from "@/utils/componentSpec";
 
+import CodeSyntaxHighlighter from "../CodeViewer/CodeSyntaxHighlighter";
 import { FullscreenElement } from "../FullscreenElement";
 import { TaskNodeCard } from "../ReactFlow/FlowCanvas/TaskNode/TaskNodeCard";
 import { withSuspenseWrapper } from "../SuspenseWrapper";
@@ -145,20 +145,7 @@ export const ComponentEditorDialog = withSuspenseWrapper(
           </InlineStack>
           <div className="w-full flex flex-row h-full">
             <BlockStack className="flex-1 h-full">
-              <MonacoEditor
-                defaultLanguage={"yaml"}
-                theme="vs-dark"
-                defaultValue={dummyComponentText}
-                options={{
-                  minimap: {
-                    enabled: true,
-                  },
-                  scrollBeyondLastLine: false,
-                  lineNumbers: "on",
-                  wordWrap: "on",
-                  automaticLayout: true,
-                }}
-              />
+              <CodeSyntaxHighlighter code={dummyComponentText} language="yaml" readOnly={false} />
             </BlockStack>
             <BlockStack className="flex-1 h-full">
               <Heading level={2}>Preview</Heading>


### PR DESCRIPTION
## Description

Added a `readOnly` prop to the `CodeSyntaxHighlighter` component with a default value of `true`. This allows the component to be used in both read-only and editable contexts. Also replaced the direct usage of `MonacoEditor` in `ComponentEditorDialog` with the `CodeSyntaxHighlighter` component, setting `readOnly={false}` to make it editable.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [x] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

1. Open the Component Editor dialog
2. Verify that the code editor is editable
3. Check that other instances of `CodeSyntaxHighlighter` throughout the application remain read-only