### PR TITLE
Fix: Prevent infinite re-renders when component has no inputs/outputs

### DIFF
--- a/src/components/shared/CodeViewer/CodeViewer.tsx
+++ b/src/components/shared/CodeViewer/CodeViewer.tsx
@@ -64,13 +64,17 @@ const CodeViewer = ({
       <div
         className={cn(
           "flex flex-col transition-shadow duration-150",
-          shouldRenderInlineCode ? "bg-slate-900 h-full rounded-md" : "bg-transparent",
+          shouldRenderInlineCode
+            ? "bg-slate-900 h-full rounded-md"
+            : "bg-transparent",
         )}
       >
         {shouldRenderInlineCode ? (
           <div className="flex items-center justify-between gap-2 bg-slate-800 sticky top-0 z-10 rounded-t-md px-3 py-2.5">
             <div className="flex items-baseline gap-2">
-              <span className="font-semibold text-base text-secondary">{filename}</span>
+              <span className="font-semibold text-base text-secondary">
+                {filename}
+              </span>
               <span className="text-sm text-secondary">(Read Only)</span>
             </div>
             <Button
@@ -82,7 +86,11 @@ const CodeViewer = ({
               title={isFullscreen ? "Exit fullscreen" : "View fullscreen"}
               aria-label={isFullscreen ? "Exit fullscreen" : "View fullscreen"}
             >
-              {isFullscreen ? <XIcon className="size-4" /> : <Maximize2 className="size-4" />}
+              {isFullscreen ? (
+                <XIcon className="size-4" />
+              ) : (
+                <Maximize2 className="size-4" />
+              )}
             </Button>
           </div>
         ) : (

--- a/src/providers/TaskNodeProvider.tsx
+++ b/src/providers/TaskNodeProvider.tsx
@@ -10,6 +10,7 @@ import type { RunStatus } from "@/types/pipelineRun";
 import type { TaskNodeData, TaskNodeDimensions } from "@/types/taskNode";
 import type {
   ArgumentType,
+  ComponentReference,
   InputSpec,
   OutputSpec,
   TaskSpec,
@@ -21,6 +22,10 @@ import {
   createRequiredContext,
   useRequiredContext,
 } from "../hooks/useRequiredContext";
+
+const EMPTY_COMPONENT_REF: Partial<ComponentReference> = {};
+const EMPTY_INPUTS: InputSpec[] = [];
+const EMPTY_OUTPUTS: OutputSpec[] = [];
 
 type TaskNodeState = Readonly<{
   selected: boolean;
@@ -77,9 +82,9 @@ export const TaskNodeProvider = ({
   const taskId = data.taskId;
   const nodeId = taskId ? taskIdToNodeId(taskId) : "";
 
-  const componentRef = taskSpec?.componentRef || {};
-  const inputs = componentRef.spec?.inputs || [];
-  const outputs = componentRef.spec?.outputs || [];
+  const componentRef = taskSpec?.componentRef ?? EMPTY_COMPONENT_REF;
+  const inputs = componentRef.spec?.inputs ?? EMPTY_INPUTS;
+  const outputs = componentRef.spec?.outputs ?? EMPTY_OUTPUTS;
 
   const name = getComponentName(componentRef);
 


### PR DESCRIPTION
## Description

## Problem

When editing a component in the component editor and removing all inputs or outputs, the app would crash with a "Maximum call stack size exceeded" error (infinite re-render loop).

## Root Cause

In `TaskNodeProvider.tsx`, the `inputs` and `outputs` arrays were derived like this:

const inputs = componentRef.spec?.inputs || [];
const outputs = componentRef.spec?.outputs || [];When `inputs` or `outputs` were `undefined` (no inputs/outputs defined), the `|| []` fallback created a **new empty array on every render**. Since these arrays are dependencies of the context value's `useMemo`, the context value was recreated on every render, causing all consumers to re-render infinitely.

## Fix

Use stable module-level empty array constants instead of inline `[]` literals:

const EMPTY_INPUTS: InputSpec[] = [];
const EMPTY_OUTPUTS: OutputSpec[] = [];

// In the provider:
const inputs = componentRef.spec?.inputs ?? EMPTY_INPUTS;
const outputs = componentRef.spec?.outputs ?? EMPTY_OUTPUTS;This ensures the same array reference is used across renders when inputs/outputs are empty, preventing unnecessary context updates and infinite re-renders.

## Type of Change

- [x] Improvement
- [x] Cleanup/Refactor

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Test Instructions

Verify that task nodes with undefined inputs or outputs still render correctly and that no console errors appear related to these properties.

- Remove all inputs or outputs from the create component preview (python)
- No errors and it should render