### PR TITLE
Fix Node Copy + Paste

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/utils/addTask.test.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/utils/addTask.test.ts
@@ -123,7 +123,7 @@ describe("addTask", () => {
         ? Object.keys(newComponentSpec.implementation.graph.tasks)
         : [];
     expect(taskIds.length).toBe(2);
-    expect(taskIds).toContain("TestTask 2");
+    expect(taskIds).toContain("TestTask (2)");
   });
 
   it("should create unique names for inputs when duplicates exist", () => {
@@ -139,7 +139,7 @@ describe("addTask", () => {
     };
 
     expect(newComponentSpec.inputs.length).toBe(2);
-    expect(newComponentSpec.inputs[1].name).toBe("Input 2");
+    expect(newComponentSpec.inputs[1].name).toBe("Input (2)");
   });
 
   it("should create unique names for outputs when duplicates exist", () => {
@@ -155,6 +155,6 @@ describe("addTask", () => {
     };
 
     expect(newComponentSpec.outputs.length).toBe(2);
-    expect(newComponentSpec.outputs[1].name).toBe("Output 2");
+    expect(newComponentSpec.outputs[1].name).toBe("Output (2)");
   });
 });

--- a/src/utils/unique.ts
+++ b/src/utils/unique.ts
@@ -4,11 +4,12 @@ const makeNameUniqueByAddingIndex = (
   name: string,
   existingNames: Set<string>,
 ): string => {
-  let finalName = name;
+  const baseName = name.replace(/ \(\d+\)$/, "");
+  let finalName = baseName;
   let index = 1;
   while (existingNames.has(finalName)) {
     index++;
-    finalName = name + " " + index.toString();
+    finalName = baseName + " (" + index.toString() + ")";
   }
   return finalName;
 };


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Fixes a couple of issues relating to copy + paste nodes & node duplication. These issues were pre-existing to this PR stack (but made easier to solve using the new Node Manager).

Fixes:
- IO Nodes don't copy metadata (name, value, type etc)
- Can't copy + paste across multiple instances of the app
- Output nodes fail to connect when pasted

KNOWN ISSUE: copy + paste output nodes between Oasis instances does not copy over the connection to that node. This is because in the new instance we do not have access to the original graphSpec.outputValues data (from the old instance) which tells us what it is connected to. This is a complex issue which will be addressed separately. For now users will need to manually remake that connection. For more info see https://github.com/Shopify/oasis-frontend/issues/314

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->
Closes https://github.com/Shopify/oasis-frontend/issues/250
Closes https://github.com/Shopify/oasis-frontend/issues/302

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->
- Verify that copy + paste single nodes and groups of nodes works as expected. Including combinations of IO nodes and tasks
- Verify that it now also works when copying across different pipelines/tabs

Note: output nodes copied across tabs will not be connected due to technical limitations in our architecture

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->

NOT FOR THIS PR - but `duplicateNodes` method desperately needs a refactor.
