### PR TITLE
Subgraph Validation

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -10,8 +10,6 @@
   "ignoreDependencies": [
     "@radix-ui/react-accordion",
     "@tanstack/react-query-devtools",
-    "tailwindcss",
-    "tailwindcss-animate",
     "@typescript-eslint/eslint-plugin",
     "@typescript-eslint/parser",
     "react-scripts"

--- a/src/components/Editor/PipelineDetails.tsx
+++ b/src/components/Editor/PipelineDetails.tsx
@@ -30,7 +30,8 @@ import { getOutputConnectedDetails } from "./utils/getOutputConnectedDetails";
 
 const PipelineDetails = () => {
   const { setContent } = useContextPanel();
-  const { componentSpec, graphSpec, isValid, errors } = useComponentSpec();
+  const { componentSpec, graphSpec, isValid, errors, hasAncestorErrors } =
+    useComponentSpec();
 
   const notify = useToastNotification();
 
@@ -310,11 +311,7 @@ const PipelineDetails = () => {
       {/* Validations */}
       <div>
         <h3 className="text-md font-medium mb-1">Validations</h3>
-        {isValid ? (
-          <InfoBox variant="success" title="No validation errors found">
-            Pipeline is ready for submission
-          </InfoBox>
-        ) : (
+        {!isValid ? (
           <InfoBox
             variant="error"
             title={`${errors.length} validation error${errors.length > 1 ? "s" : ""} found:`}
@@ -329,13 +326,25 @@ const PipelineDetails = () => {
                       align="start"
                       wrap="nowrap"
                     >
-                      <span className="text-destructive flex-shrink-0">•</span>
-                      <span className="break-words">{error}</span>
+                      <span className="text-destructive shrink-0">•</span>
+                      <span className="wrap-break-word">{error}</span>
                     </InlineStack>
                   </li>
                 ))}
               </ul>
             </ScrollArea>
+          </InfoBox>
+        ) : hasAncestorErrors ? (
+          <InfoBox
+            variant="warning"
+            title="Validation errors in parent pipeline"
+          >
+            Current subgraph is valid, but there are validation errors in the
+            parent pipeline. Navigate back to fix them.
+          </InfoBox>
+        ) : (
+          <InfoBox variant="success" title="No validation errors found">
+            Pipeline is ready for submission
           </InfoBox>
         )}
       </div>

--- a/src/providers/ComponentSpecProvider.tsx
+++ b/src/providers/ComponentSpecProvider.tsx
@@ -9,7 +9,10 @@ import {
   getSubgraphComponentSpec,
   updateSubgraphSpec,
 } from "@/utils/subgraphUtils";
-import { checkComponentSpecValidity } from "@/utils/validations";
+import {
+  checkComponentSpecValidity,
+  type ValidationResult,
+} from "@/utils/validations";
 
 import {
   createRequiredContext,
@@ -45,6 +48,7 @@ interface ComponentSpecContextType {
   isLoading: boolean;
   isValid: boolean;
   errors: string[];
+  hasAncestorErrors: boolean;
   refetch: () => void;
   updateGraphSpec: (newGraphSpec: GraphSpec) => void;
   saveComponentSpec: (name: string) => Promise<void>;
@@ -104,6 +108,32 @@ export const ComponentSpecProvider = ({
       }),
     [currentSubgraphSpec, isRootSubgraph],
   );
+
+  const hasAncestorErrors = useMemo(() => {
+    if (isRootSubgraph) {
+      return false;
+    }
+
+    const memo = new WeakMap<ComponentSpec, Map<string, ValidationResult>>();
+
+    for (let i = 1; i < currentSubgraphPath.length; i++) {
+      const ancestorPath = currentSubgraphPath.slice(0, i);
+      const ancestorSpec = getSubgraphComponentSpec(
+        componentSpec,
+        ancestorPath,
+      );
+      const ancestorValidation = checkComponentSpecValidity(ancestorSpec, {
+        skipInputValueValidation: ancestorPath.length === 1,
+        memo,
+      });
+
+      if (!ancestorValidation.isValid) {
+        return true;
+      }
+    }
+
+    return false;
+  }, [componentSpec, currentSubgraphPath, isRootSubgraph]);
 
   const clearComponentSpec = useCallback(() => {
     setComponentSpec(EMPTY_GRAPH_COMPONENT_SPEC);
@@ -229,6 +259,7 @@ export const ComponentSpecProvider = ({
       isLoading,
       isValid,
       errors,
+      hasAncestorErrors,
       refetch,
       setComponentSpec,
       clearComponentSpec,
@@ -250,6 +281,7 @@ export const ComponentSpecProvider = ({
       isLoading,
       isValid,
       errors,
+      hasAncestorErrors,
       refetch,
       setComponentSpec,
       clearComponentSpec,


### PR DESCRIPTION
## Description

Added memoization to component spec validation to improve performance when validating nested graph components. This change prevents redundant validation of the same component specs by caching validation results in a WeakMap.

Also implemented subgraph validation error bubbling, which surfaces errors from nested components to their parent tasks, making it easier to identify and fix issues in complex graph structures.

## Type of Change

- [x] Improvement
- [x] Bug fix

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging
<img width="1069" height="685" alt="Screenshot 2025-11-20 at 5 57 54 PM" src="https://github.com/user-attachments/assets/525537b3-dd85-4423-ace4-d7a72a20f216" />
<img width="1273" height="752" alt="Screenshot 2025-11-20 at 5 58 12 PM" src="https://github.com/user-attachments/assets/29664ec4-5ffa-47a3-83dc-1cf15a5226a7" />

## Test Instructions

- Create a pipeline with a task and a subgraph
- the task should have an explicit error (like a missing required value, or an input without a value)
- Subgraph internally should have an error (like a missing required value, but NOT an input without a value)