### PR TITLE
use hydrated reference in hasPublishedComponent check

### DIFF
--- a/src/components/shared/ManageComponent/hooks/useHasPublishedComponent.ts
+++ b/src/components/shared/ManageComponent/hooks/useHasPublishedComponent.ts
@@ -1,5 +1,6 @@
 import { useSuspenseQuery } from "@tanstack/react-query";
 
+import { useGuaranteedHydrateComponentReference } from "@/hooks/useHydrateComponentReference";
 import { useComponentLibrary } from "@/providers/ComponentLibraryProvider";
 import type { ComponentReference } from "@/utils/componentSpec";
 
@@ -14,10 +15,14 @@ export const useHasPublishedComponent = (componentRef: ComponentReference) => {
     "published_components",
   );
 
+  const hydratedComponentRef =
+    useGuaranteedHydrateComponentReference(componentRef);
+
   return useSuspenseQuery({
     // todo: id of the component?
     // todo: consistent queryKey naming practice
-    queryKey: ["has-component", componentRef.digest],
-    queryFn: () => publishedComponentsLibrary.hasComponent(componentRef),
+    queryKey: ["has-component", hydratedComponentRef.digest],
+    queryFn: () =>
+      publishedComponentsLibrary.hasComponent(hydratedComponentRef),
   });
 };

--- a/src/hooks/useHydrateComponentReference.ts
+++ b/src/hooks/useHydrateComponentReference.ts
@@ -32,3 +32,24 @@ export function useHydrateComponentReference(component: ComponentReference) {
 
   return componentRef;
 }
+
+class ComponentHydrationError extends Error {
+  name = "ComponentHydrationError";
+
+  constructor(public readonly component: ComponentReference) {
+    super(
+      `Failed to hydrate component reference: ${component.digest ?? component.url ?? "unknown"}`,
+    );
+  }
+}
+
+export function useGuaranteedHydrateComponentReference(
+  component: ComponentReference,
+) {
+  const hydratedComponentRef = useHydrateComponentReference(component);
+  if (!hydratedComponentRef) {
+    throw new ComponentHydrationError(component);
+  }
+
+  return hydratedComponentRef;
+}


### PR DESCRIPTION
## Description

Added a new `useGuaranteedHydrateComponentReference` hook that ensures component references are properly hydrated before use. This hook throws a custom `ComponentHydrationError` if hydration fails, providing better error handling and debugging information.

Updated `useHasPublishedComponent` to use the new guaranteed hydration hook, ensuring that component references are always properly hydrated before checking if they're published.

This change fixes the error with "Sub-graph" beta flag turned on:



![image.png](https://app.graphite.dev/user-attachments/assets/69eefa04-c9a8-478c-9a12-3be224d11a6e.png)



## Type of Change

- [x] Improvement
- [x] Bug fix

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

1. Test component publishing and verification flows
2. Verify that component references are properly hydrated
3. Check that appropriate errors are thrown when component hydration fails