### PR TITLE
wire up component editor to save component

### DIFF
--- a/src/components/shared/ComponentEditor/ComponentEditorDialog.tsx
+++ b/src/components/shared/ComponentEditor/ComponentEditorDialog.tsx
@@ -101,6 +101,15 @@ export const ComponentEditorDialog = withSuspenseWrapper(
     visible: boolean;
     onClose: (componentText: string) => void;
   }) => {
+    const [componentText, setComponentText] = useState(dummyComponentText);
+
+    const handleComponentTextChange = useCallback(
+      (value: string | undefined) => {
+        setComponentText(value ?? "");
+      },
+      [],
+    );
+
     const [componentRef, setComponentRef] = useState<
       ComponentReference | undefined
     >(undefined);
@@ -112,18 +121,18 @@ export const ComponentEditorDialog = withSuspenseWrapper(
     }, [componentRef]);
 
     const handleClose = useCallback(() => {
-      onClose(dummyComponentText);
-    }, [onClose]);
+      onClose(componentText);
+    }, [onClose, componentText]);
 
     useEffect(() => {
       let cancelled = false;
-      hydrateComponentReference({ text: dummyComponentText }).then((ref) => {
+      hydrateComponentReference({ text: componentText }).then((ref) => {
         if (!cancelled && ref) setComponentRef(ref);
       });
       return () => {
         cancelled = true;
       };
-    }, []);
+    }, [componentText]);
 
     if (!visible) {
       return null;
@@ -148,7 +157,8 @@ export const ComponentEditorDialog = withSuspenseWrapper(
               <MonacoEditor
                 defaultLanguage={"yaml"}
                 theme="vs-dark"
-                defaultValue={dummyComponentText}
+                value={componentText}
+                onChange={handleComponentTextChange}
                 options={{
                   minimap: {
                     enabled: true,


### PR DESCRIPTION
## Description

Replaced the read-only `CodeSyntaxHighlighter` with an editable `MonacoEditor` in the Component Editor Dialog. This change enables users to edit component text directly in the editor with features like syntax highlighting, line numbers, and minimap. The component preview now updates based on the edited text.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Open the Component Editor Dialog
2. Verify that the Monaco editor appears with syntax highlighting and editing capabilities
3. Make changes to the component text and confirm that the preview updates accordingly
4. Close the dialog and verify that the edited text is properly saved

## Additional Comments

The Monaco Editor provides a more robust editing experience with features like code completion, error highlighting, and better navigation compared to the previous implementation.