### PR TITLE
Get Pipeline Run metadata from Backend

### DIFF
--- a/src/components/PipelineRun/RunDetails.tsx
+++ b/src/components/PipelineRun/RunDetails.tsx
@@ -1,5 +1,4 @@
 import { Frown, Videotape } from "lucide-react";
-import { useEffect, useState } from "react";
 
 import { Spinner } from "@/components/ui/spinner";
 import { useCheckComponentSpecFromPath } from "@/hooks/useCheckComponentSpecFromPath";
@@ -13,8 +12,6 @@ import {
   isStatusComplete,
   isStatusInProgress,
 } from "@/services/executionService";
-import { fetchPipelineRunById } from "@/services/pipelineRunService";
-import type { PipelineRun } from "@/types/pipelineRun";
 
 import { InfoBox } from "../shared/InfoBox";
 import { StatusBar, StatusIcon, StatusText } from "../shared/Status";
@@ -31,6 +28,7 @@ export const RunDetails = () => {
     rootDetails: details,
     rootState: state,
     runId,
+    metadata,
     isLoading,
     error,
   } = useExecutionData();
@@ -45,30 +43,8 @@ export const RunDetails = () => {
     !componentSpec.name,
   );
 
-  const [metadata, setMetadata] = useState<PipelineRun | null>(null);
-
   const isRunCreator =
     currentUserDetails?.id && metadata?.created_by === currentUserDetails.id;
-
-  useEffect(() => {
-    const fetchData = async () => {
-      if (!runId) {
-        setMetadata(null);
-        return;
-      }
-
-      const res = await fetchPipelineRunById(runId);
-
-      if (!res) {
-        setMetadata(null);
-        return;
-      }
-
-      setMetadata(res);
-    };
-
-    fetchData();
-  }, [runId]);
 
   if (error || !details || !state || !componentSpec) {
     return (

--- a/src/routes/PipelineRun/PipelineRun.test.tsx
+++ b/src/routes/PipelineRun/PipelineRun.test.tsx
@@ -49,38 +49,43 @@ vi.mock("@/providers/BackendProvider", () => ({
   }),
 }));
 
