### PR TITLE
component editor: validate component spec yaml

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@hey-api/client-fetch": "^0.13.1",
+        "@hyperjump/json-schema": "^1.16.3",
         "@monaco-editor/react": "^4.7.0",
         "@radix-ui/react-accordion": "^1.2.12",
         "@radix-ui/react-alert-dialog": "^1.1.15",
@@ -1148,6 +1149,22 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -1178,6 +1195,12 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
       "version": "3.1.2",
@@ -1390,6 +1413,78 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@hyperjump/browser": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@hyperjump/browser/-/browser-1.3.1.tgz",
+      "integrity": "sha512-Le5XZUjnVqVjkgLYv6yyWgALat/0HpB1XaCPuCZ+GCFki9NvXloSZITIJ0H+wRW7mb9At1SxvohKBbNQbrr/cw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@hyperjump/json-pointer": "^1.1.0",
+        "@hyperjump/uri": "^1.2.0",
+        "content-type": "^1.0.5",
+        "just-curry-it": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jdesrosiers"
+      }
+    },
+    "node_modules/@hyperjump/json-pointer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@hyperjump/json-pointer/-/json-pointer-1.1.1.tgz",
+      "integrity": "sha512-M0T3s7TC2JepoWPMZQn1W6eYhFh06OXwpMqL+8c5wMVpvnCKNsPgpu9u7WyCI03xVQti8JAeAy4RzUa6SYlJLA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jdesrosiers"
+      }
+    },
+    "node_modules/@hyperjump/json-schema": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/@hyperjump/json-schema/-/json-schema-1.16.3.tgz",
+      "integrity": "sha512-Vgr6+q05/TDcxTKXFGJEtAs1UDXfisX6vtthQhO3W4r63cNH07TVGJUqgyj34LoHCL1CDsOFjH5fCgSxljfOrg==",
+      "license": "MIT",
+      "dependencies": {
+        "@hyperjump/json-pointer": "^1.1.0",
+        "@hyperjump/pact": "^1.2.0",
+        "@hyperjump/uri": "^1.2.0",
+        "content-type": "^1.0.4",
+        "json-stringify-deterministic": "^1.0.12",
+        "just-curry-it": "^5.3.0",
+        "uuid": "^9.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jdesrosiers"
+      },
+      "peerDependencies": {
+        "@hyperjump/browser": "^1.1.0"
+      }
+    },
+    "node_modules/@hyperjump/pact": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@hyperjump/pact/-/pact-1.4.0.tgz",
+      "integrity": "sha512-01Q7VY6BcAkp9W31Fv+ciiZycxZHGlR2N6ba9BifgyclHYHdbaZgITo0U6QMhYRlem4k8pf8J31/tApxvqAz8A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jdesrosiers"
+      }
+    },
+    "node_modules/@hyperjump/uri": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@hyperjump/uri/-/uri-1.3.2.tgz",
+      "integrity": "sha512-OFo5oxuSEz1ktF/LDdBTptlnPyZ66jywLO4fJRuAhnr7NGnsiL2CPoj1JRVaDqVy0nXvWNsC8O8Muw9DR++eEg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jdesrosiers"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -4428,22 +4523,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
@@ -5104,6 +5183,15 @@
       "license": "MIT",
       "engines": {
         "node": "^14.18.0 || >=16.10.0"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/convert-source-map": {
@@ -6012,6 +6100,22 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/eslint/node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -6042,6 +6146,12 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "license": "MIT"
     },
     "node_modules/eslint/node_modules/minimatch": {
       "version": "3.1.2",
@@ -7714,17 +7824,20 @@
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "license": "MIT"
     },
-    "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "license": "MIT"
-    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "license": "MIT"
+    },
+    "node_modules/json-stringify-deterministic": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/json-stringify-deterministic/-/json-stringify-deterministic-1.0.12.tgz",
+      "integrity": "sha512-q3PN0lbUdv0pmurkBNdJH3pfFvOTL/Zp0lquqpvcjfKzt6Y0j49EPHAmVHCAS4Ceq/Y+PejWTzyiVpoY71+D6g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -7765,6 +7878,12 @@
       "engines": {
         "node": ">=4.0"
       }
+    },
+    "node_modules/just-curry-it": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/just-curry-it/-/just-curry-it-5.3.0.tgz",
+      "integrity": "sha512-silMIRiFjUWlfaDhkgSzpuAyQ6EX/o09Eu8ZBfmFwQMbax7+LQzeIU2CBrICT6Ne4l86ITCGvUCBpCubWYy0Yw==",
+      "license": "MIT"
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -10751,6 +10870,19 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
     "@hey-api/client-fetch": "^0.13.1",
+    "@hyperjump/json-schema": "^1.16.3",
     "@monaco-editor/react": "^4.7.0",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.15",

