### PR TITLE
feat: gh lib - unlink lib in manage libs dialog

### DIFF
--- a/src/components/shared/GitHubLibrary/components/DeleteLibraryButton.tsx
+++ b/src/components/shared/GitHubLibrary/components/DeleteLibraryButton.tsx
@@ -1,0 +1,70 @@
+import { useMutation } from "@tanstack/react-query";
+
+import { ConfirmationDialog } from "@/components/shared/Dialogs";
+import { withSuspenseWrapper } from "@/components/shared/SuspenseWrapper";
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icon";
+import { Spinner } from "@/components/ui/spinner";
+import { Text } from "@/components/ui/typography";
+import useConfirmationDialog from "@/hooks/useConfirmationDialog";
+import useToastNotification from "@/hooks/useToastNotification";
+import type { StoredLibrary } from "@/providers/ComponentLibraryProvider/libraries/storage";
+
+import { deleteGithubLibrary } from "../utils/deleteGithubLibrary";
+
+export const DeleteLibraryButton = withSuspenseWrapper(
+  ({ library }: { library: StoredLibrary }) => {
+    const notify = useToastNotification();
+    const {
+      handlers: confirmationHandlers,
+      triggerDialog: triggerConfirmation,
+      ...confirmationProps
+    } = useConfirmationDialog();
+
+    const { mutate: unlinkLibrary, isPending } = useMutation({
+      mutationFn: async () => {
+        const confirmed = await triggerConfirmation({
+          title: "Unlink Library",
+          description: `Are you sure you want to unlink "${library.name}"?`,
+          content: (
+            <Text tone="subdued">
+              Your components will still be available in the Pipeline.
+            </Text>
+          ),
+        });
+
+        if (!confirmed) return false;
+
+        await deleteGithubLibrary(library);
+
+        return true;
+      },
+      onSuccess: (deleted) => {
+        if (!deleted) return;
+
+        notify("Library unlinked successfully", "success");
+      },
+      onError: (error) => {
+        notify(`Failed to unlink library: ${error.message}`, "error");
+      },
+    });
+
+    return (
+      <>
+        <Button
+          variant="destructiveOnHover"
+          size="sm"
+          onClick={() => unlinkLibrary()}
+          disabled={isPending}
+        >
+          {isPending ? <Spinner /> : <Icon name="Unlink" />}
+        </Button>
+        <ConfirmationDialog
+          {...confirmationProps}
+          onConfirm={() => confirmationHandlers?.onConfirm()}
+          onCancel={() => confirmationHandlers?.onCancel()}
+        />
+      </>
+    );
+  },
+);

--- a/src/components/shared/GitHubLibrary/components/LibraryList.tsx
+++ b/src/components/shared/GitHubLibrary/components/LibraryList.tsx
@@ -6,6 +6,8 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Text } from "@/components/ui/typography";
 import { useComponentLibrary } from "@/providers/ComponentLibraryProvider";
 
+import { DeleteLibraryButton } from "./DeleteLibraryButton";
+
 export const LibraryList = withSuspenseWrapper(() => {
   const { existingComponentLibraries } = useComponentLibrary();
 
@@ -37,9 +39,8 @@ export const LibraryList = withSuspenseWrapper(() => {
               <Button variant="ghost" size="sm">
                 <Icon name="Check" />
               </Button>
-              <Button variant="ghost" size="sm">
-                <Icon name="X" />
-              </Button>
+
+              <DeleteLibraryButton library={library} />
             </InlineStack>
           </InlineStack>
         ))}

--- a/src/components/shared/GitHubLibrary/utils/deleteGithubLibrary.ts
+++ b/src/components/shared/GitHubLibrary/utils/deleteGithubLibrary.ts
@@ -1,0 +1,16 @@
+import {
+  LibraryDB,
+  type StoredLibrary,
+} from "@/providers/ComponentLibraryProvider/libraries/storage";
+
+export async function deleteGithubLibrary(library: StoredLibrary) {
+  const existingLibrary = await LibraryDB.component_libraries.get(library.id);
+
+  if (!existingLibrary) {
+    throw new Error(`Library ${library.id} not found`);
+  }
+
+  await LibraryDB.component_libraries.delete(library.id);
+
+  return true;
+}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -13,6 +13,8 @@ const buttonVariants = cva(
           "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
         destructive:
           "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+        destructiveOnHover:
+          "text-foreground dark:hover:bg-accent/50 hover:bg-destructive/90 hover:text-white",
         destructiveOutline:
           "border border-destructive bg-background shadow-xs text-destructive hover:bg-destructive/90 hover:text-white dark:bg-input/30 dark:border-input dark:hover:bg-input/50", // THIS IS CUSTOM. CAREFUL WHEN UPDATING THIS COMPONENT
         outline:


### PR DESCRIPTION
## Description

Added functionality to unlink GitHub libraries from the component library system. This PR introduces a new `DeleteLibraryButton` component that allows users to remove linked libraries with a confirmation dialog. When a library is unlinked, the user receives a success notification while preserving components in the Pipeline.

## Type of Change

- [x] New feature
- [x] Improvement

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

[Screen Recording 2025-11-18 at 10.38.36 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/771afbdc-f8bf-4e98-b70b-baf755f3b04c.mov" />](https://app.graphite.com/user-attachments/video/771afbdc-f8bf-4e98-b70b-baf755f3b04c.mov)

1. Navigate to the GitHub Library section
2. Locate an existing linked library
3. Click the unlink button
4. Confirm the deletion in the dialog
5. Verify the library is removed and a success notification appears
6. Confirm that components from the unlinked library remain available in the Pipeline