### PR TITLE
hides logs and details for subgraph nodes

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfiguration/TaskConfiguration.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfiguration/TaskConfiguration.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/components/ui/tooltip";
 import { useExecutionDataOptional } from "@/providers/ExecutionDataProvider";
 import { type TaskNodeContextType } from "@/providers/TaskNodeProvider";
+import { isGraphImplementation } from "@/utils/componentSpec";
 
 import { AnnotationsSection } from "../AnnotationsEditor/AnnotationsSection";
 import ArgumentsSection from "../ArgumentsEditor/ArgumentsSection";
@@ -54,6 +55,7 @@ const TaskConfiguration = ({ taskNode, actions }: TaskConfigurationProps) => {
     return null;
   }
 
+  const isSubgraph = isGraphImplementation(componentSpec.implementation);
   const executionId = details?.child_task_execution_ids?.[taskId];
 
   return (
@@ -82,7 +84,7 @@ const TaskConfiguration = ({ taskNode, actions }: TaskConfigurationProps) => {
               Details
             </TabsTrigger>
 
-            {readOnly && (
+            {readOnly && !isSubgraph && (
               <TabsTrigger value="logs" className="flex-1">
                 <LogsIcon className="h-4 w-4" />
                 Logs
@@ -152,7 +154,7 @@ const TaskConfiguration = ({ taskNode, actions }: TaskConfigurationProps) => {
               />
             )}
           </TabsContent>
-          {readOnly && (
+          {readOnly && !isSubgraph && (
             <TabsContent value="logs" className="h-full">
               {!!executionId && (
                 <div className="flex w-full justify-end pr-4">

--- a/src/components/shared/TaskDetails/Details.tsx
+++ b/src/components/shared/TaskDetails/Details.tsx
@@ -165,7 +165,7 @@ const TaskDetails = ({
           </div>
         )}
 
-        {executionId && <ExecutionDetails executionId={executionId} />}
+        {executionId && <ExecutionDetails executionId={executionId} componentSpec={componentSpec} />}
 
         {componentSpec?.metadata?.annotations?.author && (
           <div className="flex flex-col px-3 py-2">


### PR DESCRIPTION
## Description

Added support for subgraph components in the execution details view. The PR conditionally hides container execution details and logs for subgraph components, as these are not applicable for graph implementations.

## Type of Change

- [x] Improvement
- [x] New feature

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Test Instructions

1. Create a pipeline with a subgraph component
2. Run the pipeline
3. Verify that container execution details and logs are not displayed for the subgraph component
4. Verify that regular components still show execution details and logs as before