### PR TITLE
Duplicates no longer rename the component itself

### DIFF
--- a/src/components/shared/Dialogs/ComponentDuplicateDialog.tsx
+++ b/src/components/shared/Dialogs/ComponentDuplicateDialog.tsx
@@ -34,7 +34,7 @@ const ComponentDuplicateDialog = ({
   newComponent?: ComponentSpec;
   newComponentDigest?: string;
   setClose: () => void;
-  handleImportComponent: (content: string) => Promise<void>;
+  handleImportComponent: (content: string, filename?: string) => Promise<void>;
 }) => {
   const [newName, setNewName] = useState("");
   const [newDigest, setNewDigest] = useState("");
@@ -77,12 +77,8 @@ const ComponentDuplicateDialog = ({
     async (newName: string) => {
       if (!newComponent) return;
 
-      const newComponentWithNewName = {
-        ...newComponent,
-        name: newName,
-      };
-      const yamlString = componentSpecToYaml(newComponentWithNewName);
-      handleImportComponent(yamlString);
+      const yamlString = componentSpecToYaml(newComponent);
+      handleImportComponent(yamlString, newName);
 
       setClose();
     },

--- a/src/hooks/useComponentUploader.tsx
+++ b/src/hooks/useComponentUploader.tsx
@@ -91,11 +91,11 @@ const useComponentUploader = (
     setExistingAndNewComponent(undefined);
   };
 
-  const handleImportComponent = async (content: string) => {
+  const handleImportComponent = async (content: string, filename?: string) => {
     await addComponentToListByTextWithDuplicateCheck(
       USER_COMPONENTS_LIST_NAME,
       content,
-      undefined,
+      filename,
       "Imported Component",
       true,
       { favorited: true },

--- a/src/providers/ComponentLibraryProvider/ComponentLibraryProvider.tsx
+++ b/src/providers/ComponentLibraryProvider/ComponentLibraryProvider.tsx
@@ -415,22 +415,11 @@ export const ComponentLibraryProvider = ({
   );
 
   const handleImportComponent = useCallback(
-    async (yamlString: string) => {
+    async (yamlString: string, filename?: string) => {
       try {
         const componentFromText = await loadComponentAsRefFromText(yamlString);
-        const resolvedName =
-          componentFromText.spec.name ??
-          newComponent?.name ??
-          "Imported Component";
 
-        const componentToImport = {
-          ...(newComponent ?? {}),
-          ...componentFromText,
-          name: resolvedName,
-          url: undefined,
-        };
-
-        await importComponent(componentToImport);
+        await importComponent(componentFromText, filename);
         await refreshComponentLibrary();
         await refreshUserComponents();
         setNewComponent(null);

--- a/src/utils/componentStore.ts
+++ b/src/utils/componentStore.ts
@@ -754,21 +754,26 @@ const upgradeSingleComponentListDb = async (listName: string) => {
   }
 };
 
-export const importComponent = async (component: ComponentReference) => {
+export const importComponent = async (
+  component: ComponentReference,
+  filename?: string,
+) => {
+  const nonUniqueFileName = filename || component.name || "Component";
+
   if (!component.url) {
     component.favorited = true;
 
-    if (component.spec && component.name) {
+    if (component.spec) {
       return await writeComponentRefToFile(
         USER_COMPONENTS_LIST_NAME,
-        component.name,
+        nonUniqueFileName,
         component as ComponentReferenceWithSpec,
       );
     } else if (component.text) {
       return await addComponentToListByTextWithDuplicateCheck(
         USER_COMPONENTS_LIST_NAME,
         component.text,
-        component.name,
+        nonUniqueFileName,
         "Component",
         false,
         { favorited: true },
@@ -785,10 +790,8 @@ export const importComponent = async (component: ComponentReference) => {
   return await addComponentToListByUrl(
     USER_COMPONENTS_LIST_NAME,
     component.url,
-    component.name,
+    nonUniqueFileName,
     false,
-    {
-      favorited: true,
-    },
+    { favorited: true },
   );
 };


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
[FOR DISCUSSION]

Resolving a duplicate component clash via rename no longer changes the name of the component itself - it just changes the filename.

Reminder: components are displayed int he library by their filename, and on the canvas by their component name. Hence, renaming under this scenario results in visual discrepancies between Component Library and Canvas.

This needs extensive testing as it changes the way we interact and compare components - particularly in the library.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
