### PR TITLE
component editor - extract common components

### DIFF
--- a/src/components/shared/ComponentEditor/components/NewComponentTemplateSelector.tsx
+++ b/src/components/shared/ComponentEditor/components/NewComponentTemplateSelector.tsx
@@ -1,0 +1,85 @@
+import type { ReactNode } from "react";
+import { FaPython } from "react-icons/fa";
+import { SiGnubash, SiRuby } from "react-icons/si";
+import { TbBrandJavascript } from "react-icons/tb";
+
+import { Button } from "@/components/ui/button";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Heading, Paragraph } from "@/components/ui/typography";
+
+export const NewComponentTemplateSelector = ({
+  onTemplateSelected,
+}: {
+  onTemplateSelected: (templateName: string) => void;
+}) => {
+  return (
+    <BlockStack gap="2" className="py-4">
+      <Heading level={2}>New Component</Heading>
+      <Paragraph tone="subdued">
+        Create a new component using the in-app editor
+      </Paragraph>
+      <Heading level={3}>Select a Template</Heading>
+      <div className="grid grid-cols-3 border-1 rounded-md p-2 w-full">
+        {SUPPORTED_TEMPLATES.map((template) => (
+          <Button
+            key={template.name}
+            variant="ghost"
+            className="p-0 h-full w-full"
+            onClick={() => onTemplateSelected(template.templateName)}
+          >
+            <BlockStack
+              gap="1"
+              align="center"
+              inlineAlign="space-between"
+              className="p-2"
+            >
+              <InlineStack
+                align="center"
+                blockAlign="center"
+                className="bg-gray-200 rounded-md p-4 mb-2 w-full h-24"
+              >
+                {!!template.icon && template.icon}
+              </InlineStack>
+              <Paragraph>{template.name}</Paragraph>
+            </BlockStack>
+          </Button>
+        ))}
+      </div>
+    </BlockStack>
+  );
+};
+
+type Template = {
+  name: string;
+  icon?: ReactNode;
+  color?: string;
+  templateName: string;
+};
+
+const SUPPORTED_TEMPLATES: Template[] = [
+  { name: "Empty", templateName: "empty" },
+  {
+    name: "Ruby",
+    icon: <SiRuby size={48} className="text-red-400 scale-300" />,
+    color: "text-red-400",
+    templateName: "ruby",
+  },
+  {
+    name: "Python",
+    icon: <FaPython size={48} className="text-green-400 scale-300" />,
+    color: "text-green-400",
+    templateName: "python",
+  },
+  {
+    name: "JavaScript",
+    icon: <TbBrandJavascript size={48} className="text-yellow-400 scale-300" />,
+    color: "text-yellow-400",
+    templateName: "javascript",
+  },
+  {
+    name: "Bash",
+    icon: <SiGnubash size={48} className="text-gray-400 scale-300" />,
+    color: "text-gray-400",
+    templateName: "bash",
+  },
+];

--- a/src/components/shared/ComponentEditor/components/PointersEventBlock.tsx
+++ b/src/components/shared/ComponentEditor/components/PointersEventBlock.tsx
@@ -1,0 +1,18 @@
+import type { PropsWithChildren } from "react";
+
+import { BlockStack } from "@/components/ui/layout";
+
+export const PointersEventBlock = ({ children }: PropsWithChildren) => {
+  /**
+   * protects the children from being clicked
+   */
+  return (
+    <BlockStack
+      className="!pointer-events-none isolate select-none relative before:absolute before:inset-0 before:content-[''] before:pointer-events-auto before:z-10"
+      align="center"
+      inlineAlign="center"
+    >
+      {children}
+    </BlockStack>
+  );
+};

--- a/src/components/shared/ComponentEditor/components/PythonComponentEditor.tsx
+++ b/src/components/shared/ComponentEditor/components/PythonComponentEditor.tsx
@@ -10,6 +10,7 @@ import { TaskNodeProvider } from "@/providers/TaskNodeProvider";
 
 import { usePythonYamlGenerator } from "../generators/python";
 import { usePreviewTaskNodeData } from "../usePreviewTaskNodeData";
