### PR TITLE
Prompt User for Subgraph Name

### DIFF
--- a/src/components/shared/Dialogs/InputDialog.tsx
+++ b/src/components/shared/Dialogs/InputDialog.tsx
@@ -1,0 +1,113 @@
+import { type KeyboardEvent, type ReactNode, useEffect, useState } from "react";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Input } from "@/components/ui/input";
+import { Paragraph } from "@/components/ui/typography";
+import { cn } from "@/lib/utils";
+
+export type InputDialogProps = {
+  isOpen: boolean;
+  title: string;
+  description: string;
+  placeholder: string;
+  defaultValue: string;
+  content?: ReactNode;
+  validate?: (value: string) => string | null;
+  onConfirm?: (value: string) => void;
+  onCancel?: () => void;
+};
+
+export function InputDialog({
+  isOpen,
+  title,
+  description,
+  placeholder,
+  defaultValue,
+  content,
+  validate,
+  onConfirm,
+  onCancel,
+}: InputDialogProps) {
+  const [value, setValue] = useState(defaultValue);
+  const [error, setError] = useState<string | null>(null);
+
+  const canConfirm = value.trim().length > 0 && !error;
+
+  const handleValueChange = (newValue: string) => {
+    setValue(newValue);
+
+    if (validate) {
+      const validationError = validate(newValue.trim());
+      setError(validationError);
+    } else {
+      setError(null);
+    }
+  };
+
+  const handleConfirm = () => {
+    onConfirm?.(value.trim());
+  };
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (e.key === "Enter" && value.trim()) {
+      handleConfirm();
+    }
+    if (e.key === "Escape") {
+      onCancel?.();
+    }
+  };
+
+  useEffect(() => {
+    if (isOpen) {
+      setValue(defaultValue);
+      setError(null);
+    }
+  }, [isOpen, defaultValue]);
+
+  useEffect(() => {
+    if (isOpen && defaultValue && validate) {
+      const validationError = validate(defaultValue.trim());
+      setError(validationError);
+    }
+  }, [isOpen, defaultValue, validate]);
+
+  return (
+    <AlertDialog open={isOpen}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription>{description}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <Input
+          value={value}
+          onChange={(e) => handleValueChange(e.target.value)}
+          placeholder={placeholder}
+          onKeyDown={handleKeyDown}
+          autoFocus
+          className={cn(!!error && "border-destructive")}
+        />
+        {!!error && (
+          <Paragraph tone="critical" size="sm">
+            {error}
+          </Paragraph>
+        )}
+        {content}
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={onCancel}>Cancel</AlertDialogCancel>
+          <AlertDialogAction onClick={handleConfirm} disabled={!canConfirm}>
+            Continue
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
@@ -24,6 +24,7 @@ import useConfirmationDialog from "@/hooks/useConfirmationDialog";
 import { useCopyPaste } from "@/hooks/useCopyPaste";
 import { useGhostNode } from "@/hooks/useGhostNode";
 import { useHintNode } from "@/hooks/useHintNode";
+import useInputDialog from "@/hooks/useInputDialog";
 import { useIOSelectionPersistence } from "@/hooks/useIOSelectionPersistence";
 import { useNodeCallbacks } from "@/hooks/useNodeCallbacks";
 import { useSubgraphKeyboardNavigation } from "@/hooks/useSubgraphKeyboardNavigation";
@@ -41,15 +42,16 @@ import {
 } from "@/utils/componentSpec";
 import { loadComponentAsRefFromText } from "@/utils/componentStore";
 import createNodesFromComponentSpec from "@/utils/nodes/createNodesFromComponentSpec";
-import { createSubgraphFromNodes } from "@/utils/nodes/createSubgraphFromNodes";
 import {
   getSubgraphComponentSpec,
   updateSubgraphSpec,
 } from "@/utils/subgraphUtils";
 
 import ComponentDuplicateDialog from "../../Dialogs/ComponentDuplicateDialog";
+import { InputDialog } from "../../Dialogs/InputDialog";
 import { useBetaFlagValue } from "../../Settings/useBetaFlags";
 import { useNodesOverlay } from "../NodesOverlay/NodesOverlayProvider";
+import { handleGroupNodes } from "./callbacks/handleGroupNodes";
 import { getBulkUpdateConfirmationDetails } from "./ConfirmationDialogs/BulkUpdateConfirmationDialog";
 import { getDeleteConfirmationDetails } from "./ConfirmationDialogs/DeleteConfirmation";
 import { getReplaceConfirmationDetails } from "./ConfirmationDialogs/ReplaceConfirmation";
@@ -57,6 +59,7 @@ import SmoothEdge from "./Edges/SmoothEdge";
 import GhostNode from "./GhostNode/GhostNode";
 import HintNode from "./GhostNode/HintNode";
 import IONode from "./IONode/IONode";
+import { NodesList } from "./NodesList";
 import SelectionToolbar from "./SelectionToolbar";
 import { SubgraphBreadcrumbs } from "./SubgraphBreadcrumbs/SubgraphBreadcrumbs";
 import TaskNode from "./TaskNode/TaskNode";
@@ -64,14 +67,13 @@ import type { NodesAndEdges } from "./types";
 import { addAndConnectNode } from "./utils/addAndConnectNode";
 import addTask from "./utils/addTask";
 import { duplicateNodes } from "./utils/duplicateNodes";
-import { calculateNodesCenter, isPositionInNode } from "./utils/geometry";
+import { isPositionInNode } from "./utils/geometry";
 import { getPositionFromEvent } from "./utils/getPositionFromEvent";
 import { getTaskFromEvent } from "./utils/getTaskFromEvent";
 import { handleConnection } from "./utils/handleConnection";
 import { removeEdge } from "./utils/removeEdge";
 import { removeNode } from "./utils/removeNode";
 import { replaceTaskNode } from "./utils/replaceTaskNode";
-import { updateDownstreamSubgraphConnections } from "./utils/updateDownstreamSubgraphConnections";
 import { updateNodePositions } from "./utils/updateNodePosition";
 
 const nodeTypes: Record<string, ComponentType<any>> = {
@@ -155,6 +157,8 @@ const FlowCanvas = ({
     triggerDialog: triggerConfirmation,
     ...confirmationProps
   } = useConfirmationDialog();
+
+  const { triggerInputDialog, ...inputDialogProps } = useInputDialog();
 
   const notify = useToastNotification();
 
@@ -777,51 +781,38 @@ const FlowCanvas = ({
   ]);
 
   const onGroupNodes = useCallback(async () => {
-    if (!canGroup) {
-      return;
-    }
+    if (!canGroup) return;
 
-    try {
-      const subgraphTaskSpec = await createSubgraphFromNodes(
-        selectedNodes,
-        currentSubgraphSpec,
-      );
+    const nodesList = (
+      <NodesList
+        nodes={selectedNodes}
+        title={`Nodes being grouped (${selectedNodes.length})`}
+      />
+    );
 
-      const position = calculateNodesCenter(selectedNodes);
-      const { spec: currentSubgraphSpecWithNewTask, taskId: subgraphTaskId } =
-        addTask("task", subgraphTaskSpec, position, currentSubgraphSpec);
-
-      if (!subgraphTaskId) {
-        throw new Error("Subgraph Task ID is undefined.");
-      }
-
-      const selectedTaskIds = selectedNodes
-        .filter((node) => node.type === "task")
-        .map((node) => node.data.taskId as string);
-
-      const updatedSubgraphSpec = updateDownstreamSubgraphConnections(
-        currentSubgraphSpecWithNewTask,
-        selectedTaskIds,
-        subgraphTaskId,
-      );
-
-      let finalSubgraphSpec = updatedSubgraphSpec;
-
-      selectedNodes.forEach((node) => {
-        finalSubgraphSpec = removeNode(node, finalSubgraphSpec);
-      });
-
+    const onSuccess = (updatedComponentSpec: ComponentSpec) => {
       const updatedRootSpec = updateSubgraphSpec(
         componentSpec,
         currentSubgraphPath,
-        finalSubgraphSpec,
+        updatedComponentSpec,
       );
 
       setComponentSpec(updatedRootSpec);
-    } catch (error) {
+    };
+
+    const onError = (error: Error) => {
       console.error("Failed to create subgraph:", error);
       notify("Failed to create subgraph", "error");
-    }
+    };
+
+    handleGroupNodes(
+      selectedNodes,
+      currentSubgraphSpec,
+      nodesList,
+      triggerInputDialog,
+      onSuccess,
+      onError,
+    );
   }, [
     selectedNodes,
     componentSpec,
@@ -829,6 +820,7 @@ const FlowCanvas = ({
     currentSubgraphPath,
     canGroup,
     setComponentSpec,
+    triggerInputDialog,
     notify,
   ]);
 
@@ -1040,6 +1032,7 @@ const FlowCanvas = ({
         onConfirm={() => confirmationHandlers?.onConfirm()}
         onCancel={() => confirmationHandlers?.onCancel()}
       />
+      <InputDialog {...inputDialogProps} />
       <ComponentDuplicateDialog
         existingComponent={existingAndNewComponent?.existingComponent}
         newComponent={existingAndNewComponent?.newComponent}

--- a/src/components/shared/ReactFlow/FlowCanvas/NodesList.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/NodesList.tsx
@@ -1,0 +1,75 @@
+import { type Node } from "@xyflow/react";
+import { ChevronRight } from "lucide-react";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { Paragraph } from "@/components/ui/typography";
+import { cn } from "@/lib/utils";
+
+interface NodesListProps {
+  nodes: Node[];
+  title?: string;
+}
+
+const getNodeTypeColor = (nodeType: string | undefined): string => {
+  switch (nodeType) {
+    case "input":
+      return "bg-blue-500";
+    case "output":
+      return "bg-violet-500";
+    case "task":
+    default:
+      return "bg-gray-500";
+  }
+};
+
+export function NodesList({
+  nodes,
+  title = `View nodes (${nodes.length})`,
+}: NodesListProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  if (nodes.length === 0) {
+    return null;
+  }
+
+  return (
+    <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+      <CollapsibleTrigger asChild>
+        <Button variant="ghost">
+          <ChevronRight
+            className={cn(
+              "transition-transform duration-200",
+              isOpen && "rotate-90",
+            )}
+          />
+          {title}
+        </Button>
+      </CollapsibleTrigger>
+      <CollapsibleContent className="mt-2">
+        <div className="rounded-md border p-3 bg-secondary/50">
+          <ul className="space-y-2 text-sm">
+            {nodes.map((node) => (
+              <li key={node.id} className="flex items-center gap-3">
+                <span
+                  className={cn(
+                    "w-2 h-2 rounded-full",
+                    getNodeTypeColor(node.type),
+                  )}
+                />
+                <Paragraph font="mono" size="xs">
+                  {node.id}
+                </Paragraph>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}

--- a/src/components/shared/ReactFlow/FlowCanvas/callbacks/handleGroupNodes.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/callbacks/handleGroupNodes.ts
@@ -1,0 +1,100 @@
+import type { Node } from "@xyflow/react";
+import type { ReactNode } from "react";
+
+import type { TriggerInputDialogProps } from "@/hooks/useInputDialog";
+import {
+  type ComponentSpec,
+  isGraphImplementation,
+} from "@/utils/componentSpec";
+import { createSubgraphFromNodes } from "@/utils/nodes/createSubgraphFromNodes";
+import { getUniqueTaskName } from "@/utils/unique";
+
+import addTask from "../utils/addTask";
+import { calculateNodesCenter } from "../utils/geometry";
+import { removeNode } from "../utils/removeNode";
+import { updateDownstreamSubgraphConnections } from "../utils/updateDownstreamSubgraphConnections";
+
+export const handleGroupNodes = async (
+  selectedNodes: Node[],
+  currentSubgraphSpec: ComponentSpec,
+  inputDialogContent: ReactNode,
+  triggerInputDialog: (
+    props: TriggerInputDialogProps,
+  ) => Promise<string | null>,
+  onSuccess: (updatedComponentSpec: ComponentSpec) => void,
+  onError: (error: Error) => void,
+) => {
+  if (!isGraphImplementation(currentSubgraphSpec.implementation)) return;
+
+  const currentSubgraphGraphSpec = currentSubgraphSpec.implementation.graph;
+
+  const validateName = (name: string): string | null => {
+    const trimmedName = name.trim();
+
+    if (!trimmedName) {
+      return "Name cannot be empty";
+    }
+
+    if (new Set(Object.keys(currentSubgraphGraphSpec.tasks)).has(trimmedName)) {
+      return "A task with this name already exists";
+    }
+
+    if (!/^[a-zA-Z0-9 _-]+$/.test(trimmedName)) {
+      return "Name cannot contain special characters";
+    }
+
+    return null;
+  };
+
+  try {
+    const defaultName = getUniqueTaskName(
+      currentSubgraphGraphSpec,
+      "New Subgraph",
+    );
+
+    const name = await triggerInputDialog({
+      title: "Create Subgraph",
+      description: "Enter subgraph name",
+      defaultValue: defaultName,
+      content: inputDialogContent,
+      validate: validateName,
+    });
+
+    if (!name) return;
+
+    const subgraphTaskSpec = await createSubgraphFromNodes(
+      selectedNodes,
+      currentSubgraphSpec,
+      name,
+    );
+
+    const position = calculateNodesCenter(selectedNodes);
+    const { spec: currentSubgraphSpecWithNewTask, taskId: subgraphTaskId } =
+      addTask("task", subgraphTaskSpec, position, currentSubgraphSpec);
+
+    if (!subgraphTaskId) {
+      onError(new Error("Subgraph Task ID is undefined."));
+      return;
+    }
+
+    const selectedTaskIds = selectedNodes
+      .filter((node) => node.type === "task")
+      .map((node) => node.data.taskId as string);
+
+    const updatedSubgraphSpec = updateDownstreamSubgraphConnections(
+      currentSubgraphSpecWithNewTask,
+      selectedTaskIds,
+      subgraphTaskId,
+    );
+
+    let finalSubgraphSpec = updatedSubgraphSpec;
+
+    selectedNodes.forEach((node) => {
+      finalSubgraphSpec = removeNode(node, finalSubgraphSpec);
+    });
+
+    onSuccess(finalSubgraphSpec);
+  } catch (error) {
+    onError(error as Error);
+  }
+};

--- a/src/hooks/useInputDialog.ts
+++ b/src/hooks/useInputDialog.ts
@@ -1,0 +1,81 @@
+import { type ReactNode, useState } from "react";
+
+import type { InputDialogProps } from "@/components/shared/Dialogs/InputDialog";
+
+export type TriggerInputDialogProps = {
+  title?: string;
+  description?: string;
+  placeholder?: string;
+  defaultValue?: string;
+  content?: ReactNode;
+  validate?: (value: string) => string | null;
+};
+
+const DEFAULT_TITLE = "Enter value";
+const DEFAULT_DESCRIPTION = "Please provide the required information.";
+const DEFAULT_PLACEHOLDER = "Enter value";
+
+const DEFAULT_INPUT_DIALOG = {
+  isOpen: false,
+  title: DEFAULT_TITLE,
+  description: DEFAULT_DESCRIPTION,
+  placeholder: DEFAULT_PLACEHOLDER,
+  defaultValue: "",
+  content: null,
+  validate: undefined,
+};
+
+export default function useInputDialog() {
+  const [inputDialog, setInputDialog] =
+    useState<InputDialogProps>(DEFAULT_INPUT_DIALOG);
+
+  const [resolver, setResolver] = useState<{
+    resolve: (value: string | null) => void;
+  } | null>(null);
+
+  const resetInputDialog = () => {
+    setInputDialog(DEFAULT_INPUT_DIALOG);
+  };
+
+  const triggerInputDialog = async ({
+    title = DEFAULT_TITLE,
+    description = DEFAULT_DESCRIPTION,
+    placeholder = DEFAULT_PLACEHOLDER,
+    defaultValue = "",
+    content,
+    validate,
+  }: TriggerInputDialogProps): Promise<string | null> => {
+    setInputDialog({
+      isOpen: true,
+      title,
+      description,
+      placeholder,
+      defaultValue,
+      content,
+      validate,
+    });
+
+    return new Promise<string | null>((resolve) => {
+      setResolver({ resolve });
+    });
+  };
+
+  const onConfirm = (value: string) => {
+    resolver?.resolve(value);
+    setResolver(null);
+    resetInputDialog();
+  };
+
+  const onCancel = () => {
+    resolver?.resolve(null);
+    setResolver(null);
+    resetInputDialog();
+  };
+
+  return {
+    ...inputDialog,
+    triggerInputDialog,
+    onConfirm,
+    onCancel,
+  };
+}

--- a/src/utils/nodes/createSubgraphFromNodes.ts
+++ b/src/utils/nodes/createSubgraphFromNodes.ts
@@ -37,6 +37,7 @@ const IO_NODE_SPACING_Y = IO_NODE_HEIGHT + GAP;
 export const createSubgraphFromNodes = async (
   selectedNodes: Node[],
   currentComponentSpec: ComponentSpec,
+  name?: string,
 ): Promise<TaskSpec> => {
   if (!isGraphImplementation(currentComponentSpec.implementation)) {
     throw new Error(
@@ -127,10 +128,8 @@ export const createSubgraphFromNodes = async (
   // Create the replacement task that represents the subgraph
   const subgraphPosition = calculateNodesCenter(selectedNodes);
 
-  const subgraphName = getUniqueTaskName(
-    currentGraphSpec,
-    "Generated Subgraph",
-  );
+  const subgraphName =
+    name ?? getUniqueTaskName(currentGraphSpec, "Generated Subgraph");
 
   const subgraphTask = await createSubgraphTask(
     subgraphName,


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

The user will now be prompted to name their subgraph when they create it.

This is done via a new `InputDialog` component that pauses the execution and waits for the user to enter & confirm a value. It also supports validations on the entered string and additional content below the input box (which is used here to list the impacted nodes for additional context). `InputDialog`​ follows the same pattern as `ConfirmationDialog`​, with a hook to handle all of the internal works of the dialog.

The name field will validate against the input validation function, which disallows empty names, duplicates and special characters.

`NodesList`​ has been added for displaying a list of nodes in a collapsible. This is used in the dialog if the user wants to easily refer to the `node_id`​ of the nodes they are converted, perhaps for subgraph naming inspiration. The dots on the node list correspond with task colours (blue = input etc)

Additionally, to provide better separation of concerns and improved clarity, as well as reducing bloat in `FlowCanvas`​, the business logic of `onGroupNodes`​ has been moved out of `FlowCanvas`​ and into a new `callbacks`​ directory. In future we can seek to move other major operations (e.g. duplication, replacements, upgrade) out of `FlowCanvas`​ and into their own files for improved readability and testability.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

Completes the core functionality of the Nodes -> Subgraph work

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] New feature
- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

![image.png](https://app.graphite.com/user-attachments/assets/05b5fd8e-f608-45ca-8e0b-ec5daa5e48f3.png)

![image.png](https://app.graphite.com/user-attachments/assets/e445ae58-2534-46c3-abd8-b663b0720edb.png)



## Test Instructions

1. Select a group of nodes
2. Convert to subgraph
3. Subgraph naming dialog should open
    1. name field should be prepopulated with a default
    2. collapsible box should show the correct list of affected nodes
    3. name field does not allow special characters, empty names, or duplicates
    4. "Cancel" button should close the dialog and abort the procedure
    5. "Continue" button should proceed and a new subgraph should appear with the input name

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->