### PR TITLE
fix subgraph output renaming and edges

### DIFF
--- a/src/utils/componentSpec.ts
+++ b/src/utils/componentSpec.ts
@@ -385,6 +385,15 @@ export interface TaskOutputArgument {
 export type ArgumentType = string | GraphInputArgument | TaskOutputArgument;
 
 /**
+ * Type guard to check if an argument is a TaskOutputArgument
+ */
+export const isTaskOutputArgument = (
+  argument: ArgumentType,
+): argument is TaskOutputArgument => {
+  return typeof argument !== "string" && "taskOutput" in argument;
+};
+
+/**
  * Pair of operands for a binary operation.
  */
 interface TwoArgumentOperands {


### PR DESCRIPTION
## Description

Added support for output renaming propagation in subgraphs. When a subgraph's output is renamed, the changes now properly propagate to:
1. Parent graph's outputValues that reference the renamed output
2. Sibling task arguments that consume the renamed output
3. Multiple levels of nested subgraphs

The implementation includes a new type guard `isTaskOutputArgument` to identify task output arguments, and utility functions to update both task arguments and graph output values when subgraph outputs are renamed.

## Type of Change

- [x] New feature
- [x] Improvement

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Test Instructions

The PR includes comprehensive tests covering various scenarios:
- Basic output renaming propagation to parent outputValues
- Updating sibling task arguments when outputs are renamed
- Handling both outputValues and task arguments together
- Managing output renaming across multiple nesting levels
- Ensuring unrelated outputs remain unchanged