### PR TITLE
Refactor Annotation Editor Logic

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/AnnotationsEditor.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/AnnotationsEditor.tsx
@@ -10,8 +10,7 @@ import { NewAnnotationRow } from "./NewAnnotationRow";
 
 interface AnnotationsEditorProps {
   annotations: Annotations;
-  onChange: (key: string, value: string | undefined) => void;
-  onBlur: (key: string, value: string | undefined) => void;
+  onSave: (key: string, value: string) => void;
   onRemove: (key: string) => void;
   newRows: Array<{ key: string; value: string }>;
   onNewRowBlur: (idx: number, newRow: { key: string; value: string }) => void;
@@ -32,8 +31,7 @@ const COMMON_ANNOTATIONS: AnnotationConfig[] = [
 
 export const AnnotationsEditor = ({
   annotations,
-  onChange,
-  onBlur,
+  onSave,
   onRemove,
   newRows,
   onNewRowBlur,
@@ -71,8 +69,7 @@ export const AnnotationsEditor = ({
           <AnnotationsInput
             key={config.annotation}
             value={annotations[config.annotation]}
-            onChange={(newValue) => onChange(config.annotation, newValue)}
-            onBlur={(newValue) => onBlur(config.annotation, newValue)}
+            onBlur={(newValue) => onSave(config.annotation, newValue)}
             annotations={annotations}
             config={config}
           />
@@ -88,8 +85,7 @@ export const AnnotationsEditor = ({
           <AnnotationsInput
             key={key}
             value={value}
-            onChange={(newValue) => onChange(key, newValue)}
-            onBlur={(newValue) => onBlur(key, newValue)}
+            onBlur={(newValue) => onSave(key, newValue)}
             onDelete={() => onRemove(key)}
             annotations={annotations}
             deletable

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/AnnotationsInput.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/AnnotationsInput.tsx
@@ -1,5 +1,5 @@
 import { AlertTriangle } from "lucide-react";
-import { type ChangeEvent, useCallback, useState } from "react";
+import { type ChangeEvent, useCallback, useEffect, useState } from "react";
 
 import { MultilineTextInputDialog } from "@/components/shared/Dialogs/MultilineTextInputDialog";
 import { Button } from "@/components/ui/button";
@@ -26,7 +26,6 @@ interface AnnotationsInputProps {
   deletable?: boolean;
   autoFocus?: boolean;
   className?: string;
-  onChange: (value: string) => void;
   onBlur?: (value: string) => void;
   onDelete?: () => void;
 }
@@ -38,10 +37,10 @@ export const AnnotationsInput = ({
   deletable = false,
   autoFocus = false,
   className = "",
-  onChange,
   onBlur,
   onDelete,
 }: AnnotationsInputProps) => {
+  const [inputValue, setInputValue] = useState(value);
   const [isInvalid, setIsInvalid] = useState(false);
   const [lastSavedValue, setLastSavedValue] = useState(value);
   const [isDialogOpen, setIsDialogOpen] = useState(false);
@@ -55,46 +54,37 @@ export const AnnotationsInput = ({
 
   const handleDialogConfirm = useCallback(
     (newValue: string) => {
-      onChange(newValue);
+      setInputValue(newValue);
       setIsDialogOpen(false);
       if (onBlur && newValue !== lastSavedValue) {
         onBlur(newValue);
         setLastSavedValue(newValue);
       }
     },
-    [onChange, onBlur, lastSavedValue],
+    [onBlur, lastSavedValue],
   );
 
   const handleDialogCancel = useCallback(() => {
     setIsDialogOpen(false);
   }, []);
 
-  const validateChange = useCallback(
-    (e: ChangeEvent<HTMLInputElement>) => {
-      const newValue = e.target.value;
+  const validateChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
+    const newValue = e.target.value;
 
-      onChange(newValue);
+    setInputValue(newValue);
 
-      try {
-        JSON.parse(newValue);
-        setIsInvalid(false);
-      } catch {
-        setIsInvalid(true);
-      }
-    },
-    [onChange],
-  );
-
-  const handleBlur = useCallback(() => {
-    if (onBlur && lastSavedValue !== value) {
-      if (config?.type === "number" && !isNaN(Number(value)) && value !== "") {
-        value = clamp(Number(value), config.min, config.max).toString();
-      }
-
-      onBlur(value);
-      setLastSavedValue(value);
+    if (newValue === "") {
+      setIsInvalid(false);
+      return;
     }
-  }, [onBlur, lastSavedValue, value]);
+
+    try {
+      JSON.parse(newValue);
+      setIsInvalid(false);
+    } catch {
+      setIsInvalid(true);
+    }
+  }, []);
 
   const handleQuantityKeyInputChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
@@ -106,18 +96,29 @@ export const AnnotationsInput = ({
 
       const newObj = { [selectedKey]: e.target.value };
 
-      onChange(JSON.stringify(newObj));
+      setInputValue(JSON.stringify(newObj));
     },
-    [config, annotations, onChange],
+    [config, annotations],
+  );
+
+  const handleQuantityValueInputChange = useCallback(
+    (value: string) => {
+      const key = getKeyFromInputValue(inputValue);
+
+      const newObj = { [key]: value };
+
+      setInputValue(JSON.stringify(newObj));
+    },
+    [inputValue],
   );
 
   const shouldSaveQuantityField = useCallback(() => {
-    if (!config?.enableQuantity || !config?.annotation) return false;
+    if (!config?.enableQuantity) return false;
 
-    const selectedKey = getAnnotationKey(config.annotation, annotations);
-    const quantity = getAnnotationValue(config.annotation, annotations);
+    const selectedKey = getKeyFromInputValue(inputValue);
+    const quantity = getValueFromInputValue(inputValue);
     return !!selectedKey && !!quantity && quantity.trim() !== "";
-  }, [config, annotations]);
+  }, [config, inputValue]);
 
   const handleQuantitySelectChange = useCallback(
     (selectedKey: string) => {
@@ -127,70 +128,86 @@ export const AnnotationsInput = ({
       const newObj = selectedKey ? { [selectedKey]: quantity } : {};
       const newValue = JSON.stringify(newObj);
 
-      onChange(newValue);
+      setInputValue(newValue);
 
       if (onBlur && newValue !== lastSavedValue && shouldSaveQuantityField()) {
         onBlur(newValue);
         setLastSavedValue(newValue);
       }
     },
-    [
-      config,
-      annotations,
-      onChange,
-      onBlur,
-      lastSavedValue,
-      shouldSaveQuantityField,
-    ],
+    [config, annotations, onBlur, lastSavedValue, shouldSaveQuantityField],
   );
 
   const handleNonQuantitySelectChange = useCallback(
     (selectedKey: string) => {
-      onChange(selectedKey);
+      setInputValue(selectedKey);
 
       if (onBlur && selectedKey !== lastSavedValue) {
         onBlur(selectedKey);
         setLastSavedValue(selectedKey);
       }
     },
-    [onChange, onBlur, lastSavedValue],
+    [onBlur, lastSavedValue],
   );
 
   const handleClearSelection = useCallback(() => {
     if (config?.enableQuantity) {
       const newValue = "";
-      onChange(newValue);
+      setInputValue(newValue);
       if (onBlur && newValue !== lastSavedValue) {
         onBlur(newValue);
         setLastSavedValue(newValue);
       }
     } else {
-      onChange("");
+      setInputValue("");
       if (onBlur && "" !== lastSavedValue) {
         onBlur("");
         setLastSavedValue("");
       }
     }
-  }, [config, onChange, onBlur, lastSavedValue]);
+  }, [config, onBlur, lastSavedValue]);
 
   const handleSwitchChange = useCallback(
     (checked: boolean) => {
       const newValue = checked ? "true" : "false";
-      onChange(newValue);
+      setInputValue(newValue);
       if (onBlur && newValue !== lastSavedValue) {
         onBlur(newValue);
         setLastSavedValue(newValue);
       }
     },
-    [onChange, onBlur, lastSavedValue],
+    [onBlur, lastSavedValue],
   );
+
+  const handleBlur = useCallback(() => {
+    if (config?.enableQuantity && !shouldSaveQuantityField()) return;
+
+    if (onBlur && lastSavedValue !== inputValue) {
+      let value = inputValue;
+      if (
+        config?.type === "number" &&
+        !isNaN(Number(inputValue)) &&
+        inputValue !== ""
+      ) {
+        value = clamp(Number(inputValue), config.min, config.max).toString();
+      }
+
+      onBlur(value);
+      setLastSavedValue(value);
+    }
+  }, [onBlur, shouldSaveQuantityField, lastSavedValue, inputValue, config]);
+
+  useEffect(() => {
+    setInputValue(value);
+    setLastSavedValue(value);
+  }, [value]);
 
   let inputElement = null;
 
   if (config?.options && config.options.length > 0) {
     const currentValue = config?.enableQuantity
-      ? getAnnotationKey(config.annotation, annotations)
-      : value;
+      ? getKeyFromInputValue(inputValue)
+      : inputValue;
 
     inputElement = (
       <div className="flex items-center gap-1 grow">
@@ -230,7 +247,7 @@ export const AnnotationsInput = ({
   } else if (inputType === "boolean") {
     inputElement = (
       <Switch
-        checked={value === "true"}
+        checked={inputValue === "true"}
         onCheckedChange={handleSwitchChange}
         className={className}
       />
@@ -240,10 +257,10 @@ export const AnnotationsInput = ({
       <InlineStack gap="2" blockAlign="center" wrap="nowrap" className="grow">
         <Input
           type="number"
-          value={value}
+          value={inputValue}
           min={config?.min}
           max={config?.max}
-          onChange={(e) => onChange(e.target.value)}
+          onChange={(e) => setInputValue(e.target.value)}
           onBlur={handleBlur}
           autoFocus={autoFocus}
           className={className}
@@ -258,30 +275,32 @@ export const AnnotationsInput = ({
     );
   } else {
     inputElement = (
-      <div className="flex-1 w-full relative group">
-        <Input
-          value={
-            config?.enableQuantity
-              ? getAnnotationKey(config.annotation, annotations)
-              : value
-          }
-          onChange={
-            config?.enableQuantity
-              ? handleQuantityKeyInputChange
-              : validateChange
-          }
-          onBlur={handleBlur}
-          autoFocus={autoFocus}
-          className={cn("min-w-16", className)}
-        />
-        <Button
-          className="absolute right-0 top-1/2 -translate-y-1/2 hover:bg-transparent hover:text-blue-500 hidden group-hover:flex h-8 w-8 p-0"
-          onClick={handleExpand}
-          variant="ghost"
-          type="button"
-        >
-          <Icon name="Maximize2" />
-        </Button>
+      <div>
+        <div className="flex-1 w-full relative group">
+          <Input
+            value={
+              config?.enableQuantity
+                ? getAnnotationKey(config.annotation, annotations)
+                : inputValue
+            }
+            onChange={
+              config?.enableQuantity
+                ? handleQuantityKeyInputChange
+                : validateChange
+            }
+            onBlur={handleBlur}
+            autoFocus={autoFocus}
+            className={cn("min-w-16", className)}
+          />
+          <Button
+            className="absolute right-0 top-1/2 -translate-y-1/2 hover:bg-transparent hover:text-blue-500 hidden group-hover:flex h-8 w-8 p-0"
+            onClick={handleExpand}
+            variant="ghost"
+            type="button"
+          >
+            <Icon name="Maximize2" />
+          </Button>
+        </div>
         {isInvalid && (
           <div className="flex items-center gap-1 my-1 text-xs text-warning">
             <AlertTriangle className="w-4 h-4" /> Invalid JSON
@@ -299,14 +318,15 @@ export const AnnotationsInput = ({
         {inputElement}
         {config?.enableQuantity && (
           <QuantityInput
-            annotation={config.annotation}
-            annotations={annotations}
+            value={inputValue}
             min={config.min}
             max={config.max}
-            disabled={!getAnnotationKey(config.annotation, annotations)}
-            onChange={onChange}
-            onBlur={onBlur}
-            shouldSave={shouldSaveQuantityField}
+            disabled={
+              !getAnnotationKey(config.annotation, annotations) &&
+              !getKeyFromInputValue(inputValue)
+            }
+            onBlur={handleBlur}
+            onChange={handleQuantityValueInputChange}
           />
         )}
         {deletable && onDelete && (
@@ -321,7 +341,7 @@ export const AnnotationsInput = ({
           title={dialogTitle}
           description="Enter a value for this annotation."
           placeholder={placeholder}
-          initialValue={value}
+          initialValue={inputValue}
           open={isDialogOpen}
           onCancel={handleDialogCancel}
           onConfirm={handleDialogConfirm}
@@ -332,68 +352,28 @@ export const AnnotationsInput = ({
 };
 
 const QuantityInput = ({
-  annotation,
-  annotations,
+  value,
   min,
   max,
   disabled,
-  onChange,
   onBlur,
-  shouldSave,
+  onChange,
 }: {
-  annotation: string;
-  annotations: Annotations;
+  value: string;
   min?: number;
   max?: number;
   disabled: boolean;
+  onBlur: () => void;
   onChange: (value: string) => void;
-  onBlur?: (value: string) => void;
-  shouldSave: () => boolean;
 }) => {
-  const currentQuantity = getAnnotationValue(annotation, annotations);
-  const [lastSavedQuantity, setLastSavedQuantity] = useState(currentQuantity);
+  const currentQuantity = getValueFromInputValue(value);
 
-  const handleValueInputChange = useCallback(
+  const handleValueChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
-      const selectedKey = getAnnotationKey(annotation, annotations);
-
-      if (!selectedKey) return;
-
-      const newObj = { [selectedKey]: e.target.value };
-
-      onChange(JSON.stringify(newObj));
+      onChange(e.target.value);
     },
-    [annotation, annotations, onChange],
+    [onChange],
   );
-
-  const handleValueBlur = useCallback(() => {
-    const selectedKey = getAnnotationKey(annotation, annotations);
-
-    if (!selectedKey) return;
-
-    const quantity = getAnnotationValue(annotation, annotations);
-
-    if (onBlur && quantity !== lastSavedQuantity && shouldSave()) {
-      let limitedQuantity = Number(quantity);
-      if (!isNaN(limitedQuantity) && quantity !== "") {
-        limitedQuantity = clamp(limitedQuantity, min, max);
-      }
-
-      const newObj = { [selectedKey]: limitedQuantity };
-      const newValue = JSON.stringify(newObj);
-
-      onBlur(newValue);
-      setLastSavedQuantity(limitedQuantity);
-    }
-  }, [
-    annotation,
-    annotations,
-    min,
-    max,
-    onBlur,
-    lastSavedQuantity,
-    shouldSave,
-  ]);
 
   return (
     <InlineStack
@@ -405,11 +385,11 @@ const QuantityInput = ({
       <span>x</span>
       <Input
         type="number"
-        value={getAnnotationValue(annotation, annotations)}
+        value={currentQuantity}
         min={min}
         max={max}
-        onChange={handleValueInputChange}
-        onBlur={handleValueBlur}
+        onChange={handleValueChange}
+        onBlur={onBlur}
         className={cn(
           "min-w-12 [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none",
           !currentQuantity && !disabled && "border-destructive/50",
@@ -425,20 +405,31 @@ const QuantityInput = ({
   );
 };
 
-function getAnnotationKey(annotation: string, annotations: Annotations) {
+function parseJsonAndGetProperty(
+  jsonString: string,
+  getKey: boolean = true,
+): string {
   try {
-    const obj = JSON.parse(annotations[annotation] || "{}");
-    return Object.keys(obj)[0] || "";
+    const obj = JSON.parse(jsonString || "{}");
+    const firstKey = Object.keys(obj)[0];
+    return getKey ? firstKey || "" : obj[firstKey] || "";
   } catch {
     return "";
   }
 }
 
+function getAnnotationKey(annotation: string, annotations: Annotations) {
+  return parseJsonAndGetProperty(annotations[annotation] || "{}", true);
+}
+
 function getAnnotationValue(annotation: string, annotations: Annotations) {
-  try {
-    const obj = JSON.parse(annotations[annotation] || "{}");
-    return obj[Object.keys(obj)[0]] || "";
-  } catch {
-    return "";
-  }
+  return parseJsonAndGetProperty(annotations[annotation] || "{}", false);
+}
+
+function getKeyFromInputValue(inputValue: string): string {
+  return parseJsonAndGetProperty(inputValue, true);
+}
+
+function getValueFromInputValue(inputValue: string): string {
+  return parseJsonAndGetProperty(inputValue, false);
 }

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/AnnotationsSection.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/AnnotationsSection.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 
+import { BlockStack } from "@/components/ui/layout";
 import { Separator } from "@/components/ui/separator";
 import useToastNotification from "@/hooks/useToastNotification";
 import type { Annotations } from "@/types/annotations";
@@ -65,25 +66,6 @@ export const AnnotationsSection = ({
     [newRows, annotations, onApply],
   );
 
-  const handleValueBlur = useCallback(
-    (key: string, value: string | undefined) => {
-      const newAnnotations =
-        value === undefined || value === ""
-          ? (() => {
-              const { [key]: _, ...rest } = annotations;
-              return rest;
-            })()
-          : {
-              ...annotations,
-              [key]: value,
-            };
-
-      setAnnotations(newAnnotations);
-      onApply(newAnnotations);
-    },
-    [annotations, onApply],
-  );
-
   const handleRemove = useCallback(
     (key: string) => {
       const { [key]: _, ...rest } = annotations;
@@ -94,7 +76,7 @@ export const AnnotationsSection = ({
     [annotations, onApply],
   );
 
-  const handleValueChange = useCallback(
+  const handleSave = useCallback(
     (key: string, value: string | undefined) => {
       if (value === undefined || value === "") {
         // If value is empty or undefined, remove the annotation
@@ -102,12 +84,15 @@ export const AnnotationsSection = ({
         return;
       }
 
-      setAnnotations((prev) => ({
-        ...prev,
+      const newAnnotations = {
+        ...annotations,
         [key]: value,
-      }));
+      };
+
+      setAnnotations(newAnnotations);
+      onApply(newAnnotations);
     },
-    [handleRemove],
+    [annotations, onApply, handleRemove],
   );
 
   useEffect(() => {
@@ -115,25 +100,20 @@ export const AnnotationsSection = ({
   }, [rawAnnotations]);
 
   return (
-    <div className="h-auto flex flex-col gap-2 overflow-y-auto pr-4 py-2 overflow-visible">
-      <ComputeResourcesEditor
-        annotations={annotations}
-        onChange={handleValueChange}
-        onBlur={handleValueBlur}
-      />
+    <BlockStack gap="2" className="overflow-y-auto pr-4 py-2 overflow-visible">
+      <ComputeResourcesEditor annotations={annotations} onSave={handleSave} />
 
       <Separator className="mt-4 mb-2" />
 
       <AnnotationsEditor
         annotations={annotations}
-        onChange={handleValueChange}
-        onBlur={handleValueBlur}
+        onSave={handleSave}
         onRemove={handleRemove}
         newRows={newRows}
         onNewRowBlur={handleNewRowBlur}
         onRemoveNewRow={handleRemoveNewRow}
         onAddNewRow={handleAddNewRow}
       />
-    </div>
+    </BlockStack>
   );
 };

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/ComputeResourcesEditor.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/ComputeResourcesEditor.tsx
@@ -73,14 +73,12 @@ export const COMPUTE_RESOURCES: AnnotationConfig[] = [
 
 interface ComputeResourcesEditorProps {
   annotations: Annotations;
-  onChange: (key: string, value: string | undefined) => void;
-  onBlur: (key: string, value: string | undefined) => void;
+  onSave: (key: string, value: string) => void;
 }
 
 export const ComputeResourcesEditor = ({
   annotations,
-  onChange,
-  onBlur,
+  onSave,
 }: ComputeResourcesEditorProps) => {
   return (
     <div className="flex flex-col gap-2">
@@ -90,45 +88,30 @@ export const ComputeResourcesEditor = ({
           key={resource.annotation}
           resource={resource}
           annotations={annotations}
-          onChange={onChange}
-          onBlur={onBlur}
+          onSave={onSave}
         />
       ))}
     </div>
   );
 };
 
-interface ComputeResourceFieldProps {
+interface ComputeResourceFieldProps extends ComputeResourcesEditorProps {
   resource: AnnotationConfig;
-  annotations: Annotations;
-  onChange: (key: string, value: string) => void;
-  onBlur: (key: string, value: string) => void;
 }
 
 const ComputeResourceField = ({
   resource,
   annotations,
-  onChange,
-  onBlur,
+  onSave,
 }: ComputeResourceFieldProps) => {
-  const handleValueChange = useCallback(
-    (value: string) => {
-      const formattedValue = resource.append
-        ? `${value}${resource.append}`
-        : value;
-      onChange(resource.annotation, formattedValue);
-    },
-    [resource, onChange],
-  );
-
   const handleValueBlur = useCallback(
     (value: string) => {
       const formattedValue = resource.append
         ? `${value}${resource.append}`
         : value;
-      onBlur(resource.annotation, formattedValue);
+      onSave(resource.annotation, formattedValue);
     },
-    [resource, onBlur],
+    [resource, onSave],
   );
 
   const value =
@@ -148,7 +131,6 @@ const ComputeResourceField = ({
       <AnnotationsInput
         value={value}
         config={resource}
-        onChange={handleValueChange}
         onBlur={handleValueBlur}
         annotations={annotations}
       />


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

Reworks the BUSINESS LOGIC ONLY of the annotation editor so that it is more in-line with our current practices in regard to input editing and autosave. In other words, it removes all of the external `onChange` handlers that were no longer relevant following the move to save-on-blur (but never cleaned up). The current value of the input field is now tracked internally and committed when blurred. This means it now also works with similar structure to the argument editor; thus enabling us to add save-on-unmount functionality in an upstack PR.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

Makes some progress toward https://github.com/Shopify/oasis-frontend/issues/235

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Cleanup/Refactor

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

App should behave unchanged from previous.

Editing, viewing, creating, deleting annotations and compute resources should all work without change or issue.

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->