### PR TITLE
Cache componentdigest get

### DIFF
--- a/src/providers/ComponentLibraryProvider/ComponentLibraryProvider.tsx
+++ b/src/providers/ComponentLibraryProvider/ComponentLibraryProvider.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   type ReactNode,
   useCallback,
@@ -89,18 +89,6 @@ const ComponentLibraryContext =
     "ComponentLibraryProvider",
   );
 
-const componentLibraries = new Map<AvailableComponentLibraries, Library>([
-  ["published_components", new PublishedComponentsLibrary()],
-]);
-
-function getComponentLibraryObject(libraryName: AvailableComponentLibraries) {
-  if (!componentLibraries.has(libraryName)) {
-    throw new Error(`Component library "${libraryName}" is not supported.`);
-  }
-
-  return componentLibraries.get(libraryName) as Library;
-}
-
 export const ComponentLibraryProvider = ({
   children,
 }: {
@@ -108,6 +96,26 @@ export const ComponentLibraryProvider = ({
 }) => {
   const { graphSpec } = useComponentSpec();
   const { currentSearchFilter } = useForcedSearchContext();
+  const queryClient = useQueryClient();
+
+  const componentLibraries = useMemo(
+    () =>
+      new Map<AvailableComponentLibraries, Library>([
+        ["published_components", new PublishedComponentsLibrary(queryClient)],
+      ]),
+    [queryClient],
+  );
+
+  const getComponentLibraryObject = useCallback(
+    (libraryName: AvailableComponentLibraries) => {
+      if (!componentLibraries.has(libraryName)) {
+        throw new Error(`Component library "${libraryName}" is not supported.`);
+      }
+
+      return componentLibraries.get(libraryName) as Library;
+    },
+    [componentLibraries],
+  );
 
   const [componentLibrary, setComponentLibrary] = useState<ComponentLibrary>();
   const [userComponentsFolder, setUserComponentsFolder] =

--- a/src/providers/ComponentLibraryProvider/libraries/publishedComponentsLibrary.test.ts
+++ b/src/providers/ComponentLibraryProvider/libraries/publishedComponentsLibrary.test.ts
@@ -1,3 +1,4 @@
+import { QueryClient } from "@tanstack/react-query";
 import yaml from "js-yaml";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -108,9 +109,33 @@ describe("PublishedComponentsLibrary", () => {
   });
 
   let library: PublishedComponentsLibrary;
+  let mockQueryClient: QueryClient;
 
   beforeEach(() => {
-    library = new PublishedComponentsLibrary();
+    mockQueryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+
+    // Mock the fetchQuery method
+    vi.spyOn(mockQueryClient, "fetchQuery").mockImplementation(
+      async ({ queryFn, queryKey }) => {
+        return typeof queryFn === "function"
+          ? await queryFn({
+              queryKey,
+              signal: new AbortController().signal,
+              client: mockQueryClient,
+              pageParam: undefined,
+              direction: "forward" as const,
+              meta: undefined,
+            })
+          : undefined;
+      },
+    );
+
+    library = new PublishedComponentsLibrary(mockQueryClient);
     vi.clearAllMocks();
 
     // Default fetch mock

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -73,3 +73,5 @@ export const KEYBOARD_SHORTCUTS = {
 
 // Container exit codes
 export const EXIT_CODE_OOM = 137; // SIGKILL (128 + 9) - Out of Memory
+
+export const TWENTY_FOUR_HOURS_IN_MS = 24 * 60 * 60 * 1000;


### PR DESCRIPTION
### TL;DR

Export the QueryClient instance and pass it to the PublishedComponentsLibrary to enable component caching.

### What changed?

- Exported the QueryClient instance from index.tsx to make it accessible throughout the application
- Modified the PublishedComponentsLibrary to accept a QueryClient in its constructor
- Updated the ComponentLibraryProvider to:
  - Use the QueryClient via useQueryClient hook
  - Create the componentLibraries map in a useMemo hook
  - Move the getComponentLibraryObject function inside the component and wrap it in useCallback
- Added caching for component digest fetching with a 24-hour stale time

### How to test?

1. Verify that the application loads correctly with the exported QueryClient
2. Test component loading from the published components library
3. Verify that subsequent requests for the same component digest use the cached data
4. Check that the component library provider correctly initializes with the query client

### Why make this change?

This change improves performance by caching component digest data for 24 hours, reducing redundant API calls when the same components are accessed multiple times. By injecting the QueryClient into the PublishedComponentsLibrary, we enable proper data caching and reuse across the application, which leads to a more responsive user experience and reduced server load.