### PR TITLE
Fix Bug in Argument Editor Placeholders

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/ArgumentInputField.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/ArgumentInputField.tsx
@@ -181,6 +181,11 @@ export const ArgumentInputField = ({
   );
 
   const placeholder = useMemo(() => {
+    const inputPlaceholder = getPlaceholder(argument.value);
+    if (inputPlaceholder) {
+      return inputPlaceholder;
+    }
+
     if (argument.inputSpec.default !== undefined) {
       return argument.inputSpec.default;
     }
@@ -189,7 +194,7 @@ export const ArgumentInputField = ({
       return "";
     }
 
-    return getPlaceholder(argument.value);
+    return "";
   }, [argument]);
 
   useEffect(() => {

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/utils.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/utils.ts
@@ -52,14 +52,14 @@ export const typeSpecToString = (typeSpec?: TypeSpecType): string => {
 
 export const getPlaceholder = (argument: ArgumentType) => {
   if (typeof argument === "string" || !argument) {
-    return "";
+    return null;
   }
 
   if (argument && "taskOutput" in argument) {
-    return `<from task ${argument.taskOutput.taskId} / ${argument.taskOutput.outputName}>`;
+    return `<from task: ${argument.taskOutput.taskId} / ${argument.taskOutput.outputName}>`;
   }
   if (argument && "graphInput" in argument) {
-    return `<from graph input ${argument.graphInput.inputName}>`;
+    return `<from graph input: ${argument.graphInput.inputName}>`;
   }
   return "<reference>";
 };


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Fixes a bug where arguments with default values would display the default value as a placeholder instead of indicating that it is connected to something else.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

<img width="375" height="183" alt="image" src="https://github.com/user-attachments/assets/9d2fc770-0956-4152-a547-e647088e789f" />


## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->
- add a task with inputs and at least one input with a default value
- observe that the input with a default value displays that default as a placeholder when no value is entered
- connect something into that input, e.g. an input node
- observe that the input with a default value now displays "<from graph input: ... >" as a placeholder
(previously it would continue to display the default value)

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
