### PR TITLE
Subgraph Validation++

### DIFF
--- a/src/components/Editor/GlobalValidationPanel.tsx
+++ b/src/components/Editor/GlobalValidationPanel.tsx
@@ -1,0 +1,133 @@
+import { useMemo } from "react";
+
+import { InfoBox } from "@/components/shared/InfoBox";
+import {
+    Accordion,
+    AccordionContent,
+    AccordionItem,
+    AccordionTrigger,
+} from "@/components/ui/accordion";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import type {
+    ValidationErrorDetail,
+    ValidationResult,
+} from "@/utils/validations";
+
+interface GlobalValidationPanelProps {
+    validation: ValidationResult;
+    onFocus: (detail: ValidationErrorDetail) => void;
+}
+
+const formatPathLabel = (path: string[]): string => {
+    if (path.length === 0) {
+        return "Pipeline";
+    }
+
+    return path[path.length - 1];
+};
+
+const getGroupKey = (detail: ValidationErrorDetail): string => {
+    return detail.path[0] ?? "pipeline";
+};
+
+export const GlobalValidationPanel = ({
+    validation,
+    onFocus,
+}: GlobalValidationPanelProps) => {
+    const groupedErrors = useMemo(() => {
+        const groups = new Map<
+            string,
+            { key: string; title: string; items: ValidationErrorDetail[] }
+        >();
+
+        validation.nodeErrors.forEach((detail) => {
+            const key = getGroupKey(detail);
+            const title = detail.path[0] ?? "Pipeline";
+
+            if (!groups.has(key)) {
+                groups.set(key, { key, title, items: [] });
+            }
+
+            groups.get(key)?.items.push(detail);
+        });
+
+        return Array.from(groups.values());
+    }, [validation.nodeErrors]);
+
+    if (validation.isValid) {
+        return (
+            <InfoBox variant="success" title="No validation errors found">
+                Pipeline is ready for submission
+            </InfoBox>
+        );
+    }
+
+    const totalErrors = validation.errors.length;
+
+    return (
+        <div className="space-y-2 mb-6">
+            <InfoBox
+                variant="error"
+                title={`${totalErrors} validation error${totalErrors > 1 ? "s" : ""} found:`}
+            >
+                <ScrollArea className="h-64 pr-1">
+                    <Accordion
+                        type="multiple"
+                        defaultValue={groupedErrors.map((group) => group.key)}
+                        className="w-full"
+                    >
+                        {groupedErrors.map((group) => (
+                            <AccordionItem key={group.key} value={group.key}>
+                                <AccordionTrigger className="text-left py-1.5">
+                                    <InlineStack
+                                        align="space-between"
+                                        blockAlign="center"
+                                        className="w-full"
+                                    >
+                                        <span className="text-sm font-medium">{group.title}</span>
+                                        <Badge variant="secondary">{group.items.length}</Badge>
+                                    </InlineStack>
+                                </AccordionTrigger>
+                                <AccordionContent>
+                                    <BlockStack gap="1" className="py-1">
+                                        {group.items.map((detail, index) => (
+                                            <div
+                                                key={`${detail.anchor}-${index}`}
+                                                className="rounded border border-destructive/25 bg-destructive/5 px-3 py-2"
+                                            >
+                                                <InlineStack
+                                                    align="space-between"
+                                                    blockAlign="center"
+                                                    className="w-full gap-2"
+                                                >
+                                                    <span className="text-xs font-semibold text-foreground">
+                                                        {formatPathLabel(detail.path)}
+                                                    </span>
+                                                    <Button
+                                                        variant="ghost"
+                                                        size="xs"
+                                                        className="h-6 px-2 text-xs"
+                                                        onClick={() => onFocus(detail)}
+                                                    >
+                                                        Focus
+                                                    </Button>
+                                                </InlineStack>
+                                                <p className="mt-1 text-xs text-muted-foreground leading-snug break-words">
+                                                    {detail.reason}
+                                                </p>
+                                            </div>
+                                        ))}
+                                    </BlockStack>
+                                </AccordionContent>
+                            </AccordionItem>
+                        ))}
+                    </Accordion>
+                </ScrollArea>
+            </InfoBox>
+        </div>
+    );
+};
+

