### PR TITLE
Add React Compiler-ready directories with useCallback/useMemo cleanup guide

### DIFF
--- a/react-compiler.config.js
+++ b/react-compiler.config.js
@@ -1,11 +1,46 @@
 // React Compiler: Directory-based incremental adoption
 // Add directories here as they are cleaned up for compiler compatibility
+// Sorted by useCallback/useMemo count (cleanup effort) - least to most
 export const REACT_COMPILER_ENABLED_DIRS = [
+  // ✅ Enabled
   "src/components/Home",
   "src/components/Editor",
-  // Add more directories as you clean them up:
-  // "src/components/shared/",
-  // "src/hooks/",
+
+  // 0 useCallback/useMemo - ready to enable
+  "src/components/layout",
+  "src/components/shared/ArtifactsList",
+  "src/components/shared/Buttons",
+  "src/components/shared/ContextPanel",
+  "src/components/shared/ExecutionDetails",
+  "src/components/shared/QuickStart",
+  "src/components/shared/Status",
+
+  // 2-5 useCallback/useMemo
+  // "src/components/shared/CodeViewer",          // 2
+  // "src/components/shared/FullscreenElement",   // 2
+  // "src/components/shared/CopyText",            // 3
+  // "src/components/shared/TaskDetails",         // 4
+  // "src/components/shared/GitHubAuth",          // 5
+
+  // 6-10 useCallback/useMemo
+  // "src/routes",                                // 6
+  // "src/components/shared/ComponentEditor",     // 6
+  // "src/components/shared/Settings",            // 6
+  // "src/components/shared/HuggingFaceAuth",     // 8
+  // "src/components/shared/Authentication",      // 9
+  // "src/components/shared/GitHubLibrary",       // 9
+
+  // 11-20 useCallback/useMemo
+  // "src/components/ui",                         // 12
+  // "src/components/PipelineRun",                // 14
+  // "src/components/shared/ManageComponent",     // 15
+  // "src/components/shared/Submitters",          // 16
+
+  // 20+ useCallback/useMemo - significant cleanup needed
+  // "src/components/shared/Dialogs",             // 31
+  // "src/hooks",                                 // 53
+  // "src/providers",                             // 75
+  // "src/components/shared/ReactFlow",           // 190
 ];
 
 // Convert to glob patterns for ESLint


### PR DESCRIPTION
## Description

Updated the React Compiler configuration file with a structured roadmap for incremental adoption. The config now includes clearly marked enabled directories and commented placeholders for future directories to be enabled as they are cleaned up for compiler compatibility. The structure is organized by component categories, hooks, providers, and routes.

Also fixed a minor formatting issue in the OutputNameEditor component by adding a space in an empty function.



If you have callback or memo, the linter will warn. You can see that here  
  


## ![Screenshot 2025-12-06 at 1.25.32 PM.png](https://app.graphite.com/user-attachments/assets/e21768e7-c6e8-484c-9745-75dfe7101442.png)

##   
Here is a screenshot of the linter passing  
  
![Screenshot 2025-12-06 at 1.27.14 PM.png](https://app.graphite.com/user-attachments/assets/1ad4044b-8c58-4739-877e-03798a60ce17.png)



## Type of Change

- [x] Improvement
- [x] Cleanup/Refactor

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Test Instructions

1. Verify that the React Compiler still works correctly with the enabled directories
2. Confirm that the OutputNameEditor component functions as expected