### PR TITLE
fix: Component YAML - Improved the ComponentSpec to YAML serialization style

### DIFF
--- a/src/utils/yaml.ts
+++ b/src/utils/yaml.ts
@@ -50,12 +50,12 @@ export function componentSpecFromYaml(yamlText: string): ComponentSpec {
 }
 
 export const componentSpecToYaml = (componentSpec: ComponentSpec) => {
-  return yaml.dump(componentSpec, { lineWidth: 10000 });
+  return yaml.dump(componentSpec, { lineWidth: -1 });
 };
 
 export const componentSpecToText = (componentSpec: ComponentSpec) => {
   return yaml.dump(componentSpec, {
-    lineWidth: 80,
+    lineWidth: -1,
     noRefs: true,
     indent: 2,
   });


### PR DESCRIPTION
Making `js-yaml` never choose folded string serialization style (">"). We must use the literal style ("|") instead.

https://github.com/nodeca/js-yaml/blob/74a01992953302040be3277c08ba214a06f00b87/lib/dumper.js#L310

Fixes https://github.com/TangleML/tangle-ui/issues/1531

Before:
<img width="702" height="581" alt="image" src="https://github.com/user-attachments/assets/ffee8283-0f8c-45c2-80c5-af312c68c312" />

After:
<img width="702" height="436" alt="image" src="https://github.com/user-attachments/assets/c2b82ed0-6d49-40ac-8280-c351d750c94d" />


## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [x] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
