### PR TITLE
feat: add subgraph navigation buttons and state management

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfiguration/TaskConfiguration.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfiguration/TaskConfiguration.tsx
@@ -27,7 +27,7 @@ import IOSection from "./IOSection/IOSection";
 import Logs, { OpenLogsInNewWindowLink } from "./logs";
 import OutputsList from "./OutputsList";
 
-interface ButtonPropsWithTooltip extends ButtonProps {
+export interface ButtonPropsWithTooltip extends ButtonProps {
   tooltip?: string;
 }
 interface TaskConfigurationProps {

--- a/src/components/shared/TaskDetails/Details.tsx
+++ b/src/components/shared/TaskDetails/Details.tsx
@@ -291,7 +291,7 @@ const TaskDetails = ({
             <TooltipContent>Copy YAML</TooltipContent>
           </Tooltip>
 
-          {!readOnly && actions}
+          {actions}
 
           {onDelete && !readOnly && (
             <Tooltip>

--- a/src/providers/ComponentSpecProvider.tsx
+++ b/src/providers/ComponentSpecProvider.tsx
@@ -44,6 +44,11 @@ interface ComponentSpecContextType {
   taskStatusMap: Map<string, string>;
   setTaskStatusMap: (taskStatusMap: Map<string, string>) => void;
   undoRedo: UndoRedo;
+
+  currentSubgraphPath: string[];
+  navigateToSubgraph: (taskId: string) => void;
+  navigateBack: () => void;
+  canNavigateBack: boolean;
 }
 
 const ComponentSpecContext = createRequiredContext<ComponentSpecContextType>(
@@ -69,6 +74,10 @@ export const ComponentSpecProvider = ({
 
   const [isLoading, setIsLoading] = useState(!!spec);
 
+  const [currentSubgraphPath, setCurrentSubgraphPath] = useState<string[]>([
+    "root",
+  ]);
+
   const undoRedo = useUndoRedo(componentSpec, setComponentSpec);
   const undoRedoRef = useRef(undoRedo);
   undoRedoRef.current = undoRedo;
@@ -82,6 +91,7 @@ export const ComponentSpecProvider = ({
     setComponentSpec(EMPTY_GRAPH_COMPONENT_SPEC);
     setTaskStatusMap(new Map());
     setIsLoading(false);
+    setCurrentSubgraphPath(["root"]);
     undoRedoRef.current.clearHistory();
   }, []);
 
@@ -152,6 +162,16 @@ export const ComponentSpecProvider = ({
     }));
   }, []);
 
+  const navigateToSubgraph = useCallback((taskId: string) => {
+    setCurrentSubgraphPath((prev) => [...prev, taskId]);
+  }, []);
+
+  const navigateBack = useCallback(() => {
+    setCurrentSubgraphPath((prev) => prev.slice(0, -1));
+  }, []);
+
+  const canNavigateBack = currentSubgraphPath.length > 1;
+
   const value = useMemo(
     () => ({
       componentSpec,
@@ -167,6 +187,11 @@ export const ComponentSpecProvider = ({
       updateGraphSpec,
       setTaskStatusMap,
       undoRedo,
+
+      currentSubgraphPath,
+      navigateToSubgraph,
+      navigateBack,
+      canNavigateBack,
     }),
     [
       componentSpec,
@@ -182,6 +207,11 @@ export const ComponentSpecProvider = ({
       updateGraphSpec,
       setTaskStatusMap,
       undoRedo,
+
+      currentSubgraphPath,
+      navigateToSubgraph,
+      navigateBack,
+      canNavigateBack,
     ],
   );
 


### PR DESCRIPTION
## Description

Added subgraph navigation functionality to the task node interface. Users can now navigate into subgraphs directly from the task node card via a new button that appears for subgraph nodes. The navigation system tracks the current path through a stack in the ComponentSpecProvider, allowing users to move deeper into nested subgraphs and back up to parent graphs.

Note, this adds the "bones" of the feature and does not actually navigate

## Type of Change

- [x] New feature
- [x] Improvement

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Test Instructions

1. Create a workflow with a subgraph node
2. Click the new workflow icon button on the subgraph node
3. Verify you can navigate into the subgraph
4. Verify you can navigate back to the parent graph