### PR TITLE
Rework Task Action Buttons into Action Framework

### DIFF
--- a/src/components/shared/Buttons/TooltipButton.tsx
+++ b/src/components/shared/Buttons/TooltipButton.tsx
@@ -8,7 +8,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 
-export interface TooltipButtonProps extends ButtonProps {
+interface TooltipButtonProps extends ButtonProps {
   tooltip: React.ReactNode;
   tooltipSide?: "top" | "right" | "bottom" | "left";
   tooltipAlign?: "start" | "center" | "end";

--- a/src/components/shared/ContextPanel/Blocks/ActionBlock.tsx
+++ b/src/components/shared/ContextPanel/Blocks/ActionBlock.tsx
@@ -21,7 +21,7 @@ export type Action = {
 );
 
 // Temporary: ReactNode included for backward compatibility with some existing buttons. In the long-term we should strive for only Action types.
-export type ActionOrReactNode = Action | ReactNode;
+type ActionOrReactNode = Action | ReactNode;
 
 interface ActionBlockProps {
   title?: string;

--- a/src/components/shared/Dialogs/ComponentDetailsDialog.tsx
+++ b/src/components/shared/Dialogs/ComponentDetailsDialog.tsx
@@ -17,8 +17,6 @@ import { useHydrateComponentReference } from "@/hooks/useHydrateComponentReferen
 import type { ComponentReference } from "@/utils/componentSpec";
 
 import InfoIconButton from "../Buttons/InfoIconButton";
-import TooltipButton from "../Buttons/TooltipButton";
-import { ComponentEditorDialog } from "../ComponentEditor/ComponentEditorDialog";
 import { ComponentFavoriteToggle } from "../FavoriteComponentToggle";
 import { InfoBox } from "../InfoBox";
 import { PublishComponent } from "../ManageComponent/PublishComponent";
@@ -32,7 +30,6 @@ interface ComponentDetailsProps {
   component: ComponentReference;
   displayName: string;
   trigger?: ReactNode;
-  actions?: ReactNode[];
   onClose?: () => void;
   onDelete?: () => void;
 }
@@ -64,12 +61,7 @@ const ComponentDetailsDialogContentSkeleton = () => {
 };
 
 const ComponentDetailsDialogContent = withSuspenseWrapper(
-  ({
-    component,
-    displayName,
-    actions = [],
-    onDelete,
-  }: ComponentDetailsProps) => {
+  ({ component, displayName, onDelete }: ComponentDetailsProps) => {
     const remoteComponentLibrarySearchEnabled = useBetaFlagValue(
       "remote-component-library-search",
     );
@@ -138,7 +130,6 @@ const ComponentDetailsDialogContent = withSuspenseWrapper(
                   componentRef={componentRef}
                   componentDigest={componentDigest}
                   url={url}
-                  actions={actions}
                   onDelete={onDelete}
                 />
               </TabsContent>
@@ -175,17 +166,11 @@ const ComponentDetails = ({
   component,
   displayName,
   trigger,
-  actions = [],
   onClose,
   onDelete,
 }: ComponentDetailsProps) => {
-  const hasEnabledInAppEditor = useBetaFlagValue("in-app-component-editor");
-
-  const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
   const [open, setOpen] = useState(false);
   const dialogTriggerButton = trigger || <InfoIconButton />;
-
-  const componentText = component.text;
 
   const dialogContextValue = useMemo(
     () => ({
@@ -197,10 +182,6 @@ const ComponentDetails = ({
     [],
   );
 
-  const handleCloseEditDialog = useCallback(() => {
-    setIsEditDialogOpen(false);
-  }, []);
-
   const onOpenChange = useCallback((open: boolean) => {
     setOpen(open);
     if (!open) {
@@ -208,68 +189,38 @@ const ComponentDetails = ({
     }
   }, []);
 
-  const handleEditComponent = useCallback(() => {
-    setIsEditDialogOpen(true);
-  }, []);
-
-  const actionsWithEdit = useMemo(() => {
-    if (!hasEnabledInAppEditor) return actions;
-
-    const EditButton = (
-      <TooltipButton
-        variant="secondary"
-        onClick={handleEditComponent}
-        tooltip="Edit Component Definition"
-        key={`${displayName}-edit-button`}
-      >
-        <Icon name="FilePenLine" />
-      </TooltipButton>
-    );
-
-    return [...actions, EditButton];
-  }, [actions, hasEnabledInAppEditor, handleEditComponent]);
-
   return (
-    <>
-      <Dialog modal open={open} onOpenChange={onOpenChange}>
-        <DialogTrigger asChild>{dialogTriggerButton}</DialogTrigger>
+    <Dialog modal open={open} onOpenChange={onOpenChange}>
+      <DialogTrigger asChild>{dialogTriggerButton}</DialogTrigger>
 
-        <DialogDescription
-          className="hidden"
-          aria-label={`${displayName} component details`}
-        >
-          {`${displayName} component details`}
-        </DialogDescription>
-        <DialogContent
-          className="max-w-2xl min-w-2xl overflow-hidden"
-          aria-label={`${displayName} component details`}
-        >
-          <DialogHeader>
-            <DialogTitle className="flex items-center gap-2 mr-5">
-              <span>{displayName}</span>
-              <ComponentFavoriteToggle component={component} />
-            </DialogTitle>
-          </DialogHeader>
+      <DialogDescription
+        className="hidden"
+        aria-label={`${displayName} component details`}
+      >
+        {`${displayName} component details`}
+      </DialogDescription>
+      <DialogContent
+        className="max-w-2xl min-w-2xl overflow-hidden"
+        aria-label={`${displayName} component details`}
+      >
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2 mr-5">
+            <span>{displayName}</span>
+            <ComponentFavoriteToggle component={component} />
+          </DialogTitle>
+        </DialogHeader>
 
-          <DialogContext.Provider value={dialogContextValue}>
-            <ComponentDetailsDialogContent
-              component={component}
-              displayName={displayName}
-              trigger={dialogTriggerButton}
-              actions={actionsWithEdit}
-              onClose={onClose}
-              onDelete={onDelete}
-            />
-          </DialogContext.Provider>
-        </DialogContent>
-      </Dialog>
-      {isEditDialogOpen && (
-        <ComponentEditorDialog
-          text={componentText}
-          onClose={handleCloseEditDialog}
-        />
-      )}
-    </>
+        <DialogContext.Provider value={dialogContextValue}>
+          <ComponentDetailsDialogContent
+            component={component}
+            displayName={displayName}
+            trigger={dialogTriggerButton}
+            onClose={onClose}
+            onDelete={onDelete}
+          />
+        </DialogContext.Provider>
+      </DialogContent>
+    </Dialog>
   );
 };
 

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/TaskOverview.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/TaskOverview.tsx
@@ -5,11 +5,8 @@ import {
   LogsIcon,
   Parentheses,
 } from "lucide-react";
-import { useState } from "react";
 
-import type { TooltipButtonProps } from "@/components/shared/Buttons/TooltipButton";
-import TooltipButton from "@/components/shared/Buttons/TooltipButton";
-import { CodeViewer } from "@/components/shared/CodeViewer";
+import type { Action } from "@/components/shared/ContextPanel/Blocks/ActionBlock";
 import { ComponentDetailsDialog } from "@/components/shared/Dialogs";
 import { ComponentFavoriteToggle } from "@/components/shared/FavoriteComponentToggle";
 import { StatusIcon } from "@/components/shared/Status";
@@ -22,7 +19,6 @@ import { Text } from "@/components/ui/typography";
 import { useExecutionDataOptional } from "@/providers/ExecutionDataProvider";
 import { type TaskNodeContextType } from "@/providers/TaskNodeProvider";
 import { isGraphImplementation } from "@/utils/componentSpec";
-import { componentSpecToText } from "@/utils/yaml";
 
 import ArgumentsSection from "../ArgumentsEditor/ArgumentsSection";
 import ConfigurationSection from "./ConfigurationSection";
@@ -33,13 +29,11 @@ import RenameTask from "./RenameTask";
 
 interface TaskOverviewProps {
   taskNode: TaskNodeContextType;
-  actions?: TooltipButtonProps[];
+  customActions?: Action[];
 }
 
-const TaskOverview = ({ taskNode, actions }: TaskOverviewProps) => {
+const TaskOverview = ({ taskNode, customActions }: TaskOverviewProps) => {
   const { name, taskSpec, taskId, state, callbacks } = taskNode;
-
-  const [isYamlFullscreen, setIsYamlFullscreen] = useState(false);
 
   const executionData = useExecutionDataOptional();
   const details = executionData?.details;
@@ -64,135 +58,107 @@ const TaskOverview = ({ taskNode, actions }: TaskOverviewProps) => {
   const executionId = details?.child_task_execution_ids?.[taskId];
   const canRename = !readOnly && isSubgraph;
 
-  const detailActions = [
-    ...(actions?.map((action) => (
-      <TooltipButton {...action} key={action.tooltip?.toString()} />
-    )) ?? []),
-    <TooltipButton
-      variant="outline"
-      tooltip="View YAML"
-      onClick={() => setIsYamlFullscreen(true)}
-      key="view-yaml-action"
-    >
-      <Icon name="FileCodeCorner" />
-    </TooltipButton>,
-  ];
-
   return (
-    <>
-      <BlockStack className="h-full" data-context-panel="task-overview">
-        <InlineStack gap="2" className="px-2 pb-2">
-          {isSubgraph && <Icon name="Workflow" />}
-          <Text size="lg" weight="semibold">
-            {name}
-          </Text>
-          {canRename && <RenameTask taskId={taskId} />}
-          <ComponentFavoriteToggle
-            component={taskSpec.componentRef}
-            hideDelete
-          />
-          <ComponentDetailsDialog
-            displayName={name}
-            component={taskSpec.componentRef}
-          />
-          {readOnly && <StatusIcon status={status} tooltip label="task" />}
-        </InlineStack>
+    <BlockStack className="h-full" data-context-panel="task-overview">
+      <InlineStack gap="2" className="px-2 pb-2">
+        {isSubgraph && <Icon name="Workflow" />}
+        <Text size="lg" weight="semibold">
+          {name}
+        </Text>
+        {canRename && <RenameTask taskId={taskId} />}
+        <ComponentFavoriteToggle component={taskSpec.componentRef} hideDelete />
+        <ComponentDetailsDialog
+          displayName={name}
+          component={taskSpec.componentRef}
+        />
+        {readOnly && <StatusIcon status={status} tooltip label="task" />}
+      </InlineStack>
 
-        <div className="px-4 overflow-y-auto pb-4 h-full w-full">
-          <Tabs defaultValue="io" className="h-full">
-            <TabsList className="mb-2">
-              <TabsTrigger value="io" className="flex-1">
-                {readOnly ? (
-                  <AmphoraIcon className="w-4 h-4" />
-                ) : (
-                  <Parentheses className="w-4 h-4" />
-                )}
-                {readOnly ? "Artifacts" : "Arguments"}
-              </TabsTrigger>
-              <TabsTrigger value="details" className="flex-1">
-                <InfoIcon className="h-4 w-4" />
-                Details
-              </TabsTrigger>
+      <div className="px-4 overflow-y-auto pb-4 h-full w-full">
+        <Tabs defaultValue="io" className="h-full">
+          <TabsList className="mb-2">
+            <TabsTrigger value="io" className="flex-1">
+              {readOnly ? (
+                <AmphoraIcon className="w-4 h-4" />
+              ) : (
+                <Parentheses className="w-4 h-4" />
+              )}
+              {readOnly ? "Artifacts" : "Arguments"}
+            </TabsTrigger>
+            <TabsTrigger value="details" className="flex-1">
+              <InfoIcon className="h-4 w-4" />
+              Details
+            </TabsTrigger>
 
-              {readOnly && !isSubgraph && (
-                <TabsTrigger value="logs" className="flex-1">
-                  <LogsIcon className="h-4 w-4" />
-                  Logs
-                </TabsTrigger>
-              )}
-              {!readOnly && (
-                <TabsTrigger value="configuration" className="flex-1">
-                  <FilePenLineIcon className="h-4 w-4" />
-                  Configuration
-                </TabsTrigger>
-              )}
-            </TabsList>
-            <TabsContent value="details">
-              <TaskDetails
-                displayName={name}
-                executionId={executionId}
-                componentRef={taskSpec.componentRef}
-                taskSpec={taskSpec}
-                taskId={taskId}
-                componentDigest={taskSpec.componentRef.digest}
-                url={taskSpec.componentRef.url}
-                onDelete={callbacks.onDelete}
-                status={status}
-                readOnly={readOnly}
-                actions={detailActions}
-              />
-            </TabsContent>
-            <TabsContent value="io">
-              {!readOnly && (
-                <BlockStack gap="4">
-                  <ArgumentsSection
-                    taskSpec={taskSpec}
-                    setArguments={callbacks.setArguments}
-                    disabled={disabled}
-                  />
-                  <Separator />
-                  <OutputsList taskSpec={taskSpec} />
-                </BlockStack>
-              )}
-              {readOnly && (
-                <IOSection
-                  taskSpec={taskSpec}
-                  readOnly={readOnly}
-                  executionId={executionId}
-                />
-              )}
-            </TabsContent>
             {readOnly && !isSubgraph && (
-              <TabsContent value="logs">
-                {!!executionId && (
-                  <div className="flex w-full justify-end pr-4">
-                    <OpenLogsInNewWindowLink
-                      executionId={executionId}
-                      status={status}
-                    />
-                  </div>
-                )}
-                <Logs executionId={executionId} status={status} />
-              </TabsContent>
+              <TabsTrigger value="logs" className="flex-1">
+                <LogsIcon className="h-4 w-4" />
+                Logs
+              </TabsTrigger>
             )}
             {!readOnly && (
-              <TabsContent value="configuration">
-                <ConfigurationSection taskNode={taskNode} />
-              </TabsContent>
+              <TabsTrigger value="configuration" className="flex-1">
+                <FilePenLineIcon className="h-4 w-4" />
+                Configuration
+              </TabsTrigger>
             )}
-          </Tabs>
-        </div>
-      </BlockStack>
-      {isYamlFullscreen && (
-        <CodeViewer
-          code={componentSpecToText(componentSpec)} // This should be using componentRef.text, but it is removed up-stack. It's not worth implementing a hydration strategy here just to remove it moments later.
-          language="yaml"
-          filename={componentSpec.name ?? "pipeline.yaml"}
-          isFullscreen={isYamlFullscreen}
-          onClose={() => setIsYamlFullscreen(false)}
-        />
-      )}
-    </>
+          </TabsList>
+          <TabsContent value="details">
+            <TaskDetails
+              displayName={name}
+              executionId={executionId}
+              componentRef={taskSpec.componentRef}
+              taskSpec={taskSpec}
+              taskId={taskId}
+              componentDigest={taskSpec.componentRef.digest}
+              url={taskSpec.componentRef.url}
+              onDelete={callbacks.onDelete}
+              status={status}
+              readOnly={readOnly}
+              customActions={customActions}
+            />
+          </TabsContent>
+          <TabsContent value="io">
+            {!readOnly && (
+              <BlockStack gap="4">
+                <ArgumentsSection
+                  taskSpec={taskSpec}
+                  setArguments={callbacks.setArguments}
+                  disabled={disabled}
+                />
+                <Separator />
+                <OutputsList taskSpec={taskSpec} />
+              </BlockStack>
+            )}
+            {readOnly && (
+              <IOSection
+                taskSpec={taskSpec}
+                readOnly={readOnly}
+                executionId={executionId}
+              />
+            )}
+          </TabsContent>
+          {readOnly && !isSubgraph && (
+            <TabsContent value="logs">
+              {!!executionId && (
+                <div className="flex w-full justify-end pr-4">
+                  <OpenLogsInNewWindowLink
+                    executionId={executionId}
+                    status={status}
+                  />
+                </div>
+              )}
+              <Logs executionId={executionId} status={status} />
+            </TabsContent>
+          )}
+          {!readOnly && (
+            <TabsContent value="configuration">
+              <ConfigurationSection taskNode={taskNode} />
+            </TabsContent>
+          )}
+        </Tabs>
+      </div>
+    </BlockStack>
   );
 };
 

--- a/src/components/shared/TaskDetails/Details.tsx
+++ b/src/components/shared/TaskDetails/Details.tsx
@@ -5,6 +5,7 @@ import { useGuaranteedHydrateComponentReference } from "@/hooks/useHydrateCompon
 import type { ComponentReference, TaskSpec } from "@/utils/componentSpec";
 import { getExecutionStatusLabel } from "@/utils/executionStatus";
 
+import type { Action } from "../ContextPanel/Blocks/ActionBlock";
 import { ContentBlock } from "../ContextPanel/Blocks/ContentBlock";
 import { ListBlock } from "../ContextPanel/Blocks/ListBlock";
 import { TextBlock } from "../ContextPanel/Blocks/TextBlock";
@@ -21,7 +22,7 @@ interface TaskDetailsProps {
   taskSpec?: TaskSpec;
   componentDigest?: string;
   url?: string;
-  actions?: ReactNode[];
+  customActions?: Action[];
   onDelete?: () => void;
   status?: string;
   readOnly?: boolean;
@@ -42,7 +43,7 @@ const TaskDetailsInternal = ({
   taskSpec,
   componentDigest,
   url,
-  actions = [],
+  customActions = [],
   onDelete,
   status,
   readOnly = false,
@@ -163,7 +164,7 @@ const TaskDetailsInternal = ({
       <TaskActions
         displayName={displayName}
         componentRef={hydratedComponentRef}
-        actions={actions}
+        customActions={customActions}
         onDelete={onDelete}
         readOnly={readOnly}
         className={BASE_BLOCK_CLASS}


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Moves all of the action buttons on the task card into the new ActionBlock `Action` type for consistency of UI and implementation.

This PR also tidies up where actions are defined. Previously they were scattered over various files. Now: 
- TaskNode actions are defined in TaskNodeCard
- ComponentDetails actions are defined in ComponentDetailsDialog (currently none)
- shared actions are in TaskActions

More specifically:

**TaskNodeCard**
- Duplicate Task
- Update from Source
- Enter Subgraph
- Edit Definition -> moved to TaskActions

**TaskOverview**
- View YAML -> moved to TaskNodeCard

**ComponentDetailsDialog**
- Edit Definition (again!) -> removed

**TaskActions**
- Download YAML
- Download Python
- Copy YAML
- Delete (if onDelete is provided)


Due to this change the component editor action was moved to TaskAction (it is shared), allowing us to consolidate down to one implementation of the ComponentEditor, rather than two. Additionally, the View YAML action was moved from TaskOverview to colocate with other actions in TaskNodeCard. TaskOverview is now a pass-through component as far as actions are concerned.


![image.png](https://app.graphite.com/user-attachments/assets/61c186ea-49f9-4ca6-a73b-a3d2ffda57d6.png)


## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Cleanup/Refactor

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

No change to app functionality.

Confirm that all buttons in TaskActions & ComponentDetailsDialog look consistent and continue to function as expected.

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->

Note: TaskOverview could do with a cleanup - this is not the PR for that.
