### PR TITLE
Exclude Nodes from Subgraph Selection

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
@@ -310,7 +310,7 @@ const FlowCanvas = ({
     [selectedNodes],
   );
 
-  const canGroup = useMemo(
+  const { canGroup } = useMemo(
     () => canGroupNodes(selectedNodes, isSubgraphNavigationEnabled),
     [selectedNodes, isSubgraphNavigationEnabled],
   );

--- a/src/components/shared/ReactFlow/FlowCanvas/Subgraphs/NodeListItem.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/Subgraphs/NodeListItem.tsx
@@ -1,6 +1,7 @@
 import { type Node } from "@xyflow/react";
 
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
 import { InlineStack } from "@/components/ui/layout";
 import { Paragraph } from "@/components/ui/typography";
@@ -10,13 +11,37 @@ import { getNodeTypeColor } from "./utils";
 
 interface NodeListItemProps {
   node: Node;
+  excludedNodeIds?: Set<string>;
   isOrphaned?: boolean;
+  onExcludeNode?: (nodeId: string) => void;
+  onIncludeNode?: (nodeId: string) => void;
 }
 
-export function NodeListItem({ node, isOrphaned }: NodeListItemProps) {
+export function NodeListItem({
+  node,
+  excludedNodeIds,
+  isOrphaned,
+  onExcludeNode,
+  onIncludeNode,
+}: NodeListItemProps) {
+  const isExcluded = excludedNodeIds?.has(node.id);
+
+  const handleButtonClick = () => {
+    if (onExcludeNode && !isExcluded) {
+      onExcludeNode(node.id);
+    } else if (onIncludeNode && isExcluded) {
+      onIncludeNode(node.id);
+    }
+  };
+
   return (
     <li key={node.id} className="flex justify-between items-center">
-      <InlineStack gap="3" blockAlign="center" wrap="nowrap">
+      <InlineStack
+        gap="3"
+        blockAlign="center"
+        className={cn({ "opacity-50": isExcluded })}
+        wrap="nowrap"
+      >
         <Badge variant="dot" className={cn(getNodeTypeColor(node.type))} />
         <Paragraph font="mono" size="xs">
           {node.id}
@@ -30,6 +55,19 @@ export function NodeListItem({ node, isOrphaned }: NodeListItemProps) {
           </InlineStack>
         )}
       </InlineStack>
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={handleButtonClick}
+        className={cn(
+          "hover:bg-transparent",
+          isExcluded
+            ? "text-muted-foreground hover:text-primary"
+            : "hover:text-destructive",
+        )}
+      >
+        {isExcluded ? <Icon name="SquarePlus" /> : <Icon name="Delete" />}
+      </Button>
     </li>
   );
 }

--- a/src/components/shared/ReactFlow/FlowCanvas/Subgraphs/NodesList.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/Subgraphs/NodesList.tsx
@@ -14,14 +14,20 @@ import { NodeListItem } from "./NodeListItem";
 
 interface NodesListProps {
   nodes: Node[];
-  orphanedNodeIds?: Set<string>;
   title?: string;
+  excludedNodeIds?: Set<string>;
+  orphanedNodeIds?: Set<string>;
+  onExcludeNode?: (nodeId: string) => void;
+  onIncludeNode?: (nodeId: string) => void;
 }
 
 export function NodesList({
   nodes,
-  orphanedNodeIds,
   title = `View nodes (${nodes.length})`,
+  excludedNodeIds,
+  orphanedNodeIds,
+  onExcludeNode,
+  onIncludeNode,
 }: NodesListProps) {
   const [isOpen, setIsOpen] = useState(false);
 
@@ -49,7 +55,10 @@ export function NodesList({
               <NodeListItem
                 key={node.id}
                 node={node}
+                excludedNodeIds={excludedNodeIds}
                 isOrphaned={orphanedNodeIds?.has(node.id)}
+                onExcludeNode={onExcludeNode}
+                onIncludeNode={onIncludeNode}
               />
             ))}
           </ul>

--- a/src/components/shared/ReactFlow/FlowCanvas/Subgraphs/OrphanedNodeList.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/Subgraphs/OrphanedNodeList.tsx
@@ -7,9 +7,17 @@ import { NodeListItem } from "./NodeListItem";
 
 interface OrphanedNodeListProps {
   nodes: Node[];
+  excludedNodeIds?: Set<string>;
+  onExcludeNode?: (nodeId: string) => void;
+  onIncludeNode?: (nodeId: string) => void;
 }
 
-export function OrphanedNodeList({ nodes }: OrphanedNodeListProps) {
+export function OrphanedNodeList({
+  nodes,
+  excludedNodeIds,
+  onExcludeNode,
+  onIncludeNode,
+}: OrphanedNodeListProps) {
   if (nodes.length === 0) {
     return null;
   }
@@ -27,7 +35,13 @@ export function OrphanedNodeList({ nodes }: OrphanedNodeListProps) {
       </Paragraph>
       <ul className="space-y-2 text-sm">
         {nodes.map((node) => (
-          <NodeListItem key={node.id} node={node} />
+          <NodeListItem
+            key={node.id}
+            node={node}
+            excludedNodeIds={excludedNodeIds}
+            onExcludeNode={onExcludeNode}
+            onIncludeNode={onIncludeNode}
+          />
         ))}
       </ul>
     </InfoBox>

--- a/src/components/shared/ReactFlow/FlowCanvas/Subgraphs/utils.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/Subgraphs/utils.ts
@@ -1,14 +1,38 @@
 import type { Node } from "@xyflow/react";
 
+interface GroupingValidation {
+  canGroup: boolean;
+  errorMessage?: string;
+}
+
 export const canGroupNodes = (
   nodes: Node[],
   isSubgraphNavigationEnabled: boolean = true,
-): boolean => {
-  return (
-    nodes.length > 1 &&
-    nodes.filter((node) => node.type === "task").length > 0 &&
-    isSubgraphNavigationEnabled
-  );
+): GroupingValidation => {
+  if (!isSubgraphNavigationEnabled) {
+    return {
+      canGroup: false,
+      errorMessage: "Subgraph navigation is disabled.",
+    };
+  }
+
+  if (nodes.length <= 1) {
+    return {
+      canGroup: false,
+      errorMessage: "At least 2 nodes are required to create a subgraph.",
+    };
+  }
+
+  if (nodes.filter((node) => node.type === "task").length === 0) {
+    return {
+      canGroup: false,
+      errorMessage: "At least 1 task node is required to create a subgraph.",
+    };
+  }
+
+  return {
+    canGroup: true,
+  };
 };
 
 export const getNodeTypeColor = (nodeType: string | undefined): string => {


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

Users can now add and remove nodes from their current selection from within the New Subgraph Dialog. This allows them to resolve any orphan issues and ensure on the correct nodes go into the subgraph. The subgraph creation will then ignore excluded nodes.

Note that only nodes within the original selection can be added or removed.

When adding/removing nodes from the list the system will dynamically calculate if any of the remaining nodes will be orphaned and warn the user as such. The general `canGroup`​ validation will also be run to ensure that users don't remove all nodes and then submit an empty selection; to enable this the `canGroup`​ method was updated so that it returns error messages for different validation conditions for displaying in the UI.

In other words, validations are run to ensure users don't create an invalid subgraph.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

![image.png](https://app.graphite.com/user-attachments/assets/642ffc98-645b-47de-8956-5e0bdd2df403.png)



![image.png](https://app.graphite.com/user-attachments/assets/295d14b9-238e-4ed0-a9a8-3ab2cca47b21.png)



## Test Instructions

1. select a bunch of nodes
2. create subgraph via toolbar
3. if the selection includes an isolated node, confirm the warning shows; then confirm the isolated node can be removed from the selection directly from the warning box and the subgraph can be submitted
4. add or remove nodes from the selection at your leisure via the node list
5. confirm that removing nodes to isolate a selected node will result in an isolated node warning
6. confirm that removing all tasks will result in an invalid subgraph error
7. confirm that removing everything in the selection will result in an invalid subgraph error
8. confirm that the subgraph cannot be submitted when there are any errors or warnings or in any other potentially invalid situations
9. confirm that once submitted the subgraph is created only out of the remaining selected nodes, and the ones that were excluded are left as-is

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->