### PR TITLE
Fix Task Argument Cleanup bug when deleting IO Nodes via UI

### DIFF
--- a/src/components/Editor/IOEditor/InputValueEditor/InputValueEditor.tsx
+++ b/src/components/Editor/IOEditor/InputValueEditor/InputValueEditor.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { updateInputNameOnComponentSpec } from "@/components/Editor/utils/updateInputNameOnComponentSpec";
 import { ConfirmationDialog } from "@/components/shared/Dialogs";
 import { InfoBox } from "@/components/shared/InfoBox";
+import { removeGraphInput } from "@/components/shared/ReactFlow/FlowCanvas/utils/removeNode";
 import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
 import { BlockStack } from "@/components/ui/layout";
@@ -187,14 +188,7 @@ export const InputValueEditor = ({
 
     if (!confirmed) return;
 
-    const updatedInputs = componentSpec.inputs.filter(
-      (componentInput) => componentInput.name !== input.name,
-    );
-
-    const updatedComponentSpec = {
-      ...componentSpec,
-      inputs: updatedInputs,
-    };
+    const updatedComponentSpec = removeGraphInput(inputName, componentSpec);
 
     setComponentSpec(updatedComponentSpec);
 

--- a/src/components/Editor/IOEditor/OutputNameEditor/OutputNameEditor.tsx
+++ b/src/components/Editor/IOEditor/OutputNameEditor/OutputNameEditor.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 
 import ConfirmationDialog from "@/components/shared/Dialogs/ConfirmationDialog";
+import { removeGraphOutput } from "@/components/shared/ReactFlow/FlowCanvas/utils/removeNode";
 import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
@@ -110,14 +111,7 @@ export const OutputNameEditor = ({
 
     if (!confirmed) return;
 
-    const updatedOutputs = componentSpec.outputs.filter(
-      (componentOutput) => componentOutput.name !== output.name,
-    );
-
-    const updatedComponentSpec = {
-      ...componentSpec,
-      outputs: updatedOutputs,
-    };
+    const updatedComponentSpec = removeGraphOutput(output.name, componentSpec);
 
     setComponentSpec(updatedComponentSpec);
 

--- a/src/components/shared/ReactFlow/FlowCanvas/utils/removeNode.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/utils/removeNode.ts
@@ -1,6 +1,9 @@
 import { type Node } from "@xyflow/react";
 
-import type { ComponentSpec } from "@/utils/componentSpec";
+import {
+  type ComponentSpec,
+  isGraphImplementation,
+} from "@/utils/componentSpec";
 import {
   nodeIdToInputName,
   nodeIdToOutputName,
@@ -18,24 +21,22 @@ export const removeNode = (node: Node, componentSpec: ComponentSpec) => {
 
   if (node.type === "input") {
     const inputName = nodeIdToInputName(node.id);
-    return removeComponentInput(inputName, componentSpec);
+    return removeGraphInput(inputName, componentSpec);
   }
 
   if (node.type === "output") {
     const outputName = nodeIdToOutputName(node.id);
-    return removeComponentOutput(outputName, componentSpec);
+    return removeGraphOutput(outputName, componentSpec);
   }
 
   return componentSpec;
 };
 
-const removeComponentInput = (
+export const removeGraphInput = (
   inputNameToRemove: string,
   componentSpec: ComponentSpec,
 ) => {
-  // Removing the outcoming edges
-  // Not really needed since react-flow sends the node's incoming and outcoming edges for deletion when a node is deleted
-  if ("graph" in componentSpec.implementation) {
+  if (isGraphImplementation(componentSpec.implementation)) {
     const graphSpec = componentSpec.implementation.graph;
     for (const [taskId, taskSpec] of Object.entries(graphSpec.tasks)) {
       for (const [inputName, argument] of Object.entries(
@@ -58,11 +59,11 @@ const removeComponentInput = (
   return { ...componentSpec, inputs: newInputs };
 };
 
-const removeComponentOutput = (
+export const removeGraphOutput = (
   outputNameToRemove: string,
   componentSpec: ComponentSpec,
 ) => {
-  if ("graph" in componentSpec.implementation) {
+  if (isGraphImplementation(componentSpec.implementation)) {
     const graphSpec = componentSpec.implementation.graph;
     const newGraphSpec = setGraphOutputValue(graphSpec, outputNameToRemove);
     componentSpec.implementation.graph = newGraphSpec;
@@ -78,7 +79,7 @@ const removeComponentOutput = (
 };
 
 const removeTask = (taskIdToRemove: string, componentSpec: ComponentSpec) => {
-  if ("graph" in componentSpec.implementation) {
+  if (isGraphImplementation(componentSpec.implementation)) {
     const graphSpec = componentSpec.implementation.graph;
 
     // Step 1: Remove any connections where this task is used as a source


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Fixes a bug where deleting an input node via the inputValueEditor delete button would not update the arguments for any connected tasks. Similarly fixes the same issues for output nodes & the component spec.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->
Closes https://github.com/Shopify/oasis-frontend/issues/295

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->
1. graph with an input node connected to a task
2. delete the input node via the delete button on the inputValueEditor in the right panel
3. task's arguments will now correctly update (previous it would say it was still connected and block submission of the pipeline)

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
