### PR TITLE
ComponentSpecProvider Computes Digest

### DIFF
--- a/src/components/Editor/PipelineDetails.tsx
+++ b/src/components/Editor/PipelineDetails.tsx
@@ -28,6 +28,7 @@ const PipelineDetails = () => {
   const {
     componentSpec,
     graphSpec,
+    digest,
     isComponentTreeValid,
     globalValidationIssues,
   } = useComponentSpec();
@@ -54,7 +55,6 @@ const PipelineDetails = () => {
     creationTime?: Date;
     modificationTime?: Date;
     createdBy?: string;
-    digest?: string;
   }>({});
 
   // Fetch file metadata on mount or when componentSpec.name changes
@@ -72,7 +72,6 @@ const PipelineDetails = () => {
           createdBy: file.componentRef.spec.metadata?.annotations?.author as
             | string
             | undefined,
-          digest: file.componentRef.digest,
         });
       }
     };
@@ -107,6 +106,11 @@ const PipelineDetails = () => {
 
     void navigator.clipboard.writeText(value);
     notify("Input value copied to clipboard", "success");
+  };
+
+  const handleDigestCopy = () => {
+    navigator.clipboard.writeText(digest);
+    notify("Digest copied to clipboard", "success");
   };
 
   if (!componentSpec) {
@@ -181,21 +185,16 @@ const PipelineDetails = () => {
       )}
 
       {/* Component Digest */}
-      {fileMeta.digest && (
+      {digest && (
         <div className="mb-2">
           <h3 className="text-md font-medium mb-1">Digest</h3>
           <Button
             className="bg-gray-100 border border-gray-300 rounded p-2 h-fit text-xs w-full text-left hover:bg-gray-200 active:bg-gray-300 transition cursor-pointer"
-            onClick={() => {
-              if (fileMeta.digest) {
-                navigator.clipboard.writeText(fileMeta.digest);
-                notify("Digest copied to clipboard", "success");
-              }
-            }}
+            onClick={handleDigestCopy}
             variant="ghost"
           >
             <span className="font-mono break-all w-full text-wrap">
-              {fileMeta.digest}
+              {digest}
             </span>
           </Button>
         </div>


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Fixes a bug where pipeline digest did not update in realtime when changes were made to a pipeline.

ComponentSpecProvider now exports a `digest` calculated dynamically from the spec.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

Closes https://github.com/Shopify/oasis-frontend/issues/368

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->
Verify that pipeline digest updates when changes are made to a pipeline.
Verify that digest is the same after refreshing or reloading a pipeline.

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
