### PR TITLE
Fix: Standardize interface formatting across components

### DIFF
--- a/docs/react-best-practices.md
+++ b/docs/react-best-practices.md
@@ -716,7 +716,8 @@ const cardVariants = cva(
 );
 
 interface CardProps
-  extends React.HTMLAttributes<HTMLDivElement>,
+  extends
+    React.HTMLAttributes<HTMLDivElement>,
     VariantProps<typeof cardVariants> {}
 
 export function Card({ className, padding, variant, ...props }: CardProps) {

--- a/src/components/shared/ManageComponent/ComponentHistoryTimeline.tsx
+++ b/src/components/shared/ManageComponent/ComponentHistoryTimeline.tsx
@@ -84,8 +84,8 @@ export const ComponentHistoryTimeline = withSuspenseWrapper(
 
     const isPotentiallyOutdated = Boolean(
       history.length > 0 &&
-        history.find((c) => c.digest === currentComponent.digest) !==
-          history[history.length - 1],
+      history.find((c) => c.digest === currentComponent.digest) !==
+        history[history.length - 1],
     );
 
     const isPotentialNewRelease =

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -44,8 +44,7 @@ const buttonVariants = cva(
 );
 
 interface ButtonProps
-  extends React.ComponentProps<"button">,
-    VariantProps<typeof buttonVariants> {
+  extends React.ComponentProps<"button">, VariantProps<typeof buttonVariants> {
   asChild?: boolean;
 }
 

--- a/src/components/ui/layout.tsx
+++ b/src/components/ui/layout.tsx
@@ -40,8 +40,7 @@ const blockStackVariants = cva("flex flex-col w-full", {
 });
 
 interface BlockStackProps
-  extends AriaAttributes,
-    VariantProps<typeof blockStackVariants> {
+  extends AriaAttributes, VariantProps<typeof blockStackVariants> {
   /** HTML Element type
    * @default 'div'
    */
@@ -115,8 +114,7 @@ const inlineStackVariants = cva("flex flex-row", {
 });
 
 interface InlineStackProps
-  extends AriaAttributes,
-    VariantProps<typeof inlineStackVariants> {
+  extends AriaAttributes, VariantProps<typeof inlineStackVariants> {
   /** HTML Element type
    * @default 'div'
    */

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -37,8 +37,9 @@ function TooltipTrigger({
 }
 
 // CUSTOM PROPS FROM THE TANGLE DEV TEAM
-interface TooltipContentProps
-  extends React.ComponentProps<typeof TooltipPrimitive.Content> {
+interface TooltipContentProps extends React.ComponentProps<
+  typeof TooltipPrimitive.Content
+> {
   arrowClassName?: string;
 }
 

--- a/src/components/ui/typography.tsx
+++ b/src/components/ui/typography.tsx
@@ -50,8 +50,7 @@ const textVariants = cva("", {
 });
 
 interface TextProps
-  extends PropsWithChildren<AriaAttributes>,
-    VariantProps<typeof textVariants> {
+  extends PropsWithChildren<AriaAttributes>, VariantProps<typeof textVariants> {
   /**
    * The role of the text element.
    * @default 'text'

--- a/src/providers/ComponentLibraryProvider/types.ts
+++ b/src/providers/ComponentLibraryProvider/types.ts
@@ -22,8 +22,8 @@ export function isValidFilterRequest(
 ): filter is ContentfulFilterRequest {
   return Boolean(
     isContentfulFilterRequest(filter) &&
-      filter.searchTerm.trim().length >= (options?.minLength ?? 1) &&
-      (!options.includesFilter ||
-        filter.filters.includes(options.includesFilter)),
+    filter.searchTerm.trim().length >= (options?.minLength ?? 1) &&
+    (!options.includesFilter ||
+      filter.filters.includes(options.includesFilter)),
   );
 }

--- a/src/utils/componentSpec.ts
+++ b/src/utils/componentSpec.ts
@@ -207,9 +207,9 @@ export function isNotMaterializedComponentReference(
 ): componentReference is NotMaterializedComponentReference {
   return Boolean(
     componentReference &&
-      typeof componentReference === "object" &&
-      !componentReference.spec &&
-      !componentReference.text,
+    typeof componentReference === "object" &&
+    !componentReference.spec &&
+    !componentReference.text,
   );
 }
 
@@ -228,9 +228,9 @@ export function isDiscoverableComponentReference(
 ): componentReference is DiscoverableComponentReference {
   return Boolean(
     componentReference &&
-      typeof componentReference === "object" &&
-      componentReference.digest !== undefined &&
-      componentReference.digest.length > 0,
+    typeof componentReference === "object" &&
+    componentReference.digest !== undefined &&
+    componentReference.digest.length > 0,
   );
 }
 
@@ -243,9 +243,9 @@ export function isLoadableComponentReference(
 ): componentReference is LoadableComponentReference {
   return Boolean(
     componentReference &&
-      typeof componentReference === "object" &&
-      componentReference.url !== undefined &&
-      componentReference.url.length > 0,
+    typeof componentReference === "object" &&
+    componentReference.url !== undefined &&
+    componentReference.url.length > 0,
   );
 }
 
@@ -262,11 +262,11 @@ export function isContentfulComponentReference(
 ): componentReference is ContentfulComponentReference {
   return Boolean(
     componentReference &&
-      typeof componentReference === "object" &&
-      componentReference.spec !== undefined &&
-      componentReference.text !== undefined &&
-      isValidComponentSpec(componentReference.spec) &&
-      componentReference.text.length > 0,
+    typeof componentReference === "object" &&
+    componentReference.spec !== undefined &&
+    componentReference.text !== undefined &&
+    isValidComponentSpec(componentReference.spec) &&
+    componentReference.text.length > 0,
   );
 }
 
@@ -280,10 +280,10 @@ export function isTextOnlyComponentReference(
 ): componentReference is TextOnlyComponentReference {
   return Boolean(
     componentReference &&
-      typeof componentReference === "object" &&
-      !componentReference.spec &&
-      componentReference.text !== undefined &&
-      componentReference.text.length > 0,
+    typeof componentReference === "object" &&
+    !componentReference.spec &&
+    componentReference.text !== undefined &&
+    componentReference.text.length > 0,
   );
 }
 
@@ -297,10 +297,10 @@ export function isSpecOnlyComponentReference(
 ): componentReference is SpecOnlyComponentReference {
   return Boolean(
     componentReference &&
-      typeof componentReference === "object" &&
-      componentReference.spec !== undefined &&
-      isValidComponentSpec(componentReference.spec) &&
-      (!componentReference.text || componentReference.text.length === 0),
+    typeof componentReference === "object" &&
+    componentReference.spec !== undefined &&
+    isValidComponentSpec(componentReference.spec) &&
+    (!componentReference.text || componentReference.text.length === 0),
   );
 }
 
@@ -313,7 +313,7 @@ export function isPartialContentfulComponentReference(
 ): componentReference is PartialContentfulComponentReference {
   return Boolean(
     isTextOnlyComponentReference(componentReference) ||
-      isSpecOnlyComponentReference(componentReference),
+    isSpecOnlyComponentReference(componentReference),
   );
 }
 
@@ -322,15 +322,15 @@ export function isHydratedComponentReference(
 ): componentReference is HydratedComponentReference {
   return Boolean(
     componentReference &&
-      typeof componentReference === "object" &&
-      componentReference.spec !== undefined &&
-      componentReference.text !== undefined &&
-      isValidComponentSpec(componentReference.spec) &&
-      componentReference.text.length > 0 &&
-      componentReference.digest !== undefined &&
-      componentReference.digest.length > 0 &&
-      componentReference.name !== undefined &&
-      componentReference.name.length > 0,
+    typeof componentReference === "object" &&
+    componentReference.spec !== undefined &&
+    componentReference.text !== undefined &&
+    isValidComponentSpec(componentReference.spec) &&
+    componentReference.text.length > 0 &&
+    componentReference.digest !== undefined &&
+    componentReference.digest.length > 0 &&
+    componentReference.name !== undefined &&
+    componentReference.name.length > 0,
   );
 }
 
@@ -346,11 +346,11 @@ export function isInvalidComponentReference(
 ): componentReference is InvalidComponentReference {
   return Boolean(
     !componentReference ||
-      typeof componentReference !== "object" ||
-      (!isLoadableComponentReference(componentReference) &&
-        !isDiscoverableComponentReference(componentReference) &&
-        !componentReference.spec &&
-        !componentReference.text),
+    typeof componentReference !== "object" ||
+    (!isLoadableComponentReference(componentReference) &&
+      !isDiscoverableComponentReference(componentReference) &&
+      !componentReference.spec &&
+      !componentReference.text),
   );
 }
 
@@ -367,9 +367,9 @@ export function isDisplayableComponentReference(
 ): componentReference is DisplayableComponentReference {
   return Boolean(
     componentReference &&
-      typeof componentReference === "object" &&
-      componentReference.digest !== undefined &&
-      componentReference.name !== undefined,
+    typeof componentReference === "object" &&
+    componentReference.digest !== undefined &&
+    componentReference.name !== undefined,
   );
 }
 

--- a/src/utils/componentStore.ts
+++ b/src/utils/componentStore.ts
@@ -274,8 +274,7 @@ interface FileEntry {
 }
 
 interface ComponentFileEntryV3
-  extends FileEntry,
-    ComponentReferenceWithSpecPlusData {}
+  extends FileEntry, ComponentReferenceWithSpecPlusData {}
 
 export type ComponentFileEntry = ComponentFileEntryV3;
 

--- a/src/utils/subgraphUtils.ts
+++ b/src/utils/subgraphUtils.ts
@@ -28,7 +28,7 @@ export const isSubgraph = (
   if ("componentRef" in input) {
     return Boolean(
       input.componentRef.spec &&
-        isGraphImplementation(input.componentRef.spec.implementation),
+      isGraphImplementation(input.componentRef.spec.implementation),
     );
   }
 


### PR DESCRIPTION
## Description

This is the result of running `npm run validate`.


Standardized interface formatting across the codebase by adjusting line breaks in interface extensions. This PR ensures consistent formatting for multi-line interface declarations, particularly for components that extend multiple interfaces like `VariantProps` and React HTML attributes.

## Type of Change

- [x] Cleanup/Refactor

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Additional Comments

This is a purely cosmetic change to improve code readability and maintain consistent formatting standards throughout the codebase. No functional changes were made.