### PR TITLE
Normalize input values

### DIFF
--- a/src/utils/nodes/createSubgraphFromNodes.ts
+++ b/src/utils/nodes/createSubgraphFromNodes.ts
@@ -259,6 +259,8 @@ const processSelectedInputNodes = (
 
     if (originalInputSpec?.value) {
       subgraphArguments[inputName] = originalInputSpec.value;
+    } else if (originalInputSpec?.default) {
+      subgraphArguments[inputName] = originalInputSpec.default;
     }
   });
 };


### PR DESCRIPTION
## Description

This PR enhances input handling in pipeline submissions by automatically using default values when explicit values are missing. The implementation:

1. Adds a new `normalizeInputValues` function that recursively processes component specs to copy default values to the value field when no value is provided
2. Updates `createSubgraphFromNodes.ts` to use default values for subgraph arguments when available
3. Adds comprehensive tests to verify the normalization behavior in various scenarios

## Type of Change

- [x] Improvement
- [x] Bug fix

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Test Instructions

1. Create a pipeline with components that have default values for inputs
2. Submit the pipeline without explicitly setting values for those inputs
3. Verify that the default values are correctly used in the pipeline run