--- a/src/components/Editor/PipelineDetails.tsx
+++ b/src/components/Editor/PipelineDetails.tsx
@@ -9,7 +9,6 @@ import {
 } from "@/components/ui/collapsible";
 import { Icon } from "@/components/ui/icon";
 import { InlineStack } from "@/components/ui/layout";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import useToastNotification from "@/hooks/useToastNotification";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 import { useContextPanel } from "@/providers/ContextPanelProvider";
@@ -21,8 +20,8 @@ import {
 import { getComponentFileFromList } from "@/utils/componentStore";
 import { USER_PIPELINES_LIST_NAME } from "@/utils/constants";
 
-import { InfoBox } from "../shared/InfoBox";
 import { TaskImplementation } from "../shared/TaskDetails";
+import { GlobalValidationPanel } from "./GlobalValidationPanel";
 import { InputValueEditor } from "./IOEditor/InputValueEditor";
 import { OutputNameEditor } from "./IOEditor/OutputNameEditor";
 import RenamePipeline from "./RenamePipeline";
@@ -30,7 +29,8 @@ import { getOutputConnectedDetails } from "./utils/getOutputConnectedDetails";
 
 const PipelineDetails = () => {
   const { setContent } = useContextPanel();
-  const { componentSpec, graphSpec, isValid, errors } = useComponentSpec();
+  const { componentSpec, graphSpec, rootValidation, focusValidationDetail } =
+    useComponentSpec();
 
   const notify = useToastNotification();
 
@@ -310,34 +310,10 @@ const PipelineDetails = () => {
       {/* Validations */}
       <div>
         <h3 className="text-md font-medium mb-1">Validations</h3>
-        {isValid ? (
-          <InfoBox variant="success" title="No validation errors found">
-            Pipeline is ready for submission
-          </InfoBox>
-        ) : (
-          <InfoBox
-            variant="error"
-            title={`${errors.length} validation error${errors.length > 1 ? "s" : ""} found:`}
-          >
-            <ScrollArea className="max-h-80 overflow-y-auto">
-              <ul className="text-xs space-y-1">
-                {errors.map((error) => (
-                  <li key={error}>
-                    <InlineStack
-                      gap="2"
-                      blockAlign="start"
-                      align="start"
-                      wrap="nowrap"
-                    >
-                      <span className="text-destructive flex-shrink-0">•</span>
-                      <span className="break-words">{error}</span>
-                    </InlineStack>
-                  </li>
-                ))}
-              </ul>
-            </ScrollArea>
-          </InfoBox>
-        )}
+        <GlobalValidationPanel
+          validation={rootValidation}
+          onFocus={focusValidationDetail}
+        />
       </div>
 
       {/* Pipeline YAML */}

--- a/src/components/shared/ReactFlow/FlowCanvas/IONode/IONode.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/IONode/IONode.tsx
@@ -1,4 +1,4 @@
-import { Handle, Position } from "@xyflow/react";
+import { Handle, Position, type NodeProps } from "@xyflow/react";
 import { memo, useEffect, useMemo } from "react";
 
 import { InputValueEditor } from "@/components/Editor/IOEditor/InputValueEditor";
@@ -14,20 +14,21 @@ import { isViewingSubgraph } from "@/utils/subgraphUtils";
 
 export const DEFAULT_IO_NODE_WIDTH = 300;
 
-interface IONodeProps {
-  type: "input" | "output";
-  data: {
-    label: string;
-    value?: string;
-    default?: string;
-    type?: string;
-    readOnly?: boolean;
-  };
-  selected: boolean;
-  deletable: boolean;
+interface IONodeData {
+  label: string;
+  value?: string;
+  default?: string;
+  type?: string;
+  readOnly?: boolean;
+  nodeAnchor?: string;
 }
 
-const IONode = ({ type, data, selected = false }: IONodeProps) => {
+const IONode = ({
+  id,
+  type,
+  data,
+  selected = false,
+}: NodeProps<IONodeData>) => {
   const { currentGraphSpec, currentSubgraphSpec, currentSubgraphPath } =
     useComponentSpec();
   const { setContent, clearContent } = useContextPanel();
@@ -125,7 +126,12 @@ const IONode = ({ type, data, selected = false }: IONodeProps) => {
   const value = isInput ? inputValue : outputValue;
 
   return (
-    <Card className={cn("border-2 max-w-[300px] p-0", borderColor)}>
+    <Card
+      data-node-anchor={data.nodeAnchor}
+      id={data.nodeAnchor}
+      data-node-id={id}
+      className={cn("border-2 max-w-[300px] p-0", borderColor)}
+    >
       <CardHeader className="px-2 py-2.5">
         <CardTitle className="break-words">{data.label}</CardTitle>
       </CardHeader>

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNode.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNode.tsx
@@ -10,7 +10,7 @@ import { isCacheDisabled } from "@/utils/cache";
 import { StatusIndicator } from "./StatusIndicator";
 import { TaskNodeCard } from "./TaskNodeCard";
 
-const TaskNode = ({ data, selected }: NodeProps) => {
+const TaskNode = ({ id, data, selected }: NodeProps) => {
   const executionData = useExecutionDataOptional();
 
   const typedData = useMemo(() => data as TaskNodeData, [data]);
@@ -28,13 +28,21 @@ const TaskNode = ({ data, selected }: NodeProps) => {
 
   const disabledCache = isCacheDisabled(typedData.taskSpec);
 
+  const anchor = typedData.nodeAnchor;
   return (
-    <TaskNodeProvider data={typedData} selected={selected} status={status}>
-      {!!status && (
-        <StatusIndicator status={status} disabledCache={disabledCache} />
-      )}
-      <TaskNodeCard />
-    </TaskNodeProvider>
+    <div
+      data-node-anchor={anchor}
+      id={anchor}
+      data-node-id={id}
+      className="rounded-[32px] transition-shadow duration-200"
+    >
+      <TaskNodeProvider data={typedData} selected={selected} status={status}>
+        {!!status && (
+          <StatusIndicator status={status} disabledCache={disabledCache} />
+        )}
+        <TaskNodeCard />
+      </TaskNodeProvider>
+    </div>
   );
 };
 

--- a/src/types/taskNode.ts
+++ b/src/types/taskNode.ts
@@ -15,6 +15,8 @@ export interface TaskNodeData extends Record<string, unknown> {
   highlighted?: boolean;
   callbacks?: TaskNodeCallbacks;
   nodeCallbacks?: NodeCallbacks;
+  nodePathPrefix?: string[];
+  nodeAnchor?: string;
 }
 
 export type NodeAndTaskId = {

--- a/src/utils/nodeAnchors.ts
+++ b/src/utils/nodeAnchors.ts
@@ -1,0 +1,20 @@
+export type NodePath = string[];
+
+export const ROOT_NODE_ANCHOR = "node:root";
+
+const sanitizeAnchorSegment = (segment: string): string => {
+  return segment.replace(/[^a-zA-Z0-9_-]/g, "-");
+};
+
+export const buildNodeAnchor = (path: NodePath): string => {
+  if (path.length === 0) {
+    return ROOT_NODE_ANCHOR;
+  }
+
+  return `node:${path.map(sanitizeAnchorSegment).join(".")}`;
+};
+
+export const clonePath = (path: NodePath): NodePath => {
+  return [...path];
+};
+

--- a/src/utils/nodes/createInputNode.ts
+++ b/src/utils/nodes/createInputNode.ts
@@ -1,6 +1,7 @@
 import { type Node } from "@xyflow/react";
 
 import type { TaskNodeData } from "@/types/taskNode";
+import { buildNodeAnchor } from "@/utils/nodeAnchors";
 
 import type { InputSpec } from "../componentSpec";
 import { extractPositionFromAnnotations } from "./extractPositionFromAnnotations";
@@ -11,6 +12,8 @@ export const createInputNode = (input: InputSpec, nodeData: TaskNodeData) => {
 
   const position = extractPositionFromAnnotations(annotations);
   const nodeId = inputNameToNodeId(name);
+  const pathPrefix = nodeData.nodePathPrefix ?? [];
+  const nodeAnchor = buildNodeAnchor([...pathPrefix, "inputs", name]);
 
   return {
     id: nodeId,
@@ -18,6 +21,7 @@ export const createInputNode = (input: InputSpec, nodeData: TaskNodeData) => {
       ...rest,
       ...nodeData,
       label: name,
+      nodeAnchor,
     },
     position: position,
     type: "input",

--- a/src/utils/nodes/createOutputNode.ts
+++ b/src/utils/nodes/createOutputNode.ts
@@ -1,6 +1,7 @@
 import { type Node } from "@xyflow/react";
 
 import type { TaskNodeData } from "@/types/taskNode";
+import { buildNodeAnchor } from "@/utils/nodeAnchors";
 
 import type { OutputSpec } from "../componentSpec";
 import { extractPositionFromAnnotations } from "./extractPositionFromAnnotations";
@@ -15,12 +16,16 @@ export const createOutputNode = (
   const position = extractPositionFromAnnotations(annotations);
   const nodeId = outputNameToNodeId(name);
 
+  const pathPrefix = nodeData.nodePathPrefix ?? [];
+  const nodeAnchor = buildNodeAnchor([...pathPrefix, "outputs", name]);
+
   return {
     id: nodeId,
     data: {
       ...rest,
       ...nodeData,
       label: name,
+      nodeAnchor,
     },
     position: position,
     type: "output",

--- a/src/utils/nodes/createTaskNode.ts
+++ b/src/utils/nodes/createTaskNode.ts
@@ -1,6 +1,7 @@
 import { type Node } from "@xyflow/react";
 
 import type { TaskNodeData } from "@/types/taskNode";
+import { buildNodeAnchor } from "@/utils/nodeAnchors";
 
 import type { TaskSpec } from "../componentSpec";
 import { extractPositionFromAnnotations } from "./extractPositionFromAnnotations";
@@ -20,12 +21,16 @@ export const createTaskNode = (
   const nodeCallbacks = nodeData.nodeCallbacks;
   const dynamicCallbacks = generateDynamicNodeCallbacks(nodeId, nodeCallbacks);
 
+  const pathPrefix = nodeData.nodePathPrefix ?? [];
+  const nodeAnchor = buildNodeAnchor([...pathPrefix, taskId]);
+
   return {
     id: nodeId,
     data: {
       ...nodeData,
       taskSpec,
       taskId,
+      nodeAnchor,
       highlighted: false,
       callbacks: dynamicCallbacks, // Use these callbacks internally within the node
     },


### PR DESCRIPTION
## Description

Added a new `GlobalValidationPanel` component that provides a more structured and interactive way to display pipeline validation errors. The panel groups errors by node, shows error counts, and includes a "Focus" button to navigate directly to the problematic node in the pipeline editor.

## Type of Change

- [x] New feature
- [x] Improvement

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Screenshots (if applicable)

N/A

## Test Instructions

1. Create a pipeline with validation errors (e.g., missing required inputs)
2. Verify that errors are grouped by node in the validation panel
3. Test the "Focus" button to ensure it navigates to the correct node
4. Verify that validation errors in nested subgraphs are properly displayed

## Additional Comments

This implementation adds node anchors to all pipeline elements and introduces a mechanism to focus on specific nodes when validation errors are detected. The validation system now tracks detailed error information including node paths and anchors, making it easier to locate and fix issues in complex pipelines.