### PR TITLE
fix: Corrected the default privacy policy URL

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -8,7 +8,7 @@ export const GIVE_FEEDBACK_URL =
 
 export const PRIVACY_POLICY_URL =
   import.meta.env.VITE_PRIVACY_POLICY_URL ||
-  "https://www.shopify.com/ca/legal/privacy";
+  "https://tangleml.com/docs/privacy_policy/";
 
 export const API_URL = import.meta.env.VITE_BACKEND_API_URL || "";
 export const BASE_URL = import.meta.env.VITE_BASE_URL || "/";


### PR DESCRIPTION
The default Privacy Policy link for OSS app should point to the tangleml.com website.

The Tangle instances installed by users do not share PII with the Tangle team.

See https://app.graphite.com/github/pr/TangleML/tangle-ui/1450/Update-Privacy-Policy#review-PRR_kwDON7xRzM7SRx5R

## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [x] Documentation update

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
