### PR TITLE
chore: fixes for github pages

### DIFF
--- a/src/components/shared/QuickStart/importPipelineFromUrl.ts
+++ b/src/components/shared/QuickStart/importPipelineFromUrl.ts
@@ -35,5 +35,9 @@ export async function importPipelineFromUrl(
 
 function isUrlAllowed(url: string) {
   // Allow if it's a github URL or a relative URL (starts with '/'), and ends with .yaml
-  return (isGithubUrl(url) || url.startsWith("/")) && url.endsWith(".yaml");
+  return (isGithubUrl(url) || isRelativeUrl(url)) && url.endsWith(".yaml");
+}
+
+function isRelativeUrl(url: string) {
+  return url.indexOf("://") === -1 && !url.startsWith("//");
 }

--- a/src/components/shared/QuickStart/samplePipelines.ts
+++ b/src/components/shared/QuickStart/samplePipelines.ts
@@ -11,33 +11,33 @@ export const samplePipelines: SamplePipeline[] = [
     name: "XGBoost Sample Pipeline",
     description:
       "Train and evaluate an XGBoost model with feature preprocessing and hyperparameter tuning. Demonstrates a complete ML workflow from data loading to model evaluation.",
-    url: "/example-pipelines/XGBoost pipeline.pipeline.component.yaml",
-    previewImage: "/example-pipelines/XGBoost pipeline.pipeline.component.png",
+    url: "example-pipelines/XGBoost pipeline.pipeline.component.yaml",
+    previewImage: "example-pipelines/XGBoost pipeline.pipeline.component.png",
     tags: ["XGBoost", "Classification", "Tabular Data"],
   },
   {
     name: "PyTorch Network",
     description:
       "Build and train a fully-connected neural network using PyTorch. Includes data loading, model architecture definition, training loop, and evaluation metrics.",
-    url: "/example-pipelines/Pytorch pipeline.pipeline.component.yaml",
-    previewImage: "/example-pipelines/Pytorch pipeline.pipeline.component.png",
+    url: "example-pipelines/Pytorch pipeline.pipeline.component.yaml",
+    previewImage: "example-pipelines/Pytorch pipeline.pipeline.component.png",
     tags: ["PyTorch", "Deep Learning", "Neural Network"],
   },
   {
     name: "Vertex AI AutoML Tables",
     description:
       "Leverage Google Cloud's Vertex AI AutoML to automatically build and deploy tabular models. No coding required for model training.",
-    url: "/example-pipelines/Vertex AI AutoML Tables pipeline.pipeline.component.yaml",
+    url: "example-pipelines/Vertex AI AutoML Tables pipeline.pipeline.component.yaml",
     previewImage:
-      "/example-pipelines/Vertex AI AutoML Tables pipeline.pipeline.component.png",
+      "example-pipelines/Vertex AI AutoML Tables pipeline.pipeline.component.png",
     tags: ["AutoML", "Google Cloud", "Vertex AI"],
   },
   {
     name: "TFX Pipeline",
     description:
       "Production-ready TensorFlow Extended (TFX) pipeline for end-to-end ML workflows. Includes data validation, transformation, training, and model serving.",
-    url: "/example-pipelines/Tfx pipeline.pipeline.component.yaml",
-    previewImage: "/example-pipelines/Tfx pipeline.pipeline.component.png",
+    url: "example-pipelines/Tfx pipeline.pipeline.component.yaml",
+    previewImage: "example-pipelines/Tfx pipeline.pipeline.component.png",
     tags: ["TensorFlow", "TFX", "Production"],
   },
 ];

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,6 +15,8 @@ scan({
   enabled: import.meta.env.VITE_ENABLE_SCAN === "true",
 });
 
+setBaseUrl();
+
 const rootElement = document.getElementById("app")!;
 if (!rootElement.innerHTML) {
   const root = ReactDOM.createRoot(rootElement);
@@ -25,4 +27,10 @@ if (!rootElement.innerHTML) {
       </QueryClientProvider>
     </StrictMode>,
   );
+}
+
+function setBaseUrl() {
+  const base = document.createElement("base");
+  base.setAttribute("href", import.meta.env.VITE_BASE_URL ?? "/");
+  document.head.insertBefore(base, document.head.firstChild);
 }

--- a/vite.config.ghpages.js
+++ b/vite.config.ghpages.js
@@ -12,7 +12,7 @@ export default defineConfig({
   plugins: [viteReact(), tailwindcss()],
   // Set base path for GitHub Pages deployment
   // This ensures all assets and routes are prefixed with /pipeline-studio-app/
-  base: "/pipeline-studio-app/",
+  base: "/tangle-ui/",
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),
@@ -23,7 +23,7 @@ export default defineConfig({
     port: 4173,
     strictPort: false,
     host: "localhost",
-    open: "/pipeline-studio-app/", // Auto-open browser at the correct path
+    open: "/tangle-ui/", // Auto-open browser at the correct path
   },
   // Build configuration optimized for GitHub Pages
   build: {


### PR DESCRIPTION
## Description

Improved URL handling for pipeline imports and updated base URL configuration for deployment. The changes include:

1. Enhanced the `isUrlAllowed` function to better detect relative URLs by checking for protocol presence
2. Removed leading slashes from sample pipeline URLs to make them compatible with different base URL configurations
3. Added a `setBaseUrl` function that dynamically sets the base URL using the `VITE_BASE_URL` environment variable
4. Updated GitHub Pages configuration to use `/tangle-ui/` as the base path instead of `/pipeline-studio-app/`

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

1. Verify that sample pipelines load correctly with the new URL format
2. Test the application with different base URL configurations
3. Confirm that GitHub Pages deployment works with the new `/tangle-ui/` base path