### PR TITLE
fix: wrong digest displayed in duplicate component dialog

### DIFF
--- a/src/components/shared/Dialogs/ComponentDuplicateDialog.test.tsx
+++ b/src/components/shared/Dialogs/ComponentDuplicateDialog.test.tsx
@@ -19,7 +19,10 @@ vi.mock("@/utils/componentStore", async (importOriginal) => ({
 }));
 
 // Import mocked functions
-import { deleteComponentFileFromList } from "@/utils/componentStore";
+import {
+  deleteComponentFileFromList,
+  generateDigest,
+} from "@/utils/componentStore";
 
 describe("ComponentDuplicateDialog", () => {
   // Test data
@@ -69,7 +72,6 @@ implementation:
       <ComponentDuplicateDialog
         existingComponent={mockExistingComponent}
         newComponent={mockNewComponent}
-        newComponentDigest="new-digest-456"
         setClose={mockSetClose}
         handleImportComponent={mockHandleImportComponent}
       />,
@@ -100,7 +102,6 @@ implementation:
       <ComponentDuplicateDialog
         existingComponent={mockExistingComponent}
         newComponent={mockNewComponent}
-        newComponentDigest="new-digest-456"
         setClose={mockSetClose}
         handleImportComponent={mockHandleImportComponent}
       />,
@@ -142,7 +143,6 @@ implementation:
       <ComponentDuplicateDialog
         existingComponent={mockExistingComponent}
         newComponent={mockNewComponent}
-        newComponentDigest="new-digest-456"
         setClose={mockSetClose}
         handleImportComponent={mockHandleImportComponent}
       />,
@@ -183,7 +183,6 @@ implementation:
       <ComponentDuplicateDialog
         existingComponent={mockExistingComponent}
         newComponent={mockNewComponent}
-        newComponentDigest="new-digest-456"
         setClose={mockSetClose}
         handleImportComponent={mockHandleImportComponent}
       />,
@@ -231,50 +230,56 @@ implementation:
     expect(container2.querySelector("[role='dialog']")).not.toBeInTheDocument();
   });
 
-  test("should display correct component information in the dialog", () => {
+  test("should display correct component information in the dialog", async () => {
+    const digest = await generateDigest(mockNewComponent.text);
+
     render(
       <ComponentDuplicateDialog
         existingComponent={mockExistingComponent}
         newComponent={mockNewComponent}
-        newComponentDigest="new-digest-456"
         setClose={mockSetClose}
         handleImportComponent={mockHandleImportComponent}
       />,
     );
 
-    // Check dialog title and descriptions
-    expect(screen.getByText("Component already exists")).toBeInTheDocument();
-    expect(
-      screen.getByText(/The component you are trying to import already exists/),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(/Note: "Replace existing" will use the existing name/),
-    ).toBeInTheDocument();
+    await waitFor(() => {
+      // Check dialog title and descriptions
+      expect(screen.getByText("Component already exists")).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          /The component you are trying to import already exists/,
+        ),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(/Note: "Replace existing" will use the existing name/),
+      ).toBeInTheDocument();
 
-    // Check existing component section
-    expect(screen.getByText("Existing Component")).toBeInTheDocument();
-    const textboxes = screen.getAllByRole("textbox");
+      // Check existing component section
+      expect(screen.getByText("Existing Component")).toBeInTheDocument();
+      const textboxes = screen.getAllByRole("textbox");
 
-    // Existing component name (first textbox)
-    expect(textboxes[0]).toHaveValue("ExistingComponent");
-    expect(textboxes[0]).toHaveAttribute("readonly");
-    expect(textboxes[0]).toHaveClass("border-blue-200", "bg-blue-100/50");
+      // Existing component name (first textbox)
+      expect(textboxes[0]).toHaveValue("ExistingComponent");
+      expect(textboxes[0]).toHaveAttribute("readonly");
+      expect(textboxes[0]).toHaveClass("border-blue-200", "bg-blue-100/50");
 
-    // Existing component digest (second textbox)
-    expect(textboxes[1]).toHaveValue("existing-digest-123");
-    expect(textboxes[1]).toHaveAttribute("readonly");
-    expect(textboxes[1]).toHaveClass("border-blue-200", "bg-blue-100/50");
+      // Existing component digest (second textbox)
+      expect(textboxes[1]).toHaveValue("existing-digest-123");
+      expect(textboxes[1]).toHaveAttribute("readonly");
+      expect(textboxes[1]).toHaveClass("border-blue-200", "bg-blue-100/50");
 
-    // Check new component section
-    expect(screen.getByText("New Component")).toBeInTheDocument();
+      // Check new component section
+      expect(screen.getByText("New Component")).toBeInTheDocument();
 
-    // New component name (third textbox) - should be editable
-    expect(textboxes[2]).toHaveValue("NewComponent");
-    expect(textboxes[2]).not.toHaveAttribute("readonly");
-    expect(textboxes[2]).toHaveFocus(); // Has autoFocus
+      // New component name (third textbox) - should be editable
+      expect(textboxes[2]).toHaveValue("NewComponent");
+      expect(textboxes[2]).not.toHaveAttribute("readonly");
+      expect(textboxes[2]).toHaveFocus(); // Has autoFocus
 
-    // New component digest (fourth textbox)
-    expect(textboxes[3]).toHaveValue("new-digest-456");
-    expect(textboxes[3]).toHaveAttribute("readonly");
+      // New component digest (fourth textbox)
+
+      expect(textboxes[3]).toHaveValue(digest);
+      expect(textboxes[3]).toHaveAttribute("readonly");
+    });
   });
 });

--- a/src/providers/ComponentLibraryProvider/ComponentLibraryProvider.tsx
+++ b/src/providers/ComponentLibraryProvider/ComponentLibraryProvider.tsx
@@ -601,7 +601,6 @@ export const ComponentLibraryProvider = ({
       <ComponentDuplicateDialog
         existingComponent={existingComponent ?? undefined}
         newComponent={newComponent}
-        newComponentDigest={newComponent?.digest}
         setClose={handleCloseDuplicationDialog}
         handleImportComponent={handleImportComponent}
       />


### PR DESCRIPTION
## Description

Closes https://github.com/Shopify/oasis-frontend/issues/373

Refactored the `ComponentDuplicateDialog` to generate component digests dynamically rather than passing them as props. This change:

1. Removes the `newComponentDigest` prop from `ComponentDuplicateDialog`
2. Adds a `generateNewDigest` helper function to handle digest generation
3. Updates the component to recalculate digests when the component name changes
4. Improves the regex pattern for component name replacement to be more robust
5. Makes the tests asynchronous to accommodate the dynamic digest generation

## Type of Change

- [x] Improvement
- [x] Cleanup/Refactor

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

1. [Screen Recording 2025-12-04 at 8.48.18 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/05eb4aa3-9f9c-424a-b771-ef70cdf4c02c.mov" />](https://app.graphite.com/user-attachments/video/05eb4aa3-9f9c-424a-b771-ef70cdf4c02c.mov)

    

    Import a component that already exists in the library
2. Verify the duplicate dialog shows correct digests for both existing and new components
3. Try renaming the component and confirm the digest updates accordingly
4. After "Import as new" digest displayed as preview must be the same as digest on the left panel and component details
5. Test both "Replace existing" and "Import as new" options to ensure they work as expected