### PR TITLE
Warning for Orphaned Nodes on Subgraph Creation

### DIFF
--- a/src/components/shared/Dialogs/InputDialog.tsx
+++ b/src/components/shared/Dialogs/InputDialog.tsx
@@ -60,11 +60,14 @@ export function InputDialog({
   };
 
   const handleKeyDown = (e: KeyboardEvent) => {
-    if (e.key === "Enter" && value.trim()) {
-      handleConfirm();
-    }
     if (e.key === "Escape") {
       onCancel?.();
+    }
+
+    if (disabled) return;
+
+    if (e.key === "Enter" && value.trim()) {
+      handleConfirm();
     }
   };
 

--- a/src/components/shared/ReactFlow/FlowCanvas/Subgraphs/NodeListItem.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/Subgraphs/NodeListItem.tsx
@@ -1,0 +1,35 @@
+import { type Node } from "@xyflow/react";
+
+import { Badge } from "@/components/ui/badge";
+import { Icon } from "@/components/ui/icon";
+import { InlineStack } from "@/components/ui/layout";
+import { Paragraph } from "@/components/ui/typography";
+import { cn } from "@/lib/utils";
+
+import { getNodeTypeColor } from "./utils";
+
+interface NodeListItemProps {
+  node: Node;
+  isOrphaned?: boolean;
+}
+
+export function NodeListItem({ node, isOrphaned }: NodeListItemProps) {
+  return (
+    <li key={node.id} className="flex justify-between items-center">
+      <InlineStack gap="3" blockAlign="center" wrap="nowrap">
+        <Badge variant="dot" className={cn(getNodeTypeColor(node.type))} />
+        <Paragraph font="mono" size="xs">
+          {node.id}
+        </Paragraph>
+        {isOrphaned && (
+          <InlineStack gap="1" blockAlign="center" wrap="nowrap">
+            <Icon name="TriangleAlert" className="text-destructive" />
+            <Paragraph size="xs" className="text-destructive">
+              Orphaned
+            </Paragraph>
+          </InlineStack>
+        )}
+      </InlineStack>
+    </li>
+  );
+}

--- a/src/components/shared/ReactFlow/FlowCanvas/Subgraphs/NodesList.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/Subgraphs/NodesList.tsx
@@ -8,18 +8,19 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
-import { Paragraph } from "@/components/ui/typography";
 import { cn } from "@/lib/utils";
 
-import { getNodeTypeColor } from "./utils";
+import { NodeListItem } from "./NodeListItem";
 
 interface NodesListProps {
   nodes: Node[];
+  orphanedNodeIds?: Set<string>;
   title?: string;
 }
 
 export function NodesList({
   nodes,
+  orphanedNodeIds,
   title = `View nodes (${nodes.length})`,
 }: NodesListProps) {
   const [isOpen, setIsOpen] = useState(false);
@@ -29,7 +30,7 @@ export function NodesList({
   }
 
   return (
-    <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+    <Collapsible open={isOpen} onOpenChange={setIsOpen} className="w-full">
       <CollapsibleTrigger asChild>
         <Button variant="ghost">
           <ChevronRight
@@ -45,17 +46,11 @@ export function NodesList({
         <div className="rounded-md border p-3 bg-secondary/50 max-h-[50vh] overflow-auto">
           <ul className="space-y-2 text-sm">
             {nodes.map((node) => (
-              <li key={node.id} className="flex items-center gap-3">
-                <span
-                  className={cn(
-                    "w-2 h-2 rounded-full",
-                    getNodeTypeColor(node.type),
-                  )}
-                />
-                <Paragraph font="mono" size="xs">
-                  {node.id}
-                </Paragraph>
-              </li>
+              <NodeListItem
+                key={node.id}
+                node={node}
+                isOrphaned={orphanedNodeIds?.has(node.id)}
+              />
             ))}
           </ul>
         </div>

--- a/src/components/shared/ReactFlow/FlowCanvas/Subgraphs/OrphanedNodeList.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/Subgraphs/OrphanedNodeList.tsx
@@ -1,0 +1,35 @@
+import { type Node } from "@xyflow/react";
+
+import { InfoBox } from "@/components/shared/InfoBox";
+import { Paragraph } from "@/components/ui/typography";
+
+import { NodeListItem } from "./NodeListItem";
+
+interface OrphanedNodeListProps {
+  nodes: Node[];
+}
+
+export function OrphanedNodeList({ nodes }: OrphanedNodeListProps) {
+  if (nodes.length === 0) {
+    return null;
+  }
+
+  return (
+    <InfoBox
+      className="mt-4"
+      title="Orphaned Nodes"
+      variant="error"
+      width="full"
+    >
+      <Paragraph className="mb-4" size="sm">
+        These nodes are not connected to anything else in the selection. Exclude
+        them to create a valid subgraph.
+      </Paragraph>
+      <ul className="space-y-2 text-sm">
+        {nodes.map((node) => (
+          <NodeListItem key={node.id} node={node} />
+        ))}
+      </ul>
+    </InfoBox>
+  );
+}

--- a/src/components/shared/ReactFlow/FlowCanvas/Subgraphs/checkForOrphanedNodes.test.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/Subgraphs/checkForOrphanedNodes.test.ts
@@ -1,0 +1,460 @@
+// checkForOrphanedNodes.test.ts
+import type { Node } from "@xyflow/react";
+import { describe, expect, it } from "vitest";
+
+import type {
+  ComponentSpec,
+  GraphSpec,
+  InputSpec,
+} from "@/utils/componentSpec";
+
+import { checkForOrphanedNodes } from "./checkForOrphanedNodes";
+
+// Helper functions
+const createNode = (
+  id: string,
+  type: "task" | "input" | "output",
+  data: Record<string, any> = {},
+): Node => ({
+  id,
+  type,
+  position: { x: 0, y: 0 },
+  data,
+});
+
+const createTaskNode = (id: string, taskId: string): Node =>
+  createNode(id, "task", { taskId });
+
+const createInputNode = (id: string, label: string): Node =>
+  createNode(id, "input", { label });
+
+const createOutputNode = (id: string, label: string): Node =>
+  createNode(id, "output", { label });
+
+const createGraphSpec = (
+  tasks: GraphSpec["tasks"] = {},
+  inputs: InputSpec[] = [],
+  outputValues: GraphSpec["outputValues"] = {},
+): ComponentSpec => ({
+  name: "test-component",
+  description: "Test component",
+  implementation: {
+    graph: {
+      tasks,
+      outputValues,
+    },
+  },
+  inputs,
+});
+
+// Tests
+describe("checkForOrphanedNodes", () => {
+  describe("empty spec", () => {
+    it("should return empty array when no nodes are selected", () => {
+      const spec = createGraphSpec();
+      const selectedNodes: Node[] = [];
+
+      const result = checkForOrphanedNodes(selectedNodes, spec);
+
+      expect(result).toEqual([]);
+    });
+
+    it("should return all nodes as orphaned when spec has no connections", () => {
+      const spec = createGraphSpec();
+      const selectedNodes = [
+        createTaskNode("task-1", "task1"),
+        createInputNode("input-1", "input1"),
+        createOutputNode("output-1", "output1"),
+      ];
+
+      const result = checkForOrphanedNodes(selectedNodes, spec);
+
+      expect(result).toHaveLength(3);
+      expect(result.map((n) => n.id)).toEqual([
+        "task-1",
+        "input-1",
+        "output-1",
+      ]);
+    });
+  });
+
+  describe("clean spec (no orphans)", () => {
+    it("should return no orphans when all tasks are connected via task outputs", () => {
+      const spec = createGraphSpec({
+        task1: {
+          componentRef: { name: "test-component" },
+          arguments: {},
+        },
+        task2: {
+          componentRef: { name: "test-component" },
+          arguments: {
+            input1: {
+              taskOutput: {
+                taskId: "task1",
+                outputName: "result",
+              },
+            },
+          },
+        },
+      });
+
+      const selectedNodes = [
+        createTaskNode("task-1", "task1"),
+        createTaskNode("task-2", "task2"),
+      ];
+
+      const result = checkForOrphanedNodes(selectedNodes, spec);
+
+      expect(result).toEqual([]);
+    });
+
+    it("should return no orphans when task is connected to input", () => {
+      const spec = createGraphSpec(
+        {
+          task1: {
+            componentRef: { name: "test-component" },
+            arguments: {
+              input1: {
+                graphInput: {
+                  inputName: "myInput",
+                },
+              },
+            },
+          },
+        },
+        [{ name: "myInput", type: "string" }],
+      );
+
+      const selectedNodes = [
+        createInputNode("input-1", "myInput"),
+        createTaskNode("task-1", "task1"),
+      ];
+
+      const result = checkForOrphanedNodes(selectedNodes, spec);
+
+      expect(result).toEqual([]);
+    });
+
+    it("should return no orphans when output is connected to task", () => {
+      const spec = createGraphSpec(
+        {
+          task1: {
+            componentRef: { name: "test-component" },
+            arguments: {},
+          },
+        },
+        [],
+        {
+          myOutput: {
+            taskOutput: {
+              taskId: "task1",
+              outputName: "result",
+            },
+          },
+        },
+      );
+
+      const selectedNodes = [
+        createTaskNode("task-1", "task1"),
+        createOutputNode("output-1", "myOutput"),
+      ];
+
+      const result = checkForOrphanedNodes(selectedNodes, spec);
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("one orphaned node", () => {
+    it("should return one orphaned task when it has no connections", () => {
+      const spec = createGraphSpec({
+        task1: {
+          componentRef: { name: "test-component" },
+          arguments: {},
+        },
+        task2: {
+          componentRef: { name: "test-component" },
+          arguments: {
+            input1: {
+              taskOutput: {
+                taskId: "task1",
+                outputName: "result",
+              },
+            },
+          },
+        },
+        task3: {
+          componentRef: { name: "test-component" },
+          arguments: {}, // Orphaned - no connections
+        },
+      });
+
+      const selectedNodes = [
+        createTaskNode("task-1", "task1"),
+        createTaskNode("task-2", "task2"),
+        createTaskNode("task-3", "task3"), // This will be orphaned
+      ];
+
+      const result = checkForOrphanedNodes(selectedNodes, spec);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe("task-3");
+    });
+
+    it("should return one orphaned input when no task uses it", () => {
+      const spec = createGraphSpec(
+        {
+          task1: {
+            componentRef: { name: "test-component" },
+            arguments: {
+              input1: {
+                graphInput: {
+                  inputName: "usedInput",
+                },
+              },
+            },
+          },
+        },
+        [
+          { name: "usedInput", type: "string" },
+          { name: "unusedInput", type: "string" },
+        ],
+      );
+
+      const selectedNodes = [
+        createInputNode("input-1", "usedInput"),
+        createInputNode("input-2", "unusedInput"), // This will be orphaned
+        createTaskNode("task-1", "task1"),
+      ];
+
+      const result = checkForOrphanedNodes(selectedNodes, spec);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe("input-2");
+    });
+  });
+
+  describe("multiple orphaned nodes", () => {
+    it("should return three orphaned nodes", () => {
+      const spec = createGraphSpec({
+        task1: {
+          componentRef: { name: "test-component" },
+          arguments: {
+            input1: {
+              taskOutput: {
+                taskId: "task2",
+                outputName: "result",
+              },
+            },
+          },
+        },
+        task2: {
+          componentRef: { name: "test-component" },
+          arguments: {},
+        },
+        task3: {
+          componentRef: { name: "test-component" },
+          arguments: {}, // Orphaned
+        },
+        task4: {
+          componentRef: { name: "test-component" },
+          arguments: {}, // Orphaned
+        },
+        task5: {
+          componentRef: { name: "test-component" },
+          arguments: {}, // Orphaned
+        },
+      });
+
+      const selectedNodes = [
+        createTaskNode("task-1", "task1"),
+        createTaskNode("task-2", "task2"),
+        createTaskNode("task-3", "task3"), // Orphaned
+        createTaskNode("task-4", "task4"), // Orphaned
+        createTaskNode("task-5", "task5"), // Orphaned
+      ];
+
+      const result = checkForOrphanedNodes(selectedNodes, spec);
+
+      expect(result).toHaveLength(3);
+      expect(result.map((n) => n.id).sort()).toEqual([
+        "task-3",
+        "task-4",
+        "task-5",
+      ]);
+    });
+  });
+
+  describe("multiple isolated sets of connected nodes", () => {
+    it("should return no orphans when there are multiple isolated but internally connected groups", () => {
+      const spec = createGraphSpec(
+        {
+          // First connected group: input1 -> task1 -> task2 -> output1
+          task1: {
+            componentRef: { name: "test-component" },
+            arguments: {
+              input1: {
+                graphInput: {
+                  inputName: "input1",
+                },
+              },
+            },
+          },
+          task2: {
+            componentRef: { name: "test-component" },
+            arguments: {
+              input1: {
+                taskOutput: {
+                  taskId: "task1",
+                  outputName: "result",
+                },
+              },
+            },
+          },
+          // Second connected group: input2 -> task3 -> task4 -> output2
+          task3: {
+            componentRef: { name: "test-component" },
+            arguments: {
+              input1: {
+                graphInput: {
+                  inputName: "input2",
+                },
+              },
+            },
+          },
+          task4: {
+            componentRef: { name: "test-component" },
+            arguments: {
+              input1: {
+                taskOutput: {
+                  taskId: "task3",
+                  outputName: "result",
+                },
+              },
+            },
+          },
+        },
+        [
+          { name: "input1", type: "string" },
+          { name: "input2", type: "string" },
+        ],
+        {
+          output1: {
+            taskOutput: {
+              taskId: "task2",
+              outputName: "result",
+            },
+          },
+          output2: {
+            taskOutput: {
+              taskId: "task4",
+              outputName: "result",
+            },
+          },
+        },
+      );
+
+      const selectedNodes = [
+        // First group
+        createInputNode("input-1", "input1"),
+        createTaskNode("task-1", "task1"),
+        createTaskNode("task-2", "task2"),
+        createOutputNode("output-1", "output1"),
+        // Second group
+        createInputNode("input-2", "input2"),
+        createTaskNode("task-3", "task3"),
+        createTaskNode("task-4", "task4"),
+        createOutputNode("output-2", "output2"),
+      ];
+
+      const result = checkForOrphanedNodes(selectedNodes, spec);
+
+      expect(result).toEqual([]);
+    });
+
+    it("should return no orphans for a single connected chain", () => {
+      const spec = createGraphSpec(
+        {
+          task1: {
+            componentRef: { name: "test-component" },
+            arguments: {
+              input1: {
+                graphInput: {
+                  inputName: "myInput",
+                },
+              },
+            },
+          },
+          task2: {
+            componentRef: { name: "test-component" },
+            arguments: {
+              input1: {
+                taskOutput: {
+                  taskId: "task1",
+                  outputName: "result",
+                },
+              },
+            },
+          },
+          task3: {
+            componentRef: { name: "test-component" },
+            arguments: {
+              input1: {
+                taskOutput: {
+                  taskId: "task2",
+                  outputName: "result",
+                },
+              },
+            },
+          },
+        },
+        [{ name: "myInput", type: "string" }],
+        {
+          myOutput: {
+            taskOutput: {
+              taskId: "task3",
+              outputName: "result",
+            },
+          },
+        },
+      );
+
+      const selectedNodes = [
+        createInputNode("input-1", "myInput"),
+        createTaskNode("task-1", "task1"),
+        createTaskNode("task-2", "task2"),
+        createTaskNode("task-3", "task3"),
+        createOutputNode("output-1", "myOutput"),
+      ];
+
+      const result = checkForOrphanedNodes(selectedNodes, spec);
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("non-graph implementation", () => {
+    it("should return empty array for non-graph implementation", () => {
+      const spec: ComponentSpec = {
+        name: "test-component",
+        description: "Test component",
+        implementation: {
+          container: {
+            image: "python:3.9",
+            command: ["python"],
+            args: ["-c", "print('hello')"],
+          },
+        },
+      };
+
+      const selectedNodes = [
+        createTaskNode("task-1", "task1"),
+        createInputNode("input-1", "input1"),
+      ];
+
+      const result = checkForOrphanedNodes(selectedNodes, spec);
+
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/src/components/shared/ReactFlow/FlowCanvas/Subgraphs/checkForOrphanedNodes.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/Subgraphs/checkForOrphanedNodes.ts
@@ -1,0 +1,105 @@
+import type { Node } from "@xyflow/react";
+
+import type { ArgumentType, ComponentSpec } from "@/utils/componentSpec";
+import {
+  isGraphImplementation,
+  isGraphInputArgument,
+  isTaskOutputArgument,
+} from "@/utils/componentSpec";
+
+export const checkForOrphanedNodes = (
+  selectedNodes: Node[],
+  componentSpec: ComponentSpec,
+) => {
+  if (!isGraphImplementation(componentSpec.implementation)) {
+    return [];
+  }
+
+  const currentGraphSpec = componentSpec.implementation.graph;
+
+  const taskNodesByTaskId = new Map<string, Node>();
+  const inputNodesByName = new Map<string, Node>();
+  const selectedTaskIds = new Set<string>();
+  const selectedInputNames = new Set<string>();
+
+  selectedNodes.forEach((node) => {
+    if (node.type === "task") {
+      const taskId = node.data.taskId;
+      if (taskId && typeof taskId === "string") {
+        taskNodesByTaskId.set(taskId, node);
+        selectedTaskIds.add(taskId);
+      }
+    } else if (node.type === "input") {
+      const inputName = node.data.label;
+      if (inputName && typeof inputName === "string") {
+        inputNodesByName.set(inputName, node);
+        selectedInputNames.add(inputName);
+      }
+    }
+  });
+
+  const connectedNodeIds = new Set<string>();
+
+  selectedNodes
+    .filter(
+      (node): node is Node & { type: "task"; data: { taskId: string } } =>
+        node.type === "task",
+    )
+    .forEach((taskNode) => {
+      const taskId = taskNode.data.taskId;
+      const task = currentGraphSpec.tasks[taskId];
+
+      if (!task?.arguments) return;
+
+      // Check each argument to see if it connects to another selected node
+      Object.values(task.arguments).forEach((argument: ArgumentType) => {
+        if (isTaskOutputArgument(argument)) {
+          const sourceTaskId = argument.taskOutput.taskId;
+          if (selectedTaskIds.has(sourceTaskId)) {
+            connectedNodeIds.add(taskNode.id);
+            const sourceTaskNode = taskNodesByTaskId.get(sourceTaskId);
+            if (sourceTaskNode) {
+              connectedNodeIds.add(sourceTaskNode.id);
+            }
+          }
+        } else if (isGraphInputArgument(argument)) {
+          const inputName = argument.graphInput.inputName;
+          if (selectedInputNames.has(inputName)) {
+            connectedNodeIds.add(taskNode.id);
+            const inputNode = inputNodesByName.get(inputName);
+            if (inputNode) {
+              connectedNodeIds.add(inputNode.id);
+            }
+          }
+        }
+      });
+    });
+
+  // Check output node connections within the selection
+  selectedNodes
+    .filter(
+      (node): node is Node & { type: "output"; data: { label: string } } =>
+        node.type === "output",
+    )
+    .forEach((outputNode) => {
+      const outputName = outputNode.data.label;
+      const outputValue = currentGraphSpec.outputValues?.[outputName];
+
+      if (outputValue && isTaskOutputArgument(outputValue)) {
+        const sourceTaskId = outputValue.taskOutput.taskId;
+        if (selectedTaskIds.has(sourceTaskId)) {
+          connectedNodeIds.add(outputNode.id);
+          const sourceTaskNode = taskNodesByTaskId.get(sourceTaskId);
+          if (sourceTaskNode) {
+            connectedNodeIds.add(sourceTaskNode.id);
+          }
+        }
+      }
+    });
+
+  const orphanedNodes = selectedNodes.filter(
+    (node) => !connectedNodeIds.has(node.id),
+  );
+
+  return orphanedNodes;
+};

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -28,6 +28,7 @@ const badgeVariants = cva(
           "border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
         outline:
           "text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
+        dot: "w-2 h-2 p-0 border-0 rounded-full bg-current",
       },
     },
     defaultVariants: {


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Adds a warning box to the subgraph creation dialog that lists any potentially orphaned nodes. An orphaned node is defined as not being connected to any other node in the selection.

The new checkForOrphanedNodes method achieves this.

Note that the subgraph can still be created with the orphaned nodes if the user wishes - they will then need to remove or modify them later to avoid failing their pipeline.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

![image.png](https://app.graphite.com/user-attachments/assets/0920e612-5f16-4db9-842d-057d096802c3.png)

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->
1. Select a group of nodes including one not connected to anything else in the selection
2. Create subgraph - you should see the warning box, even if the orphan is a task node (for which we create an input & output, but it still won't be connected to the rest of the selection)
3. Confirm there is no warning if you select a group of connected nodes

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
