### PR TITLE
feat: huggingface authentication provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "start": "vite --port 3000",
     "build": "vite build && tsc",
     "build:ghpages": "VITE_BASE_URL=/tangle-ui/ VITE_GITHUB_PAGES=true vite build --config vite.config.ghpages.js && tsc",
+    "build:hf": "VITE_REQUIRE_AUTHORIZATION=true VITE_HUGGING_FACE_AUTHORIZATION=true VITE_BASE_URL=/ VITE_GITHUB_PAGES=true vite build && tsc",
     "serve": "vite preview",
     "serve:ghpages": "vite preview --config vite.config.ghpages.js",
     "test": "vitest run",

--- a/src/components/shared/Authentication/AuthorizedUserProfile.tsx
+++ b/src/components/shared/Authentication/AuthorizedUserProfile.tsx
@@ -1,12 +1,42 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { LogOutIcon } from "lucide-react";
-import { useCallback, useSyncExternalStore } from "react";
+import { useEffectEvent, useSyncExternalStore } from "react";
 
 import { Icon } from "@/components/ui/icon";
+import { Spinner } from "@/components/ui/spinner";
+import { useBackend } from "@/providers/BackendProvider";
 
 import TooltipButton from "../Buttons/TooltipButton";
+import { isHuggingFaceAuthEnabled } from "../HuggingFaceAuth/constants";
 import { useAuthLocalStorage } from "./useAuthLocalStorage";
 
