### PR TITLE
add updateSubgraphSpec utility for nested graph updates

### DIFF
--- a/src/components/shared/TaskDetails/Details.tsx
+++ b/src/components/shared/TaskDetails/Details.tsx
@@ -165,7 +165,12 @@ const TaskDetails = ({
           </div>
         )}
 
-        {executionId && <ExecutionDetails executionId={executionId} componentSpec={componentSpec} />}
+        {executionId && (
+          <ExecutionDetails
+            executionId={executionId}
+            componentSpec={componentSpec}
+          />
+        )}
 
         {componentSpec?.metadata?.annotations?.author && (
           <div className="flex flex-col px-3 py-2">

--- a/src/providers/ExecutionDataProvider.tsx
+++ b/src/providers/ExecutionDataProvider.tsx
@@ -168,7 +168,13 @@ export function ExecutionDataProvider({
       executionDataCache.current,
       queryClient,
     );
-  }, [currentSubgraphPath, rootExecutionId, rootDetails, isAtRoot, queryClient]);
+  }, [
+    currentSubgraphPath,
+    rootExecutionId,
+    rootDetails,
+    isAtRoot,
+    queryClient,
+  ]);
 
   const {
     executionData: nestedExecutionData,
@@ -195,7 +201,13 @@ export function ExecutionDataProvider({
       details: nestedDetails,
       state: nestedState,
     });
-  }, [nestedDetails, nestedState, currentExecutionId, currentSubgraphPath, isAtRoot]);
+  }, [
+    nestedDetails,
+    nestedState,
+    currentExecutionId,
+    currentSubgraphPath,
+    isAtRoot,
+  ]);
 
   useEffect(() => {
     const taskStatusMap = buildTaskStatusMap(details, state);

--- a/src/utils/subgraphUtils.test.ts
+++ b/src/utils/subgraphUtils.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
 
-import type { TaskSpec } from "./componentSpec";
+import type { ComponentSpec, TaskSpec } from "./componentSpec";
+import { isGraphImplementation } from "./componentSpec";
 import {
   getSubgraphComponentSpec,
   getSubgraphDescription,
   isSubgraph,
+  updateSubgraphSpec,
 } from "./subgraphUtils";
 
 describe("subgraphUtils", () => {
@@ -233,6 +235,395 @@ describe("subgraphUtils", () => {
 
       expect(notify).not.toHaveBeenCalled();
       expect(result.name).toBe("test-graph-component");
+    });
+  });
+
+  describe("updateSubgraphSpec", () => {
+    const createRootComponentSpec = () => ({
+      name: "root-component",
+      inputs: [{ name: "rootInput", type: "string" }],
+      outputs: [{ name: "rootOutput", type: "string" }],
+      implementation: {
+        graph: {
+          tasks: {
+            task1: createContainerTaskSpec(),
+            subgraph1: createGraphTaskSpec(2),
+          },
+          outputValues: {},
+        },
+      },
+    });
+
+    const createDeeplyNestedSpec = (): ComponentSpec => ({
+      name: "root-component",
+      implementation: {
+        graph: {
+          tasks: {
+            "level1-subgraph": {
+              componentRef: {
+                spec: {
+                  name: "level1-component",
+                  implementation: {
+                    graph: {
+                      tasks: {
+                        "level2-subgraph": {
+                          componentRef: {
+                            spec: {
+                              name: "level2-component",
+                              implementation: {
+                                graph: {
+                                  tasks: {
+                                    "leaf-task": createContainerTaskSpec(),
+                                  },
+                                },
+                              },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          outputValues: {},
+        },
+      },
+    });
+
+    it("should return updated spec directly for root path", () => {
+      const rootSpec = createRootComponentSpec();
+      const updatedSpec: ComponentSpec = {
+        ...rootSpec,
+        name: "updated-root",
+      };
+
+      const result = updateSubgraphSpec(rootSpec, ["root"], updatedSpec);
+
+      expect(result).toBe(updatedSpec);
+      expect(result.name).toBe("updated-root");
+    });
+
+    it("should return updated spec directly for empty path", () => {
+      const rootSpec = createRootComponentSpec();
+      const updatedSpec: ComponentSpec = {
+        ...rootSpec,
+        name: "updated-root",
+      };
+
+      const result = updateSubgraphSpec(rootSpec, [], updatedSpec);
+
+      expect(result).toBe(updatedSpec);
+      expect(result.name).toBe("updated-root");
+    });
+
+    it("should update subgraph at depth 1", () => {
+      const rootSpec = createRootComponentSpec();
+      const updatedSubgraphSpec: ComponentSpec = {
+        name: "updated-subgraph",
+        implementation: {
+          graph: {
+            tasks: {
+              "new-task": createContainerTaskSpec(),
+            },
+          },
+        },
+      };
+
+      const result = updateSubgraphSpec(
+        rootSpec,
+        ["root", "subgraph1"],
+        updatedSubgraphSpec,
+      );
+
+      // Root spec structure should be preserved
+      expect(result.name).toBe("root-component");
+      expect(result.inputs).toEqual(rootSpec.inputs);
+      expect(result.outputs).toEqual(rootSpec.outputs);
+
+      // Verify result has graph implementation
+      expect(isGraphImplementation(result.implementation)).toBe(true);
+      expect(isGraphImplementation(rootSpec.implementation)).toBe(true);
+      if (!isGraphImplementation(result.implementation)) return;
+      if (!isGraphImplementation(rootSpec.implementation)) return;
+
+      // Subgraph should be updated
+      const updatedSubgraph =
+        result.implementation.graph.tasks["subgraph1"]?.componentRef.spec;
+      expect(updatedSubgraph?.name).toBe("updated-subgraph");
+
+      if (
+        updatedSubgraph &&
+        isGraphImplementation(updatedSubgraph.implementation)
+      ) {
+        expect(Object.keys(updatedSubgraph.implementation.graph.tasks)).toEqual(
+          ["new-task"],
+        );
+      }
+
+      // Other tasks should remain unchanged
+      expect(result.implementation.graph.tasks["task1"]).toEqual(
+        rootSpec.implementation.graph.tasks["task1"],
+      );
+    });
+
+    it("should update deeply nested subgraph", () => {
+      const rootSpec = createDeeplyNestedSpec();
+      const updatedDeepSpec: ComponentSpec = {
+        name: "updated-level2",
+        implementation: {
+          graph: {
+            tasks: {
+              "updated-leaf": createContainerTaskSpec(),
+            },
+          },
+        },
+      };
+
+      const result = updateSubgraphSpec(
+        rootSpec,
+        ["root", "level1-subgraph", "level2-subgraph"],
+        updatedDeepSpec,
+      );
+
+      // Navigate through the structure to verify the update
+      expect(isGraphImplementation(result.implementation)).toBe(true);
+      if (!isGraphImplementation(result.implementation)) return;
+
+      const level1 =
+        result.implementation.graph.tasks["level1-subgraph"]?.componentRef.spec;
+      expect(level1?.name).toBe("level1-component");
+
+      if (level1 && isGraphImplementation(level1.implementation)) {
+        const level2 =
+          level1.implementation.graph.tasks["level2-subgraph"]?.componentRef
+            .spec;
+        expect(level2?.name).toBe("updated-level2");
+
+        if (level2 && isGraphImplementation(level2.implementation)) {
+          expect(Object.keys(level2.implementation.graph.tasks)).toEqual([
+            "updated-leaf",
+          ]);
+        }
+      }
+    });
+
+    it("should maintain immutability of original spec", () => {
+      const rootSpec = createRootComponentSpec();
+      const originalRootName = rootSpec.name;
+
+      expect(isGraphImplementation(rootSpec.implementation)).toBe(true);
+      if (!isGraphImplementation(rootSpec.implementation)) return;
+
+      const originalSubgraphName =
+        rootSpec.implementation.graph.tasks["subgraph1"]?.componentRef.spec
+          ?.name;
+
+      const updatedSubgraphSpec: ComponentSpec = {
+        name: "updated-subgraph",
+        implementation: {
+          graph: { tasks: {} },
+        },
+      };
+
+      updateSubgraphSpec(rootSpec, ["root", "subgraph1"], updatedSubgraphSpec);
+
+      // Original spec should remain unchanged
+      expect(rootSpec.name).toBe(originalRootName);
+      expect(
+        rootSpec.implementation.graph.tasks["subgraph1"]?.componentRef.spec
+          ?.name,
+      ).toBe(originalSubgraphName);
+    });
+
+    it("should handle invalid task ID gracefully", () => {
+      const rootSpec = createRootComponentSpec();
+      const updatedSpec: ComponentSpec = {
+        name: "should-not-be-applied",
+        implementation: { graph: { tasks: {} } },
+      };
+
+      const consoleWarnSpy = vi
+        .spyOn(console, "warn")
+        .mockImplementation(() => {});
+
+      const result = updateSubgraphSpec(
+        rootSpec,
+        ["root", "nonexistent"],
+        updatedSpec,
+      );
+
+      // Should return original spec unchanged
+      expect(result).toEqual(rootSpec);
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('task "nonexistent" not found'),
+      );
+
+      consoleWarnSpy.mockRestore();
+    });
+
+    it("should handle non-subgraph task gracefully", () => {
+      const rootSpec = createRootComponentSpec();
+      const updatedSpec: ComponentSpec = {
+        name: "should-not-be-applied",
+        implementation: { graph: { tasks: {} } },
+      };
+
+      const consoleWarnSpy = vi
+        .spyOn(console, "warn")
+        .mockImplementation(() => {});
+
+      const result = updateSubgraphSpec(
+        rootSpec,
+        ["root", "task1"],
+        updatedSpec,
+      );
+
+      // Should return original spec unchanged
+      expect(result).toEqual(rootSpec);
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('task "task1"'),
+      );
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("is not a subgraph"),
+      );
+
+      consoleWarnSpy.mockRestore();
+    });
+
+    it("should handle task without spec gracefully", () => {
+      const rootSpec: ComponentSpec = {
+        name: "root",
+        implementation: {
+          graph: {
+            tasks: {
+              "subgraph-without-spec": {
+                componentRef: {},
+              },
+            },
+          },
+        },
+      };
+
+      const updatedSpec: ComponentSpec = {
+        name: "should-not-be-applied",
+        implementation: { graph: { tasks: {} } },
+      };
+
+      const consoleWarnSpy = vi
+        .spyOn(console, "warn")
+        .mockImplementation(() => {});
+
+      const result = updateSubgraphSpec(
+        rootSpec,
+        ["root", "subgraph-without-spec"],
+        updatedSpec,
+      );
+
+      // Should return original spec unchanged
+      expect(result).toEqual(rootSpec);
+      expect(consoleWarnSpy).toHaveBeenCalled();
+
+      consoleWarnSpy.mockRestore();
+    });
+
+    it("should create new objects at each level", () => {
+      const rootSpec = createDeeplyNestedSpec();
+      const updatedSpec: ComponentSpec = {
+        name: "updated",
+        implementation: { graph: { tasks: {} } },
+      };
+
+      const result = updateSubgraphSpec(
+        rootSpec,
+        ["root", "level1-subgraph", "level2-subgraph"],
+        updatedSpec,
+      );
+
+      // Each level should be a new object reference
+      expect(result).not.toBe(rootSpec);
+      expect(result.implementation).not.toBe(rootSpec.implementation);
+
+      expect(isGraphImplementation(result.implementation)).toBe(true);
+      expect(isGraphImplementation(rootSpec.implementation)).toBe(true);
+      if (!isGraphImplementation(result.implementation)) return;
+      if (!isGraphImplementation(rootSpec.implementation)) return;
+
+      expect(result.implementation.graph).not.toBe(
+        rootSpec.implementation.graph,
+      );
+      expect(result.implementation.graph.tasks).not.toBe(
+        rootSpec.implementation.graph.tasks,
+      );
+
+      const level1Result = result.implementation.graph.tasks["level1-subgraph"];
+      const level1Original =
+        rootSpec.implementation.graph.tasks["level1-subgraph"];
+
+      expect(level1Result).not.toBe(level1Original);
+      expect(level1Result?.componentRef).not.toBe(level1Original?.componentRef);
+      expect(level1Result?.componentRef.spec).not.toBe(
+        level1Original?.componentRef.spec,
+      );
+    });
+
+    it("should preserve sibling tasks and properties", () => {
+      const rootSpec: ComponentSpec = {
+        name: "root",
+        inputs: [{ name: "input1", type: "string" }],
+        outputs: [{ name: "output1", type: "string" }],
+        implementation: {
+          graph: {
+            tasks: {
+              subgraph1: createGraphTaskSpec(2),
+              subgraph2: createGraphTaskSpec(3),
+              task1: createContainerTaskSpec(),
+            },
+            outputValues: {
+              output1: { taskOutput: { taskId: "task1", outputName: "test" } },
+            },
+          },
+        },
+      };
+
+      const updatedSpec: ComponentSpec = {
+        name: "updated-subgraph1",
+        implementation: { graph: { tasks: {} } },
+      };
+
+      const result = updateSubgraphSpec(
+        rootSpec,
+        ["root", "subgraph1"],
+        updatedSpec,
+      );
+
+      // Root properties should be preserved
+      expect(result.name).toBe("root");
+      expect(result.inputs).toEqual(rootSpec.inputs);
+      expect(result.outputs).toEqual(rootSpec.outputs);
+
+      expect(isGraphImplementation(result.implementation)).toBe(true);
+      expect(isGraphImplementation(rootSpec.implementation)).toBe(true);
+      if (!isGraphImplementation(result.implementation)) return;
+      if (!isGraphImplementation(rootSpec.implementation)) return;
+
+      expect(result.implementation.graph.outputValues).toEqual(
+        rootSpec.implementation.graph.outputValues,
+      );
+
+      // Sibling tasks should be preserved
+      expect(result.implementation.graph.tasks["subgraph2"]).toEqual(
+        rootSpec.implementation.graph.tasks["subgraph2"],
+      );
+      expect(result.implementation.graph.tasks["task1"]).toEqual(
+        rootSpec.implementation.graph.tasks["task1"],
+      );
+
+      // Only target subgraph should be updated
+      expect(
+        result.implementation.graph.tasks["subgraph1"]?.componentRef.spec?.name,
+      ).toBe("updated-subgraph1");
     });
   });
 });


### PR DESCRIPTION
## Description

Added a new `updateSubgraphSpec` utility function that allows updating nested subgraph specifications within a component tree while maintaining immutability. This function recursively navigates through a subgraph path and replaces the target subgraph's spec with an updated version.

## Type of Change

- [x] New feature
- [x] Improvement

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Test Instructions

The implementation includes comprehensive test cases that verify:
- Updating subgraphs at different nesting levels
- Maintaining immutability of the original spec
- Preserving sibling tasks and properties
- Handling edge cases (invalid task IDs, non-subgraph tasks)

Additionally, minor code formatting changes were made to improve readability in `Details.tsx` and `ExecutionDataProvider.tsx`.