### PR TITLE
feat: Add clickable validation issues with cross-subgraph navigation


### DIFF
--- a/public/example-pipelines/validation-errors-demo.pipeline.component.yaml
+++ b/public/example-pipelines/validation-errors-demo.pipeline.component.yaml
@@ -1,0 +1,198 @@
+name: validation-errors-demo
+description: Five-level subgraph stack with intentional validation errors at each level
+inputs:
+  - name: root_input
+    type: string
+    annotations:
+      editor.position: '{"x":-260,"y":0}'
+  - name: unused_root_input
+    type: string
+    annotations:
+      editor.position: '{"x":-260,"y":100}'
+  - name: required_root_input
+    type: string
+    optional: false
+    annotations:
+      editor.position: '{"x":-260,"y":200}'
+outputs:
+  - name: root_output
+    type: string
+    annotations:
+      editor.position: '{"x":430,"y":0}'
+  - name: disconnected_output
+    type: string
+    annotations:
+      editor.position: '{"x":430,"y":100}'
+implementation:
+  graph:
+    tasks:
+      level_1:
+        annotations:
+          editor.position: '{"x":30,"y":0}'
+        componentRef:
+          name: level-1
+          spec:
+            name: level-1
+            inputs:
+              - name: l1_input
+                type: string
+                annotations:
+                  editor.position: '{"x":-190,"y":0}'
+              - name: l1_unused_input
+                type: string
+                annotations:
+                  editor.position: '{"x":-190,"y":100}'
+            outputs:
+              - name: l1_output
+                type: string
+                annotations:
+                  editor.position: '{"x":620,"y":0}'
+              - name: l1_output
+                type: string
+                annotations:
+                  editor.position: '{"x":620,"y":100}'
+            implementation:
+              graph:
+                tasks:
+                  level_2:
+                    annotations:
+                      editor.position: '{"x":100,"y":0}'
+                    componentRef:
+                      name: level-2
+                      spec:
+                        name: level-2
+                        inputs:
+                          - name: l2_input
+                            type: string
+                            annotations:
+                              editor.position: '{"x":-40,"y":0}'
+                          - name: l2_required_input
+                            type: string
+                            optional: false
+                            annotations:
+                              editor.position: '{"x":-40,"y":100}'
+                        outputs:
+                          - name: l2_output
+                            type: string
+                            annotations:
+                              editor.position: '{"x":770,"y":0}'
+                        implementation:
+                          graph:
+                            tasks:
+                              level_3:
+                                annotations:
+                                  editor.position: '{"x":330,"y":0}'
+                                componentRef:
+                                  name: level-3
+                                  spec:
+                                    name: level-3
+                                    inputs:
+                                      - name: l3_input
+                                        type: string
+                                        annotations:
+                                          editor.position: '{"x":110,"y":0}'
+                                    outputs:
+                                      - name: l3_output
+                                        type: string
+                                        annotations:
+                                          editor.position: '{"x":920,"y":0}'
+                                      - name: l3_disconnected_output
+                                        type: string
+                                        annotations:
+                                          editor.position: '{"x":920,"y":100}'
+                                    implementation:
+                                      graph:
+                                        tasks:
+                                          level_4:
+                                            annotations:
+                                              editor.position: '{"x":480,"y":0}'
+                                            componentRef:
+                                              name: level-4
+                                              spec:
+                                                name: level-4
+                                                inputs:
+                                                  - name: l4_input
+                                                    type: string
+                                                    annotations:
+                                                      editor.position: '{"x":260,"y":0}'
+                                                  - name: l4_input
+                                                    type: string
+                                                    annotations:
+                                                      editor.position: '{"x":260,"y":100}'
+                                                outputs:
+                                                  - name: l4_output
+                                                    type: string
+                                                    annotations:
+                                                      editor.position: '{"x":1070,"y":0}'
+                                                implementation:
+                                                  graph:
+                                                    tasks:
+                                                      level_5:
+                                                        annotations:
+                                                          editor.position: '{"x":630,"y":0}'
+                                                        componentRef:
+                                                          name: level-5
+                                                          spec:
+                                                            name: level-5
+                                                            inputs:
+                                                              - name: l5_input
+                                                                type: string
+                                                                annotations:
+                                                                  editor.position: '{"x":410,"y":0}'
+                                                            outputs:
+                                                              - name: l5_output
+                                                                type: string
+                                                                annotations:
+                                                                  editor.position: '{"x":1220,"y":0}'
+                                                            implementation:
+                                                              graph:
+                                                                tasks: {}
+                                                        arguments:
+                                                          l5_input:
+                                                            graphInput:
+                                                              inputName: l4_input
+                                                    outputValues:
+                                                      l4_output:
+                                                        taskOutput:
+                                                          taskId: level_5
+                                                          outputName: l5_output
+                                            arguments:
+                                              l4_input:
+                                                graphInput:
+                                                  inputName: l3_input
+                                        outputValues:
+                                          l3_output:
+                                            taskOutput:
+                                              taskId: level_4
+                                              outputName: l4_output
+                                arguments:
+                                  l3_input:
+                                    graphInput:
+                                      inputName: l2_input
+                            outputValues:
+                              l2_output:
+                                taskOutput:
+                                  taskId: level_3
+                                  outputName: l3_output
+                        arguments:
+                          l2_input:
+                            graphInput:
+                              inputName: l1_input
+                          l2_required_input:
+                            graphInput:
+                              inputName: nonexistent_input
+                outputValues:
+                  l1_output:
+                    taskOutput:
+                      taskId: level_2
+                      outputName: l2_output
+        arguments:
+          l1_input:
+            graphInput:
+              inputName: root_input
+    outputValues:
+      root_output:
+        taskOutput:
+          taskId: level_1
+          outputName: l1_output
+