+function useLogout({
+  onSuccess,
+  onError,
+}: {
+  onSuccess?: () => void;
+  onError?: (error: Error) => void;
+}) {
+  const { backendUrl } = useBackend();
+  return useMutation({
+    mutationFn: async () => {
+      if (isHuggingFaceAuthEnabled()) {
+        await fetch(`${backendUrl}/api/oauth/huggingface/logout`, {
+          method: "GET",
+        });
+      }
+    },
+    onSuccess: () => {
+      onSuccess?.();
+    },
+    onError: (error) => {
+      onError?.(error);
+    },
+  });
+}
+
 export function AuthorizedUserProfile() {
+  const queryClient = useQueryClient();
   const localTokenStorage = useAuthLocalStorage();
 
   /**
@@ -22,9 +52,13 @@ export function AuthorizedUserProfile() {
   );
   const profile = localTokenStorage.getJWT();
 
-  const handleLogout = useCallback(() => {
+  const onLogoutSuccess = useEffectEvent(() => {
+    queryClient.invalidateQueries({ queryKey: ["user"] });
     localTokenStorage.clear();
-  }, [localTokenStorage]);
+  });
+  const { mutate: logout, isPending } = useLogout({
+    onSuccess: onLogoutSuccess,
+  });
 
   if (!token || !profile) {
     return null;
@@ -56,10 +90,11 @@ export function AuthorizedUserProfile() {
       <TooltipButton
         variant="ghost"
         size="icon"
-        onClick={handleLogout}
+        onClick={() => logout()}
         tooltip="Logout"
+        disabled={isPending}
       >
-        <LogOutIcon className="w-2 h-2" />
+        {isPending ? <Spinner /> : <LogOutIcon className="w-2 h-2" />}
       </TooltipButton>
     </div>
   );

--- a/src/components/shared/Authentication/tests/useAwaitAuthorization.test.tsx
+++ b/src/components/shared/Authentication/tests/useAwaitAuthorization.test.tsx
@@ -1,4 +1,6 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, renderHook } from "@testing-library/react";
+import type { PropsWithChildren } from "react";
 import {
   afterEach,
   beforeEach,
@@ -44,10 +46,24 @@ describe("useAwaitAuthorization()", () => {
     isPopupOpen: boolean;
   };
 
+  const wrapper = ({ children }: PropsWithChildren) => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+      },
+    });
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+
   beforeEach(async () => {
     vi.clearAllMocks();
 
     vi.stubEnv("VITE_REQUIRE_AUTHORIZATION", "true");
+
+    vi.stubEnv("VITE_GITHUB_CLIENT_ID", "test-client-id");
+    vi.stubEnv("VITE_HUGGING_FACE_AUTHORIZATION", undefined);
 
     // Mock notification
     mockNotify = vi.fn();
@@ -95,7 +111,7 @@ describe("useAwaitAuthorization()", () => {
       mockAuthStorage.getToken.mockReturnValue(undefined);
       mockAuthStorage.subscribe.mockReturnValue(() => {});
 
-      const { result } = renderHook(() => useAwaitAuthorization());
+      const { result } = renderHook(() => useAwaitAuthorization(), { wrapper });
 
       expect(result.current.isAuthorized).toBe(false);
       expect(result.current.isLoading).toBe(false);
@@ -106,7 +122,7 @@ describe("useAwaitAuthorization()", () => {
       mockAuthStorage.getToken.mockReturnValue("bearer token123");
       mockAuthStorage.subscribe.mockReturnValue(() => {});
 
-      const { result } = renderHook(() => useAwaitAuthorization());
+      const { result } = renderHook(() => useAwaitAuthorization(), { wrapper });
 
       expect(result.current.isAuthorized).toBe(true);
     });
@@ -117,7 +133,7 @@ describe("useAwaitAuthorization()", () => {
       mockAuthStorage.getToken.mockReturnValue(undefined);
       mockAuthStorage.subscribe.mockReturnValue(() => {});
 
-      const { result } = renderHook(() => useAwaitAuthorization());
+      const { result } = renderHook(() => useAwaitAuthorization(), { wrapper });
 
       expect(result.current.isAuthorized).toBe(true);
     });
@@ -128,7 +144,7 @@ describe("useAwaitAuthorization()", () => {
       mockAuthStorage.getToken.mockReturnValue(undefined);
       mockAuthStorage.subscribe.mockReturnValue(() => {});
 
-      const { result } = renderHook(() => useAwaitAuthorization());
+      const { result } = renderHook(() => useAwaitAuthorization(), { wrapper });
 
       const promise = result.current.awaitAuthorization();
 
@@ -140,7 +156,7 @@ describe("useAwaitAuthorization()", () => {
       mockAuthStorage.getToken.mockReturnValue(undefined);
       mockAuthStorage.subscribe.mockReturnValue(() => {});
 
-      const { result } = renderHook(() => useAwaitAuthorization());
+      const { result } = renderHook(() => useAwaitAuthorization(), { wrapper });
 
       const promise1 = result.current.awaitAuthorization();
       const promise2 = result.current.awaitAuthorization();
@@ -211,7 +227,7 @@ describe("useAwaitAuthorization()", () => {
         return mockPopupHandlers;
       });
 
-      const { result } = renderHook(() => useAwaitAuthorization());
+      const { result } = renderHook(() => useAwaitAuthorization(), { wrapper });
 
       const promise = result.current.awaitAuthorization();
 
@@ -252,7 +268,7 @@ describe("useAwaitAuthorization()", () => {
         return mockPopupHandlers;
       });
 
-      const { result } = renderHook(() => useAwaitAuthorization());
+      const { result } = renderHook(() => useAwaitAuthorization(), { wrapper });
 
       const promise = result.current.awaitAuthorization();
 
@@ -275,7 +291,7 @@ describe("useAwaitAuthorization()", () => {
         return mockPopupHandlers;
       });
 
-      const { result } = renderHook(() => useAwaitAuthorization());
+      const { result } = renderHook(() => useAwaitAuthorization(), { wrapper });
 
       const promise = result.current.awaitAuthorization();
 
@@ -303,7 +319,7 @@ describe("useAwaitAuthorization()", () => {
 
       mockPopupHandlers.isLoading = true;
 
-      const { result } = renderHook(() => useAwaitAuthorization());
+      const { result } = renderHook(() => useAwaitAuthorization(), { wrapper });
 
       expect(result.current.isLoading).toBe(true);
     });
@@ -314,7 +330,7 @@ describe("useAwaitAuthorization()", () => {
 
       mockPopupHandlers.isPopupOpen = true;
 
-      const { result } = renderHook(() => useAwaitAuthorization());
+      const { result } = renderHook(() => useAwaitAuthorization(), { wrapper });
 
       expect(result.current.isPopupOpen).toBe(true);
     });
@@ -323,7 +339,7 @@ describe("useAwaitAuthorization()", () => {
       mockAuthStorage.getToken.mockReturnValue(undefined);
       mockAuthStorage.subscribe.mockReturnValue(() => {});
 
-      const { result } = renderHook(() => useAwaitAuthorization());
+      const { result } = renderHook(() => useAwaitAuthorization(), { wrapper });
 
       result.current.closePopup();
 
@@ -334,7 +350,7 @@ describe("useAwaitAuthorization()", () => {
       mockAuthStorage.getToken.mockReturnValue(undefined);
       mockAuthStorage.subscribe.mockReturnValue(() => {});
 
-      const { result } = renderHook(() => useAwaitAuthorization());
+      const { result } = renderHook(() => useAwaitAuthorization(), { wrapper });
 
       result.current.bringPopupToFront();
 
@@ -347,7 +363,7 @@ describe("useAwaitAuthorization()", () => {
       mockAuthStorage.getToken.mockReturnValue(undefined);
       mockAuthStorage.subscribe.mockReturnValue(() => {});
 
-      renderHook(() => useAwaitAuthorization());
+      renderHook(() => useAwaitAuthorization(), { wrapper });
 
       expect(mockAuthStorage.subscribe).toHaveBeenCalled();
     });
@@ -362,7 +378,7 @@ describe("useAwaitAuthorization()", () => {
       // Initially no token
       mockAuthStorage.getToken.mockReturnValue(undefined);
 
-      const { result } = renderHook(() => useAwaitAuthorization());
+      const { result } = renderHook(() => useAwaitAuthorization(), { wrapper });
 
       expect(result.current.isAuthorized).toBe(false);
 
@@ -383,7 +399,9 @@ describe("useAwaitAuthorization()", () => {
       mockAuthStorage.getToken.mockReturnValue(undefined);
       mockAuthStorage.subscribe.mockReturnValue(() => {});
 
-      const { result, rerender } = renderHook(() => useAwaitAuthorization());
+      const { result, rerender } = renderHook(() => useAwaitAuthorization(), {
+        wrapper,
+      });
 
       const firstResult = result.current;
 
@@ -404,7 +422,7 @@ describe("useAwaitAuthorization()", () => {
       // Initially no token
       mockAuthStorage.getToken.mockReturnValue(undefined);
 
-      const { result } = renderHook(() => useAwaitAuthorization());
+      const { result } = renderHook(() => useAwaitAuthorization(), { wrapper });
 
       const firstResult = result.current;
       expect(firstResult.isAuthorized).toBe(false);

--- a/src/components/shared/Authentication/types.ts
+++ b/src/components/shared/Authentication/types.ts
@@ -1,4 +1,4 @@
-type AuthProvider = "github" | "minerva";
+type AuthProvider = "github" | "minerva" | "huggingface";
 
 export interface OasisAuthResponse {
   token: string;

--- a/src/components/shared/GitHubAuth/GitHubAuthButton.tsx
+++ b/src/components/shared/GitHubAuth/GitHubAuthButton.tsx
@@ -6,6 +6,7 @@ import { Spinner } from "@/components/ui/spinner";
 
 import TooltipButton from "../Buttons/TooltipButton";
 import { GitHubAuthFlowBackdrop } from "./GitHubAuthFlowBackdrop";
+import { isGitHubAuthEnabled } from "./helpers";
 
 export function GitHubAuthButton() {
   const {
@@ -21,7 +22,7 @@ export function GitHubAuthButton() {
     await awaitAuthorization();
   }, [awaitAuthorization]);
 
-  if (isAuthorized) {
+  if (!isGitHubAuthEnabled() || isAuthorized) {
     return null;
   }
 

--- a/src/components/shared/GitHubAuth/helpers.ts
+++ b/src/components/shared/GitHubAuth/helpers.ts
@@ -1,0 +1,6 @@
+export function isGitHubAuthEnabled() {
+  return (
+    !!import.meta.env.VITE_GITHUB_CLIENT_ID &&
+    import.meta.env.VITE_GITHUB_CLIENT_ID !== ""
+  );
+}

--- a/src/components/shared/HuggingFaceAuth/AuthorizationResultScreen.tsx
+++ b/src/components/shared/HuggingFaceAuth/AuthorizationResultScreen.tsx
@@ -1,0 +1,27 @@
+import { useEffect } from "react";
+
+import { BlockStack } from "@/components/ui/layout";
+import { Spinner } from "@/components/ui/spinner";
+import { Text } from "@/components/ui/typography";
+
+export function AuthorizationResultScreen() {
+  useEffect(() => {
+    setTimeout(() => {
+      window.close();
+    }, 1000);
+  }, []);
+
+  return (
+    <BlockStack
+      className="min-h-screen bg-white"
+      align="center"
+      inlineAlign="center"
+      gap="4"
+    >
+      <Text size="lg" weight="bold">
+        Authorization successful!
+      </Text>
+      <Spinner size={40} />
+    </BlockStack>
+  );
+}

--- a/src/components/shared/HuggingFaceAuth/HuggingFaceAuthButton.tsx
+++ b/src/components/shared/HuggingFaceAuth/HuggingFaceAuthButton.tsx
@@ -1,0 +1,81 @@
+import { useCallback, useEffect } from "react";
+
+import type { JWTPayload } from "@/components/shared/Authentication/types";
+import { useAuthLocalStorage } from "@/components/shared/Authentication/useAuthLocalStorage";
+import { useAwaitAuthorization } from "@/components/shared/Authentication/useAwaitAuthorization";
+import TooltipButton from "@/components/shared/Buttons/TooltipButton";
+import { HOURS } from "@/components/shared/ComponentEditor/constants";
+import { withSuspenseWrapper } from "@/components/shared/SuspenseWrapper";
+import { Spinner } from "@/components/ui/spinner";
+import { useUserDetails } from "@/hooks/useUserDetails";
+
+import {
+  HUGGING_FACE_DEFAULT_JWT,
+  isHuggingFaceAuthEnabled,
+} from "./constants";
+
+const NullSkeleton = () => {
+  return null;
+};
+
+function useSyncAuthStorageWithUserDetails() {
+  const authStorage = useAuthLocalStorage();
+  const { data: user } = useUserDetails();
+
+  useEffect(() => {
+    if (user && !!user.id && user.permissions.includes("write")) {
+      authStorage.setJWT({
+        ...HUGGING_FACE_DEFAULT_JWT,
+        user_id: user.id,
+        login: user.id,
+        avatar_url: "",
+        exp: Math.floor(Date.now() / 1000) + 24 * HOURS,
+      } satisfies JWTPayload);
+    } else {
+      authStorage.clear();
+    }
+  }, [user]);
+}
+
+const HuggingFaceAuthButtonComponent = withSuspenseWrapper(() => {
+  const { awaitAuthorization, isLoading, isAuthorized } =
+    useAwaitAuthorization();
+
+  const signIn = useCallback(async () => {
+    await awaitAuthorization();
+  }, [awaitAuthorization]);
+
+  useSyncAuthStorageWithUserDetails();
+
+  if (isAuthorized) {
+    return null;
+  }
+
+  return (
+    <>
+      <TooltipButton
+        onClick={signIn}
+        disabled={isLoading}
+        className="flex items-center gap-2 w-full"
+        tooltip="Sign in with Hugging Face to submit runs"
+      >
+        {isLoading ? (
+          <>
+            <Spinner />
+            Authenticating...
+          </>
+        ) : (
+          <>Sign in with Hugging Face</>
+        )}
+      </TooltipButton>
+    </>
+  );
+}, NullSkeleton);
+
+export const HuggingFaceAuthButton = () => {
+  // Check at runtime to support testing
+  if (!isHuggingFaceAuthEnabled()) {
+    return <NullSkeleton />;
+  }
+  return <HuggingFaceAuthButtonComponent />;
+};

--- a/src/components/shared/HuggingFaceAuth/constants.ts
+++ b/src/components/shared/HuggingFaceAuth/constants.ts
@@ -1,0 +1,13 @@
+import type { JWTPayload } from "../Authentication/types";
+
+// resolved at runtime to support testing
+export const isHuggingFaceAuthEnabled = () =>
+  import.meta.env.VITE_HUGGING_FACE_AUTHORIZATION === "true";
+
+export const HUGGING_FACE_DEFAULT_JWT: Pick<
+  JWTPayload,
+  "original_token" | "auth_provider"
+> = {
+  original_token: "authorized-by-huggingface-nonce",
+  auth_provider: "huggingface",
+};

--- a/src/components/shared/HuggingFaceAuth/useHuggingFaceAuthPopup.ts
+++ b/src/components/shared/HuggingFaceAuth/useHuggingFaceAuthPopup.ts
@@ -1,0 +1,201 @@
+import { useQueryClient } from "@tanstack/react-query";
+import {
+  useCallback,
+  useEffect,
+  useEffectEvent,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+import type { GetUserResponse } from "@/api/types.gen";
+import type {
+  JWTPayload,
+  OasisAuthResponse,
+} from "@/components/shared/Authentication/types";
+import { HOURS } from "@/components/shared/ComponentEditor/constants";
+import { API_URL } from "@/utils/constants";
+import { getUserDetails } from "@/utils/user";
+
+import { HUGGING_FACE_DEFAULT_JWT } from "./constants";
+
+const POPUP_WIDTH = 600;
+const POPUP_HEIGHT = 700;
+
+function buildAuthUrl() {
+  const authUrl = new URL(
+    "/api/oauth/huggingface/login",
+    !!API_URL && API_URL !== "" ? API_URL : window.location.origin,
+  );
+
+  // todo: build target url respecting router settings
+  //   for HF realm it is ok to hardcode the target url style
+  authUrl.searchParams.set("_target_url", "/#/authorize/huggingface");
+
+  return authUrl.toString();
+}
+
+/**
+ * todo: make generic for all auth providers
+ */
+interface HuggingFaceAuthFlowPopupOptions {
+  onSuccess: (response: OasisAuthResponse) => void;
+  onError: (error: string) => void;
+  onClose?: () => void;
+}
+
+export function useHuggingFaceAuthPopup({
+  onSuccess,
+  onError,
+  onClose,
+}: HuggingFaceAuthFlowPopupOptions) {
+  const queryClient = useQueryClient();
+
+  const [isPopupOpen, setIsPopupOpen] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const pollAuthorizationInfoIntervalRef = useRef<ReturnType<
+    typeof setInterval
+  > | null>(null);
+
+  const cleanup = useEffectEvent(() => {
+    if (pollAuthorizationInfoIntervalRef.current) {
+      clearInterval(pollAuthorizationInfoIntervalRef.current);
+      pollAuthorizationInfoIntervalRef.current = null;
+    }
+  });
+
+  const closePopup = useCallback(() => {
+    setIsLoading(false);
+
+    cleanup();
+
+    setIsPopupOpen(false);
+    onClose?.();
+  }, [onClose]);
+
+  const onErrorStateHandler = useEffectEvent((error: string) => {
+    onError(error);
+    closePopup();
+  });
+
+  const pollAuthorizationInfo = useEffectEvent(async () => {
+    return queryClient
+      .fetchQuery({ queryKey: ["user"], queryFn: getUserDetails, staleTime: 0 })
+      .then((user) => {
+        if (user && !!user.id && user.permissions.includes("write")) {
+          onSuccess({
+            token: createJWTToken(user),
+            token_type: "JWT",
+          });
+
+          closePopup();
+
+          return true;
+        }
+        return false;
+      })
+      .catch((error) => {
+        onErrorStateHandler(error.message);
+        return false;
+      })
+      .finally(() => {
+        queryClient.invalidateQueries({ queryKey: ["user"] });
+      });
+  });
+
+  /**
+   * In Hugging Face auth flow, the App is embedded in an iframe, rendering it as 3rd party origin.
+   * Because of the 3P partioning we CAN NOT:
+   * - get popup window reference (so no focusing, no closing, no communication);
+   * - use postMessage() communication between same-origin;
+   * - use localStorage communication between same-origin;
+   *
+   * Therefore, we need to poll the authorization info from the API instead of using "message" based communication.
+   */
+  const openPopup = useCallback(() => {
+    // todo: prevent opening multiple popups
+    setIsLoading(true);
+
+    const { left, top } = centerPopupOnDocument();
+
+    window.open(
+      buildAuthUrl(),
+      "huggingface-auth",
+      `width=${POPUP_WIDTH},height=${POPUP_HEIGHT},left=${left},top=${top},scrollbars=yes,resizable=yes`,
+    );
+
+    pollAuthorizationInfoIntervalRef.current = setInterval(async () => {
+      await pollAuthorizationInfo();
+    }, 1500);
+
+    // todo: timeout if popup is not closed after 10 seconds
+
+    setIsPopupOpen(true);
+  }, [pollAuthorizationInfo]);
+
+  useEffect(() => {
+    return () => cleanup();
+  }, []);
+
+  const bringPopupToFront = useCallback(() => {
+    // no-op
+  }, []);
+
+  return useMemo(
+    () => ({
+      isPopupOpen,
+      isLoading,
+      openPopup,
+      closePopup,
+      bringPopupToFront,
+    }),
+    [isPopupOpen, isLoading, openPopup, closePopup, bringPopupToFront],
+  );
+}
+
+function centerPopupOnDocument() {
+  const screenWidth = window.screen.width;
+  const screenHeight = window.screen.height;
+  const left = (screenWidth - POPUP_WIDTH) / 2;
+  const top = (screenHeight - POPUP_HEIGHT) / 2;
+
+  return {
+    left: Math.max(0, left),
+    top: Math.max(0, top),
+  };
+}
+
+function base64UrlEncode(obj: object): string {
+  const json = JSON.stringify(obj);
+  const base64 = btoa(unescape(encodeURIComponent(json)));
+  return base64.replace(/=/g, "").replace(/\+/g, "-").replace(/\//g, "_");
+}
+
+/**
+ * To keep compatibility with other auth providers, we need to create a JWT token for Hugging Face manually,
+ *  since API does not support JWT tokens for Hugging Face.
+ * @param user
+ * @returns
+ */
+function createJWTToken(user: GetUserResponse) {
+  const payload: JWTPayload = {
+    ...HUGGING_FACE_DEFAULT_JWT,
+    user_id: user.id,
+    login: user.id,
+    avatar_url: "",
+
+    exp: Math.floor(Date.now() / 1000) + 24 * HOURS,
+  };
+
+  // Encode payload as an unsigned JWT token (header.payload).
+  const header = {
+    alg: "none",
+    typ: "JWT",
+  };
+
+  const encodedHeader = base64UrlEncode(header);
+  const encodedPayload = base64UrlEncode(payload);
+
+  return `${encodedHeader}.${encodedPayload}.`;
+}

--- a/src/components/shared/ReactFlow/FlowSidebar/FlowSidebar.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/FlowSidebar.tsx
@@ -4,6 +4,7 @@ import { AuthorizedUserProfile } from "@/components/shared/Authentication/Author
 import { isAuthorizationRequired } from "@/components/shared/Authentication/helpers";
 import { useAwaitAuthorization } from "@/components/shared/Authentication/useAwaitAuthorization";
 import { GitHubAuthButton } from "@/components/shared/GitHubAuth/GitHubAuthButton";
+import { HuggingFaceAuthButton } from "@/components/shared/HuggingFaceAuth/HuggingFaceAuthButton";
 import {
   Sidebar,
   SidebarContent,
@@ -29,6 +30,7 @@ const FlowSidebar = () => {
   const authorizationSectionMarkup = requiresAuthorization ? (
     <div className="p-4 max-w-md">
       {!isAuthorized && <GitHubAuthButton />}
+      {!isAuthorized && <HuggingFaceAuthButton />}
       {isAuthorized && <AuthorizedUserProfile />}
     </div>
   ) : null;

--- a/src/components/shared/Submitters/Oasis/OasisSubmitter.tsx
+++ b/src/components/shared/Submitters/Oasis/OasisSubmitter.tsx
@@ -2,6 +2,7 @@ import { useNavigate } from "@tanstack/react-router";
 import { AlertCircle, CheckCircle, Loader2, SendHorizonal } from "lucide-react";
 import { useCallback, useState } from "react";
 
+import { useAwaitAuthorization } from "@/components/shared/Authentication/useAwaitAuthorization";
 import { useBetaFlagValue } from "@/components/shared/Settings/useBetaFlags";
 import { Button } from "@/components/ui/button";
 import { SidebarMenuButton } from "@/components/ui/sidebar";
@@ -24,6 +25,7 @@ const OasisSubmitter = ({
   componentSpec,
   onSubmitComplete,
 }: OasisSubmitterProps) => {
+  const { isAuthorized } = useAwaitAuthorization();
   const { configured, available } = useBackend();
   const { submit, isSubmitting } = usePipelineRuns();
   const isAutoRedirect = useBetaFlagValue("redirect-on-new-pipeline-run");
@@ -127,12 +129,16 @@ const OasisSubmitter = ({
     if (cooldownTime > 0) {
       return `Run submitted (${cooldownTime}s)`;
     }
+    if (!isAuthorized) {
+      return "Sign in to Submit runs";
+    }
     return "Submit Run";
   };
 
   const isButtonDisabled =
     isSubmitting ||
     !componentSpec ||
+    !isAuthorized ||
     cooldownTime > 0 ||
     ("graph" in componentSpec.implementation &&
       Object.keys(componentSpec.implementation.graph.tasks).length === 0);

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -6,7 +6,8 @@ import {
   Outlet,
 } from "@tanstack/react-router";
 
-import { AuthorizationResultScreen } from "@/components/shared/GitHubAuth/AuthorizationResultScreen";
+import { AuthorizationResultScreen as GitHubAuthorizationResultScreen } from "@/components/shared/GitHubAuth/AuthorizationResultScreen";
+import { AuthorizationResultScreen as HuggingFaceAuthorizationResultScreen } from "@/components/shared/HuggingFaceAuth/AuthorizationResultScreen";
 import { BASE_URL, IS_GITHUB_PAGES } from "@/utils/constants";
 
 import RootLayout from "../components/layout/RootLayout";
@@ -34,6 +35,7 @@ export const APP_ROUTES = {
   RUN_DETAIL_WITH_SUBGRAPH: `${RUNS_BASE_PATH}/$id/$subgraphExecutionId`,
   RUNS: RUNS_BASE_PATH,
   GITHUB_AUTH_CALLBACK: "/authorize/github",
+  HUGGINGFACE_AUTH_CALLBACK: "/authorize/huggingface",
 };
 
 const rootRoute = createRootRoute({
@@ -73,7 +75,13 @@ const editorRoute = createRoute({
 const githubAuthCallbackRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: APP_ROUTES.GITHUB_AUTH_CALLBACK,
-  component: AuthorizationResultScreen,
+  component: GitHubAuthorizationResultScreen,
+});
+
+const huggingFaceAuthCallbackRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: APP_ROUTES.HUGGINGFACE_AUTH_CALLBACK,
+  component: HuggingFaceAuthorizationResultScreen,
 });
 
 const runDetailRoute = createRoute({
@@ -98,6 +106,7 @@ const appRouteTree = mainLayout.addChildren([
 
 const rootRouteTree = rootRoute.addChildren([
   githubAuthCallbackRoute,
+  huggingFaceAuthCallbackRoute,
   appRouteTree,
 ]);
 


### PR DESCRIPTION
## Description

Added Hugging Face authentication support as an alternative to GitHub authentication. This allows users to sign in with their Hugging Face accounts to submit pipeline runs.

## Type of Change

- [x] New feature
- [x] Improvement

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

[Screen Recording 2025-11-08 at 5.28.33 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/fad822a8-83ab-4485-a06f-77e0d2e6c68e.mov" />](https://app.graphite.com/user-attachments/video/fad822a8-83ab-4485-a06f-77e0d2e6c68e.mov)

Testing this feature locally is pretty tough due to backend configuration. You can use HF environment to test - https://tangleml-tangle.hf.space/#/

HF Space: https://huggingface.co/spaces/TangleML/tangle_test4 (not sure if everyone has access)

## Additional Comments

This implementation handles the unique challenges of Hugging Face authentication in an iframe environment by using a polling mechanism instead of direct communication between windows. The auth provider is determined at build time, allowing for flexible deployment configurations.