### PR TITLE
Improvements to IO Node Ghosts & Quick-Place

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/Edges/ConnectionLine.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/Edges/ConnectionLine.tsx
@@ -1,0 +1,99 @@
+import {
+  type ConnectionLineComponent,
+  type ConnectionLineComponentProps,
+  getBezierPath,
+  type Node,
+  useConnection,
+  useNodes,
+} from "@xyflow/react";
+
+import { EdgeColor } from "./utils";
+
+export const ConnectionLine: ConnectionLineComponent = ({
+  fromX,
+  fromY,
+  fromPosition,
+  toX,
+  toY,
+  toPosition,
+  connectionStatus,
+}: ConnectionLineComponentProps) => {
+  const nodes = useNodes();
+  const sourceNode = useConnection((connection) => connection.fromNode);
+  const targetNode = useConnection((connection) => connection.toNode);
+
+  const hasGhostNode = nodes.some((node) => node.type === "ghost");
+
+  if (hasGhostNode) {
+    return null;
+  }
+
+  const [path] = getBezierPath({
+    sourceX: fromX,
+    sourceY: fromY,
+    sourcePosition: fromPosition,
+    targetX: toX,
+    targetY: toY,
+    targetPosition: toPosition,
+  });
+
+  let color =
+    connectionStatus === "valid" ? EdgeColor.Valid : EdgeColor.Incomplete;
+
+  if (sourceNode && targetNode && !isValidConnection(sourceNode, targetNode)) {
+    color = EdgeColor.Invalid;
+  }
+
+  const markerId = `connection-line-arrow-${color}`;
+
+  return (
+    <g>
+      <svg style={{ height: 0 }}>
+        <defs>
+          <marker
+            id={markerId}
+            markerWidth="12"
+            markerHeight="12"
+            refX="7"
+            refY="6"
+            orient="auto"
+            markerUnits="userSpaceOnUse"
+          >
+            <path
+              d="M2,2 Q10,6 2,10 Q4,6 2,2"
+              fill={color}
+              stroke={color}
+              strokeWidth="1"
+              strokeLinejoin="round"
+            />
+          </marker>
+        </defs>
+      </svg>
+      <path
+        d={path}
+        className="react-flow__edge-path"
+        style={{
+          stroke: color,
+          strokeWidth: 4,
+        }}
+        markerEnd={`url(#${markerId})`}
+      />
+    </g>
+  );
+};
+
+const isValidConnection = (fromNode: Node, toNode: Node) => {
+  if (fromNode.id === toNode.id) {
+    return false;
+  }
+
+  // IO nodes can't connect to each other
+  const isFromIO = fromNode.type === "input" || fromNode.type === "output";
+  const isToIO = toNode.type === "input" || toNode.type === "output";
+
+  if (isFromIO && isToIO) {
+    return false;
+  }
+
+  return true;
+};

--- a/src/components/shared/ReactFlow/FlowCanvas/Edges/SmoothEdge.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/Edges/SmoothEdge.tsx
@@ -1,6 +1,8 @@
 import type { EdgeProps } from "@xyflow/react";
 import { getBezierPath } from "@xyflow/react";
 
