### PR TITLE
enable full editing capabilities for nested subgraphs

### DIFF
--- a/src/components/Editor/IOEditor/InputValueEditor/InputValueEditor.test.tsx
+++ b/src/components/Editor/IOEditor/InputValueEditor/InputValueEditor.test.tsx
@@ -24,6 +24,18 @@ vi.mock("@/providers/ComponentSpecProvider", () => ({
         },
       },
     },
+    currentSubgraphSpec: {
+      inputs: [
+        { name: "TestInput", type: "String" },
+        { name: "ExistingInput", type: "String" },
+      ],
+      implementation: {
+        container: {
+          image: "test-image",
+        },
+      },
+    },
+    currentSubgraphPath: ["root"],
     setComponentSpec: mockSetComponentSpec,
   }),
 }));

--- a/src/components/shared/ReactFlow/FlowCanvas/IONode/IONode.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/IONode/IONode.tsx
@@ -25,7 +25,7 @@ interface IONodeProps {
 }
 
 const IONode = ({ type, data, selected = false }: IONodeProps) => {
-  const { graphSpec, componentSpec } = useComponentSpec();
+  const { currentGraphSpec, currentSubgraphSpec } = useComponentSpec();
   const { setContent, clearContent } = useContextPanel();
 
   const isInput = type === "input";
@@ -44,13 +44,15 @@ const IONode = ({ type, data, selected = false }: IONodeProps) => {
   const borderColor = selected ? selectedColor : defaultColor;
 
   const input = useMemo(
-    () => componentSpec.inputs?.find((input) => input.name === data.label),
-    [componentSpec.inputs, data.label],
+    () =>
+      currentSubgraphSpec.inputs?.find((input) => input.name === data.label),
+    [currentSubgraphSpec.inputs, data.label],
   );
 
   const output = useMemo(
-    () => componentSpec.outputs?.find((output) => output.name === data.label),
-    [componentSpec.outputs, data.label],
+    () =>
+      currentSubgraphSpec.outputs?.find((output) => output.name === data.label),
+    [currentSubgraphSpec.outputs, data.label],
   );
 
   useEffect(() => {
@@ -67,7 +69,7 @@ const IONode = ({ type, data, selected = false }: IONodeProps) => {
 
       if (output && isOutput) {
         const outputConnectedDetails = getOutputConnectedDetails(
-          graphSpec,
+          currentGraphSpec,
           output.name,
         );
         setContent(
@@ -88,7 +90,10 @@ const IONode = ({ type, data, selected = false }: IONodeProps) => {
     };
   }, [input, output, selected, readOnly]);
 
-  const connectedOutput = getOutputConnectedDetails(graphSpec, data.label);
+  const connectedOutput = getOutputConnectedDetails(
+    currentGraphSpec,
+    data.label,
+  );
   const outputConnectedValue = connectedOutput.outputName;
   const outputConnectedType = connectedOutput.outputType;
   const outputConnectedTaskId = connectedOutput.taskId;

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeCard.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeCard.tsx
@@ -63,11 +63,15 @@ const TaskNodeCard = () => {
   const { dimensions, selected, highlighted, isCustomComponent, readOnly } =
     state;
 
-  const isSubgraphNode = useMemo(() => isSubgraph(taskSpec), [taskSpec]);
-  const subgraphDescription = useMemo(
-    () => getSubgraphDescription(taskSpec),
-    [taskSpec],
-  );
+  const isSubgraphNode = useMemo(() => {
+    if (!taskSpec) return false;
+    return isSubgraph(taskSpec);
+  }, [taskSpec]);
+
+  const subgraphDescription = useMemo(() => {
+    if (!taskSpec) return "";
+    return getSubgraphDescription(taskSpec);
+  }, [taskSpec]);
 
   const disabledCache = isCacheDisabled(taskSpec);
 
@@ -89,6 +93,7 @@ const TaskNodeCard = () => {
   }, []);
 
   useEffect(() => {
+    if (!taskSpec) return;
     return registerNode({
       nodeId,
       taskSpec,
@@ -219,6 +224,10 @@ const TaskNodeCard = () => {
       }
     };
   }, [selected, taskConfigMarkup, setContent, clearContent]);
+
+  if (!taskSpec) {
+    return null;
+  }
 
   const digestMarkup = taskSpec.componentRef?.digest && (
     <QuickTooltip content={taskSpec.componentRef.digest}>

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeInputs.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeInputs.tsx
@@ -40,8 +40,10 @@ export function TaskNodeInputs({
 
   const [isDragging, setIsDragging] = useState(false);
 
-  const values = taskSpec.arguments;
-  const invalidArguments = inputsWithInvalidArguments(inputs, taskSpec);
+  const values = taskSpec?.arguments;
+  const invalidArguments = taskSpec
+    ? inputsWithInvalidArguments(inputs, taskSpec)
+    : [];
 
   const inputsWithTaskOutput = inputs.filter(
     (input) =>
@@ -159,6 +161,10 @@ export function TaskNodeInputs({
     resetSearchFilter,
     toggleHighlightRelatedHandles,
   ]);
+
+  if (!taskSpec) {
+    return null;
+  }
 
   if (!inputs.length) return null;
 

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/UpgradeNodePopover.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/UpgradeNodePopover.tsx
@@ -46,16 +46,21 @@ export const UpgradeNodePopover = ({
   const { notifyNode, fitNodeIntoView } = useNodesOverlay();
 
   const replaceWithComponent = useMemo(() => {
-    return replaceWith.get(
-      taskSpec.componentRef.digest ?? "",
-    ) as HydratedComponentReference;
+    if (!taskSpec) return null;
+    return replaceWith.get(taskSpec.componentRef.digest ?? "") as
+      | HydratedComponentReference
+      | undefined;
   }, [replaceWith, taskSpec]);
 
   const updatePreview = useMemo(() => {
+    if (!taskId || !replaceWithComponent) return null;
     return replaceTaskNode(taskId, replaceWithComponent, graphSpec);
   }, [taskId, replaceWithComponent, graphSpec]);
 
   const markup = useMemo(() => {
+    if (!taskId || !taskSpec || !replaceWithComponent || !updatePreview) {
+      return null;
+    }
     const { content } = getUpgradeConfirmationDetails(
       taskId,
       taskSpec,
@@ -64,7 +69,7 @@ export const UpgradeNodePopover = ({
     );
 
     return content;
-  }, [taskId, taskSpec, updatePreview.lostInputs, replaceWithComponent.digest]);
+  }, [taskId, taskSpec, replaceWithComponent, updatePreview]);
 
   const handleOpenChange = useCallback(() => {
     setOpen(false);
@@ -96,10 +101,15 @@ export const UpgradeNodePopover = ({
   }, [fitNodeIntoView, ids, replaceWith, notifyNode, handleOpenChange]);
 
   const handleApplyAndNext = useCallback(async () => {
+    if (!updatePreview) return;
     updateGraphSpec(updatePreview.updatedGraphSpec);
 
     void handleNext();
-  }, [handleNext, updatePreview.updatedGraphSpec, updateGraphSpec]);
+  }, [handleNext, updatePreview, updateGraphSpec]);
+
+  if (!taskSpec || !taskId || !replaceWithComponent || !updatePreview) {
+    return null;
+  }
 
   return (
     <Popover {...props} open={open} onOpenChange={handleOpenChange}>

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/ConfigurationSection.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/ConfigurationSection.tsx
@@ -14,6 +14,10 @@ interface ConfigurationSectionProps {
 const ConfigurationSection = ({ taskNode }: ConfigurationSectionProps) => {
   const { taskSpec, callbacks } = taskNode;
 
+  if (!taskSpec) {
+    return null;
+  }
+
   const componentSpec = taskSpec.componentRef.spec;
 
   if (!componentSpec) {

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/TaskConfiguration.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/TaskConfiguration.tsx
@@ -14,8 +14,6 @@ interface TaskConfigurationProps {
 const TaskConfiguration = ({ taskNode }: TaskConfigurationProps) => {
   const { taskSpec, callbacks } = taskNode;
 
-  const disabledCache = isCacheDisabled(taskSpec);
-
   const handleDisableCacheChange = useCallback(
     (checked: boolean) => {
       callbacks.setCacheStaleness(
@@ -24,6 +22,12 @@ const TaskConfiguration = ({ taskNode }: TaskConfigurationProps) => {
     },
     [callbacks],
   );
+
+  if (!taskSpec) {
+    return null;
+  }
+
+  const disabledCache = isCacheDisabled(taskSpec);
 
   return (
     <BlockStack gap="2">

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/TaskOverview.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/TaskOverview.tsx
@@ -39,6 +39,10 @@ const TaskOverview = ({ taskNode, actions }: TaskOverviewProps) => {
   const { readOnly, runStatus } = state;
   const disabled = !!runStatus;
 
+  if (!taskSpec || !taskId) {
+    return null;
+  }
+
   const componentSpec = taskSpec.componentRef.spec;
 
   if (!componentSpec) {

--- a/src/hooks/useTaskNodeDimensions.ts
+++ b/src/hooks/useTaskNodeDimensions.ts
@@ -16,8 +16,12 @@ type EditorPosition = {
   h?: string;
 };
 
-export function useTaskNodeDimensions(taskSpec: TaskSpec): TaskNodeDimensions {
+export function useTaskNodeDimensions(taskSpec?: TaskSpec): TaskNodeDimensions {
   return useMemo(() => {
+    if (!taskSpec) {
+      return DEFAULT_NODE_DIMENSIONS;
+    }
+
     let annotatedDimensions;
     try {
       const parsed = JSON.parse(

--- a/src/providers/TaskNodeProvider.tsx
+++ b/src/providers/TaskNodeProvider.tsx
@@ -49,8 +49,8 @@ type TaskNodeProviderProps = {
 };
 
 export type TaskNodeContextType = {
-  taskSpec: TaskSpec;
-  taskId: string;
+  taskSpec?: TaskSpec;
+  taskId?: string;
   nodeId: string;
   inputs: InputSpec[];
   outputs: OutputSpec[];
@@ -72,23 +72,23 @@ export const TaskNodeProvider = ({
   const notify = useToastNotification();
   const reactFlowInstance = useReactFlow();
 
-  const taskSpec = data.taskSpec ?? ({} as TaskSpec);
-  const taskId = data.taskId as string;
-  const nodeId = taskIdToNodeId(taskId);
+  const taskSpec = data.taskSpec;
+  const taskId = data.taskId;
+  const nodeId = taskId ? taskIdToNodeId(taskId) : "";
 
-  const inputs = taskSpec.componentRef.spec?.inputs || [];
-  const outputs = taskSpec.componentRef.spec?.outputs || [];
+  const componentRef = taskSpec?.componentRef || {};
+  const inputs = componentRef.spec?.inputs || [];
+  const outputs = componentRef.spec?.outputs || [];
 
-  const name = getComponentName(taskSpec.componentRef);
+  const name = getComponentName(componentRef);
 
-  const isCustomComponent = !taskSpec.componentRef.url; // Custom components don't have a source url
+  const isCustomComponent = !componentRef.url; // Custom components don't have a source url
 
   const { componentRef: mostRecentComponentRef } = useComponentFromUrl(
-    taskSpec.componentRef.url,
+    componentRef.url,
   );
 
-  const isOutdated =
-    taskSpec.componentRef.digest !== mostRecentComponentRef.digest;
+  const isOutdated = componentRef.digest !== mostRecentComponentRef.digest;
 
   const dimensions = useTaskNodeDimensions(taskSpec);
 


### PR DESCRIPTION
## Description

Refactored the subgraph handling in the Flow Canvas to properly manage component specs at different levels of the component hierarchy. This PR introduces proper propagation of changes from subgraphs back to the root component spec, ensuring that modifications made within nested subgraphs are correctly reflected in the parent component.

Note: This stack does not account for any complex component saving or updating, it only save the component spec at the moment. If we choose a more complex route, that can (and will?) come later. For now, this enables our users to update and save a pipeline without worrying about complex UI/UX to propagate to existing components

## Type of Change

- [x] Improvement
- [x] Cleanup/Refactor

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Test Instructions

1. Create a component with nested subgraphs
2. Navigate into a subgraph and make changes (add nodes, connect edges, move nodes)
3. Navigate back to parent graph and verify changes are preserved
4. Test node operations like duplication, deletion, and position updates in subgraphs