### PR TITLE
Add RunStatus domain type and fix status type safety

### DIFF
--- a/src/components/PipelineRun/RunDetails.test.tsx
+++ b/src/components/PipelineRun/RunDetails.test.tsx
@@ -15,6 +15,7 @@ import { ComponentSpecProvider } from "@/providers/ComponentSpecProvider";
 import { ExecutionDataProvider } from "@/providers/ExecutionDataProvider";
 import { PipelineRunsProvider } from "@/providers/PipelineRunsProvider";
 import * as pipelineRunService from "@/services/pipelineRunService";
+import type { PipelineRun } from "@/types/pipelineRun";
 import type { ComponentSpec } from "@/utils/componentSpec";
 
 import { RunDetails } from "./RunDetails";
@@ -113,7 +114,7 @@ describe("<RunDetails/>", () => {
     },
   };
 
-  const mockPipelineRun = {
+  const mockPipelineRun: PipelineRun = {
     id: 123,
     root_execution_id: 456,
     created_by: "test-user",

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/StatusIndicator.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/StatusIndicator.tsx
@@ -10,9 +10,10 @@ import type { ContainerExecutionStatus } from "@/api/types.gen";
 import { Icon } from "@/components/ui/icon";
 import { QuickTooltip } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
+import type { RunStatus } from "@/types/pipelineRun";
 
 type StatusIndicatorProps = {
-  status: ContainerExecutionStatus;
+  status: ContainerExecutionStatus | RunStatus;
   disabledCache?: boolean;
 };
 
@@ -45,7 +46,7 @@ export const StatusIndicator = ({
   );
 };
 
-const getStatusMetadata = (status: ContainerExecutionStatus) => {
+const getStatusMetadata = (status: ContainerExecutionStatus | RunStatus) => {
   switch (status) {
     case "SUCCEEDED":
       return {
@@ -67,6 +68,7 @@ const getStatusMetadata = (status: ContainerExecutionStatus) => {
         text: "Running",
         icon: <Loader2Icon className="w-2 h-2 animate-spin" />,
       };
+    case "WAITING":
     case "PENDING":
       return {
         style: "bg-yellow-500",

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNode.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNode.tsx
@@ -1,7 +1,6 @@
 import { type NodeProps } from "@xyflow/react";
 import { memo, useMemo } from "react";
 
-import type { ContainerExecutionStatus } from "@/api/types.gen";
 import { useExecutionDataOptional } from "@/providers/ExecutionDataProvider";
 import { TaskNodeProvider } from "@/providers/TaskNodeProvider";
 import { getRunStatus } from "@/services/executionService";
@@ -24,7 +23,7 @@ const TaskNode = ({ data, selected }: NodeProps) => {
       return undefined;
     }
 
-    return getRunStatus(statusCounts) as ContainerExecutionStatus;
+    return getRunStatus(statusCounts);
   }, [executionData?.taskStatusCountsMap, typedData.taskId]);
 
   const disabledCache = isCacheDisabled(typedData.taskSpec);

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/logs.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/logs.tsx
@@ -7,6 +7,7 @@ import { InfoBox } from "@/components/shared/InfoBox";
 import { Link } from "@/components/ui/link";
 import { Spinner } from "@/components/ui/spinner";
 import { useBackend } from "@/providers/BackendProvider";
+import type { RunStatus } from "@/types/pipelineRun";
 import { getBackendStatusString } from "@/utils/backend";
 
 const LogDisplay = ({
@@ -54,7 +55,7 @@ const LogDisplay = ({
 };
 
 const isStatusActivelyLogging = (
-  status?: ContainerExecutionStatus,
+  status?: ContainerExecutionStatus | RunStatus,
 ): boolean => {
   if (!status) {
     return false;
@@ -71,7 +72,9 @@ const isStatusActivelyLogging = (
   }
 };
 
-const shouldStatusHaveLogs = (status?: ContainerExecutionStatus): boolean => {
+const shouldStatusHaveLogs = (
+  status?: ContainerExecutionStatus | RunStatus,
+): boolean => {
   if (!status) {
     return false;
   }
@@ -103,7 +106,7 @@ const Logs = ({
   status,
 }: {
   executionId?: string | number;
-  status?: ContainerExecutionStatus;
+  status?: ContainerExecutionStatus | RunStatus;
 }) => {
   const { backendUrl, configured, available } = useBackend();
 
@@ -193,7 +196,7 @@ export const OpenLogsInNewWindowLink = ({
   status,
 }: {
   executionId: string;
-  status?: ContainerExecutionStatus;
+  status?: ContainerExecutionStatus | RunStatus;
 }) => {
   const { backendUrl, available } = useBackend();
   const logsUrl = `${backendUrl}/api/executions/${executionId}/stream_container_log`;

--- a/src/providers/TaskNodeProvider.tsx
+++ b/src/providers/TaskNodeProvider.tsx
@@ -6,6 +6,7 @@ import useComponentFromUrl from "@/hooks/useComponentFromUrl";
 import { useTaskNodeDimensions } from "@/hooks/useTaskNodeDimensions";
 import useToastNotification from "@/hooks/useToastNotification";
 import type { Annotations } from "@/types/annotations";
+import type { RunStatus } from "@/types/pipelineRun";
 import type { TaskNodeData, TaskNodeDimensions } from "@/types/taskNode";
 import type {
   ArgumentType,
@@ -27,7 +28,7 @@ type TaskNodeState = Readonly<{
   readOnly: boolean;
   disabled: boolean;
   connectable: boolean;
-  status?: ContainerExecutionStatus;
+  status?: ContainerExecutionStatus | RunStatus;
   isCustomComponent: boolean;
   dimensions: TaskNodeDimensions;
 }>;
@@ -45,7 +46,7 @@ type TaskNodeProviderProps = {
   children: ReactNode;
   data: TaskNodeData;
   selected: boolean;
-  status?: ContainerExecutionStatus;
+  status?: ContainerExecutionStatus | RunStatus;
 };
 
 export type TaskNodeContextType = {

--- a/src/services/executionService.ts
+++ b/src/services/executionService.ts
@@ -7,7 +7,7 @@ import type {
   GetGraphExecutionStateResponse,
   PipelineRunResponse,
 } from "@/api/types.gen";
-import type { TaskStatusCounts } from "@/types/pipelineRun";
+import type { RunStatus, TaskStatusCounts } from "@/types/pipelineRun";
 import { fetchWithErrorHandling } from "@/utils/fetchWithErrorHandling";
 
 export const fetchExecutionState = async (
@@ -85,9 +85,9 @@ export const fetchExecutionStatus = async (
 };
 
 /**
- * Determine the overall run status based on the task statuses.
+ * Status constants for determining overall run status based on task statuses.
  */
-export const STATUS = {
+export const STATUS: Record<RunStatus, RunStatus> = {
   FAILED: "FAILED",
   RUNNING: "RUNNING",
   SUCCEEDED: "SUCCEEDED",
@@ -96,7 +96,7 @@ export const STATUS = {
   UNKNOWN: "UNKNOWN",
 } as const;
 
-export const getRunStatus = (statusData: TaskStatusCounts) => {
+export const getRunStatus = (statusData: TaskStatusCounts): RunStatus => {
   if (statusData.cancelled > 0) {
     return STATUS.CANCELLED;
   }

--- a/src/types/pipelineRun.ts
+++ b/src/types/pipelineRun.ts
@@ -1,3 +1,14 @@
+/**
+ * Possible status values for a pipeline run, derived from aggregating task statuses
+ */
+export type RunStatus =
+  | "FAILED"
+  | "RUNNING"
+  | "SUCCEEDED"
+  | "WAITING"
+  | "CANCELLED"
+  | "UNKNOWN";
+
 export interface PipelineRun {
   id: number;
   root_execution_id: number;
@@ -5,7 +16,7 @@ export interface PipelineRun {
   created_by: string;
   pipeline_name: string;
   pipeline_digest?: string;
-  status?: string;
+  status?: RunStatus;
   statusCounts?: TaskStatusCounts;
 }
 

--- a/src/utils/submitPipeline.test.ts
+++ b/src/utils/submitPipeline.test.ts
@@ -33,7 +33,7 @@ describe("submitPipelineRun", () => {
     created_at: "2024-01-01T00:00:00Z",
     created_by: "test-user",
     pipeline_name: "test-pipeline",
-    status: "running",
+    status: "RUNNING",
   };
 
   beforeEach(() => {
@@ -693,7 +693,7 @@ describe("submitPipelineRun", () => {
         created_at: "2024-01-01T00:00:00Z",
         created_by: "test-user",
         pipeline_name: "test-pipeline",
-        status: "running",
+        status: "RUNNING",
       } as PipelineRun;
 
       vi.mocked(pipelineRunService.createPipelineRun).mockResolvedValueOnce(


### PR DESCRIPTION
## Description

Improved type safety for pipeline run status by introducing a dedicated `RunStatus` type. This PR adds proper typing to the `status` field in the `PipelineRun` interface and updates all related components to use this type. The changes ensure consistent status handling across the application by properly typing status values in components like `StatusIndicator`, `TaskNode`, and log-related components.

## Type of Change

- [x] Improvement
- [x] Cleanup/Refactor

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality

![Screenshot 2025-11-06 at 4.59.14 PM.png](https://app.graphite.com/user-attachments/assets/b781261e-9819-4a3c-8322-9902987e8975.png)


## Test Instructions

1. Run the application and verify that pipeline run statuses display correctly
2. Check that status indicators and task nodes render properly with the new typing
3. Verify that logs functionality works as expected with the updated status types