### PR TITLE
replace useFetchExecutionInfo with optimized usePipelineRunData

### DIFF
--- a/src/components/PipelineRun/PipelineRunPage.tsx
+++ b/src/components/PipelineRun/PipelineRunPage.tsx
@@ -16,7 +16,7 @@ import { RunDetails } from "./RunDetails";
 
 const GRID_SIZE = 10;
 
-const PipelineRunPage = ({ rootExecutionId }: { rootExecutionId: string }) => {
+const PipelineRunPage = ({ pipelineRunId }: { pipelineRunId: string }) => {
   const [flowConfig, setFlowConfig] = useState<ReactFlowProps>({
     snapGrid: [GRID_SIZE, GRID_SIZE],
     snapToGrid: true,
@@ -36,7 +36,7 @@ const PipelineRunPage = ({ rootExecutionId }: { rootExecutionId: string }) => {
   );
 
   return (
-    <RootExecutionStatusProvider rootExecutionId={rootExecutionId}>
+    <RootExecutionStatusProvider pipelineRunId={pipelineRunId}>
       <ContextPanelProvider defaultContent={<RunDetails />}>
         <ComponentLibraryProvider>
           <ResizablePanelGroup direction="horizontal">

--- a/src/components/PipelineRun/RunDetails.test.tsx
+++ b/src/components/PipelineRun/RunDetails.test.tsx
@@ -9,10 +9,10 @@ import type {
 } from "@/api/types.gen";
 import { useCheckComponentSpecFromPath } from "@/hooks/useCheckComponentSpecFromPath";
 import { useExecutionStatusQuery } from "@/hooks/useExecutionStatusQuery";
+import { usePipelineRunData } from "@/hooks/usePipelineRunData";
 import { useBackend } from "@/providers/BackendProvider";
 import { ComponentSpecProvider } from "@/providers/ComponentSpecProvider";
 import { PipelineRunsProvider } from "@/providers/PipelineRunsProvider";
-import * as executionService from "@/services/executionService";
 import * as pipelineRunService from "@/services/pipelineRunService";
 import type { ComponentSpec } from "@/utils/componentSpec";
 
@@ -35,12 +35,7 @@ vi.mock("@tanstack/react-router", async (importOriginal) => {
 });
 vi.mock("@/hooks/useExecutionStatusQuery");
 vi.mock("@/hooks/useCheckComponentSpecFromPath");
-vi.mock("@/services/executionService", async (importOriginal) => {
-  return {
-    ...(await importOriginal()),
-    useFetchExecutionInfo: vi.fn(),
-  };
-});
+vi.mock("@/hooks/usePipelineRunData");
 vi.mock("@/services/pipelineRunService");
 vi.mock("@/providers/BackendProvider");
 
@@ -162,7 +157,7 @@ describe("<RunDetails/>", () => {
           <QueryClientProvider client={queryClient}>
             <PipelineRunsProvider pipelineName={mockPipelineRun.pipeline_name}>
               <RootExecutionStatusProvider
-                rootExecutionId={mockPipelineRun.root_execution_id.toString()}
+                pipelineRunId={mockPipelineRun.id.toString()}
               >
                 {children}
               </RootExecutionStatusProvider>
@@ -178,15 +173,13 @@ describe("<RunDetails/>", () => {
       // arrange
       vi.mocked(useCheckComponentSpecFromPath).mockReturnValue(true);
 
-      vi.mocked(executionService.useFetchExecutionInfo).mockReturnValue({
-        data: {
+      vi.mocked(usePipelineRunData).mockReturnValue({
+        executionData: {
           details: mockExecutionDetails,
           state: mockRunningExecutionState,
         },
         isLoading: false,
         error: null,
-        isFetching: false,
-        refetch: () => {},
       });
 
       // act
@@ -201,15 +194,13 @@ describe("<RunDetails/>", () => {
       // arrange
       vi.mocked(useCheckComponentSpecFromPath).mockReturnValue(false);
 
-      vi.mocked(executionService.useFetchExecutionInfo).mockReturnValue({
-        data: {
+      vi.mocked(usePipelineRunData).mockReturnValue({
+        executionData: {
           details: mockExecutionDetails,
           state: mockRunningExecutionState,
         },
         isLoading: false,
         error: null,
-        isFetching: false,
-        refetch: () => {},
       });
 
       // act
@@ -224,15 +215,13 @@ describe("<RunDetails/>", () => {
   describe("Clone Pipeline Button", () => {
     test("should render clone button", async () => {
       // arrange
-      vi.mocked(executionService.useFetchExecutionInfo).mockReturnValue({
-        data: {
+      vi.mocked(usePipelineRunData).mockReturnValue({
+        executionData: {
           details: mockExecutionDetails,
           state: mockRunningExecutionState,
         },
         isLoading: false,
         error: null,
-        isFetching: false,
-        refetch: () => {},
       });
 
       // act
@@ -247,15 +236,13 @@ describe("<RunDetails/>", () => {
   describe("Cancel Pipeline Run Button", () => {
     test("should render cancel button when status is RUNNING", async () => {
       // arrange
-      vi.mocked(executionService.useFetchExecutionInfo).mockReturnValue({
-        data: {
+      vi.mocked(usePipelineRunData).mockReturnValue({
+        executionData: {
           details: mockExecutionDetails,
           state: mockRunningExecutionState,
         },
         isLoading: false,
         error: null,
-        isFetching: false,
-        refetch: () => {},
       });
 
       // act
@@ -268,15 +255,13 @@ describe("<RunDetails/>", () => {
 
     test("should NOT render cancel button when status is not RUNNING", async () => {
       // arrange
-      vi.mocked(executionService.useFetchExecutionInfo).mockReturnValue({
-        data: {
+      vi.mocked(usePipelineRunData).mockReturnValue({
+        executionData: {
           details: mockExecutionDetails,
           state: mockCancelledExecutionState,
         },
         isLoading: false,
         error: null,
-        isFetching: false,
-        refetch: () => {},
       });
 
       // act
@@ -291,15 +276,13 @@ describe("<RunDetails/>", () => {
   describe("Rerun Pipeline Run Button", () => {
     test("should render rerun button when status is CANCELLED", async () => {
       // arrange
-      vi.mocked(executionService.useFetchExecutionInfo).mockReturnValue({
-        data: {
+      vi.mocked(usePipelineRunData).mockReturnValue({
+        executionData: {
           details: mockExecutionDetails,
           state: mockCancelledExecutionState,
         },
         isLoading: false,
         error: null,
-        isFetching: false,
-        refetch: () => {},
       });
 
       // act
@@ -312,15 +295,13 @@ describe("<RunDetails/>", () => {
 
     test("should NOT render rerun button when status is RUNNING", async () => {
       // arrange
-      vi.mocked(executionService.useFetchExecutionInfo).mockReturnValue({
-        data: {
+      vi.mocked(usePipelineRunData).mockReturnValue({
+        executionData: {
           details: mockExecutionDetails,
           state: mockRunningExecutionState,
         },
         isLoading: false,
         error: null,
-        isFetching: false,
-        refetch: () => {},
       });
 
       // act

--- a/src/routes/PipelineRun/PipelineRun.tsx
+++ b/src/routes/PipelineRun/PipelineRun.tsx
@@ -29,8 +29,7 @@ const PipelineRun = () => {
   const { configured, available, ready } = useBackend();
   const { id } = runDetailRoute.useParams() as RunDetailParams;
 
-  const { executionData, rootExecutionId, isLoading, error } =
-    usePipelineRunData(id);
+  const { executionData, isLoading, error } = usePipelineRunData(id);
 
   const { details, state } = executionData || {};
 
@@ -124,7 +123,7 @@ const PipelineRun = () => {
       <DndContext>
         <ReactFlowProvider>
           <PipelineRunContent
-            rootExecutionId={rootExecutionId}
+            pipelineRunId={id}
             details={details}
             state={state}
           />
@@ -135,11 +134,11 @@ const PipelineRun = () => {
 };
 
 const PipelineRunContent = ({
-  rootExecutionId,
+  pipelineRunId,
   details,
   state,
 }: {
-  rootExecutionId: string;
+  pipelineRunId: string;
   details?: GetExecutionInfoResponse;
   state?: GetGraphExecutionStateResponse;
 }) => {
@@ -150,7 +149,7 @@ const PipelineRunContent = ({
     setTaskStatusMap(taskStatusMap);
   }, [details, state, setTaskStatusMap]);
 
-  return <PipelineRunPage rootExecutionId={rootExecutionId} />;
+  return <PipelineRunPage pipelineRunId={pipelineRunId} />;
 };
 
 export default PipelineRun;

--- a/src/services/executionService.ts
+++ b/src/services/executionService.ts
@@ -1,5 +1,4 @@
 import { useQuery } from "@tanstack/react-query";
-import { useCallback } from "react";
 
 import type {
   GetArtifactsApiExecutionsIdArtifactsGetResponse,
@@ -56,50 +55,6 @@ export const useFetchContainerExecutionState = (
     enabled: !!executionId,
     refetchOnWindowFocus: false,
   });
-};
-
-export const useFetchExecutionInfo = (
-  executionId: string,
-  backendUrl: string,
-  poll: boolean = false,
-) => {
-  const {
-    data: details,
-    isLoading: isDetailsLoading,
-    isFetching: isDetailsFetching,
-    error: detailsError,
-    refetch: refetchDetails,
-  } = useQuery<GetExecutionInfoResponse>({
-    queryKey: ["pipeline-run-details", executionId],
-    refetchOnWindowFocus: false,
-    queryFn: () => fetchExecutionDetails(executionId, backendUrl),
-    refetchInterval: poll ? 5000 : false,
-  });
-
-  const {
-    data: state,
-    isLoading: isStateLoading,
-    isFetching: isStateFetching,
-    error: stateError,
-    refetch: refetchState,
-  } = useQuery<GetGraphExecutionStateResponse>({
-    queryKey: ["pipeline-run-state", executionId],
-    refetchOnWindowFocus: false,
-    queryFn: () => fetchExecutionState(executionId, backendUrl),
-    refetchInterval: poll ? 5000 : false,
-  });
-
-  const isLoading = isDetailsLoading || isStateLoading;
-  const isFetching = isDetailsFetching || isStateFetching;
-  const error = detailsError || stateError;
-  const data = { state, details };
-
-  const refetch = useCallback(() => {
-    refetchDetails();
-    refetchState();
-  }, [refetchDetails, refetchState]);
-
-  return { data, isLoading, isFetching, error, refetch };
 };
 
 export const fetchExecutionStatus = async (


### PR DESCRIPTION
## Description

Refactored the pipeline run data fetching mechanism by replacing the `RootExecutionStatusProvider` implementation with the `usePipelineRunData` hook. This change improves data fetching by:

1. Renaming `rootExecutionId` to `pipelineRunId` throughout the codebase for better clarity
2. Removing the custom polling logic in favor of React Query's built-in refetch capabilities
3. Simplifying the execution data fetching process with more efficient caching

Progresses https://github.com/Shopify/oasis-frontend/issues/171

## Type of Change

- [x] Improvement
- [x] Cleanup/Refactor

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

1. Navigate to a pipeline run page
2. Verify that execution data loads correctly
3. For running pipelines, verify that polling still works as expected
4. For completed pipelines, verify that polling stops appropriately