### PR TITLE
feat: add subgraph detection and visual indicators

### DIFF
--- a/src/betaFlags.ts
+++ b/src/betaFlags.ts
@@ -33,4 +33,11 @@ export const ExistingBetaFlags = {
       "Enable the in-app component editor for creating and editing Oasis components.",
     default: false,
   } as BetaFlag,
+
+  ["subgraph-navigation"]: {
+    name: "Subgraph Navigation",
+    description:
+      "⚠️ Experimental ⚠️ feature for viewing subgraphs. Navigate into nested pipeline components by double-clicking.",
+    default: false,
+  } as BetaFlag,
 };

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeCard.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeCard.tsx
@@ -6,12 +6,14 @@ import { PublishedComponentBadge } from "@/components/shared/ManageComponent/Pub
 import { trimDigest } from "@/components/shared/ManageComponent/utils/digest";
 import { useBetaFlagValue } from "@/components/shared/Settings/useBetaFlags";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { BlockStack } from "@/components/ui/layout";
+import { Icon } from "@/components/ui/icon";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { QuickTooltip } from "@/components/ui/tooltip";
 import { Text } from "@/components/ui/typography";
 import { cn } from "@/lib/utils";
 import { useContextPanel } from "@/providers/ContextPanelProvider";
 import { useTaskNode } from "@/providers/TaskNodeProvider";
