### PR TITLE
Edited Components save as a new entry in library

### DIFF
--- a/src/components/shared/ComponentEditor/ComponentEditorDialog.tsx
+++ b/src/components/shared/ComponentEditor/ComponentEditorDialog.tsx
@@ -44,17 +44,19 @@ const ComponentEditorDialogSkeleton = () => {
 
 export const ComponentEditorDialog = withSuspenseWrapper(
   ({
+    text,
+    templateName = "empty",
     onSave,
     onClose,
-    templateName = "empty",
   }: {
+    text?: string;
+    templateName?: string;
     onSave: (componentText: string) => void;
     onClose: () => void;
-    templateName: string;
   }) => {
     const { data: templateCode } = useTemplateCodeByName(templateName);
 
-    const [componentText, setComponentText] = useState(templateCode);
+    const [componentText, setComponentText] = useState(text ?? templateCode);
 
     const handleComponentTextChange = useCallback(
       (value: string | undefined) => {


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

Adds the ability to edit an existing component definition. This is accessed via the available actions on TaskDetails via the context panel or component definition dialog.

Edited components will then save as a new entry in the component library. As long as the component change has not changed the user will be prompted to replace the existing component library definition (we will follow up to make it go through the on-canvas replace flow separately)

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] New feature
- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

![image.png](https://app.graphite.dev/user-attachments/assets/594c39fd-0da0-498d-8b77-151763b0e70f.png)

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
