### PR TITLE
React compiler for huggingfaceauth

### DIFF
--- a/react-compiler.config.js
+++ b/react-compiler.config.js
@@ -24,10 +24,9 @@ export const REACT_COMPILER_ENABLED_DIRS = [
   "src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx",
   "src/components/shared/ComponentEditor",
   "src/components/shared/Settings",
+  "src/components/shared/HuggingFaceAuth",
 
   // 6-10 useCallback/useMemo
-
-  // "src/components/shared/HuggingFaceAuth",     // 8
 
   // "src/components/shared/GitHubLibrary",       // 9
 

--- a/src/components/shared/HuggingFaceAuth/HuggingFaceAuthButton.tsx
+++ b/src/components/shared/HuggingFaceAuth/HuggingFaceAuthButton.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from "react";
+import { useEffect } from "react";
 
 import type { JWTPayload } from "@/components/shared/Authentication/types";
 import { useAuthLocalStorage } from "@/components/shared/Authentication/useAuthLocalStorage";
@@ -48,9 +48,9 @@ const HuggingFaceAuthButtonComponent = withSuspenseWrapper(
     const { awaitAuthorization, isLoading, isAuthorized } =
       useAwaitAuthorization();
 
-    const signIn = useCallback(async () => {
+    const signIn = async () => {
       await awaitAuthorization();
-    }, [awaitAuthorization]);
+    };
 
     useSyncAuthStorageWithUserDetails();
 

--- a/src/components/shared/HuggingFaceAuth/useHuggingFaceAuthPopup.ts
+++ b/src/components/shared/HuggingFaceAuth/useHuggingFaceAuthPopup.ts
@@ -1,12 +1,5 @@
 import { useQueryClient } from "@tanstack/react-query";
-import {
-  useCallback,
-  useEffect,
-  useEffectEvent,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { useEffect, useEffectEvent, useRef, useState } from "react";
 
 import type { GetUserResponse } from "@/api/types.gen";
 import type {
@@ -65,14 +58,14 @@ export function useHuggingFaceAuthPopup({
     }
   });
 
-  const closePopup = useCallback(() => {
+  const closePopup = () => {
     setIsLoading(false);
 
     cleanup();
 
     setIsPopupOpen(false);
     onClose?.();
-  }, [onClose]);
+  };
 
   const onErrorStateHandler = useEffectEvent((error: string) => {
     onError(error);
@@ -113,7 +106,7 @@ export function useHuggingFaceAuthPopup({
    *
    * Therefore, we need to poll the authorization info from the API instead of using "message" based communication.
    */
-  const openPopup = useCallback(() => {
+  const openPopup = () => {
     // todo: prevent opening multiple popups
     setIsLoading(true);
 
@@ -132,26 +125,23 @@ export function useHuggingFaceAuthPopup({
     // todo: timeout if popup is not closed after 10 seconds
 
     setIsPopupOpen(true);
-  }, [pollAuthorizationInfo]);
+  };
 
   useEffect(() => {
     return () => cleanup();
   }, []);
 
-  const bringPopupToFront = useCallback(() => {
+  const bringPopupToFront = () => {
     // no-op
-  }, []);
+  };
 
-  return useMemo(
-    () => ({
-      isPopupOpen,
-      isLoading,
-      openPopup,
-      closePopup,
-      bringPopupToFront,
-    }),
-    [isPopupOpen, isLoading, openPopup, closePopup, bringPopupToFront],
-  );
+  return {
+    isPopupOpen,
+    isLoading,
+    openPopup,
+    closePopup,
+    bringPopupToFront,
+  };
 }
 
 function centerPopupOnDocument() {


### PR DESCRIPTION
## Description

Enable React Compiler for the HuggingFaceAuth component by uncommenting it in the config file and optimizing the component code. Removed unnecessary `useCallback` and `useMemo` hooks from `HuggingFaceAuthButton.tsx` and `useHuggingFaceAuthPopup.ts` to make the code more compatible with the React Compiler.

## Type of Change

- [x] Improvement
- [x] Cleanup/Refactor

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Test Instructions

1. Verify that HuggingFace authentication still works properly
2. Check that the login popup opens and closes correctly
3. Confirm that authentication state is properly maintained