### PR TITLE
InlineStack Default to BlockAlign-Center

### DIFF
--- a/src/components/Editor/IOEditor/InputValueEditor/FormFields/FormFields.tsx
+++ b/src/components/Editor/IOEditor/InputValueEditor/FormFields/FormFields.tsx
@@ -30,18 +30,14 @@ const FormField = ({
   children: ReactNode;
 }) => (
   <BlockStack>
-    <InlineStack
-      align="space-between"
-      blockAlign="center"
-      className="w-full mb-1"
-    >
-      <InlineStack gap="2" blockAlign="center">
+    <InlineStack align="space-between" className="w-full mb-1">
+      <InlineStack gap="2">
         <label htmlFor={id} className="text-xs text-muted-foreground">
           {label}
         </label>
         {labelSuffix}
       </InlineStack>
-      <InlineStack blockAlign="center" gap="1">
+      <InlineStack gap="1">
         {actions?.map(
           (action) =>
             !action.hidden && (
@@ -118,7 +114,7 @@ const TextField = ({
     id={`input-value-${inputName}`}
     actions={actions}
     labelSuffix={
-      <InlineStack gap="1" blockAlign="center" className="ml-2">
+      <InlineStack gap="1" className="ml-2">
         <Icon
           name="SquareCheckBig"
           size="sm"

--- a/src/components/Editor/components/PipelineValidationList/PipelineValidationList.tsx
+++ b/src/components/Editor/components/PipelineValidationList/PipelineValidationList.tsx
@@ -130,7 +130,7 @@ export const PipelineValidationList = ({
                         onClick={() => onIssueSelect(issue)}
                         className={issueButtonStyles}
                       >
-                        <InlineStack gap="1" blockAlign="center" wrap="nowrap">
+                        <InlineStack gap="1" wrap="nowrap">
                           <Text
                             size="xs"
                             weight="semibold"

--- a/src/components/Home/PipelineSection/BulkActionsBar.tsx
+++ b/src/components/Home/PipelineSection/BulkActionsBar.tsx
@@ -39,13 +39,13 @@ const BulkActionsBar = ({
 
   return (
     <div className="fixed bottom-4 left-1/2 transform -translate-x-1/2 bg-background border border-border rounded-lg shadow-lg p-4 z-50">
-      <InlineStack gap="4" blockAlign="center">
+      <InlineStack gap="4">
         <span className="text-sm font-medium">
           {selectedPipelines.length}{" "}
           {pluralize(selectedPipelines.length, "pipeline")} selected
         </span>
 
-        <InlineStack gap="2" blockAlign="center">
+        <InlineStack gap="2">
           <ConfirmationDialog
             trigger={
               <Button variant="destructive" size="sm">

--- a/src/components/Home/PipelineSection/PipelineRow.tsx
+++ b/src/components/Home/PipelineSection/PipelineRow.tsx
@@ -103,7 +103,7 @@ const PipelineRow = ({
         </TableCell>
         <TableCell>
           {!!latestRun && (
-            <InlineStack gap="2" blockAlign="center">
+            <InlineStack gap="2">
               <StatusIcon status={latestRun.status} />
               <Paragraph tone="subdued" size="xs">
                 {formatDate(
@@ -123,7 +123,7 @@ const PipelineRow = ({
                 <Icon name="List" />
               </PopoverTrigger>
               <PopoverContent className="w-[500px]">
-                <InlineStack gap="2" blockAlign="center" className="mb-4">
+                <InlineStack gap="2" className="mb-4">
                   <Heading level={2}>{pipelineRuns[0].pipeline_name}</Heading>
                   <Paragraph size="sm">- {pipelineRuns.length} runs</Paragraph>
                 </InlineStack>

--- a/src/components/Home/PipelineSection/PipelineSection.tsx
+++ b/src/components/Home/PipelineSection/PipelineSection.tsx
@@ -127,7 +127,7 @@ export const PipelineSection = withSuspenseWrapper(() => {
 
   if (isLoading) {
     return (
-      <InlineStack gap="2" blockAlign="center" className="mt-4">
+      <InlineStack gap="2" className="mt-4">
         <Spinner /> Loading...
       </InlineStack>
     );

--- a/src/components/Home/RunSection/RunSection.tsx
+++ b/src/components/Home/RunSection/RunSection.tsx
@@ -243,8 +243,8 @@ export const RunSection = ({ onEmptyList }: { onEmptyList?: () => void }) => {
   }
 
   const searchMarkup = (
-    <InlineStack gap="4" blockAlign="center">
-      <InlineStack gap="2" blockAlign="center">
+    <InlineStack gap="4">
+      <InlineStack gap="2">
         <Switch
           id="created-by-me"
           checked={useCreatedByMe}
@@ -252,7 +252,7 @@ export const RunSection = ({ onEmptyList }: { onEmptyList?: () => void }) => {
         />
         <Label htmlFor="created-by-me">{toggleText}</Label>
       </InlineStack>
-      <InlineStack gap="1" blockAlign="center" wrap="nowrap">
+      <InlineStack gap="1" wrap="nowrap">
         <Input
           placeholder="Search by user"
           value={searchUser}

--- a/src/components/layout/AppFooter.tsx
+++ b/src/components/layout/AppFooter.tsx
@@ -18,7 +18,7 @@ function AppFooter() {
     >
       <InlineStack className="w-full" align="space-between">
         <div />
-        <InlineStack gap="4" blockAlign="center">
+        <InlineStack gap="4">
           <Link href={ABOUT_URL} target="_blank" rel="noopener noreferrer">
             About
           </Link>
@@ -36,7 +36,7 @@ function AppFooter() {
           >
             Privacy policy
           </Link>
-          <InlineStack gap="1" blockAlign="center">
+          <InlineStack gap="1">
             Version:
             <Link
               href={`${GIT_REPO_URL}/commit/${GIT_COMMIT}`}

--- a/src/components/layout/AppMenu.tsx
+++ b/src/components/layout/AppMenu.tsx
@@ -22,12 +22,8 @@ const AppMenu = () => {
       className="w-full bg-stone-900 p-2 pt-2.5"
       style={{ height: `${TOP_NAV_HEIGHT}px` }}
     >
-      <InlineStack
-        blockAlign="center"
-        align="space-between"
-        className="pl-12 pr-2"
-      >
-        <InlineStack blockAlign="center">
+      <InlineStack align="space-between" className="pl-12 pr-2">
+        <InlineStack>
           <Link href="/" aria-label="Home" variant="block">
             <img
               src={logo}
@@ -43,14 +39,14 @@ const AppMenu = () => {
           )}
         </InlineStack>
 
-        <InlineStack blockAlign="center">
-          <InlineStack gap="4" blockAlign="center" className="mr-42">
+        <InlineStack>
+          <InlineStack gap="4" className="mr-42">
             <CloneRunButton componentSpec={componentSpec} />
             <ImportPipeline />
             <NewPipelineButton />
           </InlineStack>
 
-          <InlineStack gap="2" blockAlign="center">
+          <InlineStack gap="2">
             <BackendStatus />
             <PersonalPreferences />
             {requiresAuthorization && <TopBarAuthentication />}

--- a/src/components/shared/ArtifactsList/ArtifactsList.tsx
+++ b/src/components/shared/ArtifactsList/ArtifactsList.tsx
@@ -35,12 +35,10 @@ const ArtifactsSection = ({
             key={item.name}
             gap="2"
             align="space-between"
-            blockAlign="center"
             className="even:bg-white odd:bg-gray-100 p-2 rounded-xs w-full"
           >
             <InlineStack
               gap="1"
-              blockAlign="center"
               wrap="nowrap"
               className="flex-1 min-w-0 text-xs"
             >

--- a/src/components/shared/Authentication/TopBarAuthentication.tsx
+++ b/src/components/shared/Authentication/TopBarAuthentication.tsx
@@ -32,7 +32,7 @@ export function TopBarAuthentication() {
   const profile = localTokenStorage.getJWT();
 
   return (
-    <InlineStack blockAlign="center">
+    <InlineStack>
       {profile ? <LoggedInDetails profile={profile} /> : <LoginButton />}
     </InlineStack>
   );
@@ -63,7 +63,7 @@ function LoggedInDetails({ profile }: { profile: JWTPayload }) {
 
       <PopoverContent className="p-3">
         <BlockStack gap="2">
-          <InlineStack gap="1" blockAlign="center">
+          <InlineStack gap="1">
             <Text>Logged in as</Text>
             <Text weight="semibold">{profile.login}</Text>
           </InlineStack>

--- a/src/components/shared/ComponentEditor/ComponentEditorDialog.tsx
+++ b/src/components/shared/ComponentEditor/ComponentEditorDialog.tsx
@@ -27,7 +27,6 @@ const ComponentEditorDialogSkeleton = () => {
         <InlineStack
           className="w-full h-13"
           gap="4"
-          blockAlign="center"
           align="space-between"
           wrap="nowrap"
         >
@@ -189,10 +188,9 @@ export const ComponentEditorDialog = withSuspenseWrapper(
         <BlockStack className="h-full w-full p-2 bg-white">
           <InlineStack
             className="w-full py-3 border-b-3 border-gray-100"
-            blockAlign="center"
             align="space-between"
           >
-            <InlineStack gap="2" blockAlign="center">
+            <InlineStack gap="2">
               <Heading level={1}>{title}</Heading>
               {hasTemplate && (
                 <Paragraph size="sm" tone="subdued">
@@ -201,7 +199,7 @@ export const ComponentEditorDialog = withSuspenseWrapper(
               )}
             </InlineStack>
 
-            <InlineStack gap="2" blockAlign="center">
+            <InlineStack gap="2">
               <Button
                 variant="default"
                 onClick={handleSave}

--- a/src/components/shared/ComponentEditor/components/ComponentSpecErrorsList.tsx
+++ b/src/components/shared/ComponentEditor/components/ComponentSpecErrorsList.tsx
@@ -13,7 +13,7 @@ export const ComponentSpecErrorsList = ({
 
   return (
     <BlockStack className="p-4 px-8 bg-red-100 border border-t-4 border-red-300 text-destructive">
-      <InlineStack gap="2" blockAlign="center">
+      <InlineStack gap="2">
         <Icon name="OctagonAlert" size="lg" className="text-destructive" />
         <Text tone="critical" as="h2" size="lg">
           Invalid component spec

--- a/src/components/shared/ComponentEditor/components/NewComponentTemplateSelector.tsx
+++ b/src/components/shared/ComponentEditor/components/NewComponentTemplateSelector.tsx
@@ -38,7 +38,6 @@ export const NewComponentTemplateSelector = ({
             >
               <InlineStack
                 align="center"
-                blockAlign="center"
                 className="bg-gray-200 rounded-md p-4 mb-2 w-full h-24"
               >
                 {!!template.icon && template.icon}

--- a/src/components/shared/ComponentEditor/components/TogglePreview.tsx
+++ b/src/components/shared/ComponentEditor/components/TogglePreview.tsx
@@ -11,7 +11,7 @@ export const TogglePreview = ({
   setShowPreview: (showPreview: boolean) => void;
 }) => {
   return (
-    <InlineStack gap="1" blockAlign="center">
+    <InlineStack gap="1">
       <Text>Preview:</Text>
       <Button
         variant="link"

--- a/src/components/shared/ComponentEditor/components/YamlGeneratorOptionsEditor.tsx
+++ b/src/components/shared/ComponentEditor/components/YamlGeneratorOptionsEditor.tsx
@@ -123,12 +123,7 @@ export const YamlGeneratorOptionsEditor = ({
             className="w-full group"
             gap="1"
           >
-            <InlineStack
-              wrap="nowrap"
-              blockAlign="center"
-              className="flex-1"
-              gap="1"
-            >
+            <InlineStack wrap="nowrap" className="flex-1" gap="1">
               <Input
                 className="w-full"
                 placeholder="Annotation key"
@@ -144,7 +139,7 @@ export const YamlGeneratorOptionsEditor = ({
               />
               <Text>:</Text>
             </InlineStack>
-            <InlineStack wrap="nowrap" blockAlign="center" className="flex-1">
+            <InlineStack wrap="nowrap" className="flex-1">
               <Input
                 className="w-full"
                 placeholder="Annotation value"

--- a/src/components/shared/Dialogs/BackendConfigurationDialog.tsx
+++ b/src/components/shared/Dialogs/BackendConfigurationDialog.tsx
@@ -139,7 +139,7 @@ const BackendConfigurationDialog = ({
         </DialogDescription>
 
         <BlockStack gap="4">
-          <InlineStack gap="2" blockAlign="center">
+          <InlineStack gap="2">
             <Paragraph>Backend status: </Paragraph>
             <Tooltip>
               <TooltipTrigger className="flex items-center gap-2" tabIndex={-1}>
@@ -173,7 +173,7 @@ const BackendConfigurationDialog = ({
               <Separator />
               <BlockStack gap="2">
                 <Heading level={1}>Configure using .env</Heading>
-                <InlineStack gap="2" blockAlign="center">
+                <InlineStack gap="2">
                   <Switch
                     checked={isEnvConfig}
                     onCheckedChange={handleEnvSwitch}
@@ -191,7 +191,7 @@ const BackendConfigurationDialog = ({
               <Separator />
               <BlockStack gap="2">
                 <Heading level={1}>Use same-domain backend</Heading>
-                <InlineStack gap="2" blockAlign="center">
+                <InlineStack gap="2">
                   <Switch
                     checked={isRelativePathConfig}
                     onCheckedChange={(checked) => {
@@ -222,12 +222,7 @@ const BackendConfigurationDialog = ({
               </InfoBox>
               <BlockStack>
                 <Heading level={3}>Backend URL</Heading>
-                <InlineStack
-                  gap="2"
-                  blockAlign="center"
-                  wrap="nowrap"
-                  className="w-full"
-                >
+                <InlineStack gap="2" wrap="nowrap" className="w-full">
                   <InlineStack className="relative w-full">
                     <Input
                       value={inputBackendUrl}
@@ -263,7 +258,7 @@ const BackendConfigurationDialog = ({
                 </InlineStack>
               </BlockStack>
               {!inputBackendUrl.trim() && (
-                <InlineStack gap="2" blockAlign="center">
+                <InlineStack gap="2">
                   <Icon
                     name="CircleAlert"
                     className="inline-block text-destructive"

--- a/src/components/shared/GitHubLibrary/ManageLibrariesDialog.tsx
+++ b/src/components/shared/GitHubLibrary/ManageLibrariesDialog.tsx
@@ -56,7 +56,7 @@ export function ManageLibrariesDialog({
             <>
               <DialogHeader>
                 <DialogTitle>
-                  <InlineStack align="start" blockAlign="center" gap="1">
+                  <InlineStack align="start" gap="1">
                     <Button
                       variant="ghost"
                       size="sm"
@@ -88,7 +88,7 @@ export function ManageLibrariesDialog({
                 <Separator />
                 <BlockStack gap="1" align="end">
                   <Button variant="secondary" onClick={() => setMode("add")}>
-                    <InlineStack align="center" blockAlign="center" gap="1">
+                    <InlineStack align="center" gap="1">
                       <Icon name="Github" />
                       Link Library from GitHub
                     </InlineStack>
@@ -102,7 +102,7 @@ export function ManageLibrariesDialog({
             <>
               <DialogHeader>
                 <DialogTitle>
-                  <InlineStack align="start" blockAlign="center" gap="1">
+                  <InlineStack align="start" gap="1">
                     <Button
                       variant="ghost"
                       size="sm"

--- a/src/components/shared/GitHubLibrary/components/AddGitHubLibraryDialogContent.tsx
+++ b/src/components/shared/GitHubLibrary/components/AddGitHubLibraryDialogContent.tsx
@@ -30,7 +30,6 @@ const ComponentList = ({
         {components.map((component) => (
           <InlineStack
             align="start"
-            blockAlign="center"
             gap="1"
             className="w-full"
             key={component.digest}

--- a/src/components/shared/GitHubLibrary/components/LibraryList.tsx
+++ b/src/components/shared/GitHubLibrary/components/LibraryList.tsx
@@ -33,18 +33,17 @@ export const LibraryList = withSuspenseWrapper(
             <InlineStack
               key={library.id}
               align="space-between"
-              blockAlign="center"
               gap="1"
               className="w-full pr-3"
             >
-              <InlineStack blockAlign="center" gap="1">
+              <InlineStack gap="1">
                 <Icon
                   name={library.icon as any /** todo: fix this */}
                   className="text-gray-400"
                 />
                 <Text>{library.name}</Text>
               </InlineStack>
-              <InlineStack blockAlign="center" gap="1">
+              <InlineStack gap="1">
                 <TokenStatusButton
                   library={library}
                   onUpdateClick={onUpdateLibrary}

--- a/src/components/shared/ManageComponent/ComponentHistoryTimeline.tsx
+++ b/src/components/shared/ManageComponent/ComponentHistoryTimeline.tsx
@@ -121,7 +121,7 @@ export const ComponentHistoryTimeline = withSuspenseWrapper(
 
               return (
                 <ComponentHistoryTimelineItem key={item.digest} icon={icon}>
-                  <InlineStack gap="1" blockAlign="center">
+                  <InlineStack gap="1">
                     <ComponentQuickDetailsDialogTrigger component={item} />
                     <Text size="xs">by {item.published_by}</Text>
 
@@ -169,7 +169,7 @@ export const ComponentHistoryTimeline = withSuspenseWrapper(
                         : "| you have a version of this component that is not published yet"}
                     </Text>
                   </InlineStack>
-                  <InlineStack gap="1" blockAlign="center">
+                  <InlineStack gap="1">
                     {isPotentialNewRelease ? (
                       <DeprecatePublishedComponentButton
                         predecessorComponent={lastHydratedComponent}
@@ -193,7 +193,7 @@ export const ComponentHistoryTimeline = withSuspenseWrapper(
                 icon="CircleDashed"
                 iconClassName="text-gray-500"
               >
-                <InlineStack gap="1" blockAlign="center">
+                <InlineStack gap="1">
                   <Text size="xs" tone="subdued">
                     To release a new version, drop the new component YAML file
                     on the Pipeline Editor.

--- a/src/components/shared/ManageComponent/ComponentQualityCard.tsx
+++ b/src/components/shared/ManageComponent/ComponentQualityCard.tsx
@@ -16,7 +16,7 @@ const ComponentSpecCheckStatement = ({
   invalidLabel: string;
 }>) => {
   return (
-    <InlineStack gap="2" align="start" blockAlign="center">
+    <InlineStack gap="2" align="start">
       {isValid ? (
         <Icon name="Check" className="text-green-500" />
       ) : (

--- a/src/components/shared/ManageComponent/PublishedComponentDetails.tsx
+++ b/src/components/shared/ManageComponent/PublishedComponentDetails.tsx
@@ -16,7 +16,7 @@ import { TrimmedDigest } from "./TrimmedDigest";
 
 const PublishedComponentDetailsSkeleton = () => {
   return (
-    <InlineStack gap="1" blockAlign="center" align="center">
+    <InlineStack gap="1" align="center">
       <Spinner size={10} />
       <Text size="xs" tone="subdued">
         Looking for updates...
@@ -77,7 +77,7 @@ export const PublishedComponentDetails = withSuspenseWrapper(
               </ComponentUsageCount>
             </InlineStack>
             {isOutdated ? (
-              <InlineStack gap="1" blockAlign="center" align="center">
+              <InlineStack gap="1" align="center">
                 <Paragraph size="xs" tone="critical">
                   There is a newer version of this component available.
                 </Paragraph>

--- a/src/components/shared/ReactFlow/FlowCanvas/SelectionToolbar.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/SelectionToolbar.tsx
@@ -23,7 +23,6 @@ const SelectionToolbar = ({
   return (
     <InlineStack
       gap="1"
-      blockAlign="center"
       className="bg-white border border-[#0059dc66] border-b-0 rounded-xs"
     >
       <ToolbarButton callback={onUpgrade} icon="CircleFadingArrowUp" />

--- a/src/components/shared/ReactFlow/FlowCanvas/Subgraphs/create/NodeListItem.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/Subgraphs/create/NodeListItem.tsx
@@ -38,7 +38,6 @@ export function NodeListItem({
     <li key={node.id} className="flex justify-between items-center">
       <InlineStack
         gap="3"
-        blockAlign="center"
         className={cn({ "opacity-50": isExcluded })}
         wrap="nowrap"
       >
@@ -47,7 +46,7 @@ export function NodeListItem({
           {node.id}
         </Paragraph>
         {isOrphaned && (
-          <InlineStack gap="1" blockAlign="center" wrap="nowrap">
+          <InlineStack gap="1" wrap="nowrap">
             <Icon name="TriangleAlert" className="text-destructive" />
             <Paragraph size="xs" className="text-destructive">
               Orphaned

--- a/src/components/shared/ReactFlow/FlowCanvas/Subgraphs/view/SubgraphBreadcrumbs.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/Subgraphs/view/SubgraphBreadcrumbs.tsx
@@ -70,7 +70,6 @@ export const SubgraphBreadcrumbs = () => {
   return (
     <InlineStack
       align="space-between"
-      blockAlign="center"
       gap="0"
       className="px-4 py-2 bg-gray-50 border-b w-full z-1"
     >
@@ -92,11 +91,7 @@ export const SubgraphBreadcrumbs = () => {
                         className="h-6 px-2"
                       >
                         {isRoot ? (
-                          <InlineStack
-                            align="start"
-                            blockAlign="center"
-                            gap="1"
-                          >
+                          <InlineStack align="start" gap="1">
                             <Home className="w-3 h-3" />
                             Root
                           </InlineStack>
@@ -108,7 +103,7 @@ export const SubgraphBreadcrumbs = () => {
                   ) : (
                     <BreadcrumbPage>
                       {isRoot ? (
-                        <InlineStack align="start" blockAlign="center" gap="1">
+                        <InlineStack align="start" gap="1">
                           <Home className="w-3 h-3" />
                           Root
                         </InlineStack>

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/AnnotationsEditor.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/AnnotationsEditor.tsx
@@ -46,12 +46,7 @@ export const AnnotationsEditor = ({
 
   return (
     <BlockStack gap="2">
-      <InlineStack
-        gap="2"
-        align="space-between"
-        blockAlign="center"
-        className="w-full"
-      >
+      <InlineStack gap="2" align="space-between" className="w-full">
         <Heading level={1}>Annotations</Heading>
 
         <Button

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/AnnotationsInput.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/AnnotationsInput.tsx
@@ -263,7 +263,7 @@ export const AnnotationsInput = ({
     );
   } else if (inputType === "number") {
     inputElement = (
-      <InlineStack gap="2" blockAlign="center" wrap="nowrap" className="grow">
+      <InlineStack gap="2" wrap="nowrap" className="grow">
         <Input
           type="number"
           value={inputValue}
@@ -288,7 +288,7 @@ export const AnnotationsInput = ({
     );
   } else {
     inputElement = (
-      <InlineStack gap="2" blockAlign="center" wrap="nowrap" className="grow">
+      <InlineStack gap="2" wrap="nowrap" className="grow">
         <div className="flex-1 w-full relative group">
           <Input
             value={
@@ -315,7 +315,7 @@ export const AnnotationsInput = ({
           </Button>
         </div>
         {isInvalid && (
-          <InlineStack gap="1" blockAlign="center" className="my-1">
+          <InlineStack gap="1" className="my-1">
             <Icon name="TriangleAlert" />
             <Paragraph size="xs" tone="warning">
               Invalid JSON
@@ -330,7 +330,7 @@ export const AnnotationsInput = ({
 
   return (
     <>
-      <InlineStack gap="2" blockAlign="center" wrap="nowrap" className="w-full">
+      <InlineStack gap="2" wrap="nowrap" className="w-full">
         {inputElement}
         {config?.enableQuantity && (
           <QuantityInput
@@ -392,12 +392,7 @@ const QuantityInput = ({
   );
 
   return (
-    <InlineStack
-      gap="2"
-      blockAlign="center"
-      wrap="nowrap"
-      className="max-w-1/3"
-    >
+    <InlineStack gap="2" wrap="nowrap" className="max-w-1/3">
       <span>x</span>
       <Input
         type="number"

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/NewAnnotationRow.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/NewAnnotationRow.tsx
@@ -44,7 +44,7 @@ export const NewAnnotationRow = ({
 
   return (
     <div onBlur={handleRowBlur}>
-      <InlineStack blockAlign="center" gap="2" className="mt-2">
+      <InlineStack gap="2" className="mt-2">
         <Input
           placeholder="New annotation"
           value={key}

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/ArgumentInputField.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/ArgumentInputField.tsx
@@ -220,12 +220,7 @@ export const ArgumentInputField = ({
           className="flex w-full items-center justify-between gap-2 py-1 rounded-md hover:bg-secondary/70 cursor-pointer"
           onClick={handleBackgroundClick}
         >
-          <InlineStack
-            blockAlign="center"
-            align="space-between"
-            gap="2"
-            className="w-32 pr-2"
-          >
+          <InlineStack align="space-between" gap="2" className="w-32 pr-2">
             <div className="flex items-center gap-2">
               <Tooltip>
                 <TooltipTrigger asChild>
@@ -309,7 +304,7 @@ export const ArgumentInputField = ({
             </Button>
           </div>
 
-          <InlineStack align="end" blockAlign="center">
+          <InlineStack align="end">
             <div
               onClick={(e) => e.stopPropagation()}
               className={cn(disabledCopy && "cursor-default")}

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeCard.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeCard.tsx
@@ -284,7 +284,7 @@ const TaskNodeCard = () => {
       >
         <CardHeader className="border-b border-slate-200 px-2 py-2.5 flex flex-row justify-between items-start">
           <BlockStack>
-            <InlineStack gap="2" blockAlign="center" wrap="nowrap">
+            <InlineStack gap="2" wrap="nowrap">
               {isSubgraphNode && isSubgraphNavigationEnabled && (
                 <QuickTooltip content={`Subgraph: ${subgraphDescription}`}>
                   <Icon name="Workflow" size="sm" className="text-blue-600" />

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/IOCellHeader.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/IOCellHeader.tsx
@@ -53,12 +53,7 @@ const IOCellHeader = ({
           : "rounded-md",
       )}
     >
-      <InlineStack
-        align="space-between"
-        blockAlign="center"
-        gap="2"
-        className="px-3 w-full"
-      >
+      <InlineStack align="space-between" gap="2" className="px-3 w-full">
         <div className="flex-1 min-w-auto shrink-0">
           <Tooltip
             delayDuration={300}
@@ -84,11 +79,7 @@ const IOCellHeader = ({
 
         {artifactData && (
           <InlineStack gap="2">
-            <InlineStack
-              blockAlign="center"
-              gap="1"
-              className="text-xs text-gray-500"
-            >
+            <InlineStack gap="1" className="text-xs text-gray-500">
               {artifactData.uri && (
                 <>
                   <Link

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/TaskOverview.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/TaskOverview.tsx
@@ -75,7 +75,7 @@ const TaskOverview = ({ taskNode, actions }: TaskOverviewProps) => {
 
   return (
     <BlockStack className="h-full" data-context-panel="task-overview">
-      <InlineStack gap="2" blockAlign="center" className="px-2 pb-2">
+      <InlineStack gap="2" className="px-2 pb-2">
         {isSubgraph && <Icon name="Workflow" />}
         <Text size="lg" weight="semibold">
           {name}

--- a/src/components/shared/ReactFlow/FlowSidebar/components/ComponentItem.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/components/ComponentItem.tsx
@@ -182,7 +182,7 @@ const ComponentMarkup = ({
       draggable={!error && !isLoading}
       onDragStart={onDragStart}
     >
-      <InlineStack blockAlign="center" gap="2">
+      <InlineStack gap="2">
         {isLoading ? (
           <span className="text-gray-400 truncate text-sm">Loading...</span>
         ) : error ? (
@@ -195,12 +195,7 @@ const ComponentMarkup = ({
             data-testid="component-item"
             data-component-name={displayName}
           >
-            <InlineStack
-              gap="2"
-              blockAlign="center"
-              className="w-full"
-              wrap="nowrap"
-            >
+            <InlineStack gap="2" className="w-full" wrap="nowrap">
               {isRemoteComponentLibrarySearchEnabled ? (
                 <ComponentIcon
                   name={iconName}
@@ -230,7 +225,7 @@ const ComponentMarkup = ({
                 </span>
               </div>
             </InlineStack>
-            <InlineStack blockAlign="center" align="end" wrap="nowrap">
+            <InlineStack align="end" wrap="nowrap">
               <ComponentFavoriteToggle component={component} />
               <ComponentDetailsDialog
                 displayName={displayName}
@@ -247,7 +242,7 @@ const ComponentMarkup = ({
 const ComponentItemSkeleton = () => {
   return (
     <SidebarMenuItem className="pl-2 py-1.5">
-      <InlineStack blockAlign="center" gap="2">
+      <InlineStack gap="2">
         <Spinner size={10} />
         <Skeleton size="sm" color="default" />
       </InlineStack>

--- a/src/components/shared/ReactFlow/FlowSidebar/components/FolderItem.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/components/FolderItem.tsx
@@ -101,7 +101,6 @@ const FolderSkeleton = () => {
   return (
     <BlockStack className="w-full">
       <InlineStack
-        blockAlign="center"
         className="px-4 py-1 cursor-pointer hover:bg-gray-100 w-full"
         align="space-between"
         wrap="nowrap"

--- a/src/components/shared/ReactFlow/FlowSidebar/components/PublishedComponentsSearch.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/components/PublishedComponentsSearch.tsx
@@ -117,12 +117,7 @@ const SearchFilter = ({
             <RadioGroup onValueChange={handleFilterChange} value={activeFilter}>
               {availableFilters.map(({ label, value }) => {
                 return (
-                  <InlineStack
-                    key={value}
-                    gap="2"
-                    align="start"
-                    blockAlign="center"
-                  >
+                  <InlineStack key={value} gap="2" align="start">
                     <RadioGroupItem
                       id={value}
                       value={value}
@@ -302,7 +297,7 @@ const SearchResults = ({ searchResult }: SearchResultsProps) => {
 const SearchResultsSkeleton = () => {
   return (
     <BlockStack gap="2" className="px-2">
-      <InlineStack align="start" gap="1" blockAlign="center">
+      <InlineStack align="start" gap="1">
         <Text tone="subdued">Search Results </Text>
         <Spinner />
       </InlineStack>

--- a/src/components/shared/ReactFlow/FlowSidebar/sections/FileActions.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/sections/FileActions.tsx
@@ -112,11 +112,7 @@ const FileActions = ({ isOpen }: { isOpen: boolean }) => {
     <SidebarGroup>
       <SidebarGroupLabel>Pipeline Actions</SidebarGroupLabel>
       <SidebarContent>
-        <InlineStack
-          blockAlign="center"
-          className="ml-2 overflow-y-hidden"
-          gap="1"
-        >
+        <InlineStack className="ml-2 overflow-y-hidden" gap="1">
           {autoSaveStatus.isSaving && <Spinner size={16} />}
           <span className="text-xs text-muted-foreground">
             {getAutoSaveStatusText()}

--- a/src/components/shared/ReactFlow/FlowSidebar/sections/GraphComponents.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/sections/GraphComponents.tsx
@@ -156,11 +156,7 @@ const GraphComponents = ({ isOpen }: { isOpen: boolean }) => {
             <>
               <Separator />
               <BlockStack gap="1" className="pl-2 py-2">
-                <InlineStack
-                  className="w-full"
-                  align="space-between"
-                  blockAlign="center"
-                >
+                <InlineStack className="w-full" align="space-between">
                   <Text size="sm" tone="subdued">
                     Connected libraries
                   </Text>

--- a/src/components/ui/layout.tsx
+++ b/src/components/ui/layout.tsx
@@ -130,7 +130,7 @@ export const InlineStack = forwardRef<
   const {
     as: Element = "div",
     align = "start",
-    blockAlign = "start",
+    blockAlign = "center",
     gap = "0",
     wrap = "wrap",
     children,

--- a/src/components/ui/link.tsx
+++ b/src/components/ui/link.tsx
@@ -53,7 +53,7 @@ function Link({
       {...props}
       className={cn(linkVariants({ variant, size }), className)}
     >
-      <InlineStack gap="1" blockAlign="center" className="w-full">
+      <InlineStack gap="1" className="w-full">
         {children}
         {external && <Icon name="ExternalLink" size={size} />}
       </InlineStack>


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
A majority of our `InlineStack`s are using `blockAlign="center"` or putting identical size things in a row, so we might as well make it default.


It is VERY LIKELY that this change will result in a few cases where things are unintentionally misaligned, but we can pick those up and fix them as we go.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] (Potentially) Breaking change

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

App should look exactly the same.

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->

We currently use `InlineStack` 136 times in the codebase.
Of that, 84 of them use `blockAlign="center"`.

