### PR TITLE
ci: check formatting rules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,24 @@ jobs:
       - name: Run linting
         run: npm run lint
 
+  format:
+    name: Formatting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check formatting
+        run: npx prettier --check .
+
   knip:
     name: Knip
     runs-on: ubuntu-latest

--- a/src/components/Home/RunSection/RunRow.tsx
+++ b/src/components/Home/RunSection/RunRow.tsx
@@ -78,7 +78,9 @@ const RunRow = ({ run }: { run: PipelineRunResponse }) => {
     >
       <TableCell className="text-sm flex items-center gap-2">
         <StatusIcon status={getRunStatus(statusCounts)} />
-        <Paragraph className="truncate max-w-[400px]" title={name}>{name}</Paragraph>
+        <Paragraph className="truncate max-w-[400px]" title={name}>
+          {name}
+        </Paragraph>
         <span>{`#${runId}`}</span>
       </TableCell>
       <TableCell>

--- a/tests/e2e/componentlib.spec.ts
+++ b/tests/e2e/componentlib.spec.ts
@@ -74,11 +74,10 @@ test.describe("Component Library", () => {
       page,
       "Inputs & Outputs",
     );
-    await expect(
-      inputsOutputsFolder
-        .getByRole("button")
-        ,
-    ).toHaveAttribute("aria-expanded", "false");
+    await expect(inputsOutputsFolder.getByRole("button")).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
     const inputsOutputsFolderContent = inputsOutputsFolder.locator("li");
 
     (await inputsOutputsFolderContent.all()).forEach(async (component) => {
@@ -88,11 +87,10 @@ test.describe("Component Library", () => {
     // expand the folder
     await openComponentLibFolder(page, "Inputs & Outputs");
 
-    await expect(
-      inputsOutputsFolder
-        .getByRole("button")
-        ,
-    ).toHaveAttribute("aria-expanded", "true");
+    await expect(inputsOutputsFolder.getByRole("button")).toHaveAttribute(
+      "aria-expanded",
+      "true",
+    );
 
     // expect only two components in the folder
     const components = inputsOutputsFolder.locator("li");
@@ -100,9 +98,10 @@ test.describe("Component Library", () => {
 
     await inputsOutputsFolder.getByRole("button").click();
 
-    await expect(
-      inputsOutputsFolder.getByRole("button"),
-    ).toHaveAttribute("aria-expanded", "false");
+    await expect(inputsOutputsFolder.getByRole("button")).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
   });
 
   test("user can navigate deep into the nested folders", async () => {
@@ -115,8 +114,7 @@ test.describe("Component Library", () => {
 
     const nestedFolder = await openComponentLibFolder(page, "XGBoost");
 
-    const nestedFolderContent =
-      nestedFolder.getByTestId("component-item");
+    const nestedFolderContent = nestedFolder.getByTestId("component-item");
     await expect(await nestedFolderContent).toHaveCount(4);
   });
 


### PR DESCRIPTION
## Description

Added a new formatting check to the CI workflow to ensure consistent code style. This PR introduces a Prettier check that runs as part of the CI pipeline to verify formatting compliance across the codebase. Additionally, fixed formatting issues in several files to comply with the new standards.

## Type of Change

- [x] Improvement
- [x] Cleanup/Refactor

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Test Instructions

1. Run `npx prettier --check .` locally to verify formatting
2. Observe the new "Formatting" job in the GitHub Actions workflow