### PR TITLE
Enable React Compiler for TaskDetails and GitHubAuth components

### DIFF
--- a/react-compiler.config.js
+++ b/react-compiler.config.js
@@ -19,8 +19,8 @@ export const REACT_COMPILER_ENABLED_DIRS = [
   "src/components/shared/CodeViewer", // 2
   "src/components/shared/FullscreenElement", // 2
   "src/components/shared/CopyText", // 3
-  // "src/components/shared/TaskDetails",         // 4
-  // "src/components/shared/GitHubAuth",          // 5
+  "src/components/shared/TaskDetails", // 4
+  "src/components/shared/GitHubAuth", // 5
 
   // 6-10 useCallback/useMemo
   // "src/routes",                                // 6

--- a/src/components/shared/GitHubAuth/useGitHubAuthPopup.ts
+++ b/src/components/shared/GitHubAuth/useGitHubAuthPopup.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import type { OasisAuthResponse } from "@/components/shared/Authentication/types";
 import { APP_ROUTES } from "@/routes/router";
@@ -70,7 +70,20 @@ export function useGitHubAuthPopup({
   const popupRef = useRef<Window | null>(null);
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
 
-  const openPopup = useCallback(() => {
+  const closePopup = () => {
+    setIsLoading(false);
+
+    if (popupRef.current) {
+      popupRef.current.close();
+    }
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+    }
+    setIsPopupOpen(false);
+    onClose?.();
+  };
+
+  const openPopup = () => {
     if (popupRef.current && !popupRef.current.closed) {
       popupRef.current.focus();
       return;
@@ -137,26 +150,13 @@ export function useGitHubAuthPopup({
         // We'll continue monitoring until popup closes or returns to our domain
       }
     }, 1000);
-  }, [onError, onSuccess, onClose]);
+  };
 
-  const closePopup = useCallback(() => {
-    setIsLoading(false);
-
-    if (popupRef.current) {
-      popupRef.current.close();
-    }
-    if (intervalRef.current) {
-      clearInterval(intervalRef.current);
-    }
-    setIsPopupOpen(false);
-    onClose?.();
-  }, [onClose]);
-
-  const bringPopupToFront = useCallback(() => {
+  const bringPopupToFront = () => {
     if (popupRef.current && !popupRef.current.closed) {
       popupRef.current.focus();
     }
-  }, []);
+  };
 
   useEffect(() => {
     /**
@@ -185,14 +185,11 @@ export function useGitHubAuthPopup({
     };
   }, []);
 
-  return useMemo(
-    () => ({
-      isPopupOpen,
-      isLoading,
-      openPopup,
-      closePopup,
-      bringPopupToFront,
-    }),
-    [isPopupOpen, isLoading, openPopup, closePopup, bringPopupToFront],
-  );
+  return {
+    isPopupOpen,
+    isLoading,
+    openPopup,
+    closePopup,
+    bringPopupToFront,
+  };
 }

--- a/src/components/shared/TaskDetails/Details.tsx
+++ b/src/components/shared/TaskDetails/Details.tsx
@@ -4,7 +4,7 @@ import {
   DownloadIcon,
   TrashIcon,
 } from "lucide-react";
-import { type ReactNode, useCallback, useState } from "react";
+import { type ReactNode, useState } from "react";
 import { FaPython } from "react-icons/fa";
 
 import { Button } from "@/components/ui/button";
@@ -129,7 +129,7 @@ const TaskDetails = ({
     );
   };
 
-  const handleDelete = useCallback(() => {
+  const handleDelete = () => {
     if (confirmDelete || !hasDeletionConfirmation) {
       try {
         onDelete?.();
@@ -139,7 +139,7 @@ const TaskDetails = ({
     } else if (hasDeletionConfirmation) {
       setConfirmDelete(true);
     }
-  }, [onDelete, confirmDelete, hasDeletionConfirmation]);
+  };
 
   return (
     <div className="h-full overflow-auto hide-scrollbar">

--- a/src/components/shared/TaskDetails/Implementation.tsx
+++ b/src/components/shared/TaskDetails/Implementation.tsx
@@ -1,5 +1,3 @@
-import { useMemo } from "react";
-
 import { CodeViewer } from "@/components/shared/CodeViewer";
 import type { ComponentSpec } from "@/utils/componentSpec";
 import { componentSpecToText } from "@/utils/yaml";
@@ -15,10 +13,7 @@ const TaskImplementation = ({
   componentSpec,
   showInlineContent = true,
 }: TaskImplementationProps) => {
-  const code = useMemo(
-    () => componentSpecToText(componentSpec),
-    [componentSpec],
-  );
+  const code = componentSpecToText(componentSpec);
 
   if (!componentSpec?.implementation) {
     return (


### PR DESCRIPTION
## Description

Enable React Compiler for `TaskDetails` and `GitHubAuth` components by uncommenting their entries in the configuration file. Remove unnecessary `useCallback` and `useMemo` hooks from these components since the React Compiler will handle optimizations automatically.

## Type of Change

- [x] Improvement
- [x] Performance optimization

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Test Instructions

1. Verify that GitHub authentication still works correctly
2. Check that task details are displayed properly
3. Confirm that component performance remains optimal after removing explicit memoization