### PR TITLE
feat: gh lib - link gh lib via manage libs dialog

### DIFF
--- a/src/components/shared/GitHubLibrary/ManageLibrariesDialog.tsx
+++ b/src/components/shared/GitHubLibrary/ManageLibrariesDialog.tsx
@@ -1,0 +1,97 @@
+import { useCallback, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Icon } from "@/components/ui/icon";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Separator } from "@/components/ui/separator";
+import { Text } from "@/components/ui/typography";
+
+import { AddGitHubLibraryDialogContent } from "./components/AddGitHubLibraryDialogContent";
+
+export function ManageLibrariesDialog({
+  defaultMode = "manage",
+}: {
+  defaultMode?: "add" | "manage" | "update";
+}) {
+  const [open, setOpen] = useState(false);
+  const [mode, setMode] = useState<"add" | "manage" | "update">(defaultMode);
+
+  const handleDialogOpenChange = useCallback((open: boolean) => {
+    setOpen(open);
+    if (!open) {
+      setMode("manage");
+    }
+  }, []);
+
+  const defaultTrigger = (
+    <Button variant="ghost" size="sm">
+      <Icon name="Settings" />
+    </Button>
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={handleDialogOpenChange}>
+      <DialogTrigger asChild>{defaultTrigger}</DialogTrigger>
+      {open && (
+        <DialogContent data-testid="manage-libraries-dialog">
+          {mode === "add" && (
+            <>
+              <DialogHeader>
+                <DialogTitle>
+                  <InlineStack align="start" blockAlign="center" gap="1">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => setMode("manage")}
+                    >
+                      <Icon name="ArrowLeft" />
+                    </Button>
+                    Add Library
+                  </InlineStack>
+                </DialogTitle>
+              </DialogHeader>
+
+              <AddGitHubLibraryDialogContent
+                onOkClick={() => setMode("manage")}
+              />
+            </>
+          )}
+
+          {mode === "manage" && (
+            <>
+              <DialogHeader>
+                <DialogTitle>Manage Libraries</DialogTitle>
+              </DialogHeader>
+              <DialogDescription>
+                Manage your connected libraries.
+              </DialogDescription>
+              <BlockStack gap="4">
+                <BlockStack gap="4" className="min-h-[200px]">
+                  {/* TODO: add library list */}
+                  <Text>No libraries connected</Text>
+                </BlockStack>
+                <Separator />
+                <BlockStack gap="1" align="end">
+                  <Button variant="secondary" onClick={() => setMode("add")}>
+                    <InlineStack align="center" blockAlign="center" gap="1">
+                      <Icon name="Github" />
+                      Link Library from GitHub
+                    </InlineStack>
+                  </Button>
+                </BlockStack>
+              </BlockStack>
+            </>
+          )}
+        </DialogContent>
+      )}
+    </Dialog>
+  );
+}

