### PR TITLE
feat: navigate to my pipelines if runs are empty

### DIFF
--- a/src/routes/Home/Home.tsx
+++ b/src/routes/Home/Home.tsx
@@ -1,13 +1,33 @@
+import { useRef, useState } from "react";
+
 import { PipelineSection, RunSection } from "@/components/Home";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 const Home = () => {
+  const [activeTab, setActiveTab] = useState("runs");
+  const handleTabSelect = (value: string) => {
+    setActiveTab(value);
+  };
+
+  const handledPipelineRunsEmpty = useRef(false);
+  const handlePipelineRunsEmpty = () => {
+    if (!handledPipelineRunsEmpty.current) {
+      setActiveTab("pipelines");
+      handledPipelineRunsEmpty.current = true;
+    }
+  };
+
   return (
     <div className="container mx-auto w-3/4 p-4 flex flex-col gap-4">
       <div className="flex justify-between items-center">
         <h1 className="text-2xl font-bold">Pipelines</h1>
       </div>
-      <Tabs defaultValue="runs" className="w-full">
+      <Tabs
+        defaultValue="runs"
+        className="w-full"
+        value={activeTab}
+        onValueChange={handleTabSelect}
+      >
         <TabsList>
           <TabsTrigger value="runs">All Runs</TabsTrigger>
           <TabsTrigger value="pipelines">My pipelines</TabsTrigger>
@@ -16,7 +36,7 @@ const Home = () => {
           <PipelineSection />
         </TabsContent>
         <TabsContent value="runs" className="flex flex-col gap-1">
-          <RunSection />
+          <RunSection onEmptyList={handlePipelineRunsEmpty} />
         </TabsContent>
       </Tabs>
     </div>


### PR DESCRIPTION
## Description

Added automatic tab switching to the "My pipelines" tab when a user has no pipeline runs. The `RunSection` component now accepts an `onEmptyList` callback prop that is triggered when the runs list is empty and the backend is ready. In the Home component, this callback is used to switch to the "pipelines" tab when a user first visits the page with no runs.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

[Screen Recording 2025-11-21 at 3.39.29 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/65edc03e-e200-4dad-add0-41f13cac9778.mov" />](https://app.graphite.com/user-attachments/video/65edc03e-e200-4dad-add0-41f13cac9778.mov)

## Test Instructions

1. Clear your pipeline runs or use a new account
2. Navigate to the home page
3. Verify that the tab automatically switches to "My pipelines" if there are no runs
4. Create a run and verify that the "All Runs" tab shows the run correctly
5. Verify that manual tab switching still works as expected

## Additional Comments

The tab switching only happens once per session (tracked with a ref) to avoid constantly switching tabs if a user intentionally clears their runs or switches to the runs tab manually.