### PR TITLE
Changing waiting from penting to waiting for upstream

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/StatusIndicator.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/StatusIndicator.tsx
@@ -68,7 +68,6 @@ const getStatusMetadata = (status: ContainerExecutionStatus | RunStatus) => {
         text: "Running",
         icon: <Loader2Icon className="w-2 h-2 animate-spin" />,
       };
-    case "WAITING":
     case "PENDING":
       return {
         style: "bg-yellow-500",
@@ -94,6 +93,7 @@ const getStatusMetadata = (status: ContainerExecutionStatus | RunStatus) => {
         text: "Queued",
         icon: <ClockIcon className="w-2 h-2 animate-spin duration-2000" />,
       };
+    case "WAITING":
     case "UNINITIALIZED":
     case "WAITING_FOR_UPSTREAM":
       return {


### PR DESCRIPTION
When the state of a node is "waiting" we will show the status of `waiting for upstream` instead of pending.
<img width="1096" height="676" alt="Screenshot 2025-11-07 at 12 36 08 PM" src="https://github.com/user-attachments/assets/1c3c1ad5-5201-4896-9e59-70a5bee8c199" />
<img width="1083" height="669" alt="Screenshot 2025-11-07 at 12 36 17 PM" src="https://github.com/user-attachments/assets/99ca5017-95b3-455c-8181-586fb3008b03" />
