### PR TITLE
Enable React Compiler for CodeViewer, FullscreenElement, and CopyText components

### DIFF
--- a/react-compiler.config.js
+++ b/react-compiler.config.js
@@ -16,9 +16,9 @@ export const REACT_COMPILER_ENABLED_DIRS = [
   "src/components/shared/Status",
 
   // 2-5 useCallback/useMemo
-  // "src/components/shared/CodeViewer",          // 2
-  // "src/components/shared/FullscreenElement",   // 2
-  // "src/components/shared/CopyText",            // 3
+  "src/components/shared/CodeViewer", // 2
+  "src/components/shared/FullscreenElement", // 2
+  "src/components/shared/CopyText", // 3
   // "src/components/shared/TaskDetails",         // 4
   // "src/components/shared/GitHubAuth",          // 5
 

--- a/src/components/shared/CodeViewer/CodeViewer.tsx
+++ b/src/components/shared/CodeViewer/CodeViewer.tsx
@@ -1,5 +1,5 @@
 import { FileCode2, Maximize2, X as XIcon } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
@@ -26,9 +26,9 @@ const CodeViewer = ({
   const [isFullscreen, setIsFullscreen] = useState(false);
   const shouldRenderInlineCode = showInlineContent || isFullscreen;
 
-  const handleEnterFullscreen = useCallback(() => {
+  const handleEnterFullscreen = () => {
     setIsFullscreen((prev) => !prev);
-  }, []);
+  };
 
   const compactButton = (
     <TooltipButton

--- a/src/components/shared/CopyText/CopyText.tsx
+++ b/src/components/shared/CopyText/CopyText.tsx
@@ -1,4 +1,4 @@
-import { type MouseEvent, useCallback, useEffect, useState } from "react";
+import { type MouseEvent, useEffect, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
@@ -21,10 +21,10 @@ export const CopyText = ({
   const [isCopied, setIsCopied] = useState(false);
   const [isHovered, setIsHovered] = useState(false);
 
-  const handleCopy = useCallback(() => {
+  const handleCopy = () => {
     copyToClipboard(children);
     setIsCopied(true);
-  }, [children]);
+  };
 
   useEffect(() => {
     if (isCopied) {
@@ -35,13 +35,10 @@ export const CopyText = ({
     }
   }, [isCopied]);
 
-  const handleButtonClick = useCallback(
-    (e: MouseEvent) => {
-      e.stopPropagation();
-      handleCopy();
-    },
-    [handleCopy],
-  );
+  const handleButtonClick = (e: MouseEvent) => {
+    e.stopPropagation();
+    handleCopy();
+  };
 
   return (
     <div

--- a/src/components/shared/FullscreenElement/FullscreenElement.tsx
+++ b/src/components/shared/FullscreenElement/FullscreenElement.tsx
@@ -2,7 +2,6 @@ import {
   type PropsWithChildren,
   type RefObject,
   useEffect,
-  useMemo,
   useRef,
 } from "react";
 import { createPortal } from "react-dom";
@@ -54,9 +53,7 @@ function FullscreenElementPortal({
     };
   }, [fullscreen, defaultMountElement]);
 
-  const fragment = useMemo(() => <>{children}</>, [children]);
-
-  return createPortal(fragment, containerElementRef.current, id.current);
+  return createPortal(<>{children}</>, containerElementRef.current, id.current);
 }
 
 export function FullscreenElement({


### PR DESCRIPTION
## Description

Enabled React Compiler for three shared components with low complexity (2-3 useCallback/useMemo):
- `src/components/shared/CodeViewer`
- `src/components/shared/FullscreenElement`
- `src/components/shared/CopyText`

Removed unnecessary `useCallback` and `useMemo` hooks from these components as they're no longer needed with the React Compiler optimization.

## Type of Change

- [x] Improvement
- [x] Performance optimization

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Test Instructions

1. Verify that the CodeViewer, FullscreenElement, and CopyText components function correctly
2. Check that the React Compiler is properly optimizing these components