### PR TITLE
component editor - meta editor for python components

### DIFF
--- a/src/components/shared/ComponentEditor/ComponentEditorDialog.tsx
+++ b/src/components/shared/ComponentEditor/ComponentEditorDialog.tsx
@@ -10,13 +10,14 @@ import { Heading, Paragraph } from "@/components/ui/typography";
 import useToastNotification from "@/hooks/useToastNotification";
 import { useComponentLibrary } from "@/providers/ComponentLibraryProvider";
 import { hydrateComponentReference } from "@/services/componentService";
+import { isContainerImplementation } from "@/utils/componentSpec";
 import { saveComponent } from "@/utils/localforage";
 
 import { FullscreenElement } from "../FullscreenElement";
 import { withSuspenseWrapper } from "../SuspenseWrapper";
 import { PythonComponentEditor } from "./components/PythonComponentEditor";
 import { YamlComponentEditor } from "./components/YamlComponentEditor";
-import type { SupportedTemplate } from "./types";
+import type { SupportedTemplate, YamlGeneratorOptions } from "./types";
 import { useTemplateCodeByName } from "./useTemplateCodeByName";
 
 const ComponentEditorDialogSkeleton = () => {
@@ -58,7 +59,11 @@ const ComponentEditorDialogSkeleton = () => {
 };
 
 type PythonCodeDetection =
-  | { isPython: true; pythonOriginalCode: string }
+  | {
+      isPython: true;
+      pythonOriginalCode: string;
+      options: YamlGeneratorOptions;
+    }
   | { isPython: false };
 
 export const ComponentEditorDialog = withSuspenseWrapper(
@@ -86,7 +91,14 @@ export const ComponentEditorDialog = withSuspenseWrapper(
             text,
           });
 
-          const pythonOriginalCode = hydratedComponent?.spec?.metadata
+          if (
+            !hydratedComponent ||
+            !isContainerImplementation(hydratedComponent.spec.implementation)
+          ) {
+            return { isPython: false };
+          }
+
+          const pythonOriginalCode = hydratedComponent.spec.metadata
             ?.annotations?.python_original_code as string;
 
           if (!pythonOriginalCode) {
@@ -96,6 +108,25 @@ export const ComponentEditorDialog = withSuspenseWrapper(
           return {
             isPython: true,
             pythonOriginalCode,
+            options: {
+              baseImage:
+                hydratedComponent.spec.implementation.container.image ??
+                "python:3.12",
+              packagesToInstall: parsePythonDependencies(
+                hydratedComponent.spec.metadata?.annotations
+                  ?.python_dependencies,
+              ),
+              annotations: Object.fromEntries(
+                Object.entries(
+                  (hydratedComponent.spec.metadata?.annotations ??
+                    {}) as Record<string, string>,
+                ).filter(
+                  ([key]) =>
+                    key !== "python_original_code" &&
+                    key !== "python_dependencies",
+                ),
+              ),
+            },
           };
         }
 
@@ -110,6 +141,7 @@ export const ComponentEditorDialog = withSuspenseWrapper(
         return {
           isPython: true,
           pythonOriginalCode: defaultPythonFunctionText,
+          options: {},
         };
       },
     });
