### PR TITLE
Truncates run name on homepage

### DIFF
--- a/src/components/Home/RunSection/RunRow.tsx
+++ b/src/components/Home/RunSection/RunRow.tsx
@@ -78,7 +78,7 @@ const RunRow = ({ run }: { run: PipelineRunResponse }) => {
     >
       <TableCell className="text-sm flex items-center gap-2">
         <StatusIcon status={getRunStatus(statusCounts)} />
-        <Paragraph>{name}</Paragraph>
+        <Paragraph className="truncate max-w-[400px]" title={name}>{name}</Paragraph>
         <span>{`#${runId}`}</span>
       </TableCell>
       <TableCell>

--- a/src/components/ui/typography.tsx
+++ b/src/components/ui/typography.tsx
@@ -66,6 +66,9 @@ interface TextProps
    * @default ''
    */
   className?: string;
+
+  /** Native browser tooltip text */
+  title?: string;
 }
 
 /**


### PR DESCRIPTION
## Description

Added truncation to long pipeline run names in the RunRow component to prevent UI overflow. The name is now limited to a maximum width of 400px and displays a tooltip with the full name when hovered.

## Type of Change

- [x] Bug fix
- [x] Improvement

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Screenshots (if applicable)

Before

![Screenshot 2025-12-09 at 9.17.01 AM.png](https://app.graphite.com/user-attachments/assets/dd08a837-5290-45dd-8692-7644b2bbfa05.png)







After:

![Screenshot 2025-12-09 at 9.16.23 AM.png](https://app.graphite.com/user-attachments/assets/649dad66-1d28-4d8b-8d62-f8901bbdd3d7.png)

## Test Instructions

1. Create a pipeline run with a very long name
2. Verify that the name is truncated in the UI with an ellipsis
3. Hover over the truncated name to confirm the full name appears in a tooltip