### PR TITLE
Fix Node Highlight on Task Hover

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
@@ -575,13 +575,19 @@ const FlowCanvas = ({
           isPositionInNode(node, cursorPosition),
         );
 
-        if (hoveredNode?.id === replaceTarget?.id) return;
-        if (hoveredNode?.type && !REPLACEABLE_NODES.has(hoveredNode.type)) {
+        if (!hoveredNode && replaceTarget) {
           setReplaceTarget(null);
           return;
         }
 
-        setReplaceTarget(hoveredNode || null);
+        if (!hoveredNode || hoveredNode.id === replaceTarget?.id) return;
+
+        if (hoveredNode.type && !REPLACEABLE_NODES.has(hoveredNode.type)) {
+          setReplaceTarget(null);
+          return;
+        }
+
+        setReplaceTarget(hoveredNode);
       }
     },
     [reactFlowInstance, nodes, replaceTarget, setReplaceTarget],
@@ -912,7 +918,12 @@ const FlowCanvas = ({
     preserveIOSelectionOnSpecChange(componentSpec);
     updateReactFlow(componentSpec);
     initialCanvasLoaded.current = true;
-  }, [componentSpec, currentSubgraphPath, preserveIOSelectionOnSpecChange]);
+  }, [
+    replaceTarget,
+    componentSpec,
+    currentSubgraphPath,
+    preserveIOSelectionOnSpecChange,
+  ]);
 
   useEffect(() => {
     reactFlowInstance?.fitView({


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

Fixes a bug where dragging from the component library over a node on the canvas to replace it would not highlight the replace-target node.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

Closes https://github.com/Shopify/oasis-frontend/issues/326

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

1. Drag a task from the library and hover over a node on the canvas, it should highlight orange.
2. It should un-highlight when you move off it
3. Replace flow should trigger if you release while it is highlighted

## Additional Comments



Future: disable highlighting when an IO node is dragged over a task

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->