--- a/src/components/shared/GitHubLibrary/components/AddGitHubLibraryDialogContent.tsx
+++ b/src/components/shared/GitHubLibrary/components/AddGitHubLibraryDialogContent.tsx
@@ -1,0 +1,256 @@
+import { useMutation } from "@tanstack/react-query";
+import { useCallback, useReducer, useState } from "react";
+
+import { ensureGithubLibrary } from "@/components/shared/GitHubLibrary/utils/ensureGithubLibrary";
+import { fetchGitHubFiles } from "@/components/shared/GitHubLibrary/utils/fetchGitHubFiles";
+import { trimDigest } from "@/components/shared/ManageComponent/utils/digest";
+import { hydrateAllComponents } from "@/components/shared/ManageComponent/utils/hydrateAllComponents";
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icon";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Spinner } from "@/components/ui/spinner";
+import { Heading, Paragraph, Text } from "@/components/ui/typography";
+import useToastNotification from "@/hooks/useToastNotification";
+import { cn } from "@/lib/utils";
+import type { HydratedComponentReference } from "@/utils/componentSpec";
+import { pluralize } from "@/utils/string";
+
+import { validatePAT } from "../utils/validatePAT";
+import { InputField } from "./InputField";
+
+const ComponentList = ({
+  components,
+}: {
+  components: HydratedComponentReference[];
+}) => {
+  return (
+    <ScrollArea type="always" className="max-h-[400px] w-full">
+      <BlockStack gap="2">
+        {components.map((component) => (
+          <InlineStack
+            align="start"
+            blockAlign="center"
+            gap="1"
+            className="w-full"
+            key={component.digest}
+            wrap="nowrap"
+          >
+            <Icon name="File" className="text-gray-400" size="lg" />
+
+            <BlockStack align="start" gap="0">
+              <Text className="truncate">{component.name}</Text>
+              <Text size="xs" tone="subdued" className="font-mono">
+                Ver: {trimDigest(component.digest)}
+              </Text>
+            </BlockStack>
+          </InlineStack>
+        ))}
+      </BlockStack>
+    </ScrollArea>
+  );
+};
+
+export const AddGitHubLibraryDialogContent = ({
+  onOkClick,
+}: {
+  onOkClick: () => void;
+}) => {
+  const [components, setComponents] = useState<HydratedComponentReference[]>(
+    [],
+  );
+
+  return (
+    <BlockStack gap="2">
+      {components.length > 0 ? (
+        <ImportResults components={components} onOkClick={onOkClick} />
+      ) : (
+        <ConfigureImport onSuccess={setComponents} />
+      )}
+    </BlockStack>
+  );
+};
+
+function ImportResults({
+  components,
+  onOkClick,
+}: {
+  components: HydratedComponentReference[];
+  onOkClick: () => void;
+}) {
+  return (
+    <BlockStack gap="2">
+      <Heading level={2}>
+        Imported {components.length} {pluralize(components.length, "component")}
+        :
+      </Heading>
+      <ComponentList components={components} />
+      <BlockStack gap="1" align="end">
+        <Button type="button" variant="secondary" onClick={onOkClick}>
+          Continue
+        </Button>
+      </BlockStack>
+    </BlockStack>
+  );
+}
+
+interface GitHubLibraryProcessState {
+  repoName: string;
+  accessToken: string;
+  hasErrors: boolean;
+}
+
+type GitHubLibraryFormAction = {
+  type: "UPDATE";
+  payload: Partial<Omit<GitHubLibraryProcessState, "hasErrors">>;
+};
+
+function addGithubLibraryReducer(
+  state: GitHubLibraryProcessState,
+  action: GitHubLibraryFormAction,
+): GitHubLibraryProcessState {
+  switch (action.type) {
+    case "UPDATE": {
+      const newState = { ...state, ...action.payload };
+      return {
+        ...newState,
+        hasErrors: !isStateValid(newState),
+      };
+    }
+    default:
+      return state;
+  }
+}
+
+function ConfigureImport({
+  onSuccess,
+}: {
+  onSuccess: (components: HydratedComponentReference[]) => void;
+}) {
+  const notify = useToastNotification();
+
+  const initialState: GitHubLibraryProcessState = {
+    repoName: "",
+    accessToken: "",
+    hasErrors: true,
+  };
+
+  const [state, dispatch] = useReducer(addGithubLibraryReducer, initialState);
+  const [processError, setProcessError] = useState<string | null>(null);
+
+  const { mutate: importComponentsFromGitHubLibrary, isPending } = useMutation({
+    mutationFn: async (state: GitHubLibraryProcessState) => {
+      const files = await fetchGitHubFiles(
+        state.accessToken,
+        state.repoName,
+        // todo: in future add support for other patterns
+        (name) => name.endsWith(".component.yaml"),
+      );
+
+      const hydratedComponents = await hydrateAllComponents(
+        files.map((file) => ({
+          url: file.url,
+          text: file.content,
+        })),
+      );
+
+      // create a library with the hydrated components
+      await ensureGithubLibrary({
+        repoName: state.repoName,
+        accessToken: state.accessToken,
+        components: hydratedComponents,
+      });
+
+      return hydratedComponents;
+    },
+    onSuccess: (components) => {
+      notify(`Successfully fetched ${components.length} components`, "success");
+      onSuccess(components);
+    },
+    onError: (error) => {
+      notify(
+        `Error importing components from GitHub library: ${error.message}`,
+        "error",
+      );
+      setProcessError(error.message);
+    },
+  });
+
+  const handleSubmit = useCallback(async () => {
+    if (state.hasErrors) {
+      notify("Please fill in all fields", "error");
+      return;
+    }
+
+    setProcessError(null);
+
+    await importComponentsFromGitHubLibrary(state);
+  }, [importComponentsFromGitHubLibrary, state, notify]);
+
+  return (
+    <BlockStack
+      gap="4"
+      className={cn(isPending && "pointer-events-none opacity-50")}
+    >
+      <Paragraph tone="subdued" size="xs">
+        Connect a GitHub repository to import components from your library. You
+        can use a Personal Access Token to access repositories (ensure it has
+        the `repo` view-only scope).
+      </Paragraph>
+      <Paragraph tone="subdued" size="xs">
+        By default system will scan for files with the `.component.yaml`
+        extension.
+      </Paragraph>
+      {processError && (
+        <Text size="xs" tone="critical">
+          {processError}
+        </Text>
+      )}
+      <InputField
+        id="repo-name"
+        label="Repository Name"
+        placeholder="owner/repository"
+        value={state.repoName}
+        validate={validateRepoName}
+        onChange={(value) => {
+          dispatch({ type: "UPDATE", payload: { repoName: value ?? "" } });
+        }}
+      />
+      <InputField
+        id="pat"
+        label="Personal Access Token"
+        placeholder="ghp_..."
+        value={state.accessToken}
+        validate={validatePAT}
+        onChange={(value) => {
+          dispatch({ type: "UPDATE", payload: { accessToken: value ?? "" } });
+        }}
+      />
+
+      <InlineStack gap="2" className="w-full" align="end">
+        <Button
+          type="button"
+          disabled={state.hasErrors || isPending}
+          onClick={handleSubmit}
+        >
+          Add Library {isPending && <Spinner />}
+        </Button>
+      </InlineStack>
+    </BlockStack>
+  );
+}
+
+function isStateValid(state: GitHubLibraryProcessState): boolean {
+  return (
+    !validateRepoName(state.repoName)?.length &&
+    !validatePAT(state.accessToken)?.length
+  );
+}
+
+function validateRepoName(name: string): string[] | null {
+  // GitHub repo name format: owner/repository
+  const repoRegex = /^[a-zA-Z0-9_-]+\/[a-zA-Z0-9_.-]+$/;
+  return repoRegex.test(name)
+    ? null
+    : ["Invalid repository name. Must be in the format of owner/repository"];
+}

