### PR TITLE
cleans up component editor

### DIFF
--- a/src/components/shared/Dialogs/ComponentDetailsDialog.tsx
+++ b/src/components/shared/Dialogs/ComponentDetailsDialog.tsx
@@ -17,6 +17,8 @@ import { useHydrateComponentReference } from "@/hooks/useHydrateComponentReferen
 import type { ComponentReference } from "@/utils/componentSpec";
 
 import InfoIconButton from "../Buttons/InfoIconButton";
+import TooltipButton from "../Buttons/TooltipButton";
+import { ComponentEditorDialog } from "../ComponentEditor/ComponentEditorDialog";
 import { InfoBox } from "../InfoBox";
 import { PublishComponent } from "../ManageComponent/PublishComponent";
 import { PublishedComponentDetails } from "../ManageComponent/PublishedComponentDetails";
@@ -176,6 +178,7 @@ const ComponentDetails = ({
   onClose,
   onDelete,
 }: ComponentDetailsProps) => {
+  const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
   const [open, setOpen] = useState(false);
   const dialogTriggerButton = trigger || <InfoIconButton />;
 
@@ -196,38 +199,68 @@ const ComponentDetails = ({
     [],
   );
 
+  const handleEditComponent = () => {
+    setIsEditDialogOpen(true)
+  };
+  const EditButton = <TooltipButton
+    variant="secondary"
+    onClick={handleEditComponent}
+    tooltip="Edit Component Definition"
+  >
+    <Icon name="FilePenLine" />
+  </TooltipButton>
+
+  const actionsWithEdit = useMemo(() => {
+    return [...actions, EditButton];
+  }, [actions]);
+
+  const componentText = component.text;
+
+  const handleCloseEditDialog = () => {
+    setIsEditDialogOpen(false)
+  }
+
   return (
-    <Dialog modal open={open} onOpenChange={onOpenChange}>
-      <DialogTrigger asChild>{dialogTriggerButton}</DialogTrigger>
+    <>
+      <Dialog modal open={open} onOpenChange={onOpenChange}>
+        <DialogTrigger asChild>{dialogTriggerButton}</DialogTrigger>
 
-      <DialogDescription
-        className="hidden"
-        aria-label={`${displayName} component details`}
-      >
-        {`${displayName} component details`}
-      </DialogDescription>
-      <DialogContent
-        className="max-w-2xl min-w-2xl overflow-hidden"
-        aria-label={`${displayName} component details`}
-      >
-        <DialogHeader>
-          <DialogTitle className="flex items-center gap-2 mr-5">
-            <span>{displayName}</span>
-          </DialogTitle>
-        </DialogHeader>
+        <DialogDescription
+          className="hidden"
+          aria-label={`${displayName} component details`}
+        >
+          {`${displayName} component details`}
+        </DialogDescription>
+        <DialogContent
+          className="max-w-2xl min-w-2xl overflow-hidden"
+          aria-label={`${displayName} component details`}
+        >
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2 mr-5">
+              <span>{displayName}</span>
+            </DialogTitle>
+          </DialogHeader>
 
-        <DialogContext.Provider value={dialogContextValue}>
-          <ComponentDetailsDialogContent
-            component={component}
-            displayName={displayName}
-            trigger={dialogTriggerButton}
-            actions={actions}
-            onClose={onClose}
-            onDelete={onDelete}
-          />
-        </DialogContext.Provider>
-      </DialogContent>
-    </Dialog>
+          <DialogContext.Provider value={dialogContextValue}>
+            <ComponentDetailsDialogContent
+              component={component}
+              displayName={displayName}
+              trigger={dialogTriggerButton}
+              actions={actionsWithEdit}
+              onClose={onClose}
+              onDelete={onDelete}
+            />
+          </DialogContext.Provider>
+        </DialogContent>
+      </Dialog>
+      {isEditDialogOpen && (
+        <ComponentEditorDialog
+          text={componentText}
+          onClose={handleCloseEditDialog}
+          onSave={handleCloseEditDialog}
+        />
+      )}
+    </>
   );
 };
 

--- a/src/components/shared/ReactFlow/FlowSidebar/components/ImportComponent.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/components/ImportComponent.tsx
@@ -29,9 +29,6 @@ import { Heading, Paragraph } from "@/components/ui/typography";
 import useImportComponent from "@/hooks/useImportComponent";
 import useToastNotification from "@/hooks/useToastNotification";
 import { cn } from "@/lib/utils";
-import { useComponentLibrary } from "@/providers/ComponentLibraryProvider/ComponentLibraryProvider";
-import { hydrateComponentReference } from "@/services/componentService";
-import { saveComponent } from "@/utils/localforage";
 
 enum TabType {
   URL = "URL",
@@ -75,7 +72,6 @@ const ImportComponent = ({
   triggerComponent?: ReactNode;
 }) => {
   const notify = useToastNotification();
-  const { addToComponentLibrary } = useComponentLibrary();
 
   const [url, setUrl] = useState("");
   const [tab, setTab] = useState<TabType>(TabType.File);
@@ -85,45 +81,15 @@ const ImportComponent = ({
     null,
   );
   const [selectedFileName, setSelectedFileName] = useState<string>("");
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
   const [componentEditorTemplateSelected, setComponentEditorTemplateSelected] =
     useState<string | undefined>();
 
-  const fileInputRef = useRef<HTMLInputElement>(null);
-
-  const handleComponentEditorDialogClose = useCallback(() => {
+  const handleComponentEditorDialogClose = () => {
     setComponentEditorTemplateSelected(undefined);
     setIsOpen(false);
-  }, []);
-
-  const handleComponentEditorDialogSave = useCallback(
-    async (componentText: string) => {
-      setComponentEditorTemplateSelected(undefined);
-
-      const hydratedComponent = await hydrateComponentReference({
-        text: componentText,
-      });
-
-      if (hydratedComponent) {
-        await saveComponent({
-          id: `component-${hydratedComponent.digest}`,
-          url: "",
-          data: componentText,
-          createdAt: Date.now(),
-          updatedAt: Date.now(),
-        });
-
-        await addToComponentLibrary(hydratedComponent);
-
-        setIsOpen(false);
-
-        notify(
-          `Component ${hydratedComponent.name} imported successfully`,
-          "success",
-        );
-      }
-    },
-    [],
-  );
+  }
 
   const { onImportFromUrl, onImportFromFile, isLoading } = useImportComponent({
     successCallback: () => {
@@ -392,7 +358,7 @@ const ImportComponent = ({
         <ComponentEditorDialog
           key={componentEditorTemplateSelected}
           onClose={handleComponentEditorDialogClose}
-          onSave={handleComponentEditorDialogSave}
+          onSave={handleComponentEditorDialogClose}
           templateName={componentEditorTemplateSelected ?? "empty"}
         />
       )}


### PR DESCRIPTION
## Description

Added an edit button to the Component Details dialog that opens the Component Editor dialog, allowing users to modify component definitions directly from the details view. Refactored the component saving logic to be centralized in the ComponentEditorDialog, removing duplicate code from multiple locations. This improves the user experience by providing a consistent way to edit components throughout the application.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Improvement
- [x] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Open a component's details dialog
2. Click the new edit button (with FilePenLine icon)
3. Verify the Component Editor dialog opens with the component's content
4. Make changes and save
5. Verify the component is updated correctly

## Additional Comments

The edit functionality was removed from TaskDetails and consolidated in ComponentEditorDialog to provide a more consistent editing experience across the application.