### PR TITLE
chore: Hide all example pipelines except XGBoost

### DIFF
--- a/src/components/shared/QuickStart/samplePipelines.ts
+++ b/src/components/shared/QuickStart/samplePipelines.ts
@@ -15,6 +15,7 @@ export const samplePipelines: SamplePipeline[] = [
     previewImage: "example-pipelines/XGBoost pipeline.pipeline.component.png",
     tags: ["XGBoost", "Classification", "Tabular Data"],
   },
+/*
   {
     name: "PyTorch Network",
     description:
@@ -40,4 +41,5 @@ export const samplePipelines: SamplePipeline[] = [
     previewImage: "example-pipelines/Tfx pipeline.pipeline.component.png",
     tags: ["TensorFlow", "TFX", "Production"],
   },
+  */
 ];


### PR DESCRIPTION
Fixes https://github.com/TangleML/tangle-ui/issues/1324