### PR TITLE
Fix Duplicated and Disconnected Subgraph Outputs

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/callbacks/handleGroupNodes.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/callbacks/handleGroupNodes.ts
@@ -45,11 +45,8 @@ export const handleGroupNodes = async (
 
     if (!name) return;
 
-    const subgraphTaskSpec = await createSubgraphFromNodes(
-      selectedNodes,
-      currentSubgraphSpec,
-      name,
-    );
+    const { subgraphTask: subgraphTaskSpec, connectionMappings } =
+      await createSubgraphFromNodes(selectedNodes, currentSubgraphSpec, name);
 
     const position = calculateNodesCenter(selectedNodes);
     const { spec: currentSubgraphSpecWithNewTask, taskId: subgraphTaskId } =
@@ -60,14 +57,14 @@ export const handleGroupNodes = async (
       return;
     }
 
-    const selectedTaskIds = selectedNodes
-      .filter((node) => node.type === "task")
-      .map((node) => node.data.taskId as string);
+    const actualMappings = connectionMappings.map((mapping) => ({
+      ...mapping,
+      newTaskId: subgraphTaskId,
+    }));
 
     const updatedSubgraphSpec = updateDownstreamSubgraphConnections(
       currentSubgraphSpecWithNewTask,
-      selectedTaskIds,
-      subgraphTaskId,
+      actualMappings,
     );
 
     let finalSubgraphSpec = updatedSubgraphSpec;

--- a/src/utils/componentSpec.ts
+++ b/src/utils/componentSpec.ts
@@ -510,11 +510,11 @@ export const isGraphImplementationOutput = (
   implementation.graph !== undefined;
 
 export const isTaskOutputArgument = (
-  arg: ArgumentType,
+  arg?: ArgumentType,
 ): arg is TaskOutputArgument =>
   typeof arg === "object" && arg !== null && "taskOutput" in arg;
 
 export const isGraphInputArgument = (
-  arg: ArgumentType,
+  arg?: ArgumentType,
 ): arg is GraphInputArgument =>
   typeof arg === "object" && arg !== null && "graphInput" in arg;


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

Streamlines autoconnection logic and fixes two issues:

1. Duplicate/conflicting subgraph output names when multiple different task in the selection have same output name
2. Autoconnection failing when a task has multiple variations of the same output name (e.g. output 1, output 2)

This has been achieved by storing the existing connection info when the subgraph is generated and then passing that into the connectionr econfiguration function. Previously the reconfiguration function was iterating through the entire graph spec and trying to infer what was connected to the new subgraph - this worked fine except in scenarios where multiple outputs have the same name as it wouldn't know which one it's supposed to connect to.

As such,  `createSubgraphFromNodes`​ now outputs a `connectionmappings`​ object alongside the new subgraph task. This is then passed into `updateDownstreamSubgraphConnections`​as the sole source of truth for how the reconfiguration should be done. This means we can greatly simplify the remapping procedure and cut out the expensive nested looping of the graphspec.



## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

Follow up to #1289

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

Example setup:

![image.png](https://app.graphite.com/user-attachments/assets/f195ec17-baed-4ce5-a8c9-223a32e70bcd.png)

Before bugfixes:

![image.png](https://app.graphite.com/user-attachments/assets/95ef04dd-7369-4427-9f74-566fa34e2410.png)

After bugfixes:

![image.png](https://app.graphite.com/user-attachments/assets/2388bd26-fa8b-46d9-a41a-a43777847605.png)

More complex pipeline:

![image.png](https://app.graphite.com/user-attachments/assets/312c73a2-9282-46ee-9149-f7988cc1c715.png)

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

1. import or create a complex pipeline. The pipeline must have at least two different tasks with the same output name
2. create a subgraph with those tasks along the edge
3. new subgraph should be automatically generated with two outputs uniquely named (output, output 2) and connections should be automatically reconfigured
4. all other subgraph and connection functionality should remain the same

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->