### PR TITLE
Enable React Compiler for Settings components and remove unnecessary hooks

### DIFF
--- a/react-compiler.config.js
+++ b/react-compiler.config.js
@@ -23,9 +23,10 @@ export const REACT_COMPILER_ENABLED_DIRS = [
   "src/routes",
   "src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx",
   "src/components/shared/ComponentEditor",
+  "src/components/shared/Settings",
 
   // 6-10 useCallback/useMemo
-  // "src/components/shared/Settings",            // 6
+
   // "src/components/shared/HuggingFaceAuth",     // 8
 
   // "src/components/shared/GitHubLibrary",       // 9

--- a/src/components/shared/Settings/PersonalPreferencesDialog.tsx
+++ b/src/components/shared/Settings/PersonalPreferencesDialog.tsx
@@ -1,5 +1,3 @@
-import { useCallback } from "react";
-
 import { ExistingBetaFlags } from "@/betaFlags";
 import { Button } from "@/components/ui/button";
 import {
@@ -26,12 +24,9 @@ export function PersonalPreferencesDialog({
 }: PersonalPreferencesDialogProps) {
   const [betaFlags, dispatch] = useBetaFlagsReducer(ExistingBetaFlags);
 
-  const handleSetFlag = useCallback(
-    (flag: string, enabled: boolean) => {
-      dispatch({ type: "setFlag", payload: { key: flag, enabled } });
-    },
-    [dispatch],
-  );
+  const handleSetFlag = (flag: string, enabled: boolean) => {
+    dispatch({ type: "setFlag", payload: { key: flag, enabled } });
+  };
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>

--- a/src/components/shared/Settings/useBetaFlagReducer.ts
+++ b/src/components/shared/Settings/useBetaFlagReducer.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useReducer } from "react";
+import { useEffect, useReducer } from "react";
 
 import type { BetaFlag, BetaFlags } from "@/types/betaFlags";
 
@@ -27,7 +27,7 @@ export function useBetaFlagsReducer(betaFlags: BetaFlags) {
       .forEach((flag) => removeFlag(flag));
   }, [betaFlags, getFlags, removeFlag]);
 
-  const reducer = useCallback((state: State, action: Action) => {
+  const reducer = (state: State, action: Action) => {
     switch (action.type) {
       case "setFlag":
         setFlag(action.payload.key, action.payload.enabled);
@@ -40,7 +40,7 @@ export function useBetaFlagsReducer(betaFlags: BetaFlags) {
       default:
         return state;
     }
-  }, []);
+  };
 
   return useReducer(
     reducer,


### PR DESCRIPTION
## Description

Added the Settings directory to the React Compiler enabled directories and optimized the Settings components by removing unnecessary `useCallback` and `useMemo` hooks. This change simplifies the code in `PersonalPreferencesDialog.tsx`, `useBetaFlagReducer.ts`, and `useBetaFlags.ts` while maintaining the same functionality. Also includes minor formatting fixes in the ComponentEditor files.

## Type of Change

- [x] Improvement
- [x] Cleanup/Refactor

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Test Instructions

1. Open the Settings dialog and verify that all beta flags can be toggled correctly
2. Confirm that beta flag state persists between page refreshes
3. Verify that the ComponentEditor still functions properly