--- a/src/components/shared/GitHubLibrary/components/InputField.tsx
+++ b/src/components/shared/GitHubLibrary/components/InputField.tsx
@@ -1,0 +1,70 @@
+import { type ChangeEvent, type ReactNode, useCallback, useState } from "react";
+
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { BlockStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
+import { cn } from "@/lib/utils";
+
+interface InputFieldProps {
+  id: string;
+  label: string;
+  placeholder: string;
+  value: string;
+  hint?: ReactNode | string;
+  validate: (value: string) => string[] | null;
+  onChange: (value: string | null, error: string[] | null) => void;
+}
+
+export const InputField = ({
+  id,
+  label,
+  placeholder,
+  value,
+  hint,
+  validate,
+  onChange,
+}: InputFieldProps) => {
+  const [inputValue, setInputValue] = useState(value);
+  const [error, setError] = useState<string[] | null>(null);
+  const handleChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      const value = e.target.value;
+
+      setInputValue(value);
+
+      const validationErrors = validate(value);
+      setError(validationErrors);
+
+      if (validationErrors && validationErrors.length > 0) {
+        onChange(null, validationErrors);
+      } else {
+        onChange(value, null);
+      }
+    },
+    [validate, onChange],
+  );
+
+  return (
+    <BlockStack gap="2">
+      <Label htmlFor={id}>{label}</Label>
+      <BlockStack gap="0">
+        <Input
+          id={id}
+          placeholder={placeholder}
+          value={inputValue}
+          onChange={handleChange}
+          aria-invalid={!!error}
+          aria-describedby={`${id}-hint`}
+          className={cn(error && "aria-invalid:border-destructive")}
+        />
+        {!!error && error.length > 0 && (
+          <Text size="xs" tone="critical">
+            {error.join("\n")}
+          </Text>
+        )}
+      </BlockStack>
+      <div id={`${id}-hint`}>{hint}</div>
+    </BlockStack>
+  );
+};

