### PR TITLE
Add JSON Annotation Input Type

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/AnnotationsEditor.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/AnnotationsEditor.tsx
@@ -22,6 +22,7 @@ const COMMON_ANNOTATIONS: AnnotationConfig[] = [
   {
     annotation: "editor.position",
     label: "Node position",
+    type: "json",
   },
   {
     annotation: "shopify.io/showback_cost_owner_ref",

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/AnnotationsInput.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/AnnotationsInput.tsx
@@ -79,11 +79,13 @@ export const AnnotationsInput = ({
       return;
     }
 
-    try {
-      JSON.parse(newValue);
-      setIsInvalid(false);
-    } catch {
-      setIsInvalid(true);
+    if (config?.type === "json") {
+      try {
+        JSON.parse(newValue);
+        setIsInvalid(false);
+      } catch {
+        setIsInvalid(true);
+      }
     }
   }, []);
 
@@ -183,7 +185,7 @@ export const AnnotationsInput = ({
   const handleBlur = useCallback(() => {
     if (config?.enableQuantity && !shouldSaveQuantityField()) return;
 
-    if (onBlur && lastSavedValue !== inputValue) {
+    if (onBlur && lastSavedValue !== inputValue && !isInvalid) {
       let value = inputValue;
       if (
         config?.type === "number" &&
@@ -196,7 +198,14 @@ export const AnnotationsInput = ({
       onBlur(value);
       setLastSavedValue(value);
     }
-  }, [onBlur, shouldSaveQuantityField, lastSavedValue, inputValue, config]);
+  }, [
+    onBlur,
+    shouldSaveQuantityField,
+    isInvalid,
+    lastSavedValue,
+    inputValue,
+    config,
+  ]);
 
   useCallbackOnUnmount(handleBlur);
 
@@ -317,7 +326,7 @@ export const AnnotationsInput = ({
 
   return (
     <>
-      <InlineStack gap="2" blockAlign="center" className="grow flex-wrap">
+      <InlineStack gap="2" blockAlign="center" wrap="nowrap" className="grow">
         {inputElement}
         {config?.enableQuantity && (
           <QuantityInput

--- a/src/types/annotations.ts
+++ b/src/types/annotations.ts
@@ -12,7 +12,7 @@ export type AnnotationConfig = {
   append?: string;
   options?: AnnotationOption[];
   enableQuantity?: boolean;
-  type?: "string" | "number" | "boolean";
+  type?: "string" | "number" | "boolean" | "json";
   min?: number;
   max?: number;
 };


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Splits JSON annotation input type from STRING. Both will be rendered as a string field, but `json` type will be validated as a json object whilst `string` will not.

`editor.position` annotation has been moved to the new json type.
`showback cost owner` remains on string type.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->
Follows #1198. 

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

![image.png](https://app.graphite.dev/user-attachments/assets/6e99eb0b-abed-4a96-8da8-6d81433dd4cb.png)

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->
1. Edit annotations for a task. Editing the Node position should produce a invalid json warning if the input is not valid json. For a string field, such as "Showback Cost Owner", no warning should be displayed under any scenario.

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
