### PR TITLE
subgraph-navigation-polish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@radix-ui/react-scroll-area": "^1.2.10",
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-separator": "^1.1.7",
-        "@radix-ui/react-slot": "^1.2.0",
+        "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-switch": "^1.2.6",
         "@radix-ui/react-tabs": "^1.1.13",
         "@radix-ui/react-tooltip": "^1.2.8",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@radix-ui/react-scroll-area": "^1.2.10",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-separator": "^1.1.7",
-    "@radix-ui/react-slot": "^1.2.0",
+    "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-tooltip": "^1.2.8",

--- a/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
@@ -16,6 +16,7 @@ import type { ComponentType, DragEvent } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { ConfirmationDialog } from "@/components/shared/Dialogs";
+import { BlockStack } from "@/components/ui/layout";
 import useComponentSpecToEdges from "@/hooks/useComponentSpecToEdges";
 import useComponentUploader from "@/hooks/useComponentUploader";
 import useConfirmationDialog from "@/hooks/useConfirmationDialog";
@@ -24,6 +25,7 @@ import { useGhostNode } from "@/hooks/useGhostNode";
 import { useHintNode } from "@/hooks/useHintNode";
 import { useIOSelectionPersistence } from "@/hooks/useIOSelectionPersistence";
 import { useNodeCallbacks } from "@/hooks/useNodeCallbacks";
+import { useSubgraphKeyboardNavigation } from "@/hooks/useSubgraphKeyboardNavigation";
 import useToastNotification from "@/hooks/useToastNotification";
 import { cn } from "@/lib/utils";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
@@ -50,6 +52,7 @@ import GhostNode from "./GhostNode/GhostNode";
 import HintNode from "./GhostNode/HintNode";
 import IONode from "./IONode/IONode";
 import SelectionToolbar from "./SelectionToolbar";
+import { SubgraphBreadcrumbs } from "./SubgraphBreadcrumbs/SubgraphBreadcrumbs";
 import TaskNode from "./TaskNode/TaskNode";
 import type { NodesAndEdges } from "./types";
 import { addAndConnectNode } from "./utils/addAndConnectNode";