--- a/src/components/shared/GitHubLibrary/types.ts
+++ b/src/components/shared/GitHubLibrary/types.ts
@@ -1,0 +1,41 @@
+/**
+ * Type definitions for GitHub API responses
+ * Based on GitHub REST API v3 structure
+ */
+
+/**
+ * Represents a tree item from the GitHub Trees API
+ * @see https://docs.github.com/en/rest/git/trees
+ */
+export interface GitHubTreeItem {
+  path: string;
+  mode: string;
+  type: "blob" | "tree" | "commit";
+  size?: number;
+  sha: string;
+  url: string;
+}
+
+/**
+ * Represents a blob (file content) from the GitHub Blobs API
+ * @see https://docs.github.com/en/rest/git/blobs
+ */
+export interface GitHubBlob {
+  sha: string;
+  node_id: string;
+  size: number;
+  url: string;
+  content: string; // Base64 encoded content
+  encoding: string;
+}
+
+/**
+ * Represents a processed GitHub file with content and metadata
+ * This is the return type of fetchGitHubFiles function
+ */
+export interface GitHubFile {
+  repoName: string;
+  sha: string;
+  url: string;
+  content: string;
+}

--- a/src/components/shared/GitHubLibrary/utils/ensureGithubLibrary.ts
+++ b/src/components/shared/GitHubLibrary/utils/ensureGithubLibrary.ts
@@ -1,0 +1,46 @@
+import { LibraryDB } from "@/providers/ComponentLibraryProvider/libraries/storage";
+import type { HydratedComponentReference } from "@/utils/componentSpec";
+
+import { getGitHubLibraryId } from "./libraryId";
+
+interface CreateGithubLibraryOptions {
+  repoName: string;
+  accessToken: string;
+  components: HydratedComponentReference[];
+}
+
+export async function ensureGithubLibrary({
+  repoName,
+  accessToken,
+  components,
+}: CreateGithubLibraryOptions) {
+  const id = getGitHubLibraryId(repoName);
+
+  const existingLibrary = await LibraryDB.component_libraries.get(id);
+
+  if (existingLibrary) {
+    return existingLibrary;
+  }
+
+  await LibraryDB.component_libraries.put({
+    id,
+    name: repoName,
+    icon: "Github",
+    type: "github",
+    knownDigests: components.map((component) => component.digest),
+    configuration: {
+      created_at: new Date().toISOString(),
+      last_updated_at: new Date().toISOString(),
+      repo_name: repoName,
+      access_token: accessToken,
+      auto_update: true,
+    },
+    components: components.map((component) => ({
+      digest: component.digest,
+      name: component.name,
+      url: component.url,
+    })),
+  });
+
+  return await LibraryDB.component_libraries.get(id);
+}

