### PR TITLE
Navigate into subgraph by index

### DIFF
--- a/src/routes/PipelineRun/PipelineRun.test.tsx
+++ b/src/routes/PipelineRun/PipelineRun.test.tsx
@@ -13,9 +13,11 @@ import PipelineRun from "./PipelineRun";
 
 // Mock the router and other dependencies
 vi.mock("@tanstack/react-router", async (importOriginal) => {
+  const actual = (await importOriginal()) as object;
   return {
-    ...(await importOriginal()),
+    ...actual,
     useNavigate: () => vi.fn(),
+    useSearch: () => ({ indexPath: undefined }),
     useLocation: () => ({
       pathname: "/runs/test-run-id-123",
       search: {},
@@ -32,6 +34,7 @@ vi.mock("@tanstack/react-router", async (importOriginal) => {
 vi.mock("@/routes/router", () => ({
   runDetailRoute: {
     useParams: () => ({ id: "test-run-id-123" }),
+    useSearch: () => ({ indexPath: undefined }),
   },
   RUNS_BASE_PATH: "/runs",
 }));
@@ -201,6 +204,15 @@ describe("<PipelineRun/>", () => {
     // arrange
     mockUseComponentSpec.mockReturnValue({
       componentSpec: null,
+      currentSubgraphSpec: {
+        implementation: {
+          graph: {
+            tasks: {},
+            outputValues: {},
+          },
+        },
+      },
+      currentGraphSpec: { tasks: {}, outputValues: {} },
       setComponentSpec: vi.fn(),
       clearComponentSpec: vi.fn(),
       setTaskStatusMap: vi.fn(),

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -47,10 +47,19 @@ const mainLayout = createRoute({
   component: RootLayout,
 });
 
-const indexRoute = createRoute({
+export interface HomeSearch {
+  page_token?: string;
+  filter?: string;
+}
+
+export const indexRoute = createRoute({
   getParentRoute: () => mainLayout,
   path: APP_ROUTES.HOME,
   component: Home,
+  validateSearch: (search: Record<string, unknown>): HomeSearch => ({
+    page_token: search.page_token as string | undefined,
+    filter: search.filter as string | undefined,
+  }),
 });
 
 const quickStartRoute = createRoute({
@@ -79,10 +88,17 @@ export interface RunDetailParams {
   id: string;
 }
 
+interface RunDetailSearch {
+  indexPath?: string;
+}
+
 export const runDetailRoute = createRoute({
   getParentRoute: () => mainLayout,
   path: APP_ROUTES.RUN_DETAIL,
   component: PipelineRun,
+  validateSearch: (search: Record<string, unknown>): RunDetailSearch => ({
+    indexPath: search.indexPath as string | undefined,
+  }),
 });
 
 const appRouteTree = mainLayout.addChildren([

--- a/src/utils/subgraphUtils.ts
+++ b/src/utils/subgraphUtils.ts
@@ -299,3 +299,66 @@ export const updateSubgraphSpec = (
     },
   };
 };
+
+export const subgraphPathToIndexPath = (
+  subgraphPath: string[],
+  rootComponentSpec: ComponentSpec,
+): string[] => {
+  const indexPath: string[] = [];
+  let currentSpec = rootComponentSpec;
+
+  for (let i = 1; i < subgraphPath.length; i++) {
+    const taskId = subgraphPath[i];
+    if (!isGraphImplementation(currentSpec.implementation)) {
+      return [];
+    }
+    const taskIndex = Object.keys(
+      currentSpec.implementation.graph.tasks,
+    ).indexOf(taskId);
+    if (taskIndex === -1) {
+      return [];
+    }
+
+    indexPath.push(taskIndex.toString());
+    if (!currentSpec.implementation.graph.tasks[taskId].componentRef.spec) {
+      return [];
+    }
+    currentSpec =
+      currentSpec.implementation.graph.tasks[taskId].componentRef.spec;
+  }
+  return indexPath;
+};
+
+export const indexPathToSubgraphPath = (
+  indexPath: string[],
+  rootComponentSpec: ComponentSpec,
+): string[] => {
+  const subgraphPath: string[] = [];
+  let currentSpec = rootComponentSpec;
+
+  for (let i = 0; i < indexPath.length; i++) {
+    const taskIndex = parseInt(indexPath[i]);
+
+    if (!isGraphImplementation(currentSpec.implementation)) {
+      return [];
+    }
+
+    const taskNames = Object.keys(currentSpec.implementation.graph.tasks);
+
+    if (taskIndex < 0 || taskIndex >= taskNames.length) {
+      return [];
+    }
+
+    const taskName = taskNames[taskIndex];
+    subgraphPath.push(taskName);
+
+    if (i < indexPath.length - 1) {
+      const task = currentSpec.implementation.graph.tasks[taskName];
+      if (!task.componentRef.spec) {
+        return [];
+      }
+      currentSpec = task.componentRef.spec;
+    }
+  }
+  return subgraphPath;
+};


### PR DESCRIPTION
## Description

Added URL persistence for subgraph navigation in the Pipeline Run view. This implementation allows users to navigate through nested subgraphs and maintains the current location in the URL, enabling direct linking to specific subgraphs and preserving navigation state during page refreshes.

Note: Navigating directly does NOT fetch the status. That will be fixed in the following PR

## Type of Change

- [x] New feature
- [x] Improvement

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Test Instructions

1. Open a pipeline run with nested subgraphs
2. Navigate to a nested subgraph
3. Verify the URL updates with the `indexPath` query parameter
4. Copy the URL and open in a new tab to confirm it navigates directly to the same subgraph
5. Test navigation between different subgraph levels and verify URL persistence