### PR TITLE
feat: gh lib - view linked libs in manage libs dialog

### DIFF
--- a/src/components/shared/GitHubLibrary/ManageLibrariesDialog.tsx
+++ b/src/components/shared/GitHubLibrary/ManageLibrariesDialog.tsx
@@ -12,9 +12,9 @@ import {
 import { Icon } from "@/components/ui/icon";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Separator } from "@/components/ui/separator";
-import { Text } from "@/components/ui/typography";
 
 import { AddGitHubLibraryDialogContent } from "./components/AddGitHubLibraryDialogContent";
+import { LibraryList } from "./components/LibraryList";
 
 export function ManageLibrariesDialog({
   defaultMode = "manage",
@@ -74,10 +74,7 @@ export function ManageLibrariesDialog({
                 Manage your connected libraries.
               </DialogDescription>
               <BlockStack gap="4">
-                <BlockStack gap="4" className="min-h-[200px]">
-                  {/* TODO: add library list */}
-                  <Text>No libraries connected</Text>
-                </BlockStack>
+                <LibraryList />
                 <Separator />
                 <BlockStack gap="1" align="end">
                   <Button variant="secondary" onClick={() => setMode("add")}>

--- a/src/components/shared/GitHubLibrary/components/AddGitHubLibraryDialogContent.tsx
+++ b/src/components/shared/GitHubLibrary/components/AddGitHubLibraryDialogContent.tsx
@@ -39,7 +39,7 @@ const ComponentList = ({
             <Icon name="File" className="text-gray-400" size="lg" />
 
             <BlockStack align="start" gap="0">
-              <Text className="truncate">{component.name}</Text>
+              <Text className="truncate max-w-[425px]">{component.name}</Text>
               <Text size="xs" tone="subdued" className="font-mono">
                 Ver: {trimDigest(component.digest)}
               </Text>

--- a/src/components/shared/GitHubLibrary/components/LibraryList.tsx
+++ b/src/components/shared/GitHubLibrary/components/LibraryList.tsx
@@ -1,0 +1,49 @@
+import { withSuspenseWrapper } from "@/components/shared/SuspenseWrapper";
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icon";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Text } from "@/components/ui/typography";
+import { useComponentLibrary } from "@/providers/ComponentLibraryProvider";
+
+export const LibraryList = withSuspenseWrapper(() => {
+  const { existingComponentLibraries } = useComponentLibrary();
+
+  return (
+    <BlockStack gap="1">
+      <ScrollArea className="w-full min-h-[100px] max-h-[500px]" type="always">
+        {existingComponentLibraries?.length === 0 && (
+          <InlineStack className="w-full">
+            <Text>No libraries connected</Text>
+          </InlineStack>
+        )}
+
+        {existingComponentLibraries?.map((library) => (
+          <InlineStack
+            key={library.id}
+            align="space-between"
+            blockAlign="center"
+            gap="1"
+            className="w-full pr-3"
+          >
+            <InlineStack blockAlign="center" gap="1">
+              <Icon
+                name={library.icon as any /** todo: fix this */}
+                className="text-gray-400"
+              />
+              <Text>{library.name}</Text>
+            </InlineStack>
+            <InlineStack blockAlign="center" gap="1">
+              <Button variant="ghost" size="sm">
+                <Icon name="Check" />
+              </Button>
+              <Button variant="ghost" size="sm">
+                <Icon name="X" />
+              </Button>
+            </InlineStack>
+          </InlineStack>
+        ))}
+      </ScrollArea>
+    </BlockStack>
+  );
+});


### PR DESCRIPTION
## Description

Added a new `LibraryList` component to display connected GitHub libraries in the `ManageLibrariesDialog`. The component shows a scrollable list of libraries with their icons and names, along with action buttons. When no libraries are connected, it displays a "No libraries connected" message.

## Type of Change

- [x] New feature
- [x] Improvement

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Test Instructions

![image.png](https://app.graphite.com/user-attachments/assets/21ec6fc0-e8e6-4153-bb16-305a540353c1.png)

1. Open the Manage Libraries dialog
2. Verify that the list of connected libraries appears correctly
3. Test the scrolling behavior with multiple libraries
4. Confirm the empty state shows correctly when no libraries are connected