### PR TITLE
useNodeManager Hook

### DIFF
--- a/src/hooks/useNodeManager.ts
+++ b/src/hooks/useNodeManager.ts
@@ -1,0 +1,126 @@
+import { useCallback, useMemo } from "react";
+
+import type { HandleInfo, NodeType } from "@/nodeManager";
+import { useComponentSpec } from "@/providers/ComponentSpecProvider";
+
+export const useNodeManager = () => {
+  const { nodeManager } = useComponentSpec();
+
+  // Get node ID utilities
+  const getNodeId = useCallback(
+    (refId: string, type: NodeType): string => {
+      return nodeManager.getNodeId(refId, type);
+    },
+    [nodeManager],
+  );
+
+  const getHandleNodeId = useCallback(
+    (
+      refId: string,
+      handleName: string,
+      handleType: "handle-in" | "handle-out",
+    ): string => {
+      return nodeManager.getHandleNodeId(refId, handleName, handleType);
+    },
+    [nodeManager],
+  );
+
+  const getTaskNodeId = useCallback(
+    (taskId: string): string => {
+      return nodeManager.getNodeId(taskId, "task");
+    },
+    [nodeManager],
+  );
+
+  const getInputNodeId = useCallback(
+    (inputId: string): string => {
+      return nodeManager.getNodeId(inputId, "input");
+    },
+    [nodeManager],
+  );
+
+  const getOutputNodeId = useCallback(
+    (outputId: string): string => {
+      return nodeManager.getNodeId(outputId, "output");
+    },
+    [nodeManager],
+  );
+
+  const getInputHandleNodeId = useCallback(
+    (refId: string, inputName: string): string => {
+      return nodeManager.getHandleNodeId(refId, inputName, "handle-in");
+    },
+    [nodeManager],
+  );
+
+  const getOutputHandleNodeId = useCallback(
+    (refId: string, outputName: string): string => {
+      return nodeManager.getHandleNodeId(refId, outputName, "handle-out");
+    },
+    [nodeManager],
+  );
+
+  // Get task ID from node ID
+  const getRefId = useCallback(
+    (nodeId: string): string | undefined => {
+      return nodeManager.getRefId(nodeId);
+    },
+    [nodeManager],
+  );
+
+  // Core NodeManager operations
+  const updateRefId = useCallback(
+    (oldRefId: string, newRefId: string): void => {
+      nodeManager.updateRefId(oldRefId, newRefId);
+    },
+    [nodeManager],
+  );
+
+  const getNodeType = useCallback(
+    (nodeId: string): NodeType | undefined => {
+      return nodeManager.getNodeType(nodeId);
+    },
+    [nodeManager],
+  );
+
+  const getHandleInfo = useCallback(
+    (nodeId: string): HandleInfo | undefined => {
+      return nodeManager.getHandleInfo(nodeId);
+    },
+    [nodeManager],
+  );
+
+  return useMemo(
+    () => ({
+      // Core operations
+      getNodeId,
+      getHandleNodeId,
+      getHandleInfo,
+      getNodeType,
+      getRefId,
+      updateRefId,
+      // Specific getters
+      getInputNodeId,
+      getOutputNodeId,
+      getTaskNodeId,
+      getInputHandleNodeId,
+      getOutputHandleNodeId,
+      // NodeManager instance
+      nodeManager,
+    }),
+    [
+      getNodeId,
+      getHandleNodeId,
+      getHandleInfo,
+      getNodeType,
+      getRefId,
+      updateRefId,
+      getInputNodeId,
+      getOutputNodeId,
+      getTaskNodeId,
+      getInputHandleNodeId,
+      getOutputHandleNodeId,
+      nodeManager,
+    ],
+  );
+};


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Add a hook `useNodeManager` to simplify common node manager tasks. This is essentially a wrapper around NodeManager via ComponentSpecProvider.

No change to app functionality. Implementation will come in upstack PRs.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->
Progresses https://github.com/Shopify/oasis-frontend/issues/261

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->
Wrapper around `nodeManager.ts` without any implementation. There isn't really any testing to do here as the operations are very simple.

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
