### PR TITLE
Unify Digest Functions

### DIFF
--- a/src/components/shared/Dialogs/ComponentDuplicateDialog.tsx
+++ b/src/components/shared/Dialogs/ComponentDuplicateDialog.tsx
@@ -12,11 +12,11 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { BlockStack } from "@/components/ui/layout";
-import { generateDigest } from "@/services/componentService";
 import type { ComponentSpec } from "@/utils/componentSpec";
 import {
   componentSpecToYaml,
   deleteComponentFileFromList,
+  generateDigest,
 } from "@/utils/componentStore";
 import { USER_COMPONENTS_LIST_NAME } from "@/utils/constants";
 import type { UserComponent } from "@/utils/localforage";

--- a/src/components/shared/GitHubLibrary/utils/checkComponentUpdates.ts
+++ b/src/components/shared/GitHubLibrary/utils/checkComponentUpdates.ts
@@ -1,9 +1,7 @@
 import type { StoredLibrary } from "@/providers/ComponentLibraryProvider/libraries/storage";
-import {
-  generateDigest,
-  hydrateComponentReference,
-} from "@/services/componentService";
+import { hydrateComponentReference } from "@/services/componentService";
 import type { HydratedComponentReference } from "@/utils/componentSpec";
+import { generateDigest } from "@/utils/componentStore";
 
 import { isGitHubLibraryConfiguration } from "../types";
 import { createGitHubApiClient } from "./githubApiClient";

