### PR TITLE
Add Cache Toggle for Tasks

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/AnnotationsEditor.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/AnnotationsEditor.tsx
@@ -1,6 +1,7 @@
 import { PlusCircleIcon } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import { Heading } from "@/components/ui/typography";
 import type { AnnotationConfig, Annotations } from "@/types/annotations";
 
 import { AnnotationsInput } from "./AnnotationsInput";
@@ -48,7 +49,7 @@ export const AnnotationsEditor = ({
   return (
     <div className="h-auto flex flex-col gap-2">
       <div className="flex justify-between items-center">
-        <h3>Other Annotations</h3>
+        <Heading level={1}>Annotations</Heading>
 
         <Button
           onClick={onAddNewRow}

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/AnnotationsSection.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/AnnotationsSection.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 
+import { Separator } from "@/components/ui/separator";
 import useToastNotification from "@/hooks/useToastNotification";
 import type { Annotations } from "@/types/annotations";
 import type { TaskSpec } from "@/utils/componentSpec";
@@ -121,7 +122,7 @@ export const AnnotationsSection = ({
         onBlur={handleValueBlur}
       />
 
-      <hr className="border-t border-dashed border-gray-200 my-4" />
+      <Separator className="mt-4 mb-2" />
 
       <AnnotationsEditor
         annotations={annotations}

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/ComputeResourcesEditor.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/ComputeResourcesEditor.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from "react";
 
+import { Heading } from "@/components/ui/typography";
 import type {
   AnnotationConfig,
   AnnotationOption,
@@ -83,7 +84,7 @@ export const ComputeResourcesEditor = ({
 }: ComputeResourcesEditorProps) => {
   return (
     <div className="flex flex-col gap-2">
-      <h3>Compute Resources</h3>
+      <Heading level={1}>Compute Resources</Heading>
       {COMPUTE_RESOURCES.map((resource) => (
         <ComputeResourceField
           key={resource.annotation}

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/ConfigurationSection.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/ConfigurationSection.tsx
@@ -1,0 +1,49 @@
+import { BlockStack } from "@/components/ui/layout";
+import { Separator } from "@/components/ui/separator";
+import { Paragraph } from "@/components/ui/typography";
+import { type TaskNodeContextType } from "@/providers/TaskNodeProvider";
+import { isGraphImplementation } from "@/utils/componentSpec";
+
+import { AnnotationsSection } from "../AnnotationsEditor/AnnotationsSection";
+import TaskConfiguration from "./TaskConfiguration";
+
+interface ConfigurationSectionProps {
+  taskNode: TaskNodeContextType;
+}
+
+const ConfigurationSection = ({ taskNode }: ConfigurationSectionProps) => {
+  const { taskSpec, callbacks } = taskNode;
+
+  const componentSpec = taskSpec.componentRef.spec;
+
+  if (!componentSpec) {
+    console.error(
+      "TaskOverview called with missing taskSpec.componentRef.spec",
+    );
+    return null;
+  }
+
+  const isSubgraph = isGraphImplementation(componentSpec.implementation);
+
+  return (
+    <BlockStack gap="4">
+      <Paragraph tone="subdued" size="sm">
+        Configure task annotations, resources and custom data.
+      </Paragraph>
+
+      {!isSubgraph && (
+        <>
+          <TaskConfiguration taskNode={taskNode} />
+          <Separator />
+        </>
+      )}
+
+      <AnnotationsSection
+        taskSpec={taskSpec}
+        onApply={callbacks.setAnnotations}
+      />
+    </BlockStack>
+  );
+};
+
+export default ConfigurationSection;

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/TaskConfiguration.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/TaskConfiguration.tsx
@@ -1,0 +1,45 @@
+import { useCallback } from "react";
+
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Switch } from "@/components/ui/switch";
+import { Heading, Paragraph } from "@/components/ui/typography";
+import { type TaskNodeContextType } from "@/providers/TaskNodeProvider";
+import { ISO8601_DURATION_ZERO_DAYS } from "@/utils/constants";
+
+interface TaskConfigurationProps {
+  taskNode: TaskNodeContextType;
+}
+
+const TaskConfiguration = ({ taskNode }: TaskConfigurationProps) => {
+  const { taskSpec, callbacks } = taskNode;
+
+  const disableCache =
+    taskSpec.executionOptions?.cachingStrategy?.maxCacheStaleness ===
+    ISO8601_DURATION_ZERO_DAYS;
+
+  const handleDisableCacheChange = useCallback(
+    (checked: boolean) => {
+      callbacks.setCacheStaleness(
+        checked ? ISO8601_DURATION_ZERO_DAYS : undefined,
+      );
+    },
+    [callbacks],
+  );
+
+  return (
+    <BlockStack gap="2">
+      <Heading level={1}>Configuration</Heading>
+      <InlineStack align="space-between" gap="2" className="w-full">
+        <Paragraph tone="subdued" size="sm">
+          Disable cache
+        </Paragraph>
+        <Switch
+          checked={disableCache}
+          onCheckedChange={handleDisableCacheChange}
+        />
+      </InlineStack>
+    </BlockStack>
+  );
+};
+
+export default TaskConfiguration;

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/TaskOverview.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/TaskOverview.tsx
@@ -19,8 +19,8 @@ import { useExecutionDataOptional } from "@/providers/ExecutionDataProvider";
 import { type TaskNodeContextType } from "@/providers/TaskNodeProvider";
 import { isGraphImplementation } from "@/utils/componentSpec";
 
-import { AnnotationsSection } from "../AnnotationsEditor/AnnotationsSection";
 import ArgumentsSection from "../ArgumentsEditor/ArgumentsSection";
+import ConfigurationSection from "./ConfigurationSection";
 import IOSection from "./IOSection/IOSection";
 import Logs, { OpenLogsInNewWindowLink } from "./logs";
 import OutputsList from "./OutputsList";
@@ -81,9 +81,9 @@ const TaskOverview = ({ taskNode, actions }: TaskOverviewProps) => {
               </TabsTrigger>
             )}
             {!readOnly && (
-              <TabsTrigger value="annotations" className="flex-1">
+              <TabsTrigger value="configuration" className="flex-1">
                 <FilePenLineIcon className="h-4 w-4" />
-                Annotations
+                Configuration
               </TabsTrigger>
             )}
           </TabsList>
@@ -153,14 +153,8 @@ const TaskOverview = ({ taskNode, actions }: TaskOverviewProps) => {
             </TabsContent>
           )}
           {!readOnly && (
-            <TabsContent value="annotations">
-              <p className="text-sm text-muted-foreground mb-2">
-                Configure task annotations, resources and custom data.
-              </p>
-              <AnnotationsSection
-                taskSpec={taskSpec}
-                onApply={callbacks.setAnnotations}
-              />
+            <TabsContent value="configuration">
+              <ConfigurationSection taskNode={taskNode} />
             </TabsContent>
           )}
         </Tabs>

--- a/src/components/shared/ReactFlow/FlowCanvas/utils/duplicateNodes.test.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/utils/duplicateNodes.test.ts
@@ -80,6 +80,7 @@ const createMockComponentSpecWithOutputs = (
 const createMockTaskNodeCallbacks = () => ({
   setArguments: vi.fn(),
   setAnnotations: vi.fn(),
+  setCacheStaleness: vi.fn(),
   onDelete: vi.fn(),
   onDuplicate: vi.fn(),
   onUpgrade: vi.fn(),
@@ -88,6 +89,7 @@ const createMockTaskNodeCallbacks = () => ({
 const createMockNodeCallbacks = (): NodeCallbacks => ({
   setArguments: vi.fn(),
   setAnnotations: vi.fn(),
+  setCacheStaleness: vi.fn(),
   onDelete: vi.fn(),
   onDuplicate: vi.fn(),
   onUpgrade: vi.fn(),

--- a/src/hooks/useNodeCallbacks.ts
+++ b/src/hooks/useNodeCallbacks.ts
@@ -126,6 +126,41 @@ export const useNodeCallbacks = ({
     [graphSpec, updateGraphSpec],
   );
 
+  const setCacheStaleness = useCallback(
+    (ids: NodeAndTaskId, cacheStaleness: string | undefined) => {
+      const taskId = ids.taskId;
+      const task = graphSpec.tasks[taskId];
+
+      if (!task) {
+        console.warn(`Task with id ${taskId} not found in graph spec.`);
+        return;
+      }
+
+      const cachingStrategy = cacheStaleness
+        ? { maxCacheStaleness: cacheStaleness }
+        : undefined;
+
+      const updatedTask: TaskSpec = {
+        ...task,
+        executionOptions: {
+          ...task.executionOptions,
+          cachingStrategy,
+        },
+      };
+
+      const newGraphSpec = {
+        ...graphSpec,
+        tasks: {
+          ...graphSpec.tasks,
+          [taskId]: updatedTask,
+        },
+      };
+
+      updateGraphSpec(newGraphSpec);
+    },
+    [graphSpec, updateGraphSpec],
+  );
+
   const onDuplicate = useCallback(
     (ids: NodeAndTaskId, selected = true) => {
       const nodeId = ids.nodeId;
@@ -194,6 +229,7 @@ export const useNodeCallbacks = ({
     onDelete,
     setArguments,
     setAnnotations,
+    setCacheStaleness,
     onDuplicate,
     onUpgrade,
   };

--- a/src/providers/TaskNodeProvider.tsx
+++ b/src/providers/TaskNodeProvider.tsx
@@ -35,6 +35,7 @@ type TaskNodeState = Readonly<{
 type TaskNodeCallbacks = {
   setArguments: (args: Record<string, ArgumentType>) => void;
   setAnnotations: (annotations: Annotations) => void;
+  setCacheStaleness: (cacheStaleness: string | undefined) => void;
   onDelete?: () => void;
   onDuplicate?: () => void;
   onUpgrade?: () => void;
@@ -105,6 +106,13 @@ export const TaskNodeProvider = ({
     [data.callbacks],
   );
 
+  const handleSetCacheStaleness = useCallback(
+    (cacheStaleness: string | undefined) => {
+      data.callbacks?.setCacheStaleness(cacheStaleness);
+    },
+    [data.callbacks],
+  );
+
   const handleDeleteTaskNode = useCallback(() => {
     data.callbacks?.onDelete();
   }, [data.callbacks]);
@@ -156,6 +164,7 @@ export const TaskNodeProvider = ({
     () => ({
       setArguments: handleSetArguments,
       setAnnotations: handleSetAnnotations,
+      setCacheStaleness: handleSetCacheStaleness,
       onDelete: handleDeleteTaskNode,
       onDuplicate: handleDuplicateTaskNode,
       onUpgrade: handleUpgradeTaskNode,

--- a/src/types/taskNode.ts
+++ b/src/types/taskNode.ts
@@ -28,6 +28,7 @@ export type TaskType = "task" | "input" | "output";
 interface TaskNodeCallbacks {
   setArguments: (args: Record<string, ArgumentType>) => void;
   setAnnotations: (annotations: Annotations) => void;
+  setCacheStaleness: (cacheStaleness: string | undefined) => void;
   onDelete: () => void;
   onDuplicate: (selected?: boolean) => void;
   onUpgrade: (newComponentRef: ComponentReference) => void;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -73,3 +73,5 @@ export const EXIT_CODE_OOM = 137; // SIGKILL (128 + 9) - Out of Memory
 export const TWENTY_FOUR_HOURS_IN_MS = 24 * 60 * 60 * 1000;
 
 export const ROOT_TASK_ID = "root";
+
+export const ISO8601_DURATION_ZERO_DAYS = "P0D";

--- a/src/utils/nodes/createNodesFromComponentSpec.test.ts
+++ b/src/utils/nodes/createNodesFromComponentSpec.test.ts
@@ -16,6 +16,7 @@ describe("createNodesFromComponentSpec", () => {
     onDelete: vi.fn(),
     setArguments: vi.fn(),
     setAnnotations: vi.fn(),
+    setCacheStaleness: vi.fn(),
     onDuplicate: vi.fn(),
     onUpgrade: vi.fn(),
   };


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Reworks the Annotation tab of the task details into "Configuration" and adds a section to toggle Task Caching on or off. Includes a little more refactoring/moving/renaming of code, just so things make more sense.

This toggle goes through the standard Task Callback process to set `task_spec.execution_options.caching_strategy.max_cache_staleness = "P0D"`, which is currently the only accepted value on the backend. This can be expanded in future when the backend supports it.

Note: the backend does not support caching strategies for Subgraph Nodes, so the interface has been hidden in that scenario. Additionally, due to overlap with #1185 the ability to toggle cache on nested components in a subgraph will come as a follow-up once #1185 is merged.

Tasks with caching disabled will run fresh when the pipeline is executed!

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

Closes https://github.com/Shopify/oasis-frontend/issues/223

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] New feature

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

![image.png](https://app.graphite.dev/user-attachments/assets/edc02bf5-55f4-458d-ad25-1e388e3b243e.png)

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->
Note: this requires the backend is updated to at least commit https://github.com/Cloud-Pipelines/backend/commit/5b4bdd5c37e3c386b569d2fdc7e9cdd2ce3bc23d

1. Create a basic pipeline
2. Run it
3. When finished, run it again and confirm it is using the cache
4. Go into the pipeline, select a task, navigate to the new "Configuration" tab and disabled the cache via the toggle.
5. Run the pipeline again and confirm that the task did not use the cache this time
6. Go back again, reactive cache, run the pipeline and confirm the task now uses cache again

Note: cache strategies are disabled for subgraph nodes and are not (yet) possible within subgraphs

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
