### PR TITLE
fix: do not remove underscore from pipelines names so they can be open properly

### DIFF
--- a/src/components/Home/PipelineSection/PipelineSection.tsx
+++ b/src/components/Home/PipelineSection/PipelineSection.tsx
@@ -214,7 +214,7 @@ export const PipelineSection = withSuspenseWrapper(() => {
             {filteredPipelines.map(([name, fileEntry]) => (
               <PipelineRow
                 key={fileEntry.componentRef.digest}
-                name={name.replace(/_/g, " ")}
+                name={name}
                 modificationTime={fileEntry.modificationTime}
                 onDelete={fetchUserPipelines}
                 isSelected={selectedPipelines.has(name)}


### PR DESCRIPTION
## Description

Closes https://github.com/Shopify/oasis-frontend/issues/392

Removed the underscore replacement in pipeline names displayed in the PipelineSection component. Pipeline names are now shown exactly as they are stored, preserving underscores instead of converting them to spaces.

## Related Issue and Pull requests

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [x] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions



1. [Screen Recording 2025-12-09 at 10.27.01 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/4b9dad8d-e505-4da2-87f5-26e0fae0d0b9.mov" />](https://app.graphite.com/user-attachments/video/4b9dad8d-e505-4da2-87f5-26e0fae0d0b9.mov)

    

    Create a Pipeline with name containing underscore (e.g. "test_pipeline_")
2. Navigate to the Pipeline Section on the Home page / My Pipelines
3. Verify that pipeline names with underscores now display the underscores correctly
4. Confirm that pipeline functionality (selection, deletion, etc.) works as expected with the updated name display
5. Confirm that the pipeline can be opened properly

## Additional Comments

This change ensures consistency between how pipeline names are stored and displayed throughout the application.