--- a/src/components/Editor/PipelineDetails.tsx
+++ b/src/components/Editor/PipelineDetails.tsx
@@ -1,10 +1,11 @@
 import { Frown, Network } from "lucide-react";
 import { useEffect, useState } from "react";
 
+import { PipelineValidationList } from "@/components/Editor/components/PipelineValidationList/PipelineValidationList";
+import { useValidationIssueNavigation } from "@/components/Editor/hooks/useValidationIssueNavigation";
 import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
 import { InlineStack } from "@/components/ui/layout";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import useToastNotification from "@/hooks/useToastNotification";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 import { useContextPanel } from "@/providers/ContextPanelProvider";
@@ -16,7 +17,6 @@ import {
 import { getComponentFileFromList } from "@/utils/componentStore";
 import { USER_PIPELINES_LIST_NAME } from "@/utils/constants";
 
-import { InfoBox } from "../shared/InfoBox";
 import { TaskImplementation } from "../shared/TaskDetails";
 import { InputValueEditor } from "./IOEditor/InputValueEditor";
 import { OutputNameEditor } from "./IOEditor/OutputNameEditor";
@@ -25,9 +25,18 @@ import { getOutputConnectedDetails } from "./utils/getOutputConnectedDetails";
 
 const PipelineDetails = () => {
   const { setContent } = useContextPanel();
-  const { componentSpec, graphSpec, isValid, errors } = useComponentSpec();
+  const {
+    componentSpec,
+    graphSpec,
+    isComponentTreeValid,
+    globalValidationIssues,
+  } = useComponentSpec();
 
   const notify = useToastNotification();
+
+  const { handleIssueClick, groupedIssues } = useValidationIssueNavigation(
+    globalValidationIssues,
+  );
 
   // Utility function to convert TypeSpecType to string
   const typeSpecToString = (typeSpec?: TypeSpecType): string => {
@@ -309,36 +318,14 @@ const PipelineDetails = () => {
       </div>
 
       {/* Validations */}
-      <div>
+      <div className="mt-2">
         <h3 className="text-md font-medium mb-1">Validations</h3>
-        {isValid ? (
-          <InfoBox variant="success" title="No validation errors found">
-            Pipeline is ready for submission
-          </InfoBox>
-        ) : (
-          <InfoBox
-            variant="error"
-            title={`${errors.length} validation error${errors.length > 1 ? "s" : ""} found:`}
-          >
-            <ScrollArea className="max-h-80 overflow-y-auto">
-              <ul className="text-xs space-y-1">
-                {errors.map((error) => (
-                  <li key={error}>
-                    <InlineStack
-                      gap="2"
-                      blockAlign="start"
-                      align="start"
-                      wrap="nowrap"
-                    >
-                      <span className="text-destructive shrink-0">•</span>
-                      <span className="wrap-break-word">{error}</span>
-                    </InlineStack>
-                  </li>
-                ))}
-              </ul>
-            </ScrollArea>
-          </InfoBox>
-        )}
+        <PipelineValidationList
+          isComponentTreeValid={isComponentTreeValid}
+          groupedIssues={groupedIssues}
+          totalIssueCount={globalValidationIssues.length}
+          onIssueSelect={handleIssueClick}
+        />
       </div>
     </div>
   );

--- a/src/components/Editor/components/PipelineValidationList/PipelineValidationList.tsx
+++ b/src/components/Editor/components/PipelineValidationList/PipelineValidationList.tsx
@@ -1,0 +1,163 @@
+import { useState } from "react";
+
+import { InfoBox } from "@/components/shared/InfoBox";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { Icon } from "@/components/ui/icon";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { Paragraph, Text } from "@/components/ui/typography";
+import { cn } from "@/lib/utils";
+import { pluralize } from "@/utils/string";
+import type { ComponentValidationIssue } from "@/utils/validations";
+
+import type { ValidationIssueGroup } from "../../hooks/useValidationIssueNavigation";
+
+interface PipelineValidationListProps {
+  isComponentTreeValid: boolean;
+  groupedIssues: ValidationIssueGroup[];
+  totalIssueCount: number;
+  onIssueSelect: (issue: ComponentValidationIssue) => void;
+}
+
+const groupTriggerStyles = cn(
+  "w-full justify-start gap-2 rounded-lg font-medium",
+  "bg-destructive/10 text-destructive-foreground hover:bg-destructive/15",
+);
+
+const issueButtonStyles = cn(
+  "h-auto w-full flex-col items-start justify-start gap-1 rounded-lg",
+  "whitespace-normal border-destructive/20 bg-white/80 px-3 py-2 text-left",
+  "hover:border-destructive/40 hover:bg-destructive/5",
+  "focus-visible:ring-destructive/40",
+);
+
+export const PipelineValidationList = ({
+  isComponentTreeValid,
+  groupedIssues,
+  totalIssueCount,
+  onIssueSelect,
+}: PipelineValidationListProps) => {
+  const [openGroups, setOpenGroups] = useState<Set<string>>(new Set());
+
+  const toggleGroup = (pathKey: string) => {
+    setOpenGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(pathKey)) {
+        next.delete(pathKey);
+      } else {
+        next.add(pathKey);
+      }
+      return next;
+    });
+  };
+
+  if (isComponentTreeValid) {
+    return (
+      <InfoBox variant="success" title="No validation issues found">
+        Pipeline is ready for submission
+      </InfoBox>
+    );
+  }
+
+  return (
+    <InfoBox
+      variant="error"
+      title={`${totalIssueCount} ${pluralize(totalIssueCount, "issue")} detected`}
+    >
+      <Paragraph size="sm" className="mb-4">
+        {" "}
+        Select an item to jump to its location in the pipeline.
+      </Paragraph>
+
+      <BlockStack gap="2">
+        {groupedIssues.map((group) => {
+          const isOpen = openGroups.has(group.pathKey);
+          return (
+            <Collapsible
+              key={group.pathKey}
+              open={isOpen}
+              onOpenChange={() => toggleGroup(group.pathKey)}
+              className="w-full"
+            >
+              <Tooltip>
+                <TooltipTrigger asChild className="w-full">
+                  <CollapsibleTrigger asChild>
+                    <Button variant="ghost" className={groupTriggerStyles}>
+                      <Icon
+                        name="ChevronRight"
+                        size="sm"
+                        className={cn(
+                          "text-destructive/60 transition-transform duration-200",
+                          isOpen && "rotate-90",
+                        )}
+                      />
+                      <Text className="flex-1 truncate">
+                        {group.depth === 0
+                          ? "Root Pipeline"
+                          : `Subgraph: ${group.pathLabel}`}
+                      </Text>
+                      <Badge
+                        size="sm"
+                        className="rounded-full bg-destructive/20 text-destructive"
+                      >
+                        {group.issues.length}
+                      </Badge>
+                    </Button>
+                  </CollapsibleTrigger>
+                </TooltipTrigger>
+                <TooltipContent side="top" sideOffset={4}>
+                  {group.fullPath}
+                </TooltipContent>
+              </Tooltip>
+
+              <CollapsibleContent>
+                <BlockStack gap="1" className="mt-1 pl-2">
+                  {group.issues.map(
+                    ({ issue, displayName, typeLabel, displayMessage }) => (
+                      <Button
+                        key={issue.id}
+                        variant="outline"
+                        onClick={() => onIssueSelect(issue)}
+                        className={issueButtonStyles}
+                      >
+                        <InlineStack gap="1" blockAlign="center" wrap="nowrap">
+                          <Text
+                            size="xs"
+                            weight="semibold"
+                            tone="critical"
+                            className="shrink-0 uppercase tracking-wide"
+                          >
+                            {typeLabel}
+                          </Text>
+                          <Text tone="critical" className="shrink-0 opacity-40">
+                            •
+                          </Text>
+                          <Text size="xs" tone="subdued" className="truncate">
+                            {displayName}
+                          </Text>
+                        </InlineStack>
+                        <Text as="p" size="sm">
+                          {displayMessage}
+                        </Text>
+                      </Button>
+                    ),
+                  )}
+                </BlockStack>
+              </CollapsibleContent>
+            </Collapsible>
+          );
+        })}
+      </BlockStack>
+    </InfoBox>
+  );
+};