-vi.mock("@/services/executionService", () => ({
-  useFetchExecutionInfo: vi.fn(),
-  useFetchPipelineRun: () => ({
-    data: null,
-    isLoading: false,
-    error: null,
-    isFetching: false,
-    refetch: () => {},
-    enabled: false,
-  }),
-  countTaskStatuses: vi.fn(),
-  getRunStatus: vi.fn(() => "RUNNING"),
-  convertExecutionStatsToStatusCounts: vi.fn((stats) => ({
-    succeeded: stats?.SUCCEEDED || 0,
-    failed: stats?.FAILED || 0,
-    running: stats?.RUNNING || 0,
-    waiting: stats?.WAITING_FOR_UPSTREAM || stats?.WAITING || 0,
-    cancelled: stats?.CANCELLED || 0,
-    total: Object.values(stats || {}).reduce(
-      (a: number, b) => a + (b as number),
-      0,
-    ),
-  })),
-  STATUS: {
-    SUCCEEDED: "SUCCEEDED",
-    FAILED: "FAILED",
-    RUNNING: "RUNNING",
-    WAITING: "WAITING",
-    CANCELLED: "CANCELLED",
-    UNKNOWN: "UNKNOWN",
-  },
-}));
+vi.mock("@/services/executionService", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/services/executionService")>();
+  return {
+    ...actual,
+    useFetchExecutionInfo: vi.fn(),
+    useFetchPipelineRun: () => ({
+      data: null,
+      isLoading: false,
+      error: null,
+      isFetching: false,
+      refetch: () => {},
+      enabled: false,
+    }),
+    countTaskStatuses: vi.fn(),
+    getRunStatus: vi.fn(() => "RUNNING"),
+    convertExecutionStatsToStatusCounts: vi.fn((stats) => ({
+      succeeded: stats?.SUCCEEDED || 0,
+      failed: stats?.FAILED || 0,
+      running: stats?.RUNNING || 0,
+      waiting: stats?.WAITING_FOR_UPSTREAM || stats?.WAITING || 0,
+      cancelled: stats?.CANCELLED || 0,
+      total: Object.values(stats || {}).reduce(
+        (a: number, b) => a + (b as number),
+        0,
+      ),
+    })),
+    STATUS: {
+      SUCCEEDED: "SUCCEEDED",
+      FAILED: "FAILED",
+      RUNNING: "RUNNING",
+      WAITING: "WAITING",
+      CANCELLED: "CANCELLED",
+      UNKNOWN: "UNKNOWN",
+    },
+  };
+});
 
 const mockUsePipelineRunData = vi.fn();
 vi.mock("@/hooks/usePipelineRunData", () => ({

--- a/src/services/executionService.ts
+++ b/src/services/executionService.ts
@@ -7,7 +7,9 @@ import type {
   GetGraphExecutionStateResponse,
   PipelineRunResponse,
 } from "@/api/types.gen";
+import { useBackend } from "@/providers/BackendProvider";
 import type { RunStatus, TaskStatusCounts } from "@/types/pipelineRun";
+import { TWENTY_FOUR_HOURS_IN_MS } from "@/utils/constants";
 import { fetchWithErrorHandling } from "@/utils/fetchWithErrorHandling";
 
 export const fetchExecutionState = async (
@@ -35,6 +37,18 @@ export const fetchPipelineRun = async (
     throw new Error(`Failed to fetch pipeline run: ${response.statusText}`);
   }
   return response.json();
+};
+
+export const useFetchPipelineRunMetadata = (runId: string | undefined) => {
+  const { backendUrl } = useBackend();
+
+  return useQuery<PipelineRunResponse>({
+    queryKey: ["pipeline-run", runId],
+    queryFn: () => fetchPipelineRun(runId!, backendUrl),
+    enabled: !!runId,
+    refetchOnWindowFocus: false,
+    staleTime: TWENTY_FOUR_HOURS_IN_MS,
+  });
 };
 
 const fetchContainerExecutionState = async (

--- a/src/services/pipelineRunService.ts
+++ b/src/services/pipelineRunService.ts
@@ -188,21 +188,6 @@ export const fetchPipelineRuns = async (pipelineName: string) => {
   }
 };
 
-export const fetchPipelineRunById = async (runId: string) => {
-  try {
-    const pipelineRunsDb = localForage.createInstance({
-      name: "components",
-      storeName: "pipeline_runs",
-    });
-
-    const run = (await pipelineRunsDb.getItem(runId.toString())) as PipelineRun;
-    return run;
-  } catch (error) {
-    console.error("Error fetching pipeline run by ID:", error);
-    return null;
-  }
-};
-
 export const cancelPipelineRun = async (runId: string, backendUrl: string) => {
   await fetchWithErrorHandling(
     `${backendUrl}/api/pipeline_runs/${runId}/cancel`,


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Get Pipeline Run metadata from the backend via `pipeline_run/{id}`. Currently it is fetched from local storage.

This should fixes issues where Pipeline Metadata (e.g. `created_by`) would not show on pipelines that a user did not create. Furthermore, it should fix the issue where users cannot cancel a run they initiated via API (since running via API doesn't add the pipeline to your storage).


The current local storage fetch returns a little more data, but we don't actually use the additional info. It relies on the user having the pipeline in local storage, i.e. they created it. This is not fit for purpose and thus fetching from the backend is preferred.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->
Closes https://github.com/Shopify/oasis-frontend/issues/363
Closes https://github.com/Shopify/oasis-frontend/issues/342
Closes https://github.com/Shopify/oasis-frontend/issues/323


## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix
- [x] Improvement
- [x] Cleanup/Refactor

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->
1. go to a run
2. confirm the metadata is loaded and shows (i.e. created_by etc)

Verification that this fixes issues with things such as the cancel button will need to be done on staging.

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