@@ -184,6 +216,7 @@ export const ComponentEditorDialog = withSuspenseWrapper(
           {pythonCodeDetection?.isPython ? (
             <PythonComponentEditor
               text={pythonCodeDetection.pythonOriginalCode}
+              options={pythonCodeDetection.options}
               onComponentTextChange={handleComponentTextChange}
               onErrorsChange={setErrors}
             />
@@ -200,3 +233,13 @@ export const ComponentEditorDialog = withSuspenseWrapper(
   },
   ComponentEditorDialogSkeleton,
 );
+
+function parsePythonDependencies(dependencies: unknown | undefined): string[] {
+  try {
+    return (
+      JSON.parse(typeof dependencies === "string" ? dependencies : "[]") ?? []
+    );
+  } catch {
+    return [];
+  }
+}

--- a/src/components/shared/ComponentEditor/components/YamlGeneratorOptionsEditor.tsx
+++ b/src/components/shared/ComponentEditor/components/YamlGeneratorOptionsEditor.tsx
@@ -1,0 +1,295 @@
+import {
+  type PropsWithChildren,
+  type ReactNode,
+  useEffect,
+  useReducer,
+} from "react";
+
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icon";
+import { Input, InputGroup } from "@/components/ui/input";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Heading, Paragraph, Text } from "@/components/ui/typography";
+
+import type { YamlGeneratorOptions } from "../types";
+
+type Annotation = { id: number; key: string; value: string };
+type YamlOptionsEditorState = Pick<
+  YamlGeneratorOptions,
+  "baseImage" | "packagesToInstall"
+> & {
+  annotations: Annotation[];
+};
+
+type YamlGeneratorOptionsStateAction =
+  | { type: "SET_BASE_IMAGE"; payload: string }
+  | { type: "ADD_PACKAGE"; payload: string }
+  | { type: "UPDATE_PACKAGE"; index: number; value: string }
+  | { type: "REMOVE_PACKAGE"; index: number }
+  | { type: "ADD_ANNOTATION"; payload: { key: string; value: string } }
+  | { type: "UPDATE_ANNOTATION"; id: number; key: string; value: string }
+  | { type: "REMOVE_ANNOTATION"; id: number };
+
+export const YamlGeneratorOptionsEditor = ({
+  onChange,
+  initialOptions,
+}: {
+  initialOptions: YamlGeneratorOptions;
+  onChange: (options: YamlGeneratorOptions) => void;
+}) => {
+  const { state, dispatch } = useYamlGeneratorOptionsReducer(initialOptions);
+
+  useEffect(() => {
+    onChange({
+      baseImage: state.baseImage,
+      packagesToInstall: state.packagesToInstall?.filter(Boolean) ?? [],
+      annotations: Object.fromEntries(
+        state.annotations
+          .filter(({ key, value }) => key && value)
+          .map(({ key, value }) => [key, value]),
+      ),
+    });
+  }, [state, onChange]);
+
+  return (
+    <BlockStack className="flex-1 relative px-1" gap="4">
+      <Section
+        title="Container Image"
+        description='The container image to use for the component. Default is "python:3.12".'
+      >
+        <Input
+          name="container-image"
+          placeholder="python:3.12"
+          value={state.baseImage}
+          onChange={(e) =>
+            dispatch({ type: "SET_BASE_IMAGE", payload: e.target.value })
+          }
+        />
+      </Section>
+
+      <Section
+        title="Packages to Install"
+        description="The PIP packages to install in the container."
+        actions={
+          <AddButton
+            onClick={() => dispatch({ type: "ADD_PACKAGE", payload: "" })}
+          />
+        }
+      >
+        {state.packagesToInstall?.map((pkg, index) => (
+          <InputGroup
+            key={`${pkg}-${index}`}
+            className="w-full group"
+            suffixElement={
+              <RemoveButton
+                onClick={() => dispatch({ type: "REMOVE_PACKAGE", index })}
+              />
+            }
+          >
+            <Input
+              variant="noBorder"
+              placeholder="Package name"
+              defaultValue={pkg}
+              onBlur={(e) =>
+                dispatch({
+                  type: "UPDATE_PACKAGE",
+                  index,
+                  value: e.target.value,
+                })
+              }
+            />
+          </InputGroup>
+        ))}
+      </Section>
+
+      <Section
+        title="Annotations"
+        description="The annotations to add to the component. Empty values will be ignored in the final YAML."
+        actions={
+          <AddButton
+            onClick={() =>
+              dispatch({
+                type: "ADD_ANNOTATION",
+                payload: { key: "", value: "" },
+              })
+            }
+          />
+        }
+      >
+        {(state.annotations ?? []).map(({ id, key, value }) => (
+          <InlineStack
+            key={`annotation-${id}`}
+            align="space-between"
+            className="w-full group"
+            gap="1"
+          >
+            <InlineStack
+              wrap="nowrap"
+              blockAlign="center"
+              className="flex-1"
+              gap="1"
+            >
+              <Input
+                className="w-full"
+                placeholder="Annotation key"
+                defaultValue={key}
+                onBlur={(e) =>
+                  dispatch({
+                    type: "UPDATE_ANNOTATION",
+                    id,
+                    key: e.target.value,
+                    value,
+                  })
+                }
+              />
+              <Text>:</Text>
+            </InlineStack>
+            <InlineStack wrap="nowrap" blockAlign="center" className="flex-1">
+              <Input
+                className="w-full"
+                placeholder="Annotation value"
+                defaultValue={value}
+                onBlur={(e) =>
+                  dispatch({
+                    type: "UPDATE_ANNOTATION",
+                    id,
+                    key,
+                    value: e.target.value,
+                  })
+                }
+              />
+              <RemoveButton
+                onClick={() => dispatch({ type: "REMOVE_ANNOTATION", id })}
+              />
+            </InlineStack>
+          </InlineStack>
+        ))}
+      </Section>
+    </BlockStack>
+  );
+};
+
+let autoincrementId = 0;
+
+function yamlGeneratorOptionsReducer(
+  state: YamlOptionsEditorState,
+  action: YamlGeneratorOptionsStateAction,
+): YamlOptionsEditorState {
+  switch (action.type) {
+    case "SET_BASE_IMAGE":
+      return { ...state, baseImage: action.payload };
+
+    case "ADD_PACKAGE":
+      return {
+        ...state,
+        packagesToInstall: [...(state.packagesToInstall ?? []), action.payload],
+      };
+    case "UPDATE_PACKAGE":
+      return {
+        ...state,
+        packagesToInstall: (state.packagesToInstall ?? []).map((pkg, index) =>
+          index === action.index ? action.value : pkg,
+        ),
+      };
+    case "REMOVE_PACKAGE":
+      return {
+        ...state,
+        packagesToInstall: (state.packagesToInstall ?? []).filter(
+          (_, index) => index !== action.index,
+        ),
+      };
+    case "ADD_ANNOTATION":
+      return {
+        ...state,
+        annotations: [
+          ...(state.annotations ?? []),
+          { id: autoincrementId++, ...action.payload },
+        ],
+      };
+    case "UPDATE_ANNOTATION":
+      return {
+        ...state,
+        annotations: (state.annotations ?? []).map((annotation) =>
+          annotation.id === action.id
+            ? { ...annotation, key: action.key, value: action.value }
+            : annotation,
+        ),
+      };
+    case "REMOVE_ANNOTATION":
+      if (!state.annotations) return state;
+      return {
+        ...state,
+        annotations: (state.annotations ?? []).filter(
+          (annotation) => annotation.id !== action.id,
+        ),
+      };
+    default:
+      return state;
+  }
+}
+
+function useYamlGeneratorOptionsReducer(
+  initial?: Partial<YamlGeneratorOptions>,
+) {
+  const [state, dispatch] = useReducer(yamlGeneratorOptionsReducer, {
+    baseImage: initial?.baseImage ?? "python:3.12",
+    packagesToInstall: initial?.packagesToInstall ?? [],
+    annotations:
+      Object.entries(initial?.annotations ?? {}).map(([key, value]) => ({
+        key,
+        value,
+        id: autoincrementId++,
+      })) ?? [],
+  });
+  return { state, dispatch };
+}
+
+const RemoveButton = ({ onClick }: { onClick: () => void }) => {
+  return (
+    <Button
+      variant="ghost"
+      size="xs"
+      className="group-hover:visible group-focus-within:visible invisible"
+      onClick={onClick}
+    >
+      <Icon name="Trash" className="text-destructive" />
+    </Button>
+  );
+};
+
+const AddButton = ({ onClick }: { onClick: () => void }) => {
+  return (
+    <Button variant="ghost" size="xs" onClick={onClick}>
+      <Icon name="CirclePlus" /> Add
+    </Button>
+  );
+};
+
+const Section = ({
+  title,
+  description,
+  actions,
+  children,
+}: PropsWithChildren<{
+  title: string;
+  description?: string;
+  actions?: ReactNode;
+}>) => {
+  return (
+    <BlockStack gap="3" className="border rounded-md p-3">
+      <BlockStack>
+        <InlineStack align="space-between" className="w-full">
+          <Heading level={2}>{title}</Heading>
+          {actions}
+        </InlineStack>
+        {description && (
+          <Paragraph tone="subdued" size="xs">
+            {description}
+          </Paragraph>
+        )}
+      </BlockStack>
+
+      <BlockStack gap="1">{children}</BlockStack>
+    </BlockStack>
+  );
+};

--- a/src/components/shared/ComponentEditor/types.ts
+++ b/src/components/shared/ComponentEditor/types.ts
@@ -4,3 +4,14 @@ export type SupportedTemplate =
   | "python"
   | "javascript"
   | "bash";
+
+export interface YamlGeneratorOptions {
+  baseImage?: string;
+  packagesToInstall?: string[];
+  annotations?: Record<string, string>;
+}
+
+export type YamlGenerator = (
+  text: string,
+  options?: YamlGeneratorOptions,
+) => Promise<string>;


### PR DESCRIPTION
## Description

Closes https://github.com/Cloud-Pipelines/pipeline-studio-app/issues/1111

Closes https://github.com/Cloud-Pipelines/pipeline-studio-app/issues/1110

Closes https://github.com/Cloud-Pipelines/pipeline-studio-app/issues/1109

Enhanced the Python Component Editor with a new metadata tab that allows users to configure container settings. This update enables users to:

1. Specify a custom base image for the container
2. Add Python packages to be installed in the container
3. Define custom annotations for the component

The PR also adds functionality to parse and preserve existing metadata when editing Python components, ensuring that previously configured settings are maintained.

## Type of Change

- [x] New feature
- [x] Improvement

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Test Instructions

[Screen Recording 2025-10-21 at 7.19.00 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/user-attachments/thumbnails/dd65e1e9-8961-4ba0-b2c1-3ea0ade47e45.mov" />](https://app.graphite.dev/user-attachments/video/dd65e1e9-8961-4ba0-b2c1-3ea0ade47e45.mov)

1. Open the Component Editor for a Python component
2. Switch to the "Metadata" tab
3. Verify you can set a custom container image
4. Add Python packages to be installed
5. Add custom annotations
6. Save the component and verify the settings are preserved