### PR TITLE
Subgraphs use default when no value from inputs

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/utils/getArgumentsFromInputs.test.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/utils/getArgumentsFromInputs.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it } from "vitest";
+
+import type { ComponentSpec } from "@/utils/componentSpec";
+
+import { getArgumentsFromInputs } from "./getArgumentsFromInputs";
+
+describe("getArgumentsFromInputs", () => {
+  it("should return empty object when no inputs are defined", () => {
+    const componentSpec: ComponentSpec = {
+      name: "test-component",
+      implementation: { container: { image: "test:latest" } },
+    };
+
+    const result = getArgumentsFromInputs(componentSpec);
+
+    expect(result).toEqual({});
+  });
+
+  it("should return arguments for inputs with values", () => {
+    const componentSpec: ComponentSpec = {
+      name: "test-component",
+      inputs: [
+        {
+          name: "input1",
+          value: "value1",
+        },
+        {
+          name: "input2",
+          value: "value2",
+        },
+      ],
+      implementation: { container: { image: "test:latest" } },
+    };
+
+    const result = getArgumentsFromInputs(componentSpec);
+
+    expect(result).toEqual({
+      input1: "value1",
+      input2: "value2",
+    });
+  });
+
+  it("should use default value when value is not provided", () => {
+    const componentSpec: ComponentSpec = {
+      name: "test-component",
+      inputs: [
+        {
+          name: "input1",
+          default: "default1",
+        },
+        {
+          name: "input2",
+          default: "default2",
+        },
+      ],
+      implementation: { container: { image: "test:latest" } },
+    };
+
+    const result = getArgumentsFromInputs(componentSpec);
+
+    expect(result).toEqual({
+      input1: "default1",
+      input2: "default2",
+    });
+  });
+
+  it("should prefer value over default when both are provided", () => {
+    const componentSpec: ComponentSpec = {
+      name: "test-component",
+      inputs: [
+        {
+          name: "input1",
+          value: "explicit-value",
+          default: "default-value",
+        },
+      ],
+      implementation: { container: { image: "test:latest" } },
+    };
+
+    const result = getArgumentsFromInputs(componentSpec);
+
+    expect(result).toEqual({
+      input1: "explicit-value",
+    });
+  });
+
+  it("should handle mix of inputs with values, defaults, and neither", () => {
+    const componentSpec: ComponentSpec = {
+      name: "test-component",
+      inputs: [
+        {
+          name: "input1",
+          value: "value1",
+        },
+        {
+          name: "input2",
+          default: "default2",
+        },
+        {
+          name: "input3",
+        },
+        {
+          name: "input4",
+          value: "value4",
+          default: "default4",
+        },
+      ],
+      implementation: { container: { image: "test:latest" } },
+    };
+
+    const result = getArgumentsFromInputs(componentSpec);
+
+    expect(result).toEqual({
+      input1: "value1",
+      input2: "default2",
+      input4: "value4",
+    });
+  });
+
+  it("should exclude inputs with undefined value and no default", () => {
+    const componentSpec: ComponentSpec = {
+      name: "test-component",
+      inputs: [
+        {
+          name: "input1",
+        },
+        {
+          name: "input2",
+          value: undefined,
+        },
+      ],
+      implementation: { container: { image: "test:latest" } },
+    };
+
+    const result = getArgumentsFromInputs(componentSpec);
+
+    expect(result).toEqual({});
+  });
+
+  it("should exclude inputs with null value and no default", () => {
+    const componentSpec: ComponentSpec = {
+      name: "test-component",
+      inputs: [
+        {
+          name: "input1",
+          value: null as any,
+        },
+      ],
+      implementation: { container: { image: "test:latest" } },
+    };
+
+    const result = getArgumentsFromInputs(componentSpec);
+
+    expect(result).toEqual({});
+  });
+
+  it("should include empty string values", () => {
+    const componentSpec: ComponentSpec = {
+      name: "test-component",
+      inputs: [
+        {
+          name: "input1",
+          value: "",
+        },
+        {
+          name: "input2",
+          default: "",
+        },
+      ],
+      implementation: { container: { image: "test:latest" } },
+    };
+
+    const result = getArgumentsFromInputs(componentSpec);
+
+    expect(result).toEqual({
+      input1: "",
+      input2: "",
+    });
+  });
+
+  it("should handle real-world subgraph scenario", () => {
+    // Simulating a subgraph where input nodes have defaults but no explicit values
+    const componentSpec: ComponentSpec = {
+      name: "financial_data_processor",
+      inputs: [
+        {
+          name: "pdf_url",
+          type: "String",
+          default: "https://example.com/report.pdf",
+        },
+        {
+          name: "days_ahead",
+          type: "Integer",
+          default: "30",
+          optional: true,
+        },
+        {
+          name: "prediction_column_name",
+          type: "String",
+          default: "predicted_value",
+        },
+      ],
+      implementation: {
+        graph: {
+          tasks: {},
+        },
+      },
+    };
+
+    const result = getArgumentsFromInputs(componentSpec);
+
+    expect(result).toEqual({
+      pdf_url: "https://example.com/report.pdf",
+      days_ahead: "30",
+      prediction_column_name: "predicted_value",
+    });
+  });
+});
+

--- a/src/components/shared/ReactFlow/FlowCanvas/utils/getArgumentsFromInputs.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/utils/getArgumentsFromInputs.ts
@@ -1,9 +1,10 @@
 import type { ComponentSpec } from "@/utils/componentSpec";
 
 /**
- * Generates arguments object from component spec inputs that have values
+ * Generates arguments object from component spec inputs that have values or defaults.
+ * Falls back to default if value is not provided.
  * @param componentSpec - The component specification containing inputs
- * @returns Object with input names as keys and their values as values
+ * @returns Object with input names as keys and their values/defaults as values
  */
 export const getArgumentsFromInputs = (
   componentSpec: ComponentSpec,
@@ -15,8 +16,9 @@ export const getArgumentsFromInputs = (
   }
 
   for (const input of componentSpec.inputs) {
-    if (input.value !== undefined && input.value !== null) {
-      args[input.name] = input.value;
+    const inputValue = input.value ?? input.default;
+    if (inputValue !== undefined && inputValue !== null) {
+      args[input.name] = inputValue;
     }
   }
 

--- a/src/utils/nodes/createSubgraphFromNodes.ts
+++ b/src/utils/nodes/createSubgraphFromNodes.ts
@@ -252,13 +252,14 @@ const processSelectedInputNodes = (
       },
     });
 
-    // Migrate the Input Node value to the subgraph arguments
+    // Migrate the Input Node value or default to the subgraph arguments
     const originalInputSpec = currentComponentSpec.inputs?.find(
       (input) => input.name === inputName,
     );
 
-    if (originalInputSpec?.value) {
-      subgraphArguments[inputName] = originalInputSpec.value;
+    const inputValue = originalInputSpec?.value ?? originalInputSpec?.default;
+    if (inputValue) {
+      subgraphArguments[inputName] = inputValue;
     }
   });
 };


### PR DESCRIPTION
## Description

Enhance `getArgumentsFromInputs` to use default values when explicit values are not provided. This improves handling of component inputs by falling back to defaults, ensuring more consistent behavior in subgraphs. Added comprehensive test coverage for the utility function and updated the subgraph creation logic to also consider default values.

## Type of Change

- [x] Improvement
- [x] Bug fix

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Test Instructions

1. Create a component with inputs that have default values but no explicit values
2. Verify that the default values are correctly used when generating arguments
3. Create a subgraph from nodes with input components that have default values
4. Verify that the default values are correctly propagated to the subgraph arguments