--- a/src/components/Editor/hooks/useValidationIssueNavigation.ts
+++ b/src/components/Editor/hooks/useValidationIssueNavigation.ts
@@ -1,0 +1,162 @@
+import equal from "fast-deep-equal";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { useNodesOverlay } from "@/components/shared/ReactFlow/NodesOverlay/NodesOverlayProvider";
+import { useComponentSpec } from "@/providers/ComponentSpecProvider";
+import {
+  inputNameToNodeId,
+  outputNameToNodeId,
+  taskIdToNodeId,
+} from "@/utils/nodes/nodeIdUtils";
+import type { ComponentValidationIssue } from "@/utils/validations";
+
+const ISSUE_TYPE_LABELS: Record<ComponentValidationIssue["type"], string> = {
+  graph: "Graph",
+  task: "Task",
+  input: "Input",
+  output: "Output",
+};
+
+const getIssueNodeId = (issue: ComponentValidationIssue): string | null => {
+  if (issue.taskId) return taskIdToNodeId(issue.taskId);
+  if (issue.inputName) return inputNameToNodeId(issue.inputName);
+  if (issue.outputName) return outputNameToNodeId(issue.outputName);
+  return null;
+};
+
+interface ValidationIssueListItem {
+  issue: ComponentValidationIssue;
+  displayName: string;
+  displayMessage: string;
+  typeLabel: string;
+}
+
+export interface ValidationIssueGroup {
+  pathKey: string;
+  pathLabel: string;
+  fullPath: string;
+  depth: number;
+  issues: ValidationIssueListItem[];
+}
+
+export const useValidationIssueNavigation = (
+  validationIssues: ComponentValidationIssue[],
+) => {
+  const { currentSubgraphPath, navigateToPath } = useComponentSpec();
+  const { fitNodeIntoView, notifyNode } = useNodesOverlay();
+
+  const [pendingIssue, setPendingIssue] =
+    useState<ComponentValidationIssue | null>(null);
+
+  const highlightedNodeRef = useRef<string | null>(null);
+
+  const focusIssue = useCallback(
+    async (issue: ComponentValidationIssue) => {
+      const nodeId = getIssueNodeId(issue);
+      if (!nodeId) return;
+
+      // Clear previous highlight
+      if (highlightedNodeRef.current && highlightedNodeRef.current !== nodeId) {
+        notifyNode(highlightedNodeRef.current, { type: "clear" });
+      }
+
+      await fitNodeIntoView(nodeId);
+
+      if (issue.type === "task") {
+        highlightedNodeRef.current = nodeId;
+        notifyNode(nodeId, { type: "highlight" });
+      } else {
+        highlightedNodeRef.current = null;
+      }
+    },
+    [fitNodeIntoView, notifyNode],
+  );
+
+  useEffect(() => {
+    return () => {
+      if (highlightedNodeRef.current) {
+        notifyNode(highlightedNodeRef.current, { type: "clear" });
+      }
+    };
+  }, [notifyNode]);
+
+  const handleIssueClick = useCallback(
+    (issue: ComponentValidationIssue) => {
+      if (!equal(issue.subgraphPath, currentSubgraphPath)) {
+        setPendingIssue(issue);
+        navigateToPath(issue.subgraphPath);
+        return;
+      }
+
+      focusIssue(issue);
+    },
+    [currentSubgraphPath, focusIssue, navigateToPath],
+  );
+
+  useEffect(() => {
+    if (!pendingIssue) return;
+    if (!equal(pendingIssue.subgraphPath, currentSubgraphPath)) return;
+
+    const frameId = requestAnimationFrame(() => {
+      focusIssue(pendingIssue);
+      setPendingIssue(null);
+    });
+
+    return () => cancelAnimationFrame(frameId);
+  }, [currentSubgraphPath, focusIssue, pendingIssue]);
+
+  const issueItems = useMemo<ValidationIssueListItem[]>(() => {
+    return validationIssues.map((issue) => {
+      const nodeLabel =
+        issue.taskId ?? issue.inputName ?? issue.outputName ?? null;
+      const fallbackName =
+        issue.subgraphPath.length <= 1
+          ? "Pipeline"
+          : (issue.subgraphPath[issue.subgraphPath.length - 1] ?? "Pipeline");
+      const displayName = nodeLabel ?? fallbackName;
+
+      return {
+        issue,
+        displayName,
+        typeLabel: ISSUE_TYPE_LABELS[issue.type],
+        displayMessage: issue.message,
+      };
+    });
+  }, [validationIssues]);
+
+  const groupedIssues = useMemo<ValidationIssueGroup[]>(() => {
+    const groupsMap = issueItems.reduce((acc, item) => {
+      const pathKey = item.issue.subgraphPath.join(" > ");
+      const existing = acc.get(pathKey);
+      if (existing) {
+        return acc.set(pathKey, [...existing, item]);
+      }
+      return acc.set(pathKey, [item]);
+    }, new Map<string, ValidationIssueListItem[]>());
+
+    return Array.from(groupsMap.entries())
+      .map(([pathKey, items]) => {
+        const { subgraphPath } = items[0].issue;
+        const depth = subgraphPath.length - 1;
+        const isRoot = depth === 0;
+
+        const taskId = subgraphPath[subgraphPath.length - 1] ?? "Subgraph";
+
+        return {
+          pathKey,
+          pathLabel: isRoot ? "Root Pipeline" : taskId,
+          fullPath: isRoot
+            ? "Root Pipeline"
+            : subgraphPath.slice(1).join(" → "),
+          depth,
+          issues: items,
+        };
+      })
+      .sort((a, b) => a.depth - b.depth);
+  }, [issueItems]);
+
+  return {
+    handleIssueClick,
+    groupedIssues,
+  };
+};