+import { getSubgraphDescription, isSubgraph } from "@/utils/subgraphUtils";
 
 import {
   type NotifyMessage,
@@ -27,6 +29,7 @@ const TaskNodeCard = () => {
   const isRemoteComponentLibrarySearchEnabled = useBetaFlagValue(
     "remote-component-library-search",
   );
+  const isSubgraphNavigationEnabled = useBetaFlagValue("subgraph-navigation");
   const { registerNode } = useNodesOverlay();
   const taskNode = useTaskNode();
   const { setContent, clearContent } = useContextPanel();
@@ -51,6 +54,12 @@ const TaskNodeCard = () => {
 
   const { name, state, callbacks, nodeId, taskSpec, taskId } = taskNode;
   const { dimensions, selected, highlighted, isCustomComponent } = state;
+
+  const isSubgraphNode = useMemo(() => isSubgraph(taskSpec), [taskSpec]);
+  const subgraphDescription = useMemo(
+    () => getSubgraphDescription(taskSpec),
+    [taskSpec],
+  );
 
   const onNotify = useCallback((message: NotifyMessage) => {
     switch (message.type) {
@@ -174,9 +183,16 @@ const TaskNodeCard = () => {
     >
       <CardHeader className="border-b border-slate-200 px-2 py-2.5 flex flex-row justify-between items-start">
         <BlockStack>
-          <CardTitle className="break-words text-left text-xs text-slate-900">
-            {name}
-          </CardTitle>
+          <InlineStack gap="2" blockAlign="center">
+            {isSubgraphNode && isSubgraphNavigationEnabled && (
+              <QuickTooltip content={`Subgraph: ${subgraphDescription}`}>
+                <Icon name="Workflow" size="sm" className="text-blue-600" />
+              </QuickTooltip>
+            )}
+            <CardTitle className="break-words text-left text-xs text-slate-900">
+              {name}
+            </CardTitle>
+          </InlineStack>
           {taskId &&
             taskId !== name &&
             !taskId.match(new RegExp(`^${name}\\s*\\d+$`)) && (

--- a/src/utils/subgraphUtils.test.ts
+++ b/src/utils/subgraphUtils.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+
+import type { TaskSpec } from "./componentSpec";
+import { getSubgraphDescription, isSubgraph } from "./subgraphUtils";
+
+describe("subgraphUtils", () => {
+  const createContainerTaskSpec = (): TaskSpec => ({
+    componentRef: {
+      spec: {
+        implementation: {
+          container: {
+            image: "alpine",
+            command: ["echo", "hello"],
+          },
+        },
+      },
+    },
+  });
+
+  const createGraphTaskSpec = (taskCount = 2): TaskSpec => ({
+    componentRef: {
+      spec: {
+        implementation: {
+          graph: {
+            tasks: Object.fromEntries(
+              Array.from({ length: taskCount }, (_, i) => [
+                `task${i + 1}`,
+                createContainerTaskSpec(),
+              ]),
+            ),
+          },
+        },
+      },
+    },
+  });
+
+  const createNestedGraphTaskSpec = (): TaskSpec => ({
+    componentRef: {
+      spec: {
+        implementation: {
+          graph: {
+            tasks: {
+              "container-task": createContainerTaskSpec(),
+              "subgraph-task": createGraphTaskSpec(3),
+            },
+          },
+        },
+      },
+    },
+  });
+
+  describe("isSubgraph", () => {
+    it("should return false for container tasks", () => {
+      const taskSpec = createContainerTaskSpec();
+      expect(isSubgraph(taskSpec)).toBe(false);
+    });
+
+    it("should return true for graph tasks", () => {
+      const taskSpec = createGraphTaskSpec();
+      expect(isSubgraph(taskSpec)).toBe(true);
+    });
+
+    it("should return false for tasks without spec", () => {
+      const taskSpec: TaskSpec = {
+        componentRef: {},
+      };
+      expect(isSubgraph(taskSpec)).toBe(false);
+    });
+  });
+
+  describe("getSubgraphDescription", () => {
+    it("should return empty string for container tasks", () => {
+      const taskSpec = createContainerTaskSpec();
+      expect(getSubgraphDescription(taskSpec)).toBe("");
+    });
+
+    it("should return correct description for empty subgraph", () => {
+      const taskSpec = createGraphTaskSpec(0);
+      expect(getSubgraphDescription(taskSpec)).toBe("Empty subgraph");
+    });
+
+    it("should return correct description for single task", () => {
+      const taskSpec = createGraphTaskSpec(1);
+      expect(getSubgraphDescription(taskSpec)).toBe("1 task");
+    });
+
+    it("should return correct description for multiple tasks", () => {
+      const taskSpec = createGraphTaskSpec(3);
+      expect(getSubgraphDescription(taskSpec)).toBe("3 tasks");
+    });
+
+    it("should not include depth information for nested subgraphs", () => {
+      const taskSpec = createNestedGraphTaskSpec();
+      const description = getSubgraphDescription(taskSpec);
+      expect(description).toBe("2 tasks");
+    });
+  });
+});

--- a/src/utils/subgraphUtils.ts
+++ b/src/utils/subgraphUtils.ts
@@ -1,0 +1,35 @@
+import type { TaskSpec } from "./componentSpec";
+import { isGraphImplementation } from "./componentSpec";
+import { pluralize } from "./string";
+
+/**
+ * Determines if a task specification represents a subgraph (contains nested graph implementation)
+ */
+export const isSubgraph = (taskSpec: TaskSpec): boolean => {
+  return Boolean(
+    taskSpec.componentRef.spec &&
+      isGraphImplementation(taskSpec.componentRef.spec.implementation),
+  );
+};
+
+/**
+ * Gets a human-readable description of the subgraph content
+ */
+export const getSubgraphDescription = (taskSpec: TaskSpec): string => {
+  if (!isSubgraph(taskSpec)) {
+    return "";
+  }
+
+  const subgraphSpec = taskSpec.componentRef.spec!;
+  if (!isGraphImplementation(subgraphSpec.implementation)) {
+    return "Empty subgraph";
+  }
+
+  const taskCount = Object.keys(subgraphSpec.implementation.graph.tasks).length;
+
+  if (taskCount === 0) {
+    return "Empty subgraph";
+  }
+
+  return `${taskCount} ${pluralize(taskCount, "task")}`;
+};


### PR DESCRIPTION
## Description

Added visual indicators for subgraph nodes in the task node card UI. This enhancement displays a workflow icon next to subgraph node names with a tooltip showing the number of tasks contained within the subgraph.

## Type of Change

- [x] New feature
- [x] Improvement

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Screenshots (if applicable)

![Subgraph node with workflow icon and tooltip]()

## Test Instructions

1. Create a workflow with a subgraph component
2. Verify that subgraph nodes display a blue workflow icon next to their name
3. Hover over the icon to see a tooltip with the subgraph description (e.g., "Subgraph: 3 tasks")
4. Test with empty subgraphs and single-task subgraphs to verify correct descriptions

## Additional Comments

This PR introduces new utility functions for subgraph detection and description generation, with comprehensive test coverage. The implementation is non-invasive and maintains backward compatibility with existing node rendering.