### PR TITLE
component editor: handle errors during editing

### DIFF
--- a/src/components/shared/ComponentEditor/ComponentEditorDialog.tsx
+++ b/src/components/shared/ComponentEditor/ComponentEditorDialog.tsx
@@ -76,6 +76,7 @@ export const ComponentEditorDialog = withSuspenseWrapper(
 
     const { data: templateCode } = useTemplateCodeByName(templateName);
     const [componentText, setComponentText] = useState(text ?? templateCode);
+    const [errors, setErrors] = useState<string[]>([]);
 
     const { data: pythonCodeDetection } = useSuspenseQuery({
       queryKey: ["isPython", `${templateName}-${JSON.stringify(text)}`],
@@ -167,7 +168,11 @@ export const ComponentEditorDialog = withSuspenseWrapper(
             </InlineStack>
 
             <InlineStack gap="2" blockAlign="center">
-              <Button variant="secondary" onClick={handleSave}>
+              <Button
+                variant="default"
+                onClick={handleSave}
+                disabled={errors.length > 0}
+              >
                 <Icon name="Save" /> Save
               </Button>
               <Button variant="ghost" size="icon" onClick={handleClose}>
@@ -180,11 +185,13 @@ export const ComponentEditorDialog = withSuspenseWrapper(
             <PythonComponentEditor
               text={pythonCodeDetection.pythonOriginalCode}
               onComponentTextChange={handleComponentTextChange}
+              onErrorsChange={setErrors}
             />
           ) : (
             <YamlComponentEditor
               text={componentText}
               onComponentTextChange={handleComponentTextChange}
+              onErrorsChange={setErrors}
             />
           )}
         </BlockStack>

--- a/src/components/shared/ComponentEditor/components/PythonComponentEditor.tsx
+++ b/src/components/shared/ComponentEditor/components/PythonComponentEditor.tsx
@@ -1,17 +1,15 @@
 import MonacoEditor from "@monaco-editor/react";
 import { useCallback, useEffect, useState } from "react";
 
-import { TaskNodeCard } from "@/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard";
 import { withSuspenseWrapper } from "@/components/shared/SuspenseWrapper";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Text } from "@/components/ui/typography";
-import { TaskNodeProvider } from "@/providers/TaskNodeProvider";
 
 import { DEFAULT_MONACO_OPTIONS } from "../constants";
 import { usePythonYamlGenerator } from "../generators/python";
-import { usePreviewTaskNodeData } from "../usePreviewTaskNodeData";
-import { PointersEventBlock } from "./PointersEventBlock";
+import { ComponentSpecErrorsList } from "./ComponentSpecErrorsList";
+import { PreviewTaskNodeCard } from "./PreviewTaskNodeCard";
 import { TogglePreview } from "./TogglePreview";
 
 const PythonComponentEditorSkeleton = () => {
@@ -46,21 +44,32 @@ export const PythonComponentEditor = withSuspenseWrapper(
   ({
     text,
     onComponentTextChange,
+    onErrorsChange,
   }: {
     text: string;
     onComponentTextChange: (yaml: string) => void;
+    onErrorsChange: (errors: string[]) => void;
   }) => {
     const [componentText, setComponentText] = useState("");
+    const [validationErrors, setValidationErrors] = useState<string[]>([]);
     const [showPreview, setShowPreview] = useState(true);
     const yamlGenerator = usePythonYamlGenerator();
 
     const handleFunctionTextChange = useCallback(
       async (value: string | undefined) => {
-        const yaml = await yamlGenerator(value ?? "").catch((error) => {
-          return `❌ Error In Component Code ❌ \n\n ${error instanceof Error ? error.message : String(error)}`;
-        });
-        setComponentText(yaml);
-        onComponentTextChange(yaml);
+        try {
+          const yaml = await yamlGenerator(value ?? "");
+          setComponentText(yaml);
+          onComponentTextChange(yaml);
+          setValidationErrors([]);
+          onErrorsChange([]);
+        } catch (error) {
+          const errors = [
+            error instanceof Error ? error.message : String(error),
+          ];
+          onErrorsChange(errors);
+          setValidationErrors(errors);
+        }
       },
       [yamlGenerator, onComponentTextChange],
     );
@@ -70,21 +79,24 @@ export const PythonComponentEditor = withSuspenseWrapper(
       handleFunctionTextChange(text);
     }, [text, handleFunctionTextChange]);
 
-    const previewNodeData = usePreviewTaskNodeData(componentText);
-
     return (
       <InlineStack className="w-full h-full" gap="4">
         <BlockStack className="flex-1 h-full" data-testid="python-editor">
           <InlineStack className="h-10 py-2">
             <Text>Python Code</Text>
           </InlineStack>
-          <MonacoEditor
-            defaultLanguage="python"
-            theme="vs-dark"
-            value={text}
-            onChange={handleFunctionTextChange}
-            options={DEFAULT_MONACO_OPTIONS}
-          />
+          <BlockStack className="flex-1 relative">
+            <div className="absolute inset-0">
+              <MonacoEditor
+                defaultLanguage="python"
+                theme="vs-dark"
+                value={text}
+                onChange={handleFunctionTextChange}
+                options={DEFAULT_MONACO_OPTIONS}
+              />
+            </div>
+          </BlockStack>
+          <ComponentSpecErrorsList validationErrors={validationErrors} />
         </BlockStack>
 
         <BlockStack className="flex-1 h-full">
@@ -101,19 +113,17 @@ export const PythonComponentEditor = withSuspenseWrapper(
               inlineAlign="center"
               data-testid="python-editor-preview"
             >
-              {previewNodeData && showPreview && (
-                <PointersEventBlock>
-                  <TaskNodeProvider data={previewNodeData} selected={false}>
-                    <TaskNodeCard />
-                  </TaskNodeProvider>
-                </PointersEventBlock>
-              )}
-              {!showPreview && (
+              {showPreview ? (
+                <PreviewTaskNodeCard componentText={componentText} />
+              ) : (
                 <MonacoEditor
                   defaultLanguage="yaml"
                   theme="vs-dark"
                   value={componentText}
-                  options={DEFAULT_MONACO_OPTIONS}
+                  options={{
+                    ...DEFAULT_MONACO_OPTIONS,
+                    readOnly: true,
+                  }}
                 />
               )}
             </BlockStack>

--- a/src/components/shared/ComponentEditor/components/YamlComponentEditor.tsx
+++ b/src/components/shared/ComponentEditor/components/YamlComponentEditor.tsx
@@ -13,9 +13,11 @@ export const YamlComponentEditor = withSuspenseWrapper(
   ({
     text,
     onComponentTextChange,
+    onErrorsChange,
   }: {
     text: string;
     onComponentTextChange: (yaml: string) => void;
+    onErrorsChange: (errors: string[]) => void;
   }) => {
     const [componentText, setComponentText] = useState(text);
     const validateComponentSpec = useComponentSpecValidator();
@@ -26,15 +28,16 @@ export const YamlComponentEditor = withSuspenseWrapper(
         const validationResult = validateComponentSpec(value ?? "");
 
         if (!validationResult.valid) {
-          setValidationErrors(
-            validationResult.errors ?? ["Invalid component spec"],
-          );
+          const errors = validationResult.errors ?? ["Invalid component spec"];
+          setValidationErrors(errors);
+          onErrorsChange(errors);
           return;
         }
 
         setComponentText(value ?? "");
         onComponentTextChange(value ?? "");
         setValidationErrors([]);
+        onErrorsChange([]);
       },
       [onComponentTextChange, validateComponentSpec],
     );


### PR DESCRIPTION
## Description

Disabled the Save button in the Component Editor when there are validation errors in the component code. Added error handling for both Python and YAML component editors to display validation errors and prevent saving invalid components.

## Type of Change

- [x] Improvement
- [x] Bug fix

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

[Screen Recording 2025-10-19 at 2.20.48 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/user-attachments/thumbnails/f985a5ce-ce92-4543-8c75-a78c5ae99226.mov" />](https://app.graphite.dev/user-attachments/video/f985a5ce-ce92-4543-8c75-a78c5ae99226.mov)

1. Open the Component Editor
2. Enter invalid Python or YAML code
3. Verify that validation errors are displayed and the Save button is disabled
4. Fix the errors and verify the Save button becomes enabled again