### PR TITLE
Enable React Compiler for GitHubLibrary and remove unnecessary useCallback hooks

### DIFF
--- a/react-compiler.config.js
+++ b/react-compiler.config.js
@@ -25,10 +25,7 @@ export const REACT_COMPILER_ENABLED_DIRS = [
   "src/components/shared/ComponentEditor",
   "src/components/shared/Settings",
   "src/components/shared/HuggingFaceAuth",
-
-  // 6-10 useCallback/useMemo
-
-  // "src/components/shared/GitHubLibrary",       // 9
+  "src/components/shared/GitHubLibrary",
 
   // 11-20 useCallback/useMemo
   // "src/components/ui",                         // 12

--- a/src/components/shared/GitHubLibrary/ManageLibrariesDialog.tsx
+++ b/src/components/shared/GitHubLibrary/ManageLibrariesDialog.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -29,17 +29,17 @@ export function ManageLibrariesDialog({
     StoredLibrary | undefined
   >();
 
-  const handleDialogOpenChange = useCallback((open: boolean) => {
+  const handleDialogOpenChange = (open: boolean) => {
     setOpen(open);
     if (!open) {
       setMode("manage");
     }
-  }, []);
+  };
 
-  const handleUpdateLibrary = useCallback((library: StoredLibrary) => {
+  const handleUpdateLibrary = (library: StoredLibrary) => {
     setLibraryToUpdate(library);
     setMode("update");
-  }, []);
+  };
 
   const defaultTrigger = (
     <Button variant="ghost" size="sm">

--- a/src/components/shared/GitHubLibrary/components/AddGitHubLibraryDialogContent.tsx
+++ b/src/components/shared/GitHubLibrary/components/AddGitHubLibraryDialogContent.tsx
@@ -1,5 +1,5 @@
 import { useMutation } from "@tanstack/react-query";
-import { useCallback, useReducer, useState } from "react";
+import { useReducer, useState } from "react";
 
 import { ensureGithubLibrary } from "@/components/shared/GitHubLibrary/utils/ensureGithubLibrary";
 import { fetchGitHubFiles } from "@/components/shared/GitHubLibrary/utils/fetchGitHubFiles";
@@ -175,7 +175,7 @@ function ConfigureImport({
     },
   });
 
-  const handleSubmit = useCallback(async () => {
+  const handleSubmit = async () => {
     if (state.hasErrors) {
       notify("Please fill in all fields", "error");
       return;
@@ -184,7 +184,7 @@ function ConfigureImport({
     setProcessError(null);
 
     await importComponentsFromGitHubLibrary(state);
-  }, [importComponentsFromGitHubLibrary, state, notify]);
+  };
 
   return (
     <BlockStack

--- a/src/components/shared/GitHubLibrary/components/InputField.tsx
+++ b/src/components/shared/GitHubLibrary/components/InputField.tsx
@@ -1,4 +1,4 @@
-import { type ChangeEvent, type ReactNode, useCallback, useState } from "react";
+import { type ChangeEvent, type ReactNode, useState } from "react";
 
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -27,23 +27,20 @@ export const InputField = ({
 }: InputFieldProps) => {
   const [inputValue, setInputValue] = useState(value);
   const [error, setError] = useState<string[] | null>(null);
-  const handleChange = useCallback(
-    (e: ChangeEvent<HTMLInputElement>) => {
-      const value = e.target.value;
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
 
-      setInputValue(value);
+    setInputValue(value);
 
-      const validationErrors = validate(value);
-      setError(validationErrors);
+    const validationErrors = validate(value);
+    setError(validationErrors);
 
-      if (validationErrors && validationErrors.length > 0) {
-        onChange(null, validationErrors);
-      } else {
-        onChange(value, null);
-      }
-    },
-    [validate, onChange],
-  );
+    if (validationErrors && validationErrors.length > 0) {
+      onChange(null, validationErrors);
+    } else {
+      onChange(value, null);
+    }
+  };
 
   return (
     <BlockStack gap="2">

--- a/src/components/shared/GitHubLibrary/components/UpdateGitHubLibrary.tsx
+++ b/src/components/shared/GitHubLibrary/components/UpdateGitHubLibrary.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useCallback, useState } from "react";
+import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
@@ -55,14 +55,14 @@ export const UpdateGitHubLibrary = ({
     },
   });
 
-  const handleSubmit = useCallback(async () => {
+  const handleSubmit = async () => {
     if (state.hasErrors) {
       notify("Please fill in all fields", "error");
       return;
     }
 
     await updateGitHubLibrary(state.value);
-  }, [updateGitHubLibrary, state]);
+  };
 
   return (
     <BlockStack gap="2">


### PR DESCRIPTION
## Description

Enabled React Compiler for the GitHubLibrary component by adding it to the enabled directories list in the config file. Removed unnecessary `useCallback` hooks from various components in the GitHubLibrary folder, including:

- `ManageLibrariesDialog.tsx`: Removed `useCallback` from `handleDialogOpenChange` and `handleUpdateLibrary` functions
- `AddGitHubLibraryDialogContent.tsx`: Removed `useCallback` from `handleSubmit` function
- `InputField.tsx`: Removed `useCallback` from `handleChange` function
- `UpdateGitHubLibrary.tsx`: Removed `useCallback` from `handleSubmit` function

## Type of Change

- [x] Improvement
- [x] Cleanup/Refactor

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Test Instructions

Verify that the GitHubLibrary component and its related functionality continue to work as expected after enabling the React Compiler and removing the unnecessary `useCallback` hooks.