### PR TITLE
Navigate into subgraph from url

### DIFF
--- a/src/components/Editor/PipelineDetails.tsx
+++ b/src/components/Editor/PipelineDetails.tsx
@@ -10,6 +10,7 @@ import {
 import { Icon } from "@/components/ui/icon";
 import { InlineStack } from "@/components/ui/layout";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { useSubgraphNavigationFromUrl } from "@/hooks/useSubgraphNavigationFromUrl";
 import useToastNotification from "@/hooks/useToastNotification";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 import { useContextPanel } from "@/providers/ContextPanelProvider";
@@ -35,6 +36,8 @@ const PipelineDetails = () => {
   const notify = useToastNotification();
 
   const [isYamlOpen, setIsYamlOpen] = useState(false);
+
+  useSubgraphNavigationFromUrl(false, undefined, true);
 
   // Utility function to convert TypeSpecType to string
   const typeSpecToString = (typeSpec?: TypeSpecType): string => {

--- a/src/components/shared/ReactFlow/FlowCanvas/SubgraphBreadcrumbs/SubgraphBreadcrumbs.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/SubgraphBreadcrumbs/SubgraphBreadcrumbs.tsx
@@ -1,6 +1,7 @@
 import { Home } from "lucide-react";
 import { Fragment } from "react";
 
+import { ShareSubgraphButton } from "@/components/shared/ShareSubgraphButton";
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -83,10 +84,13 @@ export const SubgraphBreadcrumbs = () => {
         </BreadcrumbList>
       </Breadcrumb>
 
-      <div className="text-xs text-gray-500">
-        {currentSubgraphPath.length - 1} level
-        {currentSubgraphPath.length - 1 !== 1 ? "s" : ""} deep
-      </div>
+      <InlineStack gap="2" blockAlign="center">
+        <div className="text-xs text-gray-500">
+          {currentSubgraphPath.length - 1} level
+          {currentSubgraphPath.length - 1 !== 1 ? "s" : ""} deep
+        </div>
+        <ShareSubgraphButton />
+      </InlineStack>
     </InlineStack>
   );
 };

--- a/src/components/shared/ShareSubgraphButton.tsx
+++ b/src/components/shared/ShareSubgraphButton.tsx
@@ -1,0 +1,46 @@
+import { Share2 } from "lucide-react";
+import { useCallback } from "react";
+
+import { Button } from "@/components/ui/button";
+import useToastNotification from "@/hooks/useToastNotification";
+import { useComponentSpec } from "@/providers/ComponentSpecProvider";
+
+export const ShareSubgraphButton = () => {
+    const { currentSubgraphPath } = useComponentSpec();
+    const notify = useToastNotification();
+
+    const handleShare = useCallback(() => {
+        try {
+            const url = new URL(window.location.href);
+
+            if (currentSubgraphPath.length > 1) {
+                const pathString = currentSubgraphPath.join(",");
+                url.searchParams.set("subgraphPath", pathString);
+            } else {
+                url.searchParams.delete("subgraphPath");
+            }
+
+            navigator.clipboard.writeText(url.toString());
+            notify("Link copied to clipboard", "success");
+        } catch (error) {
+            console.error("Failed to copy link:", error);
+            notify("Failed to copy link", "error");
+        }
+    }, [currentSubgraphPath, notify]);
+
+    if (currentSubgraphPath.length <= 1) {
+        return null;
+    }
+
+    return (
+        <Button
+            variant="secondary"
+            size="sm"
+            onClick={handleShare}
+            className="gap-2"
+        >
+            <Share2 className="w-4 h-4" />
+            Share
+        </Button>
+    );
+};

--- a/src/hooks/useSubgraphNavigationFromUrl.ts
+++ b/src/hooks/useSubgraphNavigationFromUrl.ts
@@ -1,0 +1,183 @@
+import { useNavigate, useSearch } from "@tanstack/react-router";
+import { useEffect, useRef, useState } from "react";
+
+import { useComponentSpec } from "@/providers/ComponentSpecProvider";
+
+function hasSubgraphPath(search: unknown): search is { subgraphPath: string } {
+  if (search === null || typeof search !== "object") {
+    return false;
+  }
+
+  if (!("subgraphPath" in search)) {
+    return false;
+  }
+
+  const value = (search as Record<string, unknown>)["subgraphPath"];
+  return typeof value === "string";
+}
+
+/**
+ * Navigates to a subgraph from URL parameters on mount
+ *
+ * For run routes, recursively navigates through each level to ensure execution
+ * data is fetched at each step. For editor routes, navigates directly.
+ *
+ * @param isLoading - Wait for this to be false before starting navigation
+ * @param currentExecutionId - Current execution ID (run routes only)
+ * @param isEditorRoute - True for editor routes (direct navigation)
+ * @returns isNavigatingToUrl - True while navigation is in progress
+ */
+export const useSubgraphNavigationFromUrl = (
+  isLoading = false,
+  currentExecutionId?: string,
+  isEditorRoute = false,
+) => {
+  const search = useSearch({ strict: false });
+  const navigate = useNavigate();
+  const { componentSpec, navigateToPath, currentSubgraphPath } =
+    useComponentSpec();
+  const initialSearchRef = useRef(search);
+  const [targetPath, setTargetPath] = useState<string[] | null>(null);
+  const [currentStep, setCurrentStep] = useState(0);
+  const isNavigatingRef = useRef(false);
+
+  const hasUrlSubgraphPath =
+    search !== null &&
+    typeof search === "object" &&
+    "subgraphPath" in search &&
+    typeof (search as Record<string, unknown>).subgraphPath === "string";
+
+  const isNavigatingToUrl =
+    hasUrlSubgraphPath && targetPath !== null && targetPath.length > 0;
+
+  useEffect(() => {
+    if (!componentSpec || isLoading || targetPath !== null) {
+      return;
+    }
+
+    const urlSubgraphPath = hasSubgraphPath(initialSearchRef.current)
+      ? initialSearchRef.current.subgraphPath
+      : undefined;
+
+    if (!urlSubgraphPath) {
+      setTargetPath([]);
+      return;
+    }
+
+    try {
+      const decodedPath = decodeURIComponent(urlSubgraphPath);
+      const pathArray = decodedPath.split(",");
+
+      if (pathArray.length > 0 && pathArray[0] === "root") {
+        setTargetPath(pathArray);
+        setCurrentStep(1);
+      } else {
+        setTargetPath([]);
+      }
+    } catch (error) {
+      console.warn("Failed to parse subgraphPath URL parameter:", error);
+      setTargetPath([]);
+    }
+  }, [componentSpec, isLoading, targetPath]);
+
+  useEffect(() => {
+    if (!isEditorRoute || !targetPath || targetPath.length === 0) {
+      return;
+    }
+
+    if (currentStep === 1 && currentSubgraphPath.length === 1) {
+      navigateToPath(targetPath);
+
+      const timer = setTimeout(() => {
+        const searchObj = initialSearchRef.current;
+        if (
+          searchObj &&
+          typeof searchObj === "object" &&
+          "subgraphPath" in searchObj
+        ) {
+          const { subgraphPath: _removed, ...rest } = searchObj;
+          void navigate({
+            search: rest as any,
+            replace: true,
+          });
+        }
+        setCurrentStep(999);
+      }, 200);
+
+      return () => clearTimeout(timer);
+    }
+  }, [
+    isEditorRoute,
+    targetPath,
+    currentStep,
+    currentSubgraphPath,
+    navigateToPath,
+    navigate,
+  ]);
+
+  useEffect(() => {
+    if (
+      isEditorRoute ||
+      !targetPath ||
+      targetPath.length === 0 ||
+      currentStep === 0
+    ) {
+      return;
+    }
+
+    const currentDepth = currentSubgraphPath.length;
+    const targetDepth = targetPath.length;
+
+    if (currentDepth === targetDepth) {
+      const isAtTarget =
+        JSON.stringify(currentSubgraphPath) === JSON.stringify(targetPath);
+
+      if (isAtTarget) {
+        const searchObj = initialSearchRef.current;
+        if (
+          searchObj &&
+          typeof searchObj === "object" &&
+          "subgraphPath" in searchObj
+        ) {
+          const { subgraphPath: _removed, ...rest } = searchObj;
+          void navigate({
+            search: rest as any,
+            replace: true,
+          });
+        }
+        setCurrentStep(999);
+      }
+      return;
+    }
+
+    if (isNavigatingRef.current) {
+      return;
+    }
+
+    const nextLevelPath = targetPath.slice(0, currentDepth + 1);
+    const shouldNavigate =
+      JSON.stringify(currentSubgraphPath) ===
+      JSON.stringify(targetPath.slice(0, currentDepth));
+
+    if (shouldNavigate) {
+      isNavigatingRef.current = true;
+      navigateToPath(nextLevelPath);
+
+      const timer = setTimeout(() => {
+        isNavigatingRef.current = false;
+      }, 300);
+
+      return () => clearTimeout(timer);
+    }
+  }, [
+    isEditorRoute,
+    targetPath,
+    currentStep,
+    currentSubgraphPath,
+    currentExecutionId,
+    navigateToPath,
+    navigate,
+  ]);
+
+  return { isNavigatingToUrl };
+};


### PR DESCRIPTION
## Description

Added a subgraph sharing feature that allows users to share links to specific subgraphs within a pipeline. The feature includes:

- A new "Share" button in the subgraph breadcrumbs that copies a URL with the current subgraph path
- Automatic navigation to shared subgraphs when opening a shared link
- Loading states while navigating to deep subgraphs
- Support for both editor and run detail views

## Type of Change

- [x] New feature
- [x] Improvement

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Test Instructions

1. Navigate to a nested subgraph in either the pipeline editor or run details view
2. Click the "Share" button that appears in the breadcrumbs
3. The link will be copied to your clipboard with the subgraph path as a URL parameter
4. Open the link in a new tab to verify it navigates directly to the shared subgraph