### PR TITLE
Check for Inputs with External Connections

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/Subgraphs/ExternalInputConnectionsList.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/Subgraphs/ExternalInputConnectionsList.tsx
@@ -1,0 +1,49 @@
+import { type Node } from "@xyflow/react";
+
+import { InfoBox } from "@/components/shared/InfoBox";
+import { Paragraph } from "@/components/ui/typography";
+
+import { NodeListItem } from "./NodeListItem";
+
+interface ExternalInputConnectionsListProps {
+  nodes: Node[];
+  excludedNodeIds?: Set<string>;
+  onExcludeNode?: (nodeId: string) => void;
+  onIncludeNode?: (nodeId: string) => void;
+}
+
+export function ExternalInputConnectionsList({
+  nodes,
+  excludedNodeIds,
+  onExcludeNode,
+  onIncludeNode,
+}: ExternalInputConnectionsListProps) {
+  if (nodes.length === 0) {
+    return null;
+  }
+
+  return (
+    <InfoBox
+      className="mt-4"
+      title="External Input Connections"
+      variant="warning"
+      width="full"
+    >
+      <Paragraph className="mb-4" size="sm">
+        These inputs are connected to tasks that are not part of the selection.
+        Exclude them to keep their external connections intact.
+      </Paragraph>
+      <ul className="space-y-2 text-sm">
+        {nodes.map((node) => (
+          <NodeListItem
+            key={node.id}
+            node={node}
+            excludedNodeIds={excludedNodeIds}
+            onExcludeNode={onExcludeNode}
+            onIncludeNode={onIncludeNode}
+          />
+        ))}
+      </ul>
+    </InfoBox>
+  );
+}

--- a/src/components/shared/ReactFlow/FlowCanvas/Subgraphs/NewSubgraphDialog.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/Subgraphs/NewSubgraphDialog.tsx
@@ -11,7 +11,9 @@ import {
 } from "@/utils/componentSpec";
 import { getUniqueTaskName, validateTaskName } from "@/utils/unique";
 
+import { checkExternalInputConnections } from "./checkExternalInputConnections";
 import { checkForOrphanedNodes } from "./checkForOrphanedNodes";
+import { ExternalInputConnectionsList } from "./ExternalInputConnectionsList";
 import { NodesList } from "./NodesList";
 import { OrphanedNodeList } from "./OrphanedNodeList";
 import { canGroupNodes } from "./utils";
@@ -68,6 +70,12 @@ export const NewSubgraphDialog = ({
     [activeNodes, currentSubgraphSpec],
   );
 
+  // Inputs with external connections in the current active selection (after user exclusions)
+  const inputsWithExternalConnections = useMemo(
+    () => checkExternalInputConnections(activeNodes, currentSubgraphSpec),
+    [activeNodes, currentSubgraphSpec],
+  );
+
   const hasActiveOrphans = activeOrphanedNodes.length > 0;
 
   const { canGroup, errorMessage } = canGroupNodes(
@@ -105,6 +113,15 @@ export const NewSubgraphDialog = ({
           />
         )}
 
+        {canGroup && inputsWithExternalConnections.length > 0 && (
+          <ExternalInputConnectionsList
+            nodes={inputsWithExternalConnections}
+            excludedNodeIds={excludedNodeIds}
+            onExcludeNode={excludeNode}
+            onIncludeNode={includeNode}
+          />
+        )}
+
         {!canGroup && errorMessage && (
           <InfoBox title="Cannot Create Subgraph" variant="error" width="full">
             {errorMessage}
@@ -117,6 +134,7 @@ export const NewSubgraphDialog = ({
     activeNodes,
     orphanedNodes,
     activeOrphanedNodes,
+    inputsWithExternalConnections,
     hasActiveOrphans,
     canGroup,
     errorMessage,

--- a/src/components/shared/ReactFlow/FlowCanvas/Subgraphs/checkExternalInputConnections.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/Subgraphs/checkExternalInputConnections.ts
@@ -1,0 +1,60 @@
+import type { Node } from "@xyflow/react";
+
+import type { ComponentSpec } from "@/utils/componentSpec";
+import {
+  isGraphImplementation,
+  isGraphInputArgument,
+} from "@/utils/componentSpec";
+
+export const checkExternalInputConnections = (
+  selectedNodes: Node[],
+  componentSpec: ComponentSpec,
+): Node[] => {
+  if (!isGraphImplementation(componentSpec.implementation)) {
+    return [];
+  }
+
+  const currentGraphSpec = componentSpec.implementation.graph;
+  const selectedInputNodes = selectedNodes.filter(
+    (node) => node.type === "input",
+  );
+
+  const selectedTaskIds = new Set(
+    selectedNodes
+      .filter(
+        (node): node is Node & { type: "task"; data: { taskId: string } } =>
+          node.type === "task",
+      )
+      .map((node) => node.data.taskId),
+  );
+
+  const inputsWithExternalConnections = selectedInputNodes
+    .filter(
+      (node): node is Node & { type: "input"; data: { label: string } } =>
+        node.type === "input",
+    )
+    .filter((node) => {
+      const inputName = node.data.label;
+
+      const isConnectedExternally = Object.entries(currentGraphSpec.tasks).some(
+        ([taskId, taskSpec]) => {
+          if (selectedTaskIds.has(taskId)) {
+            return false;
+          }
+
+          if (taskSpec.arguments) {
+            return Object.values(taskSpec.arguments).some(
+              (arg) =>
+                isGraphInputArgument(arg) &&
+                arg.graphInput.inputName === inputName,
+            );
+          }
+          return false;
+        },
+      );
+
+      return isConnectedExternally;
+    });
+
+  return inputsWithExternalConnections;
+};


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Warn users about selected input nodes with external connections that may be broken. Users can then choose to proceed with the operation, or exclude the input node from the selection.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

![image.png](https://app.graphite.com/user-attachments/assets/b904559b-36b7-4479-a7d2-d08747e51696.png)

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->
1. create a subgraph from a group of nodes with an input node that is connected both internally to the selection and externally (i.e. to a task that will not be part of the subgraph)
2. confirm that the dialog warns the user about the external connection
3. confirm that the users can exclude the input from the selection
4. confirm that the subgraph is created without the input if it is exclude
5. confirm that the current behaviour (the connection is broken) continues if the node is not excluded

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
