### PR TITLE
Add run deep linking by execution id

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Please take a look at the short video demonstrating the first version of the vis
 
 ## Demo
 
-[Demo]([https://cloud-pipelines.net/pipeline-studio-app](https://tangleml-tangle.hf.space/#/quick-start))
+[Demo](<[https://cloud-pipelines.net/pipeline-studio-app](https://tangleml-tangle.hf.space/#/quick-start)>)
 
 The experimental new version of the Tangle app is now available at <https://tangleml-tangle.hf.space/#/quick-start> . No registration is required to experiment with building pipelines. To install your own app instance, [duplicate](https://huggingface.co/spaces/TangleML/tangle?duplicate=true) the HuggingFace space or follow the [backend installation instructions](https://github.com/Cloud-Pipelines/backend?tab=readme-ov-file#installation).
 

--- a/src/components/shared/QuickStart/samplePipelines.ts
+++ b/src/components/shared/QuickStart/samplePipelines.ts
@@ -15,7 +15,7 @@ export const samplePipelines: SamplePipeline[] = [
     previewImage: "example-pipelines/XGBoost pipeline.pipeline.component.png",
     tags: ["XGBoost", "Classification", "Tabular Data"],
   },
-/*
+  /*
   {
     name: "PyTorch Network",
     description:

--- a/src/hooks/useSubgraphBreadcrumbs.test.tsx
+++ b/src/hooks/useSubgraphBreadcrumbs.test.tsx
@@ -1,0 +1,213 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { GetExecutionInfoResponse } from "@/api/types.gen";
+import * as executionService from "@/services/executionService";
+
+import {
+  buildExecutionUrl,
+  useSubgraphBreadcrumbs,
+} from "./useSubgraphBreadcrumbs";
+
+vi.mock("@/providers/BackendProvider", () => ({
+  useBackend: () => ({
+    backendUrl: "http://test-backend",
+    configured: true,
+    available: true,
+    ready: true,
+  }),
+}));
+
+describe("useSubgraphBreadcrumbs", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+      },
+    });
+    vi.clearAllMocks();
+  });
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  it("should return empty segments when subgraphExecutionId equals rootExecutionId", async () => {
+    const rootExecutionId = "root-exec-123";
+    const { result } = renderHook(
+      () => useSubgraphBreadcrumbs(rootExecutionId, rootExecutionId),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.segments).toEqual([]);
+    expect(result.current.path).toEqual(["root"]);
+  });
+
+  it("should return empty segments when subgraphExecutionId is undefined", async () => {
+    const rootExecutionId = "root-exec-123";
+    const { result } = renderHook(
+      () => useSubgraphBreadcrumbs(rootExecutionId, undefined),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.segments).toEqual([]);
+    expect(result.current.path).toEqual(["root"]);
+  });
+
+  it("should traverse backwards to build breadcrumb path", async () => {
+    const rootExecutionId = "root-exec-123";
+    const level1ExecutionId = "level1-exec-456";
+    const level2ExecutionId = "level2-exec-789";
+
+    const rootDetails: GetExecutionInfoResponse = {
+      id: rootExecutionId,
+      task_spec: {
+        componentRef: {
+          name: "Root Pipeline",
+          digest: "root-digest",
+          spec: {
+            name: "Root Pipeline",
+            implementation: {
+              graph: {
+                tasks: {
+                  "Task Level 1": {
+                    componentRef: {
+                      name: "Subgraph Level 1",
+                      digest: "level1-digest",
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      child_task_execution_ids: {
+        "Task Level 1": level1ExecutionId,
+      },
+      pipeline_run_id: "run-123",
+    };
+
+    const level1Details: GetExecutionInfoResponse = {
+      id: level1ExecutionId,
+      parent_execution_id: rootExecutionId,
+      task_spec: {
+        componentRef: {
+          name: "Subgraph Level 1",
+          digest: "level1-digest",
+          spec: {
+            name: "Subgraph Level 1",
+            implementation: {
+              graph: {
+                tasks: {
+                  "Task Level 2": {
+                    componentRef: {
+                      name: "Subgraph Level 2",
+                      digest: "level2-digest",
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      child_task_execution_ids: {
+        "Task Level 2": level2ExecutionId,
+      },
+      pipeline_run_id: "run-123",
+    };
+
+    const level2Details: GetExecutionInfoResponse = {
+      id: level2ExecutionId,
+      parent_execution_id: level1ExecutionId,
+      task_spec: {
+        componentRef: {
+          name: "Subgraph Level 2",
+          digest: "level2-digest",
+          spec: {
+            name: "Subgraph Level 2",
+            implementation: {
+              graph: {
+                tasks: {},
+              },
+            },
+          },
+        },
+      },
+      child_task_execution_ids: {},
+      pipeline_run_id: "run-123",
+    };
+
+    // The hook traverses backwards and caches execution details:
+    // 1. Fetch level2 details (gets parent_execution_id = level1)
+    // 2. Fetch level1 details (cached for subsequent calls)
+    // 3. Fetch root details
+    vi.spyOn(executionService, "fetchExecutionDetails").mockImplementation(
+      async (executionId: string) => {
+        if (executionId === level2ExecutionId) return level2Details;
+        if (executionId === level1ExecutionId) return level1Details;
+        if (executionId === rootExecutionId) return rootDetails;
+        throw new Error(`Unexpected execution ID: ${executionId}`);
+      },
+    );
+
+    const { result } = renderHook(
+      () => useSubgraphBreadcrumbs(rootExecutionId, level2ExecutionId),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.segments).toHaveLength(2);
+    expect(result.current.segments[0]).toMatchObject({
+      taskId: "Task Level 1",
+      executionId: level1ExecutionId,
+      taskName: "Subgraph Level 1",
+    });
+    expect(result.current.segments[1]).toMatchObject({
+      taskId: "Task Level 2",
+      executionId: level2ExecutionId,
+      taskName: "Subgraph Level 2",
+    });
+    expect(result.current.path).toEqual([
+      "root",
+      "Task Level 1",
+      "Task Level 2",
+    ]);
+  });
+});
+
+describe("buildExecutionUrl", () => {
+  it("should return root URL when subgraphExecutionId is undefined", () => {
+    const url = buildExecutionUrl("root-exec-123");
+    expect(url).toBe("/runs/root-exec-123");
+  });
+
+  it("should return root URL when subgraphExecutionId equals rootExecutionId", () => {
+    const rootExecutionId = "root-exec-123";
+    const url = buildExecutionUrl(rootExecutionId, rootExecutionId);
+    expect(url).toBe("/runs/root-exec-123");
+  });
+
+  it("should return nested URL when subgraphExecutionId is different", () => {
+    const rootExecutionId = "root-exec-123";
+    const subgraphExecutionId = "subgraph-exec-456";
+    const url = buildExecutionUrl(rootExecutionId, subgraphExecutionId);
+    expect(url).toBe("/runs/root-exec-123/subgraph-exec-456");
+  });
+});

--- a/src/hooks/useSubgraphBreadcrumbs.ts
+++ b/src/hooks/useSubgraphBreadcrumbs.ts
@@ -1,0 +1,123 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMemo } from "react";
+
+import { useBackend } from "@/providers/BackendProvider";
+import { fetchExecutionDetails } from "@/services/executionService";
+import { isGraphImplementationOutput } from "@/utils/componentSpec";
+import { ONE_MINUTE_IN_MS } from "@/utils/constants";
+
+export interface BreadcrumbSegment {
+  taskId: string;
+  executionId: string;
+  taskName: string;
+}
+
+interface SubgraphBreadcrumbsResult {
+  segments: BreadcrumbSegment[];
+  path: string[];
+  isLoading: boolean;
+  error: Error | null;
+}
+
+/**
+ * Traverses backwards from a subgraph execution ID to build the breadcrumb path
+ * by fetching parent execution details recursively until reaching the root.
+ */
+export const useSubgraphBreadcrumbs = (
+  rootExecutionId: string | undefined,
+  subgraphExecutionId: string | undefined,
+): SubgraphBreadcrumbsResult => {
+  const { backendUrl } = useBackend();
+  const queryClient = useQueryClient();
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["subgraph-breadcrumbs", rootExecutionId, subgraphExecutionId],
+    queryFn: async () => {
+      if (!rootExecutionId || !subgraphExecutionId) {
+        return { segments: [] };
+      }
+
+      if (subgraphExecutionId === rootExecutionId) {
+        return { segments: [] };
+      }
+
+      const segmentsInReverseOrder: BreadcrumbSegment[] = [];
+      let currentExecutionId = subgraphExecutionId;
+      let currentDetails = await queryClient.ensureQueryData({
+        queryKey: ["execution-details", currentExecutionId],
+        queryFn: () => fetchExecutionDetails(currentExecutionId, backendUrl),
+        staleTime: ONE_MINUTE_IN_MS,
+      });
+
+      while (currentExecutionId && currentExecutionId !== rootExecutionId) {
+        const parentExecutionId = currentDetails.parent_execution_id;
+
+        if (!parentExecutionId) {
+          break;
+        }
+
+        const parentDetails = await queryClient.ensureQueryData({
+          queryKey: ["execution-details", parentExecutionId],
+          queryFn: () => fetchExecutionDetails(parentExecutionId, backendUrl),
+          staleTime: ONE_MINUTE_IN_MS,
+        });
+
+        const taskIdInParent = Object.entries(
+          parentDetails.child_task_execution_ids || {},
+        ).find(([_, execId]) => execId === currentExecutionId)?.[0];
+
+        if (taskIdInParent) {
+          const implementation =
+            parentDetails.task_spec?.componentRef?.spec?.implementation;
+          let taskName = taskIdInParent;
+
+          if (isGraphImplementationOutput(implementation)) {
+            taskName =
+              implementation.graph.tasks?.[taskIdInParent]?.componentRef
+                ?.name || taskIdInParent;
+          }
+
+          segmentsInReverseOrder.push({
+            taskId: taskIdInParent,
+            executionId: currentExecutionId,
+            taskName,
+          });
+        }
+
+        currentExecutionId = parentExecutionId;
+        currentDetails = parentDetails;
+      }
+
+      const segments = segmentsInReverseOrder.reverse();
+
+      return { segments };
+    },
+    enabled:
+      !!rootExecutionId &&
+      !!subgraphExecutionId &&
+      rootExecutionId !== subgraphExecutionId,
+    staleTime: ONE_MINUTE_IN_MS,
+    retry: 1,
+  });
+
+  const segments = data?.segments || [];
+  const path = useMemo(() => {
+    return ["root", ...segments.map((seg) => seg.taskId)];
+  }, [segments]);
+
+  return {
+    segments,
+    path,
+    isLoading,
+    error: error as Error | null,
+  };
+};
+
+export const buildExecutionUrl = (
+  rootExecutionId: string,
+  subgraphExecutionId?: string,
+): string => {
+  return !subgraphExecutionId || subgraphExecutionId === rootExecutionId
+    ? `/runs/${rootExecutionId}`
+    : `/runs/${rootExecutionId}/${subgraphExecutionId}`;
+};

--- a/src/routes/PipelineRun/PipelineRun.test.tsx
+++ b/src/routes/PipelineRun/PipelineRun.test.tsx
@@ -16,6 +16,7 @@ vi.mock("@tanstack/react-router", async (importOriginal) => {
   return {
     ...(await importOriginal()),
     useNavigate: () => vi.fn(),
+    useParams: () => ({ id: "test-run-id-123" }),
     useLocation: () => ({
       pathname: "/runs/test-run-id-123",
       search: {},
@@ -30,9 +31,6 @@ vi.mock("@tanstack/react-router", async (importOriginal) => {
 });
 
 vi.mock("@/routes/router", () => ({
-  runDetailRoute: {
-    useParams: () => ({ id: "test-run-id-123" }),
-  },
   RUNS_BASE_PATH: "/runs",
 }));
 

--- a/src/routes/PipelineRun/PipelineRun.tsx
+++ b/src/routes/PipelineRun/PipelineRun.tsx
@@ -1,4 +1,5 @@
 import { DndContext } from "@dnd-kit/core";
+import { useParams } from "@tanstack/react-router";
 import { ReactFlowProvider } from "@xyflow/react";
 import { useEffect } from "react";
 
@@ -13,7 +14,6 @@ import {
   ExecutionDataProvider,
   useExecutionData,
 } from "@/providers/ExecutionDataProvider";
-import { type RunDetailParams, runDetailRoute } from "@/routes/router";
 import {
   countTaskStatuses,
   getRunStatus,
@@ -125,13 +125,27 @@ const PipelineRunContent = () => {
 };
 
 const PipelineRun = () => {
-  const { id } = runDetailRoute.useParams() as RunDetailParams;
+  const params = useParams({ strict: false });
+
+  if (!("id" in params) || typeof params.id !== "string") {
+    throw new Error("Missing required id parameter");
+  }
+
+  const id = params.id;
+  const subgraphExecutionId =
+    "subgraphExecutionId" in params &&
+    typeof params.subgraphExecutionId === "string"
+      ? params.subgraphExecutionId
+      : undefined;
 
   return (
     <div className="dndflow">
       <DndContext>
         <ReactFlowProvider>
-          <ExecutionDataProvider pipelineRunId={id}>
+          <ExecutionDataProvider
+            pipelineRunId={id}
+            subgraphExecutionId={subgraphExecutionId}
+          >
             <PipelineRunContent />
           </ExecutionDataProvider>
         </ReactFlowProvider>

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -31,6 +31,7 @@ export const APP_ROUTES = {
   QUICK_START: QUICK_START_PATH,
   PIPELINE_EDITOR: `${EDITOR_PATH}/$name`,
   RUN_DETAIL: `${RUNS_BASE_PATH}/$id`,
+  RUN_DETAIL_WITH_SUBGRAPH: `${RUNS_BASE_PATH}/$id/$subgraphExecutionId`,
   RUNS: RUNS_BASE_PATH,
   GITHUB_AUTH_CALLBACK: "/authorize/github",
 };
@@ -75,13 +76,15 @@ const githubAuthCallbackRoute = createRoute({
   component: AuthorizationResultScreen,
 });
 
-export interface RunDetailParams {
-  id: string;
-}
-
-export const runDetailRoute = createRoute({
+const runDetailRoute = createRoute({
   getParentRoute: () => mainLayout,
   path: APP_ROUTES.RUN_DETAIL,
+  component: PipelineRun,
+});
+
+const runDetailWithSubgraphRoute = createRoute({
+  getParentRoute: () => mainLayout,
+  path: APP_ROUTES.RUN_DETAIL_WITH_SUBGRAPH,
   component: PipelineRun,
 });
 
@@ -90,6 +93,7 @@ const appRouteTree = mainLayout.addChildren([
   quickStartRoute,
   editorRoute,
   runDetailRoute,
+  runDetailWithSubgraphRoute,
 ]);
 
 const rootRouteTree = rootRoute.addChildren([

--- a/src/utils/componentSpec.ts
+++ b/src/utils/componentSpec.ts
@@ -6,6 +6,11 @@
  * @copyright 2021 Alexey Volkov <alexey.volkov+oss@ark-kun.com>
  */
 
+import type {
+  ContainerImplementationOutput,
+  GraphImplementationOutput,
+} from "@/api/types.gen";
+
 export type TypeSpecType =
   | string
   | {
@@ -490,6 +495,19 @@ export const isContainerImplementation = (
 export const isGraphImplementation = (
   implementation: ImplementationType,
 ): implementation is GraphImplementation => "graph" in implementation;
+
+export const isGraphImplementationOutput = (
+  implementation:
+    | ContainerImplementationOutput
+    | GraphImplementationOutput
+    | null
+    | undefined,
+): implementation is GraphImplementationOutput =>
+  implementation !== null &&
+  implementation !== undefined &&
+  "graph" in implementation &&
+  implementation.graph !== null &&
+  implementation.graph !== undefined;
 
 export const isTaskOutputArgument = (
   arg: ArgumentType,

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -70,6 +70,8 @@ export const KEYBOARD_SHORTCUTS = {
 // Container exit codes
 export const EXIT_CODE_OOM = 137; // SIGKILL (128 + 9) - Out of Memory
 
+// Time constants
+export const ONE_MINUTE_IN_MS = 60 * 1000;
 export const TWENTY_FOUR_HOURS_IN_MS = 24 * 60 * 60 * 1000;
 
 export const ROOT_TASK_ID = "root";


### PR DESCRIPTION
## Description

Implemented subgraph navigation in pipeline runs with URL persistence. This allows users to navigate through nested subgraphs in pipeline runs while maintaining the navigation state in the URL, enabling direct linking to specific subgraphs.

Key changes:

- Added URL-based navigation for subgraphs in pipeline runs with a new route pattern `/runs/:id/:subgraphExecutionId`
- Created `useSubgraphBreadcrumbs` hook to build breadcrumb paths by traversing execution hierarchies
- Updated breadcrumb navigation to maintain URL state when navigating between subgraphs
- Modified task node double-click behaviour to update URLs when navigating into subgraphs
- Replaced Link component with button in PipelineRow for better control over navigation
- Added comprehensive tests for the new breadcrumb functionality

## Type of Change

- [x] New feature
- [x] Improvement

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Test Instructions

1. Run a pipeline with nested subgraphs
2. Navigate into a subgraph by double-clicking on it
3. Verify the URL updates to include the subgraph execution ID
4. Use breadcrumbs to navigate back up the hierarchy
5. Refresh the page and verify you remain at the same subgraph level
6. Copy the URL and open in a new tab to verify direct linking works
7. Confirm that the pipeline editor and subgraphs still work (you can't deep link to a pipeline)