### PR TITLE
Fix: Preserve Python code changes when switching editor tabs

### DIFF
--- a/src/components/shared/ComponentEditor/components/PythonComponentEditor.tsx
+++ b/src/components/shared/ComponentEditor/components/PythonComponentEditor.tsx
@@ -57,6 +57,7 @@ export const PythonComponentEditor = withSuspenseWrapper(
     onErrorsChange: (errors: string[]) => void;
     preserveComponentName?: string;
   }) => {
+    const [pythonCode, setPythonCode] = useState(text);
     const [componentText, setComponentText] = useState("");
     const [validationErrors, setValidationErrors] = useState<string[]>([]);
     const [showPreview, setShowPreview] = useState(true);
@@ -71,8 +72,10 @@ export const PythonComponentEditor = withSuspenseWrapper(
 
     const handleFunctionTextChange = useCallback(
       async (value: string | undefined) => {
+        const code = value ?? "";
+        setPythonCode(code);
         try {
-          const yaml = await yamlGenerator(value ?? "", yamlGeneratorOptions);
+          const yaml = await yamlGenerator(code, yamlGeneratorOptions);
           const yamlWithPreservedName = preserveComponentName(
             yaml,
             preservedNameRef.current,
@@ -89,13 +92,13 @@ export const PythonComponentEditor = withSuspenseWrapper(
           setValidationErrors(errors);
         }
       },
-      [yamlGenerator, onComponentTextChange, yamlGeneratorOptions],
+      [yamlGenerator, onComponentTextChange, onErrorsChange, yamlGeneratorOptions],
     );
 
     useEffect(() => {
       // first time loading
       handleFunctionTextChange(text);
-    }, [text, handleFunctionTextChange]);
+    }, []);
 
     return (
       <InlineStack className="w-full h-full" gap="4">
@@ -115,7 +118,7 @@ export const PythonComponentEditor = withSuspenseWrapper(
                   <MonacoEditor
                     defaultLanguage="python"
                     theme="vs-dark"
-                    value={text}
+                    value={pythonCode}
                     onChange={handleFunctionTextChange}
                     options={DEFAULT_MONACO_OPTIONS}
                   />


### PR DESCRIPTION
## Description
resolves: https://github.com/TangleML/tangle-ui/issues/1432

## Problem

When editing Python code in the component editor and switching from the "Python Code" tab to the "Configuration" tab and back, all code changes were lost.

## Root Cause

The Monaco editor was using `value={text}` where `text` is the initial prop passed to the component, not a local state variable. When the user typed in the editor, `handleFunctionTextChange` processed the changes but the editor's displayed value remained bound to the original `text` prop. Switching tabs caused the editor to remount with the original value.

## Fix

- Added `pythonCode` local state initialized with the `text` prop
- Update `pythonCode` in `handleFunctionTextChange` when the user types
- Changed Monaco editor to use `value={pythonCode}` instead of `value={text}`

Now the editor's value is controlled by local state that persists across tab switches.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Test Instructions

1. Open the Python Component Editor
2. Enter Python code with syntax errors
3. Verify that your edits remain in the editor even when validation errors occur
4. Fix the errors and confirm the component updates correctly
5. make changes (likey inputs and outputs)
6. go to "configuration" tab
7. Confirm the UI is whats expected on the component
8. switch back to code view
9. Verify that your edits remain in the editor 