### PR TITLE
move useCurrentLevelExecutionData deps into function

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfiguration/TaskConfiguration.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfiguration/TaskConfiguration.tsx
@@ -1,4 +1,3 @@
-import { useMatch } from "@tanstack/react-router";
 import {
   AmphoraIcon,
   FilePenLineIcon,
@@ -22,7 +21,6 @@ import {
 } from "@/components/ui/tooltip";
 import { useCurrentLevelExecutionData } from "@/hooks/useCurrentLevelExecutionData";
 import { type TaskNodeContextType } from "@/providers/TaskNodeProvider";
-import { runDetailRoute } from "@/routes/router";
 
 import { AnnotationsSection } from "../AnnotationsEditor/AnnotationsSection";
 import ArgumentsSection from "../ArgumentsEditor/ArgumentsSection";
@@ -41,10 +39,7 @@ interface TaskConfigurationProps {
 const TaskConfiguration = ({ taskNode, actions }: TaskConfigurationProps) => {
   const { name, taskSpec, taskId, state, callbacks } = taskNode;
 
-  const runMatch = useMatch({ from: runDetailRoute.id, shouldThrow: false });
-  const runId = (runMatch?.params as { id?: string })?.id || "";
-
-  const { details } = useCurrentLevelExecutionData(runId);
+  const { details } = useCurrentLevelExecutionData();
 
   const { readOnly, runStatus } = state;
   const disabled = !!runStatus;

--- a/src/hooks/useCurrentLevelExecutionData.test.tsx
+++ b/src/hooks/useCurrentLevelExecutionData.test.tsx
@@ -11,6 +11,15 @@ import type {
 import { useCurrentLevelExecutionData } from "./useCurrentLevelExecutionData";
 
 // Mock dependencies
+vi.mock("@tanstack/react-router", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@tanstack/react-router")>();
+  return {
+    ...actual,
+    useMatch: vi.fn(),
+  };
+});
+
 vi.mock("@/providers/BackendProvider", () => ({
   useBackend: vi.fn(),
 }));
@@ -22,6 +31,8 @@ vi.mock("@/providers/ComponentSpecProvider", () => ({
 vi.mock("@/hooks/usePipelineRunData", () => ({
   usePipelineRunData: vi.fn(),
 }));
+
+import { useMatch } from "@tanstack/react-router";
 
 import { usePipelineRunData } from "@/hooks/usePipelineRunData";
 import { useBackend } from "@/providers/BackendProvider";
@@ -74,6 +85,10 @@ describe("useCurrentLevelExecutionData", () => {
         },
       },
     });
+
+    vi.mocked(useMatch).mockReturnValue({
+      params: { id: "root-exec-123" },
+    } as never);
 
     vi.mocked(useBackend).mockReturnValue({
       backendUrl: "http://test-backend.com",
@@ -129,10 +144,9 @@ describe("useCurrentLevelExecutionData", () => {
 
   describe("root level execution", () => {
     it("should return root execution ID at root level", () => {
-      const { result } = renderHook(
-        () => useCurrentLevelExecutionData("root-exec-123"),
-        { wrapper: createWrapper },
-      );
+      const { result } = renderHook(() => useCurrentLevelExecutionData(), {
+        wrapper: createWrapper,
+      });
 
       expect(result.current.currentExecutionId).toBe("root-exec-123");
     });
@@ -151,7 +165,7 @@ describe("useCurrentLevelExecutionData", () => {
         error: null,
       });
 
-      renderHook(() => useCurrentLevelExecutionData("root-exec-123"), {
+      renderHook(() => useCurrentLevelExecutionData(), {
         wrapper: createWrapper,
       });
 
@@ -165,7 +179,7 @@ describe("useCurrentLevelExecutionData", () => {
     });
 
     it("should build task status map with actual statuses", async () => {
-      renderHook(() => useCurrentLevelExecutionData("root-exec-123"), {
+      renderHook(() => useCurrentLevelExecutionData(), {
         wrapper: createWrapper,
       });
 
@@ -236,10 +250,9 @@ describe("useCurrentLevelExecutionData", () => {
         },
       );
 
-      const { result } = renderHook(
-        () => useCurrentLevelExecutionData("root-exec-123"),
-        { wrapper: createWrapper },
-      );
+      const { result } = renderHook(() => useCurrentLevelExecutionData(), {
+        wrapper: createWrapper,
+      });
 
       expect(result.current.currentExecutionId).toBe("456");
     });
@@ -300,7 +313,7 @@ describe("useCurrentLevelExecutionData", () => {
         },
       );
 
-      renderHook(() => useCurrentLevelExecutionData("root-exec-123"), {
+      renderHook(() => useCurrentLevelExecutionData(), {
         wrapper: createWrapper,
       });
 
@@ -323,10 +336,9 @@ describe("useCurrentLevelExecutionData", () => {
         error: null,
       });
 
-      const { result } = renderHook(
-        () => useCurrentLevelExecutionData("root-exec-123"),
-        { wrapper: createWrapper },
-      );
+      const { result } = renderHook(() => useCurrentLevelExecutionData(), {
+        wrapper: createWrapper,
+      });
 
       expect(result.current.isLoading).toBe(true);
     });
@@ -341,10 +353,9 @@ describe("useCurrentLevelExecutionData", () => {
         error: mockError,
       });
 
-      const { result } = renderHook(
-        () => useCurrentLevelExecutionData("root-exec-123"),
-        { wrapper: createWrapper },
-      );
+      const { result } = renderHook(() => useCurrentLevelExecutionData(), {
+        wrapper: createWrapper,
+      });
 
       expect(result.current.error).toBe(mockError);
     });
@@ -367,7 +378,7 @@ describe("useCurrentLevelExecutionData", () => {
         error: null,
       });
 
-      renderHook(() => useCurrentLevelExecutionData("root-exec-123"), {
+      renderHook(() => useCurrentLevelExecutionData(), {
         wrapper: createWrapper,
       });
 
@@ -408,10 +419,9 @@ describe("useCurrentLevelExecutionData", () => {
         error: null,
       });
 
-      const { result } = renderHook(
-        () => useCurrentLevelExecutionData("root-exec-123"),
-        { wrapper: createWrapper },
-      );
+      const { result } = renderHook(() => useCurrentLevelExecutionData(), {
+        wrapper: createWrapper,
+      });
 
       // Should return root ID since we can't traverse further
       expect(result.current.currentExecutionId).toBe("root-exec-123");

--- a/src/hooks/useCurrentLevelExecutionData.ts
+++ b/src/hooks/useCurrentLevelExecutionData.ts
@@ -1,3 +1,4 @@
+import { useMatch } from "@tanstack/react-router";
 import { useEffect, useMemo, useRef } from "react";
 
 import type {
@@ -5,6 +6,7 @@ import type {
   GetGraphExecutionStateResponse,
 } from "@/api/types.gen";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
+import { runDetailRoute } from "@/routes/router";
 
 import { usePipelineRunData } from "./usePipelineRunData";
 
@@ -115,7 +117,10 @@ const buildTaskStatusMap = (
  * This hook manages all data fetching internally, so parent components don't need
  * to fetch execution data separately.
  */
-export const useCurrentLevelExecutionData = (rootExecutionOrRunId: string) => {
+export const useCurrentLevelExecutionData = () => {
+  const runMatch = useMatch({ from: runDetailRoute.id, shouldThrow: false });
+  const rootExecutionOrRunId = (runMatch?.params as { id?: string })?.id || "";
+
   const { currentSubgraphPath, setTaskStatusMap } = useComponentSpec();
 
   const executionDataCache = useRef<Map<string, CachedExecutionData>>(

--- a/src/routes/PipelineRun/PipelineRun.test.tsx
+++ b/src/routes/PipelineRun/PipelineRun.test.tsx
@@ -23,6 +23,9 @@ vi.mock("@tanstack/react-router", async (importOriginal) => {
       href: "/runs/test-run-id-123",
       state: {},
     }),
+    useMatch: () => ({
+      params: { id: "test-run-id-123" },
+    }),
   };
 });
 
@@ -55,7 +58,7 @@ vi.mock("@/services/executionService", () => ({
     isLoading: false,
     error: null,
     isFetching: false,
-    refetch: () => {},
+    refetch: () => { },
     enabled: false,
   }),
   countTaskStatuses: vi.fn(),
@@ -85,11 +88,11 @@ vi.mock("@/providers/ComponentSpecProvider", async (importOriginal) => {
 });
 
 vi.mock("@/hooks/useDocumentTitle", () => ({
-  useDocumentTitle: () => {},
+  useDocumentTitle: () => { },
 }));
 
 vi.mock("@/hooks/useFavicon", () => ({
-  useFavicon: () => {},
+  useFavicon: () => { },
 }));
 
 describe("<PipelineRun/>", () => {

--- a/src/routes/PipelineRun/PipelineRun.tsx
+++ b/src/routes/PipelineRun/PipelineRun.tsx
@@ -31,7 +31,7 @@ const PipelineRun = () => {
     isLoading: isLoadingCurrentLevelData,
     error: currentLevelError,
     rootDetails,
-  } = useCurrentLevelExecutionData(id || "");
+  } = useCurrentLevelExecutionData();
 
   const isLoading = isLoadingCurrentLevelData;
   const error = currentLevelError;


### PR DESCRIPTION
## Description

Refactored `useCurrentLevelExecutionData` hook to extract the run ID directly from the router instead of requiring it as a parameter. This simplifies the API by removing the need to pass the run ID explicitly to the hook.

## Type of Change

- [x] Cleanup/Refactor

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Test Instructions

1. Navigate to a pipeline run detail page
2. Verify that task configurations load correctly
3. Verify that execution data is properly displayed
4. Test navigation between different subgraphs to ensure execution data is correctly updated