### PR TITLE
feat: navigate to example pipelines button

### DIFF
--- a/src/components/Home/PipelineSection/PipelineSection.tsx
+++ b/src/components/Home/PipelineSection/PipelineSection.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from "@tanstack/react-router";
 import { type ChangeEvent, useCallback, useEffect, useState } from "react";
 
 import NewPipelineButton from "@/components/shared/NewPipelineButton";
@@ -20,6 +21,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Paragraph, Text } from "@/components/ui/typography";
+import { QUICK_START_PATH } from "@/routes/router";
 import {
   type ComponentFileEntry,
   getAllComponentFilesFromList,
@@ -174,17 +176,27 @@ export const PipelineSection = withSuspenseWrapper(() => {
         </AlertDescription>
       </Alert>
 
-      <BlockStack className="w-full">
-        <Label className="mb-2">Search pipelines</Label>
-        <InlineStack gap="1" wrap="nowrap">
-          <Input type="text" value={searchQuery} onChange={handleSearch} />
-          {!!searchQuery && (
-            <Button variant="ghost" onClick={() => setSearchQuery("")}>
-              <Icon name="CircleX" />
-            </Button>
-          )}
-        </InlineStack>
-      </BlockStack>
+      <InlineStack
+        gap="2"
+        align="space-between"
+        blockAlign="end"
+        wrap="nowrap"
+        className="w-full"
+      >
+        <BlockStack className="w-full">
+          <Label className="mb-2">Search pipelines</Label>
+          <InlineStack gap="1" wrap="nowrap">
+            <Input type="text" value={searchQuery} onChange={handleSearch} />
+            {!!searchQuery && (
+              <Button variant="ghost" onClick={() => setSearchQuery("")}>
+                <Icon name="CircleX" />
+              </Button>
+            )}
+          </InlineStack>
+        </BlockStack>
+
+        <QuickStartButton />
+      </InlineStack>
 
       {pipelines.size > 0 && (
         <Table>
@@ -235,3 +247,18 @@ export const PipelineSection = withSuspenseWrapper(() => {
     </BlockStack>
   );
 }, PipelineSectionSkeleton);
+
+function QuickStartButton() {
+  const navigate = useNavigate();
+  return (
+    <Button
+      variant="secondary"
+      onClick={() =>
+        navigate({ to: QUICK_START_PATH as string /* todo: fix this */ })
+      }
+    >
+      <Icon name="Sparkles" />
+      Example Pipelines
+    </Button>
+  );
+}

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -26,7 +26,7 @@ declare module "@tanstack/react-router" {
 
 export const EDITOR_PATH = "/editor";
 export const RUNS_BASE_PATH = "/runs";
-const QUICK_START_PATH = "/quick-start";
+export const QUICK_START_PATH = "/quick-start";
 export const APP_ROUTES = {
   HOME: "/",
   QUICK_START: QUICK_START_PATH,


### PR DESCRIPTION
## Description

Added an "Example Pipelines" button to the Pipeline Section that navigates to the Quick Start page. The button appears alongside the search functionality and includes a sparkles icon for visual appeal.

## Type of Change

- [x] New feature
- [x] Improvement

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

[Screen Recording 2025-11-21 at 3.39.29 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/50712d4b-13d2-4a9f-9e18-0d763d8d608c.mov" />](https://app.graphite.com/user-attachments/video/50712d4b-13d2-4a9f-9e18-0d763d8d608c.mov)

## Test Instructions

1. Navigate to the home page
2. Verify the "Example Pipelines" button appears next to the search box
3. Click the button and confirm it navigates to the Quick Start page

## Additional Comments

Also exported the `QUICK_START_PATH` constant from router.ts to make it accessible to other components.