+import { PointersEventBlock } from "./PointersEventBlock";
 import { TogglePreview } from "./TogglePreview";
 
 const PythonComponentEditorSkeleton = () => {
@@ -107,14 +108,7 @@ export const PythonComponentEditor = withSuspenseWrapper(
               inlineAlign="center"
             >
               {previewNodeData && showPreview && (
-                /**
-                 * protects the preview from being clicked
-                 */
-                <BlockStack
-                  className="!pointer-events-none isolate select-none relative before:absolute before:inset-0 before:content-[''] before:pointer-events-auto before:z-10"
-                  align="center"
-                  inlineAlign="center"
-                >
+                <PointersEventBlock>
                   <TaskNodeProvider
                     data={previewNodeData}
                     selected={false}
@@ -122,7 +116,7 @@ export const PythonComponentEditor = withSuspenseWrapper(
                   >
                     <TaskNodeCard />
                   </TaskNodeProvider>
-                </BlockStack>
+                </PointersEventBlock>
               )}
               {!showPreview && (
                 <MonacoEditor

--- a/src/components/shared/ComponentEditor/components/YamlComponentEditor.tsx
+++ b/src/components/shared/ComponentEditor/components/YamlComponentEditor.tsx
@@ -7,6 +7,7 @@ import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { TaskNodeProvider } from "@/providers/TaskNodeProvider";
 
 import { usePreviewTaskNodeData } from "../usePreviewTaskNodeData";
+import { PointersEventBlock } from "./PointersEventBlock";
 
 export const YamlComponentEditor = withSuspenseWrapper(
   ({
@@ -56,14 +57,15 @@ export const YamlComponentEditor = withSuspenseWrapper(
               inlineAlign="center"
             >
               {previewNodeData ? (
-                <TaskNodeProvider
-                  data={previewNodeData}
-                  selected={false}
-                  runStatus={undefined}
-                  preview
-                >
-                  <TaskNodeCard />
-                </TaskNodeProvider>
+                <PointersEventBlock>
+                  <TaskNodeProvider
+                    data={previewNodeData}
+                    selected={false}
+                    runStatus={undefined}
+                  >
+                    <TaskNodeCard />
+                  </TaskNodeProvider>
+                </PointersEventBlock>
               ) : null}
             </BlockStack>
           </BlockStack>

--- a/src/components/shared/ReactFlow/FlowSidebar/components/ImportComponent.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/components/ImportComponent.tsx
@@ -7,11 +7,9 @@ import {
   useRef,
   useState,
 } from "react";
-import { FaPython } from "react-icons/fa";
-import { SiGnubash, SiRuby } from "react-icons/si";
-import { TbBrandJavascript } from "react-icons/tb";
 
 import { ComponentEditorDialog } from "@/components/shared/ComponentEditor/ComponentEditorDialog";
+import { NewComponentTemplateSelector } from "@/components/shared/ComponentEditor/components/NewComponentTemplateSelector";
 import { useBetaFlagValue } from "@/components/shared/Settings/useBetaFlags";
 import { Button } from "@/components/ui/button";
 import {
@@ -26,9 +24,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Heading, Paragraph } from "@/components/ui/typography";
 import useImportComponent from "@/hooks/useImportComponent";
 import useToastNotification from "@/hooks/useToastNotification";
 import { cn } from "@/lib/utils";
@@ -38,41 +34,6 @@ enum TabType {
   File = "File",
   New = "New",
 }
-
-type Template = {
-  name: string;
-  icon?: ReactNode;
-  color?: string;
-  templateName: string;
-};
-
-const SUPPORTED_TEMPLATES: Template[] = [
-  { name: "Empty", templateName: "empty" },
-  {
-    name: "Ruby",
-    icon: <SiRuby size={48} className="text-red-400 scale-300" />,
-    color: "text-red-400",
-    templateName: "ruby",
-  },
-  {
-    name: "Python",
-    icon: <FaPython size={48} className="text-green-400 scale-300" />,
-    color: "text-green-400",
-    templateName: "python",
-  },
-  {
-    name: "JavaScript",
-    icon: <TbBrandJavascript size={48} className="text-yellow-400 scale-300" />,
-    color: "text-yellow-400",
-    templateName: "javascript",
-  },
-  {
-    name: "Bash",
-    icon: <SiGnubash size={48} className="text-gray-400 scale-300" />,
-    color: "text-gray-400",
-    templateName: "bash",
-  },
-];
 
 const ImportComponent = ({
   triggerComponent,
@@ -196,6 +157,11 @@ const ImportComponent = ({
       <PackagePlus className="w-4 h-4" />
     </Button>
   );
+
+  const dialogDescription = hasEnabledInAppEditor
+    ? "Create a new component, or import from a file or a URL."
+    : "Import a new component from a file or a URL.";
+
   return (
     <>
       <Dialog open={isOpen} onOpenChange={handleOpenChange}>
@@ -203,9 +169,7 @@ const ImportComponent = ({
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Add Component</DialogTitle>
-            <DialogDescription>
-              Create a new component, or import from a file or a URL.
-            </DialogDescription>
+            <DialogDescription>{dialogDescription}</DialogDescription>
             <Tabs
               value={tab}
               className="w-full"
@@ -304,43 +268,9 @@ const ImportComponent = ({
               </TabsContent>
               {hasEnabledInAppEditor && (
                 <TabsContent value={TabType.New}>
-                  <BlockStack gap="2" className="py-4">
-                    <Heading level={2}>New Component</Heading>
-                    <Paragraph tone="subdued">
-                      Create a new component using the in-app editor
-                    </Paragraph>
-                    <Heading level={3}>Select a Template</Heading>
-                    <div className="grid grid-cols-3 border-1 rounded-md p-2 w-full">
-                      {SUPPORTED_TEMPLATES.map((template) => (
-                        <Button
-                          key={template.name}
-                          variant="ghost"
-                          className="p-0 h-full w-full"
-                          onClick={() =>
-                            setComponentEditorTemplateSelected(
-                              template.templateName,
-                            )
-                          }
-                        >
-                          <BlockStack
-                            gap="1"
-                            align="center"
-                            inlineAlign="space-between"
-                            className="p-2"
-                          >
-                            <InlineStack
-                              align="center"
-                              blockAlign="center"
-                              className="bg-gray-200 rounded-md p-4 mb-2 w-full h-24"
-                            >
-                              {!!template.icon && template.icon}
-                            </InlineStack>
-                            <Paragraph>{template.name}</Paragraph>
-                          </BlockStack>
-                        </Button>
-                      ))}
-                    </div>
-                  </BlockStack>
+                  <NewComponentTemplateSelector
+                    onTemplateSelected={setComponentEditorTemplateSelected}
+                  />
                 </TabsContent>
               )}
             </Tabs>


### PR DESCRIPTION
## Description

Added a new component template selector for the in-app editor, allowing users to create components from various templates (Empty, Ruby, Python, JavaScript, and Bash). Also extracted the `PointersEventBlock` component to prevent click events from propagating through preview elements.

## Type of Change

- [x] New feature
- [x] Cleanup/Refactor

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

1. Open the flow editor
2. Click "Add Component" button
3. Navigate to the "New" tab
4. Verify that the template selector displays all available templates
5. Select a template and confirm it opens the component editor with the correct template