### PR TITLE
Fix: Adds waiting status

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/StatusIndicator.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/StatusIndicator.tsx
@@ -94,6 +94,11 @@ const getStatusMetadata = (status: ContainerExecutionStatus | RunStatus) => {
         icon: <ClockIcon className="w-2 h-2 animate-spin duration-2000" />,
       };
     case "WAITING":
+      return {
+        style: "bg-slate-500",
+        text: "Waiting",
+        icon: <ClockIcon className="w-2 h-2 animate-spin duration-2000" />,
+      };
     case "UNINITIALIZED":
     case "WAITING_FOR_UPSTREAM":
       return {


### PR DESCRIPTION
## Description

Added a specific status indicator for the "WAITING" state in the TaskNode component. Previously, "WAITING" was handled by the same case as "UNINITIALIZED" and "WAITING_FOR_UPSTREAM", but now it has its own distinct visual representation with a slate-500 background color, "Waiting" text, and a spinning clock icon.

## Type of Change

- [x] Improvement

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging