### PR TITLE
Cleanup: Cache Indicator and Clean ComponentSpec

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/StatusIndicator.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/StatusIndicator.tsx
@@ -7,28 +7,42 @@ import {
 } from "lucide-react";
 
 import type { ContainerExecutionStatus } from "@/api/types.gen";
+import { Icon } from "@/components/ui/icon";
+import { QuickTooltip } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 
 type StatusIndicatorProps = {
   status?: ContainerExecutionStatus;
+  disabledCache?: boolean;
 };
 
-export const StatusIndicator = ({ status }: StatusIndicatorProps) => {
+export const StatusIndicator = ({
+  status,
+  disabledCache = false,
+}: StatusIndicatorProps) => {
   if (!status) return null;
 
   const { style, text, icon } = getRunStatus(status);
 
   return (
-    <div
-      className={cn(
-        "absolute -z-1 -top-5 left-0 h-[35px] rounded-t-md px-2.5 py-1 text-[10px]",
-        style,
-      )}
-    >
-      <div className="flex items-center gap-1 font-mono text-white">
-        {icon}
-        {text}
+    <div className="absolute -z-1 -top-5 left-0 flex items-start">
+      <div
+        className={cn("h-[35px] rounded-t-md px-2.5 py-1 text-[10px]", style, {
+          "rounded-tr-none": disabledCache,
+        })}
+      >
+        <div className="flex items-center gap-1 font-mono text-white">
+          {icon}
+          {text}
+        </div>
       </div>
+      {disabledCache && (
+        <div className="h-[22px] bg-orange-400 rounded-tr-md flex items-center px-1.5">
+          <QuickTooltip content="Cache Disabled" className="whitespace-nowrap">
+            <Icon name="ZapOff" size="xs" className="text-white" />
+          </QuickTooltip>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNode.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNode.tsx
@@ -5,6 +5,7 @@ import type { ContainerExecutionStatus } from "@/api/types.gen";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 import { TaskNodeProvider } from "@/providers/TaskNodeProvider";
 import type { TaskNodeData } from "@/types/taskNode";
+import { isCacheDisabled } from "@/utils/cache";
 
 import { StatusIndicator } from "./StatusIndicator";
 import { TaskNodeCard } from "./TaskNodeCard";
@@ -18,13 +19,15 @@ const TaskNode = ({ data, selected }: NodeProps) => {
     typedData.taskId ?? "",
   ) as ContainerExecutionStatus;
 
+  const disabledCache = isCacheDisabled(typedData.taskSpec);
+
   return (
     <TaskNodeProvider
       data={typedData}
       selected={selected}
       runStatus={runStatus}
     >
-      <StatusIndicator status={runStatus} />
+      <StatusIndicator status={runStatus} disabledCache={disabledCache} />
       <TaskNodeCard />
     </TaskNodeProvider>
   );

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeCard.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeCard.tsx
@@ -16,6 +16,7 @@ import { cn } from "@/lib/utils";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 import { useContextPanel } from "@/providers/ContextPanelProvider";
 import { useTaskNode } from "@/providers/TaskNodeProvider";
+import { isCacheDisabled } from "@/utils/cache";
 import { getSubgraphDescription, isSubgraph } from "@/utils/subgraphUtils";
 
 import {
@@ -67,6 +68,8 @@ const TaskNodeCard = () => {
     () => getSubgraphDescription(taskSpec),
     [taskSpec],
   );
+
+  const disabledCache = isCacheDisabled(taskSpec);
 
   const onNotify = useCallback((message: NotifyMessage) => {
     switch (message.type) {
@@ -244,10 +247,18 @@ const TaskNodeCard = () => {
       >
         <CardHeader className="border-b border-slate-200 px-2 py-2.5 flex flex-row justify-between items-start">
           <BlockStack>
-            <InlineStack gap="2" blockAlign="center">
+            <InlineStack gap="2" blockAlign="center" wrap="nowrap">
               {isSubgraphNode && isSubgraphNavigationEnabled && (
                 <QuickTooltip content={`Subgraph: ${subgraphDescription}`}>
                   <Icon name="Workflow" size="sm" className="text-blue-600" />
+                </QuickTooltip>
+              )}
+              {disabledCache && !readOnly && (
+                <QuickTooltip
+                  content="Cache Disabled"
+                  className="whitespace-nowrap"
+                >
+                  <Icon name="ZapOff" size="sm" className="text-orange-400" />
                 </QuickTooltip>
               )}
               <CardTitle className="break-words text-left text-xs text-slate-900">

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/TaskConfiguration.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/TaskConfiguration.tsx
@@ -4,6 +4,7 @@ import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Switch } from "@/components/ui/switch";
 import { Heading, Paragraph } from "@/components/ui/typography";
 import { type TaskNodeContextType } from "@/providers/TaskNodeProvider";
+import { isCacheDisabled } from "@/utils/cache";
 import { ISO8601_DURATION_ZERO_DAYS } from "@/utils/constants";
 
 interface TaskConfigurationProps {
@@ -13,9 +14,7 @@ interface TaskConfigurationProps {
 const TaskConfiguration = ({ taskNode }: TaskConfigurationProps) => {
   const { taskSpec, callbacks } = taskNode;
 
-  const disableCache =
-    taskSpec.executionOptions?.cachingStrategy?.maxCacheStaleness ===
-    ISO8601_DURATION_ZERO_DAYS;
+  const disabledCache = isCacheDisabled(taskSpec);
 
   const handleDisableCacheChange = useCallback(
     (checked: boolean) => {
@@ -34,7 +33,7 @@ const TaskConfiguration = ({ taskNode }: TaskConfigurationProps) => {
           Disable cache
         </Paragraph>
         <Switch
-          checked={disableCache}
+          checked={disabledCache}
           onCheckedChange={handleDisableCacheChange}
         />
       </InlineStack>

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -8,6 +8,9 @@
 
 import yaml from "js-yaml";
 
+import type { TaskSpec } from "./componentSpec";
+import { ISO8601_DURATION_ZERO_DAYS } from "./constants";
+
 const httpGetDataWithCache = async <T>(
   url: string,
   transformer: (buffer: ArrayBuffer) => T,
@@ -73,4 +76,25 @@ export function loadObjectFromYamlData(buffer: ArrayBuffer): object {
     return obj;
   }
   throw Error(`Expected a YAML-encoded object, but got "${typeof obj}"`);
+}
+
+export function isCacheDisabled(taskSpec?: TaskSpec): boolean {
+  return (
+    taskSpec?.executionOptions?.cachingStrategy?.maxCacheStaleness ===
+    ISO8601_DURATION_ZERO_DAYS
+  );
+}
+
+export function removeCachingStrategyFromSpec(taskSpec: TaskSpec): TaskSpec {
+  if (taskSpec.executionOptions?.cachingStrategy) {
+    const updatedExecutionOptions = {
+      ...taskSpec.executionOptions,
+    };
+    delete updatedExecutionOptions.cachingStrategy;
+    return {
+      ...taskSpec,
+      executionOptions: updatedExecutionOptions,
+    };
+  }
+  return taskSpec;
 }


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Quick followup/cleanup items:
- Cloned pipelines will not copy over caching strategies for tasks
- Added a "cache disabled" indicator to the task card so cache status can be seen at a glance.
- Moved the cache enabled/disabled check into a utility

I couldn't decide the best way or place to put the cache-disabled icon, so I went with both options and I invite feedback.
1. on the top left of the task node card, next to the subgraph icon
2. extend the status indicator


see below for screenshots

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] New feature
- [x] Improvement
- [x] Cleanup/Refactor

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->
Run view:

![image.png](https://app.graphite.dev/user-attachments/assets/69cade72-7f05-4d66-831b-eea05188e550.png)

Editor view:

![image.png](https://app.graphite.dev/user-attachments/assets/db460fd0-a174-4f11-a45c-4a67005263b5.png)

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
