### PR TITLE
Subgraph Input Node Value indicates that it is read from Subgraph Arguments

### DIFF
--- a/src/components/Editor/IOEditor/InputValueEditor/InputValueEditor.tsx
+++ b/src/components/Editor/IOEditor/InputValueEditor/InputValueEditor.tsx
@@ -67,6 +67,7 @@ export const InputValueEditor = ({
   }, [input.name, currentSubgraphSpec]);
 
   const effectiveOptionalValue = isConnectedToRequired ? false : inputOptional;
+  const isInSubgraph = currentSubgraphPath.length > 1;
 
   const handleInputChange = useCallback(
     (
@@ -272,7 +273,9 @@ export const InputValueEditor = ({
     }
   }, [triggerSave, saveChanges]);
 
-  const placeholder = input.default ?? `Enter ${input.name}...`;
+  const placeholder = isInSubgraph
+    ? "→ from subgraph arguments"
+    : (input.default ?? `Enter ${input.name}...`);
 
   return (
     <BlockStack gap="3" className="p-4 w-full">
@@ -323,7 +326,7 @@ export const InputValueEditor = ({
         inputName={input.name}
       />
 
-      {!initialInputValue && !inputOptional && (
+      {!initialInputValue && !inputOptional && !isInSubgraph && (
         <InfoBox title="Missing value" variant="error">
           Input is not optional. Value is required.
         </InfoBox>

--- a/src/components/shared/ReactFlow/FlowCanvas/IONode/IONode.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/IONode/IONode.tsx
@@ -10,6 +10,7 @@ import { Paragraph } from "@/components/ui/typography";
 import { cn } from "@/lib/utils";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 import { useContextPanel } from "@/providers/ContextPanelProvider";
+import { isViewingSubgraph } from "@/utils/subgraphUtils";
 
 interface IONodeProps {
   type: "input" | "output";
@@ -25,13 +26,16 @@ interface IONodeProps {
 }
 
 const IONode = ({ type, data, selected = false }: IONodeProps) => {
-  const { currentGraphSpec, currentSubgraphSpec } = useComponentSpec();
+  const { currentGraphSpec, currentSubgraphSpec, currentSubgraphPath } =
+    useComponentSpec();
   const { setContent, clearContent } = useContextPanel();
 
   const isInput = type === "input";
   const isOutput = type === "output";
 
   const readOnly = !!data.readOnly;
+
+  const isInSubgraph = isViewingSubgraph(currentSubgraphPath);
 
   const handleType = isInput ? "source" : "target";
   const handlePosition = isInput ? Position.Right : Position.Left;
@@ -110,7 +114,9 @@ const IONode = ({ type, data, selected = false }: IONodeProps) => {
     ? data.value
     : hasDataDefault
       ? data.default
-      : null;
+      : isInSubgraph
+        ? "→subgraph arguments"
+        : null;
 
   const outputValue = outputConnectedValue ?? null;
 

--- a/src/utils/subgraphUtils.ts
+++ b/src/utils/subgraphUtils.ts
@@ -424,3 +424,7 @@ export const updateSubgraphSpec = (
     },
   };
 };
+
+export const isViewingSubgraph = (subgraphPath: string[]): boolean => {
+  return subgraphPath.length > 1;
+};


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

Input nodes inside a subgraph will no longer show "No value" in red, and the input value editor will no longer have a validation error for value. Instead, the field will indicate that the value is taken from the subgraph arguments.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

![image.png](https://app.graphite.com/user-attachments/assets/4be9d558-acd9-4709-adcb-9c4856709a88.png)

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->