### PR TITLE
Add a Comment to the Canvas

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/CommentNode/CommentNode.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/CommentNode/CommentNode.tsx
@@ -1,0 +1,24 @@
+import { type NodeProps } from "@xyflow/react";
+import { memo } from "react";
+
+import { cn } from "@/lib/utils";
+
+const CommentNode = memo(({ data }: NodeProps) => {
+  const typedData = data as { message: string };
+  return (
+    <div
+      className={cn(
+        "border-2 border-dashed border-gray-400/60 rounded-lg p-2 bg-gray-100",
+        "dark:border-gray-600/60 dark:bg-gray-800",
+        "min-w-[120px] min-h-[60px] flex items-center justify-center",
+        "text-sm text-gray-600 dark:text-gray-300",
+      )}
+    >
+      <p>{typedData.message}</p>
+    </div>
+  );
+});
+
+CommentNode.displayName = "CommentNode";
+
+export default CommentNode;

--- a/src/components/shared/ReactFlow/FlowCanvas/utils/removeNode.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/utils/removeNode.ts
@@ -29,6 +29,21 @@ export const removeNode = (node: Node, componentSpec: ComponentSpec) => {
     return removeGraphOutput(outputName, componentSpec);
   }
 
+  if (node.type === "comment") {
+    // Comments can be removed directly from the component spec
+    const commentId = node.id;
+    const newMetadata = {
+      ...componentSpec.metadata,
+      annotations: {
+        ...componentSpec.metadata?.annotations,
+        comments: (componentSpec.metadata?.annotations?.comments || []).filter(
+          (comment) => comment.id !== commentId,
+        ),
+      },
+    };
+    return { ...componentSpec, metadata: newMetadata };
+  }
+
   return componentSpec;
 };
 

--- a/src/components/shared/ReactFlow/FlowCanvas/utils/updateNodePosition.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/utils/updateNodePosition.ts
@@ -94,6 +94,22 @@ export const updateNodePositions = (
 
         newComponentSpec.outputs = outputs;
       }
+    } else if (node.type === "comment") {
+      if (newComponentSpec.metadata?.annotations?.comments) {
+        const comments = [...newComponentSpec.metadata.annotations.comments];
+        const commentIndex = comments.findIndex(
+          (comment) => comment.id === node.id,
+        );
+
+        if (commentIndex >= 0) {
+          comments[commentIndex] = {
+            ...comments[commentIndex],
+            position: newPosition,
+          };
+
+          newComponentSpec.metadata.annotations.comments = comments;
+        }
+      }
     }
   }
 

--- a/src/utils/componentSpec.ts
+++ b/src/utils/componentSpec.ts
@@ -1,3 +1,5 @@
+import type { XYPosition } from "@xyflow/react";
+
 import type {
   ContainerImplementationOutput,
   GraphImplementationOutput,
@@ -136,12 +138,20 @@ interface ContainerImplementation {
   container: ContainerSpec;
 }
 type ImplementationType = ContainerImplementation | GraphImplementation;
+
+export type Comment = {
+  id: string;
+  message: string;
+  position: XYPosition;
+};
+
 export interface MetadataSpec {
   annotations?: {
     [k: string]: unknown;
     canonical_location?: string;
     author?: string;
     python_original_code?: string;
+    comments?: Comment[];
   };
 }
 /**

--- a/src/utils/nodes/createCommentsFromComponentSpec.ts
+++ b/src/utils/nodes/createCommentsFromComponentSpec.ts
@@ -1,0 +1,30 @@
+import { type Node, type XYPosition } from "@xyflow/react";
+
+import type { Comment, ComponentSpec } from "../componentSpec";
+
+export function createCommentsFromComponentSpec(
+  componentSpec: ComponentSpec,
+): Node[] {
+  const comments: Comment[] =
+    componentSpec.metadata?.annotations?.comments || [];
+
+  return comments.map(({ message, position, id }) =>
+    createCommentNode(message, position, id),
+  );
+}
+
+const createCommentNode = (
+  message: string,
+  position: XYPosition,
+  id: string,
+) => {
+  return {
+    id,
+    data: {
+      message,
+    },
+    position,
+    connectable: false,
+    type: "comment",
+  } as Node;
+};


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

Adds the ability to add comment nodes to the canvas by clicking when the "comment" toggle is active.

Comment nodes can be moved and deleted.

Note: currently comment nodes are hardcoded string - design, ux and functionality will come later.


Todo:
- Proper delete dialog text for comment nodes
- improve Comment data type; does it belong in component spec?
- fix comment summary list in pipeline details
- Edit & delete
- toggle to switch between label and comment
    - labels are just nodes with some words in them 0 the words display on the node in the canvas
    - comments are nodes that are a just a faint icon  - they expand when clicked, showing their content in a popover
- condensed mode (like google docs) for minimal visual impact
- Do comments and/or labels get copied or involved with bulk actions?

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [ ] Bug fix
- [x] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

![image.png](https://app.graphite.dev/user-attachments/assets/a0d0d427-088b-44a2-9474-12bb5b7a781c.png)

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
