### PR TITLE
[POC] Highlight Edges when Task Input/Output is selected

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/Edges/SmoothEdge.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/Edges/SmoothEdge.tsx
@@ -11,6 +11,7 @@ const SmoothEdge = ({
   targetPosition,
   style = {},
   selected,
+  data,
 }: EdgeProps) => {
   const [edgePath] = getBezierPath({
     sourceX,
@@ -21,8 +22,13 @@ const SmoothEdge = ({
     targetPosition,
   });
 
-  const edgeColor = selected ? "#38bdf8" : "#6b7280";
-  const markerIdSuffix = selected ? "selected" : "default";
+  const state = selected
+    ? "selected"
+    : data?.highlighted
+      ? "highlighted"
+      : "default";
+
+  const { edgeColor, markerIdSuffix } = getEdgeMetadata(state);
 
   return (
     <>
@@ -87,3 +93,24 @@ const SmoothEdge = ({
 };
 
 export default SmoothEdge;
+
+function getEdgeMetadata(state: "default" | "selected" | "highlighted") {
+  switch (state) {
+    case "selected":
+      return {
+        edgeColor: "#38bdf8",
+        markerIdSuffix: "selected",
+      };
+    case "highlighted":
+      return {
+        edgeColor: "#ec4899",
+        markerIdSuffix: "highlighted",
+      };
+    case "default":
+    default:
+      return {
+        edgeColor: "#6b7280",
+        markerIdSuffix: "default",
+      };
+  }
+}

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/Handles.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/Handles.tsx
@@ -19,7 +19,10 @@ type InputHandleProps = {
   input: InputSpec;
   invalid: boolean;
   value?: string;
-  highlight?: boolean;
+  highlight?: {
+    searchHighlight: boolean;
+    connectionHighlight: boolean;
+  };
   onLabelClick?: (e: ReactMouseEvent<HTMLDivElement>) => void;
   onHandleSelectionChange?: (key: string, selected: boolean) => void;
 };
@@ -119,12 +122,14 @@ export const InputHandle = ({
     };
   }, [selected]);
 
+  const { searchHighlight, connectionHighlight } = highlight || {};
+
   return (
     <div
       className="relative w-full h-fit"
       key={input.name}
       data-testid={`input-connection-${input.name}`}
-      data-highlighted={highlight}
+      data-highlighted={searchHighlight || connectionHighlight}
       data-selected={selected}
       data-active={active}
     >
@@ -138,8 +143,13 @@ export const InputHandle = ({
           className={cn(
             "border-0! h-full! w-full! transform-none!",
             missing,
+            searchHighlight &&
+              !connectionHighlight &&
+              !selected &&
+              !active &&
+              "bg-green-500!",
+            connectionHighlight && !selected && !active && "bg-pink-500!",
             (selected || active) && "bg-blue-500!",
-            highlight && "bg-green-500!",
             state.readOnly && "cursor-pointer!",
           )}
           onClick={handleHandleClick}
@@ -163,9 +173,18 @@ export const InputHandle = ({
             <div
               className={cn(
                 "text-xs text-gray-800! rounded-md px-2 py-1 truncate",
-                onLabelClick && !selected && !highlight && "hover:bg-gray-300",
+                onLabelClick &&
+                  !selected &&
+                  !searchHighlight &&
+                  !connectionHighlight &&
+                  "hover:bg-gray-300",
                 selected || active ? "bg-blue-200" : "bg-gray-200",
-                highlight && "bg-green-200",
+                searchHighlight &&
+                  !connectionHighlight &&
+                  !selected &&
+                  !active &&
+                  "bg-green-200",
+                connectionHighlight && !selected && !active && "bg-pink-200",
                 !hasValue && hasDefault && "opacity-50 italic",
               )}
               onClick={handleLabelClick}
@@ -206,7 +225,10 @@ export const InputHandle = ({
 type OutputHandleProps = {
   output: OutputSpec;
   value?: string;
-  highlight?: boolean;
+  highlight?: {
+    searchHighlight: boolean;
+    connectionHighlight: boolean;
+  };
   onLabelClick?: (e: ReactMouseEvent<HTMLDivElement>) => void;
   onHandleSelectionChange?: (key: string, selected: boolean) => void;
 };
@@ -302,12 +324,14 @@ export const OutputHandle = ({
     };
   }, [selected]);
 
+  const { searchHighlight, connectionHighlight } = highlight || {};
+
   return (
     <div
       className="flex items-center justify-end w-full cursor-pointer"
       key={output.name}
       data-testid={`output-connection-${output.name}`}
-      data-highlighted={highlight}
+      data-highlighted={searchHighlight || connectionHighlight}
       data-selected={selected}
       data-active={active}
     >
@@ -321,9 +345,18 @@ export const OutputHandle = ({
           <div
             className={cn(
               "text-xs text-gray-800! rounded-md px-2 py-1 truncate",
-              onLabelClick && !selected && !highlight && "hover:bg-gray-300",
+              onLabelClick &&
+                !selected &&
+                !searchHighlight &&
+                !connectionHighlight &&
+                "hover:bg-gray-300",
               selected || active ? "bg-blue-200" : "bg-gray-200",
-              highlight && "bg-green-200",
+              searchHighlight &&
+                !connectionHighlight &&
+                !selected &&
+                !active &&
+                "bg-green-200",
+              connectionHighlight && !selected && !active && "bg-pink-200",
             )}
             onClick={handleLabelClick}
           >
@@ -344,9 +377,14 @@ export const OutputHandle = ({
         isConnectable={true}
         onClick={handleHandleClick}
         className={cn(
-          "relative! border-0! !w-[12px] !h-[12px] transform-none! translate-x-6 cursor-pointer bg-gray-500!",
+          "relative! border-0! w-3! h-3! transform-none! translate-x-6 cursor-pointer bg-gray-500!",
+          searchHighlight &&
+            !connectionHighlight &&
+            !selected &&
+            !active &&
+            "bg-green-500!",
+          connectionHighlight && !selected && !active && "bg-pink-500!",
           (selected || active) && "bg-blue-500!",
-          highlight && "bg-green-500!",
           state.readOnly && "cursor-pointer!",
         )}
         data-testid={`output-handle-${output.name}`}
@@ -355,11 +393,11 @@ export const OutputHandle = ({
   );
 };
 
-const getOutputHandleId = (outputName: string) => {
+export const getOutputHandleId = (outputName: string) => {
   return `output_${outputName}`;
 };
 
-const getInputHandleId = (inputName: string) => {
+export const getInputHandleId = (inputName: string) => {
   return `input_${inputName}`;
 };
 

--- a/src/components/shared/ReactFlow/FlowCanvas/hooks/useConnectionHighlighting.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/hooks/useConnectionHighlighting.ts
@@ -1,0 +1,61 @@
+import { useEdges } from "@xyflow/react";
+import { useCallback, useEffect, useState } from "react";
+
+import {
+  clearHighlights,
+  getSelectedHandle,
+  highlightConnections,
+  subscribeToHandleHighlights,
+} from "@/utils/nodes/highlightingState";
+
+export const useConnectionHighlighting = () => {
+  const [, forceUpdate] = useState({});
+  const edges = useEdges();
+
+  const triggerUpdate = useCallback(() => {
+    forceUpdate({});
+  }, []);
+
+  useEffect(() => {
+    return subscribeToHandleHighlights(triggerUpdate);
+  }, [triggerUpdate]);
+
+  const isHandleHighlighted = useCallback(
+    (nodeId: string, handleId: string) => {
+      const globalSelectedHandle = getSelectedHandle();
+      if (!globalSelectedHandle) return false;
+
+      if (
+        nodeId === globalSelectedHandle.nodeId &&
+        handleId === globalSelectedHandle.handleId
+      ) {
+        return true;
+      }
+
+      return edges.some((edge) => {
+        if (globalSelectedHandle.handleType === "input") {
+          return (
+            edge.target === globalSelectedHandle.nodeId &&
+            edge.targetHandle === globalSelectedHandle.handleId &&
+            edge.source === nodeId &&
+            edge.sourceHandle === handleId
+          );
+        } else {
+          return (
+            edge.source === globalSelectedHandle.nodeId &&
+            edge.sourceHandle === globalSelectedHandle.handleId &&
+            edge.target === nodeId &&
+            edge.targetHandle === handleId
+          );
+        }
+      });
+    },
+    [edges],
+  );
+
+  return {
+    highlightConnections,
+    clearHighlights,
+    isHandleHighlighted,
+  };
+};

--- a/src/utils/nodes/highlightingState.ts
+++ b/src/utils/nodes/highlightingState.ts
@@ -1,0 +1,56 @@
+interface SelectedHandle {
+  nodeId: string;
+  handleId: string;
+  handleType: "input" | "output";
+}
+
+// Global state - single source of truth
+let globalSelectedHandle: SelectedHandle | null = null;
+
+// Listeners for handle highlighting changes
+const handleHighlightListeners = new Set<() => void>();
+
+// Listeners for edge highlighting changes
+const edgeHighlightListeners = new Set<() => void>();
+
+const notifyHandleListeners = () => {
+  handleHighlightListeners.forEach((listener) => listener());
+};
+
+const notifyEdgeListeners = () => {
+  edgeHighlightListeners.forEach((listener) => listener());
+};
+
+// Public API
+export const highlightConnections = (
+  nodeId: string,
+  handleId: string,
+  handleType: "input" | "output",
+) => {
+  globalSelectedHandle = { nodeId, handleId, handleType };
+  notifyHandleListeners();
+  notifyEdgeListeners();
+};
+
+export const clearHighlights = () => {
+  globalSelectedHandle = null;
+  notifyHandleListeners();
+  notifyEdgeListeners();
+};
+
+export const getSelectedHandle = () => globalSelectedHandle;
+
+// Subscription functions
+export const subscribeToHandleHighlights = (listener: () => void) => {
+  handleHighlightListeners.add(listener);
+  return () => {
+    handleHighlightListeners.delete(listener);
+  };
+};
+
+export const subscribeToEdgeHighlights = (listener: () => void) => {
+  edgeHighlightListeners.add(listener);
+  return () => {
+    edgeHighlightListeners.delete(listener);
+  };
+};


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Select a task input or output handle -> all edges and connected handles will be highlighted pink (as well as potential connections in green)

PROOF OF CONCEPT FOR DISCUSSION


Note: this will be made a bit easier/more stable once the node manager is shipped.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->
Closes https://github.com/Shopify/oasis-frontend/issues/358

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

![image.png](https://app.graphite.com/user-attachments/assets/14d0d7cc-32eb-4b5c-b613-c7ffba89cbc6.png)

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
