### PR TITLE
Fix Shift+Click on Canvas Selecting Text in Panels

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
@@ -227,15 +227,26 @@ const FlowCanvas = ({
     }
   }, []);
 
+  const handleMouseDown = useCallback((event: MouseEvent) => {
+    if (event.shiftKey && event.target instanceof HTMLElement) {
+      const reactFlowWrapper = event.target.closest(".react-flow");
+      if (reactFlowWrapper) {
+        event.preventDefault();
+      }
+    }
+  }, []);
+
   useEffect(() => {
     document.addEventListener("keydown", handleKeyDown);
     document.addEventListener("keyup", handleKeyUp);
+    document.addEventListener("mousedown", handleMouseDown);
 
     return () => {
       document.removeEventListener("keydown", handleKeyDown);
       document.removeEventListener("keyup", handleKeyUp);
+      document.removeEventListener("mousedown", handleMouseDown);
     };
-  }, [handleKeyDown, handleKeyUp]);
+  }, [handleKeyDown, handleKeyUp, handleMouseDown]);
 
   const [reactFlowInstance, setReactFlowInstance] =
     useState<ReactFlowInstance>();


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Fixes an issue where if the previous selection or active element was inside the sidebar or context panel a shift + click operation on the canvas would select content in that panel instead of on the canvas.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

HOW TO REPRODUCE THE ORIGINAL BUG
go on master branch:
1. click inside the sidebar or context panel
2. shift + drag to select nodes on the canvas
3. text in the panel you click on should be selected

bad!

HOW TO TEST THAT IT'S FIXED
switch to the branch for this PR
1. repeat the steps above
2. text in the panel should no longer get selected - only the nodes you've chosen

good!

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
