### PR TITLE
Removes icons next to title in run and editor

### DIFF
--- a/src/components/Editor/PipelineDetails.tsx
+++ b/src/components/Editor/PipelineDetails.tsx
@@ -1,4 +1,4 @@
-import { Frown, Network } from "lucide-react";
+import { Frown } from "lucide-react";
 import { useEffect, useState } from "react";
 
 import { PipelineValidationList } from "@/components/Editor/components/PipelineValidationList/PipelineValidationList";
@@ -134,7 +134,6 @@ const PipelineDetails = () => {
     >
       {/* Header */}
       <div className="flex items-center gap-2 max-w-[90%]">
-        <Network className="w-6 h-6 text-secondary-foreground rotate-270 min-w-6 min-h-6" />
         <CopyText className="text-lg font-semibold" alwaysShowButton>
           {componentSpec.name ?? "Unnamed Pipeline"}
         </CopyText>

--- a/src/components/PipelineRun/RunDetails.tsx
+++ b/src/components/PipelineRun/RunDetails.tsx
@@ -1,4 +1,4 @@
-import { Frown, Videotape } from "lucide-react";
+import { Frown } from "lucide-react";
 
 import { CopyText } from "@/components/shared/CopyText/CopyText";
 import { Spinner } from "@/components/ui/spinner";
@@ -84,7 +84,6 @@ export const RunDetails = () => {
   return (
     <div className="p-2 flex flex-col gap-6 h-full">
       <div className="flex items-center gap-2 max-w-[90%]">
-        <Videotape className="w-6 h-6 text-gray-500" />
         <CopyText className="text-lg font-semibold" alwaysShowButton>
           {componentSpec.name ?? "Unnamed Pipeline"}
         </CopyText>


### PR DESCRIPTION
## Description

Removed unnecessary icon imports and their usage from the PipelineDetails and RunDetails components. Specifically:

- Removed the Network icon and its rendering from PipelineDetails
- Removed the Videotape icon and its rendering from RunDetails

Do we actually need these? I personally think no icon is cleaner. Also this section has a lot of information already, so adding in this visual flare seems a little too much.

## Related Issue and Pull requests

## Type of Change

- [x] Improvement
- [x] Cleanup/Refactor

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Screenshots (if applicable)  
Before

![Screenshot 2025-12-05 at 1.48.21 PM.png](https://app.graphite.com/user-attachments/assets/6e7e357b-f830-4eeb-8b2a-b58781bd52d3.png)

After:  
  
![Screenshot 2025-12-05 at 1.48.38 PM.png](https://app.graphite.com/user-attachments/assets/30ba6b73-3980-42de-92c3-e23d97c9eba2.png)



## Test Instructions

Verify that the Pipeline Details and Run Details pages display correctly without the icons that were previously shown next to the pipeline/run names.

## Additional Comments

This change simplifies the UI by removing decorative icons that weren't adding significant value to the interface.