--- a/src/components/shared/ComponentEditor/components/ComponentSpecErrorsList.tsx
+++ b/src/components/shared/ComponentEditor/components/ComponentSpecErrorsList.tsx
@@ -1,0 +1,31 @@
+import { Icon } from "@/components/ui/icon";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
+
+export const ComponentSpecErrorsList = ({
+  validationErrors,
+}: {
+  validationErrors: string[];
+}) => {
+  if (validationErrors.length === 0) {
+    return null;
+  }
+
+  return (
+    <BlockStack className="p-4 px-8 bg-red-100 border border-t-4 border-red-300 text-destructive">
+      <InlineStack gap="2" blockAlign="center">
+        <Icon name="OctagonAlert" size="lg" className="text-destructive" />
+        <Text tone="critical" as="h2" size="lg">
+          Invalid component spec
+        </Text>
+      </InlineStack>
+      <ul className="list-disc list-inside space-y-1 p-4">
+        {validationErrors.map((error, idx) => (
+          <li key={`${idx}-${error}`} className="text-sm">
+            {error}
+          </li>
+        ))}
+      </ul>
+    </BlockStack>
+  );
+};

--- a/src/components/shared/ComponentEditor/components/YamlComponentEditor.tsx
+++ b/src/components/shared/ComponentEditor/components/YamlComponentEditor.tsx
@@ -5,6 +5,8 @@ import { withSuspenseWrapper } from "@/components/shared/SuspenseWrapper";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 
 import { DEFAULT_MONACO_OPTIONS } from "../constants";
