### PR TITLE
Fix infinite loop in Python editor when changing configuration

### DIFF
--- a/src/components/shared/ComponentEditor/components/PythonComponentEditor.tsx
+++ b/src/components/shared/ComponentEditor/components/PythonComponentEditor.tsx
@@ -65,19 +65,14 @@ export const PythonComponentEditor = withSuspenseWrapper(
 
     const yamlGenerator = usePythonYamlGenerator();
     const preservedNameRef = useRef(initialComponentName);
-
-    useEffect(() => {
-      handleFunctionTextChange(text);
-    }, []);
-
-    // Sync ref with prop
     preservedNameRef.current = initialComponentName;
 
-    const handleFunctionTextChange = async (value: string | undefined) => {
-      const code = value ?? "";
-      setPythonCode(code);
+    const pythonCodeRef = useRef(pythonCode);
+    pythonCodeRef.current = pythonCode;
+
+    const regenerateYaml = async (code: string, opts: YamlGeneratorOptions) => {
       try {
-        const yaml = await yamlGenerator(code, yamlGeneratorOptions);
+        const yaml = await yamlGenerator(code, opts);
         const yamlWithPreservedName = preserveComponentName(
           yaml,
           preservedNameRef.current,
@@ -93,9 +88,19 @@ export const PythonComponentEditor = withSuspenseWrapper(
       }
     };
 
-    const handleOptionsChange = (options: YamlGeneratorOptions) => {
-      setYamlGeneratorOptions(options);
-      handleFunctionTextChange(pythonCode);
+    useEffect(() => {
+      regenerateYaml(text, yamlGeneratorOptions);
+    }, []);
+
+    const handleFunctionTextChange = (value: string | undefined) => {
+      const code = value ?? "";
+      setPythonCode(code);
+      regenerateYaml(code, yamlGeneratorOptions);
+    };
+
+    const handleOptionsChange = (newOptions: YamlGeneratorOptions) => {
+      setYamlGeneratorOptions(newOptions);
+      regenerateYaml(pythonCodeRef.current, newOptions);
     };
 
     return (

--- a/src/components/shared/ComponentEditor/components/YamlGeneratorOptionsEditor.tsx
+++ b/src/components/shared/ComponentEditor/components/YamlGeneratorOptionsEditor.tsx
@@ -3,6 +3,7 @@ import {
   type ReactNode,
   useEffect,
   useReducer,
+  useRef,
 } from "react";
 
 import { Button } from "@/components/ui/button";
@@ -39,8 +40,13 @@ export const YamlGeneratorOptionsEditor = ({
 }) => {
   const { state, dispatch } = useYamlGeneratorOptionsReducer(initialOptions);
 
+  const onChangeRef = useRef(onChange);
   useEffect(() => {
-    onChange({
+    onChangeRef.current = onChange;
+  });
+
+  useEffect(() => {
+    onChangeRef.current({
       baseImage: state.baseImage,
       packagesToInstall: state.packagesToInstall?.filter(Boolean) ?? [],
       annotations: Object.fromEntries(
@@ -49,7 +55,7 @@ export const YamlGeneratorOptionsEditor = ({
           .map(({ key, value }) => [key, value]),
       ),
     });
-  }, [state, onChange]);
+  }, [state]);
 
   return (
     <BlockStack className="flex-1 relative px-1" gap="4">


### PR DESCRIPTION
## Description

## What

Fixed the Python editor hanging when switching to the Configuration tab or changing configuration values.

## Why

The editor was stuck in an infinite render loop:

1. Changing config triggers `useEffect` → calls `onChange`
2. Parent re-renders → creates new `onChange` function
3. `onChange` was in the effect's dependency array → effect runs again
4. Loop repeats forever

## How

**YamlGeneratorOptionsEditor:** Store `onChange` in a ref so it's not in the dependency array. The effect now only runs when `state` changes.

**PythonComponentEditor:** Pass the new options directly to `regenerateYaml` instead of reading from state (which would be stale due to React's async updates).

## Type of Change

- [x] Improvement
- [x] Cleanup/Refactor

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Test Instructions

1. Open the Python component editor
2. Verify that YAML generation works correctly when:
   - Editing Python code
   - Changing base image
   - Adding/removing packages
   - Modifying annotations