### PR TITLE
Enable React Compiler for Home components and remove unnecessary hooks

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,6 +5,9 @@ import simpleImportSort from "eslint-plugin-simple-import-sort";
 import globals from "globals";
 import tseslint from "typescript-eslint";
 
+// Keep in sync with REACT_COMPILER_ENABLED_DIRS in vite.config.js
+const REACT_COMPILER_ENABLED_GLOBS = ["src/components/Home/**/*.{ts,tsx}"];
+
 /** @type {import('eslint').Linter.Config[]} */
 export default [
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"] },
@@ -57,6 +60,25 @@ export default [
     plugins: {
       "simple-import-sort": simpleImportSort,
       "react-compiler": reactCompiler,
+    },
+  },
+  // React Compiler enabled directories: warn about unnecessary useCallback/useMemo
+  {
+    files: REACT_COMPILER_ENABLED_GLOBS,
+    rules: {
+      "no-restricted-syntax": [
+        "warn",
+        {
+          selector: "CallExpression[callee.name='useCallback']",
+          message:
+            "useCallback is unnecessary with React Compiler. The compiler auto-memoizes functions.",
+        },
+        {
+          selector: "CallExpression[callee.name='useMemo']",
+          message:
+            "useMemo may be unnecessary with React Compiler. The compiler auto-memoizes values.",
+        },
+      ],
     },
   },
   {

--- a/src/components/Home/PipelineSection/BulkActionsBar.tsx
+++ b/src/components/Home/PipelineSection/BulkActionsBar.tsx
@@ -1,5 +1,3 @@
-import { useCallback } from "react";
-
 import { ConfirmationDialog } from "@/components/shared/Dialogs";
 import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
@@ -21,7 +19,7 @@ const BulkActionsBar = ({
 }: BulkActionsBarProps) => {
   const notify = useToastNotification();
 
-  const handleBulkDelete = useCallback(async () => {
+  const handleBulkDelete = async () => {
     const deletePromises = selectedPipelines.map((pipelineName) =>
       deletePipeline(pipelineName),
     );
@@ -37,7 +35,7 @@ const BulkActionsBar = ({
       const errorMessage = getErrorMessage(error);
       notify("Failed to delete some pipelines: " + errorMessage, "error");
     }
-  }, [selectedPipelines, onDeleteSuccess]);
+  };
 
   return (
     <div className="fixed bottom-4 left-1/2 transform -translate-x-1/2 bg-background border border-border rounded-lg shadow-lg p-4 z-50">

--- a/src/components/Home/PipelineSection/PipelineRow.tsx
+++ b/src/components/Home/PipelineSection/PipelineRow.tsx
@@ -1,5 +1,5 @@
 import { useNavigate } from "@tanstack/react-router";
-import { type MouseEvent, useCallback, useMemo } from "react";
+import { type MouseEvent } from "react";
 
 import { ConfirmationDialog } from "@/components/shared/Dialogs";
 import RunOverview from "@/components/shared/RunOverview";
@@ -48,25 +48,19 @@ const PipelineRow = ({
     backendUrl,
   );
 
-  const handleRowClick = useCallback(
-    (e: MouseEvent) => {
-      // Don't navigate if clicking on the popover trigger
-      if ((e.target as HTMLElement).closest("[data-popover-trigger]")) {
-        return;
-      }
-      navigate({ to: `${EDITOR_PATH}/${name}` });
-    },
-    [navigate, name],
-  );
+  const handleRowClick = (e: MouseEvent) => {
+    // Don't navigate if clicking on the popover trigger
+    if ((e.target as HTMLElement).closest("[data-popover-trigger]")) {
+      return;
+    }
+    navigate({ to: `${EDITOR_PATH}/${name}` });
+  };
 
-  const handleCheckboxChange = useCallback(
-    (checked: boolean) => {
-      onSelect?.(checked);
-    },
-    [onSelect],
-  );
+  const handleCheckboxChange = (checked: boolean) => {
+    onSelect?.(checked);
+  };
 
-  const confirmPipelineDelete = useCallback(async () => {
+  const confirmPipelineDelete = async () => {
     if (!name) return;
 
     const deleteCallback = () => {
@@ -74,17 +68,14 @@ const PipelineRow = ({
     };
 
     await deletePipeline(name, deleteCallback);
-  }, [name]);
+  };
 
-  const handleClick = useCallback((e: MouseEvent) => {
+  const handleClick = (e: MouseEvent) => {
     // Prevent row click when clicking on the checkbox
     e.stopPropagation();
-  }, []);
+  };
 
-  const formattedDate = useMemo(() => {
-    if (!modificationTime) return "N/A";
-    return formatDate(modificationTime.toISOString());
-  }, [modificationTime]);
+  const formattedDate = modificationTime ? formatDate(modificationTime.toISOString()) : "N/A";
 
   return (
     <>

--- a/src/components/Home/PipelineSection/PipelineSection.tsx
+++ b/src/components/Home/PipelineSection/PipelineSection.tsx
@@ -1,5 +1,5 @@
 import { useNavigate } from "@tanstack/react-router";
-import { type ChangeEvent, useCallback, useEffect, useState } from "react";
+import { type ChangeEvent, useEffect, useState } from "react";
 
 import NewPipelineButton from "@/components/shared/NewPipelineButton";
 import QuickStartCards from "@/components/shared/QuickStart/QuickStartCards";
@@ -71,7 +71,7 @@ export const PipelineSection = withSuspenseWrapper(() => {
     return name.toLowerCase().includes(searchQuery.toLowerCase());
   });
 
-  const fetchUserPipelines = useCallback(async () => {
+  const fetchUserPipelines = async () => {
     setIsLoading(true);
     try {
       const pipelines = await getAllComponentFilesFromList(
@@ -91,47 +91,39 @@ export const PipelineSection = withSuspenseWrapper(() => {
     } finally {
       setIsLoading(false);
     }
-  }, []);
+  };
 
-  const handleSearch = useCallback((e: ChangeEvent<HTMLInputElement>) => {
+  const handleSearch = (e: ChangeEvent<HTMLInputElement>) => {
     setSearchQuery(e.target.value);
-  }, []);
+  };
 
-  const handleSelectAll = useCallback(
-    (checked: boolean) => {
-      if (checked) {
-        const allPipelineNames = new Set(
-          filteredPipelines.map(([name]) => name),
-        );
-        setSelectedPipelines(allPipelineNames);
-      } else {
-        setSelectedPipelines(new Set());
-      }
-    },
-    [filteredPipelines],
-  );
+  const handleSelectAll = (checked: boolean) => {
+    if (checked) {
+      const allPipelineNames = new Set(filteredPipelines.map(([name]) => name));
+      setSelectedPipelines(allPipelineNames);
+    } else {
+      setSelectedPipelines(new Set());
+    }
+  };
 
-  const handleSelectPipeline = useCallback(
-    (pipelineName: string, checked: boolean) => {
-      const newSelected = new Set(selectedPipelines);
-      if (checked) {
-        newSelected.add(pipelineName);
-      } else {
-        newSelected.delete(pipelineName);
-      }
-      setSelectedPipelines(newSelected);
-    },
-    [selectedPipelines],
-  );
+  const handleSelectPipeline = (pipelineName: string, checked: boolean) => {
+    const newSelected = new Set(selectedPipelines);
+    if (checked) {
+      newSelected.add(pipelineName);
+    } else {
+      newSelected.delete(pipelineName);
+    }
+    setSelectedPipelines(newSelected);
+  };
 
-  const handleBulkDelete = useCallback(() => {
+  const handleBulkDelete = () => {
     setSelectedPipelines(new Set());
     fetchUserPipelines();
-  }, [fetchUserPipelines]);
+  };
 
   useEffect(() => {
     fetchUserPipelines();
-  }, [fetchUserPipelines]);
+  }, []);
 
   if (isLoading) {
     return (

--- a/src/components/shared/Authentication/tests/useAwaitAuthorization.test.tsx
+++ b/src/components/shared/Authentication/tests/useAwaitAuthorization.test.tsx
@@ -121,7 +121,7 @@ describe("useAwaitAuthorization()", () => {
   describe("Initial state", () => {
     it("should return correct initial state when not authorized", () => {
       mockAuthStorage.getToken.mockReturnValue(undefined);
-      mockAuthStorage.subscribe.mockReturnValue(() => { });
+      mockAuthStorage.subscribe.mockReturnValue(() => {});
 
       const { result } = renderHook(() => useAwaitAuthorization(), { wrapper });
 
@@ -132,7 +132,7 @@ describe("useAwaitAuthorization()", () => {
 
     it("should return correct initial state when authorized with token", () => {
       mockAuthStorage.getToken.mockReturnValue("bearer token123");
-      mockAuthStorage.subscribe.mockReturnValue(() => { });
+      mockAuthStorage.subscribe.mockReturnValue(() => {});
 
       const { result } = renderHook(() => useAwaitAuthorization(), { wrapper });
 
@@ -143,7 +143,7 @@ describe("useAwaitAuthorization()", () => {
       vi.stubEnv("VITE_REQUIRE_AUTHORIZATION", "false");
 
       mockAuthStorage.getToken.mockReturnValue(undefined);
-      mockAuthStorage.subscribe.mockReturnValue(() => { });
+      mockAuthStorage.subscribe.mockReturnValue(() => {});
 
       const { result } = renderHook(() => useAwaitAuthorization(), { wrapper });
 
@@ -154,7 +154,7 @@ describe("useAwaitAuthorization()", () => {
   describe("awaitAuthorization function", () => {
     it("should open popup and return promise", async () => {
       mockAuthStorage.getToken.mockReturnValue(undefined);
-      mockAuthStorage.subscribe.mockReturnValue(() => { });
+      mockAuthStorage.subscribe.mockReturnValue(() => {});
 
       const { result } = renderHook(() => useAwaitAuthorization(), { wrapper });
 
@@ -166,7 +166,7 @@ describe("useAwaitAuthorization()", () => {
 
     it("should create new promise on each call", () => {
       mockAuthStorage.getToken.mockReturnValue(undefined);
-      mockAuthStorage.subscribe.mockReturnValue(() => { });
+      mockAuthStorage.subscribe.mockReturnValue(() => {});
 
       const { result } = renderHook(() => useAwaitAuthorization(), { wrapper });
 
@@ -181,7 +181,7 @@ describe("useAwaitAuthorization()", () => {
   describe("Success flow", () => {
     it("should handle successful authorization", async () => {
       mockAuthStorage.getToken.mockReturnValue(undefined);
-      mockAuthStorage.subscribe.mockReturnValue(() => { });
+      mockAuthStorage.subscribe.mockReturnValue(() => {});
 
       const mockResponse = {
         token:
@@ -228,7 +228,7 @@ describe("useAwaitAuthorization()", () => {
   describe("Error flow", () => {
     it("should handle authorization error", async () => {
       mockAuthStorage.getToken.mockReturnValue(undefined);
-      mockAuthStorage.subscribe.mockReturnValue(() => { });
+      mockAuthStorage.subscribe.mockReturnValue(() => {});
 
       const errorMessage = "access_denied";
 
@@ -268,7 +268,7 @@ describe("useAwaitAuthorization()", () => {
   describe("Close flow", () => {
     it("should resolve promise when popup closes and user is authorized", async () => {
       mockAuthStorage.getToken.mockReturnValue(undefined);
-      mockAuthStorage.subscribe.mockReturnValue(() => { });
+      mockAuthStorage.subscribe.mockReturnValue(() => {});
 
       // Mock token to be available after popup closes
       mockAuthStorage.getToken.mockReturnValue("bearer token123");
@@ -294,7 +294,7 @@ describe("useAwaitAuthorization()", () => {
 
     it("should reject promise when popup closes and user is not authorized", async () => {
       mockAuthStorage.getToken.mockReturnValue(undefined);
-      mockAuthStorage.subscribe.mockReturnValue(() => { });
+      mockAuthStorage.subscribe.mockReturnValue(() => {});
 
       // Mock the popup hook to capture the onClose callback
       let capturedOnClose: (() => void) | undefined;
@@ -327,7 +327,7 @@ describe("useAwaitAuthorization()", () => {
   describe("Popup state propagation", () => {
     it("should propagate isLoading from popup hook", () => {
       mockAuthStorage.getToken.mockReturnValue(undefined);
-      mockAuthStorage.subscribe.mockReturnValue(() => { });
+      mockAuthStorage.subscribe.mockReturnValue(() => {});
 
       mockPopupHandlers.isLoading = true;
 
@@ -338,7 +338,7 @@ describe("useAwaitAuthorization()", () => {
 
     it("should propagate isPopupOpen from popup hook", () => {
       mockAuthStorage.getToken.mockReturnValue(undefined);
-      mockAuthStorage.subscribe.mockReturnValue(() => { });
+      mockAuthStorage.subscribe.mockReturnValue(() => {});
 
       mockPopupHandlers.isPopupOpen = true;
 
@@ -349,7 +349,7 @@ describe("useAwaitAuthorization()", () => {
 
     it("should propagate closePopup from popup hook", () => {
       mockAuthStorage.getToken.mockReturnValue(undefined);
-      mockAuthStorage.subscribe.mockReturnValue(() => { });
+      mockAuthStorage.subscribe.mockReturnValue(() => {});
 
       const { result } = renderHook(() => useAwaitAuthorization(), { wrapper });
 
@@ -360,7 +360,7 @@ describe("useAwaitAuthorization()", () => {
 
     it("should propagate bringPopupToFront from popup hook", () => {
       mockAuthStorage.getToken.mockReturnValue(undefined);
-      mockAuthStorage.subscribe.mockReturnValue(() => { });
+      mockAuthStorage.subscribe.mockReturnValue(() => {});
 
       const { result } = renderHook(() => useAwaitAuthorization(), { wrapper });
 
@@ -373,7 +373,7 @@ describe("useAwaitAuthorization()", () => {
   describe("Token subscription", () => {
     it("should subscribe to token changes", () => {
       mockAuthStorage.getToken.mockReturnValue(undefined);
-      mockAuthStorage.subscribe.mockReturnValue(() => { });
+      mockAuthStorage.subscribe.mockReturnValue(() => {});
 
       renderHook(() => useAwaitAuthorization(), { wrapper });
 
@@ -384,7 +384,7 @@ describe("useAwaitAuthorization()", () => {
       let subscribedCallback: (() => void) | undefined;
       mockAuthStorage.subscribe.mockImplementation((callback) => {
         subscribedCallback = callback;
-        return () => { };
+        return () => {};
       });
 
       // Initially no token
@@ -409,7 +409,7 @@ describe("useAwaitAuthorization()", () => {
   describe("Memory stability", () => {
     it("should memoize returned object to prevent unnecessary re-renders", () => {
       mockAuthStorage.getToken.mockReturnValue(undefined);
-      mockAuthStorage.subscribe.mockReturnValue(() => { });
+      mockAuthStorage.subscribe.mockReturnValue(() => {});
 
       const { result, rerender } = renderHook(() => useAwaitAuthorization(), {
         wrapper,
@@ -428,7 +428,7 @@ describe("useAwaitAuthorization()", () => {
       let subscribedCallback: (() => void) | undefined;
       mockAuthStorage.subscribe.mockImplementation((callback) => {
         subscribedCallback = callback;
-        return () => { };
+        return () => {};
       });
 
       // Initially no token

--- a/vite.config.js
+++ b/vite.config.js
@@ -11,7 +11,8 @@ const __dirname = path.dirname(__filename);
 // React Compiler: Directory-based incremental adoption
 // Add directories here as they are cleaned up for compiler compatibility
 const REACT_COMPILER_ENABLED_DIRS = [
-  "src/components/Home/RunSection",
+  "src/components/Home",
+
   // Add more directories as you clean them up:
   // "src/components/shared/",
   // "src/hooks/",


### PR DESCRIPTION
## Description

Enabled React Compiler for the Home component directory and removed unnecessary `useCallback` and `useMemo` hooks from components in this directory. Added ESLint rules to warn about unnecessary hook usage in React Compiler-enabled directories.

## Type of Change

- [x] Improvement
- [x] Cleanup/Refactor

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Additional Comments

The React Compiler automatically memoizes functions and values, making manual `useCallback` and `useMemo` hooks redundant in the enabled directories. This change keeps the configuration in sync between ESLint and Vite configs.