### PR TITLE
Default InfoBox to 'auto' Width

### DIFF
--- a/src/components/shared/InfoBox.tsx
+++ b/src/components/shared/InfoBox.tsx
@@ -44,7 +44,7 @@ const widthStyles: Record<NonNullable<InfoBoxProps["width"]>, string> = {
 
 export const InfoBox = ({
   title,
-  width = "fit",
+  width = "auto",
   className,
   children,
   variant = "info",


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Default width for info box set to "auto" instead of "fit".

Fixes regressions in scenarios like the replace dialog:

![image.png](https://app.graphite.com/user-attachments/assets/ed3821af-12dd-4055-8efc-9ceb57b6d6b6.png)


## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