@@ -102,6 +105,8 @@ const FlowCanvas = ({
   const initialCanvasLoaded = useRef(false);
 
   const { clearContent } = useContextPanel();
+
+  useSubgraphKeyboardNavigation();
   const { setReactFlowInstance: setReactFlowInstanceForOverlay } =
     useNodesOverlay();
   const {
@@ -862,7 +867,9 @@ const FlowCanvas = ({
   };
 
   return (
-    <>
+    <BlockStack gap="0" className="h-full w-full">
+      <SubgraphBreadcrumbs />
+
       <ReactFlow
         {...rest}
         nodes={allNodes}
@@ -906,6 +913,7 @@ const FlowCanvas = ({
         </NodeToolbar>
         {children}
       </ReactFlow>
+
       <ConfirmationDialog
         {...confirmationProps}
         onConfirm={() => confirmationHandlers?.onConfirm()}
@@ -917,7 +925,7 @@ const FlowCanvas = ({
         setClose={handleCancelUpload}
         handleImportComponent={handleImportComponent}
       />
-    </>
+    </BlockStack>
   );
 };
 

--- a/src/components/shared/ReactFlow/FlowCanvas/SubgraphBreadcrumbs/SubgraphBreadcrumbs.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/SubgraphBreadcrumbs/SubgraphBreadcrumbs.tsx
@@ -1,0 +1,92 @@
+import { Home } from "lucide-react";
+import { Fragment } from "react";
+
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
+import { Button } from "@/components/ui/button";
+import { InlineStack } from "@/components/ui/layout";
+import { useComponentSpec } from "@/providers/ComponentSpecProvider";
+
+export const SubgraphBreadcrumbs = () => {
+  const { currentSubgraphPath, navigateToPath } = useComponentSpec();
+
+  // Don't show breadcrumbs if we're at root
+  if (currentSubgraphPath.length <= 1) {
+    return null;
+  }
+
+  return (
+    <InlineStack
+      align="space-between"
+      blockAlign="center"
+      gap="0"
+      className="px-4 py-2 bg-gray-50 border-b w-full"
+    >
+      <Breadcrumb>
+        <BreadcrumbList>
+          {currentSubgraphPath.map((pathSegment, index) => {
+            const isLast = index === currentSubgraphPath.length - 1;
+            const isRoot = index === 0;
+
+            return (
+              <Fragment key={`${pathSegment}-${index}`}>
+                <BreadcrumbItem>
+                  {!isLast ? (
+                    <BreadcrumbLink asChild>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() =>
+                          navigateToPath(
+                            currentSubgraphPath.slice(0, index + 1),
+                          )
+                        }
+                        className="h-6 px-2"
+                      >
+                        {isRoot ? (
+                          <InlineStack
+                            align="start"
+                            blockAlign="center"
+                            gap="1"
+                          >
+                            <Home className="w-3 h-3" />
+                            Root
+                          </InlineStack>
+                        ) : (
+                          pathSegment
+                        )}
+                      </Button>
+                    </BreadcrumbLink>
+                  ) : (
+                    <BreadcrumbPage>
+                      {isRoot ? (
+                        <InlineStack align="start" blockAlign="center" gap="1">
+                          <Home className="w-3 h-3" />
+                          Root
+                        </InlineStack>
+                      ) : (
+                        pathSegment
+                      )}
+                    </BreadcrumbPage>
+                  )}
+                </BreadcrumbItem>
+                {!isLast && <BreadcrumbSeparator />}
+              </Fragment>
+            );
+          })}
+        </BreadcrumbList>
+      </Breadcrumb>
+
+      <div className="text-xs text-gray-500">
+        {currentSubgraphPath.length - 1} level
+        {currentSubgraphPath.length - 1 !== 1 ? "s" : ""} deep
+      </div>
+    </InlineStack>
+  );
+};

--- a/src/components/ui/breadcrumb.tsx
+++ b/src/components/ui/breadcrumb.tsx
@@ -1,0 +1,115 @@
+import { Slot } from "@radix-ui/react-slot";
+import { ChevronRight, MoreHorizontal } from "lucide-react";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Breadcrumb = React.forwardRef<
+  HTMLElement,
+  React.ComponentPropsWithoutRef<"nav"> & {
+    separator?: React.ReactNode;
+  }
+>(({ ...props }, ref) => <nav ref={ref} aria-label="breadcrumb" {...props} />);
+Breadcrumb.displayName = "Breadcrumb";
+
+const BreadcrumbList = React.forwardRef<
+  HTMLOListElement,
+  React.ComponentPropsWithoutRef<"ol">
+>(({ className, ...props }, ref) => (
+  <ol
+    ref={ref}
+    className={cn(
+      "flex flex-wrap items-center gap-1.5 break-words text-sm text-muted-foreground sm:gap-2.5",
+      className,
+    )}
+    {...props}
+  />
+));
+BreadcrumbList.displayName = "BreadcrumbList";
+
+const BreadcrumbItem = React.forwardRef<
+  HTMLLIElement,
+  React.ComponentPropsWithoutRef<"li">
+>(({ className, ...props }, ref) => (
+  <li
+    ref={ref}
+    className={cn("inline-flex items-center gap-1.5", className)}
+    {...props}
+  />
+));
+BreadcrumbItem.displayName = "BreadcrumbItem";
+
+const BreadcrumbLink = React.forwardRef<
+  HTMLAnchorElement,
+  React.ComponentPropsWithoutRef<"a"> & {
+    asChild?: boolean;
+  }
+>(({ asChild, className, ...props }, ref) => {
+  const Comp = asChild ? Slot : "a";
+
+  return (
+    <Comp
+      ref={ref}
+      className={cn("transition-colors hover:text-foreground", className)}
+      {...props}
+    />
+  );
+});
+BreadcrumbLink.displayName = "BreadcrumbLink";
+
+const BreadcrumbPage = React.forwardRef<
+  HTMLSpanElement,
+  React.ComponentPropsWithoutRef<"span">
+>(({ className, ...props }, ref) => (
+  <span
+    ref={ref}
+    role="link"
+    aria-disabled="true"
+    aria-current="page"
+    className={cn("font-normal text-foreground", className)}
+    {...props}
+  />
+));
+BreadcrumbPage.displayName = "BreadcrumbPage";
+
+const BreadcrumbSeparator = ({
+  children,
+  className,
+  ...props
+}: React.ComponentProps<"li">) => (
+  <li
+    role="presentation"
+    aria-hidden="true"
+    className={cn("[&>svg]:w-3.5 [&>svg]:h-3.5", className)}
+    {...props}
+  >
+    {children ?? <ChevronRight />}
+  </li>
+);
+BreadcrumbSeparator.displayName = "BreadcrumbSeparator";
+
+const BreadcrumbEllipsis = ({
+  className,
+  ...props
+}: React.ComponentProps<"span">) => (
+  <span
+    role="presentation"
+    aria-hidden="true"
+    className={cn("flex h-9 w-9 items-center justify-center", className)}
+    {...props}
+  >
+    <MoreHorizontal className="h-4 w-4" />
+    <span className="sr-only">More</span>
+  </span>
+);
+BreadcrumbEllipsis.displayName = "BreadcrumbElipssis";
+
+export {
+  Breadcrumb,
+  BreadcrumbEllipsis,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+};

--- a/src/hooks/useSubgraphKeyboardNavigation.ts
+++ b/src/hooks/useSubgraphKeyboardNavigation.ts
@@ -1,0 +1,38 @@
+import { useEffect } from "react";
+
+import { useComponentSpec } from "@/providers/ComponentSpecProvider";
+
+/**
+ * Hook to handle keyboard navigation for subgraphs
+ * - Escape: Navigate back to parent subgraph
+ */
+export const useSubgraphKeyboardNavigation = () => {
+  const { canNavigateBack, navigateBack } = useComponentSpec();
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (!canNavigateBack) return;
+
+      // Don't interfere with typing in input fields, textareas, or contenteditable elements
+      const activeElement = document.activeElement;
+      if (
+        activeElement instanceof HTMLInputElement ||
+        activeElement instanceof HTMLTextAreaElement ||
+        activeElement?.getAttribute("contenteditable") === "true"
+      ) {
+        return;
+      }
+
+      if (event.key === "Escape") {
+        event.preventDefault();
+        navigateBack();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [canNavigateBack, navigateBack]);
+};

--- a/src/providers/ComponentSpecProvider.tsx
+++ b/src/providers/ComponentSpecProvider.tsx
@@ -48,6 +48,7 @@ interface ComponentSpecContextType {
   currentSubgraphPath: string[];
   navigateToSubgraph: (taskId: string) => void;
   navigateBack: () => void;
+  navigateToPath: (targetPath: string[]) => void;
   canNavigateBack: boolean;
 }
 
@@ -170,6 +171,10 @@ export const ComponentSpecProvider = ({
     setCurrentSubgraphPath((prev) => prev.slice(0, -1));
   }, []);
 
+  const navigateToPath = useCallback((targetPath: string[]) => {
+    setCurrentSubgraphPath(targetPath);
+  }, []);
+
   const canNavigateBack = currentSubgraphPath.length > 1;
 
   const value = useMemo(
@@ -191,6 +196,7 @@ export const ComponentSpecProvider = ({
       currentSubgraphPath,
       navigateToSubgraph,
       navigateBack,
+      navigateToPath,
       canNavigateBack,
     }),
     [
@@ -211,6 +217,7 @@ export const ComponentSpecProvider = ({
       currentSubgraphPath,
       navigateToSubgraph,
       navigateBack,
+      navigateToPath,
       canNavigateBack,
     ],
   );


### PR DESCRIPTION
## Description

Added subgraph navigation breadcrumbs and keyboard shortcuts to improve navigation between nested subgraphs. The breadcrumbs display the current path hierarchy and allow users to quickly navigate to any parent level. Users can also press the Escape key to navigate back to the parent subgraph.

## Type of Change

- [x] New feature
- [x] Improvement

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Test Instructions

1. Create a component with nested subgraphs (at least 2 levels deep)
2. Navigate into a nested subgraph
3. Verify the breadcrumbs appear showing the navigation path
4. Click on a breadcrumb to navigate to that level
5. Press Escape to navigate back to the parent subgraph