### PR TITLE
Migrate Legacy NodeId Utilities to NodeManager

### DIFF
--- a/src/components/Editor/IOEditor/InputValueEditor/InputValueEditor.tsx
+++ b/src/components/Editor/IOEditor/InputValueEditor/InputValueEditor.tsx
@@ -9,13 +9,14 @@ import { Icon } from "@/components/ui/icon";
 import { BlockStack } from "@/components/ui/layout";
 import { Heading, Paragraph } from "@/components/ui/typography";
 import useConfirmationDialog from "@/hooks/useConfirmationDialog";
+import { useNodeManager } from "@/hooks/useNodeManager";
 import { useNodeSelectionTransfer } from "@/hooks/useNodeSelectionTransfer";
 import useToastNotification from "@/hooks/useToastNotification";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 import { useContextPanel } from "@/providers/ContextPanelProvider";
 import { type InputSpec } from "@/utils/componentSpec";
 import { checkInputConnectionToRequiredFields } from "@/utils/inputConnectionUtils";
-import { inputNameToNodeId } from "@/utils/nodes/nodeIdUtils";
+import { inputNameToInputId } from "@/utils/nodes/nodeIdUtils";
 
 import { NameField, TextField, TypeField } from "./FormFields/FormFields";
 import { checkNameCollision } from "./FormFields/utils";
@@ -30,6 +31,16 @@ export const InputValueEditor = ({
   input,
   disabled = false,
 }: InputValueEditorProps) => {
+  const { getInputNodeId } = useNodeManager();
+
+  const inputNameToNodeId = useCallback(
+    (inputName: string): string => {
+      const inputId = inputNameToInputId(inputName);
+      return getInputNodeId(inputId);
+    },
+    [getInputNodeId],
+  );
+
   const notify = useToastNotification();
   const { transferSelection } = useNodeSelectionTransfer(inputNameToNodeId);
   const { componentSpec, setComponentSpec } = useComponentSpec();

--- a/src/components/Editor/IOEditor/OutputNameEditor/OutputNameEditor.tsx
+++ b/src/components/Editor/IOEditor/OutputNameEditor/OutputNameEditor.tsx
@@ -7,11 +7,11 @@ import { Icon } from "@/components/ui/icon";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Heading, Paragraph } from "@/components/ui/typography";
 import useConfirmationDialog from "@/hooks/useConfirmationDialog";
+import { useNodeManager } from "@/hooks/useNodeManager";
 import { useNodeSelectionTransfer } from "@/hooks/useNodeSelectionTransfer";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 import { useContextPanel } from "@/providers/ContextPanelProvider";
 import { type OutputSpec } from "@/utils/componentSpec";
-import { outputNameToNodeId } from "@/utils/nodes/nodeIdUtils";
 
 import { type OutputConnectedDetails } from "../../utils/getOutputConnectedDetails";
 import { updateOutputNameOnComponentSpec } from "../../utils/updateOutputNameOnComponentSpec";