+import { useComponentSpecValidator } from "../useComponentSpecValidator";
+import { ComponentSpecErrorsList } from "./ComponentSpecErrorsList";
 import { PreviewTaskNodeCard } from "./PreviewTaskNodeCard";
 
 export const YamlComponentEditor = withSuspenseWrapper(
@@ -16,37 +18,51 @@ export const YamlComponentEditor = withSuspenseWrapper(
     onComponentTextChange: (yaml: string) => void;
   }) => {
     const [componentText, setComponentText] = useState(text);
+    const validateComponentSpec = useComponentSpecValidator();
+    const [validationErrors, setValidationErrors] = useState<string[]>([]);
 
     const handleComponentTextChange = useCallback(
       (value: string | undefined) => {
+        const validationResult = validateComponentSpec(value ?? "");
+
+        if (!validationResult.valid) {
+          setValidationErrors(
+            validationResult.errors ?? ["Invalid component spec"],
+          );
+          return;
+        }
+
         setComponentText(value ?? "");
         onComponentTextChange(value ?? "");
+        setValidationErrors([]);
       },
-      [onComponentTextChange],
+      [onComponentTextChange, validateComponentSpec],
     );
 
     return (
       <InlineStack className="w-full h-full" gap="4">
         <BlockStack className="flex-1 h-full pt-7" data-testid="yaml-editor">
-          <MonacoEditor
-            defaultLanguage={"yaml"}
-            theme="vs-dark"
-            value={componentText}
-            onChange={handleComponentTextChange}
-            options={DEFAULT_MONACO_OPTIONS}
-          />
+          <BlockStack className="flex-1 relative">
+            <div className="absolute inset-0">
+              <MonacoEditor
+                defaultLanguage={"yaml"}
+                theme="vs-dark"
+                value={componentText}
+                onChange={handleComponentTextChange}
+                options={DEFAULT_MONACO_OPTIONS}
+              />
+            </div>
+          </BlockStack>
+          <ComponentSpecErrorsList validationErrors={validationErrors} />
         </BlockStack>
 
-        <BlockStack className="flex-1 h-full" data-testid="yaml-editor-preview">
-          <BlockStack className="w-full h-full">
-            <BlockStack
-              className="w-full h-full"
-              align="center"
-              inlineAlign="center"
-            >
-              <PreviewTaskNodeCard componentText={componentText} />
-            </BlockStack>
-          </BlockStack>
+        <BlockStack
+          className="flex-1 h-full"
+          data-testid="yaml-editor-preview"
+          align="center"
+          inlineAlign="center"
+        >
+          <PreviewTaskNodeCard componentText={componentText} />
         </BlockStack>
       </InlineStack>
     );

--- a/src/components/shared/ComponentEditor/useComponentSpecValidator.tsx
+++ b/src/components/shared/ComponentEditor/useComponentSpecValidator.tsx
@@ -1,0 +1,133 @@
+import { addMediaTypePlugin } from "@hyperjump/browser";
+import { type OutputUnit, validate } from "@hyperjump/json-schema/draft-06";
+import { buildSchemaDocument } from "@hyperjump/json-schema/experimental";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import yaml from "js-yaml";
+
+const COMPONENT_SPEC_SCHEMA_URL =
+  "https://raw.githubusercontent.com/Cloud-Pipelines/component_spec_schema/refs/heads/master/component_spec.json_schema.json";
+
+addMediaTypePlugin("text/plain", {
+  parse: async (response) =>
+    buildSchemaDocument(JSON.parse(await response.text())),
+  fileMatcher: async (path) => path.endsWith(".json_schema.json"),
+});
+
+interface ValidationResult {
+  valid: boolean;
+  errors?: string[];
+}
+
+export const useComponentSpecValidator = () => {
+  const { data: validator } = useSuspenseQuery({
+    queryKey: ["componentSpecValidator"],
+    queryFn: async () => {
+      const validator = await validate(COMPONENT_SPEC_SCHEMA_URL);
+
+      return (value: any): ValidationResult => {
+        const normalizedValue = normalizeValue(value);
+
+        if (!normalizedValue) {
+          return {
+            valid: false,
+            errors: ["Failed to parse YAML: Invalid syntax"],
+          };
+        }
+
+        const result = validator(normalizedValue, { outputFormat: "BASIC" });
+
+        if (!result.valid && result.errors) {
+          return {
+            valid: false,
+            errors: formatValidationErrors(result.errors),
+          };
+        }
+
+        return { valid: result.valid };
+      };
+    },
+    staleTime: Infinity,
+  });
+  return validator;
+};
+
+function formatValidationErrors(errors: OutputUnit[]): string[] {
+  const formattedErrors: string[] = [];
+
+  for (const error of errors) {
+    const location = error.instanceLocation || "#";
+    const keyword = extractKeyword(error.keyword);
+
+    // Extract the field path from the instance location
+    const fieldPath = location.replace("#/", "").replace(/\//g, ".");
+
+    // Format error based on keyword type
+    let message: string;
+
+    if (keyword === "required") {
+      // Extract which field is missing from the error location
+      const parentPath = fieldPath || "root";
+      message = `Missing required field in ${parentPath}`;
+    } else if (keyword === "additionalProperties") {
+      // For additional properties, the field path includes the invalid property
+      const parts = fieldPath.split(".");
+      const invalidField = parts[parts.length - 1];
+      const parentPath = parts.slice(0, -1).join(".") || "root";
+      message = `Unknown property "${invalidField}" in ${parentPath}`;
+    } else if (keyword === "type") {
+      message = `Invalid type at ${fieldPath || "root"}`;
+    } else if (keyword === "enum") {
+      message = `Invalid value at ${fieldPath || "root"} - must be one of the allowed values`;
+    } else if (keyword === "pattern") {
+      message = `Invalid format at ${fieldPath || "root"}`;
+    } else if (keyword === "minLength" || keyword === "maxLength") {
+      message = `Invalid length at ${fieldPath || "root"}`;
+    } else if (keyword === "minimum" || keyword === "maximum") {
+      message = `Value out of range at ${fieldPath || "root"}`;
+    } else if (keyword === "oneOf" || keyword === "anyOf") {
+      message = `Value at ${fieldPath || "root"} doesn't match any of the expected formats`;
+    } else if (keyword === "validate") {
+      // This is typically a wrapper error, check if it's about additional properties
+      if (error.absoluteKeywordLocation?.includes("additionalProperties")) {
+        const parts = fieldPath.split(".");
+        const invalidField = parts[parts.length - 1];
+        const parentPath = parts.slice(0, -1).join(".") || "root";
+        message = `Unknown property "${invalidField}" in ${parentPath}`;
+      } else {
+        message = `Validation failed at ${fieldPath || "root"}`;
+      }
+    } else {
+      // Generic message for other keywords
+      message = `${keyword} validation failed at ${fieldPath || "root"}`;
+    }
+
+    // Avoid duplicate messages
+    if (!formattedErrors.includes(message)) {
+      formattedErrors.push(message);
+    }
+  }
+
+  return formattedErrors;
+}
+
+function extractKeyword(keywordUrl: string): string {
+  // Extract the keyword from the URL format
+  // e.g., "https://json-schema.org/keyword/required" -> "required"
+  // or "https://json-schema.org/evaluation/validate" -> "validate"
+  const parts = keywordUrl.split("/");
+  return parts[parts.length - 1] || "unknown";
+}
+
+function normalizeValue(value: any): any {
+  if (typeof value === "string") {
+    // assuming it is YAML
+    // todo: worth revisiting
+    try {
+      return yaml.load(value) as any;
+    } catch {
+      return undefined;
+    }
+  }
+
+  return value;
+}


### PR DESCRIPTION
## Description

Closes https://github.com/Shopify/oasis-frontend/issues/305

Added JSON Schema validation for component specifications in the YAML editor. This implementation uses the `@hyperjump/json-schema` library to validate component specs against the official schema from the Cloud-Pipelines repository.

## Related Issue and Pull requests

## Type of Change

- [x] New feature
- [x] Improvement

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

[Screen Recording 2025-10-19 at 2.21.59 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/user-attachments/thumbnails/2e21c785-9592-4b68-84b7-82b55e460c93.mov" />](https://app.graphite.dev/user-attachments/video/2e21c785-9592-4b68-84b7-82b55e460c93.mov)

1. Open the YAML component editor
2. Enter an invalid component specification
3. Verify that an error message appears
4. Enter a valid component specification
5. Verify that the error message disappears and the component preview updates

## Additional Comments

The validation currently shows a generic error message. Future improvements could include displaying specific validation errors to help users fix their component specs.