### PR TITLE
feat: gh lib - detect expired pat and update pat dialog

### DIFF
--- a/src/components/shared/GitHubLibrary/ManageLibrariesDialog.tsx
+++ b/src/components/shared/GitHubLibrary/ManageLibrariesDialog.tsx
@@ -12,9 +12,11 @@ import {
 import { Icon } from "@/components/ui/icon";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Separator } from "@/components/ui/separator";
+import type { StoredLibrary } from "@/providers/ComponentLibraryProvider/libraries/storage";
 
 import { AddGitHubLibraryDialogContent } from "./components/AddGitHubLibraryDialogContent";
 import { LibraryList } from "./components/LibraryList";
+import { UpdateGitHubLibrary } from "./components/UpdateGitHubLibrary";
 
 export function ManageLibrariesDialog({
   defaultMode = "manage",
@@ -23,12 +25,20 @@ export function ManageLibrariesDialog({
 }) {
   const [open, setOpen] = useState(false);
   const [mode, setMode] = useState<"add" | "manage" | "update">(defaultMode);
+  const [libraryToUpdate, setLibraryToUpdate] = useState<
+    StoredLibrary | undefined
+  >();
 
   const handleDialogOpenChange = useCallback((open: boolean) => {
     setOpen(open);
     if (!open) {
       setMode("manage");
     }
+  }, []);
+
+  const handleUpdateLibrary = useCallback((library: StoredLibrary) => {
+    setLibraryToUpdate(library);
+    setMode("update");
   }, []);
 
   const defaultTrigger = (
@@ -74,7 +84,7 @@ export function ManageLibrariesDialog({
                 Manage your connected libraries.
               </DialogDescription>
               <BlockStack gap="4">
-                <LibraryList />
+                <LibraryList onUpdateLibrary={handleUpdateLibrary} />
                 <Separator />
                 <BlockStack gap="1" align="end">
                   <Button variant="secondary" onClick={() => setMode("add")}>
@@ -84,6 +94,34 @@ export function ManageLibrariesDialog({
                     </InlineStack>
                   </Button>
                 </BlockStack>
+              </BlockStack>
+            </>
+          )}
+
+          {mode === "update" && libraryToUpdate && (
+            <>
+              <DialogHeader>
+                <DialogTitle>
+                  <InlineStack align="start" blockAlign="center" gap="1">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => setMode("manage")}
+                    >
+                      <Icon name="ArrowLeft" />
+                    </Button>
+                    Update Library {libraryToUpdate.name}
+                  </InlineStack>
+                </DialogTitle>
+              </DialogHeader>
+              <DialogDescription>
+                Update linked GitHub library.
+              </DialogDescription>
+              <BlockStack gap="4">
+                <UpdateGitHubLibrary
+                  library={libraryToUpdate}
+                  onSuccess={() => setMode("manage")}
+                />
               </BlockStack>
             </>
           )}

--- a/src/components/shared/GitHubLibrary/components/LibraryList.tsx
+++ b/src/components/shared/GitHubLibrary/components/LibraryList.tsx
@@ -1,50 +1,61 @@
 import { withSuspenseWrapper } from "@/components/shared/SuspenseWrapper";
-import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Text } from "@/components/ui/typography";
 import { useComponentLibrary } from "@/providers/ComponentLibraryProvider";
+import type { StoredLibrary } from "@/providers/ComponentLibraryProvider/libraries/storage";
 
 import { DeleteLibraryButton } from "./DeleteLibraryButton";
+import { TokenStatusButton } from "./TokenStatusButton";
 
-export const LibraryList = withSuspenseWrapper(() => {
-  const { existingComponentLibraries } = useComponentLibrary();
+export const LibraryList = withSuspenseWrapper(
+  ({
+    onUpdateLibrary,
+  }: {
+    onUpdateLibrary: (library: StoredLibrary) => void;
+  }) => {
+    const { existingComponentLibraries } = useComponentLibrary();
 
-  return (
-    <BlockStack gap="1">
-      <ScrollArea className="w-full min-h-[100px] max-h-[500px]" type="always">
-        {existingComponentLibraries?.length === 0 && (
-          <InlineStack className="w-full">
-            <Text>No libraries connected</Text>
-          </InlineStack>
-        )}
-
-        {existingComponentLibraries?.map((library) => (
-          <InlineStack
-            key={library.id}
-            align="space-between"
-            blockAlign="center"
-            gap="1"
-            className="w-full pr-3"
-          >
-            <InlineStack blockAlign="center" gap="1">
-              <Icon
-                name={library.icon as any /** todo: fix this */}
-                className="text-gray-400"
-              />
-              <Text>{library.name}</Text>
+    return (
+      <BlockStack gap="1">
+        <ScrollArea
+          className="w-full min-h-[100px] max-h-[500px]"
+          type="always"
+        >
+          {existingComponentLibraries?.length === 0 && (
+            <InlineStack className="w-full">
+              <Text>No libraries connected</Text>
             </InlineStack>
-            <InlineStack blockAlign="center" gap="1">
-              <Button variant="ghost" size="sm">
-                <Icon name="Check" />
-              </Button>
+          )}
 
-              <DeleteLibraryButton library={library} />
+          {existingComponentLibraries?.map((library) => (
+            <InlineStack
+              key={library.id}
+              align="space-between"
+              blockAlign="center"
+              gap="1"
+              className="w-full pr-3"
+            >
+              <InlineStack blockAlign="center" gap="1">
+                <Icon
+                  name={library.icon as any /** todo: fix this */}
+                  className="text-gray-400"
+                />
+                <Text>{library.name}</Text>
+              </InlineStack>
+              <InlineStack blockAlign="center" gap="1">
+                <TokenStatusButton
+                  library={library}
+                  onUpdateClick={onUpdateLibrary}
+                />
+
+                <DeleteLibraryButton library={library} />
+              </InlineStack>
             </InlineStack>
-          </InlineStack>
-        ))}
-      </ScrollArea>
-    </BlockStack>
-  );
-});
+          ))}
+        </ScrollArea>
+      </BlockStack>
+    );
+  },
+);

--- a/src/components/shared/GitHubLibrary/components/TokenStatusButton.tsx
+++ b/src/components/shared/GitHubLibrary/components/TokenStatusButton.tsx
@@ -1,0 +1,50 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+
+import TooltipButton from "@/components/shared/Buttons/TooltipButton";
+import { HOURS } from "@/components/shared/ComponentEditor/constants";
+import { withSuspenseWrapper } from "@/components/shared/SuspenseWrapper";
+import { Icon } from "@/components/ui/icon";
+import { cn } from "@/lib/utils";
+import type { StoredLibrary } from "@/providers/ComponentLibraryProvider/libraries/storage";
+
+import { isGitHubLibraryConfiguration } from "../types";
+import { checkPATStatus } from "../utils/checkPATStatus";
+
+export const TokenStatusButton = withSuspenseWrapper(
+  ({
+    library,
+    onUpdateClick,
+  }: {
+    library: StoredLibrary;
+    onUpdateClick: (library: StoredLibrary) => void;
+  }) => {
+    const { data: tokenStatus } = useSuspenseQuery({
+      queryKey: ["github-token-status", library.id],
+      queryFn: async () => {
+        if (!isGitHubLibraryConfiguration(library.configuration)) {
+          throw new Error("Invalid library configuration");
+        }
+
+        return checkPATStatus(
+          library.configuration.repo_name,
+          library.configuration.access_token,
+        );
+      },
+      staleTime: 1 * HOURS,
+    });
+    return (
+      <TooltipButton
+        tooltip={`Token is ${tokenStatus ? "valid" : "invalid. Click to update."}`}
+        variant="ghost"
+        size="sm"
+        disabled={tokenStatus}
+        onClick={() => onUpdateClick(library)}
+      >
+        <Icon
+          name={tokenStatus ? "Check" : "X"}
+          className={cn(!tokenStatus && "text-red-500")}
+        />
+      </TooltipButton>
+    );
+  },
+);

--- a/src/components/shared/GitHubLibrary/components/UpdateGitHubLibrary.tsx
+++ b/src/components/shared/GitHubLibrary/components/UpdateGitHubLibrary.tsx
@@ -1,0 +1,95 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useCallback, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Spinner } from "@/components/ui/spinner";
+import useToastNotification from "@/hooks/useToastNotification";
+import type { StoredLibrary } from "@/providers/ComponentLibraryProvider/libraries/storage";
+
+import { checkPATStatus } from "../utils/checkPATStatus";
+import { updateGitHubLibraryPAT } from "../utils/updateGitHubLibraryPAT";
+import { validatePAT } from "../utils/validatePAT";
+import { InputField } from "./InputField";
+
+export const UpdateGitHubLibrary = ({
+  library,
+  onSuccess,
+}: {
+  onSuccess: () => void;
+  library: StoredLibrary;
+}) => {
+  const queryClient = useQueryClient();
+  const notify = useToastNotification();
+  const [state, setState] = useState<{
+    value: string;
+    hasErrors: boolean;
+  }>({
+    value: "",
+    hasErrors: true,
+  });
+
+  const { mutate: updateGitHubLibrary, isPending } = useMutation({
+    mutationFn: async (pat: string) => {
+      const status = await checkPATStatus(
+        library.configuration?.repo_name as string,
+        pat,
+      );
+
+      if (!status) {
+        throw new Error("Invalid Personal Access Token");
+      }
+
+      return await updateGitHubLibraryPAT(library, pat);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["github-token-status", library.id],
+      });
+
+      notify("GitHub library PAT updated successfully", "success");
+      onSuccess?.();
+    },
+    onError: (error) => {
+      notify(`Failed to update GitHub library PAT: ${error.message}`, "error");
+    },
+  });
+
+  const handleSubmit = useCallback(async () => {
+    if (state.hasErrors) {
+      notify("Please fill in all fields", "error");
+      return;
+    }
+
+    await updateGitHubLibrary(state.value);
+  }, [updateGitHubLibrary, state]);
+
+  return (
+    <BlockStack gap="2">
+      <InputField
+        id="pat"
+        label="Personal Access Token"
+        placeholder="ghp_..."
+        value=""
+        validate={validatePAT}
+        onChange={(value, error) => {
+          setState((prev) => ({
+            ...prev,
+            value: value ?? "",
+            hasErrors: !!error && error.length > 0,
+          }));
+        }}
+      />
+
+      <InlineStack gap="2" className="w-full" align="end">
+        <Button
+          type="button"
+          disabled={state.hasErrors || isPending}
+          onClick={handleSubmit}
+        >
+          Update PAT {isPending ? <Spinner /> : null}
+        </Button>
+      </InlineStack>
+    </BlockStack>
+  );
+};

--- a/src/components/shared/GitHubLibrary/types.ts
+++ b/src/components/shared/GitHubLibrary/types.ts
@@ -39,3 +39,25 @@ export interface GitHubFile {
   url: string;
   content: string;
 }
+
+interface GitHubLibraryConfiguration {
+  created_at: string;
+  last_updated_at: string;
+  repo_name: string;
+  access_token: string;
+  auto_update: boolean;
+}
+
+export function isGitHubLibraryConfiguration(
+  configuration: any,
+): configuration is GitHubLibraryConfiguration {
+  return (
+    typeof configuration === "object" &&
+    configuration !== null &&
+    "created_at" in configuration &&
+    "last_updated_at" in configuration &&
+    "repo_name" in configuration &&
+    "access_token" in configuration &&
+    "auto_update" in configuration
+  );
+}

--- a/src/components/shared/GitHubLibrary/utils/checkPATStatus.ts
+++ b/src/components/shared/GitHubLibrary/utils/checkPATStatus.ts
@@ -1,0 +1,11 @@
+export async function checkPATStatus(repository: string, pat: string) {
+  const response = await fetch(`https://api.github.com/repos/${repository}`, {
+    headers: {
+      Authorization: `Bearer ${pat}`,
+      Accept: "application/vnd.github.v3+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+  });
+
+  return response.ok;
+}

--- a/src/components/shared/GitHubLibrary/utils/updateGitHubLibraryPAT.ts
+++ b/src/components/shared/GitHubLibrary/utils/updateGitHubLibraryPAT.ts
@@ -1,0 +1,22 @@
+import {
+  LibraryDB,
+  type StoredLibrary,
+} from "@/providers/ComponentLibraryProvider/libraries/storage";
+
+export async function updateGitHubLibraryPAT(
+  library: StoredLibrary,
+  accessToken: string,
+) {
+  const existingLibrary = await LibraryDB.component_libraries.get(library.id);
+
+  if (!existingLibrary) {
+    throw new Error(`Library ${library.id} not found`);
+  }
+
+  return (
+    // @ts-expect-error dexie has some issues with nested types, tmp patch here
+    (await LibraryDB.component_libraries.update(library.id, {
+      "configuration.access_token": accessToken,
+    })) === 1
+  );
+}

--- a/src/providers/ComponentLibraryProvider/ComponentLibraryProvider.tsx
+++ b/src/providers/ComponentLibraryProvider/ComponentLibraryProvider.tsx
@@ -10,6 +10,7 @@ import {
 
 import ComponentDuplicateDialog from "@/components/shared/Dialogs/ComponentDuplicateDialog";
 import { GitHubFlatComponentLibrary } from "@/components/shared/GitHubLibrary/githubFlatComponentLibrary";
+import { isGitHubLibraryConfiguration } from "@/components/shared/GitHubLibrary/types";
 import { fetchAndStoreComponentLibrary } from "@/services/componentService";
 import type {
   ComponentFolder,
@@ -99,11 +100,15 @@ const ComponentLibraryContext =
 /**
  * Register the GitHub library factory. This allows to have multiple instances of the same library type.
  */
-registerLibraryFactory(
-  "github",
-  (library) =>
-    new GitHubFlatComponentLibrary(library.configuration?.repo_name as string),
-);
+registerLibraryFactory("github", (library) => {
+  if (!isGitHubLibraryConfiguration(library.configuration)) {
+    throw new Error(
+      `GitHub library configuration is not valid for "${library.id}"`,
+    );
+  }
+
+  return new GitHubFlatComponentLibrary(library.configuration.repo_name);
+});
 
 function useComponentLibraryRegistry() {
   const queryClient = useQueryClient();


### PR DESCRIPTION
## Description

Added functionality to update GitHub Personal Access Tokens (PATs) for connected component libraries. This feature allows users to refresh invalid tokens directly from the Manage Libraries dialog.

## Type of Change

- [x] New feature
- [x] Improvement

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

[Screen Recording 2025-11-18 at 10.42.21 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/74191160-c5ea-44cb-bbeb-66a5c342f172.mov" />](https://app.graphite.com/user-attachments/video/74191160-c5ea-44cb-bbeb-66a5c342f172.mov)

1. Open the Manage Libraries dialog
2. For a library with an invalid token, click the X icon
3. Enter a new valid PAT in the update form
4. Verify the token status updates to valid (green checkmark)

To emulate invalid token I added a tmp command to file `src/components/shared/GitHubLibrary/utils/updateGitHubLibraryPAT.ts` 

```
(window as any)["__updateGitHubLibraryPAT"] = updateGitHubLibraryPAT;

```

So I can access it from dev console

## Additional Comments

This PR adds:
- Token status indicator in the library list
- Update flow for GitHub PATs
- Utility functions to check PAT validity and update tokens in storage