### PR TITLE
support HF urls

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/IOCellDetails.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/IOCellDetails.tsx
@@ -2,7 +2,7 @@ import type { ArtifactDataResponse } from "@/api/types.gen";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Link } from "@/components/ui/link";
 import type { InputSpec, OutputSpec } from "@/utils/componentSpec";
-import { convertGcsUrlToBrowserUrl } from "@/utils/URL";
+import { convertArtifactUriToHTTPUrl } from "@/utils/URL";
 
 import type { IOCellActions } from "./IOCell";
 import IOCodeViewer from "./IOCodeViewer";
@@ -34,7 +34,7 @@ const IOCellDetails = ({ io, artifactData, actions }: IOCellDetailsProps) => {
           <span className="font-medium text-xs min-w-24 max-w-24">URI:</span>
           <Link
             external
-            href={convertGcsUrlToBrowserUrl(
+            href={convertArtifactUriToHTTPUrl(
               artifactData.uri,
               artifactData.is_dir,
             )}

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/IOCellHeader.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/IOCellHeader.tsx
@@ -16,7 +16,7 @@ import type {
   TypeSpecType,
 } from "@/utils/componentSpec";
 import { formatBytes } from "@/utils/string";
-import { convertGcsUrlToBrowserUrl } from "@/utils/URL";
+import { convertArtifactUriToHTTPUrl } from "@/utils/URL";
 
 import type { IOCellActions, IOCellCopyState } from "./IOCell";
 
@@ -92,7 +92,7 @@ const IOCellHeader = ({
               {artifactData.uri && (
                 <>
                   <Link
-                    href={convertGcsUrlToBrowserUrl(
+                    href={convertArtifactUriToHTTPUrl(
                       artifactData.uri || "",
                       artifactData.is_dir || false,
                     )}

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOExtras.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOExtras.tsx
@@ -4,7 +4,7 @@ import { Link } from "@/components/ui/link";
 import { Heading, Paragraph } from "@/components/ui/typography";
 import type { InputSpec, OutputSpec } from "@/utils/componentSpec";
 import { formatBytes } from "@/utils/string";
-import { convertGcsUrlToBrowserUrl } from "@/utils/URL";
+import { convertArtifactUriToHTTPUrl } from "@/utils/URL";
 
 interface IOExtrasProps {
   inputs?: InputSpec[];
@@ -67,7 +67,7 @@ const IOExtras = ({ inputs, outputs, artifacts }: IOExtrasProps) => {
                           URI:
                         </Paragraph>
                         <Link
-                          href={convertGcsUrlToBrowserUrl(
+                          href={convertArtifactUriToHTTPUrl(
                             artifact.artifact_data.uri,
                             artifact.artifact_data.is_dir,
                           )}
@@ -137,7 +137,7 @@ const IOExtras = ({ inputs, outputs, artifacts }: IOExtrasProps) => {
                           URI:
                         </Paragraph>
                         <Link
-                          href={convertGcsUrlToBrowserUrl(
+                          href={convertArtifactUriToHTTPUrl(
                             artifact.artifact_data.uri,
                             artifact.artifact_data.is_dir,
                           )}

--- a/src/utils/URL.ts
+++ b/src/utils/URL.ts
@@ -21,6 +21,46 @@ const convertGcsUrlToBrowserUrl = (
   return url.replace("gs://", "https://storage.cloud.google.com/");
 };
 
+const convertHfUrlToDirectoryUrl = (url: string, isDirectory: boolean) => {
+  if (!url.startsWith("hf://")) {
+    return url;
+  }
+
+  /**
+   * Common Hugging Face URL format:
+   *
+   * hf://<repo-type-plural>/<user>/<repo>/<path>
+   *
+   * e.g. `hf://datasets/Ark-kun/tangle_data/path/a/b/c`
+   */
+  const hfUrl = url.replace("hf://", "");
+
+  const urlParts = hfUrl.split("/");
+  const repoTypePlural = urlParts[0];
+  const user = urlParts[1];
+  const repo = urlParts[2];
+  const path = urlParts.slice(3).join("/");
+
+  if (isDirectory) {
+    return `https://huggingface.co/${repoTypePlural}/${user}/${repo}/tree/main/${path}`;
+  } else {
+    return `https://huggingface.co/${repoTypePlural}/${user}/${repo}/blob/main/${path}`;
+  }
+};
+
+const convertArtifactUriToHTTPUrl = (
+  artifactUrl: string,
+  isDirectory: boolean,
+) => {
+  if (artifactUrl.startsWith("gs://")) {
+    return convertGcsUrlToBrowserUrl(artifactUrl, isDirectory);
+  } else if (artifactUrl.startsWith("hf://")) {
+    return convertHfUrlToDirectoryUrl(artifactUrl, isDirectory);
+  } else {
+    return artifactUrl;
+  }
+};
+
 const convertRawUrlToDirectoryUrl = (rawUrl: string) => {
   const urlPattern =
     /^https:\/\/raw.githubusercontent.com\/([^/]+)\/([^/]+)\/([^/]+)\/(.+)$/;
@@ -130,8 +170,10 @@ const normalizeUrl = (url: string) => {
 };
 
 export {
+  convertArtifactUriToHTTPUrl,
   convertGcsUrlToBrowserUrl,
   convertGithubUrlToDirectoryUrl,
+  convertHfUrlToDirectoryUrl,
   downloadYamlFromComponentText,
   getIdOrTitleFromPath,
   isGithubUrl,


### PR DESCRIPTION
## Description

Added support for Hugging Face artifact URLs in the UI. This PR introduces a new utility function `convertHfUrlToDirectoryUrl` that transforms Hugging Face URLs (hf://) into browser-accessible HTTP URLs, similar to how GCS URLs are handled. The existing `convertGcsUrlToBrowserUrl` function has been generalized into `convertArtifactUriToHTTPUrl`, which now handles both GCS and Hugging Face URLs.

Fixes https://github.com/TangleML/tangle-ui/issues/1148

## Type of Change

- [x] New feature
- [x] Improvement

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

1. Create a pipeline that uses Hugging Face artifacts
2. Verify that the artifact links in the UI correctly redirect to the Hugging Face website
3. Confirm that existing GCS links still work as expected