### PR TITLE
Argument Editor - Save on Unmount

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/ArgumentInputField.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/ArgumentInputField.tsx
@@ -14,6 +14,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 
@@ -58,6 +59,8 @@ export const ArgumentInputField = ({
   );
 
   const [isTextareaDialogOpen, setIsTextareaDialogOpen] = useState(false);
+
+  const inputValueRef = useRef(inputValue);
 
   const undoValue = useMemo(() => argument, []);
   const hint = argument.inputSpec.annotations?.hint as string | undefined;
@@ -217,6 +220,24 @@ export const ArgumentInputField = ({
       argument.value === getDefaultValue(argument),
     [argument, disabled],
   );
+
+  useEffect(() => {
+    inputValueRef.current = inputValue;
+  }, [inputValue]);
+
+  useEffect(() => {
+    return () => {
+      const value = inputValueRef.current.trim();
+      if (value !== lastSubmittedValue) {
+        const updatedArgument = {
+          ...argument,
+          value,
+          isRemoved: false,
+        };
+        onSave(updatedArgument);
+      }
+    };
+  }, []);
 
   return (
     <>


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

Makes argument editor input fields automatically save their value when unmounted, even if not blurred. e.g. in the scenario where a user types in a value then changes tab.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->
Closes https://github.com/Cloud-Pipelines/pipeline-studio-app/issues/823

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->
- confirm arguments save and load and behave as expected when edited
- confirm argument values save when entered and the node is deselected or a new task detail tab is selected

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
