### PR TITLE
fix: fix new pipeline for hashhistory

### DIFF
--- a/src/components/shared/NewPipelineButton.tsx
+++ b/src/components/shared/NewPipelineButton.tsx
@@ -6,6 +6,7 @@ import { EDITOR_PATH } from "@/routes/router";
 import { writeComponentToFileListFromText } from "@/utils/componentStore";
 import {
   defaultPipelineYamlWithName,
+  IS_GITHUB_PAGES,
   USER_PIPELINES_LIST_NAME,
 } from "@/utils/constants";
 
@@ -23,9 +24,9 @@ const NewPipelineButton = () => {
       componentText,
     );
 
-    navigate({
+    await navigate({
       to: `${EDITOR_PATH}/${name}`,
-      reloadDocument: true,
+      reloadDocument: !IS_GITHUB_PAGES,
     });
   };
 


### PR DESCRIPTION
## Description

Fixed navigation in the `NewPipelineButton` component to handle GitHub Pages deployment correctly. Made the navigate function asynchronous and conditionally set the `reloadDocument` parameter based on whether the application is running on GitHub Pages.

Closes https://github.com/TangleML/tangle-ui/issues/1334

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

1. [Screen Recording 2025-11-12 at 11.12.53 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/3fd1bd78-3ef5-41de-b0f8-6c2239eb21d4.mov" />](https://app.graphite.com/user-attachments/video/3fd1bd78-3ef5-41de-b0f8-6c2239eb21d4.mov)

    Test creating a new pipeline on both GitHub Pages deployment and regular deployment
2. Verify navigation works correctly in both environments without page reload issues on GitHub Pages