### PR TITLE
feat: implement functional subgraph navigation with back button

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
@@ -38,6 +38,7 @@ import {
 } from "@/utils/componentSpec";
 import { loadComponentAsRefFromText } from "@/utils/componentStore";
 import createNodesFromComponentSpec from "@/utils/nodes/createNodesFromComponentSpec";
+import { getSubgraphComponentSpec } from "@/utils/subgraphUtils";
 
 import ComponentDuplicateDialog from "../../Dialogs/ComponentDuplicateDialog";
 import { useNodesOverlay } from "../NodesOverlay/NodesOverlayProvider";
@@ -103,8 +104,13 @@ const FlowCanvas = ({
   const { clearContent } = useContextPanel();
   const { setReactFlowInstance: setReactFlowInstanceForOverlay } =
     useNodesOverlay();
-  const { componentSpec, setComponentSpec, graphSpec, updateGraphSpec } =
-    useComponentSpec();
+  const {
+    componentSpec,
+    setComponentSpec,
+    graphSpec,
+    updateGraphSpec,
+    currentSubgraphPath,
+  } = useComponentSpec();
   const { preserveIOSelectionOnSpecChange, resetPrevSpec } =
     useIOSelectionPersistence();
 
@@ -714,7 +720,15 @@ const FlowCanvas = ({
 
   const updateReactFlow = useCallback(
     (newComponentSpec: ComponentSpec) => {
-      const newNodes = createNodesFromComponentSpec(newComponentSpec, nodeData);
+      const currentSubgraphSpec = getSubgraphComponentSpec(
+        newComponentSpec,
+        currentSubgraphPath,
+        notify,
+      );
+      const newNodes = createNodesFromComponentSpec(
+        currentSubgraphSpec,
+        nodeData,
+      );
 
       const updatedNewNodes = newNodes.map((node) => ({
         ...node,
@@ -733,14 +747,14 @@ const FlowCanvas = ({
         return updatedNodes;
       });
     },
-    [setNodes, nodeData, replaceTarget],
+    [setNodes, nodeData, replaceTarget, currentSubgraphPath],
   );
 
   useEffect(() => {
     preserveIOSelectionOnSpecChange(componentSpec);
     updateReactFlow(componentSpec);
     initialCanvasLoaded.current = true;
-  }, [componentSpec, preserveIOSelectionOnSpecChange]);
+  }, [componentSpec, currentSubgraphPath, preserveIOSelectionOnSpecChange]);
 
   // Reset when loading a new component file
   useEffect(() => {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -71,3 +71,5 @@ export const KEYBOARD_SHORTCUTS = {
 export const EXIT_CODE_OOM = 137; // SIGKILL (128 + 9) - Out of Memory
 
 export const TWENTY_FOUR_HOURS_IN_MS = 24 * 60 * 60 * 1000;
+
+export const ROOT_TASK_ID = "root";

--- a/src/utils/subgraphUtils.test.ts
+++ b/src/utils/subgraphUtils.test.ts
@@ -1,7 +1,11 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import type { TaskSpec } from "./componentSpec";
-import { getSubgraphDescription, isSubgraph } from "./subgraphUtils";
+import {
+  getSubgraphComponentSpec,
+  getSubgraphDescription,
+  isSubgraph,
+} from "./subgraphUtils";
 
 describe("subgraphUtils", () => {
   const createContainerTaskSpec = (): TaskSpec => ({
@@ -20,6 +24,7 @@ describe("subgraphUtils", () => {
   const createGraphTaskSpec = (taskCount = 2): TaskSpec => ({
     componentRef: {
       spec: {
+        name: "test-graph-component",
         implementation: {
           graph: {
             tasks: Object.fromEntries(
@@ -93,6 +98,141 @@ describe("subgraphUtils", () => {
       const taskSpec = createNestedGraphTaskSpec();
       const description = getSubgraphDescription(taskSpec);
       expect(description).toBe("2 tasks");
+    });
+  });
+
+  describe("getSubgraphComponentSpec", () => {
+    const createRootComponentSpec = () => ({
+      name: "root-component",
+      inputs: [{ name: "rootInput", type: "string" }],
+      outputs: [{ name: "rootOutput", type: "string" }],
+      implementation: {
+        graph: {
+          tasks: {
+            task1: createContainerTaskSpec(),
+            subgraph1: createGraphTaskSpec(2),
+          },
+          outputValues: {},
+        },
+      },
+    });
+
+    it("should return original spec for root path", () => {
+      const rootSpec = createRootComponentSpec();
+      const result = getSubgraphComponentSpec(rootSpec, ["root"]);
+      expect(result).toBe(rootSpec);
+    });
+
+    it("should return original spec for empty path", () => {
+      const rootSpec = createRootComponentSpec();
+      const result = getSubgraphComponentSpec(rootSpec, []);
+      expect(result).toBe(rootSpec);
+    });
+
+    it("should navigate to subgraph", () => {
+      const rootSpec = createRootComponentSpec();
+      const result = getSubgraphComponentSpec(rootSpec, ["root", "subgraph1"]);
+
+      // Should return the subgraph's component spec
+      expect(result.name).toBe("test-graph-component");
+      expect(result.implementation).toHaveProperty("graph");
+    });
+
+    it("should handle invalid task ID gracefully", () => {
+      const rootSpec = createRootComponentSpec();
+      const result = getSubgraphComponentSpec(rootSpec, [
+        "root",
+        "nonexistent",
+      ]);
+
+      // Should return original spec when navigation fails
+      expect(result).toBe(rootSpec);
+    });
+
+    it("should handle non-subgraph task gracefully", () => {
+      const rootSpec = createRootComponentSpec();
+      const result = getSubgraphComponentSpec(rootSpec, ["root", "task1"]);
+
+      // Should return original spec when trying to navigate into non-subgraph
+      expect(result).toBe(rootSpec);
+    });
+
+    it("should call notify when task ID is invalid", () => {
+      const rootSpec = createRootComponentSpec();
+      const notify = vi.fn();
+
+      const result = getSubgraphComponentSpec(
+        rootSpec,
+        ["root", "nonexistent"],
+        notify,
+      );
+
+      expect(notify).toHaveBeenCalledWith(
+        expect.stringContaining('task "nonexistent" not found'),
+        "warning",
+      );
+      expect(result).toBe(rootSpec);
+    });
+
+    it("should call notify when task is not a subgraph", () => {
+      const rootSpec = createRootComponentSpec();
+      const notify = vi.fn();
+
+      const result = getSubgraphComponentSpec(
+        rootSpec,
+        ["root", "task1"],
+        notify,
+      );
+
+      expect(notify).toHaveBeenCalledWith(
+        expect.stringContaining('task "task1" is not a subgraph'),
+        "warning",
+      );
+      expect(result).toBe(rootSpec);
+    });
+
+    it("should call notify when task has no spec", () => {
+      const rootSpec = {
+        ...createRootComponentSpec(),
+        implementation: {
+          graph: {
+            tasks: {
+              "task-without-spec": {
+                componentRef: {},
+              },
+            },
+            outputValues: {},
+          },
+        },
+      };
+      const notify = vi.fn();
+
+      const result = getSubgraphComponentSpec(
+        rootSpec,
+        ["root", "task-without-spec"],
+        notify,
+      );
+
+      // Task without spec fails the isSubgraph check first
+      expect(notify).toHaveBeenCalledWith(
+        expect.stringContaining('task "task-without-spec" is not a subgraph'),
+        "warning",
+      );
+      expect(result).toBe(rootSpec);
+    });
+
+    it("should not call notify on successful navigation", () => {
+      const rootSpec = createRootComponentSpec();
+      const notify = vi.fn();
+
+      const result = getSubgraphComponentSpec(
+        rootSpec,
+        ["root", "subgraph1"],
+        notify,
+      );
+
+      expect(notify).not.toHaveBeenCalled();
+      expect(result.name).toBe("test-graph-component");
     });
   });
 });

--- a/src/utils/subgraphUtils.ts
+++ b/src/utils/subgraphUtils.ts
@@ -1,6 +1,12 @@
-import type { TaskSpec } from "./componentSpec";
+import type { ComponentSpec, TaskSpec } from "./componentSpec";
 import { isGraphImplementation } from "./componentSpec";
+import { ROOT_TASK_ID } from "./constants";
 import { pluralize } from "./string";
+
+type NotifyFunction = (
+  message: string,
+  type: "success" | "warning" | "error" | "info",
+) => void;
 
 /**
  * Determines if a task specification represents a subgraph (contains nested graph implementation)
@@ -20,8 +26,8 @@ export const getSubgraphDescription = (taskSpec: TaskSpec): string => {
     return "";
   }
 
-  const subgraphSpec = taskSpec.componentRef.spec!;
-  if (!isGraphImplementation(subgraphSpec.implementation)) {
+  const subgraphSpec = taskSpec.componentRef.spec;
+  if (!subgraphSpec || !isGraphImplementation(subgraphSpec.implementation)) {
     return "Empty subgraph";
   }
 
@@ -32,4 +38,72 @@ export const getSubgraphDescription = (taskSpec: TaskSpec): string => {
   }
 
   return `${taskCount} ${pluralize(taskCount, "task")}`;
+};
+
+/**
+ * Navigates to a specific subgraph within a ComponentSpec based on a path
+ * @param componentSpec - The root component specification
+ * @param subgraphPath - Array of task IDs representing the path to the desired subgraph
+ * @param notify - Optional notification function to display warnings
+ * @returns ComponentSpec representing the subgraph, or the original spec if path is ["root"]
+ */
+export const getSubgraphComponentSpec = (
+  componentSpec: ComponentSpec,
+  subgraphPath: string[],
+  notify?: NotifyFunction,
+): ComponentSpec => {
+  if (subgraphPath.length <= 1 || subgraphPath[0] !== ROOT_TASK_ID) {
+    return componentSpec;
+  }
+
+  let currentSpec = componentSpec;
+
+  for (let i = 1; i < subgraphPath.length; i++) {
+    const taskId = subgraphPath[i];
+
+    if (!isGraphImplementation(currentSpec.implementation)) {
+      const message = `Cannot navigate to subgraph: current spec does not have graph implementation at path ${subgraphPath.slice(0, i + 1).join(".")}`;
+      if (notify) {
+        notify(message, "warning");
+      } else {
+        console.warn(message);
+      }
+      return componentSpec;
+    }
+
+    const task = currentSpec.implementation.graph.tasks[taskId];
+    if (!task) {
+      const message = `Cannot navigate to subgraph: task "${taskId}" not found at path ${subgraphPath.slice(0, i + 1).join(".")}`;
+      if (notify) {
+        notify(message, "warning");
+      } else {
+        console.warn(message);
+      }
+      return componentSpec;
+    }
+
+    if (!isSubgraph(task)) {
+      const message = `Cannot navigate to subgraph: task "${taskId}" is not a subgraph at path ${subgraphPath.slice(0, i + 1).join(".")}`;
+      if (notify) {
+        notify(message, "warning");
+      } else {
+        console.warn(message);
+      }
+      return componentSpec;
+    }
+
+    if (!task.componentRef.spec) {
+      const message = `Cannot navigate to subgraph: task "${taskId}" has no spec at path ${subgraphPath.slice(0, i + 1).join(".")}`;
+      if (notify) {
+        notify(message, "warning");
+      } else {
+        console.warn(message);
+      }
+      return componentSpec;
+    }
+
+    currentSpec = task.componentRef.spec;
+  }
+
+  return currentSpec;
 };


### PR DESCRIPTION
## Description

Added subgraph navigation functionality to the ReactFlow canvas. This allows users to navigate into nested subgraphs and back to parent graphs. The implementation includes:

- A new utility function `getSubgraphComponentSpec` to retrieve the component spec for a specific subgraph based on a path
- A back button in the flow controls to return to the parent graph
- Updated the flow canvas to render the current subgraph based on the navigation path


NOTE: You can drill into pipeline components but you are not able to edit them yet.

## Type of Change

- [x] New feature
- [x] Improvement

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Test Instructions

1. Create a component with a subgraph
2. Click on the subgraph node to navigate into it
3. Use the back button (chevron left) in the flow controls to return to the parent graph