### PR TITLE
Fix Crashes in Component Editor

### DIFF
--- a/src/components/shared/ComponentEditor/components/YamlComponentEditor.tsx
+++ b/src/components/shared/ComponentEditor/components/YamlComponentEditor.tsx
@@ -1,9 +1,11 @@
 import MonacoEditor from "@monaco-editor/react";
+import yaml from "js-yaml";
 import { useCallback, useState } from "react";
 
 import { withSuspenseWrapper } from "@/components/shared/SuspenseWrapper";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 
+import { InfoBox } from "../../InfoBox";
 import { DEFAULT_MONACO_OPTIONS } from "../constants";
 import { PreviewTaskNodeCard } from "./PreviewTaskNodeCard";
 
@@ -16,18 +18,28 @@ export const YamlComponentEditor = withSuspenseWrapper(
     onComponentTextChange: (yaml: string) => void;
   }) => {
     const [componentText, setComponentText] = useState(text);
+    const [safeComponentText, setSafeComponentText] = useState(text);
+    const [error, setError] = useState<string | null>(null);
 
     const handleComponentTextChange = useCallback(
       (value: string | undefined) => {
         setComponentText(value ?? "");
         onComponentTextChange(value ?? "");
+
+        try {
+          yaml.load(value ?? "");
+          setSafeComponentText(value ?? "");
+          setError(null);
+        } catch (e) {
+          setError((e as Error).message);
+        }
       },
       [onComponentTextChange],
     );
 
     return (
-      <InlineStack className="w-full h-full" gap="4">
-        <BlockStack className="flex-1 h-full pt-7" data-testid="yaml-editor">
+      <InlineStack className="w-full h-full pt-7" gap="4">
+        <BlockStack className="flex-1 h-full" data-testid="yaml-editor">
           <MonacoEditor
             defaultLanguage={"yaml"}
             theme="vs-dark"
@@ -39,12 +51,19 @@ export const YamlComponentEditor = withSuspenseWrapper(
 
         <BlockStack className="flex-1 h-full" data-testid="yaml-editor-preview">
           <BlockStack className="w-full h-full">
+            <div className="h-8">
+              {error && (
+                <InfoBox variant="error" title="Invalid YAML">
+                  {error}
+                </InfoBox>
+              )}
+            </div>
             <BlockStack
               className="w-full h-full"
               align="center"
               inlineAlign="center"
             >
-              <PreviewTaskNodeCard componentText={componentText} />
+              <PreviewTaskNodeCard componentText={safeComponentText} />
             </BlockStack>
           </BlockStack>
         </BlockStack>

--- a/src/providers/TaskNodeProvider.tsx
+++ b/src/providers/TaskNodeProvider.tsx
@@ -75,8 +75,18 @@ export const TaskNodeProvider = ({
   const taskId = data.taskId as string;
   const nodeId = taskIdToNodeId(taskId);
 
-  const inputs = taskSpec.componentRef.spec?.inputs || [];
-  const outputs = taskSpec.componentRef.spec?.outputs || [];
+  const inputs = useMemo(
+    () =>
+      taskSpec.componentRef.spec?.inputs?.filter((input) => !!input?.name) ||
+      [],
+    [taskSpec],
+  );
+  const outputs = useMemo(
+    () =>
+      taskSpec.componentRef.spec?.outputs?.filter((output) => !!output?.name) ||
+      [],
+    [taskSpec],
+  );
 
   const name = getComponentName(taskSpec.componentRef);
 


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

Fixes an issue where the in-app component editor would crash when incomplete or invalid YAML was entered.

Now the app will handle incomplete input/output entries (the crash caused by hyphens). And the app will display an error message and previously valid task if invalid YAML is entered (the crash when incomplete lines are added)

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

Closes https://github.com/Shopify/oasis-frontend/issues/305
Closes https://github.com/Shopify/oasis-frontend/issues/306

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

![image.png](https://app.graphite.dev/user-attachments/assets/c4b963ad-c938-4cd8-8745-ca54f8e90e21.png)

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->
Can now enter invalid YAML (such as a line with just a hyphen, or lists without colons) into the editor and the app will not crash and the preview will remain visible (without changes).

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
