### PR TITLE
UndoRedo now saves Metadata alongside the History Stack

### DIFF
--- a/src/providers/ComponentSpecProvider.tsx
+++ b/src/providers/ComponentSpecProvider.tsx
@@ -1,3 +1,4 @@
+import equal from "fast-deep-equal";
 import { type ReactNode, useCallback, useMemo, useRef, useState } from "react";
 
 import { type UndoRedo, useUndoRedo } from "@/hooks/useUndoRedo";
@@ -79,7 +80,14 @@ export const ComponentSpecProvider = ({
     "root",
   ]);
 
-  const undoRedo = useUndoRedo(componentSpec, setComponentSpec);
+  const undoRedo = useUndoRedo(componentSpec, setComponentSpec, {
+    getMetadata: () => ({ subgraphPath: currentSubgraphPath }),
+    onMetadataRestore: (metadata: { subgraphPath: string[] }) => {
+      if (!equal(metadata.subgraphPath, currentSubgraphPath)) {
+        setCurrentSubgraphPath(metadata.subgraphPath);
+      }
+    },
+  });
   const undoRedoRef = useRef(undoRedo);
   undoRedoRef.current = undoRedo;
 


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Adds an optional metadata section to entries in the Undo/Redo history stack. if provided, the undo/redo hook will now take a snapshot of whatever metadata when an update is processed. It will then provide this metadata alongside the actual updated object when undo or redo is called.

This is used to record the subgraph path of each saved action such that when undoing or redoing changes the viewport will take you to the relevant spot in the subgraphs. Notably, this fixes the issue where you can create a subgraph, navigate inside it and then undo it and end up with a confused UI (because the subgraph no longer exists but you're somehow still inside it).

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->
Closes https://github.com/Shopify/oasis-frontend/issues/335

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->
1. Create a subgraph
2. Navigate inside it
3. Undo
4. You should be taken back outside the subgraph


Similarly
1. Make a change within a subgraph
2. Undo - you should be taken back to the view you were at before making that change
3. Redo - you should be taken back inside the subgraph and can see your change 

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
