### PR TITLE
Autoconnect Newly Created Subgraph Nodes

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/utils/addAndConnectNode.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/utils/addAndConnectNode.ts
@@ -50,7 +50,7 @@ export function addAndConnectNode({
       ? { ...position, x: position.x - DEFAULT_NODE_DIMENSIONS.w }
       : position;
 
-  const newComponentSpec = addTask(
+  const { spec: newComponentSpec } = addTask(
     "task",
     taskSpec,
     adjustedPosition,

--- a/src/components/shared/ReactFlow/FlowCanvas/utils/addTask.test.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/utils/addTask.test.ts
@@ -26,7 +26,8 @@ describe("addTask", () => {
   it("should do nothing if dropped data is empty", () => {
     const result = addTask("task", null, position, mockComponentSpec);
 
-    expect(result).toStrictEqual(mockComponentSpec);
+    expect(result.spec).toStrictEqual(mockComponentSpec);
+    expect(result.taskId).toBeUndefined();
   });
 
   it("should add a task node when task type is dropped", () => {
@@ -42,7 +43,7 @@ describe("addTask", () => {
 
     const result = addTask("task", mockTaskSpec, position, mockComponentSpec);
 
-    const newComponentSpec = result as typeof mockComponentSpec & {
+    const newComponentSpec = result.spec as typeof mockComponentSpec & {
       implementation: { graph: { tasks: Record<string, any> } };
     };
 
@@ -50,7 +51,11 @@ describe("addTask", () => {
       Object.keys(newComponentSpec.implementation.graph.tasks).length,
     ).toBe(1);
 
-    const taskId = Object.keys(newComponentSpec.implementation.graph.tasks)[0];
+    const taskId = result.taskId;
+    expect(taskId).toBeDefined();
+
+    if (!taskId) return;
+
     const task = newComponentSpec.implementation.graph.tasks[taskId];
     expect(task.annotations).toHaveProperty("editor.position");
     expect(task.annotations["editor.position"]).toBe(
@@ -61,7 +66,7 @@ describe("addTask", () => {
   it("should add an input node when input type is dropped", () => {
     const result = addTask("input", null, position, mockComponentSpec);
 
-    const newComponentSpec = result as typeof mockComponentSpec & {
+    const newComponentSpec = result.spec as typeof mockComponentSpec & {
       inputs: Array<{ name: string; annotations: Record<string, any> }>;
     };
 
@@ -70,12 +75,13 @@ describe("addTask", () => {
     expect(newComponentSpec.inputs[0].annotations).toHaveProperty(
       "editor.position",
     );
+    expect(result.taskId).toBeUndefined();
   });
 
   it("should add an output node when output type is dropped", () => {
     const result = addTask("output", null, position, mockComponentSpec);
 
-    const newComponentSpec = result as typeof mockComponentSpec & {
+    const newComponentSpec = result.spec as typeof mockComponentSpec & {
       outputs: Array<{ name: string; annotations: Record<string, any> }>;
     };
 
@@ -84,6 +90,7 @@ describe("addTask", () => {
     expect(newComponentSpec.outputs[0].annotations).toHaveProperty(
       "editor.position",
     );
+    expect(result.taskId).toBeUndefined();
   });
 
   it("should create unique names for tasks when duplicates exist", () => {
@@ -115,7 +122,11 @@ describe("addTask", () => {
       newMockComponentSpec,
     );
 
-    const newComponentSpec = result;
+    const newComponentSpec = result.spec;
+    const taskId = result.taskId;
+
+    expect(taskId).toBeDefined();
+    if (!taskId) return;
 
     const taskIds =
       "graph" in newComponentSpec.implementation &&
@@ -134,7 +145,7 @@ describe("addTask", () => {
 
     const result = addTask("input", null, position, newMockComponentSpec);
 
-    const newComponentSpec = result as typeof newMockComponentSpec & {
+    const newComponentSpec = result.spec as typeof newMockComponentSpec & {
       inputs: Array<{ name: string; annotations: Record<string, any> }>;
     };
 
@@ -150,7 +161,7 @@ describe("addTask", () => {
 
     const result = addTask("output", null, position, newMockComponentSpec);
 
-    const newComponentSpec = result as typeof newMockComponentSpec & {
+    const newComponentSpec = result.spec as typeof newMockComponentSpec & {
       outputs: Array<{ name: string; annotations: Record<string, any> }>;
     };
 

--- a/src/components/shared/ReactFlow/FlowCanvas/utils/updateDownstreamSubgraphConnections.test.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/utils/updateDownstreamSubgraphConnections.test.ts
@@ -1,0 +1,470 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  type ArgumentType,
+  type ComponentSpec,
+  isGraphImplementation,
+  type TaskOutputArgument,
+  type TaskSpec,
+} from "@/utils/componentSpec";
+
+import { updateDownstreamSubgraphConnections } from "./updateDownstreamSubgraphConnections";
+
+describe("updateDownstreamSubgraphConnections", () => {
+  const createMockComponentSpec = (
+    tasks: Record<string, TaskSpec>,
+    outputValues?: Record<string, TaskOutputArgument>,
+  ): ComponentSpec => ({
+    name: "Test Component",
+    implementation: {
+      graph: {
+        tasks,
+        ...(outputValues && { outputValues }),
+      },
+    },
+  });
+
+  const createMockTask = (
+    name: string,
+    arguments_?: Record<string, ArgumentType>,
+    outputs: Array<{ name: string; type?: string }> = [],
+  ): TaskSpec => ({
+    componentRef: {
+      name,
+      spec: {
+        name,
+        outputs,
+        implementation: { container: { image: "test" } },
+      },
+    },
+    ...(arguments_ && { arguments: arguments_ }),
+  });
+
+  describe("Scenario 1: TaskOutput connected to TaskInput", () => {
+    it("should redirect task arguments to replacement task when output exists", () => {
+      const originalTask1 = createMockTask("OriginalTask1", {}, [
+        { name: "result", type: "string" },
+      ]);
+      const originalTask2 = createMockTask("OriginalTask2", {}, [
+        { name: "data", type: "string" },
+      ]);
+      const replacementTask = createMockTask("ReplacementTask", {}, [
+        { name: "result", type: "string" },
+        { name: "data", type: "string" },
+      ]);
+      const externalTask = createMockTask("ExternalTask", {
+        input1: {
+          taskOutput: {
+            taskId: "original1",
+            outputName: "result",
+            type: "string",
+          },
+        },
+        input2: {
+          taskOutput: {
+            taskId: "original2",
+            outputName: "data",
+            type: "string",
+          },
+        },
+      });
+
+      const componentSpec = createMockComponentSpec({
+        original1: originalTask1,
+        original2: originalTask2,
+        replacement1: replacementTask,
+        external1: externalTask,
+      });
+
+      const result = updateDownstreamSubgraphConnections(
+        componentSpec,
+        ["original1", "original2"],
+        "replacement1",
+      );
+
+      if (!isGraphImplementation(result.implementation)) {
+        throw new Error("Expected graph implementation");
+      }
+
+      const updatedExternalTask = result.implementation.graph.tasks.external1;
+
+      expect(updatedExternalTask.arguments?.input1).toEqual({
+        taskOutput: {
+          taskId: "replacement1",
+          outputName: "result",
+          type: "string",
+        },
+      });
+
+      expect(updatedExternalTask.arguments?.input2).toEqual({
+        taskOutput: {
+          taskId: "replacement1",
+          outputName: "data",
+          type: "string",
+        },
+      });
+    });
+
+    it("should remove task arguments when replacement task lacks matching output", () => {
+      const originalTask = createMockTask("OriginalTask", {}, [
+        { name: "result", type: "string" },
+      ]);
+      const replacementTask = createMockTask("ReplacementTask", {}, [
+        { name: "different_output", type: "string" },
+      ]);
+      const externalTask = createMockTask("ExternalTask", {
+        input1: {
+          taskOutput: {
+            taskId: "original1",
+            outputName: "result",
+            type: "string",
+          },
+        },
+        keepMe: "static_value",
+      });
+
+      const componentSpec = createMockComponentSpec({
+        original1: originalTask,
+        replacement1: replacementTask,
+        external1: externalTask,
+      });
+
+      const result = updateDownstreamSubgraphConnections(
+        componentSpec,
+        ["original1"],
+        "replacement1",
+      );
+
+      if (!isGraphImplementation(result.implementation)) {
+        throw new Error("Expected graph implementation");
+      }
+
+      const updatedExternalTask = result.implementation.graph.tasks.external1;
+
+      expect(updatedExternalTask.arguments?.input1).toBeUndefined();
+      expect(updatedExternalTask.arguments?.keepMe).toBe("static_value");
+    });
+
+    it("should leave unrelated connections unchanged", () => {
+      const originalTask = createMockTask("OriginalTask", {}, [
+        { name: "result", type: "string" },
+      ]);
+      const replacementTask = createMockTask("ReplacementTask", {}, [
+        { name: "result", type: "string" },
+      ]);
+      const unrelatedTask = createMockTask("UnrelatedTask", {}, [
+        { name: "other", type: "string" },
+      ]);
+      const externalTask = createMockTask("ExternalTask", {
+        input1: {
+          taskOutput: {
+            taskId: "original1",
+            outputName: "result",
+            type: "string",
+          },
+        },
+        input2: {
+          taskOutput: {
+            taskId: "unrelated1",
+            outputName: "other",
+            type: "string",
+          },
+        },
+      });
+
+      const componentSpec = createMockComponentSpec({
+        original1: originalTask,
+        replacement1: replacementTask,
+        unrelated1: unrelatedTask,
+        external1: externalTask,
+      });
+
+      const result = updateDownstreamSubgraphConnections(
+        componentSpec,
+        ["original1"],
+        "replacement1",
+      );
+
+      if (!isGraphImplementation(result.implementation)) {
+        throw new Error("Expected graph implementation");
+      }
+
+      const updatedExternalTask = result.implementation.graph.tasks.external1;
+
+      expect(updatedExternalTask.arguments?.input1).toEqual({
+        taskOutput: {
+          taskId: "replacement1",
+          outputName: "result",
+          type: "string",
+        },
+      });
+
+      // Unrelated connection should remain unchanged
+      expect(updatedExternalTask.arguments?.input2).toEqual({
+        taskOutput: {
+          taskId: "unrelated1",
+          outputName: "other",
+          type: "string",
+        },
+      });
+    });
+  });
+
+  describe("Scenario 2: TaskOutput connected to GraphOutput", () => {
+    it("should redirect graph output values to replacement task", () => {
+      const originalTask1 = createMockTask("OriginalTask1", {}, [
+        { name: "final_result", type: "string" },
+      ]);
+      const originalTask2 = createMockTask("OriginalTask2", {}, [
+        { name: "summary", type: "string" },
+      ]);
+      const replacementTask = createMockTask("ReplacementTask", {}, [
+        { name: "final result", type: "string" },
+        { name: "summary", type: "string" },
+      ]);
+
+      const componentSpec = createMockComponentSpec(
+        {
+          original1: originalTask1,
+          original2: originalTask2,
+          replacement1: replacementTask,
+        },
+        {
+          output1: {
+            taskOutput: {
+              taskId: "original1",
+              outputName: "final_result",
+              type: "string",
+            },
+          },
+          output2: {
+            taskOutput: {
+              taskId: "original2",
+              outputName: "summary",
+              type: "string",
+            },
+          },
+        },
+      );
+
+      const result = updateDownstreamSubgraphConnections(
+        componentSpec,
+        ["original1", "original2"],
+        "replacement1",
+      );
+
+      if (!isGraphImplementation(result.implementation)) {
+        throw new Error("Expected graph implementation");
+      }
+
+      expect(result.implementation.graph.outputValues?.output1).toEqual({
+        taskOutput: {
+          taskId: "replacement1",
+          outputName: "final_result",
+          type: "string",
+        },
+      });
+
+      expect(result.implementation.graph.outputValues?.output2).toEqual({
+        taskOutput: {
+          taskId: "replacement1",
+          outputName: "summary",
+          type: "string",
+        },
+      });
+    });
+
+    it("should remove graph output values when replacement task lacks matching output", () => {
+      const originalTask = createMockTask("OriginalTask", {}, [
+        { name: "result", type: "string" },
+      ]);
+      const replacementTask = createMockTask("ReplacementTask", {}, [
+        { name: "different_output", type: "string" },
+      ]);
+
+      const componentSpec = createMockComponentSpec(
+        {
+          original1: originalTask,
+          replacement1: replacementTask,
+        },
+        {
+          output1: {
+            taskOutput: {
+              taskId: "original1",
+              outputName: "result",
+              type: "string",
+            },
+          },
+          keepOutput: {
+            taskOutput: {
+              taskId: "other_task",
+              outputName: "other_result",
+              type: "string",
+            },
+          },
+        },
+      );
+
+      const result = updateDownstreamSubgraphConnections(
+        componentSpec,
+        ["original1"],
+        "replacement1",
+      );
+
+      if (!isGraphImplementation(result.implementation)) {
+        throw new Error("Expected graph implementation");
+      }
+
+      expect(result.implementation.graph.outputValues?.output1).toBeUndefined();
+      expect(result.implementation.graph.outputValues?.keepOutput).toEqual({
+        taskOutput: {
+          taskId: "other_task",
+          outputName: "other_result",
+          type: "string",
+        },
+      });
+    });
+  });
+
+  describe("Edge cases", () => {
+    it("should handle empty originalTaskIds array", () => {
+      const componentSpec = createMockComponentSpec({
+        task1: createMockTask("Task1"),
+      });
+
+      const result = updateDownstreamSubgraphConnections(
+        componentSpec,
+        [],
+        "replacement1",
+      );
+
+      expect(result).toEqual(componentSpec);
+    });
+
+    it("should handle missing replacement task", () => {
+      const originalTask = createMockTask("OriginalTask", {}, [
+        { name: "result", type: "string" },
+      ]);
+      const externalTask = createMockTask("ExternalTask", {
+        input1: {
+          taskOutput: {
+            taskId: "original1",
+            outputName: "result",
+            type: "string",
+          },
+        },
+      });
+
+      const componentSpec = createMockComponentSpec({
+        original1: originalTask,
+        external1: externalTask,
+      });
+
+      const result = updateDownstreamSubgraphConnections(
+        componentSpec,
+        ["original1"],
+        "nonexistent_replacement",
+      );
+
+      if (!isGraphImplementation(result.implementation)) {
+        throw new Error("Expected graph implementation");
+      }
+
+      // Should remove the connection since replacement task doesn't exist
+      const updatedExternalTask = result.implementation.graph.tasks.external1;
+      expect(updatedExternalTask.arguments?.input1).toBeUndefined();
+    });
+
+    it("should handle non-graph implementations gracefully", () => {
+      const componentSpec: ComponentSpec = {
+        name: "Container Component",
+        implementation: {
+          container: {
+            image: "test-image",
+          },
+        },
+      };
+
+      const result = updateDownstreamSubgraphConnections(
+        componentSpec,
+        ["task1"],
+        "replacement1",
+      );
+
+      expect(result).toEqual(componentSpec);
+    });
+
+    it("should handle tasks without arguments", () => {
+      const originalTask = createMockTask("OriginalTask", {}, [
+        { name: "result", type: "string" },
+      ]);
+      const replacementTask = createMockTask("ReplacementTask", {}, [
+        { name: "result", type: "string" },
+      ]);
+      const taskWithoutArgs = createMockTask("TaskWithoutArgs");
+
+      const componentSpec = createMockComponentSpec({
+        original1: originalTask,
+        replacement1: replacementTask,
+        no_args: taskWithoutArgs,
+      });
+
+      const result = updateDownstreamSubgraphConnections(
+        componentSpec,
+        ["original1"],
+        "replacement1",
+      );
+
+      if (!isGraphImplementation(result.implementation)) {
+        throw new Error("Expected graph implementation");
+      }
+
+      // Should not throw and leave task unchanged
+      expect(result.implementation.graph.tasks.no_args).toEqual(
+        taskWithoutArgs,
+      );
+    });
+
+    it("should not modify the original componentSpec", () => {
+      const originalTask = createMockTask("OriginalTask", {}, [
+        { name: "result", type: "string" },
+      ]);
+      const replacementTask = createMockTask("ReplacementTask", {}, [
+        { name: "result", type: "string" },
+      ]);
+      const externalTask = createMockTask("ExternalTask", {
+        input1: {
+          taskOutput: {
+            taskId: "original1",
+            outputName: "result",
+            type: "string",
+          },
+        },
+      });
+
+      const componentSpec = createMockComponentSpec({
+        original1: originalTask,
+        replacement1: replacementTask,
+        external1: externalTask,
+      });
+
+      if (!isGraphImplementation(componentSpec.implementation)) {
+        throw new Error("Expected graph implementation");
+      }
+
+      const originalTaskInput =
+        componentSpec.implementation.graph.tasks.external1.arguments?.input1;
+
+      updateDownstreamSubgraphConnections(
+        componentSpec,
+        ["original1"],
+        "replacement1",
+      );
+
+      // Original should be unchanged
+      expect(
+        componentSpec.implementation.graph.tasks.external1.arguments?.input1,
+      ).toEqual(originalTaskInput);
+    });
+  });
+});

--- a/src/components/shared/ReactFlow/FlowCanvas/utils/updateDownstreamSubgraphConnections.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/utils/updateDownstreamSubgraphConnections.ts
@@ -1,0 +1,128 @@
+import type { OutputSpec, TaskOutputArgument } from "@/api/types.gen";
+import {
+  type ComponentSpec,
+  isGraphImplementation,
+  isTaskOutputArgument,
+} from "@/utils/componentSpec";
+import { deepClone } from "@/utils/deepClone";
+
+/**
+ * Updates downstream connections after replacing multiple tasks with a single replacement task.
+ *
+ * Handles two scenarios:
+ * 1. External task arguments that reference outputs from the original tasks
+ * 2. Graph-level output values that reference outputs from the original tasks
+ *
+ * For each connection:
+ * - If the replacement task has a matching output, the connection is redirected
+ * - If no matching output exists, the connection is removed
+ *
+ * @param componentSpec - The component specification containing the graph
+ * @param originalTaskIds - Array of task IDs that are being replaced
+ * @param replacementTaskId - The ID of the task that replaces the original tasks
+ * @returns Updated component specification with redirected connections
+ *
+ */
+
+export const updateDownstreamSubgraphConnections = (
+  componentSpec: ComponentSpec,
+  originalTaskIds: string[],
+  replacementTaskId: string,
+): ComponentSpec => {
+  if (originalTaskIds.length === 0) {
+    return componentSpec;
+  }
+
+  const updatedComponentSpec = deepClone(componentSpec);
+
+  if (!isGraphImplementation(updatedComponentSpec.implementation)) {
+    return updatedComponentSpec;
+  }
+
+  const updatedGraphSpec = updatedComponentSpec.implementation.graph;
+
+  const replacementTaskSpec = updatedGraphSpec.tasks[replacementTaskId];
+  const replacementOutputs =
+    replacementTaskSpec?.componentRef?.spec?.outputs || [];
+
+  const originalTaskIdSet = new Set(originalTaskIds);
+
+  // Scenario 1: TaskOutput connected to TaskInput
+  Object.values(updatedGraphSpec.tasks).forEach((task) => {
+    if (!task.arguments) return;
+
+    const updatedArguments = { ...task.arguments };
+
+    Object.entries(updatedArguments).forEach(([inputName, argument]) => {
+      if (!isTaskOutputArgument(argument)) return;
+
+      if (!originalTaskIdSet.has(argument.taskOutput.taskId)) return;
+
+      const reassignedArgument = reassignTaskOutput(
+        argument,
+        replacementTaskId,
+        replacementOutputs,
+      );
+
+      if (!reassignedArgument) {
+        delete updatedArguments[inputName];
+      } else {
+        updatedArguments[inputName] = reassignedArgument;
+      }
+    });
+
+    task.arguments = updatedArguments;
+  });
+
+  // Scenario 2: TaskOutput connected to GraphOutput
+  if (updatedGraphSpec.outputValues) {
+    Object.entries(updatedGraphSpec.outputValues).forEach(
+      ([outputName, outputValue]) => {
+        if (!updatedGraphSpec.outputValues) return;
+
+        if (!originalTaskIdSet.has(outputValue.taskOutput.taskId)) return;
+
+        const reassignedOutputValue = reassignTaskOutput(
+          outputValue,
+          replacementTaskId,
+          replacementOutputs,
+        );
+
+        if (!reassignedOutputValue) {
+          delete updatedGraphSpec.outputValues[outputName];
+        } else {
+          updatedGraphSpec.outputValues[outputName] = reassignedOutputValue;
+        }
+      },
+    );
+  }
+
+  updatedComponentSpec.implementation.graph = updatedGraphSpec;
+
+  return updatedComponentSpec;
+};
+
+function reassignTaskOutput(
+  argument: TaskOutputArgument,
+  replacementTaskId: string,
+  replacementOutputs: OutputSpec[],
+): TaskOutputArgument | undefined {
+  const outputName = argument.taskOutput.outputName;
+  const isReconfiguredOutput = replacementOutputs.some(
+    (output) => output.name === outputName.replace(/_/g, " "),
+  );
+
+  if (isReconfiguredOutput) {
+    // Update the taskOutput to point to the replacement taskId
+    return {
+      ...argument,
+      taskOutput: {
+        ...argument.taskOutput,
+        taskId: replacementTaskId,
+      },
+    };
+  } else {
+    // This output no longer exists in the replacement task (it should be removed)
+    return undefined;
+  }
+}

--- a/src/utils/nodes/createSubgraphFromNodes.ts
+++ b/src/utils/nodes/createSubgraphFromNodes.ts
@@ -107,7 +107,13 @@ export const createSubgraphFromNodes = async (
   });
 
   // Handle selected Input & Output Nodes
-  processSelectedInputNodes(inputNodes, bounds, subgraphInputs);
+  processSelectedInputNodes(
+    inputNodes,
+    bounds,
+    subgraphInputs,
+    subgraphArguments,
+    currentComponentSpec,
+  );
 
   processSelectedOutputNodes(
     outputNodes,
@@ -195,6 +201,8 @@ const processSelectedInputNodes = (
   inputNodes: Node[],
   bounds: Bounds,
   subgraphInputs: InputSpec[],
+  subgraphArguments: Record<string, ArgumentType>,
+  currentComponentSpec: ComponentSpec,
 ): void => {
   inputNodes.forEach((node) => {
     const inputName = node.data.label as string | undefined;
@@ -219,6 +227,15 @@ const processSelectedInputNodes = (
         "editor.position": JSON.stringify(normalizedPosition),
       },
     });
+
+    // Migrate the Input Node value to the subgraph arguments
+    const originalInputSpec = currentComponentSpec.inputs?.find(
+      (input) => input.name === inputName,
+    );
+
+    if (originalInputSpec?.value) {
+      subgraphArguments[inputName] = originalInputSpec.value;
+    }
   });
 };
 


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

A continuation of the Nodes -> Subgraph work.

This PR adds auto-reconnection functionality to newly created subgraph nodes.

Any connections in and out of the newly created subgraph node will be retained and redirected to the subgraph's task inputs and outputs. The result is that the node will seamless appear, fully connected, in the current graph!

To make this work `addTask` needed to be updated:

- Fix a bug where arguments were no properly copied over when adding a task
- `addTask` now returns the generated taskId.

Values of input nodes captured within the selection will also be moved over to the new subgraph's task arguments.

## Related Issue and Pull requests

Follows #1231

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] New feature
- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

[subgraph-autoconnection.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/9fd54576-c357-4197-a72a-4eb0d9599a37.mov" />](https://app.graphite.com/user-attachments/video/9fd54576-c357-4197-a72a-4eb0d9599a37.mov)

## Test Instructions

1. create a pipeline with tasks, inputs and outputs
2. select some of the nodes and create a subgraph out of them
3. the new subgraph node should automatically maintain connections to the res of the graph
4. input node values within the selection should migrate over to the subgraph node's task arguments
5. everything else should work as expected (including run submission)

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

Note: input nodes that are moved into the subgraph will have their value extracted and copied into the subgraph node's task arguments (i.e. the task input will be autopopulated). This means that the input node inside the subgraph has no assigned value. 

Currently all input nodes must have a value so this is technically incorrect. However, this still works because Input nodes are intended to be optional - but we have temporarily disabled the UI functionality for this. Once the nodes -> subgraph work is complete we will revisit Input Node optionality and can update the methods here accordingly. 

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->