### PR TITLE
Annotation Editor - Save on Unmount

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/AnnotationsInput.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/AnnotationsInput.tsx
@@ -1,5 +1,11 @@
 import { AlertTriangle } from "lucide-react";
-import { type ChangeEvent, useCallback, useEffect, useState } from "react";
+import {
+  type ChangeEvent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 
 import { MultilineTextInputDialog } from "@/components/shared/Dialogs/MultilineTextInputDialog";
 import { Button } from "@/components/ui/button";
@@ -197,10 +203,22 @@ export const AnnotationsInput = ({
     }
   }, [onBlur, shouldSaveQuantityField, lastSavedValue, inputValue, config]);
 
+  const handleBlurRef = useRef(handleBlur);
+
+  useEffect(() => {
+    handleBlurRef.current = handleBlur;
+  }, [handleBlur]);
+
   useEffect(() => {
     setInputValue(value);
     setLastSavedValue(value);
   }, [value]);
+
+  useEffect(() => {
+    return () => {
+      handleBlurRef.current();
+    };
+  }, []);
 
   let inputElement = null;
 


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Makes annotation editor input fields automatically save their value (if valid) when unmounted, even if not blurred. e.g. in the scenario where a user types in a value then changes tab.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->
Closes https://github.com/Shopify/oasis-frontend/issues/318

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

Enter a value into an annotation field.
Without directly deselecting the field, change tab to "Details" or "arguments"
Switch back to "Annotations" and confirm that the value entered was saved

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
