### PR TITLE
Provide Node Manager

### DIFF
--- a/src/providers/ComponentSpecProvider.tsx
+++ b/src/providers/ComponentSpecProvider.tsx
@@ -1,6 +1,14 @@
-import { type ReactNode, useCallback, useMemo, useRef, useState } from "react";
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
 import { type UndoRedo, useUndoRedo } from "@/hooks/useUndoRedo";
+import { NodeManager } from "@/nodeManager";
 import { loadPipelineByName } from "@/services/pipelineService";
 import { USER_PIPELINES_LIST_NAME } from "@/utils/constants";
 import { prepareComponentRefForEditor } from "@/utils/prepareComponentRefForEditor";
@@ -56,6 +64,8 @@ interface ComponentSpecContextType {
   navigateBack: () => void;
   navigateToPath: (targetPath: string[]) => void;
   canNavigateBack: boolean;
+
+  nodeManager: NodeManager;
 }
 
 const ComponentSpecContext = createRequiredContext<ComponentSpecContextType>(
@@ -71,6 +81,7 @@ export const ComponentSpecProvider = ({
   readOnly?: boolean;
   children: ReactNode;
 }) => {
+  const [nodeManager] = useState(() => new NodeManager());
   const [componentSpec, setComponentSpec] = useState<ComponentSpec>(
     spec ?? EMPTY_GRAPH_COMPONENT_SPEC,
   );
@@ -214,6 +225,10 @@ export const ComponentSpecProvider = ({
 
   const canNavigateBack = currentSubgraphPath.length > 1;
 
+  useEffect(() => {
+    nodeManager.syncWithComponentSpec(componentSpec);
+  }, [componentSpec, nodeManager]);
+
   const value = useMemo(
     () => ({
       componentSpec,
@@ -237,6 +252,8 @@ export const ComponentSpecProvider = ({
       navigateBack,
       navigateToPath,
       canNavigateBack,
+
+      nodeManager,
     }),
     [
       componentSpec,
@@ -260,6 +277,8 @@ export const ComponentSpecProvider = ({
       navigateBack,
       navigateToPath,
       canNavigateBack,
+
+      nodeManager,
     ],
   );
 


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

Integrate the new NodeManager with `ComponentSpecProvider` so that the nodes stay in sync with the component spec.

No change to app functionality. Consumption of the node manager is implemented later.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->
Progresses https://github.com/Shopify/oasis-frontend/issues/261

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] New feature

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

Just adds a new export to the componentspec provider, but does not consume it. So if the app is, in general, functioning as expected, all should be well.

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
