### PR TITLE
Subgraph icon on task overview

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/TaskOverview.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/TaskOverview.tsx
@@ -15,6 +15,7 @@ import {
   TaskDetails,
   TaskImplementation,
 } from "@/components/shared/TaskDetails";
+import { Icon } from "@/components/ui/icon";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Text } from "@/components/ui/typography";
@@ -61,6 +62,7 @@ const TaskOverview = ({ taskNode, actions }: TaskOverviewProps) => {
   return (
     <BlockStack className="h-full" data-context-panel="task-overview">
       <InlineStack gap="2" blockAlign="center" className="px-2 pb-2">
+        {isSubgraph && <Icon name="Workflow" />}
         <Text size="lg" weight="semibold">
           {name}
         </Text>


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Add Subgraph Icon to task overview so it's easy to be reminded at a glance if the task is focus is subgraph or not


## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

![image.png](https://app.graphite.com/user-attachments/assets/a767d142-29eb-4344-8ba7-064890981939.png)

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