@@ -29,6 +29,16 @@ export const OutputNameEditor = ({
   disabled,
   connectedDetails,
 }: OutputNameEditorProps) => {
+  const { getOutputNodeId } = useNodeManager();
+
+  const outputNameToNodeId = useCallback(
+    (outputName: string): string => {
+      const outputId = outputNameToNodeId(outputName);
+      return getOutputNodeId(outputId);
+    },
+    [getOutputNodeId],
+  );
+
   const { transferSelection } = useNodeSelectionTransfer(outputNameToNodeId);
   const { setComponentSpec, componentSpec } = useComponentSpec();
   const { clearContent } = useContextPanel();

--- a/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
@@ -303,15 +303,23 @@ const FlowCanvas = ({
       let updatedComponentSpec = { ...componentSpec };
 
       for (const edge of params.edges) {
-        updatedComponentSpec = removeEdge(edge, updatedComponentSpec);
+        updatedComponentSpec = removeEdge(
+          edge,
+          updatedComponentSpec,
+          nodeManager,
+        );
       }
       for (const node of params.nodes) {
-        updatedComponentSpec = removeNode(node, updatedComponentSpec);
+        updatedComponentSpec = removeNode(
+          node,
+          updatedComponentSpec,
+          nodeManager,
+        );
       }
 
       setComponentSpec(updatedComponentSpec);
     },
-    [componentSpec, setComponentSpec],
+    [componentSpec, nodeManager, setComponentSpec],
   );
 
   const nodeCallbacks = useNodeCallbacks({
@@ -334,7 +342,11 @@ const FlowCanvas = ({
     (connection: Connection) => {
       if (connection.source === connection.target) return;
 
-      const updatedGraphSpec = handleConnection(graphSpec, connection);
+      const updatedGraphSpec = handleConnection(
+        graphSpec,
+        connection,
+        nodeManager,
+      );
       updateGraphSpec(updatedGraphSpec);
     },
     [graphSpec, handleConnection, updateGraphSpec],
@@ -374,7 +386,11 @@ const FlowCanvas = ({
         );
 
       if (existingInputEdge) {
-        newComponentSpec = removeEdge(existingInputEdge, newComponentSpec);
+        newComponentSpec = removeEdge(
+          existingInputEdge,
+          newComponentSpec,
+          nodeManager,
+        );
       }
 
       const updatedComponentSpec = addAndConnectNode({
@@ -382,11 +398,18 @@ const FlowCanvas = ({
         fromHandle,
         position,
         componentSpec: newComponentSpec,
+        nodeManager,
       });
 
       setComponentSpec(updatedComponentSpec);
     },
-    [reactFlowInstance, componentSpec, setComponentSpec, updateOrAddNodes],
+    [
+      reactFlowInstance,
+      componentSpec,
+      nodeManager,
+      setComponentSpec,
+      updateOrAddNodes,
+    ],
   );
 
   useEffect(() => {
@@ -633,6 +656,7 @@ const FlowCanvas = ({
           const updatedComponentSpec = updateNodePositions(
             updatedNodes,
             componentSpec,
+            nodeManager,
           );
           setComponentSpec(updatedComponentSpec);
         }
@@ -640,7 +664,7 @@ const FlowCanvas = ({
 
       onNodesChange(changes);
     },
-    [nodes, componentSpec, setComponentSpec, onNodesChange],
+    [nodes, componentSpec, nodeManager, setComponentSpec, onNodesChange],
   );
 
   const handleBeforeDelete = async (params: NodesAndEdges) => {

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/Handles.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/Handles.tsx
@@ -11,9 +11,14 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { useNodeManager } from "@/hooks/useNodeManager";
 import { cn } from "@/lib/utils";
 import { useTaskNode } from "@/providers/TaskNodeProvider";
 import type { InputSpec, OutputSpec } from "@/utils/componentSpec";
+import {
+  inputNameToInputId,
+  outputNameToOutputId,
+} from "@/utils/nodes/nodeIdUtils";
 
 type InputHandleProps = {
   input: InputSpec;
@@ -32,6 +37,7 @@ export const InputHandle = ({
   onLabelClick,
   onHandleSelectionChange,
 }: InputHandleProps) => {
+  const { getInputNodeId } = useNodeManager();
   const { nodeId, state } = useTaskNode();
 
   const fromHandle = useConnection((connection) => connection.fromHandle?.id);
@@ -44,7 +50,7 @@ export const InputHandle = ({
   const [selected, setSelected] = useState(false);
   const [active, setActive] = useState(false);
 
-  const handleId = getInputHandleId(input.name);
+  const handleId = getInputNodeId(inputNameToInputId(input.name));
 
   const missing = invalid ? "bg-red-700!" : "bg-gray-500!";
   const hasValue = value !== undefined && value !== null;
@@ -218,6 +224,7 @@ export const OutputHandle = ({
   onLabelClick,
   onHandleSelectionChange,
 }: OutputHandleProps) => {
+  const { getOutputNodeId } = useNodeManager();
   const { nodeId, state } = useTaskNode();
 
   const fromHandle = useConnection((connection) => connection.fromHandle?.id);
@@ -230,7 +237,7 @@ export const OutputHandle = ({
   const [selected, setSelected] = useState(false);
   const [active, setActive] = useState(false);
 
-  const handleId = getOutputHandleId(output.name);
+  const handleId = getOutputNodeId(outputNameToOutputId(output.name));
   const hasValue = value !== undefined && value !== "" && value !== null;
 
   const handleHandleClick = useCallback(
@@ -353,14 +360,6 @@ export const OutputHandle = ({
       />
     </div>
   );
-};
-
-const getOutputHandleId = (outputName: string) => {
-  return `output_${outputName}`;
-};
-
-const getInputHandleId = (inputName: string) => {
-  return `input_${inputName}`;
 };
 
 const skipHandleDeselect = (e: MouseEvent) => {

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeInputs.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeInputs.tsx
@@ -2,6 +2,7 @@ import { useConnection } from "@xyflow/react";
 import { AlertCircle } from "lucide-react";
 import { type MouseEvent, useCallback, useEffect, useState } from "react";
 
+import { useNodeManager } from "@/hooks/useNodeManager";
 import { cn } from "@/lib/utils";
 import { useForcedSearchContext } from "@/providers/ComponentLibraryProvider/ForcedSearchProvider";
 import { isValidFilterRequest } from "@/providers/ComponentLibraryProvider/types";
@@ -10,7 +11,7 @@ import { useTaskNode } from "@/providers/TaskNodeProvider";
 import { inputsWithInvalidArguments } from "@/services/componentService";
 import type { InputSpec } from "@/utils/componentSpec";
 import { ComponentSearchFilter } from "@/utils/constants";
-import { inputNameToNodeId } from "@/utils/nodes/nodeIdUtils";
+import { inputNameToInputId } from "@/utils/nodes/nodeIdUtils";
 import { checkArtifactMatchesSearchFilters } from "@/utils/searchUtils";
 
 import { InputHandle } from "./Handles";
@@ -27,6 +28,7 @@ export function TaskNodeInputs({
   expanded,
   onBackgroundClick,
 }: TaskNodeInputsProps) {
+  const { getInputNodeId } = useNodeManager();
   const { inputs, taskSpec, state, select } = useTaskNode();
   const { graphSpec } = useComponentSpec();
   const {
@@ -145,7 +147,7 @@ export function TaskNodeInputs({
     }
 
     const input = inputs.find(
-      (i) => inputNameToNodeId(i.name) === fromHandle?.id,
+      (i) => getInputNodeId(inputNameToInputId(i.name)) === fromHandle?.id,
     );
 
     if (!input) return;

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeOutputs.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeOutputs.tsx
@@ -1,13 +1,14 @@
 import { useConnection, useEdges } from "@xyflow/react";
 import { type MouseEvent, useCallback, useEffect, useState } from "react";
 
+import { useNodeManager } from "@/hooks/useNodeManager";
 import { cn } from "@/lib/utils";
 import { useForcedSearchContext } from "@/providers/ComponentLibraryProvider/ForcedSearchProvider";
 import { isValidFilterRequest } from "@/providers/ComponentLibraryProvider/types";
 import { useTaskNode } from "@/providers/TaskNodeProvider";
 import type { OutputSpec } from "@/utils/componentSpec";
 import { ComponentSearchFilter } from "@/utils/constants";
-import { outputNameToNodeId } from "@/utils/nodes/nodeIdUtils";
+import { outputNameToOutputId } from "@/utils/nodes/nodeIdUtils";
 import { checkArtifactMatchesSearchFilters } from "@/utils/searchUtils";
 
 import { OutputHandle } from "./Handles";
@@ -23,6 +24,7 @@ export function TaskNodeOutputs({
   expanded,
   onBackgroundClick,
 }: TaskNodeOutputsProps) {
+  const { getOutputNodeId } = useNodeManager();
   const { nodeId, outputs, state, select } = useTaskNode();
   const {
     highlightSearchFilter,
@@ -40,7 +42,8 @@ export function TaskNodeOutputs({
     edges.some(
       (edge) =>
         edge.source === nodeId &&
-        edge.sourceHandle === outputNameToNodeId(output.name),
+        edge.sourceHandle ===
+          getOutputNodeId(outputNameToOutputId(output.name)),
     ),
   );
 
@@ -138,7 +141,7 @@ export function TaskNodeOutputs({
     }
 
     const output = outputs.find(
-      (o) => outputNameToNodeId(o.name) === fromHandle?.id,
+      (o) => getOutputNodeId(outputNameToOutputId(o.name)) === fromHandle?.id,
     );
 
     if (!output) return;

--- a/src/components/shared/ReactFlow/FlowCanvas/utils/addTask.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/utils/addTask.ts
@@ -9,6 +9,7 @@ import {
   type OutputSpec,
   type TaskSpec,
 } from "@/utils/componentSpec";
+import { taskNameToTaskId } from "@/utils/nodes/nodeIdUtils";
 import {
   getUniqueInputName,
   getUniqueOutputName,
@@ -61,10 +62,12 @@ const addTask = (
       arguments: taskArguments ?? {},
     };
 
-    const taskId = getUniqueTaskName(
+    const uniqueTaskName = getUniqueTaskName(
       graphSpec,
       taskSpec.componentRef.spec?.name ?? "Task",
     );
+
+    const taskId = taskNameToTaskId(uniqueTaskName);
 
     const newGraphSpec: GraphSpec = {
       ...graphSpec,
@@ -78,9 +81,9 @@ const addTask = (
   }
 
   if (taskType === "input") {
-    const inputId = getUniqueInputName(componentSpec);
+    const uniqueInputName = getUniqueInputName(componentSpec);
     const inputSpec: InputSpec = {
-      name: inputId,
+      name: uniqueInputName,
       annotations: positionAnnotations,
     };
     const inputs = (componentSpec.inputs ?? []).concat([inputSpec]);
@@ -89,9 +92,9 @@ const addTask = (
   }
 
   if (taskType === "output") {
-    const outputId = getUniqueOutputName(componentSpec);
+    const uniqueOutputName = getUniqueOutputName(componentSpec);
     const outputSpec: OutputSpec = {
-      name: outputId,
+      name: uniqueOutputName,
       annotations: positionAnnotations,
     };
 

--- a/src/components/shared/ReactFlow/FlowCanvas/utils/duplicateNodes.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/utils/duplicateNodes.ts
@@ -16,12 +16,10 @@ import { createOutputNode } from "@/utils/nodes/createOutputNode";
 import { createTaskNode } from "@/utils/nodes/createTaskNode";
 import { getNodesBounds } from "@/utils/nodes/getNodesBounds";
 import {
-  inputNameToNodeId,
-  nodeIdToInputName,
-  nodeIdToOutputName,
-  nodeIdToTaskId,
-  outputNameToNodeId,
-  taskIdToNodeId,
+  inputNameToInputId,
+  outputNameToOutputId,
+  taskIdToTaskName,
+  taskNameToTaskId,
 } from "@/utils/nodes/nodeIdUtils";
 import { setPositionInAnnotations } from "@/utils/nodes/setPositionInAnnotations";
 import { convertTaskCallbacksToNodeCallbacks } from "@/utils/nodes/taskCallbackUtils";
@@ -74,9 +72,16 @@ export const duplicateNodes = (
     const oldNodeId = node.id;
 
     if (node.type === "task") {
-      const oldTaskId = nodeIdToTaskId(oldNodeId);
-      const newTaskId = getUniqueTaskName(graphSpec, oldTaskId);
-      const newNodeId = taskIdToNodeId(newTaskId);
+      const oldTaskId = nodeManager.getTaskId(oldNodeId);
+      if (!oldTaskId) {
+        console.warn("Could not find taskId for node:", node);
+        return;
+      }
+
+      const oldTaskName = taskIdToTaskName(oldTaskId);
+      const newTaskName = getUniqueTaskName(graphSpec, oldTaskName);
+      const newTaskId = taskNameToTaskId(newTaskName);
+      const newNodeId = nodeManager.getNodeId(newTaskId, "task");
 
       nodeIdMap[oldNodeId] = newNodeId;
 
@@ -103,9 +108,12 @@ export const duplicateNodes = (
         (input) => input.name === node.data.label,
       );
 
-      const newInputId = getUniqueInputName(componentSpec, inputSpec?.name);
-
-      const newNodeId = inputNameToNodeId(newInputId);
+      const uniqueInputName = getUniqueInputName(
+        componentSpec,
+        inputSpec?.name,
+      );
+      const newInputId = inputNameToInputId(uniqueInputName);
+      const newNodeId = nodeManager.getNodeId(newInputId, "input");
 
       nodeIdMap[oldNodeId] = newNodeId;
 
@@ -118,19 +126,22 @@ export const duplicateNodes = (
 
       const newInputSpec = {
         ...inputSpec,
-        name: newInputId,
+        name: uniqueInputName,
         annotations: updatedAnnotations,
       };
 
-      newInputs[newInputId] = newInputSpec;
+      newInputs[uniqueInputName] = newInputSpec; // tbc if this should be uniqueInputName or newInputId
     } else if (node.type === "output") {
       const outputSpec = componentSpec.outputs?.find(
         (output) => output.name === node.data.label,
       );
 
-      const newOutputId = getUniqueOutputName(componentSpec, outputSpec?.name);
-
-      const newNodeId = outputNameToNodeId(newOutputId);
+      const uniqueOutputName = getUniqueOutputName(
+        componentSpec,
+        outputSpec?.name,
+      );
+      const newOutputId = outputNameToOutputId(uniqueOutputName);
+      const newNodeId = nodeManager.getNodeId(newOutputId, "output");
 
       nodeIdMap[oldNodeId] = newNodeId;
 
@@ -143,11 +154,11 @@ export const duplicateNodes = (
 
       const newOutputSpec = {
         ...outputSpec,
-        name: newOutputId,
+        name: uniqueOutputName,
         annotations: updatedAnnotations,
       };
 
-      newOutputs[newOutputId] = newOutputSpec;
+      newOutputs[uniqueOutputName] = newOutputSpec; // tbc if this should be uniqueOutputName or newOutputId
     }
   });
 
@@ -173,6 +184,7 @@ export const duplicateNodes = (
             nodesToDuplicate,
             componentSpec,
             connection,
+            nodeManager,
           );
         } else {
           // If the Argument is not a TaskOutput or GraphInput, copy it over
@@ -194,7 +206,7 @@ export const duplicateNodes = (
     /* Reconfigure Outputs */
     Object.entries(newOutputs).forEach((output) => {
       const [outputId] = output;
-      const newNodeId = outputNameToNodeId(outputId);
+      const newNodeId = nodeManager.getNodeId(outputId, "output");
       const oldNodeId = Object.keys(nodeIdMap).find(
         (key) => nodeIdMap[key] === newNodeId,
       );
@@ -203,9 +215,9 @@ export const duplicateNodes = (
         return;
       }
 
-      const oldOutputId = nodeIdToOutputName(oldNodeId);
+      const oldOutputId = nodeManager.getTaskId(oldNodeId);
 
-      if (!graphSpec.outputValues) {
+      if (!graphSpec.outputValues || !oldOutputId) {
         return;
       }
 
@@ -226,9 +238,13 @@ export const duplicateNodes = (
       ) {
         if ("taskOutput" in updatedOutputValue) {
           const oldTaskId = updatedOutputValue.taskOutput.taskId;
-          const oldTaskNodeId = taskIdToNodeId(oldTaskId);
+          const oldTaskNodeId = nodeManager.getNodeId(oldTaskId, "task");
           if (oldTaskNodeId in nodeIdMap) {
-            const newTaskId = nodeIdToTaskId(nodeIdMap[oldTaskNodeId]);
+            const newTaskId = nodeManager.getTaskId(nodeIdMap[oldTaskNodeId]);
+            if (!newTaskId) {
+              return;
+            }
+
             updatedOutputValue.taskOutput = {
               ...updatedOutputValue.taskOutput,
               taskId: newTaskId,
@@ -279,10 +295,14 @@ export const duplicateNodes = (
         return null;
       }
 
-      if (originalNode.type === "task") {
-        const newTaskId = nodeIdToTaskId(newNodeId);
+      const newId = nodeManager.getTaskId(newNodeId);
 
-        const newTaskSpec = updatedGraphSpec.tasks[newTaskId];
+      if (!newId) {
+        return null;
+      }
+
+      if (originalNode.type === "task") {
+        const newTaskSpec = updatedGraphSpec.tasks[newId];
 
         const taskData = originalNode.data as TaskNodeData;
         const nodeData: NodeData = {
@@ -292,7 +312,7 @@ export const duplicateNodes = (
           nodeManager,
         };
 
-        const newNode = createTaskNode([newTaskId, newTaskSpec], nodeData);
+        const newNode = createTaskNode([newId, newTaskSpec], nodeData);
 
         newNode.id = newNodeId;
         newNode.selected = false;
@@ -309,9 +329,8 @@ export const duplicateNodes = (
 
         return newNode;
       } else if (originalNode.type === "input") {
-        const newInputId = nodeIdToInputName(newNodeId);
         const newInputSpec = updatedInputs.find(
-          (input) => input.name === newInputId,
+          (input) => input.name === newId,
         );
 
         if (!newInputSpec) {
@@ -341,9 +360,8 @@ export const duplicateNodes = (
 
         return newNode;
       } else if (originalNode.type === "output") {
-        const newOutputId = nodeIdToOutputName(newNodeId);
         const newOutputSpec = updatedOutputs.find(
-          (output) => output.name === newOutputId,
+          (output) => output.name === newId,
         );
 
         if (!newOutputSpec) {
@@ -394,9 +412,13 @@ export const duplicateNodes = (
         y: node.position.y + offset.y,
       };
 
-      if (node.type === "task") {
-        const taskId = nodeIdToTaskId(node.id);
+      const newId = nodeManager.getTaskId(node.id);
 
+      if (!newId) {
+        return null;
+      }
+
+      if (node.type === "task") {
         const taskSpec = node.data.taskSpec as TaskSpec;
         const annotations = taskSpec.annotations || {};
 
@@ -410,11 +432,9 @@ export const duplicateNodes = (
           annotations: updatedAnnotations,
         };
 
-        updatedGraphSpec.tasks[taskId] = newTaskSpec;
+        updatedGraphSpec.tasks[newId] = newTaskSpec;
       } else if (node.type === "input") {
-        const inputId = nodeIdToInputName(node.id);
-
-        const inputSpec = updatedInputs.find((input) => input.name === inputId);
+        const inputSpec = updatedInputs.find((input) => input.name === newId);
 
         if (!inputSpec) {
           return;
@@ -433,17 +453,15 @@ export const duplicateNodes = (
         };
 
         const updatedInputIndex = updatedInputs.findIndex(
-          (input) => input.name === inputId,
+          (input) => input.name === newId,
         );
 
         if (updatedInputIndex !== -1) {
           updatedInputs[updatedInputIndex] = newInputSpec;
         }
       } else if (node.type === "output") {
-        const outputId = nodeIdToOutputName(node.id);
-
         const outputSpec = updatedOutputs.find(
-          (output) => output.name === outputId,
+          (output) => output.name === newId,
         );
 
         if (!outputSpec) {
@@ -463,7 +481,7 @@ export const duplicateNodes = (
         };
 
         const updatedOutputIndex = updatedOutputs.findIndex(
-          (output) => output.name === outputId,
+          (output) => output.name === newId,
         );
 
         if (updatedOutputIndex !== -1) {
@@ -496,14 +514,15 @@ function reconfigureConnections(
   nodes: Node[],
   componentSpec: ComponentSpec,
   mode: ConnectionMode,
+  nodeManager: NodeManager,
 ) {
-  let oldNodeId = undefined;
+  const oldNodeId = undefined;
   let newArgId = undefined;
   let isExternal = false;
 
   if ("taskOutput" in argument) {
     const oldTaskId = argument.taskOutput.taskId;
-    oldNodeId = taskIdToNodeId(oldTaskId);
+    const oldNodeId = nodeManager.getNodeId(oldTaskId, "task");
 
     if (!isGraphImplementation(componentSpec.implementation)) {
       throw new Error("ComponentSpec does not contain a graph implementation.");
@@ -518,12 +537,12 @@ function reconfigureConnections(
       return reconfigureExternalConnection(taskSpec, argKey, mode);
     }
 
-    const newTaskId = nodeIdToTaskId(newNodeId);
+    const newTaskId = nodeManager.getTaskId(newNodeId);
 
     newArgId = newTaskId;
   } else if ("graphInput" in argument) {
     const oldInputId = argument.graphInput.inputName;
-    oldNodeId = inputNameToNodeId(oldInputId);
+    const oldNodeId = nodeManager.getNodeId(oldInputId, "input");
 
     if (!("inputs" in componentSpec)) {
       throw new Error("ComponentSpec does not contain inputs.");
@@ -538,7 +557,7 @@ function reconfigureConnections(
       return reconfigureExternalConnection(taskSpec, argKey, mode);
     }
 
-    const newInputId = nodeIdToInputName(newNodeId);
+    const newInputId = nodeManager.getTaskId(newNodeId);
 
     newArgId = newInputId;
   }

--- a/src/components/shared/ReactFlow/FlowCanvas/utils/handleConnection.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/utils/handleConnection.ts
@@ -1,15 +1,12 @@
 import type { Connection } from "@xyflow/react";
 
+import type { NodeManager } from "@/nodeManager";
 import type {
   GraphInputArgument,
   GraphSpec,
   TaskOutputArgument,
 } from "@/utils/componentSpec";
-import {
-  nodeIdToInputName,
-  nodeIdToOutputName,
-  nodeIdToTaskId,
-} from "@/utils/nodes/nodeIdUtils";
+import { inputIdToInputName } from "@/utils/nodes/nodeIdUtils";
 
 import { setGraphOutputValue } from "./setGraphOutputValue";
 import { setTaskArgument } from "./setTaskArgument";
@@ -17,44 +14,83 @@ import { setTaskArgument } from "./setTaskArgument";
 export const handleConnection = (
   graphSpec: GraphSpec,
   connection: Connection,
+  nodeManager: NodeManager,
 ) => {
   const targetTaskInputName = connection.targetHandle?.replace(/^input_/, "");
   const sourceTaskOutputName = connection.sourceHandle?.replace(/^output_/, "");
 
+  const targetId = nodeManager.getTaskId(connection.target);
+  const sourceId = nodeManager.getTaskId(connection.source);
+
   if (sourceTaskOutputName !== undefined) {
+    if (!sourceId) {
+      console.error(
+        "addConnection: Could not find task ID for source node: ",
+        connection.source,
+      );
+      return graphSpec;
+    }
+
     const taskOutputArgument: TaskOutputArgument = {
       taskOutput: {
-        taskId: nodeIdToTaskId(connection.source),
+        taskId: sourceId,
         outputName: sourceTaskOutputName,
       },
     };
 
     if (targetTaskInputName !== undefined) {
+      if (!targetId) {
+        console.error(
+          "addConnection: Could not find Input ID for target node: ",
+          connection.target,
+        );
+        return graphSpec;
+      }
+
       return setTaskArgument(
         graphSpec,
-        nodeIdToTaskId(connection.target),
+        targetId,
         targetTaskInputName,
         taskOutputArgument,
       );
     } else {
-      return setGraphOutputValue(
-        graphSpec,
-        nodeIdToOutputName(connection.target),
-        taskOutputArgument,
-      );
+      if (!targetId) {
+        console.error(
+          "addConnection: Could not find Output ID for target node: ",
+          connection.target,
+        );
+        return graphSpec;
+      }
+
+      return setGraphOutputValue(graphSpec, targetId, taskOutputArgument);
       // TODO: Perhaps propagate type information
     }
   } else {
-    const graphInputName = nodeIdToInputName(connection.source);
+    if (!sourceId) {
+      console.error(
+        "addConnection: Could not find task ID for source node: ",
+        connection.source,
+      );
+      return graphSpec;
+    }
+    const inputName = inputIdToInputName(sourceId);
     const graphInputArgument: GraphInputArgument = {
       graphInput: {
-        inputName: graphInputName,
+        inputName: inputName,
       },
     };
     if (targetTaskInputName !== undefined) {
+      if (!targetId) {
+        console.error(
+          "addConnection: Could not find Output ID for target node: ",
+          connection.target,
+        );
+        return graphSpec;
+      }
+
       return setTaskArgument(
         graphSpec,
-        nodeIdToTaskId(connection.target),
+        targetId,
         targetTaskInputName,
         graphInputArgument,
       );

--- a/src/components/shared/ReactFlow/FlowCanvas/utils/removeEdge.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/utils/removeEdge.ts
@@ -1,12 +1,17 @@
 import type { Edge } from "@xyflow/react";
 
+import type { NodeManager } from "@/nodeManager";
 import type { ComponentSpec, GraphImplementation } from "@/utils/componentSpec";
-import { nodeIdToOutputName, nodeIdToTaskId } from "@/utils/nodes/nodeIdUtils";
+import { outputIdToOutputName } from "@/utils/nodes/nodeIdUtils";
 
 import { setGraphOutputValue } from "./setGraphOutputValue";
 import { setTaskArgument } from "./setTaskArgument";
 
-export const removeEdge = (edge: Edge, componentSpec: ComponentSpec) => {
+export const removeEdge = (
+  edge: Edge,
+  componentSpec: ComponentSpec,
+  nodeManager: NodeManager,
+) => {
   const graphSpec = (componentSpec.implementation as GraphImplementation)
     ?.graph;
 
@@ -16,8 +21,10 @@ export const removeEdge = (edge: Edge, componentSpec: ComponentSpec) => {
     ...componentSpec,
   };
 
+  const taskId = nodeManager.getTaskId(edge.target);
+  if (!taskId) return componentSpec;
+
   if (inputName !== undefined && graphSpec) {
-    const taskId = nodeIdToTaskId(edge.target);
     const newGraphSpec = setTaskArgument(graphSpec, taskId, inputName);
     updatedComponentSpec.implementation = {
       ...updatedComponentSpec.implementation,
@@ -26,7 +33,7 @@ export const removeEdge = (edge: Edge, componentSpec: ComponentSpec) => {
 
     return updatedComponentSpec;
   } else {
-    const outputName = nodeIdToOutputName(edge.target);
+    const outputName = outputIdToOutputName(taskId);
     const newGraphSpec = setGraphOutputValue(graphSpec, outputName);
     updatedComponentSpec.implementation = {
       ...updatedComponentSpec.implementation,

--- a/src/components/shared/ReactFlow/FlowCanvas/utils/removeNode.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/utils/removeNode.ts
@@ -1,31 +1,38 @@
 import { type Node } from "@xyflow/react";
 
+import type { NodeManager } from "@/nodeManager";
 import {
   type ComponentSpec,
   isGraphImplementation,
 } from "@/utils/componentSpec";
 import {
-  nodeIdToInputName,
-  nodeIdToOutputName,
-  nodeIdToTaskId,
+  inputIdToInputName,
+  outputIdToOutputName,
 } from "@/utils/nodes/nodeIdUtils";
 
 import { setGraphOutputValue } from "./setGraphOutputValue";
 import { setTaskArgument } from "./setTaskArgument";
 
-export const removeNode = (node: Node, componentSpec: ComponentSpec) => {
+export const removeNode = (
+  node: Node,
+  componentSpec: ComponentSpec,
+  nodeManager: NodeManager,
+) => {
+  const id = nodeManager.getTaskId(node.id);
+
+  if (!id) return componentSpec;
+
   if (node.type === "task") {
-    const taskId = nodeIdToTaskId(node.id);
-    return removeTask(taskId, componentSpec);
+    return removeTask(id, componentSpec);
   }
 
   if (node.type === "input") {
-    const inputName = nodeIdToInputName(node.id);
+    const inputName = inputIdToInputName(id);
     return removeGraphInput(inputName, componentSpec);
   }
 
   if (node.type === "output") {
-    const outputName = nodeIdToOutputName(node.id);
+    const outputName = outputIdToOutputName(id);
     return removeGraphOutput(outputName, componentSpec);
   }
 

--- a/src/components/shared/ReactFlow/FlowCanvas/utils/replaceTaskNode.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/utils/replaceTaskNode.ts
@@ -6,6 +6,7 @@ import type {
   TaskSpec,
 } from "@/utils/componentSpec";
 import { deepClone } from "@/utils/deepClone";
+import { taskNameToTaskId } from "@/utils/nodes/nodeIdUtils";
 import { getUniqueTaskName } from "@/utils/unique";
 
 export const replaceTaskNode = (
@@ -18,7 +19,8 @@ export const replaceTaskNode = (
   const taskName = newComponentRef.spec?.name;
   const newTaskInputs = newComponentRef.spec?.inputs;
   const newTaskOutputs = newComponentRef.spec?.outputs;
-  const newTaskId = getUniqueTaskName(graphSpec, taskName);
+  const uniqueTaskName = getUniqueTaskName(graphSpec, taskName);
+  const newTaskId = taskNameToTaskId(uniqueTaskName);
 
   const oldTaskId = taskId;
   const oldTask = deepClone(updatedGraphSpec.tasks[oldTaskId]) as TaskSpec;

--- a/src/components/shared/ReactFlow/FlowCanvas/utils/updateNodePosition.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/utils/updateNodePosition.ts
@@ -1,19 +1,20 @@
 import type { Node } from "@xyflow/react";
 
+import type { NodeManager } from "@/nodeManager";
 import {
   type ComponentSpec,
   isGraphImplementation,
 } from "@/utils/componentSpec";
 import {
-  nodeIdToInputName,
-  nodeIdToOutputName,
-  nodeIdToTaskId,
+  inputIdToInputName,
+  outputIdToOutputName,
 } from "@/utils/nodes/nodeIdUtils";
 import { setPositionInAnnotations } from "@/utils/nodes/setPositionInAnnotations";
 
 export const updateNodePositions = (
   updatedNodes: Node[],
   componentSpec: ComponentSpec,
+  nodeManager: NodeManager,
 ) => {
   const newComponentSpec = { ...componentSpec };
 
@@ -31,10 +32,13 @@ export const updateNodePositions = (
       y: node.position.y,
     };
 
+    const id = nodeManager.getTaskId(node.id);
+
+    if (!id) continue;
+
     if (node.type === "task") {
-      const taskId = nodeIdToTaskId(node.id);
-      if (updatedGraphSpec.tasks[taskId]) {
-        const taskSpec = { ...updatedGraphSpec.tasks[taskId] };
+      if (updatedGraphSpec.tasks[id]) {
+        const taskSpec = { ...updatedGraphSpec.tasks[id] };
 
         const annotations = taskSpec.annotations || {};
 
@@ -48,12 +52,12 @@ export const updateNodePositions = (
           annotations: updatedAnnotations,
         };
 
-        updatedGraphSpec.tasks[taskId] = newTaskSpec;
+        updatedGraphSpec.tasks[id] = newTaskSpec;
 
         newComponentSpec.implementation.graph = updatedGraphSpec;
       }
     } else if (node.type === "input") {
-      const inputName = nodeIdToInputName(node.id);
+      const inputName = inputIdToInputName(id);
       const inputs = [...(newComponentSpec.inputs || [])];
       const inputIndex = inputs.findIndex((input) => input.name === inputName);
 
@@ -73,7 +77,7 @@ export const updateNodePositions = (
         newComponentSpec.inputs = inputs;
       }
     } else if (node.type === "output") {
-      const outputName = nodeIdToOutputName(node.id);
+      const outputName = outputIdToOutputName(id);
       const outputs = [...(newComponentSpec.outputs || [])];
       const outputIndex = outputs.findIndex(
         (output) => output.name === outputName,

--- a/src/providers/TaskNodeProvider.tsx
+++ b/src/providers/TaskNodeProvider.tsx
@@ -3,6 +3,7 @@ import { type ReactNode, useCallback, useMemo } from "react";
 
 import type { ContainerExecutionStatus } from "@/api/types.gen";
 import useComponentFromUrl from "@/hooks/useComponentFromUrl";
+import { useNodeManager } from "@/hooks/useNodeManager";
 import { useTaskNodeDimensions } from "@/hooks/useTaskNodeDimensions";
 import useToastNotification from "@/hooks/useToastNotification";
 import type { Annotations } from "@/types/annotations";
@@ -15,7 +16,6 @@ import type {
   TaskSpec,
 } from "@/utils/componentSpec";
 import { getComponentName } from "@/utils/getComponentName";
-import { taskIdToNodeId } from "@/utils/nodes/nodeIdUtils";
 
 import {
   createRequiredContext,
@@ -71,10 +71,11 @@ export const TaskNodeProvider = ({
 }: TaskNodeProviderProps) => {
   const notify = useToastNotification();
   const reactFlowInstance = useReactFlow();
+  const { getStableNodeId } = useNodeManager();
 
   const taskSpec = data.taskSpec ?? ({} as TaskSpec);
   const taskId = data.taskId as string;
-  const nodeId = taskIdToNodeId(taskId);
+  const nodeId = getStableNodeId(taskId, "task");
 
   const inputs = taskSpec.componentRef.spec?.inputs || [];
   const outputs = taskSpec.componentRef.spec?.outputs || [];

--- a/src/utils/nodes/createInputNode.ts
+++ b/src/utils/nodes/createInputNode.ts
@@ -4,12 +4,14 @@ import type { IONodeData, NodeData } from "@/types/nodes";
 
 import type { InputSpec } from "../componentSpec";
 import { extractPositionFromAnnotations } from "./extractPositionFromAnnotations";
+import { inputNameToInputId } from "./nodeIdUtils";
 
 export const createInputNode = (input: InputSpec, nodeData: NodeData) => {
   const { name, annotations } = input;
   const { nodeManager, readOnly } = nodeData;
 
-  const nodeId = nodeManager?.getNodeId(name, "input");
+  const inputId = inputNameToInputId(name);
+  const nodeId = nodeManager.getNodeId(inputId, "input");
   console.log("Creating input node:", { name, nodeId });
 
   const position = extractPositionFromAnnotations(annotations);

--- a/src/utils/nodes/createOutputNode.ts
+++ b/src/utils/nodes/createOutputNode.ts
@@ -4,12 +4,14 @@ import type { IONodeData, NodeData } from "@/types/nodes";
 
 import type { OutputSpec } from "../componentSpec";
 import { extractPositionFromAnnotations } from "./extractPositionFromAnnotations";
+import { outputNameToOutputId } from "./nodeIdUtils";
 
 export const createOutputNode = (output: OutputSpec, nodeData: NodeData) => {
   const { name, annotations } = output;
   const { nodeManager, readOnly } = nodeData;
 
-  const nodeId = nodeManager?.getNodeId(name, "output");
+  const outputId = outputNameToOutputId(name);
+  const nodeId = nodeManager.getNodeId(outputId, "output");
   console.log("Creating output node:", { name, nodeId });
 
   const position = extractPositionFromAnnotations(annotations);

--- a/src/utils/nodes/nodeIdUtils.ts
+++ b/src/utils/nodes/nodeIdUtils.ts
@@ -1,43 +1,9 @@
-import type { NodeManager, NodeType } from "@/nodeManager";
+/* Conversions between names and IDs for tasks, inputs, and outputs. */
+/* Conversion between IDs and ReactFlow NodeId is done via the Node Manager. */
 
-// DEPRECATED: Legacy functions - use NodeManager instead
-export const taskIdToNodeId = (taskId: string): string => `task_${taskId}`; // Legacy
-export const inputNameToNodeId = (inputName: string): string =>
-  `input_${inputName}`; // Legacy
-export const outputNameToNodeId = (outputName: string): string =>
-  `output_${outputName}`; // Legacy
-
-// RENAMED: For backwards compatibility and clarity
-export const inputNameToInputId = (inputName: string): string => inputName; // 1:1 mapping
-export const outputNameToOutputId = (outputName: string): string => outputName; // 1:1 mapping
-export const inputIdToInputName = (inputId: string): string => inputId; // 1:1 mapping
-export const outputIdToOutputName = (outputId: string): string => outputId; // 1:1 mapping
-
-// LEGACY: Keep for backwards compatibility
-export const nodeIdToTaskId = (nodeId: string): string => {
-  return nodeId.replace(/^task_/, "");
-};
-
-export const nodeIdToInputName = (nodeId: string): string => {
-  return nodeId.replace(/^input_/, "");
-};
-
-export const nodeIdToOutputName = (nodeId: string): string => {
-  return nodeId.replace(/^output_/, "");
-};
-
-// NEW: NodeManager-aware functions
-export const getTaskIdFromNodeId = (
-  nodeId: string,
-  nodeManager: NodeManager,
-): string | undefined => {
-  return nodeManager.getTaskId(nodeId);
-};
-
-export const getStableNodeId = (
-  taskId: string,
-  nodeType: NodeType,
-  nodeManager: NodeManager,
-): string => {
-  return nodeManager.getNodeId(taskId, nodeType);
-};
+export const taskNameToTaskId = (taskName: string): string => taskName;
+export const inputNameToInputId = (inputName: string): string => inputName;
+export const outputNameToOutputId = (outputName: string): string => outputName;
+export const taskIdToTaskName = (taskId: string): string => taskId;
+export const inputIdToInputName = (inputId: string): string => inputId;
+export const outputIdToOutputName = (outputId: string): string => outputId;


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Folded into #1004

Replace all existing name->node id conversions with NodeManager. To facilitate this the `useNodeManager` hook was added.

Also implements a clearer delineation between io name, io id and node id.

All tasks and nodes will now run on the new node manager id system

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->
Progresses Progresses Shopify/oasis-frontend#261

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Improvement
- [x] Cleanup/Refactor
- [x] Breaking change

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
