### PR TITLE
Standardize our use of yaml.dump

### DIFF
--- a/src/components/shared/ComponentEditor/utils/preserveComponentName.ts
+++ b/src/components/shared/ComponentEditor/utils/preserveComponentName.ts
@@ -2,6 +2,7 @@ import yaml from "js-yaml";
 
 import type { ComponentSpec } from "@/utils/componentSpec";
 import { isValidComponentSpec } from "@/utils/componentSpec";
+import { componentSpecToYaml } from "@/utils/componentStore";
 
 export const preserveComponentName = (
   yamlText: string,
@@ -20,7 +21,7 @@ export const preserveComponentName = (
         name: preservedName,
       };
 
-      return yaml.dump(updatedSpec, { lineWidth: 10000 });
+      return componentSpecToYaml(updatedSpec);
     }
   } catch (error) {
     console.error("Failed to preserve component name:", error);

--- a/src/components/shared/Dialogs/ComponentDuplicateDialog.tsx
+++ b/src/components/shared/Dialogs/ComponentDuplicateDialog.tsx
@@ -1,4 +1,3 @@
-import yaml from "js-yaml";
 import { useCallback, useEffect, useState } from "react";
 
 import { Button } from "@/components/ui/button";
@@ -15,7 +14,10 @@ import { Label } from "@/components/ui/label";
 import { BlockStack } from "@/components/ui/layout";
 import { generateDigest } from "@/services/componentService";
 import type { ComponentSpec } from "@/utils/componentSpec";
-import { deleteComponentFileFromList } from "@/utils/componentStore";
+import {
+  componentSpecToYaml,
+  deleteComponentFileFromList,
+} from "@/utils/componentStore";
 import { USER_COMPONENTS_LIST_NAME } from "@/utils/constants";
 import type { UserComponent } from "@/utils/localforage";
 
@@ -53,7 +55,7 @@ const ComponentDuplicateDialog = ({
 
     if (newComponent && newName) {
       const digest = await generateDigest(
-        yaml.dump({
+        componentSpecToYaml({
           ...newComponent,
           name: newName,
         }),
@@ -73,11 +75,13 @@ const ComponentDuplicateDialog = ({
 
   const handleRenameAndImport = useCallback(
     async (newName: string) => {
+      if (!newComponent) return;
+
       const newComponentWithNewName = {
         ...newComponent,
         name: newName,
       };
-      const yamlString = yaml.dump(newComponentWithNewName);
+      const yamlString = componentSpecToYaml(newComponentWithNewName);
       handleImportComponent(yamlString);
 
       setClose();
@@ -86,7 +90,9 @@ const ComponentDuplicateDialog = ({
   );
 
   const handleReplaceAndImport = useCallback(async () => {
-    const yamlString = yaml.dump(newComponent);
+    if (!newComponent) return;
+
+    const yamlString = componentSpecToYaml(newComponent);
     await deleteComponentFileFromList(
       USER_COMPONENTS_LIST_NAME,
       existingComponent?.name ?? "",
@@ -103,7 +109,7 @@ const ComponentDuplicateDialog = ({
   useEffect(() => {
     const generateNewDigest = async () => {
       if (newComponent) {
-        const digest = await generateDigest(yaml.dump(newComponent));
+        const digest = await generateDigest(componentSpecToYaml(newComponent));
         setNewDigest(digest);
       }
     };

--- a/src/components/shared/TaskDetails/Implementation.tsx
+++ b/src/components/shared/TaskDetails/Implementation.tsx
@@ -1,8 +1,8 @@
-import yaml from "js-yaml";
 import { useMemo } from "react";
 
 import { CodeViewer } from "@/components/shared/CodeViewer";
 import type { ComponentSpec } from "@/utils/componentSpec";
+import { componentSpecToText } from "@/utils/componentStore";
 
 interface TaskImplementationProps {
   displayName: string;
@@ -16,12 +16,7 @@ const TaskImplementation = ({
   showInlineContent = true,
 }: TaskImplementationProps) => {
   const code = useMemo(
-    () =>
-      yaml.dump(componentSpec, {
-        lineWidth: 80,
-        noRefs: true,
-        indent: 2,
-      }),
+    () => componentSpecToText(componentSpec),
     [componentSpec],
   );
 

--- a/src/providers/ComponentLibraryProvider/libraries/browserPersistedLibrary.test.ts
+++ b/src/providers/ComponentLibraryProvider/libraries/browserPersistedLibrary.test.ts
@@ -15,6 +15,12 @@ import type { ComponentReference } from "@/utils/componentSpec";
 import { BrowserPersistedLibrary } from "./browserPersistedLibrary";
 import { LibraryDB, type StoredLibrary } from "./storage";
 
+vi.mock("@/services/componentService", () => ({
+  hydrateComponentReference: vi.fn(),
+  generateDigest: vi.fn(),
+  fetchComponentTextFromUrl: vi.fn(),
+}));
+
 describe("BrowserPersistedLibrary", () => {
   const createMockComponentReference = (
     name = "test-component",

--- a/src/services/componentService.ts
+++ b/src/services/componentService.ts
@@ -27,6 +27,7 @@ import {
   type TaskSpec,
   type UnknownComponentReference,
 } from "@/utils/componentSpec";
+import { componentSpecToYaml } from "@/utils/componentStore";
 import {
   componentExistsByUrl,
   getAllUserComponents,
@@ -261,7 +262,7 @@ export const getComponentText = async (
   }
 
   if (component.spec) {
-    return yaml.dump(component.spec);
+    return componentSpecToYaml(component.spec);
   }
 
   return undefined;
@@ -432,7 +433,7 @@ async function hydrateFromPartialContentfulComponentReference(
   }
   // it is ok to fail here, as we will try to fetch the text from the URL or local storage
   const text = isSpecOnlyComponentReference(component)
-    ? yaml.dump(component.spec)
+    ? componentSpecToYaml(component.spec)
     : component.text;
 
   const spec = isTextOnlyComponentReference(component)

--- a/src/utils/URL.ts
+++ b/src/utils/URL.ts
@@ -1,8 +1,7 @@
-import yaml from "js-yaml";
-
 import { RUNS_BASE_PATH } from "@/routes/router";
 
 import type { ComponentSpec } from "./componentSpec";
+import { componentSpecToText } from "./componentStore";
 
 const convertGcsUrlToBrowserUrl = (
   url: string,
@@ -119,12 +118,8 @@ const downloadYamlFromComponentText = (
   componentSpec: ComponentSpec,
   displayName: string,
 ) => {
-  const componentText = yaml.dump(componentSpec, {
-    lineWidth: 80,
-    noRefs: true,
-    indent: 2,
-  });
-  const blob = new Blob([componentText], { type: "text/yaml" });
+  const code = componentSpecToText(componentSpec);
+  const blob = new Blob([code], { type: "text/yaml" });
   const url = URL.createObjectURL(blob);
   const a = document.createElement("a");
   a.href = url;

--- a/src/utils/componentStore.ts
+++ b/src/utils/componentStore.ts
@@ -619,6 +619,14 @@ export const componentSpecToYaml = (componentSpec: ComponentSpec) => {
   return yaml.dump(componentSpec, { lineWidth: 10000 });
 };
 
+export const componentSpecToText = (componentSpec: ComponentSpec) => {
+  return yaml.dump(componentSpec, {
+    lineWidth: 80,
+    noRefs: true,
+    indent: 2,
+  });
+};
+
 // TODO: Remove the upgrade code in several weeks.
 const upgradeSingleComponentListDb = async (listName: string) => {
   const componentListVersionKey = "component_list_format_version_" + listName;

--- a/src/utils/yaml.ts
+++ b/src/utils/yaml.ts
@@ -1,15 +1,12 @@
-import yaml from "js-yaml";
+import type { ComponentSpec } from "./componentSpec";
+import { componentSpecToText } from "./componentStore";
 
 const copyToYaml = (
-  text: string | object,
+  spec: ComponentSpec,
   onSuccess: (message: string) => void,
   onFail: (message: string) => void,
 ) => {
-  const code = yaml.dump(text, {
-    lineWidth: 80,
-    noRefs: true,
-    indent: 2,
-  });
+  const code = componentSpecToText(spec);
 
   navigator.clipboard.writeText(code).then(
     () => onSuccess("YAML copied to clipboard"),


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
We are dumping yaml all over to generate digests and stuff. But different dump configs lead to different digests.

This PR standardizes it all into two simple methods
- `componentSpecToYaml`
- `componentSpecToText`

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Cleanup/Refactor

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->
Digests and all other yaml dumping works as expected

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
