### PR TITLE
Ignore subgraph input validation

### DIFF
--- a/src/providers/ComponentSpecProvider.tsx
+++ b/src/providers/ComponentSpecProvider.tsx
@@ -87,9 +87,14 @@ export const ComponentSpecProvider = ({
     return getSubgraphComponentSpec(componentSpec, currentSubgraphPath);
   }, [componentSpec, currentSubgraphPath]);
 
+  const isRootSubgraph = currentSubgraphPath.length === 1;
+
   const { isValid, errors } = useMemo(
-    () => checkComponentSpecValidity(currentSubgraphSpec),
-    [currentSubgraphSpec],
+    () =>
+      checkComponentSpecValidity(currentSubgraphSpec, {
+        skipInputValueValidation: !isRootSubgraph,
+      }),
+    [currentSubgraphSpec, isRootSubgraph],
   );
 
   const clearComponentSpec = useCallback(() => {

--- a/src/utils/validations.test.ts
+++ b/src/utils/validations.test.ts
@@ -106,6 +106,23 @@ describe("checkComponentSpecValidity", () => {
       );
     });
 
+    it("should skip required input value validation when option enabled", () => {
+      const componentSpec: ComponentSpec = {
+        name: "test-component",
+        implementation: { container: { image: "test-image" } },
+        inputs: [{ name: "no-value", type: "string", optional: false }],
+      };
+
+      const result = checkComponentSpecValidity(componentSpec, {
+        skipInputValueValidation: true,
+      });
+
+      expect(result.isValid).toBe(true);
+      expect(result.errors).not.toContain(
+        'Pipeline input "no-value" is required and does not have a value',
+      );
+    });
+
     it("should return error for output without name", () => {
       const componentSpec: ComponentSpec = {
         name: "test-component",

--- a/src/utils/validations.ts
+++ b/src/utils/validations.ts
@@ -9,10 +9,16 @@ import {
   type TaskSpec,
 } from "./componentSpec";
 
+interface ValidationOptions {
+  skipInputValueValidation?: boolean;
+}
+
 export const checkComponentSpecValidity = (
   componentSpec: ComponentSpec,
+  options?: ValidationOptions,
 ): { isValid: boolean; errors: string[] } => {
   const errors: string[] = [];
+  const { skipInputValueValidation = false } = options ?? {};
 
   // Basic validation
   const basicErrors = validateBasicComponentSpec(componentSpec);
@@ -26,7 +32,9 @@ export const checkComponentSpecValidity = (
   }
 
   // Validate inputs and outputs
-  errors.push(...validateInputsAndOutputs(componentSpec));
+  errors.push(
+    ...validateInputsAndOutputs(componentSpec, skipInputValueValidation),
+  );
 
   // Skip further validation for non-graph implementations
   if (!isGraphImplementation(componentSpec.implementation)) {
@@ -68,7 +76,10 @@ const validateBasicComponentSpec = (componentSpec: ComponentSpec): string[] => {
   return errors;
 };
 
-const validateInputsAndOutputs = (componentSpec: ComponentSpec): string[] => {
+const validateInputsAndOutputs = (
+  componentSpec: ComponentSpec,
+  skipInputValueValidation: boolean,
+): string[] => {
   const errors: string[] = [];
 
   // Validate inputs array structure
@@ -87,7 +98,12 @@ const validateInputsAndOutputs = (componentSpec: ComponentSpec): string[] => {
       }
 
       // Check that required inputs have a value or default
-      if (!input.optional && !input.default && !input.value) {
+      if (
+        !skipInputValueValidation &&
+        !input.optional &&
+        !input.default &&
+        !input.value
+      ) {
         errors.push(
           `Pipeline input "${input.name}" is required and does not have a value`,
         );


### PR DESCRIPTION
## Description

Added an option to skip input value validation for non-root subgraphs in the component spec validation process. This change allows subgraphs to have required inputs without values, which is valid when they're not at the root level of a pipeline.

## Type of Change

- [x] Bug fix
- [x] Improvement

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Test Instructions

1. Create a pipeline with nested subgraphs
2. Add required inputs to a non-root subgraph without providing values
3. Verify that validation errors are not shown for these inputs
4. Verify that root-level subgraphs still properly validate required inputs