--- a/src/components/shared/ComponentEditor/components/PythonComponentEditor.tsx
+++ b/src/components/shared/ComponentEditor/components/PythonComponentEditor.tsx
@@ -92,7 +92,12 @@ export const PythonComponentEditor = withSuspenseWrapper(
           setValidationErrors(errors);
         }
       },
-      [yamlGenerator, onComponentTextChange, onErrorsChange, yamlGeneratorOptions],
+      [
+        yamlGenerator,
+        onComponentTextChange,
+        onErrorsChange,
+        yamlGeneratorOptions,
+      ],
     );
 
     useEffect(() => {

--- a/src/components/shared/ReactFlow/FlowSidebar/sections/RunsAndSubmission.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/sections/RunsAndSubmission.tsx
@@ -16,7 +16,7 @@ import { RecentExecutionsButton } from "../components/RecentExecutionsButton";
 
 const RunsAndSubmission = ({ isOpen }: { isOpen: boolean }) => {
   const { isAuthorized } = useAwaitAuthorization();
-  const { componentSpec } = useComponentSpec();
+  const { componentSpec, isComponentTreeValid } = useComponentSpec();
 
   const showGoogleSubmitter =
     import.meta.env.VITE_ENABLE_GOOGLE_CLOUD_SUBMITTER === "true";
@@ -29,7 +29,10 @@ const RunsAndSubmission = ({ isOpen }: { isOpen: boolean }) => {
           <SidebarMenu>
             <SidebarMenuItem>
               {isAuthorized ? (
-                <OasisSubmitter componentSpec={componentSpec} />
+                <OasisSubmitter
+                  componentSpec={componentSpec}
+                  isComponentTreeValid={isComponentTreeValid}
+                />
               ) : (
                 <HuggingFaceAuthButton title="Sign in to Submit Runs" />
               )}
@@ -60,7 +63,10 @@ const RunsAndSubmission = ({ isOpen }: { isOpen: boolean }) => {
         <SidebarMenu>
           <SidebarMenuItem>
             {isAuthorized ? (
-              <OasisSubmitter componentSpec={componentSpec} />
+              <OasisSubmitter
+                componentSpec={componentSpec}
+                isComponentTreeValid={isComponentTreeValid}
+              />
             ) : (
               <HuggingFaceAuthButton
                 title="Sign in to Submit Runs"

--- a/src/providers/ComponentSpecProvider.tsx
+++ b/src/providers/ComponentSpecProvider.tsx
@@ -9,7 +9,12 @@ import {
   getSubgraphComponentSpec,
   updateSubgraphSpec,
 } from "@/utils/subgraphUtils";
-import { checkComponentSpecValidity } from "@/utils/validations";
+import {
+  checkComponentSpecValidity,
+  collectComponentValidationIssues,
+  type ComponentValidationIssue,
+  type ValidationError,
+} from "@/utils/validations";
 
 import {
   createRequiredContext,
@@ -44,7 +49,9 @@ interface ComponentSpecContextType {
   currentSubgraphSpec: ComponentSpec;
   isLoading: boolean;
   isValid: boolean;
-  errors: string[];
+  errors: ValidationError[];
+  isComponentTreeValid: boolean;
+  globalValidationIssues: ComponentValidationIssue[];
   refetch: () => void;
   updateGraphSpec: (newGraphSpec: GraphSpec) => void;
   saveComponentSpec: (name: string) => Promise<void>;
@@ -104,6 +111,12 @@ export const ComponentSpecProvider = ({
       }),
     [currentSubgraphSpec, isRootSubgraph],
   );
+
+  const globalValidationIssues = useMemo(
+    () => collectComponentValidationIssues(componentSpec),
+    [componentSpec],
+  );
+  const isComponentTreeValid = globalValidationIssues.length === 0;
 
   const clearComponentSpec = useCallback(() => {
     setComponentSpec(EMPTY_GRAPH_COMPONENT_SPEC);
@@ -229,6 +242,8 @@ export const ComponentSpecProvider = ({
       isLoading,
       isValid,
       errors,
+      isComponentTreeValid,
+      globalValidationIssues,
       refetch,
       setComponentSpec,
       clearComponentSpec,
@@ -250,6 +265,8 @@ export const ComponentSpecProvider = ({
       isLoading,
       isValid,
       errors,
+      isComponentTreeValid,
+      globalValidationIssues,
       refetch,
       setComponentSpec,
       clearComponentSpec,


### PR DESCRIPTION
## **Description**

Adds a new validation system that collects issues across all nested subgraphs and allows users to click on any issue to navigate directly to the problematic node.

### **What Changed**

**New Components:**

- PipelineValidationList - Displays validation issues as clickable cards
- useValidationIssueNavigation - Hook handling navigation and node highlighting

**Modified:**

- ComponentSpecProvider - Now exposes globalValidationIssues and isComponentTreeValid
- OasisSubmitter - Uses centralized validation instead of checking locally
- validations.ts - Added collectComponentValidationIssues() for recursive validation

### **Features**

- Click any validation issue to jump to the node (input, output, or task)
- Works across nested subgraphs (auto-navigates to correct level)
- Task nodes get a temporary highlight animation when focused
- Issues display human-readable messages with type labels

**Test Instructions**

1. Create a pipeline with validation issues (missing connections, required inputs, etc.)
2. Verify that the validation panel shows a list of clickable issues
3. Click on an issue and confirm it navigates to the relevant node in the graph
4. Test with nested subgraphs to ensure navigation works across different levels

[validation.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/338050fc-dfa8-4c0a-8eb6-d6ea194dae03.mov" />](https://app.graphite.com/user-attachments/video/338050fc-dfa8-4c0a-8eb6-d6ea194dae03.mov)