### PR TITLE
fix: infinite loop in PythonComponentEditor

### DIFF
--- a/src/components/shared/ComponentEditor/components/PythonComponentEditor.tsx
+++ b/src/components/shared/ComponentEditor/components/PythonComponentEditor.tsx
@@ -67,17 +67,15 @@ export const PythonComponentEditor = withSuspenseWrapper(
     const preservedNameRef = useRef(initialComponentName);
 
     useEffect(() => {
-      handleFunctionTextChange(text);
-    }, []);
+      preservedNameRef.current = initialComponentName;
+    }, [initialComponentName]);
 
-    // Sync ref with prop
-    preservedNameRef.current = initialComponentName;
-
-    const handleFunctionTextChange = async (value: string | undefined) => {
-      const code = value ?? "";
-      setPythonCode(code);
+    const generateYaml = async (
+      code: string,
+      options: YamlGeneratorOptions,
+    ) => {
       try {
-        const yaml = await yamlGenerator(code, yamlGeneratorOptions);
+        const yaml = await yamlGenerator(code, options);
         const yamlWithPreservedName = preserveComponentName(
           yaml,
           preservedNameRef.current,
@@ -93,10 +91,15 @@ export const PythonComponentEditor = withSuspenseWrapper(
       }
     };
 
-    const handleOptionsChange = (options: YamlGeneratorOptions) => {
-      setYamlGeneratorOptions(options);
-      handleFunctionTextChange(pythonCode);
+    const handleFunctionTextChange = async (value: string | undefined) => {
+      const code = value ?? "";
+      setPythonCode(code);
     };
+
+    useEffect(() => {
+      // first time loading
+      void generateYaml(pythonCode, yamlGeneratorOptions);
+    }, [pythonCode, yamlGeneratorOptions]);
 
     return (
       <InlineStack className="w-full h-full" gap="4">
@@ -131,7 +134,7 @@ export const PythonComponentEditor = withSuspenseWrapper(
             >
               <YamlGeneratorOptionsEditor
                 initialOptions={yamlGeneratorOptions}
-                onChange={handleOptionsChange}
+                onChange={setYamlGeneratorOptions}
               />
             </TabsContent>
           </Tabs>


### PR DESCRIPTION
## Description

Refactored the Python Component Editor to improve state management and YAML generation. Key changes include:

1. Added proper dependency tracking in useEffect hooks
2. Extracted YAML generation logic into a separate function for reuse
3. Fixed initialization flow to properly generate YAML on first load
4. Made options change handler async to properly handle YAML generation
5. Added a comment in YamlGeneratorOptionsEditor explaining why onChange is intentionally excluded from dependencies

## Type of Change

- [x] Cleanup/Refactor
- [x] Bug fix

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

[Screen Recording 2025-12-11 at 2.47.53 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/a18a7b77-1407-4926-b8db-f6dfeeddf19e.mov" />](https://app.graphite.com/user-attachments/video/a18a7b77-1407-4926-b8db-f6dfeeddf19e.mov)

1. Open the Python Component Editor
2. Verify that YAML is properly generated on initial load
3. Make changes to the Python code and confirm YAML updates correctly
4. Change generator options and verify YAML updates accordingly



### Notes

Also restored logic from https://github.com/TangleML/tangle-ui/pull/1505