### PR TITLE
Add progress indicator for subgraph task nodes

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNode.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNode.tsx
@@ -1,8 +1,10 @@
 import { type NodeProps } from "@xyflow/react";
 import { memo, useMemo } from "react";
 
+import type { ContainerExecutionStatus } from "@/api/types.gen";
 import { useExecutionDataOptional } from "@/providers/ExecutionDataProvider";
 import { TaskNodeProvider } from "@/providers/TaskNodeProvider";
+import { getRunStatus } from "@/services/executionService";
 import type { TaskNodeData } from "@/types/taskNode";
 import { isCacheDisabled } from "@/utils/cache";
 
@@ -11,9 +13,19 @@ import { TaskNodeCard } from "./TaskNodeCard";
 
 const TaskNode = ({ data, selected }: NodeProps) => {
   const executionData = useExecutionDataOptional();
+
   const typedData = useMemo(() => data as TaskNodeData, [data]);
 
-  const status = executionData?.taskStatusMap?.[typedData.taskId ?? ""];
+  const status = useMemo(() => {
+    const taskId = typedData.taskId ?? "";
+    const statusCounts = executionData?.taskStatusCountsMap.get(taskId);
+
+    if (!statusCounts) {
+      return undefined;
+    }
+
+    return getRunStatus(statusCounts) as ContainerExecutionStatus;
+  }, [executionData?.taskStatusCountsMap, typedData.taskId]);
 
   const disabledCache = isCacheDisabled(typedData.taskSpec);
 

--- a/src/routes/PipelineRun/PipelineRun.test.tsx
+++ b/src/routes/PipelineRun/PipelineRun.test.tsx
@@ -62,7 +62,18 @@ vi.mock("@/services/executionService", () => ({
     enabled: false,
   }),
   countTaskStatuses: vi.fn(),
-  getRunStatus: vi.fn(),
+  getRunStatus: vi.fn(() => "RUNNING"),
+  convertExecutionStatsToStatusCounts: vi.fn((stats) => ({
+    succeeded: stats?.SUCCEEDED || 0,
+    failed: stats?.FAILED || 0,
+    running: stats?.RUNNING || 0,
+    waiting: stats?.WAITING_FOR_UPSTREAM || stats?.WAITING || 0,
+    cancelled: stats?.CANCELLED || 0,
+    total: Object.values(stats || {}).reduce(
+      (a: number, b) => a + (b as number),
+      0,
+    ),
+  })),
   STATUS: {
     SUCCEEDED: "SUCCEEDED",
     FAILED: "FAILED",


### PR DESCRIPTION
## Description

Refactored task status tracking in the execution data provider to use a more granular approach. Instead of storing a single status per task, we now maintain a map of status counts that allows for better representation of complex task states, especially for tasks with multiple child executions.

## Type of Change

- [x] Improvement
- [x] Refactoring

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Test Instructions

1. Run a pipeline with multiple tasks
2. Verify that task statuses are displayed correctly in the flow canvas
3. Check that tasks with multiple child executions show the appropriate aggregated status
4. Confirm that status updates correctly as tasks progress through their execution lifecycle

## Technical Details

- Replaced `taskStatusMap` with `taskStatusCountsMap` in the ExecutionDataProvider
- Added utility to convert execution stats to status counts
- Updated TaskNode component to determine status based on aggregated counts
- Improved type safety with proper imports from API types

This change provides a foundation for more detailed task status visualization and better handling of complex execution scenarios.