### PR TITLE
refactoring: introduce componentSpecFromYaml

### DIFF
--- a/src/services/componentService.test.ts
+++ b/src/services/componentService.test.ts
@@ -78,13 +78,15 @@ describe("componentService", () => {
 
   describe("parseComponentData", () => {
     it("should parse valid YAML data", () => {
-      const yamlData = "name: test-component\nversion: 1.2";
-      const result = parseComponentData(yamlData);
-
-      expect(result).toEqual({
+      const spec = {
         name: "test-component",
         version: 1.2,
-      });
+        implementation: { container: { image: "test" } },
+      };
+      const yamlData = yaml.dump(spec);
+      const result = parseComponentData(yamlData);
+
+      expect(result).toEqual(spec);
     });
 
     it("should return null for invalid YAML", () => {

--- a/src/services/componentService.ts
+++ b/src/services/componentService.ts
@@ -1,5 +1,3 @@
-import yaml from "js-yaml";
-
 import { getAppSettings } from "@/appSettings";
 import {
   type ComponentFolder,
@@ -36,6 +34,7 @@ import {
   saveComponent,
   type UserComponent,
 } from "@/utils/localforage";
+import { componentSpecFromYaml } from "@/utils/yaml";
 
 export interface ExistingAndNewComponent {
   existingComponent: UserComponent | undefined;
@@ -154,7 +153,7 @@ export const fetchAndStoreComponentByUrl = async (
       const text = await fetchComponentTextFromUrl(url);
       if (text) {
         try {
-          return yaml.load(text) as ComponentSpec;
+          return componentSpecFromYaml(text);
         } catch (error) {
           console.error(`Error parsing component at ${url}:`, error);
         }
@@ -182,7 +181,7 @@ export const fetchAndStoreComponentByUrl = async (
     });
 
     try {
-      return yaml.load(text) as ComponentSpec;
+      return componentSpecFromYaml(text);
     } catch (error) {
       console.error(`Error parsing component at ${url}:`, error);
       return null;
@@ -263,7 +262,7 @@ const parseTextToSpec = async (
 ): Promise<ComponentSpec | null> => {
   if (text) {
     try {
-      return yaml.load(text) as ComponentSpec;
+      return componentSpecFromYaml(text);
     } catch (error) {
       console.error("Error parsing component text:", error);
     }
@@ -316,7 +315,7 @@ export const fetchComponentTextFromUrl = async (
  */
 export const parseComponentData = (data: string): ComponentSpec | null => {
   try {
-    return yaml.load(data) as ComponentSpec;
+    return componentSpecFromYaml(data);
   } catch (error) {
     console.error("Error parsing component data:", error);
     return null;
@@ -445,7 +444,7 @@ async function hydrateFromPartialContentfulComponentReference(
     : component.text;
 
   const spec = isTextOnlyComponentReference(component)
-    ? (yaml.load(component.text) as ComponentSpec)
+    ? componentSpecFromYaml(component.text)
     : component.spec;
 
   if (!text || !spec) {

--- a/src/services/pipelineService.ts
+++ b/src/services/pipelineService.ts
@@ -17,6 +17,7 @@ import {
   writeComponentToFileListFromText,
 } from "@/utils/componentStore";
 import { USER_PIPELINES_LIST_NAME } from "@/utils/constants";
+import { componentSpecFromYaml } from "@/utils/yaml";
 
 export const deletePipeline = async (name: string, onDelete?: () => void) => {
   try {
@@ -178,19 +179,7 @@ export async function importPipelineFromYaml(
 ): Promise<ImportResult> {
   try {
     // Parse the YAML content to get the component spec
-    const componentSpec = yaml.load(yamlContent) as ComponentSpec;
-
-    if (!componentSpec || typeof componentSpec !== "object") {
-      const errorMessage =
-        "Invalid YAML content. Could not parse as a component spec.";
-      console.error(errorMessage);
-      return {
-        name: "",
-        overwritten: false,
-        successful: false,
-        errorMessage,
-      };
-    }
+    const componentSpec = componentSpecFromYaml(yamlContent);
 
     // Validate the component spec has the required structure
     if (

--- a/src/utils/componentStore.ts
+++ b/src/utils/componentStore.ts
@@ -6,9 +6,9 @@ import { fetchComponentTextFromUrl } from "@/services/componentService";
 import type { DownloadDataType } from "./cache";
 import { downloadDataWithCache } from "./cache";
 import type { ComponentReference, ComponentSpec } from "./componentSpec";
-import { isValidComponentSpec } from "./componentSpec";
 import { USER_COMPONENTS_LIST_NAME } from "./constants";
 import { getIdOrTitleFromPath } from "./URL";
+import { componentSpecFromYaml } from "./yaml";
 
 // IndexedDB: DB and table names
 const DB_NAME = "components";
@@ -74,16 +74,7 @@ export const loadComponentAsRefFromText = async (
       ? new TextEncoder().encode(componentText)
       : componentText;
 
-  const loadedObj = yaml.load(componentString);
-  if (typeof loadedObj !== "object" || loadedObj === null) {
-    throw Error(`componentText is not a YAML-encoded object: ${loadedObj}`);
-  }
-  if (!isValidComponentSpec(loadedObj)) {
-    throw Error(
-      `componentText does not encode a valid pipeline component: ${loadedObj}`,
-    );
-  }
-  const componentSpec: ComponentSpec = loadedObj;
+  const componentSpec = componentSpecFromYaml(componentString);
 
   const digest = await generateDigest(componentBytes as ArrayBuffer);
   const componentRef: ComponentReferenceWithSpec = {

--- a/src/utils/submitPipeline.ts
+++ b/src/utils/submitPipeline.ts
@@ -1,5 +1,3 @@
-import yaml from "js-yaml";
-
 import type { BodyCreateApiPipelineRunsPost } from "@/api/types.gen";
 import { getArgumentsFromInputs } from "@/components/shared/ReactFlow/FlowCanvas/utils/getArgumentsFromInputs";
 import {
@@ -9,6 +7,7 @@ import {
 import type { PipelineRun } from "@/types/pipelineRun";
 
 import type { ComponentReference, ComponentSpec } from "./componentSpec";
+import { componentSpecFromYaml } from "./yaml";
 
 export async function submitPipelineRun(
   componentSpec: ComponentSpec,
@@ -159,13 +158,7 @@ const parseComponentYaml = (text: string): ComponentSpec => {
     throw new Error("Received empty component specification");
   }
 
-  const loadedSpec = yaml.load(text) as ComponentSpec;
-
-  if (!loadedSpec || typeof loadedSpec !== "object") {
-    throw new Error("Invalid component specification format");
-  }
-
-  return loadedSpec;
+  return componentSpecFromYaml(text);
 };
 
 // Fetch component with timeout to avoid hanging on unresponsive URLs

--- a/src/utils/yaml.ts
+++ b/src/utils/yaml.ts
@@ -1,4 +1,6 @@
-import type { ComponentSpec } from "./componentSpec";
+import yaml from "js-yaml";
+
+import { type ComponentSpec, isValidComponentSpec } from "./componentSpec";
 import { componentSpecToText } from "./componentStore";
 
 const copyToYaml = (
@@ -13,5 +15,39 @@ const copyToYaml = (
     (err) => onFail("Failed to copy YAML: " + err),
   );
 };
+
+class ComponentSpecParsingError extends Error {
+  readonly name = "ComponentSpecParsingError";
+
+  constructor(
+    message: string,
+    public readonly extra: {
+      yamlText?: string;
+      loadedSpec?: any;
+    } = {},
+  ) {
+    super(message);
+  }
+}
+
+export function componentSpecFromYaml(yamlText: string): ComponentSpec {
+  const loadedSpec = yaml.load(yamlText);
+  if (typeof loadedSpec !== "object" || loadedSpec === null) {
+    throw new ComponentSpecParsingError(
+      "Invalid component specification format",
+      { yamlText },
+    );
+  }
+
+  // todo: consider advanced validation
+  if (!isValidComponentSpec(loadedSpec)) {
+    throw new ComponentSpecParsingError(
+      "Invalid component specification format",
+      { loadedSpec },
+    );
+  }
+
+  return loadedSpec;
+}
 
 export default copyToYaml;


### PR DESCRIPTION
## Description

Added a new `componentSpecFromYaml` function in `utils/yaml.ts` that safely parses YAML text into a ComponentSpec object with proper validation. This function replaces the direct use of `yaml.load()` in the component service, adding type checking and validation to prevent invalid component specifications.

## Type of Change

- [x] Improvement
- [x] Cleanup/Refactor

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

1. No functional changes to the app
2. No regression should be found across the app