### PR TITLE
fix: trigger yaml generation on options changed in python component editor

### DIFF
--- a/src/components/shared/ComponentEditor/components/PythonComponentEditor.tsx
+++ b/src/components/shared/ComponentEditor/components/PythonComponentEditor.tsx
@@ -70,12 +70,10 @@ export const PythonComponentEditor = withSuspenseWrapper(
       preservedNameRef.current = initialComponentName;
     }, [initialComponentName]);
 
-    const handleFunctionTextChange = useCallback(
-      async (value: string | undefined) => {
-        const code = value ?? "";
-        setPythonCode(code);
+    const generateYaml = useCallback(
+      async (code: string, options: YamlGeneratorOptions) => {
         try {
-          const yaml = await yamlGenerator(code, yamlGeneratorOptions);
+          const yaml = await yamlGenerator(code, options);
           const yamlWithPreservedName = preserveComponentName(
             yaml,
             preservedNameRef.current,
@@ -92,17 +90,29 @@ export const PythonComponentEditor = withSuspenseWrapper(
           setValidationErrors(errors);
         }
       },
-      [
-        yamlGenerator,
-        onComponentTextChange,
-        onErrorsChange,
-        yamlGeneratorOptions,
-      ],
+      [yamlGenerator, onComponentTextChange, onErrorsChange],
+    );
+
+    const handleFunctionTextChange = useCallback(
+      async (value: string | undefined) => {
+        const code = value ?? "";
+        setPythonCode(code);
+        generateYaml(code, yamlGeneratorOptions);
+      },
+      [generateYaml, yamlGeneratorOptions],
+    );
+
+    const handleOptionsChange = useCallback(
+      (options: YamlGeneratorOptions) => {
+        setYamlGeneratorOptions(options);
+        generateYaml(pythonCode, options);
+      },
+      [pythonCode, generateYaml],
     );
 
     useEffect(() => {
       // first time loading
-      handleFunctionTextChange(text);
+      generateYaml(text, options);
     }, []);
 
     return (
@@ -138,7 +148,7 @@ export const PythonComponentEditor = withSuspenseWrapper(
             >
               <YamlGeneratorOptionsEditor
                 initialOptions={yamlGeneratorOptions}
-                onChange={setYamlGeneratorOptions}
+                onChange={handleOptionsChange}
               />
             </TabsContent>
           </Tabs>


### PR DESCRIPTION
## Description

Closes https://github.com/TangleML/tangle-ui/issues/1504

Refactored the Python component editor to separate YAML generation logic from UI event handling. Created a dedicated `generateYaml` function that handles the YAML generation process, which is now reused by both the text change handler and the new options change handler. This ensures that when either the code or options change, the YAML is regenerated consistently.

## Type of Change

- [x] Improvement
- [x] Cleanup/Refactor

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions<img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/7b00c136-9e04-4e44-93e1-70e4138b1f4f.mov">

Video: https://app.graphite.com/user-attachments/video/7b00c136-9e04-4e44-93e1-70e4138b1f4f.mov 

1. Open the Python component editor
2. Modify Python code and verify YAML updates correctly
3. Change YAML generator options and confirm YAML updates immediately without requiring code changes