### PR TITLE
support multiple templates for new components

### DIFF
--- a/src/components/shared/ComponentEditor/ComponentEditorDialog.tsx
+++ b/src/components/shared/ComponentEditor/ComponentEditorDialog.tsx
@@ -14,6 +14,7 @@ import type { ComponentReference, TaskSpec } from "@/utils/componentSpec";
 import { FullscreenElement } from "../FullscreenElement";
 import { TaskNodeCard } from "../ReactFlow/FlowCanvas/TaskNode/TaskNodeCard";
 import { withSuspenseWrapper } from "../SuspenseWrapper";
+import { useTemplateCodeByName } from "./useTemplateCodeByName";
 
 const ComponentEditorDialogSkeleton = () => {
   return (
@@ -41,67 +42,17 @@ const ComponentEditorDialogSkeleton = () => {
   );
 };
 
-const dummyComponentText = `name: Filter text using Ruby
-inputs:
-- {name: Text}
-- {name: Pattern, default: '.*'}
-outputs:
-- {name: Filtered text}
-metadata:
-  annotations:
-    author: Alexey Volkov <alexey.volkov@ark-kun.com>
-    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/sample/Ruby_script/component.yaml'
-implementation:
-  container:
-    image: ruby:3.4.3
-    command:
-    - sh
-    - -ec
-    - |
-      # This is how additional gems can be installed dynamically
-      # gem install something
-      # Run the rest of the command after installing the gems.
-      "$0" "$@"
-    - ruby
-    - -e
-    - |
-      require 'fileutils'
-
-      text_path = ARGV[0]
-      pattern = ARGV[1]
-      filtered_text_path = ARGV[2]
-
-      regex = Regexp.new(pattern)
-
-      # Create the directory for the output file if it doesn't exist
-      FileUtils.mkdir_p(File.dirname(filtered_text_path))
-
-      # Open the input file for reading
-      File.open(text_path, 'r') do |reader|
-        # Open the output file for writing
-        File.open(filtered_text_path, 'w') do |writer|
-          reader.each_line do |line|
-            if regex.match(line)
-              writer.write(line)
-            end
-          end
-        end
-      end
-
-    - {inputPath: Text}
-    - {inputValue: Pattern}
-    - {outputPath: Filtered text}
-`;
-
 export const ComponentEditorDialog = withSuspenseWrapper(
   ({
-    visible,
     onClose,
+    templateName = "empty",
   }: {
-    visible: boolean;
     onClose: (componentText: string) => void;
+    templateName: string;
   }) => {
-    const [componentText, setComponentText] = useState(dummyComponentText);
+    const { data: templateCode } = useTemplateCodeByName(templateName);
+
+    const [componentText, setComponentText] = useState(templateCode);
 
     const handleComponentTextChange = useCallback(
       (value: string | undefined) => {
@@ -133,10 +84,6 @@ export const ComponentEditorDialog = withSuspenseWrapper(
         cancelled = true;
       };
     }, [componentText]);
-
-    if (!visible) {
-      return null;
-    }
 
     return (
       <FullscreenElement fullscreen={true}>

--- a/src/components/shared/ComponentEditor/templates/bash.yaml
+++ b/src/components/shared/ComponentEditor/templates/bash.yaml
@@ -1,0 +1,26 @@
+name: Filter text using shell and grep
+inputs:
+- {name: Text}
+- {name: Pattern, default: '.*'}
+outputs:
+- {name: Filtered text}
+metadata:
+  annotations:
+    author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/sample/Shell_script/component.yaml'
+implementation:
+  container:
+    image: alpine
+    command:
+    - sh
+    - -ec
+    - |
+      text_path=$0
+      pattern=$1
+      filtered_text_path=$2
+      mkdir -p "$(dirname "$filtered_text_path")"
+
+      grep "$pattern" < "$text_path" > "$filtered_text_path"
+    - {inputPath: Text}
+    - {inputValue: Pattern}
+    - {outputPath: Filtered text}

--- a/src/components/shared/ComponentEditor/templates/javascript.yaml
+++ b/src/components/shared/ComponentEditor/templates/javascript.yaml
@@ -1,0 +1,43 @@
+name: Filter text with pattern using JavaScript
+inputs:
+- {name: Text}
+- {name: Pattern, type: String, default: '.*'}
+outputs:
+- {name: Filtered text}
+metadata:
+  annotations:
+    author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/sample/JavaScript/component.yaml'
+implementation:
+  container:
+    image: node:18.0.0-slim
+    command:
+    - node
+    - --eval
+    - |
+      const fs = require("fs");
+      const readline = require("readline");
+      const path = require("path");
+
+      // Skip 1 argument when running the script using node --eval
+      // Skip 2 arguments when running from file: `node grep.js`.
+      const args = process.argv.slice(1);
+      const input_path = args[0];
+      const pattern = args[1];
+      const output_path = args[2];
+
+      fs.mkdirSync(path.dirname(output_path), { recursive: true });
+      const inputStream = fs.createReadStream(input_path);
+      const outputStream = fs.createWriteStream(output_path, { encoding: "utf8" });
+      var lineReader = readline.createInterface({
+        input: inputStream,
+        terminal: false,
+      });
+      lineReader.on("line", function (line) {
+        if (line.match(pattern)) {
+          outputStream.write(line + "\n");
+        }
+      });
+    - {inputPath: Text}
+    - {inputValue: Pattern}
+    - {outputPath: Filtered text}

--- a/src/components/shared/ComponentEditor/templates/python.yaml
+++ b/src/components/shared/ComponentEditor/templates/python.yaml
@@ -1,0 +1,44 @@
+name: Filter text
+inputs:
+- {name: Text}
+- {name: Pattern, default: '.*'}
+outputs:
+- {name: Filtered text}
+metadata:
+  annotations:
+    author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/sample/Python_script/component.yaml'
+implementation:
+  container:
+    image: python:3.8
+    command:
+    - sh
+    - -ec
+    - |
+      # This is how additional packages can be installed dynamically
+      python3 -m pip install pip six
+      # Run the rest of the command after installing the packages.
+      "$0" "$@"
+    - python3
+    - -u  # Auto-flush. We want the logs to appear in the console immediately.
+    - -c  # Inline scripts are easy, but have size limitaions and the error traces do not show source lines.
+    - |
+      import os
+      import re
+      import sys
+
+      text_path = sys.argv[1]
+      pattern = sys.argv[2]
+      filtered_text_path = sys.argv[3]
+
+      regex = re.compile(pattern)
+
+      os.makedirs(os.path.dirname(filtered_text_path), exist_ok=True)
+      with open(text_path, 'r') as reader:
+          with open(filtered_text_path, 'w') as writer:
+              for line in reader:
+                  if regex.search(line):
+                      writer.write(line)
+    - {inputPath: Text}
+    - {inputValue: Pattern}
+    - {outputPath: Filtered text}

--- a/src/components/shared/ComponentEditor/templates/ruby.yaml
+++ b/src/components/shared/ComponentEditor/templates/ruby.yaml
@@ -1,0 +1,50 @@
+name: Filter text using Ruby
+inputs:
+- {name: Text}
+- {name: Pattern, default: '.*'}
+outputs:
+- {name: Filtered text}
+metadata:
+  annotations:
+    author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/sample/Ruby_script/component.yaml'
+implementation:
+  container:
+    image: ruby:3.4.3
+    command:
+    - sh
+    - -ec
+    - |
+      # This is how additional gems can be installed dynamically
+      # gem install something
+      # Run the rest of the command after installing the gems.
+      "$0" "$@"
+    - ruby
+    - -e
+    - |
+      require 'fileutils'
+
+      text_path = ARGV[0]
+      pattern = ARGV[1]
+      filtered_text_path = ARGV[2]
+
+      regex = Regexp.new(pattern)
+
+      # Create the directory for the output file if it doesn't exist
+      FileUtils.mkdir_p(File.dirname(filtered_text_path))
+
+      # Open the input file for reading
+      File.open(text_path, 'r') do |reader|
+        # Open the output file for writing
+        File.open(filtered_text_path, 'w') do |writer|
+          reader.each_line do |line|
+            if regex.match(line)
+              writer.write(line)
+            end
+          end
+        end
+      end
+
+    - {inputPath: Text}
+    - {inputValue: Pattern}
+    - {outputPath: Filtered text}

--- a/src/components/shared/ComponentEditor/useTemplateCodeByName.ts
+++ b/src/components/shared/ComponentEditor/useTemplateCodeByName.ts
@@ -1,0 +1,34 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+
+const cachedTemplates = new Map<string, Promise<string>>([
+  ["empty", Promise.resolve("")],
+]);
+
+const availableTemplates = import.meta.glob("./templates/*.yaml", {
+  query: "?raw",
+  import: "default",
+});
+
+async function getTemplateCodeByName(name: string) {
+  if (name === "empty") {
+    return "";
+  }
+
+  return availableTemplates[`./templates/${name}.yaml`]().then(
+    (content) => content as unknown as string,
+  );
+}
+
+/**
+ * Get the code for a template by name
+ *
+ * @param name - The name of the template to get the code for
+ * @returns
+ */
+export function useTemplateCodeByName(name: string) {
+  return useSuspenseQuery({
+    queryKey: ["template", name],
+    queryFn: () => getTemplateCodeByName(name),
+    staleTime: 1000 * 60 * 60 * 24, // 24 hours
+  });
+}

--- a/src/components/shared/ReactFlow/FlowSidebar/components/ImportComponent.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/components/ImportComponent.tsx
@@ -37,14 +37,30 @@ type Template = {
   name: string;
   icon?: keyof typeof icons;
   color?: string;
+  templateName: string;
 };
 
 const SUPPORTED_TEMPLATES: Template[] = [
-  { name: "Empty" },
-  { name: "Ruby", icon: "Gem", color: "text-red-400" },
-  { name: "Python", icon: "Worm", color: "text-green-400" },
-  { name: "JavaScript", icon: "Hexagon", color: "text-yellow-400" },
-  { name: "Bash", icon: "Terminal", color: "text-gray-400" },
+  { name: "Empty", templateName: "empty" },
+  { name: "Ruby", icon: "Gem", color: "text-red-400", templateName: "ruby" },
+  {
+    name: "Python",
+    icon: "Worm",
+    color: "text-green-400",
+    templateName: "python",
+  },
+  {
+    name: "JavaScript",
+    icon: "Hexagon",
+    color: "text-yellow-400",
+    templateName: "javascript",
+  },
+  {
+    name: "Bash",
+    icon: "Terminal",
+    color: "text-gray-400",
+    templateName: "bash",
+  },
 ];
 
 const ImportComponent = ({
@@ -64,11 +80,12 @@ const ImportComponent = ({
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const { addToComponentLibrary } = useComponentLibrary();
-  const [isComponentEditorDialogOpen, setIsComponentEditorDialogOpen] =
-    useState(false);
+  const [componentEditorTemplateSelected, setComponentEditorTemplateSelected] =
+    useState<string | undefined>();
+
   const handleComponentEditorDialogClose = useCallback(
     async (componentText: string) => {
-      setIsComponentEditorDialogOpen(false);
+      setComponentEditorTemplateSelected(undefined);
       // saveNewComponentToFile
       const hydratedComponent = await hydrateComponentReference({
         text: componentText,
@@ -294,7 +311,11 @@ const ImportComponent = ({
                         key={template.name}
                         variant="ghost"
                         className="p-0 h-full w-full"
-                        onClick={() => setIsComponentEditorDialogOpen(true)}
+                        onClick={() =>
+                          setComponentEditorTemplateSelected(
+                            template.templateName,
+                          )
+                        }
                       >
                         <BlockStack
                           gap="1"
@@ -346,10 +367,13 @@ const ImportComponent = ({
           </DialogFooter>
         </DialogContent>
       </Dialog>
-      <ComponentEditorDialog
-        visible={isComponentEditorDialogOpen}
-        onClose={handleComponentEditorDialogClose}
-      />
+      {componentEditorTemplateSelected !== undefined && (
+        <ComponentEditorDialog
+          key={componentEditorTemplateSelected}
+          onClose={handleComponentEditorDialogClose}
+          templateName={componentEditorTemplateSelected ?? "empty"}
+        />
+      )}
     </>
   );
 };

--- a/vite.config.js
+++ b/vite.config.js
@@ -16,6 +16,7 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  assetsInclude: ["**/*.yaml"],
   test: {
     globals: true,
     environment: "jsdom",


### PR DESCRIPTION
## Description

Added component templates for the component editor dialog. This PR introduces a template system that allows users to select from predefined component templates (Python, Ruby, JavaScript, Bash) when creating new components. The implementation includes:

- Created a template utility function to load and cache templates
- Added YAML template files for different programming languages
- Modified the ComponentEditorDialog to accept and use templates
- Updated the ImportComponent to pass the selected template to the editor

## Type of Change

- [x] New feature
- [x] Improvement

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

1. Open the component import dialog
2. Select one of the template options (Python, Ruby, JavaScript, Bash, or Empty)
3. Verify the component editor opens with the correct template code
4. Test saving the component with modifications