### PR TITLE
Use taskExecutionIdMap instead of annotations for execution IDs

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/AnnotationsEditor.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/AnnotationsEditor.tsx
@@ -29,8 +29,6 @@ const COMMON_ANNOTATIONS: AnnotationConfig[] = [
   },
 ];
 
-const HIDDEN_ANNOTATIONS = new Set(["executionId"]);
-
 export const AnnotationsEditor = ({
   annotations,
   onChange,
@@ -44,8 +42,7 @@ export const AnnotationsEditor = ({
   const remainingAnnotations = Object.entries(annotations).filter(
     ([key]) =>
       !COMPUTE_RESOURCES.some((resource) => resource.annotation === key) &&
-      !COMMON_ANNOTATIONS.some((common) => common.annotation === key) &&
-      !HIDDEN_ANNOTATIONS.has(key),
+      !COMMON_ANNOTATIONS.some((common) => common.annotation === key),
   );
 
   return (

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfiguration/TaskConfiguration.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfiguration/TaskConfiguration.tsx
@@ -1,3 +1,4 @@
+import { useMatch } from "@tanstack/react-router";
 import {
   AmphoraIcon,
   FilePenLineIcon,
@@ -19,7 +20,9 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { useCurrentLevelExecutionData } from "@/hooks/useCurrentLevelExecutionData";
 import { type TaskNodeContextType } from "@/providers/TaskNodeProvider";
+import { runDetailRoute } from "@/routes/router";
 
 import { AnnotationsSection } from "../AnnotationsEditor/AnnotationsSection";
 import ArgumentsSection from "../ArgumentsEditor/ArgumentsSection";
@@ -38,6 +41,11 @@ interface TaskConfigurationProps {
 const TaskConfiguration = ({ taskNode, actions }: TaskConfigurationProps) => {
   const { name, taskSpec, taskId, state, callbacks } = taskNode;
 
+  const runMatch = useMatch({ from: runDetailRoute.id, shouldThrow: false });
+  const runId = (runMatch?.params as { id?: string })?.id || "";
+
+  const { details } = useCurrentLevelExecutionData(runId);
+
   const { readOnly, runStatus } = state;
   const disabled = !!runStatus;
 
@@ -50,7 +58,7 @@ const TaskConfiguration = ({ taskNode, actions }: TaskConfigurationProps) => {
     return null;
   }
 
-  const executionId = taskSpec.annotations?.executionId as string;
+  const executionId = details?.child_task_execution_ids?.[taskId];
 
   return (
     <div

--- a/src/components/shared/ReactFlow/FlowCanvas/utils/duplicateNodes.test.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/utils/duplicateNodes.test.ts
@@ -307,37 +307,6 @@ describe("duplicateNodes", () => {
       expect(taskNode.selected).toBe(true);
     });
 
-    it("should respect status: false config and remove status annotations", () => {
-      const taskSpecWithStatus = {
-        ...mockTaskSpec,
-        annotations: {
-          status: "running",
-          executionId: "exec-123",
-          "editor.position": JSON.stringify({ x: 100, y: 100 }),
-        },
-      };
-
-      const componentSpec = createMockComponentSpec({
-        "original-task": taskSpecWithStatus,
-      });
-
-      const taskNode = createMockTaskNode("original-task", taskSpecWithStatus);
-
-      const result = duplicateNodes(componentSpec, [taskNode], {
-        status: false,
-      });
-
-      if ("graph" in result.updatedComponentSpec.implementation!) {
-        const duplicatedTask =
-          result.updatedComponentSpec.implementation.graph.tasks[
-            "original-task 2"
-          ];
-        expect(duplicatedTask.annotations).not.toHaveProperty("status");
-        expect(duplicatedTask.annotations).not.toHaveProperty("executionId");
-        expect(duplicatedTask.annotations).toHaveProperty("editor.position");
-      }
-    });
-
     it("should position nodes at specified location", () => {
       const componentSpec = createMockComponentSpec({
         task1: mockTaskSpec,

--- a/src/components/shared/ReactFlow/FlowCanvas/utils/duplicateNodes.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/utils/duplicateNodes.ts
@@ -31,7 +31,7 @@ import {
 
 const OFFSET = 10;
 
-/* 
+/*
   config.connection:
     none = all links between nodes will be removed
     internal = duplicated nodes will maintain links with each other, but not with nodes outside the group
@@ -65,7 +65,6 @@ export const duplicateNodes = (
   // Default Config
   const selected = config?.selected ?? true;
   const connection = config?.connection ?? "all";
-  const status = config?.status ?? false;
 
   /* Create new Nodes and map old Task IDs to new Task IDs */
   nodesToDuplicate.forEach((node) => {
@@ -85,11 +84,6 @@ export const duplicateNodes = (
         x: node.position.x + OFFSET,
         y: node.position.y + OFFSET,
       });
-
-      if (!status) {
-        delete updatedAnnotations["status"];
-        delete updatedAnnotations["executionId"];
-      }
 
       const newTaskSpec = {
         ...taskSpec,

--- a/src/routes/PipelineRun/PipelineRun.test.tsx
+++ b/src/routes/PipelineRun/PipelineRun.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { act, cleanup, render } from "@testing-library/react";
+import { cleanup, render } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import type {
@@ -194,138 +194,51 @@ describe("<PipelineRun/>", () => {
     queryClient.clear();
   });
 
-  describe("Task Execution IDs", () => {
-    test("should add execution IDs to tasks when on runs route", async () => {
-      // arrange
-      const setComponentSpecSpy = vi.fn();
-      mockUseComponentSpec.mockReturnValue({
-        componentSpec: null,
-        setComponentSpec: setComponentSpecSpy,
-        clearComponentSpec: vi.fn(),
-        setTaskStatusMap: vi.fn(),
-        currentSubgraphPath: ["root"],
-        navigateToSubgraph: vi.fn(),
-        navigateBack: vi.fn(),
-        navigateToPath: vi.fn(),
-        canNavigateBack: false,
-        taskStatusMap: new Map(),
-        graphSpec: {} as never,
-        isLoading: false,
-        isValid: true,
-        errors: [],
-        refetch: vi.fn(),
-        updateGraphSpec: vi.fn(),
-        saveComponentSpec: vi.fn(),
-        undoRedo: {} as never,
-      });
-
-      // act
-      await act(async () =>
-        render(
-          <QueryClientProvider client={queryClient}>
-            <ComponentSpecProvider spec={undefined}>
-              <PipelineRun />
-            </ComponentSpecProvider>
-          </QueryClientProvider>,
-        ),
-      );
-
-      // assert - verify that setComponentSpec was called with execution IDs added
-      expect(setComponentSpecSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          implementation: expect.objectContaining({
-            graph: expect.objectContaining({
-              tasks: expect.objectContaining({
-                "task-1": expect.objectContaining({
-                  annotations: expect.objectContaining({
-                    executionId: "execution-1",
-                  }),
-                }),
-                "task-2": expect.objectContaining({
-                  annotations: expect.objectContaining({
-                    executionId: "execution-2",
-                  }),
-                }),
-              }),
-            }),
-          }),
-        }),
-      );
+  test("should render loading state initially", async () => {
+    // arrange
+    mockUseComponentSpec.mockReturnValue({
+      componentSpec: null,
+      setComponentSpec: vi.fn(),
+      clearComponentSpec: vi.fn(),
+      setTaskStatusMap: vi.fn(),
+      currentSubgraphPath: ["root"],
+      navigateToSubgraph: vi.fn(),
+      navigateBack: vi.fn(),
+      navigateToPath: vi.fn(),
+      canNavigateBack: false,
+      taskStatusMap: new Map(),
+      graphSpec: {} as never,
+      isLoading: false,
+      isValid: true,
+      errors: [],
+      refetch: vi.fn(),
+      updateGraphSpec: vi.fn(),
+      saveComponentSpec: vi.fn(),
+      undoRedo: {} as never,
     });
 
-    test("should not add execution IDs when child_task_execution_ids is missing", async () => {
-      // arrange
-      const setComponentSpecSpy = vi.fn();
-      mockUseComponentSpec.mockReturnValue({
-        componentSpec: null,
-        setComponentSpec: setComponentSpecSpy,
-        clearComponentSpec: vi.fn(),
-        setTaskStatusMap: vi.fn(),
-        currentSubgraphPath: ["root"],
-        navigateToSubgraph: vi.fn(),
-        navigateBack: vi.fn(),
-        navigateToPath: vi.fn(),
-        canNavigateBack: false,
-        taskStatusMap: new Map(),
-        graphSpec: {} as never,
-        isLoading: false,
-        isValid: true,
-        errors: [],
-        refetch: vi.fn(),
-        updateGraphSpec: vi.fn(),
-        saveComponentSpec: vi.fn(),
-        undoRedo: {} as never,
-      });
-
-      const mockExecutionDetailsWithoutIds = {
-        ...mockExecutionDetails,
-        child_task_execution_ids: {},
-      };
-
-      mockUsePipelineRunData.mockReturnValue({
-        executionData: {
-          details: mockExecutionDetailsWithoutIds,
-          state: mockExecutionState,
-        },
-        rootExecutionId: "test-execution-id",
-        isLoading: false,
-        error: null,
-        isFetching: false,
-        refetch: vi.fn(),
-      });
-
-      // act
-      await act(async () =>
-        render(
-          <QueryClientProvider client={queryClient}>
-            <ComponentSpecProvider spec={undefined}>
-              <PipelineRun />
-            </ComponentSpecProvider>
-          </QueryClientProvider>,
-        ),
-      );
-
-      // assert - verify that tasks don't have executionId annotations
-      expect(setComponentSpecSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          implementation: expect.objectContaining({
-            graph: expect.objectContaining({
-              tasks: expect.objectContaining({
-                "task-1": expect.not.objectContaining({
-                  annotations: expect.objectContaining({
-                    executionId: expect.anything(),
-                  }),
-                }),
-                "task-2": expect.not.objectContaining({
-                  annotations: expect.objectContaining({
-                    executionId: expect.anything(),
-                  }),
-                }),
-              }),
-            }),
-          }),
-        }),
-      );
+    mockUsePipelineRunData.mockReturnValue({
+      executionData: {
+        details: mockExecutionDetails,
+        state: mockExecutionState,
+      },
+      rootExecutionId: "test-execution-id",
+      isLoading: true,
+      error: null,
+      isFetching: false,
+      refetch: vi.fn(),
     });
+
+    // act
+    const { getByText } = render(
+      <QueryClientProvider client={queryClient}>
+        <ComponentSpecProvider spec={undefined}>
+          <PipelineRun />
+        </ComponentSpecProvider>
+      </QueryClientProvider>,
+    );
+
+    // assert
+    expect(getByText("Loading Pipeline Run...")).toBeInTheDocument();
   });
 });

--- a/src/routes/PipelineRun/PipelineRun.tsx
+++ b/src/routes/PipelineRun/PipelineRun.tsx
@@ -2,10 +2,6 @@ import { DndContext } from "@dnd-kit/core";
 import { ReactFlowProvider } from "@xyflow/react";
 import { useEffect } from "react";
 
-import type {
-  GetExecutionInfoResponse,
-  GetGraphExecutionStateResponse,
-} from "@/api/types.gen";
 import PipelineRunPage from "@/components/PipelineRun";
 import { InfoBox } from "@/components/shared/InfoBox";
 import { Spinner } from "@/components/ui/spinner";
@@ -58,13 +54,11 @@ const PipelineRun = () => {
 
   useEffect(() => {
     if (rootDetails?.task_spec.componentRef.spec) {
-      const componentSpecWithExecutionIds = addExecutionIdToComponent(
+      setComponentSpec(
         rootDetails.task_spec.componentRef.spec as ComponentSpec,
-        rootDetails,
       );
-
-      setComponentSpec(componentSpecWithExecutionIds);
     }
+
     return () => {
       clearComponentSpec();
     };
@@ -129,118 +123,14 @@ const PipelineRun = () => {
     <div className="dndflow">
       <DndContext>
         <ReactFlowProvider>
-          <PipelineRunContent
-            pipelineRunId={id}
-            details={details}
-            state={state}
-          />
+          <PipelineRunPage pipelineRunId={id} />
         </ReactFlowProvider>
       </DndContext>
     </div>
   );
 };
 
-const PipelineRunContent = ({
-  pipelineRunId,
-  details,
-  state,
-}: {
-  pipelineRunId: string;
-  details?: GetExecutionInfoResponse;
-  state?: GetGraphExecutionStateResponse;
-}) => {
-  const { setTaskStatusMap } = useComponentSpec();
-
-  useEffect(() => {
-    const taskStatusMap = buildTaskStatusMap(details, state);
-    setTaskStatusMap(taskStatusMap);
-  }, [details, state, setTaskStatusMap]);
-
-  return <PipelineRunPage pipelineRunId={pipelineRunId} />;
-};
-
 export default PipelineRun;
-
-const buildTaskStatusMap = (
-  detailsData?: GetExecutionInfoResponse,
-  stateData?: GetGraphExecutionStateResponse,
-) => {
-  const taskStatusMap = new Map();
-  if (!detailsData) {
-    return taskStatusMap;
-  }
-
-  // If no state data is available, set all tasks to WAITING_FOR_UPSTREAM
-  if (!stateData && detailsData?.child_task_execution_ids) {
-    Object.keys(detailsData.child_task_execution_ids).forEach((taskId) => {
-      taskStatusMap.set(taskId, "WAITING_FOR_UPSTREAM");
-    });
-    return taskStatusMap;
-  }
-
-  if (
-    detailsData?.child_task_execution_ids &&
-    stateData?.child_execution_status_stats
-  ) {
-    Object.entries(detailsData.child_task_execution_ids).forEach(
-      ([taskId, executionId]) => {
-        const executionIdStr = String(executionId);
-        const statusStats =
-          stateData.child_execution_status_stats[executionIdStr];
-
-        if (statusStats) {
-          const status = Object.keys(statusStats)[0];
-          taskStatusMap.set(taskId, status);
-        } else {
-          // If this task doesn't have status in state data, mark as WAITING
-          taskStatusMap.set(taskId, "WAITING_FOR_UPSTREAM");
-        }
-      },
-    );
-  }
-
-  return taskStatusMap;
-};
-
-const addExecutionIdToComponent = (
-  componentSpec: ComponentSpec,
-  detailsData?: GetExecutionInfoResponse,
-): ComponentSpec => {
-  if (
-    !componentSpec ||
-    !("graph" in componentSpec.implementation) ||
-    !detailsData
-  ) {
-    return componentSpec;
-  }
-
-  const tasksWithExecutionId = Object.fromEntries(
-    Object.entries(componentSpec.implementation.graph.tasks).map(
-      ([taskId, taskSpec]) => {
-        const executionId = detailsData?.child_task_execution_ids?.[taskId];
-        const enhancedTaskSpec = {
-          ...taskSpec,
-          annotations: {
-            ...taskSpec.annotations,
-            executionId: executionId,
-          },
-        };
-        return [taskId, enhancedTaskSpec];
-      },
-    ),
-  );
-
-  return {
-    ...componentSpec,
-    implementation: {
-      ...componentSpec.implementation,
-      graph: {
-        ...componentSpec.implementation.graph,
-        tasks: tasksWithExecutionId,
-      },
-    },
-  };
-};
 
 const mapRunStatusToFavicon = (
   runStatus: string,

--- a/src/services/pipelineRunService.ts
+++ b/src/services/pipelineRunService.ts
@@ -3,11 +3,7 @@ import localForage from "localforage";
 import type { BodyCreateApiPipelineRunsPost } from "@/api/types.gen";
 import { APP_ROUTES } from "@/routes/router";
 import type { PipelineRun } from "@/types/pipelineRun";
-import {
-  type ComponentSpec,
-  isGraphImplementation,
-  type TaskSpec,
-} from "@/utils/componentSpec";
+import type { ComponentSpec } from "@/utils/componentSpec";
 import {
   componentSpecToYaml,
   getComponentFileFromList,
@@ -18,8 +14,6 @@ import {
   PIPELINE_RUNS_STORE_NAME,
   USER_PIPELINES_LIST_NAME,
 } from "@/utils/constants";
-
-const ANNOTATIONS_NOT_COPIED = new Set(["status", "executionId"]);
 
 export const createPipelineRun = async (
   payload: BodyCreateApiPipelineRunsPost,
@@ -89,22 +83,6 @@ export const copyRunToPipeline = async (
   try {
     const cleanComponentSpec = structuredClone(componentSpec);
 
-    if (
-      isGraphImplementation(cleanComponentSpec.implementation) &&
-      cleanComponentSpec.implementation?.graph?.tasks
-    ) {
-      Object.values(cleanComponentSpec.implementation.graph.tasks).forEach(
-        (task: TaskSpec) => {
-          if (task.annotations) {
-            for (const key of ANNOTATIONS_NOT_COPIED) {
-              if (key in task.annotations) {
-                delete task.annotations[key];
-              }
-            }
-          }
-        },
-      );
-    }
     // The editor now only supports left-to-right layouts direction, so we mark every cloned pipelines with this annotation.
     // Ideally, we should have tried to properly convert the pipelines (transpose the node positions).
     // But there are already many runs that are left-to-right but not marked as such.


### PR DESCRIPTION
## Description

Refactored how execution IDs are managed in the pipeline run interface by introducing a dedicated context provider instead of storing them as task annotations. This approach provides a cleaner separation between execution data and component specifications.

The key changes include:
- Created a new `CurrentExecutionProvider` to make execution details available throughout the component tree
- Removed the logic that was adding execution IDs to task annotations
- Updated `TaskConfiguration` to retrieve execution IDs from the context provider
- Removed the hidden annotation filter for "executionId" since it's no longer stored in annotations
- Removed execution ID handling from the node duplication logic
- Simplified the PipelineRun component by removing annotation manipulation code

## Type of Change

- [x] Bug fix
- [x] Improvement
- [x] Cleanup/Refactor

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Test Instructions

1. Create and run a pipeline with nested subgraphs
2. Navigate into the nested subgraph during execution
3. Verify that task status is correctly displayed at all levels of nesting (details, artifacts, logs)
4. Navigate back to parent graph and confirm status is maintained