### PR TITLE
Extract React Compiler config to shared file and enable for Editor components

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,8 +5,7 @@ import simpleImportSort from "eslint-plugin-simple-import-sort";
 import globals from "globals";
 import tseslint from "typescript-eslint";
 
-// Keep in sync with REACT_COMPILER_ENABLED_DIRS in vite.config.js
-const REACT_COMPILER_ENABLED_GLOBS = ["src/components/Home/**/*.{ts,tsx}"];
+import { REACT_COMPILER_ENABLED_GLOBS } from "./react-compiler.config.js";
 
 /** @type {import('eslint').Linter.Config[]} */
 export default [

--- a/react-compiler.config.js
+++ b/react-compiler.config.js
@@ -1,0 +1,14 @@
+// React Compiler: Directory-based incremental adoption
+// Add directories here as they are cleaned up for compiler compatibility
+export const REACT_COMPILER_ENABLED_DIRS = [
+  "src/components/Home",
+  "src/components/Editor",
+  // Add more directories as you clean them up:
+  // "src/components/shared/",
+  // "src/hooks/",
+];
+
+// Convert to glob patterns for ESLint
+export const REACT_COMPILER_ENABLED_GLOBS = REACT_COMPILER_ENABLED_DIRS.map(
+  (dir) => `${dir}/**/*.{ts,tsx}`,
+);

--- a/src/components/Editor/IOEditor/InputValueEditor/InputValueEditor.tsx
+++ b/src/components/Editor/IOEditor/InputValueEditor/InputValueEditor.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 
 import { updateInputNameOnComponentSpec } from "@/components/Editor/utils/updateInputNameOnComponentSpec";
 import { ConfirmationDialog } from "@/components/shared/Dialogs";
@@ -59,110 +59,94 @@ export const InputValueEditor = ({
   const [validationError, setValidationError] = useState<string | null>(null);
 
   // Check if this input is connected to any required fields
-  const { isConnectedToRequired } = useMemo(() => {
-    return checkInputConnectionToRequiredFields(
-      input.name,
-      currentSubgraphSpec,
-    );
-  }, [input.name, currentSubgraphSpec]);
+  const { isConnectedToRequired } = checkInputConnectionToRequiredFields(
+    input.name,
+    currentSubgraphSpec,
+  );
 
   const effectiveOptionalValue = isConnectedToRequired ? false : inputOptional;
   const isInSubgraph = currentSubgraphPath.length > 1;
 
-  const handleInputChange = useCallback(
-    (
-      oldName: string,
-      value: string,
-      newName: string,
-      optional: boolean,
-      type: string,
-    ) => {
-      if (!currentSubgraphSpec.inputs) return;
+  const handleInputChange = (
+    oldName: string,
+    value: string,
+    newName: string,
+    optional: boolean,
+    type: string,
+  ) => {
+    if (!currentSubgraphSpec.inputs) return;
 
-      if (newName === "") {
-        setValidationError("Input name cannot be empty");
-        return;
+    if (newName === "") {
+      setValidationError("Input name cannot be empty");
+      return;
+    }
+
+    const updatedInputs = currentSubgraphSpec.inputs.map((componentInput) => {
+      if (componentInput.name === oldName) {
+        return {
+          ...componentInput,
+          value,
+          default: value,
+          name: newName,
+          optional,
+          type,
+        };
       }
+      return componentInput;
+    });
 
-      const updatedInputs = currentSubgraphSpec.inputs.map((componentInput) => {
-        if (componentInput.name === oldName) {
-          return {
-            ...componentInput,
-            value,
-            default: value,
-            name: newName,
-            optional,
-            type,
-          };
-        }
-        return componentInput;
-      });
+    const updatedComponentSpecValues = {
+      ...currentSubgraphSpec,
+      inputs: updatedInputs,
+    };
 
-      const updatedComponentSpecValues = {
-        ...currentSubgraphSpec,
-        inputs: updatedInputs,
-      };
+    const updatedComponentSpec = updateInputNameOnComponentSpec(
+      updatedComponentSpecValues,
+      oldName,
+      newName,
+    );
 
-      const updatedComponentSpec = updateInputNameOnComponentSpec(
-        updatedComponentSpecValues,
-        oldName,
-        newName,
-      );
+    transferSelection(oldName, newName);
 
-      transferSelection(oldName, newName);
+    return updatedComponentSpec;
+  };
 
-      return updatedComponentSpec;
-    },
-    [currentSubgraphSpec, transferSelection],
-  );
-
-  const handleValueChange = useCallback((value: string) => {
+  const handleValueChange = (value: string) => {
     setInputValue(value);
-  }, []);
+  };
 
-  const handleTypeChange = useCallback((value: string) => {
+  const handleTypeChange = (value: string) => {
     setInputType(value);
-  }, []);
+  };
 
-  const handleNameChange = useCallback(
-    (newName: string) => {
-      setInputName(newName);
+  const handleNameChange = (newName: string) => {
+    setInputName(newName);
 
-      if (
-        checkNameCollision(
-          newName.trim(),
-          input.name.trim(),
-          componentSpec,
-          "inputs",
-        )
-      ) {
-        setValidationError("An input with this name already exists");
-        return;
-      }
+    if (
+      checkNameCollision(
+        newName.trim(),
+        input.name.trim(),
+        componentSpec,
+        "inputs",
+      )
+    ) {
+      setValidationError("An input with this name already exists");
+      return;
+    }
 
-      setValidationError(null);
-    },
-    [input.name, currentSubgraphSpec],
-  );
+    setValidationError(null);
+  };
 
-  const hasChanges = useCallback(() => {
+  const hasChanges = () => {
     return (
       inputValue !== initialInputValue ||
       inputName.trim() !== input.name ||
       inputType !== (input.type?.toString() ?? "any") ||
       inputOptional !== initialIsOptional
     );
-  }, [
-    inputValue,
-    inputName,
-    inputType,
-    inputOptional,
-    initialInputValue,
-    initialIsOptional,
-    input,
-  ]);
+  };
 
-  const saveChanges = useCallback(() => {
+  const saveChanges = () => {
     if (!hasChanges() || validationError) return;
 
     const updatedSubgraphSpec = handleInputChange(
@@ -181,32 +165,20 @@ export const InputValueEditor = ({
       );
       setComponentSpec(updatedRootSpec);
     }
-  }, [
-    handleInputChange,
-    setComponentSpec,
-    hasChanges,
-    validationError,
-    input.name,
-    inputValue,
-    inputName,
-    effectiveOptionalValue,
-    inputType,
-    componentSpec,
-    currentSubgraphPath,
-  ]);
+  };
 
-  const handleBlur = useCallback(() => {
+  const handleBlur = () => {
     saveChanges();
-  }, [saveChanges]);
+  };
 
-  const handleCopyValue = useCallback(() => {
+  const handleCopyValue = () => {
     if (inputValue.trim()) {
       void navigator.clipboard.writeText(inputValue.trim());
       notify("Input value copied to clipboard", "success");
     }
-  }, [inputValue]);
+  };
 
-  const deleteNode = useCallback(async () => {
+  const deleteNode = async () => {
     if (!currentSubgraphSpec.inputs) return;
 
     const confirmed = await triggerConfirmation({
@@ -231,32 +203,23 @@ export const InputValueEditor = ({
     setComponentSpec(updatedRootSpec);
 
     clearContent();
-  }, [
-    currentSubgraphSpec,
-    input.name,
-    setComponentSpec,
-    clearContent,
-    triggerConfirmation,
-    inputName,
-    componentSpec,
-    currentSubgraphPath,
-  ]);
+  };
 
-  const handleExpandValueEditor = useCallback(() => {
+  const handleExpandValueEditor = () => {
     if (disabled) return;
 
     setIsValueDialogOpen(true);
-  }, [disabled]);
+  };
 
-  const handleDialogCancel = useCallback(() => {
+  const handleDialogCancel = () => {
     setIsValueDialogOpen(false);
-  }, []);
+  };
 
-  const handleDialogConfirm = useCallback((value: string) => {
+  const handleDialogConfirm = (value: string) => {
     setInputValue(value);
     setIsValueDialogOpen(false);
     setTriggerSave(true);
-  }, []);
+  };
 
   useEffect(() => {
     setInputValue(initialInputValue);

--- a/src/components/Editor/IOEditor/OutputNameEditor/OutputNameEditor.tsx
+++ b/src/components/Editor/IOEditor/OutputNameEditor/OutputNameEditor.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
 import ConfirmationDialog from "@/components/shared/Dialogs/ConfirmationDialog";
 import { removeGraphOutput } from "@/components/shared/ReactFlow/FlowCanvas/utils/removeNode";
@@ -47,28 +47,25 @@ export const OutputNameEditor = ({
   const [outputName, setOutputName] = useState(output.name);
   const [validationError, setValidationError] = useState<string | null>(null);
 
-  const hasChanges = useCallback(() => {
+  const hasChanges = () => {
     return outputName.trim() !== output.name;
-  }, [outputName, output.name]);
+  };
 
-  const handleOutputNameChange = useCallback(
-    (oldName: string, newName: string) => {
-      if (!currentSubgraphSpec.outputs) return null;
+  const handleOutputNameChange = (oldName: string, newName: string) => {
+    if (!currentSubgraphSpec.outputs) return null;
 
-      const updatedComponentSpec = updateOutputNameOnComponentSpec(
-        currentSubgraphSpec,
-        oldName,
-        newName,
-      );
+    const updatedComponentSpec = updateOutputNameOnComponentSpec(
+      currentSubgraphSpec,
+      oldName,
+      newName,
+    );
 
-      transferSelection(oldName, newName);
+    transferSelection(oldName, newName);
 
-      return updatedComponentSpec;
-    },
-    [currentSubgraphSpec, transferSelection],
-  );
+    return updatedComponentSpec;
+  };
 
-  const saveChanges = useCallback(() => {
+  const saveChanges = () => {
     if (!hasChanges() || validationError) return;
 
     if (outputName.trim() === "") {
@@ -89,43 +86,31 @@ export const OutputNameEditor = ({
       );
       setComponentSpec(updatedRootSpec);
     }
-  }, [
-    hasChanges,
-    validationError,
-    handleOutputNameChange,
-    output.name,
-    outputName,
-    setComponentSpec,
-    componentSpec,
-    currentSubgraphPath,
-  ]);
+  };
 
-  const handleBlur = useCallback(() => {
+  const handleBlur = () => {
     saveChanges();
-  }, [saveChanges]);
+  };
 
-  const handleNameChange = useCallback(
-    (value: string) => {
-      setOutputName(value);
+  const handleNameChange = (value: string) => {
+    setOutputName(value);
 
-      if (
-        checkNameCollision(
-          value.trim(),
-          output.name.trim(),
-          componentSpec,
-          "outputs",
-        )
-      ) {
-        setValidationError("An output with this name already exists");
-        return;
-      }
+    if (
+      checkNameCollision(
+        value.trim(),
+        output.name.trim(),
+        componentSpec,
+        "outputs",
+      )
+    ) {
+      setValidationError("An output with this name already exists");
+      return;
+    }
 
-      setValidationError(null);
-    },
-    [currentSubgraphSpec, output.name],
-  );
+    setValidationError(null);
+  };
 
-  const deleteNode = useCallback(async () => {
+  const deleteNode = async () => {
     if (!currentSubgraphSpec.outputs) return;
 
     const confirmed = await triggerConfirmation({
@@ -150,15 +135,7 @@ export const OutputNameEditor = ({
     setComponentSpec(updatedRootSpec);
 
     clearContent();
-  }, [
-    currentSubgraphSpec,
-    output.name,
-    setComponentSpec,
-    clearContent,
-    triggerConfirmation,
-    componentSpec,
-    currentSubgraphPath,
-  ]);
+  };
 
   useEffect(() => {
     setOutputName(output.name);

--- a/src/components/Editor/PipelineEditor.tsx
+++ b/src/components/Editor/PipelineEditor.tsx
@@ -1,7 +1,7 @@
 import "@/styles/editor.css";
 
 import { Background, MiniMap, type ReactFlowProps } from "@xyflow/react";
-import { useCallback, useState } from "react";
+import { useState } from "react";
 
 import { CollapsibleContextPanel } from "@/components/shared/ContextPanel/CollapsibleContextPanel";
 import {
@@ -38,15 +38,12 @@ const PipelineEditor = () => {
     nodesDraggable: true,
   });
 
-  const updateFlowConfig = useCallback(
-    (updatedConfig: Partial<ReactFlowProps>) => {
-      setFlowConfig((prevConfig) => ({
-        ...prevConfig,
-        ...updatedConfig,
-      }));
-    },
-    [],
-  );
+  const updateFlowConfig = (updatedConfig: Partial<ReactFlowProps>) => {
+    setFlowConfig((prevConfig) => ({
+      ...prevConfig,
+      ...updatedConfig,
+    }));
+  };
 
   // If the pipeline is loading or the component spec is empty, show a loading spinner
   if (isLoading || componentSpec === EMPTY_GRAPH_COMPONENT_SPEC) {

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,19 +4,11 @@ import path from "path";
 import { fileURLToPath } from "url";
 import { defineConfig } from "vite";
 
+import { REACT_COMPILER_ENABLED_DIRS } from "./react-compiler.config.js";
+
 // Create __dirname equivalent for ES modules
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-
-// React Compiler: Directory-based incremental adoption
-// Add directories here as they are cleaned up for compiler compatibility
-const REACT_COMPILER_ENABLED_DIRS = [
-  "src/components/Home",
-
-  // Add more directories as you clean them up:
-  // "src/components/shared/",
-  // "src/hooks/",
-];
 
 export default defineConfig({
   plugins: [


### PR DESCRIPTION
## Description

Extracted React Compiler configuration into a dedicated file to improve maintainability and enable incremental adoption across more components. Added the Editor component directory to the React Compiler enabled paths and refactored several Editor components to be compatible with React Compiler by converting callback-based hooks to regular functions.

## Type of Change

- [x] Improvement
- [x] Cleanup/Refactor

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Additional Comments

This change centralizes React Compiler configuration in `react-compiler.config.js` and makes it easier to add more directories as they're cleaned up for compiler compatibility. The Editor components have been refactored to work with React Compiler by removing unnecessary `useCallback` wrappers around functions that don't need memoization.