### PR TITLE
fix: e2e tests

### DIFF
--- a/tests/e2e/flowcanvas.spec.ts
+++ b/tests/e2e/flowcanvas.spec.ts
@@ -7,6 +7,7 @@ import {
   fitToView,
   locateFlowCanvas,
   locateFlowViewport,
+  openComponentLibFolder,
   panCanvas,
   waitForContextPanel,
   zoomIn,
@@ -45,6 +46,7 @@ test.describe("FlowCanvas Basic Functionality", () => {
   }) => {
     // Create new pipeline and wait for it to load
     await createNewPipeline(page);
+    await openComponentLibFolder(page, "Standard library");
 
     // Add a component from the Quick start library
     const node = await dropComponentFromLibraryOnCanvas(
@@ -70,6 +72,7 @@ test.describe("FlowCanvas Basic Functionality", () => {
   }) => {
     // Create new pipeline and wait for it to load
     await createNewPipeline(page);
+    await openComponentLibFolder(page, "Standard library");
 
     // Add a component from the Quick start library
     const nodeA = await dropComponentFromLibraryOnCanvas(


### PR DESCRIPTION
## Description

Added a call to `openComponentLibFolder` with "Standard library" parameter in two test cases within the FlowCanvas Basic Functionality test suite. This ensures the Standard library folder is explicitly opened before attempting to drop components from the library onto the canvas.

## Related Issue and Pull requests

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Test Instructions

Run the e2e tests for the FlowCanvas functionality to verify that components can be properly dropped from the Standard library onto the canvas.