### PR TITLE
Fix crash when reviewing task upgrades inside a subgraph

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/UpgradeNodePopover.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/UpgradeNodePopover.tsx
@@ -42,7 +42,7 @@ export const UpgradeNodePopover = ({
   }) => {
   const [open, setOpen] = useState(true);
   const { taskId, taskSpec } = currentNode;
-  const { graphSpec, updateGraphSpec } = useComponentSpec();
+  const { currentGraphSpec, updateGraphSpec } = useComponentSpec();
   const { notifyNode, fitNodeIntoView } = useNodesOverlay();
 
   const replaceWithComponent = useMemo(() => {
@@ -54,8 +54,8 @@ export const UpgradeNodePopover = ({
 
   const updatePreview = useMemo(() => {
     if (!taskId || !replaceWithComponent) return null;
-    return replaceTaskNode(taskId, replaceWithComponent, graphSpec);
-  }, [taskId, replaceWithComponent, graphSpec]);
+    return replaceTaskNode(taskId, replaceWithComponent, currentGraphSpec);
+  }, [taskId, replaceWithComponent, currentGraphSpec]);
 
   const markup = useMemo(() => {
     if (!taskId || !taskSpec || !replaceWithComponent || !updatePreview) {


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Fix a bug where the review flow for outdated nodes would crash the app when used inside a subgraph

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

This now works in a subgraph

![image.png](https://app.graphite.com/user-attachments/assets/e2131885-3313-4c18-bd21-90772fe78f78.png)

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->
1. use outdated tasks in a subgraph
2. use the review flow to update them
3. everything should work as expected

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->

Side note: "This cannot be undone" is technically untrue -- "Undo", in fact, does undo the upgrade.
