### PR TITLE
Fix unable to create subgraphs when backend is not responsive

### DIFF
--- a/src/utils/nodes/createSubgraphFromNodes.ts
+++ b/src/utils/nodes/createSubgraphFromNodes.ts
@@ -160,8 +160,15 @@ const createSubgraphTask = async (
   position: XYPosition,
   args: Record<string, ArgumentType>,
 ) => {
-  const userDetails = await getUserDetails();
-  const author = userDetails?.id;
+  let author: string = "Unknown";
+  try {
+    const userDetails = await getUserDetails();
+    if (userDetails?.id) {
+      author = userDetails.id;
+    }
+  } catch (error) {
+    console.error("Error retrieving user details:", error);
+  }
 
   const spec: ComponentSpec = {
     name,


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Simple bugfix. Right now if the backend is not running (or is turned off) the user cannot create a subgraph because the `getUserDetails` API call fails. We not safely handle this in a `try ... catch` and fallback to `unknown` author.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->
1. turn off the backend, or configure a faulty backend route.
2. create a subgraph
3. Subgraph should be created (previously it was a no-op)

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