--- a/src/components/shared/ReactFlow/FlowCanvas/Subgraphs/create/handleGroupNodes.test.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/Subgraphs/create/handleGroupNodes.test.ts
@@ -22,8 +22,10 @@ vi.mock("../../utils/geometry");
 vi.mock("../../utils/removeNode");
 vi.mock("../../utils/updateDownstreamSubgraphConnections");
 vi.mock("@/services/componentService", () => ({
-  generateDigest: vi.fn().mockResolvedValue("mock-digest"),
   getComponentText: vi.fn().mockResolvedValue("mock-component-text"),
+}));
+vi.mock("@/utils/componentStore", () => ({
+  generateDigest: vi.fn().mockResolvedValue("mock-digest"),
 }));
 vi.mock("@/utils/user", () => ({
   getUserDetails: vi.fn().mockResolvedValue({ id: "test-user" }),

--- a/src/hooks/useComponentFromUrl.ts
+++ b/src/hooks/useComponentFromUrl.ts
@@ -2,10 +2,10 @@ import { useEffect, useMemo, useState } from "react";
 
 import {
   fetchAndStoreComponentByUrl,
-  generateDigest,
   parseComponentData,
 } from "@/services/componentService";
 import type { ComponentSpec } from "@/utils/componentSpec";
+import { generateDigest } from "@/utils/componentStore";
 import { getComponentByUrl } from "@/utils/localforage";
 
 const useComponentFromUrl = (url?: string) => {

--- a/src/providers/ComponentLibraryProvider/componentLibrary.test.ts
+++ b/src/providers/ComponentLibraryProvider/componentLibrary.test.ts
@@ -351,7 +351,7 @@ describe("componentLibrary", () => {
             implementation: { graph: { tasks: {} } },
           }) as ComponentSpec,
       );
-      mockComponentService.generateDigest.mockImplementation(
+      mockComponentStore.generateDigest.mockImplementation(
         async (text) => `digest-${text}`,
       );
     });
@@ -391,7 +391,7 @@ describe("componentLibrary", () => {
       expect(mockComponentStore.componentSpecToYaml).toHaveBeenCalledWith(
         componentRef.spec,
       );
-      expect(mockComponentService.generateDigest).toHaveBeenCalledWith(
+      expect(mockComponentStore.generateDigest).toHaveBeenCalledWith(
         "spec-as-yaml",
       );
       expect(mockComponentService.parseComponentData).not.toHaveBeenCalled();
@@ -426,7 +426,7 @@ describe("componentLibrary", () => {
       expect(mockComponentService.parseComponentData).toHaveBeenCalledWith(
         "component-yaml-text",
       );
-      expect(mockComponentService.generateDigest).toHaveBeenCalledWith(
+      expect(mockComponentStore.generateDigest).toHaveBeenCalledWith(
         "component-yaml-text",
       );
     });

--- a/src/providers/ComponentLibraryProvider/componentLibrary.ts
+++ b/src/providers/ComponentLibraryProvider/componentLibrary.ts
@@ -1,7 +1,4 @@
-import {
-  generateDigest,
-  parseComponentData,
-} from "@/services/componentService";
+import { parseComponentData } from "@/services/componentService";
 import type {
   ComponentFolder,
   ComponentLibrary,
@@ -13,6 +10,7 @@ import type {
 } from "@/utils/componentSpec";
 import {
   componentSpecToYaml,
+  generateDigest,
   getAllComponentFilesFromList,
 } from "@/utils/componentStore";
 import { USER_COMPONENTS_LIST_NAME } from "@/utils/constants";

--- a/src/providers/ComponentLibraryProvider/libraries/browserPersistedLibrary.test.ts
+++ b/src/providers/ComponentLibraryProvider/libraries/browserPersistedLibrary.test.ts
@@ -17,8 +17,11 @@ import { LibraryDB, type StoredLibrary } from "./storage";
 
 vi.mock("@/services/componentService", () => ({
   hydrateComponentReference: vi.fn(),
-  generateDigest: vi.fn(),
   fetchComponentTextFromUrl: vi.fn(),
+}));
+
+vi.mock("@/services/componentStore", () => ({
+  generateDigest: vi.fn(),
 }));
 
 describe("BrowserPersistedLibrary", () => {

--- a/src/providers/ComponentLibraryProvider/libraries/publishedComponentsLibrary.test.ts
+++ b/src/providers/ComponentLibraryProvider/libraries/publishedComponentsLibrary.test.ts
@@ -9,7 +9,10 @@ import type {
   PublishedComponentResponse,
 } from "@/api/types.gen";
 import type { ComponentReference, ComponentSpec } from "@/utils/componentSpec";
-import type { ComponentReferenceWithSpec } from "@/utils/componentStore";
+import {
+  type ComponentReferenceWithSpec,
+  generateDigest,
+} from "@/utils/componentStore";
 
 import { PublishedComponentsLibrary } from "./publishedComponentsLibrary";
 import {
@@ -22,7 +25,6 @@ vi.mock("@/api/sdk.gen");
 
 // Import mocked modules
 import * as apiSdk from "@/api/sdk.gen";
-import { generateDigest } from "@/services/componentService";
 
 // Mock fetch globally
 global.fetch = vi.fn();

--- a/src/services/componentService.test.ts
+++ b/src/services/componentService.test.ts
@@ -3,13 +3,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { ComponentLibrary } from "@/types/componentLibrary";
 import type { ComponentReference, ComponentSpec } from "@/utils/componentSpec";
+import { generateDigest } from "@/utils/componentStore";
 import * as localforage from "@/utils/localforage";
 
 import {
   fetchAndStoreComponent,
   fetchAndStoreComponentByUrl,
   fetchAndStoreComponentLibrary,
-  generateDigest,
   getExistingAndNewUserComponent,
   inputsWithInvalidArguments,
   parseComponentData,

--- a/src/services/componentService.ts
+++ b/src/services/componentService.ts
@@ -27,7 +27,7 @@ import {
   type TaskSpec,
   type UnknownComponentReference,
 } from "@/utils/componentSpec";
-import { componentSpecToYaml } from "@/utils/componentStore";
+import { componentSpecToYaml, generateDigest } from "@/utils/componentStore";
 import {
   componentExistsByUrl,
   getAllUserComponents,
@@ -43,20 +43,6 @@ export interface ExistingAndNewComponent {
 }
 
 const COMPONENT_LIBRARY_URL = getAppSettings().componentLibraryUrl;
-
-/**
- * Generate a digest for a component
- */
-export const generateDigest = async (text: string): Promise<string> => {
-  const hashBuffer = await crypto.subtle.digest(
-    "SHA-256",
-    new TextEncoder().encode(text),
-  );
-
-  return Array.from(new Uint8Array(hashBuffer))
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
-};
 
 /**
  * Fetches the component library from local storage

--- a/src/utils/componentStore.ts
+++ b/src/utils/componentStore.ts
@@ -33,7 +33,7 @@ interface ComponentReferenceWithSpecPlusData {
   data: ArrayBuffer;
 }
 
-const calculateHashDigestHex = async (data: string | ArrayBuffer) => {
+export const generateDigest = async (data: string | ArrayBuffer) => {
   const dataBytes =
     typeof data === "string" ? new TextEncoder().encode(data) : data;
   const hashBuffer = await crypto.subtle.digest("SHA-256", dataBytes);
@@ -85,7 +85,7 @@ export const loadComponentAsRefFromText = async (
   }
   const componentSpec: ComponentSpec = loadedObj;
 
-  const digest = await calculateHashDigestHex(componentBytes as ArrayBuffer);
+  const digest = await generateDigest(componentBytes as ArrayBuffer);
   const componentRef: ComponentReferenceWithSpec = {
     spec: componentSpec,
     digest: digest,
@@ -700,7 +700,7 @@ const upgradeSingleComponentListDb = async (listName: string) => {
         const componentText = componentSpecToYaml(fileEntry.componentRef.spec);
         const encodedData = new TextEncoder().encode(componentText);
         data = encodedData.buffer;
-        const newDigest = await calculateHashDigestHex(data);
+        const newDigest = await generateDigest(data);
         componentRef.digest = newDigest;
         console.warn(
           `The component "${fileName}" was re-serialized. Old digest: ${fileEntry.componentRef.digest}. New digest ${newDigest}.`,

--- a/src/utils/nodes/createSubgraphFromNodes.test.ts
+++ b/src/utils/nodes/createSubgraphFromNodes.test.ts
@@ -15,8 +15,11 @@ import {
 
 // Mock the services
 vi.mock("@/services/componentService", () => ({
-  generateDigest: vi.fn().mockResolvedValue("mock-digest"),
   getComponentText: vi.fn().mockResolvedValue("mock-component-text"),
+}));
+
+vi.mock("@/utils/componentStore", () => ({
+  generateDigest: vi.fn().mockResolvedValue("mock-digest"),
 }));
 
 vi.mock("@/utils/user", () => ({

--- a/src/utils/nodes/createSubgraphFromNodes.ts
+++ b/src/utils/nodes/createSubgraphFromNodes.ts
@@ -6,7 +6,7 @@ import {
   getNodesBounds,
   normalizeNodePosition,
 } from "@/components/shared/ReactFlow/FlowCanvas/utils/geometry";
-import { generateDigest, getComponentText } from "@/services/componentService";
+import { getComponentText } from "@/services/componentService";
 import type {
   ArgumentType,
   ComponentSpec,
@@ -23,6 +23,7 @@ import {
   isTaskOutputArgument,
 } from "@/utils/componentSpec";
 
+import { generateDigest } from "../componentStore";
 import { getUniqueName, getUniqueTaskName } from "../unique";
 import { getUserDetails } from "../user";
 import { extractPositionFromAnnotations } from "./extractPositionFromAnnotations";


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
I was hoping this would resolve https://github.com/Shopify/oasis-frontend/issues/373 but it does not. Nonetheless it's good to have our digest calculations unified into one method.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Cleanup/Refactor

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->
Confirm existing digests are unchanged and everything works as expected.

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
