### PR TITLE
Enables subgraphs by default

### DIFF
--- a/src/betaFlags.ts
+++ b/src/betaFlags.ts
@@ -11,7 +11,7 @@ export const ExistingBetaFlags = {
   ["remote-component-library-search"]: {
     name: "Published Components Library",
     description: "Enable the Published Components Library feature.",
-    default: false,
+    default: true,
   } as BetaFlag,
 
   ["redirect-on-new-pipeline-run"]: {
@@ -38,7 +38,7 @@ export const ExistingBetaFlags = {
     name: "Subgraph Navigation",
     description:
       "⚠️ Experimental ⚠️ feature for viewing subgraphs. Navigate into nested pipeline components by double-clicking.",
-    default: false,
+    default: true,
   } as BetaFlag,
 
   ["partial-selection"]: {


### PR DESCRIPTION
## Description

Enable Subgraph Navigation by default. This change sets the default value of the "Subgraph Navigation" beta flag from `false` to `true`, making the experimental feature for viewing subgraphs available to all users without requiring them to manually enable it.

## Related Issue and Pull requests

## Type of Change

- [x] Improvement
- [x] New feature

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Test Instructions

Verify that users can now navigate into nested pipeline components by double-clicking without needing to enable the beta flag manually.

## Additional Comments

This feature allows users to explore subgraphs more intuitively by double-clicking on nested components.