### PR TITLE
feat: gh lib - detect upgraded components

### DIFF
--- a/src/components/shared/GitHubLibrary/utils/checkComponentUpdates.ts
+++ b/src/components/shared/GitHubLibrary/utils/checkComponentUpdates.ts
@@ -1,0 +1,74 @@
+import type { StoredLibrary } from "@/providers/ComponentLibraryProvider/libraries/storage";
+import {
+  generateDigest,
+  hydrateComponentReference,
+} from "@/services/componentService";
+import type { HydratedComponentReference } from "@/utils/componentSpec";
+
+import { parseGitHubUrl } from "./githubUrl";
+
+class GitHubUpdateCheckError extends Error {
+  name = "GitHubUpdateCheckError";
+  constructor(message: string) {
+    super(message);
+  }
+}
+
+export async function checkComponentUpdates(
+  component: HydratedComponentReference,
+  library: StoredLibrary,
+) {
+  if (library.type != "github") {
+    return false;
+  }
+
+  const accessToken = library.configuration?.access_token;
+
+  if (!accessToken) {
+    return false;
+  }
+
+  if (!component.url) {
+    return false;
+  }
+
+  const headers = {
+    Authorization: `Bearer ${accessToken}`,
+    Accept: "application/vnd.github.v3+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+
+  const { owner, repo, path: componentPath } = parseGitHubUrl(component.url);
+
+  const apiUrl = new URL(
+    `https://api.github.com/repos/${owner}/${repo}/contents/${componentPath}`,
+  );
+
+  const response = await fetch(apiUrl.toString(), { headers });
+
+  if (!response.ok) {
+    return false;
+  }
+
+  const data = await response.json();
+
+  if (data.content && data.encoding === "base64") {
+    // works only in browser, not in node
+    const decodedText = atob(data.content);
+
+    const digest = await generateDigest(decodedText);
+
+    if (digest === component.digest) {
+      return false;
+    }
+
+    return await hydrateComponentReference({
+      text: decodedText,
+      url: component.url,
+    });
+  }
+
+  throw new GitHubUpdateCheckError(
+    "Unexpected response format from GitHub API",
+  );
+}

--- a/src/components/shared/GitHubLibrary/utils/githubUrl.ts
+++ b/src/components/shared/GitHubLibrary/utils/githubUrl.ts
@@ -1,0 +1,61 @@
+interface ParsedGitHubUrl {
+  owner: string;
+  repo: string;
+  path: string;
+  branch?: string;
+}
+
+/**
+ * Parse GitHub URL to extract owner, repo, path, and branch
+ */
+export function parseGitHubUrl(url: string): ParsedGitHubUrl {
+  const urlObj = new URL(url);
+  const hostname = urlObj.hostname;
+  const pathname = urlObj.pathname;
+  const parts = pathname.split("/").filter(Boolean);
+
+  let owner = "";
+  let repo = "";
+  let path = "";
+  let branch: string | undefined;
+
+  if (hostname === "raw.githubusercontent.com") {
+    owner = parts[0];
+    repo = parts[1];
+
+    if (parts[2] === "refs" && parts[3] === "heads") {
+      branch = parts[4];
+      path = parts.slice(5).join("/");
+    } else if (parts[2] === "refs" && parts[3] === "tags") {
+      branch = `tags/${parts[4]}`;
+      path = parts.slice(5).join("/");
+    } else {
+      branch = parts[2];
+      path = parts.slice(3).join("/");
+    }
+  } else if (hostname === "github.com" || hostname === "www.github.com") {
+    owner = parts[0];
+    repo = parts[1];
+
+    if (["blob", "tree", "raw", "blame", "edit"].includes(parts[2])) {
+      branch = parts[3];
+      path = parts.slice(4).join("/");
+    }
+  } else if (hostname === "api.github.com") {
+    if (parts[0] === "repos" && parts[3] === "contents") {
+      owner = parts[1];
+      repo = parts[2];
+      path = parts.slice(4).join("/");
+      const ref = urlObj.searchParams.get("ref");
+      if (ref) branch = ref;
+    }
+  }
+
+  if (!owner || !repo) {
+    throw new Error(
+      `Invalid GitHub URL: Could not extract owner and repo from ${url}`,
+    );
+  }
+
+  return { owner, repo, path, branch };
+}


### PR DESCRIPTION
## Description

Added GitHub component update checking functionality to detect when components from GitHub libraries have newer versions available. This feature allows the application to identify outdated components and offer updates.

## Type of Change

- [x] New feature
- [x] Improvement

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Implementation Details

- Created `checkComponentUpdates.ts` to fetch and compare component versions from GitHub repositories
- Added `parseGitHubUrl.ts` utility to extract owner, repo, path, and branch information from GitHub URLs
- Enhanced `useOutdatedComponents` hook to check for updates in GitHub components
- Implemented proper error handling for GitHub API interactions

## Test Instructions

![Screenshot 2025-11-18 at 10.29.20 PM.png](https://app.graphite.com/user-attachments/assets/bc566022-0650-4570-90da-0d5ae0f17adf.png)

1. Add a GitHub component library with a valid access token
2. Import components from the GitHub library
3. Make changes to the original component in the GitHub repository
4. Verify that the application detects the component as outdated and offers an update