+import { EdgeColor } from "./utils";
+
 const SmoothEdge = ({
   id,
   sourceX,
@@ -21,7 +23,7 @@ const SmoothEdge = ({
     targetPosition,
   });
 
-  const edgeColor = selected ? "#38bdf8" : "#6b7280";
+  const edgeColor = selected ? EdgeColor.Selected : EdgeColor.Neutral;
   const markerIdSuffix = selected ? "selected" : "default";
 
   return (

--- a/src/components/shared/ReactFlow/FlowCanvas/Edges/utils.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/Edges/utils.ts
@@ -1,0 +1,9 @@
+export enum EdgeColor {
+  Incomplete = "#b1b1b7",
+  Neutral = "#6b7280",
+  Valid = "#8db88d",
+  Invalid = "#d47a7a",
+  Input = "#3b82f6",
+  Output = "#a855f7",
+  Selected = "#38bdf8",
+}

--- a/src/components/shared/ReactFlow/FlowCanvas/GhostNode/GhostNode.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/GhostNode/GhostNode.tsx
@@ -1,4 +1,4 @@
-import type { Node, NodeProps } from "@xyflow/react";
+import { type Node, type NodeProps, Position } from "@xyflow/react";
 import { memo, useMemo } from "react";
 
 import { cn } from "@/lib/utils";
@@ -9,11 +9,12 @@ import { GHOST_NODE_BASE_OFFSET_X, GHOST_NODE_BASE_OFFSET_Y } from "./utils";
 
 type GhostNodeProps = NodeProps<Node<GhostNodeData>>;
 
-const GhostNode = ({ data }: GhostNodeProps) => {
+const GhostNode = ({ data, id }: GhostNodeProps) => {
   const { ioType, label, dataType, value, defaultValue } = data;
 
-  const side = ioType === "input" ? "left" : "right";
-  const transformOrigin = side === "left" ? "center right" : "center left";
+  const side = ioType === "input" ? Position.Left : Position.Right;
+  const transformOrigin =
+    side === Position.Left ? "center right" : "center left";
   const offsetX = GHOST_NODE_BASE_OFFSET_X;
   const offsetY = GHOST_NODE_BASE_OFFSET_Y;
 
@@ -32,7 +33,7 @@ const GhostNode = ({ data }: GhostNodeProps) => {
     <div
       className={cn(
         "pointer-events-none select-none opacity-60",
-        side === "left" && "-translate-x-full",
+        side === Position.Left && "-translate-x-full",
       )}
       style={{
         filter: "brightness(0.9) saturate(0.7)",
@@ -42,6 +43,7 @@ const GhostNode = ({ data }: GhostNodeProps) => {
     >
       <div className="rounded-lg border-2 border-dashed border-blue-400/60 bg-white/40 p-1">
         <IONode
+          id={id}
           type={ioType}
           data={ghostNodeData}
           selected={false}

--- a/src/components/shared/ReactFlow/FlowCanvas/IONode/IONode.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/IONode/IONode.tsx
@@ -12,9 +12,12 @@ import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 import { useContextPanel } from "@/providers/ContextPanelProvider";
 import { isViewingSubgraph } from "@/utils/subgraphUtils";
 
+import { getGhostHandleId, GHOST_NODE_ID } from "../GhostNode/utils";
+
 export const DEFAULT_IO_NODE_WIDTH = 300;
 
 interface IONodeProps {
+  id: string;
   type: "input" | "output";
   data: {
     label: string;
@@ -27,7 +30,7 @@ interface IONodeProps {
   deletable: boolean;
 }
 
-const IONode = ({ type, data, selected = false }: IONodeProps) => {
+const IONode = ({ id, type, data, selected = false }: IONodeProps) => {
   const { currentGraphSpec, currentSubgraphSpec, currentSubgraphPath } =
     useComponentSpec();
   const {
@@ -130,10 +133,14 @@ const IONode = ({ type, data, selected = false }: IONodeProps) => {
 
   const value = isInput ? inputValue : outputValue;
 
+  // The rest of our code doesn't support IO Handles having ids (yet).
+  // For now, only assign an id to the Handle if this is a ghost node.
+  const handleId = id === GHOST_NODE_ID ? getGhostHandleId() : undefined;
+
   return (
     <Card className={cn("border-2 max-w-[300px] p-0", borderColor)}>
       <CardHeader className="px-2 py-2.5">
-        <CardTitle className="wrap-break-word">{data.label}</CardTitle>
+        <CardTitle className="wrap-break-word text-sm">{data.label}</CardTitle>
       </CardHeader>
       <CardContent className="p-2 max-w-[250px]">
         <BlockStack gap="2">
@@ -144,7 +151,7 @@ const IONode = ({ type, data, selected = false }: IONodeProps) => {
           </Paragraph>
 
           {!!outputConnectedTaskId && (
-            <Paragraph weight="bold" className="text-slate-700">
+            <Paragraph size="xs" weight="bold" className="text-slate-700">
               {outputConnectedTaskId}
             </Paragraph>
           )}
@@ -170,6 +177,7 @@ const IONode = ({ type, data, selected = false }: IONodeProps) => {
           </InlineStack>
         </BlockStack>
         <Handle
+          id={handleId}
           type={handleType}
           position={handlePosition}
           className={cn(handleDefaultClassName, handleClassName)}

--- a/src/components/shared/ReactFlow/FlowCanvas/utils/createConnectedIONode.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/utils/createConnectedIONode.ts
@@ -17,11 +17,6 @@ import addTask from "./addTask";
 import { setGraphOutputValue } from "./setGraphOutputValue";
 import { setTaskArgument } from "./setTaskArgument";
 
-const IO_NAME_SUFFIX: Record<"INPUT" | "OUTPUT", string> = {
-  INPUT: " input",
-  OUTPUT: " output",
-};
-
 type CreateConnectedIONodeParams = {
   componentSpec: ComponentSpec;
   taskNodeId: string;
@@ -66,8 +61,6 @@ export const createConnectedIONode = ({
       ? nodeIdToInputName(handleId)
       : nodeIdToOutputName(handleId);
   const taskType: TaskType = ioType;
-  const nameSuffix =
-    ioType === "input" ? IO_NAME_SUFFIX.INPUT : IO_NAME_SUFFIX.OUTPUT;
 
   const taskSpec = componentSpec.implementation.graph.tasks[taskId];
   const taskComponentSpec = taskSpec?.componentRef?.spec;
@@ -96,7 +89,7 @@ export const createConnectedIONode = ({
     position,
     componentSpec,
     {
-      name: `${argName}${nameSuffix}`,
+      name: argName,
       type: ioNodeType,
       ...(ioNodeDefault && { default: ioNodeDefault }),
     },

--- a/src/hooks/useGhostNode.ts
+++ b/src/hooks/useGhostNode.ts
@@ -3,10 +3,7 @@ import { useConnection } from "@xyflow/react";
 import { useMemo } from "react";
 
 import type { GhostNodeData } from "@/components/shared/ReactFlow/FlowCanvas/GhostNode/types";
-import {
-  createGhostNode,
-  getGhostNodeLabel,
-} from "@/components/shared/ReactFlow/FlowCanvas/GhostNode/utils";
+import { createGhostNode } from "@/components/shared/ReactFlow/FlowCanvas/GhostNode/utils";
 import type { ComponentSpec } from "@/utils/componentSpec";
 import { isGraphImplementation } from "@/utils/componentSpec";
 import {
@@ -17,7 +14,7 @@ import {
 
 type UseGhostNodeParams = {
   readOnly?: boolean;
-  metaKeyPressed: boolean;
+  active: boolean;
   isConnecting: boolean;
   implementation: ComponentSpec["implementation"];
 };
@@ -94,7 +91,7 @@ const extractOutputGhostData = (
 
 export const useGhostNode = ({
   readOnly,
-  metaKeyPressed,
+  active,
   isConnecting,
   implementation,
 }: UseGhostNodeParams): UseGhostNodeReturn => {
@@ -102,6 +99,7 @@ export const useGhostNode = ({
   const connectionFromHandle = useConnection(
     (connection) => connection.fromHandle,
   );
+  const connectionFromNode = useConnection((connection) => connection.fromNode);
   const connectionToHandle = useConnection((connection) => connection.toHandle);
   const connectionIsValid = useConnection((connection) => connection.isValid);
 
@@ -111,11 +109,11 @@ export const useGhostNode = ({
   const ghostNode = useMemo<Node<GhostNodeData> | null>(() => {
     if (
       readOnly ||
-      !metaKeyPressed ||
+      !active ||
       !isConnecting ||
       !connectionPosition ||
       !connectionFromHandle ||
-      !connectionFromHandle.nodeId?.startsWith("task_") ||
+      connectionFromNode?.type !== "task" ||
       !connectionFromHandle.type ||
       !isGraphImplementation(implementation) ||
       isConnectionTemporarilyValid
@@ -143,12 +141,12 @@ export const useGhostNode = ({
     return createGhostNode({
       position: connectionPosition,
       ioType,
-      label: getGhostNodeLabel(handleName, ioType),
+      label: handleName,
       ...extractedData,
     });
   }, [
     readOnly,
-    metaKeyPressed,
+    active,
     isConnecting,
     connectionPosition,
     connectionFromHandle,


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
IO Ghost nodes now:
- Measure their own size and position themselves correctly (instead of working with an assumed default)
- End up in the same position when placed
- Have the connection line drawn to their handle, not the top of the node
- No longer append "Input" or "Output" to the name when placed

To enable this a custom connection line component was added. This component renders for all in-progress connections, except when a GhostNode is active. This is used in conjunction with a GhostEdge to draw the line to the ghost node's handle instead of the cursor.

Additionally, Edges:
- The default drawn edge is now similar in style to our placed edges (i.e. thicker)
- Now color a slight green whilst drawn when valid (e.g. task -> task)
- Now color a slight red whilst drawn when invalid (e.g. input -> output)
- Now color a dashed blue whilst drawn when placing a ghost Input
- Now color a dashed purple whilst drawn when placing a ghost Output

Finally, some additional code improvements were made to the Ghost Node logic. e.g. consolidating refs and removing and expensive `nodes.find` statement.

Note: due to our existing connection architecture the IO Node handles cannot have ids, but for the ghost node connections they need an id. Hence, there is a ternary to separate the two cases. In future we should revise (e.g. as per node manager stack) and all handles should have ids.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix
- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->
Confirm that edges can still be drawn as expected
Confirm that ghost nodes position and move and behave as expected
Confirm that ghost nodes place in the same location as they were when dropped
Confirm that drawing a connection goes green when valid and red when invalid

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
