### PR TITLE
Replace remote_sha with remote_branch

### DIFF
--- a/src/components/shared/TaskDetails/Details.tsx
+++ b/src/components/shared/TaskDetails/Details.tsx
@@ -83,14 +83,14 @@ const TaskDetails = ({
     const annotations = componentSpec?.metadata?.annotations || {};
     const {
       git_remote_url,
-      git_remote_sha,
+      git_remote_branch,
       git_relative_dir,
       component_yaml_path,
     } = annotations;
 
     if (
       git_remote_url &&
-      git_remote_sha &&
+      git_remote_branch &&
       git_relative_dir &&
       component_yaml_path
     ) {
@@ -99,7 +99,7 @@ const TaskDetails = ({
         .replace(
           /\.git$/,
           "",
-        )}/blob/${git_remote_sha}/${git_relative_dir}/${component_yaml_path}`;
+        )}/blob/${git_remote_branch}/${git_relative_dir}/${component_yaml_path}`;
     }
   }
 


### PR DESCRIPTION
## Description

Updated the component source URL construction in TaskDetails to use `git_remote_branch` instead of `git_remote_sha`. This change affects how the component source URL is generated when viewing task details, ensuring it points to the correct branch rather than a specific SHA.


Resolves an issue in this slack thread: https://shopify.slack.com/archives/C08HUHQU0Q2/p1759975264632239
## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

1. Open a task with component specifications that include git annotations
2. Verify that the component source URL correctly uses the branch name instead of SHA
3. Confirm the link works and directs to the proper location in the repository