--- a/src/components/shared/GitHubLibrary/utils/fetchGitHubFiles.ts
+++ b/src/components/shared/GitHubLibrary/utils/fetchGitHubFiles.ts
@@ -1,0 +1,95 @@
+import type { GitHubBlob, GitHubFile, GitHubTreeItem } from "../types";
+
+/**
+ * Fetches files from a GitHub repository that match the provided filter
+ *
+ * @param pat - GitHub Personal Access Token for authentication
+ * @param repository - Repository in "owner/repo" format
+ * @param filterFn - Function to filter files by name
+ * @returns Promise of array of matched files with their content and metadata
+ */
+export async function fetchGitHubFiles(
+  pat: string,
+  repository: string,
+  filterFn: (fileName: string) => boolean,
+): Promise<GitHubFile[]> {
+  const [owner, repo] = repository.split("/");
+
+  if (!owner || !repo) {
+    throw new Error('Repository must be in "owner/repo" format');
+  }
+
+  const headers = {
+    Authorization: `Bearer ${pat}`,
+    Accept: "application/vnd.github.v3+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+
+  try {
+    // Step 1: Get the default branch
+    const repoResponse = await fetch(
+      `https://api.github.com/repos/${owner}/${repo}`,
+      { headers },
+    );
+
+    if (!repoResponse.ok) {
+      throw new Error(
+        `Failed to fetch repository: ${repoResponse.status} ${repoResponse.statusText}`,
+      );
+    }
+
+    const repoData = await repoResponse.json();
+    const defaultBranch = repoData.default_branch;
+
+    // Step 2: Get the tree for the default branch (recursively to get all files)
+    const treeResponse = await fetch(
+      `https://api.github.com/repos/${owner}/${repo}/git/trees/${defaultBranch}?recursive=1`,
+      { headers },
+    );
+
+    if (!treeResponse.ok) {
+      throw new Error(
+        `Failed to fetch tree: ${treeResponse.status} ${treeResponse.statusText}`,
+      );
+    }
+
+    const treeData = await treeResponse.json();
+    const files: GitHubTreeItem[] = treeData.tree;
+
+    // Step 3: Filter files based on the provided function
+    const matchedFiles = files.filter(
+      (file) => file.type === "blob" && filterFn(file.path),
+    );
+
+    // Step 4: Fetch content and last modified date for each matched file
+    const filePromises = matchedFiles.map(async (file): Promise<GitHubFile> => {
+      // Fetch file content
+      const blobResponse = await fetch(file.url, { headers });
+
+      if (!blobResponse.ok) {
+        throw new Error(
+          `Failed to fetch blob for ${file.path}: ${blobResponse.status}`,
+        );
+      }
+
+      const blobData: GitHubBlob = await blobResponse.json();
+
+      // Decode base64 content
+      const content = atob(blobData.content);
+
+      return {
+        repoName: repository,
+        sha: file.sha,
+        url: `https://github.com/${owner}/${repo}/blob/${defaultBranch}/${file.path}`,
+        content,
+      };
+    });
+
+    // Wait for all file fetches to complete
+    return await Promise.all(filePromises);
+  } catch (error) {
+    throw new Error(
+      `Failed to fetch GitHub files: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}

--- a/src/components/shared/GitHubLibrary/utils/validatePAT.ts
+++ b/src/components/shared/GitHubLibrary/utils/validatePAT.ts
@@ -1,0 +1,7 @@
+export function validatePAT(token: string): string[] | null {
+  if (!token) return ["Personal Access Token is required"];
+  // Basic PAT validation - GitHub PATs start with ghp_ or github_pat_
+  return token.startsWith("ghp_") || token.startsWith("github_pat_")
+    ? null
+    : ["Invalid Personal Access Token. Must start with ghp_ or github_pat_"];
+}

--- a/src/components/shared/ManageComponent/hooks/useOutdatedComponents.ts
+++ b/src/components/shared/ManageComponent/hooks/useOutdatedComponents.ts
@@ -6,19 +6,11 @@ import {
   type ComponentReferenceWithDigest,
   type HydratedComponentReference,
   isDiscoverableComponentReference,
-  isHydratedComponentReference,
 } from "@/utils/componentSpec";
 
 import { hasSupersededBy } from "../types";
+import { hydrateAllComponents } from "../utils/hydrateAllComponents";
 import { useAllPublishedComponents } from "./useAllPublishedComponents";
-
-async function hydrateAllComponents(
-  components: ComponentReference[],
-): Promise<HydratedComponentReference[]> {
-  return (
-    await Promise.all(components.map((c) => hydrateComponentReference(c)))
-  ).filter(isHydratedComponentReference);
-}
 
 /**
  * Hook to get the outdated components in the graph

--- a/src/components/shared/ManageComponent/utils/hydrateAllComponents.ts
+++ b/src/components/shared/ManageComponent/utils/hydrateAllComponents.ts
@@ -1,0 +1,14 @@
+import { hydrateComponentReference } from "@/services/componentService";
+import {
+  type ComponentReference,
+  type HydratedComponentReference,
+} from "@/utils/componentSpec";
+import { isHydratedComponentReference } from "@/utils/componentSpec";
+
+export async function hydrateAllComponents(
+  components: ComponentReference[],
+): Promise<HydratedComponentReference[]> {
+  return (
+    await Promise.all(components.map((c) => hydrateComponentReference(c)))
+  ).filter(isHydratedComponentReference);
+}

--- a/src/components/shared/ReactFlow/FlowSidebar/sections/GraphComponents.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/sections/GraphComponents.tsx
@@ -1,6 +1,7 @@
 import { PackagePlus } from "lucide-react";
 import { type ChangeEvent, useCallback, useMemo } from "react";
 
+import { ManageLibrariesDialog } from "@/components/shared/GitHubLibrary/ManageLibrariesDialog";
 import { useBetaFlagValue } from "@/components/shared/Settings/useBetaFlags";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Separator } from "@/components/ui/separator";
@@ -157,12 +158,13 @@ const GraphComponents = ({ isOpen }: { isOpen: boolean }) => {
               <BlockStack gap="1" className="pl-2 py-2">
                 <InlineStack
                   className="w-full"
-                  align="start"
+                  align="space-between"
                   blockAlign="center"
                 >
                   <Text size="sm" tone="subdued">
                     Connected libraries
                   </Text>
+                  <ManageLibrariesDialog />
                 </InlineStack>
 
                 {existingComponentLibraries?.length === 0 && (


### PR DESCRIPTION
## Description

Added a GitHub library management system that allows users to connect and manage component libraries from GitHub repositories. The implementation includes a dialog interface for managing libraries, adding new libraries, and validating GitHub Personal Access Tokens.

## Type of Change

- [x] New feature
- [x] Improvement

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

[Screen Recording 2025-11-18 at 10.34.01 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/17543664-57c5-46b5-886a-18d8d59fc9ef.mov" />](https://app.graphite.com/user-attachments/video/17543664-57c5-46b5-886a-18d8d59fc9ef.mov)

1. Open the component sidebar
2. Click on the settings icon next to "Connected libraries"
3. Try adding a GitHub library using a valid repository name (format: owner/repo) and PAT
4. Verify that components from the repository are properly imported and displayed

I cannot share PAT - Github automatically detects leaked tokens and disables them. But it is easy to create one:



![GithubLib - Create Token.png](https://app.graphite.com/user-attachments/assets/48a22b99-2885-4e19-b527-aa3827ba7fcd.png)



## Additional Comments

This PR introduces the ability to import components from GitHub repositories, supporting both public and private repositories through Personal Access Token authentication. The implementation includes validation for repository names and PATs, as well as proper error handling during the import process.