### PR TITLE
select mode partial

### DIFF
--- a/src/betaFlags.ts
+++ b/src/betaFlags.ts
@@ -40,4 +40,11 @@ export const ExistingBetaFlags = {
       "⚠️ Experimental ⚠️ feature for viewing subgraphs. Navigate into nested pipeline components by double-clicking.",
     default: false,
   } as BetaFlag,
+
+  ["partial-selection"]: {
+    name: "Partial Node Selection",
+    description:
+      "Allow nodes to be selected when partially covered by the selection box. Use Shift+drag for full selection, or Shift+Cmd+drag (Shift+Ctrl on Windows) for partial selection.",
+    default: false,
+  } as BetaFlag,
 };

--- a/src/components/shared/ReactFlow/FlowCanvas/utils/getArgumentsFromInputs.test.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/utils/getArgumentsFromInputs.test.ts
@@ -216,4 +216,3 @@ describe("getArgumentsFromInputs", () => {
     });
   });
 });
-


### PR DESCRIPTION
## Description

Added a new beta flag "partial-selection" that enables partial node selection in the FlowCanvas. When enabled, users can select nodes that are partially covered by the selection box, rather than requiring nodes to be fully contained within the selection area.

The feature works with keyboard modifiers:
- Normal drag: Full selection (nodes must be completely inside selection box)
- Shift+Cmd+drag (or Shift+Ctrl on Windows): Partial selection (nodes can be partially inside selection box)

## Type of Change

- [x] Improvement

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Test Instructions

1. Enable the "Partial Node Selection" beta flag
2. Create a pipeline with multiple nodes
3. Try selecting nodes using different selection methods:
   - Regular drag: Only fully contained nodes are selected
   - Shift+Cmd+drag (Mac) or Shift+Ctrl+drag (Windows): Nodes partially covered by selection box are also selected