### PR TITLE
Add Subgraph Creation Tests

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/Subgraphs/create/checkExternalInputConnections.test.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/Subgraphs/create/checkExternalInputConnections.test.ts
@@ -1,0 +1,581 @@
+import type { Node } from "@xyflow/react";
+import { describe, expect, it } from "vitest";
+
+import type { ComponentSpec, GraphSpec } from "@/utils/componentSpec";
+
+import { checkExternalInputConnections } from "./checkExternalInputConnections";
+
+// Helper to create a node
+const createNode = (
+  id: string,
+  type: "task" | "input" | "output",
+  data: Record<string, any>,
+): Node => ({
+  id,
+  type,
+  position: { x: 0, y: 0 },
+  data,
+});
+
+// Helper to create a task node
+const createTaskNode = (id: string, taskId: string): Node =>
+  createNode(id, "task", { taskId });
+
+// Helper to create an input node
+const createInputNode = (id: string, label: string): Node =>
+  createNode(id, "input", { label });
+
+// Helper to create a component spec with graph implementation
+const createGraphSpec = (
+  tasks: GraphSpec["tasks"] = {},
+  outputValues: GraphSpec["outputValues"] = {},
+): ComponentSpec => ({
+  name: "test-component",
+  description: "Test component",
+  implementation: {
+    graph: {
+      tasks,
+      outputValues,
+    },
+  },
+});
+
+describe("checkExternalInputConnections", () => {
+  describe("no external connections", () => {
+    it("should return empty array when no input nodes are selected", () => {
+      const spec = createGraphSpec({
+        task1: {
+          componentRef: { name: "test-component" },
+          arguments: {},
+        },
+      });
+
+      const selectedNodes = [createTaskNode("task-1", "task1")];
+
+      const result = checkExternalInputConnections(selectedNodes, spec);
+
+      expect(result).toEqual([]);
+    });
+
+    it("should return empty array when input has no connections at all", () => {
+      const spec = createGraphSpec({
+        task1: {
+          componentRef: { name: "test-component" },
+          arguments: {},
+        },
+      });
+
+      const selectedNodes = [
+        createInputNode("input-1", "myInput"),
+        createTaskNode("task-1", "task1"),
+      ];
+
+      const result = checkExternalInputConnections(selectedNodes, spec);
+
+      expect(result).toEqual([]);
+    });
+
+    it("should return empty array when input is only connected to selected tasks", () => {
+      const spec = createGraphSpec({
+        task1: {
+          componentRef: { name: "test-component" },
+          arguments: {
+            input1: {
+              graphInput: {
+                inputName: "myInput",
+                type: "string",
+              },
+            },
+          },
+        },
+      });
+
+      const selectedNodes = [
+        createInputNode("input-1", "myInput"),
+        createTaskNode("task-1", "task1"),
+      ];
+
+      const result = checkExternalInputConnections(selectedNodes, spec);
+
+      expect(result).toEqual([]);
+    });
+
+    it("should return empty array when input is connected internally only", () => {
+      const spec = createGraphSpec({
+        task1: {
+          componentRef: { name: "test-component" },
+          arguments: {
+            input1: {
+              graphInput: {
+                inputName: "myInput",
+                type: "string",
+              },
+            },
+          },
+        },
+        task2: {
+          componentRef: { name: "test-component" },
+          arguments: {
+            input1: {
+              graphInput: {
+                inputName: "myInput",
+                type: "string",
+              },
+            },
+          },
+        },
+      });
+
+      const selectedNodes = [
+        createInputNode("input-1", "myInput"),
+        createTaskNode("task-1", "task1"),
+        createTaskNode("task-2", "task2"),
+      ];
+
+      const result = checkExternalInputConnections(selectedNodes, spec);
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("with external connections", () => {
+    it("should return input node when connected to external task", () => {
+      const spec = createGraphSpec({
+        internalTask: {
+          componentRef: { name: "test-component" },
+          arguments: {
+            input1: {
+              graphInput: {
+                inputName: "myInput",
+                type: "string",
+              },
+            },
+          },
+        },
+        externalTask: {
+          componentRef: { name: "test-component" },
+          arguments: {
+            input1: {
+              graphInput: {
+                inputName: "myInput",
+                type: "string",
+              },
+            },
+          },
+        },
+      });
+
+      const selectedNodes = [
+        createInputNode("input-1", "myInput"),
+        createTaskNode("task-1", "internalTask"),
+      ];
+
+      const result = checkExternalInputConnections(selectedNodes, spec);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe("input-1");
+      expect(result[0].data.label).toBe("myInput");
+    });
+
+    it("should return input node when connected ONLY to external task", () => {
+      const spec = createGraphSpec({
+        externalTask: {
+          componentRef: { name: "test-component" },
+          arguments: {
+            input1: {
+              graphInput: {
+                inputName: "myInput",
+                type: "string",
+              },
+            },
+          },
+        },
+      });
+
+      const selectedNodes = [
+        createInputNode("input-1", "myInput"),
+        createTaskNode("task-1", "someOtherTask"),
+      ];
+
+      const result = checkExternalInputConnections(selectedNodes, spec);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe("input-1");
+    });
+
+    it("should return multiple input nodes when multiple have external connections", () => {
+      const spec = createGraphSpec({
+        internalTask: {
+          componentRef: { name: "test-component" },
+          arguments: {},
+        },
+        externalTask1: {
+          componentRef: { name: "test-component" },
+          arguments: {
+            input1: {
+              graphInput: {
+                inputName: "input1",
+                type: "string",
+              },
+            },
+          },
+        },
+        externalTask2: {
+          componentRef: { name: "test-component" },
+          arguments: {
+            input1: {
+              graphInput: {
+                inputName: "input2",
+                type: "string",
+              },
+            },
+          },
+        },
+      });
+
+      const selectedNodes = [
+        createInputNode("input-1", "input1"),
+        createInputNode("input-2", "input2"),
+        createTaskNode("task-1", "internalTask"),
+      ];
+
+      const result = checkExternalInputConnections(selectedNodes, spec);
+
+      expect(result).toHaveLength(2);
+      expect(result.map((n) => n.id).sort()).toEqual(["input-1", "input-2"]);
+    });
+
+    it("should only return inputs with external connections, not all selected inputs", () => {
+      const spec = createGraphSpec({
+        internalTask: {
+          componentRef: { name: "test-component" },
+          arguments: {
+            input1: {
+              graphInput: {
+                inputName: "internalInput",
+                type: "string",
+              },
+            },
+          },
+        },
+        externalTask: {
+          componentRef: { name: "test-component" },
+          arguments: {
+            input1: {
+              graphInput: {
+                inputName: "externalInput",
+                type: "string",
+              },
+            },
+          },
+        },
+      });
+
+      const selectedNodes = [
+        createInputNode("input-1", "internalInput"),
+        createInputNode("input-2", "externalInput"),
+        createInputNode("input-3", "unusedInput"),
+        createTaskNode("task-1", "internalTask"),
+      ];
+
+      const result = checkExternalInputConnections(selectedNodes, spec);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe("input-2");
+      expect(result[0].data.label).toBe("externalInput");
+    });
+
+    it("should detect external connection when input used by multiple external tasks", () => {
+      const spec = createGraphSpec({
+        internalTask: {
+          componentRef: { name: "test-component" },
+          arguments: {},
+        },
+        externalTask1: {
+          componentRef: { name: "test-component" },
+          arguments: {
+            input1: {
+              graphInput: {
+                inputName: "sharedInput",
+                type: "string",
+              },
+            },
+          },
+        },
+        externalTask2: {
+          componentRef: { name: "test-component" },
+          arguments: {
+            input1: {
+              graphInput: {
+                inputName: "sharedInput",
+                type: "string",
+              },
+            },
+          },
+        },
+      });
+
+      const selectedNodes = [
+        createInputNode("input-1", "sharedInput"),
+        createTaskNode("task-1", "internalTask"),
+      ];
+
+      const result = checkExternalInputConnections(selectedNodes, spec);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe("input-1");
+    });
+
+    it("should handle mixed internal and external connections", () => {
+      const spec = createGraphSpec({
+        internalTask1: {
+          componentRef: { name: "test-component" },
+          arguments: {
+            input1: {
+              graphInput: {
+                inputName: "myInput",
+                type: "string",
+              },
+            },
+          },
+        },
+        internalTask2: {
+          componentRef: { name: "test-component" },
+          arguments: {
+            input1: {
+              graphInput: {
+                inputName: "myInput",
+                type: "string",
+              },
+            },
+          },
+        },
+        externalTask: {
+          componentRef: { name: "test-component" },
+          arguments: {
+            input1: {
+              graphInput: {
+                inputName: "myInput",
+                type: "string",
+              },
+            },
+          },
+        },
+      });
+
+      const selectedNodes = [
+        createInputNode("input-1", "myInput"),
+        createTaskNode("task-1", "internalTask1"),
+        createTaskNode("task-2", "internalTask2"),
+      ];
+
+      const result = checkExternalInputConnections(selectedNodes, spec);
+
+      // Should still detect the external connection even with internal ones
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe("input-1");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should return empty array for non-graph implementation", () => {
+      const spec: ComponentSpec = {
+        name: "test-component",
+        description: "Test component",
+        implementation: {
+          container: {
+            image: "test:latest",
+          },
+        },
+      };
+
+      const selectedNodes = [
+        createInputNode("input-1", "myInput"),
+        createTaskNode("task-1", "task1"),
+      ];
+
+      const result = checkExternalInputConnections(selectedNodes, spec);
+
+      expect(result).toEqual([]);
+    });
+
+    it("should handle empty selection", () => {
+      const spec = createGraphSpec({
+        task1: {
+          componentRef: { name: "test-component" },
+          arguments: {},
+        },
+      });
+
+      const selectedNodes: Node[] = [];
+
+      const result = checkExternalInputConnections(selectedNodes, spec);
+
+      expect(result).toEqual([]);
+    });
+
+    it("should handle tasks with no arguments", () => {
+      const spec = createGraphSpec({
+        task1: {
+          componentRef: { name: "test-component" },
+          // No arguments property
+        },
+      });
+
+      const selectedNodes = [
+        createInputNode("input-1", "myInput"),
+        createTaskNode("task-1", "task1"),
+      ];
+
+      const result = checkExternalInputConnections(selectedNodes, spec);
+
+      expect(result).toEqual([]);
+    });
+
+    it("should handle input node with missing label", () => {
+      const spec = createGraphSpec({
+        task1: {
+          componentRef: { name: "test-component" },
+          arguments: {
+            input1: {
+              graphInput: {
+                inputName: "myInput",
+                type: "string",
+              },
+            },
+          },
+        },
+      });
+
+      const selectedNodes = [
+        createNode("input-1", "input", {}), // Missing label
+        createTaskNode("task-1", "someOtherTask"),
+      ];
+
+      const result = checkExternalInputConnections(selectedNodes, spec);
+
+      expect(result).toEqual([]);
+    });
+
+    it("should ignore non-graphInput arguments", () => {
+      const spec = createGraphSpec({
+        task1: {
+          componentRef: { name: "test-component" },
+          arguments: {
+            input1: {
+              taskOutput: {
+                taskId: "task0",
+                outputName: "result",
+                type: "string",
+              },
+            },
+          },
+        },
+      });
+
+      const selectedNodes = [
+        createInputNode("input-1", "myInput"),
+        createTaskNode("task-1", "someOtherTask"),
+      ];
+
+      const result = checkExternalInputConnections(selectedNodes, spec);
+
+      expect(result).toEqual([]);
+    });
+
+    it("should handle tasks that reference inputs with different names", () => {
+      const spec = createGraphSpec({
+        externalTask: {
+          componentRef: { name: "test-component" },
+          arguments: {
+            input1: {
+              graphInput: {
+                inputName: "differentInput",
+                type: "string",
+              },
+            },
+          },
+        },
+      });
+
+      const selectedNodes = [
+        createInputNode("input-1", "myInput"),
+        createTaskNode("task-1", "someOtherTask"),
+      ];
+
+      const result = checkExternalInputConnections(selectedNodes, spec);
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("complex scenarios", () => {
+    it("should handle large selection with multiple inputs and tasks", () => {
+      const spec = createGraphSpec({
+        internal1: {
+          componentRef: { name: "test-component" },
+          arguments: {
+            input1: {
+              graphInput: {
+                inputName: "input1",
+                type: "string",
+              },
+            },
+          },
+        },
+        internal2: {
+          componentRef: { name: "test-component" },
+          arguments: {
+            input1: {
+              graphInput: {
+                inputName: "input2",
+                type: "string",
+              },
+            },
+          },
+        },
+        external1: {
+          componentRef: { name: "test-component" },
+          arguments: {
+            input1: {
+              graphInput: {
+                inputName: "input1",
+                type: "string",
+              },
+            },
+          },
+        },
+        external2: {
+          componentRef: { name: "test-component" },
+          arguments: {
+            input1: {
+              graphInput: {
+                inputName: "input3",
+                type: "string",
+              },
+            },
+          },
+        },
+      });
+
+      const selectedNodes = [
+        createInputNode("input-1", "input1"),
+        createInputNode("input-2", "input2"),
+        createInputNode("input-3", "input3"),
+        createTaskNode("task-1", "internal1"),
+        createTaskNode("task-2", "internal2"),
+      ];
+
+      const result = checkExternalInputConnections(selectedNodes, spec);
+
+      // input1 has external connection (external1)
+      // input2 has no external connection
+      // input3 has external connection (external2) but no internal connection
+      expect(result).toHaveLength(2);
+      expect(result.map((n) => n.data.label).sort()).toEqual([
+        "input1",
+        "input3",
+      ]);
+    });
+  });
+});

--- a/src/components/shared/ReactFlow/FlowCanvas/Subgraphs/create/handleGroupNodes.test.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/Subgraphs/create/handleGroupNodes.test.ts
@@ -1,0 +1,811 @@
+import type { Node } from "@xyflow/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  type ComponentSpec,
+  type GraphSpec,
+  isGraphImplementation,
+  type TaskSpec,
+} from "@/utils/componentSpec";
+import { createSubgraphFromNodes } from "@/utils/nodes/createSubgraphFromNodes";
+
+import addTask from "../../utils/addTask";
+import { calculateNodesCenter } from "../../utils/geometry";
+import { removeNode } from "../../utils/removeNode";
+import { updateDownstreamSubgraphConnections } from "../../utils/updateDownstreamSubgraphConnections";
+import { handleGroupNodes } from "./handleGroupNodes";
+
+// Mock dependencies
+vi.mock("@/utils/nodes/createSubgraphFromNodes");
+vi.mock("../../utils/addTask");
+vi.mock("../../utils/geometry");
+vi.mock("../../utils/removeNode");
+vi.mock("../../utils/updateDownstreamSubgraphConnections");
+vi.mock("@/services/componentService", () => ({
+  generateDigest: vi.fn().mockResolvedValue("mock-digest"),
+  getComponentText: vi.fn().mockResolvedValue("mock-component-text"),
+}));
+vi.mock("@/utils/user", () => ({
+  getUserDetails: vi.fn().mockResolvedValue({ id: "test-user" }),
+}));
+
+// Helper to create a node
+const createNode = (
+  id: string,
+  type: "task" | "input" | "output",
+  data: Record<string, any>,
+  position: { x: number; y: number } = { x: 0, y: 0 },
+): Node => ({
+  id,
+  type,
+  position,
+  data,
+  measured: { width: 200, height: 100 },
+});
+
+// Helper to create a task node
+const createTaskNode = (
+  id: string,
+  taskId: string,
+  position: { x: number; y: number } = { x: 0, y: 0 },
+): Node => createNode(id, "task", { taskId }, position);
+
+// Helper to create a component spec with graph implementation
+const createGraphSpec = (
+  tasks: GraphSpec["tasks"] = {},
+  outputValues: GraphSpec["outputValues"] = {},
+): ComponentSpec => ({
+  name: "test-component",
+  description: "Test component",
+  implementation: {
+    graph: {
+      tasks,
+      outputValues,
+    },
+  },
+});
+
+describe("handleGroupNodes", () => {
+  let onSuccess: ReturnType<typeof vi.fn>;
+  let onError: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    onSuccess = vi.fn();
+    onError = vi.fn();
+
+    // Setup default mock implementations
+    vi.mocked(calculateNodesCenter).mockReturnValue({ x: 100, y: 100 });
+    vi.mocked(removeNode).mockImplementation((_, spec) => spec);
+  });
+
+  describe("successful grouping", () => {
+    it("should group nodes and call onSuccess with updated spec", async () => {
+      const spec = createGraphSpec({
+        task1: {
+          componentRef: { name: "component1" },
+          arguments: {},
+        },
+        task2: {
+          componentRef: { name: "component2" },
+          arguments: {},
+        },
+      });
+
+      if (!isGraphImplementation(spec.implementation)) {
+        return;
+      }
+
+      const selectedNodes = [
+        createTaskNode("node-1", "task1"),
+        createTaskNode("node-2", "task2"),
+      ];
+
+      const mockSubgraphTask: TaskSpec = {
+        componentRef: {
+          name: "MySubgraph",
+          spec: {
+            name: "MySubgraph",
+            description: "Subgraph",
+            implementation: {
+              graph: {
+                tasks: {
+                  task1: spec.implementation.graph!.tasks.task1,
+                  task2: spec.implementation.graph!.tasks.task2,
+                },
+              },
+            },
+          },
+        },
+        arguments: {},
+      };
+
+      vi.mocked(createSubgraphFromNodes).mockResolvedValue({
+        subgraphTask: mockSubgraphTask,
+        connectionMappings: [],
+      });
+
+      const specWithNewTask = createGraphSpec({
+        ...spec.implementation.graph!.tasks,
+        subgraph1: mockSubgraphTask,
+      });
+
+      vi.mocked(addTask).mockReturnValue({
+        spec: specWithNewTask,
+        taskId: "subgraph1",
+      });
+
+      vi.mocked(updateDownstreamSubgraphConnections).mockReturnValue(
+        specWithNewTask,
+      );
+
+      await handleGroupNodes(
+        selectedNodes,
+        spec,
+        "MySubgraph",
+        onSuccess,
+        onError,
+      );
+
+      expect(createSubgraphFromNodes).toHaveBeenCalledWith(
+        selectedNodes,
+        spec,
+        "MySubgraph",
+      );
+      expect(calculateNodesCenter).toHaveBeenCalledWith(selectedNodes);
+      expect(addTask).toHaveBeenCalledWith(
+        "task",
+        mockSubgraphTask,
+        { x: 100, y: 100 },
+        spec,
+      );
+      expect(removeNode).toHaveBeenCalledTimes(2);
+      expect(onSuccess).toHaveBeenCalled();
+      expect(onError).not.toHaveBeenCalled();
+    });
+
+    it("should calculate center position from selected nodes", async () => {
+      const spec = createGraphSpec({
+        task1: {
+          componentRef: { name: "component1" },
+          arguments: {},
+        },
+      });
+
+      const selectedNodes = [
+        createTaskNode("node-1", "task1", { x: 50, y: 50 }),
+        createTaskNode("node-2", "task2", { x: 150, y: 150 }),
+      ];
+
+      const mockSubgraphTask: TaskSpec = {
+        componentRef: {
+          name: "MySubgraph",
+          spec: {
+            name: "MySubgraph",
+            description: "Subgraph",
+            implementation: {
+              graph: { tasks: {} },
+            },
+          },
+        },
+        arguments: {},
+      };
+
+      vi.mocked(createSubgraphFromNodes).mockResolvedValue({
+        subgraphTask: mockSubgraphTask,
+        connectionMappings: [],
+      });
+
+      vi.mocked(calculateNodesCenter).mockReturnValue({ x: 100, y: 100 });
+
+      vi.mocked(addTask).mockReturnValue({
+        spec: createGraphSpec({ subgraph1: mockSubgraphTask }),
+        taskId: "subgraph1",
+      });
+
+      vi.mocked(updateDownstreamSubgraphConnections).mockReturnValue(
+        createGraphSpec({ subgraph1: mockSubgraphTask }),
+      );
+
+      await handleGroupNodes(
+        selectedNodes,
+        spec,
+        "MySubgraph",
+        onSuccess,
+        onError,
+      );
+
+      expect(calculateNodesCenter).toHaveBeenCalledWith(selectedNodes);
+      expect(addTask).toHaveBeenCalledWith(
+        "task",
+        mockSubgraphTask,
+        { x: 100, y: 100 },
+        spec,
+      );
+    });
+
+    it("should remove all selected nodes from parent spec", async () => {
+      const spec = createGraphSpec({
+        task1: {
+          componentRef: { name: "component1" },
+          arguments: {},
+        },
+        task2: {
+          componentRef: { name: "component2" },
+          arguments: {},
+        },
+        task3: {
+          componentRef: { name: "component3" },
+          arguments: {},
+        },
+      });
+
+      if (!isGraphImplementation(spec.implementation)) {
+        return;
+      }
+
+      const selectedNodes = [
+        createTaskNode("node-1", "task1"),
+        createTaskNode("node-2", "task2"),
+      ];
+
+      const mockSubgraphTask: TaskSpec = {
+        componentRef: {
+          name: "MySubgraph",
+          spec: {
+            name: "MySubgraph",
+            description: "Subgraph",
+            implementation: {
+              graph: { tasks: {} },
+            },
+          },
+        },
+        arguments: {},
+      };
+
+      vi.mocked(createSubgraphFromNodes).mockResolvedValue({
+        subgraphTask: mockSubgraphTask,
+        connectionMappings: [],
+      });
+
+      const specWithNewTask = createGraphSpec({
+        task3: spec.implementation.graph!.tasks.task3,
+        subgraph1: mockSubgraphTask,
+      });
+
+      vi.mocked(addTask).mockReturnValue({
+        spec: specWithNewTask,
+        taskId: "subgraph1",
+      });
+
+      vi.mocked(updateDownstreamSubgraphConnections).mockReturnValue(
+        specWithNewTask,
+      );
+
+      await handleGroupNodes(
+        selectedNodes,
+        spec,
+        "MySubgraph",
+        onSuccess,
+        onError,
+      );
+
+      expect(removeNode).toHaveBeenCalledTimes(2);
+      expect(removeNode).toHaveBeenNthCalledWith(
+        1,
+        selectedNodes[0],
+        expect.any(Object),
+      );
+      expect(removeNode).toHaveBeenNthCalledWith(
+        2,
+        selectedNodes[1],
+        expect.any(Object),
+      );
+    });
+  });
+
+  describe("connection mappings", () => {
+    it("should update connection mappings with actual subgraph task ID", async () => {
+      const spec = createGraphSpec({
+        task1: {
+          componentRef: { name: "component1" },
+          arguments: {},
+        },
+        externalTask: {
+          componentRef: { name: "external" },
+          arguments: {
+            input1: {
+              taskOutput: {
+                taskId: "task1",
+                outputName: "result",
+                type: "string",
+              },
+            },
+          },
+        },
+      });
+
+      const selectedNodes = [createTaskNode("node-1", "task1")];
+
+      const mockSubgraphTask: TaskSpec = {
+        componentRef: {
+          name: "MySubgraph",
+          spec: {
+            name: "MySubgraph",
+            description: "Subgraph",
+            implementation: {
+              graph: { tasks: {} },
+            },
+          },
+        },
+        arguments: {},
+      };
+
+      const connectionMappings = [
+        {
+          originalTaskId: "task1",
+          originalOutputName: "result",
+          newTaskId: "PLACEHOLDER_SUBGRAPH_ID",
+          newOutputName: "output1",
+          targetTaskId: "externalTask",
+          targetInputName: "input1",
+        },
+      ];
+
+      vi.mocked(createSubgraphFromNodes).mockResolvedValue({
+        subgraphTask: mockSubgraphTask,
+        connectionMappings,
+      });
+
+      vi.mocked(addTask).mockReturnValue({
+        spec: createGraphSpec({ subgraph1: mockSubgraphTask }),
+        taskId: "subgraph1",
+      });
+
+      vi.mocked(updateDownstreamSubgraphConnections).mockReturnValue(
+        createGraphSpec({ subgraph1: mockSubgraphTask }),
+      );
+
+      await handleGroupNodes(
+        selectedNodes,
+        spec,
+        "MySubgraph",
+        onSuccess,
+        onError,
+      );
+
+      expect(updateDownstreamSubgraphConnections).toHaveBeenCalledWith(
+        expect.any(Object),
+        [
+          {
+            originalTaskId: "task1",
+            originalOutputName: "result",
+            newTaskId: "subgraph1", // Should be updated from placeholder
+            newOutputName: "output1",
+            targetTaskId: "externalTask",
+            targetInputName: "input1",
+          },
+        ],
+      );
+    });
+
+    it("should handle multiple connection mappings", async () => {
+      const spec = createGraphSpec({
+        task1: {
+          componentRef: { name: "component1" },
+          arguments: {},
+        },
+        task2: {
+          componentRef: { name: "component2" },
+          arguments: {},
+        },
+        externalTask1: {
+          componentRef: { name: "external1" },
+          arguments: {
+            input1: {
+              taskOutput: {
+                taskId: "task1",
+                outputName: "result",
+                type: "string",
+              },
+            },
+          },
+        },
+        externalTask2: {
+          componentRef: { name: "external2" },
+          arguments: {
+            input1: {
+              taskOutput: {
+                taskId: "task2",
+                outputName: "result",
+                type: "string",
+              },
+            },
+          },
+        },
+      });
+
+      const selectedNodes = [
+        createTaskNode("node-1", "task1"),
+        createTaskNode("node-2", "task2"),
+      ];
+
+      const mockSubgraphTask: TaskSpec = {
+        componentRef: {
+          name: "MySubgraph",
+          spec: {
+            name: "MySubgraph",
+            description: "Subgraph",
+            implementation: {
+              graph: { tasks: {} },
+            },
+          },
+        },
+        arguments: {},
+      };
+
+      const connectionMappings = [
+        {
+          originalTaskId: "task1",
+          originalOutputName: "result",
+          newTaskId: "PLACEHOLDER_SUBGRAPH_ID",
+          newOutputName: "output1",
+          targetTaskId: "externalTask1",
+          targetInputName: "input1",
+        },
+        {
+          originalTaskId: "task2",
+          originalOutputName: "result",
+          newTaskId: "PLACEHOLDER_SUBGRAPH_ID",
+          newOutputName: "output2",
+          targetTaskId: "externalTask2",
+          targetInputName: "input1",
+        },
+      ];
+
+      vi.mocked(createSubgraphFromNodes).mockResolvedValue({
+        subgraphTask: mockSubgraphTask,
+        connectionMappings,
+      });
+
+      vi.mocked(addTask).mockReturnValue({
+        spec: createGraphSpec({ subgraph1: mockSubgraphTask }),
+        taskId: "subgraph1",
+      });
+
+      vi.mocked(updateDownstreamSubgraphConnections).mockReturnValue(
+        createGraphSpec({ subgraph1: mockSubgraphTask }),
+      );
+
+      await handleGroupNodes(
+        selectedNodes,
+        spec,
+        "MySubgraph",
+        onSuccess,
+        onError,
+      );
+
+      expect(updateDownstreamSubgraphConnections).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.arrayContaining([
+          expect.objectContaining({ newTaskId: "subgraph1" }),
+          expect.objectContaining({ newTaskId: "subgraph1" }),
+        ]),
+      );
+    });
+  });
+
+  describe("error handling", () => {
+    it("should call onError when createSubgraphFromNodes fails", async () => {
+      const spec = createGraphSpec({
+        task1: {
+          componentRef: { name: "component1" },
+          arguments: {},
+        },
+      });
+
+      const selectedNodes = [createTaskNode("node-1", "task1")];
+
+      const error = new Error("Failed to create subgraph");
+      vi.mocked(createSubgraphFromNodes).mockRejectedValue(error);
+
+      await handleGroupNodes(
+        selectedNodes,
+        spec,
+        "MySubgraph",
+        onSuccess,
+        onError,
+      );
+
+      expect(onError).toHaveBeenCalledWith(error);
+      expect(onSuccess).not.toHaveBeenCalled();
+    });
+
+    it("should call onError when addTask returns undefined taskId", async () => {
+      const spec = createGraphSpec({
+        task1: {
+          componentRef: { name: "component1" },
+          arguments: {},
+        },
+      });
+
+      const selectedNodes = [createTaskNode("node-1", "task1")];
+
+      const mockSubgraphTask: TaskSpec = {
+        componentRef: {
+          name: "MySubgraph",
+          spec: {
+            name: "MySubgraph",
+            description: "Subgraph",
+            implementation: {
+              graph: { tasks: {} },
+            },
+          },
+        },
+        arguments: {},
+      };
+
+      vi.mocked(createSubgraphFromNodes).mockResolvedValue({
+        subgraphTask: mockSubgraphTask,
+        connectionMappings: [],
+      });
+
+      vi.mocked(addTask).mockReturnValue({
+        spec: createGraphSpec({ subgraph1: mockSubgraphTask }),
+        taskId: undefined, // Simulating error case
+      });
+
+      await handleGroupNodes(
+        selectedNodes,
+        spec,
+        "MySubgraph",
+        onSuccess,
+        onError,
+      );
+
+      expect(onError).toHaveBeenCalledWith(
+        new Error("Subgraph Task ID is undefined."),
+      );
+      expect(onSuccess).not.toHaveBeenCalled();
+    });
+
+    it("should call onError when updateDownstreamSubgraphConnections throws", async () => {
+      const spec = createGraphSpec({
+        task1: {
+          componentRef: { name: "component1" },
+          arguments: {},
+        },
+      });
+
+      const selectedNodes = [createTaskNode("node-1", "task1")];
+
+      const mockSubgraphTask: TaskSpec = {
+        componentRef: {
+          name: "MySubgraph",
+          spec: {
+            name: "MySubgraph",
+            description: "Subgraph",
+            implementation: {
+              graph: { tasks: {} },
+            },
+          },
+        },
+        arguments: {},
+      };
+
+      vi.mocked(createSubgraphFromNodes).mockResolvedValue({
+        subgraphTask: mockSubgraphTask,
+        connectionMappings: [],
+      });
+
+      vi.mocked(addTask).mockReturnValue({
+        spec: createGraphSpec({ subgraph1: mockSubgraphTask }),
+        taskId: "subgraph1",
+      });
+
+      const error = new Error("Failed to update connections");
+      vi.mocked(updateDownstreamSubgraphConnections).mockImplementation(() => {
+        throw error;
+      });
+
+      await handleGroupNodes(
+        selectedNodes,
+        spec,
+        "MySubgraph",
+        onSuccess,
+        onError,
+      );
+
+      expect(onError).toHaveBeenCalledWith(error);
+      expect(onSuccess).not.toHaveBeenCalled();
+    });
+
+    it("should call onError when removeNode throws", async () => {
+      const spec = createGraphSpec({
+        task1: {
+          componentRef: { name: "component1" },
+          arguments: {},
+        },
+      });
+
+      const selectedNodes = [createTaskNode("node-1", "task1")];
+
+      const mockSubgraphTask: TaskSpec = {
+        componentRef: {
+          name: "MySubgraph",
+          spec: {
+            name: "MySubgraph",
+            description: "Subgraph",
+            implementation: {
+              graph: { tasks: {} },
+            },
+          },
+        },
+        arguments: {},
+      };
+
+      vi.mocked(createSubgraphFromNodes).mockResolvedValue({
+        subgraphTask: mockSubgraphTask,
+        connectionMappings: [],
+      });
+
+      vi.mocked(addTask).mockReturnValue({
+        spec: createGraphSpec({ subgraph1: mockSubgraphTask }),
+        taskId: "subgraph1",
+      });
+
+      vi.mocked(updateDownstreamSubgraphConnections).mockReturnValue(
+        createGraphSpec({ subgraph1: mockSubgraphTask }),
+      );
+
+      const error = new Error("Failed to remove node");
+      vi.mocked(removeNode).mockImplementation(() => {
+        throw error;
+      });
+
+      await handleGroupNodes(
+        selectedNodes,
+        spec,
+        "MySubgraph",
+        onSuccess,
+        onError,
+      );
+
+      expect(onError).toHaveBeenCalledWith(error);
+      expect(onSuccess).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("non-graph implementation", () => {
+    it("should do nothing for non-graph implementation", async () => {
+      const spec: ComponentSpec = {
+        name: "test-component",
+        description: "Test component",
+        implementation: {
+          container: {
+            image: "test:latest",
+          },
+        },
+      };
+
+      const selectedNodes = [createTaskNode("node-1", "task1")];
+
+      await handleGroupNodes(
+        selectedNodes,
+        spec,
+        "MySubgraph",
+        onSuccess,
+        onError,
+      );
+
+      expect(createSubgraphFromNodes).not.toHaveBeenCalled();
+      expect(onSuccess).not.toHaveBeenCalled();
+      expect(onError).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle empty selection", async () => {
+      const spec = createGraphSpec({
+        task1: {
+          componentRef: { name: "component1" },
+          arguments: {},
+        },
+      });
+
+      const selectedNodes: Node[] = [];
+
+      const mockSubgraphTask: TaskSpec = {
+        componentRef: {
+          name: "MySubgraph",
+          spec: {
+            name: "MySubgraph",
+            description: "Subgraph",
+            implementation: {
+              graph: { tasks: {} },
+            },
+          },
+        },
+        arguments: {},
+      };
+
+      vi.mocked(createSubgraphFromNodes).mockResolvedValue({
+        subgraphTask: mockSubgraphTask,
+        connectionMappings: [],
+      });
+
+      vi.mocked(addTask).mockReturnValue({
+        spec: createGraphSpec({ subgraph1: mockSubgraphTask }),
+        taskId: "subgraph1",
+      });
+
+      vi.mocked(updateDownstreamSubgraphConnections).mockReturnValue(
+        createGraphSpec({ subgraph1: mockSubgraphTask }),
+      );
+
+      await handleGroupNodes(
+        selectedNodes,
+        spec,
+        "MySubgraph",
+        onSuccess,
+        onError,
+      );
+
+      expect(removeNode).not.toHaveBeenCalled();
+      expect(onSuccess).toHaveBeenCalled();
+    });
+
+    it("should handle subgraph with no connection mappings", async () => {
+      const spec = createGraphSpec({
+        task1: {
+          componentRef: { name: "component1" },
+          arguments: {},
+        },
+      });
+
+      const selectedNodes = [createTaskNode("node-1", "task1")];
+
+      const mockSubgraphTask: TaskSpec = {
+        componentRef: {
+          name: "MySubgraph",
+          spec: {
+            name: "MySubgraph",
+            description: "Subgraph",
+            implementation: {
+              graph: { tasks: {} },
+            },
+          },
+        },
+        arguments: {},
+      };
+
+      vi.mocked(createSubgraphFromNodes).mockResolvedValue({
+        subgraphTask: mockSubgraphTask,
+        connectionMappings: [], // No external connections
+      });
+
+      vi.mocked(addTask).mockReturnValue({
+        spec: createGraphSpec({ subgraph1: mockSubgraphTask }),
+        taskId: "subgraph1",
+      });
+
+      vi.mocked(updateDownstreamSubgraphConnections).mockReturnValue(
+        createGraphSpec({ subgraph1: mockSubgraphTask }),
+      );
+
+      await handleGroupNodes(
+        selectedNodes,
+        spec,
+        "MySubgraph",
+        onSuccess,
+        onError,
+      );
+
+      expect(updateDownstreamSubgraphConnections).toHaveBeenCalledWith(
+        expect.any(Object),
+        [],
+      );
+      expect(onSuccess).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/utils/nodes/createSubgraphFromNodes.test.ts
+++ b/src/utils/nodes/createSubgraphFromNodes.test.ts
@@ -1,0 +1,772 @@
+import type { Node } from "@xyflow/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  type ComponentSpec,
+  type GraphSpec,
+  isGraphImplementation,
+} from "@/utils/componentSpec";
+
+import {
+  createSubgraphFromNodes,
+  GRAPH_OUTPUT,
+  PLACEHOLDER_SUBGRAPH_ID,
+} from "./createSubgraphFromNodes";
+
+// Mock the services
+vi.mock("@/services/componentService", () => ({
+  generateDigest: vi.fn().mockResolvedValue("mock-digest"),
+  getComponentText: vi.fn().mockResolvedValue("mock-component-text"),
+}));
+
+vi.mock("@/utils/user", () => ({
+  getUserDetails: vi.fn().mockResolvedValue({ id: "test-user" }),
+}));
+
+// Helper to create a node
+const createNode = (
+  id: string,
+  type: "task" | "input" | "output",
+  data: Record<string, any>,
+  position: { x: number; y: number } = { x: 0, y: 0 },
+): Node => ({
+  id,
+  type,
+  position,
+  data,
+  measured: { width: 200, height: 100 },
+});
+
+// Helper to create a task node
+const createTaskNode = (
+  id: string,
+  taskId: string,
+  position: { x: number; y: number } = { x: 0, y: 0 },
+): Node => createNode(id, "task", { taskId }, position);
+
+// Helper to create an input node
+const createInputNode = (
+  id: string,
+  label: string,
+  type: string = "string",
+  position: { x: number; y: number } = { x: 0, y: 0 },
+): Node => createNode(id, "input", { label, type, optional: false }, position);
+
+// Helper to create an output node
+const createOutputNode = (
+  id: string,
+  label: string,
+  type: string = "string",
+  position: { x: number; y: number } = { x: 0, y: 0 },
+): Node => createNode(id, "output", { label, type }, position);
+
+// Helper to create a component spec with graph implementation
+const createGraphSpec = (
+  tasks: GraphSpec["tasks"] = {},
+  outputValues: GraphSpec["outputValues"] = {},
+): ComponentSpec => ({
+  name: "test-component",
+  description: "Test component",
+  implementation: {
+    graph: {
+      tasks,
+      outputValues,
+    },
+  },
+});
+
+describe("createSubgraphFromNodes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("basic subgraph creation", () => {
+    it("should create a subgraph from a single task", async () => {
+      const spec = createGraphSpec({
+        task1: {
+          componentRef: {
+            name: "test-task",
+            spec: {
+              name: "test-task",
+              description: "Test task",
+              outputs: [{ name: "result", type: "string" }],
+              implementation: {
+                container: {
+                  image: "test:latest",
+                },
+              },
+            },
+          },
+          arguments: {},
+        },
+      });
+
+      const selectedNodes = [
+        createTaskNode("node-1", "task1", { x: 100, y: 100 }),
+      ];
+
+      const result = await createSubgraphFromNodes(
+        selectedNodes,
+        spec,
+        "MySubgraph",
+      );
+
+      expect(result.subgraphTask).toBeDefined();
+      expect(result.subgraphTask.componentRef.name).toBe("MySubgraph");
+
+      if (
+        !isGraphImplementation(
+          result.subgraphTask.componentRef.spec!.implementation,
+        )
+      ) {
+        throw new Error("Subgraph implementation is not a graph");
+      }
+
+      expect(
+        result.subgraphTask.componentRef.spec?.implementation.graph?.tasks,
+      ).toHaveProperty("task1");
+      expect(result.connectionMappings).toEqual([]);
+    });
+
+    it("should create a subgraph from multiple connected tasks", async () => {
+      const spec = createGraphSpec({
+        task1: {
+          componentRef: {
+            name: "task1-component",
+            spec: {
+              name: "task1-component",
+              description: "Task 1",
+              outputs: [{ name: "output1", type: "string" }],
+              implementation: {
+                container: { image: "test:latest" },
+              },
+            },
+          },
+          arguments: {},
+        },
+        task2: {
+          componentRef: {
+            name: "task2-component",
+            spec: {
+              name: "task2-component",
+              description: "Task 2",
+              inputs: [{ name: "input1", type: "string" }],
+              implementation: {
+                container: { image: "test:latest" },
+              },
+            },
+          },
+          arguments: {
+            input1: {
+              taskOutput: {
+                taskId: "task1",
+                outputName: "output1",
+                type: "string",
+              },
+            },
+          },
+        },
+      });
+
+      const selectedNodes = [
+        createTaskNode("node-1", "task1", { x: 0, y: 0 }),
+        createTaskNode("node-2", "task2", { x: 300, y: 0 }),
+      ];
+
+      const result = await createSubgraphFromNodes(selectedNodes, spec);
+
+      if (
+        !isGraphImplementation(
+          result.subgraphTask.componentRef.spec!.implementation,
+        )
+      ) {
+        throw new Error("Subgraph implementation is not a graph");
+      }
+
+      expect(
+        result.subgraphTask.componentRef.spec?.implementation.graph?.tasks,
+      ).toHaveProperty("task1");
+      expect(
+        result.subgraphTask.componentRef.spec?.implementation.graph?.tasks,
+      ).toHaveProperty("task2");
+
+      const task2 =
+        result.subgraphTask.componentRef.spec?.implementation.graph?.tasks
+          .task2;
+      expect(task2?.arguments?.input1).toEqual({
+        taskOutput: {
+          taskId: "task1",
+          outputName: "output1",
+          type: "string",
+        },
+      });
+    });
+
+    it("should normalize node positions relative to bounds", async () => {
+      const spec = createGraphSpec({
+        task1: {
+          componentRef: {
+            name: "test-task",
+            spec: {
+              name: "test-task",
+              description: "Test",
+              implementation: {
+                container: { image: "test:latest" },
+              },
+            },
+          },
+          arguments: {},
+        },
+      });
+
+      const selectedNodes = [
+        createTaskNode("node-1", "task1", { x: 500, y: 300 }),
+      ];
+
+      const result = await createSubgraphFromNodes(selectedNodes, spec);
+
+      if (
+        !isGraphImplementation(
+          result.subgraphTask.componentRef.spec!.implementation,
+        )
+      ) {
+        throw new Error("Subgraph implementation is not a graph");
+      }
+
+      const task1 =
+        result.subgraphTask.componentRef.spec?.implementation.graph?.tasks
+          .task1;
+      const position = JSON.parse(
+        task1?.annotations?.["editor.position"] as string,
+      );
+
+      // Position should be normalized (close to 0,0 since it's the only node)
+      expect(position.x).toBeLessThan(100);
+      expect(position.y).toBeLessThan(100);
+    });
+  });
+
+  describe("external input connections", () => {
+    it("should create subgraph input for external task output connection", async () => {
+      const spec = createGraphSpec({
+        externalTask: {
+          componentRef: {
+            name: "external",
+            spec: {
+              name: "external",
+              description: "External task",
+              outputs: [{ name: "result", type: "string" }],
+              implementation: {
+                container: { image: "test:latest" },
+              },
+            },
+          },
+          arguments: {},
+        },
+        task1: {
+          componentRef: {
+            name: "internal",
+            spec: {
+              name: "internal",
+              description: "Internal task",
+              inputs: [{ name: "input1", type: "string" }],
+              implementation: {
+                container: { image: "test:latest" },
+              },
+            },
+          },
+          arguments: {
+            input1: {
+              taskOutput: {
+                taskId: "externalTask",
+                outputName: "result",
+                type: "string",
+              },
+            },
+          },
+        },
+      });
+
+      const selectedNodes = [createTaskNode("node-1", "task1")];
+
+      const result = await createSubgraphFromNodes(selectedNodes, spec);
+
+      const subgraphSpec = result.subgraphTask.componentRef.spec;
+
+      // Should create a subgraph input
+      expect(subgraphSpec?.inputs).toHaveLength(1);
+      expect(subgraphSpec?.inputs?.[0].type).toBe("string");
+
+      // Should wire the subgraph argument to external source
+      expect(result.subgraphTask.arguments).toBeDefined();
+      const argValue = Object.values(result.subgraphTask.arguments!)[0];
+      expect(argValue).toEqual({
+        taskOutput: {
+          taskId: "externalTask",
+          outputName: "result",
+          type: "string",
+        },
+      });
+    });
+
+    it("should create subgraph input for external graph input connection", async () => {
+      const spec: ComponentSpec = {
+        name: "test-component",
+        description: "Test",
+        inputs: [{ name: "externalInput", type: "string" }],
+        implementation: {
+          graph: {
+            tasks: {
+              task1: {
+                componentRef: {
+                  name: "test-task",
+                  spec: {
+                    name: "test-task",
+                    description: "Test",
+                    inputs: [{ name: "input1", type: "string" }],
+                    implementation: {
+                      container: { image: "test:latest" },
+                    },
+                  },
+                },
+                arguments: {
+                  input1: {
+                    graphInput: {
+                      inputName: "externalInput",
+                      type: "string",
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const selectedNodes = [createTaskNode("node-1", "task1")];
+
+      const result = await createSubgraphFromNodes(selectedNodes, spec);
+
+      const subgraphSpec = result.subgraphTask.componentRef.spec;
+
+      // Should create a subgraph input
+      expect(subgraphSpec?.inputs).toHaveLength(1);
+
+      // Should wire the subgraph argument to external input
+      expect(result.subgraphTask.arguments).toBeDefined();
+      const argValue = Object.values(result.subgraphTask.arguments!)[0];
+      expect(argValue).toEqual({
+        graphInput: {
+          inputName: "externalInput",
+          type: "string",
+        },
+      });
+    });
+
+    it("should reuse existing subgraph input for multiple tasks with same external connection", async () => {
+      const spec = createGraphSpec({
+        externalTask: {
+          componentRef: {
+            name: "external",
+            spec: {
+              name: "external",
+              description: "External",
+              outputs: [{ name: "result", type: "string" }],
+              implementation: {
+                container: { image: "test:latest" },
+              },
+            },
+          },
+          arguments: {},
+        },
+        task1: {
+          componentRef: {
+            name: "internal1",
+            spec: {
+              name: "internal1",
+              description: "Internal 1",
+              inputs: [{ name: "input1", type: "string" }],
+              implementation: {
+                container: { image: "test:latest" },
+              },
+            },
+          },
+          arguments: {
+            input1: {
+              taskOutput: {
+                taskId: "externalTask",
+                outputName: "result",
+                type: "string",
+              },
+            },
+          },
+        },
+        task2: {
+          componentRef: {
+            name: "internal2",
+            spec: {
+              name: "internal2",
+              description: "Internal 2",
+              inputs: [{ name: "input1", type: "string" }],
+              implementation: {
+                container: { image: "test:latest" },
+              },
+            },
+          },
+          arguments: {
+            input1: {
+              taskOutput: {
+                taskId: "externalTask",
+                outputName: "result",
+                type: "string",
+              },
+            },
+          },
+        },
+      });
+
+      const selectedNodes = [
+        createTaskNode("node-1", "task1"),
+        createTaskNode("node-2", "task2"),
+      ];
+
+      const result = await createSubgraphFromNodes(selectedNodes, spec);
+
+      const subgraphSpec = result.subgraphTask.componentRef.spec;
+
+      if (!isGraphImplementation(subgraphSpec!.implementation)) {
+        throw new Error("Subgraph implementation is not a graph");
+      }
+
+      // Should only create ONE subgraph input for both tasks
+      expect(subgraphSpec?.inputs).toHaveLength(1);
+
+      // Both tasks should reference the same input
+      const task1Args =
+        subgraphSpec?.implementation.graph?.tasks.task1.arguments;
+      const task2Args =
+        subgraphSpec?.implementation.graph?.tasks.task2.arguments;
+      expect(task1Args?.input1).toEqual(task2Args?.input1);
+    });
+  });
+
+  describe("external output connections", () => {
+    it("should create subgraph output for task consumed by external task", async () => {
+      const spec = createGraphSpec({
+        task1: {
+          componentRef: {
+            name: "internal",
+            spec: {
+              name: "internal",
+              description: "Internal",
+              outputs: [{ name: "result", type: "string" }],
+              implementation: {
+                container: { image: "test:latest" },
+              },
+            },
+          },
+          arguments: {},
+        },
+        externalTask: {
+          componentRef: {
+            name: "external",
+            spec: {
+              name: "external",
+              description: "External",
+              inputs: [{ name: "input1", type: "string" }],
+              implementation: {
+                container: { image: "test:latest" },
+              },
+            },
+          },
+          arguments: {
+            input1: {
+              taskOutput: {
+                taskId: "task1",
+                outputName: "result",
+                type: "string",
+              },
+            },
+          },
+        },
+      });
+
+      const selectedNodes = [createTaskNode("node-1", "task1")];
+
+      const result = await createSubgraphFromNodes(selectedNodes, spec);
+
+      const subgraphSpec = result.subgraphTask.componentRef.spec;
+
+      if (!isGraphImplementation(subgraphSpec!.implementation)) {
+        throw new Error("Subgraph implementation is not a graph");
+      }
+
+      // Should create a subgraph output
+      expect(subgraphSpec?.outputs).toHaveLength(1);
+      expect(subgraphSpec?.outputs?.[0].type).toBe("string");
+
+      // Should have output value pointing to internal task
+      expect(subgraphSpec?.implementation.graph?.outputValues).toBeDefined();
+      const outputValue = Object.values(
+        subgraphSpec!.implementation.graph!.outputValues!,
+      )[0];
+      expect(outputValue.taskOutput.taskId).toBe("task1");
+      expect(outputValue.taskOutput.outputName).toBe("result");
+
+      // Should create connection mapping
+      expect(result.connectionMappings).toHaveLength(1);
+      expect(result.connectionMappings[0]).toMatchObject({
+        originalTaskId: "task1",
+        originalOutputName: "result",
+        newTaskId: PLACEHOLDER_SUBGRAPH_ID,
+        targetTaskId: "externalTask",
+        targetInputName: "input1",
+      });
+    });
+
+    it("should create subgraph output for task consumed by external graph output", async () => {
+      const spec = createGraphSpec(
+        {
+          task1: {
+            componentRef: {
+              name: "internal",
+              spec: {
+                name: "internal",
+                description: "Internal",
+                outputs: [{ name: "result", type: "string" }],
+                implementation: {
+                  container: { image: "test:latest" },
+                },
+              },
+            },
+            arguments: {},
+          },
+        },
+        {
+          graphOutput: {
+            taskOutput: {
+              taskId: "task1",
+              outputName: "result",
+              type: "string",
+            },
+          },
+        },
+      );
+
+      const selectedNodes = [createTaskNode("node-1", "task1")];
+
+      const result = await createSubgraphFromNodes(selectedNodes, spec);
+
+      const subgraphSpec = result.subgraphTask.componentRef.spec;
+
+      // Should create a subgraph output
+      expect(subgraphSpec?.outputs).toHaveLength(1);
+
+      // Should create connection mapping to GRAPH_OUTPUT
+      expect(result.connectionMappings).toHaveLength(1);
+      expect(result.connectionMappings[0]).toMatchObject({
+        originalTaskId: "task1",
+        originalOutputName: "result",
+        newTaskId: PLACEHOLDER_SUBGRAPH_ID,
+        targetTaskId: GRAPH_OUTPUT,
+        targetInputName: "graphOutput",
+      });
+    });
+  });
+
+  describe("selected input and output nodes", () => {
+    it("should include selected input nodes in subgraph", async () => {
+      const spec: ComponentSpec = {
+        name: "test-component",
+        description: "Test",
+        inputs: [{ name: "myInput", type: "string", value: "default-value" }],
+        implementation: {
+          graph: {
+            tasks: {
+              task1: {
+                componentRef: {
+                  name: "test-task",
+                  spec: {
+                    name: "test-task",
+                    description: "Test",
+                    inputs: [{ name: "input1", type: "string" }],
+                    implementation: {
+                      container: { image: "test:latest" },
+                    },
+                  },
+                },
+                arguments: {
+                  input1: {
+                    graphInput: {
+                      inputName: "myInput",
+                      type: "string",
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const selectedNodes = [
+        createInputNode("input-1", "myInput"),
+        createTaskNode("task-1", "task1"),
+      ];
+
+      const result = await createSubgraphFromNodes(selectedNodes, spec);
+
+      const subgraphSpec = result.subgraphTask.componentRef.spec;
+
+      // Should include the input in subgraph
+      expect(subgraphSpec?.inputs).toHaveLength(1);
+      expect(subgraphSpec?.inputs?.[0].name).toBe("myInput");
+
+      // Should migrate the input value to subgraph arguments
+      expect(result.subgraphTask.arguments?.myInput).toBe("default-value");
+    });
+
+    it("should include selected output nodes in subgraph", async () => {
+      const spec = createGraphSpec(
+        {
+          task1: {
+            componentRef: {
+              name: "test-task",
+              spec: {
+                name: "test-task",
+                description: "Test",
+                outputs: [{ name: "result", type: "string" }],
+                implementation: {
+                  container: { image: "test:latest" },
+                },
+              },
+            },
+            arguments: {},
+          },
+        },
+        {
+          myOutput: {
+            taskOutput: {
+              taskId: "task1",
+              outputName: "result",
+              type: "string",
+            },
+          },
+        },
+      );
+
+      const selectedNodes = [
+        createTaskNode("task-1", "task1"),
+        createOutputNode("output-1", "myOutput"),
+      ];
+
+      const result = await createSubgraphFromNodes(selectedNodes, spec);
+
+      const subgraphSpec = result.subgraphTask.componentRef.spec;
+
+      if (!isGraphImplementation(subgraphSpec!.implementation)) {
+        throw new Error("Subgraph implementation is not a graph");
+      }
+
+      // Should include the output in subgraph
+      expect(subgraphSpec?.outputs).toHaveLength(1);
+      expect(subgraphSpec?.outputs?.[0].name).toBe("myOutput");
+
+      // Should include output value
+      expect(
+        subgraphSpec?.implementation.graph?.outputValues?.myOutput,
+      ).toEqual({
+        taskOutput: {
+          taskId: "task1",
+          outputName: "result",
+          type: "string",
+        },
+      });
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should throw error for non-graph implementation", async () => {
+      const spec: ComponentSpec = {
+        name: "test-component",
+        description: "Test",
+        implementation: {
+          container: {
+            image: "test:latest",
+          },
+        },
+      };
+
+      const selectedNodes = [createTaskNode("node-1", "task1")];
+
+      await expect(
+        createSubgraphFromNodes(selectedNodes, spec),
+      ).rejects.toThrow(
+        "Current component spec does not have a graph implementation",
+      );
+    });
+
+    it("should handle empty selection", async () => {
+      const spec = createGraphSpec();
+      const selectedNodes: Node[] = [];
+
+      const result = await createSubgraphFromNodes(selectedNodes, spec);
+
+      if (
+        !isGraphImplementation(
+          result.subgraphTask.componentRef.spec!.implementation,
+        )
+      ) {
+        throw new Error("Subgraph implementation is not a graph");
+      }
+
+      expect(
+        result.subgraphTask.componentRef.spec?.implementation.graph?.tasks,
+      ).toEqual({});
+      expect(result.connectionMappings).toEqual([]);
+    });
+
+    it("should generate unique names when name not provided", async () => {
+      const spec = createGraphSpec({
+        task1: {
+          componentRef: {
+            name: "test",
+            spec: {
+              name: "test",
+              description: "Test",
+              implementation: {
+                container: { image: "test:latest" },
+              },
+            },
+          },
+          arguments: {},
+        },
+        "Generated Subgraph": {
+          componentRef: {
+            name: "existing",
+            spec: {
+              name: "existing",
+              description: "Existing",
+              implementation: {
+                container: { image: "test:latest" },
+              },
+            },
+          },
+          arguments: {},
+        },
+      });
+
+      const selectedNodes = [createTaskNode("node-1", "task1")];
+
+      const result = await createSubgraphFromNodes(selectedNodes, spec);
+
+      // Should generate a unique name (not "Generated Subgraph" since it exists)
+      expect(result.subgraphTask.componentRef.name).not.toBe(
+        "Generated Subgraph",
+      );
+      expect(result.subgraphTask.componentRef.name).toContain(
+        "Generated Subgraph",
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Adds a bunch of tests to cover recently introduced methods & utilities for subgraph creation:
- checkExternalInputConnections
- handleGroupNodes
- createSubgraphFromNodes

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
