### PR TITLE
Fix status reporting for subgraphs and improve status display consistency

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/StatusIndicator.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/StatusIndicator.tsx
@@ -93,12 +93,17 @@ const getStatusMetadata = (status: ContainerExecutionStatus | RunStatus) => {
         text: "Queued",
         icon: <ClockIcon className="w-2 h-2 animate-spin duration-2000" />,
       };
-    case "WAITING":
-    case "UNINITIALIZED":
     case "WAITING_FOR_UPSTREAM":
       return {
         style: "bg-slate-500",
         text: "Waiting for upstream",
+        icon: <ClockIcon className="w-2 h-2 animate-spin duration-2000" />,
+      };
+    case "WAITING":
+    case "UNINITIALIZED":
+      return {
+        style: "bg-yellow-500",
+        text: "Pending",
         icon: <ClockIcon className="w-2 h-2 animate-spin duration-2000" />,
       };
     default:

--- a/src/components/shared/Status/StatusIcon.tsx
+++ b/src/components/shared/Status/StatusIcon.tsx
@@ -57,10 +57,14 @@ const Icon = ({ status }: { status?: string }) => {
     case "STARTING":
       return <RefreshCw className="w-4 h-4 text-blue-500 animate-spin" />;
     case "PENDING":
+    case "QUEUED":
       return <RefreshCw className="w-4 h-4 text-yellow-500 animate-spin" />;
     case "CANCELLING":
       return <CircleX className="w-4 h-4 text-orange-500 animate-pulse" />;
     case "WAITING":
+    case "UNINITIALIZED":
+      return <CircleEllipsis className="w-4 h-4 text-yellow-500" />;
+    case "WAITING_FOR_UPSTREAM":
       return <CircleEllipsis className="w-4 h-4 text-gray-500" />;
     case "SKIPPED":
       return <CircleMinus className="w-4 h-4 text-gray-500" />;

--- a/src/components/shared/Status/StatusText.tsx
+++ b/src/components/shared/Status/StatusText.tsx
@@ -1,6 +1,19 @@
 import { cn } from "@/lib/utils";
 import type { TaskStatusCounts } from "@/types/pipelineRun";
 
+const STATUS_COLORS: Record<string, string> = {
+  succeeded: "text-green-500",
+  failed: "text-red-500",
+  running: "text-blue-500",
+  skipped: "text-gray-800",
+  waiting: "text-yellow-600",
+  cancelled: "text-gray-800",
+};
+
+const STATUS_DISPLAY_NAMES: Record<string, string> = {
+  waiting: "pending",
+};
+
 const StatusText = ({
   statusCounts,
   shorthand,
@@ -16,23 +29,14 @@ const StatusText = ({
       )}
     >
       {Object.entries(statusCounts).map(([key, count]) => {
-        if (key === "total") return;
+        if (key === "total" || count === 0) return null;
 
-        if (count === 0) return;
-
-        const statusColors: Record<string, string> = {
-          succeeded: "text-green-500",
-          failed: "text-red-500",
-          running: "text-blue-500",
-          skipped: "text-gray-800",
-          waiting: "text-gray-500",
-          cancelled: "text-gray-800",
-        };
+        const displayKey = STATUS_DISPLAY_NAMES[key] ?? key;
         const statusText = shorthand
-          ? `${key[0]}`
-          : `${key}${count > 1 ? " " : ""}`;
+          ? `${displayKey[0]}`
+          : `${displayKey}${count > 1 ? " " : ""}`;
 
-        const statusColor = statusColors[key];
+        const statusColor = STATUS_COLORS[key];
 
         if (shorthand) {
           return (

--- a/src/components/shared/Status/TaskStatusBar.tsx
+++ b/src/components/shared/Status/TaskStatusBar.tsx
@@ -60,7 +60,7 @@ const TaskStatusBar = ({
       )}
       {waiting > 0 && (
         <div
-          className="bg-gray-200"
+          className="bg-yellow-500"
           style={getSegmentStyle(waitingWidth, hatched)}
         ></div>
       )}


### PR DESCRIPTION
## Summary

Fixes incorrect status reporting for subgraphs and improves the consistency of status display across the UI.



NOTE: This goes back to some of the colours we previously had, that were changed as a mistake.

## Problem

1. **Subgraph status was incorrectly calculated** - When a subgraph had multiple tasks with different statuses (e.g., 2 succeeded, 1 running), the code only looked at the first status key from the stats object, leading to unpredictable/wrong status reporting.
2. **"Waiting" vs "Waiting for upstream" confusion** - All pending states (`WAITING`, `UNINITIALIZED`, `WAITING_FOR_UPSTREAM`) were displayed as "Waiting for upstream", even when tasks were simply pending (not blocked by dependencies).
3. **CANCELLING mapped incorrectly** - Tasks being cancelled were mapped to "skipped" instead of "cancelled".
4. **Missing status icons** - `QUEUED`, `UNINITIALIZED`, and `WAITING_FOR_UPSTREAM` fell through to unknown/default icon.

## Solution

### Subgraph status aggregation

Changed `countTaskStatuses()` to properly aggregate child statuses using priority:

### Status display improvements

| Status | Before | After |
| --- | --- | --- |
| `WAITING` | "Waiting for upstream" (gray) | **"Pending"** (yellow) |
| `WAITING_FOR_UPSTREAM` | "Waiting for upstream" (gray) | "Waiting for upstream" (gray) |
| `CANCELLING` | mapped to "skipped" | mapped to **"cancelled"** |
| Status bar (waiting) | Gray (invisible) | Yellow |
| Status text | "1 waiting" | "1 pending" |

### Code quality

- Moved `STATUS_COLORS` constant outside component (was recreated every render)
- Added missing API status handlers to `StatusIcon`
- Added JSDoc explaining the aggregation priority

## Files Changed

- `executionService.ts` - Fixed subgraph aggregation logic, fixed CANCELLING mapping
- `StatusIndicator.tsx` - Split WAITING from WAITING_FOR_UPSTREAM display
- `StatusText.tsx` - Display "pending" instead of "waiting", moved constants
- `TaskStatusBar.tsx` - Yellow colour for pending segment
- `StatusIcon.tsx` - Added missing status handlers

## Testing

- Verified subgraph with mixed statuses shows correct aggregate
- Verified "Pending" displays for tasks not yet running
- Verified "Waiting for upstream" displays for blocked tasks