### PR TITLE
Fix status

### DIFF
--- a/src/services/executionService.test.ts
+++ b/src/services/executionService.test.ts
@@ -64,11 +64,11 @@ describe("getRunStatus()", () => {
   it("should return SUCCEEDED when there are succeeded tasks but no other active/problematic tasks", () => {
     const statusData: TaskStatusCounts = {
       total: 3,
-      succeeded: 2,
+      succeeded: 3,
       failed: 0,
       running: 0,
       waiting: 0,
-      skipped: 1,
+      skipped: 0,
       cancelled: 0,
     };
 
@@ -89,7 +89,7 @@ describe("getRunStatus()", () => {
     expect(getRunStatus(statusData)).toBe(STATUS.UNKNOWN);
   });
 
-  it("should return UNKNOWN when only skipped tasks exist", () => {
+  it("should return SKIPPED when only skipped tasks exist", () => {
     const statusData: TaskStatusCounts = {
       total: 2,
       succeeded: 0,
@@ -100,7 +100,7 @@ describe("getRunStatus()", () => {
       cancelled: 0,
     };
 
-    expect(getRunStatus(statusData)).toBe(STATUS.UNKNOWN);
+    expect(getRunStatus(statusData)).toBe(STATUS.SKIPPED);
   });
 
   it("should prioritize CANCELLED over all other statuses", () => {
@@ -131,7 +131,7 @@ describe("getRunStatus()", () => {
     expect(getRunStatus(statusData)).toBe(STATUS.FAILED);
   });
 
-  it("should prioritize RUNNING over WAITING and SUCCEEDED", () => {
+  it("should prioritize RUNNING over SKIPPED, WAITING, and SUCCEEDED", () => {
     const statusData: TaskStatusCounts = {
       total: 4,
       succeeded: 1,
@@ -145,7 +145,7 @@ describe("getRunStatus()", () => {
     expect(getRunStatus(statusData)).toBe(STATUS.RUNNING);
   });
 
-  it("should prioritize WAITING over SUCCEEDED", () => {
+  it("should prioritize SKIPPED over WAITING and SUCCEEDED", () => {
     const statusData: TaskStatusCounts = {
       total: 3,
       succeeded: 1,
@@ -153,6 +153,20 @@ describe("getRunStatus()", () => {
       running: 0,
       waiting: 1,
       skipped: 1,
+      cancelled: 0,
+    };
+
+    expect(getRunStatus(statusData)).toBe(STATUS.SKIPPED);
+  });
+
+  it("should prioritize WAITING over SUCCEEDED when nothing else is active", () => {
+    const statusData: TaskStatusCounts = {
+      total: 3,
+      succeeded: 1,
+      failed: 0,
+      running: 0,
+      waiting: 1,
+      skipped: 0,
       cancelled: 0,
     };
 

--- a/src/services/executionService.ts
+++ b/src/services/executionService.ts
@@ -107,6 +107,7 @@ export const STATUS: Record<RunStatus, RunStatus> = {
   SUCCEEDED: "SUCCEEDED",
   WAITING: "WAITING",
   CANCELLED: "CANCELLED",
+  SKIPPED: "SKIPPED",
   UNKNOWN: "UNKNOWN",
 } as const;
 
@@ -120,10 +121,13 @@ export const getRunStatus = (statusData: TaskStatusCounts): RunStatus => {
   if (statusData.running > 0) {
     return STATUS.RUNNING;
   }
+  if (statusData.skipped > 0) {
+    return STATUS.SKIPPED;
+  }
   if (statusData.waiting > 0) {
     return STATUS.WAITING;
   }
-  if (statusData.succeeded > 0) {
+  if (statusData.total > 0 && statusData.succeeded === statusData.total) {
     return STATUS.SUCCEEDED;
   }
   return STATUS.UNKNOWN;

--- a/src/types/pipelineRun.ts
+++ b/src/types/pipelineRun.ts
@@ -7,6 +7,7 @@ export type RunStatus =
   | "SUCCEEDED"
   | "WAITING"
   | "CANCELLED"
+  | "SKIPPED"
   | "UNKNOWN";
 
 export interface PipelineRun {


### PR DESCRIPTION
## Description

Added a new `SKIPPED` status for pipeline runs and updated the status prioritization logic. Now, when all tasks are skipped, the run status will be `SKIPPED` instead of `UNKNOWN`. Also fixed the `SUCCEEDED` status to only apply when all tasks have succeeded.

## Type of Change

- [x] Bug fix
- [x] Improvement

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Test Instructions

Run the updated tests to verify the new status prioritization logic:
1. Runs with only skipped tasks should now show as `SKIPPED`
2. Runs should only show as `SUCCEEDED` when all tasks have succeeded
3. Status prioritization now follows: CANCELLED > FAILED > RUNNING > SKIPPED > WAITING > SUCCEEDED