### PR TITLE
Show subgraph icon in component library

### DIFF
--- a/src/components/shared/ReactFlow/FlowSidebar/components/ComponentItem.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/components/ComponentItem.tsx
@@ -7,12 +7,14 @@ import { useOutdatedComponents } from "@/components/shared/ManageComponent/hooks
 import { useBetaFlagValue } from "@/components/shared/Settings/useBetaFlags";
 import { withSuspenseWrapper } from "@/components/shared/SuspenseWrapper";
 import { Icon } from "@/components/ui/icon";
+import { InlineStack } from "@/components/ui/layout";
 import { SidebarMenuItem } from "@/components/ui/sidebar";
 import { useHydrateComponentReference } from "@/hooks/useHydrateComponentReference";
 import { cn } from "@/lib/utils";
 import { useComponentLibrary } from "@/providers/ComponentLibraryProvider";
-import type { ComponentReference, TaskSpec } from "@/utils/componentSpec";
+import { type ComponentReference, type TaskSpec } from "@/utils/componentSpec";
 import { getComponentName } from "@/utils/getComponentName";
+import { isSubgraph } from "@/utils/subgraphUtils";
 
 import { useNodesOverlay } from "../../NodesOverlay/NodesOverlayProvider";
 
@@ -69,6 +71,8 @@ const ComponentMarkup = ({
     () => name ?? getComponentName({ spec, url }),
     [spec, url, name],
   );
+
+  const isSubgraphSpec = isSubgraph(spec);
 
   const onDragStart = useCallback(
     (event: DragEvent) => {
@@ -138,6 +142,13 @@ const ComponentMarkup = ({
     isHighlightTasksOnComponentHoverEnabled,
   ]);
 
+  const iconName = isSubgraphSpec ? "Workflow" : owned ? "FileBadge" : "File";
+
+  const iconClass = cn(
+    "shrink-0",
+    isSubgraphSpec ? "text-blue-400" : "text-gray-400",
+  );
+
   return (
     <SidebarMenuItem
       className={cn(
@@ -150,7 +161,7 @@ const ComponentMarkup = ({
       draggable={!error && !isLoading}
       onDragStart={onDragStart}
     >
-      <div className="flex items-center gap-2">
+      <InlineStack blockAlign="center" gap="2">
         {isLoading ? (
           <span className="text-gray-400 truncate text-sm">Loading...</span>
         ) : error ? (
@@ -158,27 +169,24 @@ const ComponentMarkup = ({
             Error loading component
           </span>
         ) : (
-          <div
-            className="flex-1 flex"
+          <InlineStack
+            wrap="nowrap"
             data-testid="component-item"
             data-component-name={displayName}
           >
-            <div className="flex gap-2 w-full items-center">
+            <InlineStack gap="2" blockAlign="center" className="w-full">
               {isRemoteComponentLibrarySearchEnabled ? (
                 <ComponentIcon
-                  name={owned ? "FileBadge" : "File"}
-                  className="shrink-0 text-gray-400"
+                  name={iconName}
+                  className={iconClass}
                   component={component}
                 />
               ) : (
-                <Icon
-                  name={owned ? "FileBadge" : "File"}
-                  className="shrink-0 text-gray-400"
-                />
+                <Icon name={iconName} className={iconClass} />
               )}
 
               <div
-                className="flex flex-col w-36"
+                className="flex flex-col w-32"
                 onMouseEnter={onMouseEnter}
                 onMouseLeave={onMouseLeave}
                 onClick={onMouseClick}
@@ -186,26 +194,26 @@ const ComponentMarkup = ({
                 <span className="truncate text-xs text-gray-800">
                   {displayName}
                 </span>
-                {author && author.length > 0 ? (
+                {author && author.length > 0 && (
                   <span className="truncate text-[10px] text-gray-500 max-w-[100px] font-mono">
                     {author}
                   </span>
-                ) : null}
+                )}
                 <span className="truncate text-[10px] text-gray-500 max-w-[100px] font-mono">
                   Ver: {digest}
                 </span>
               </div>
-            </div>
-            <div className="flex align-items justify-end mr-[15px] h-full">
+            </InlineStack>
+            <InlineStack blockAlign="center" align="end" wrap="nowrap">
               <ComponentFavoriteToggle component={component} />
               <ComponentDetailsDialog
                 displayName={displayName}
                 component={component}
               />
-            </div>
-          </div>
+            </InlineStack>
+          </InlineStack>
         )}
-      </div>
+      </InlineStack>
     </SidebarMenuItem>
   );
 };

--- a/src/utils/subgraphUtils.ts
+++ b/src/utils/subgraphUtils.ts
@@ -16,13 +16,23 @@ type NotifyFunction = (
 ) => void;
 
 /**
- * Determines if a task specification represents a subgraph (contains nested graph implementation)
+ * Determines if a task or component specification represents a subgraph (contains nested graph implementation)
  */
-export const isSubgraph = (taskSpec: TaskSpec): boolean => {
-  return Boolean(
-    taskSpec.componentRef.spec &&
-      isGraphImplementation(taskSpec.componentRef.spec.implementation),
-  );
+export const isSubgraph = (
+  input: TaskSpec | ComponentSpec | undefined,
+): boolean => {
+  if (!input) {
+    return false;
+  }
+
+  if ("componentRef" in input) {
+    return Boolean(
+      input.componentRef.spec &&
+        isGraphImplementation(input.componentRef.spec.implementation),
+    );
+  }
+
+  return isGraphImplementation(input.implementation);
 };
 
 /**


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Subgraph components in the library will have the blue subgraph icon instead of the file icon.

Also moves a couple divs over to our UI primitives. And fix a horizontal overflow.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Improvement
- [x] Cleanup/Refactor

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

![image.png](https://app.graphite.com/user-attachments/assets/80dfa0c1-e604-4ca9-97f1-91966c39437e.png)

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->
UI still looks and works as expected,

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
