### PR TITLE
Fix duplicate IO Names

### DIFF
--- a/src/components/Editor/IOEditor/InputValueEditor/InputValueEditor.tsx
+++ b/src/components/Editor/IOEditor/InputValueEditor/InputValueEditor.tsx
@@ -118,7 +118,14 @@ export const InputValueEditor = ({
     (newName: string) => {
       setInputName(newName);
 
-      if (checkNameCollision(newName, input.name, componentSpec, "inputs")) {
+      if (
+        checkNameCollision(
+          newName.trim(),
+          input.name.trim(),
+          componentSpec,
+          "inputs",
+        )
+      ) {
         setValidationError("An input with this name already exists");
         return;
       }
@@ -131,7 +138,7 @@ export const InputValueEditor = ({
   const hasChanges = useCallback(() => {
     return (
       inputValue !== initialInputValue ||
-      inputName !== input.name ||
+      inputName.trim() !== input.name ||
       inputType !== (input.type?.toString() ?? "any") ||
       inputOptional !== initialIsOptional
     );

--- a/src/components/Editor/IOEditor/OutputNameEditor/OutputNameEditor.tsx
+++ b/src/components/Editor/IOEditor/OutputNameEditor/OutputNameEditor.tsx
@@ -95,7 +95,14 @@ export const OutputNameEditor = ({
     (value: string) => {
       setOutputName(value);
 
-      if (checkNameCollision(value, output.name, componentSpec, "outputs")) {
+      if (
+        checkNameCollision(
+          value.trim(),
+          output.name.trim(),
+          componentSpec,
+          "outputs",
+        )
+      ) {
         setValidationError("An output with this name already exists");
         return;
       }


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

Fixes a bug where it was possible to define multiple IO nodes with the same name due to whitespace not being trimmed correctly. The validator will now trim whitespace before validation.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
