### PR TITLE
add check to query useRootExecutionId

### DIFF
--- a/src/hooks/usePipelineRunData.ts
+++ b/src/hooks/usePipelineRunData.ts
@@ -27,6 +27,7 @@ const useRootExecutionId = (id: string) => {
       // assuming id is root_execution_id
       return id;
     },
+    enabled: !!id && id.length > 0,
     staleTime: Infinity,
   });
 


### PR DESCRIPTION
## Description

Added an `enabled` condition to the `useRootExecutionId` hook to prevent unnecessary query execution when the ID is empty or undefined. This ensures that the query only runs when there's a valid ID to work with.

In some cases `useRootExecutionId`​ requests `pipeline_runs`​ with empty id.

| Before | After |
| --- | --- |
| ![image.png](https://app.graphite.dev/user-attachments/assets/7ddceb91-cc77-4d1e-bcd6-ad8b35d68262.png)<br><br> | ![image.png](https://app.graphite.dev/user-attachments/assets/e457fe82-bbf7-4fc3-b597-ff4d16b5acd0.png)<br> |

## Related Issue and Pull requests

## Type of Change

- [x] Improvement
- [x] Bug fix

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

1. Verify that the hook doesn't trigger API calls when the ID is empty or undefined
2. Confirm that the hook works normally when a valid ID is provided