### PR TITLE
fix: download and copy yaml in component details to take yaml from text not spec

### DIFF
--- a/src/components/shared/Dialogs/ComponentDetailsDialog.tsx
+++ b/src/components/shared/Dialogs/ComponentDetailsDialog.tsx
@@ -135,7 +135,7 @@ const ComponentDetailsDialogContent = withSuspenseWrapper(
 
                 <TaskDetails
                   displayName={displayName}
-                  componentSpec={componentSpec}
+                  componentRef={componentRef}
                   componentDigest={componentDigest}
                   url={url}
                   actions={actions}

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/TaskOverview.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/TaskOverview.tsx
@@ -123,7 +123,7 @@ const TaskOverview = ({ taskNode, actions }: TaskOverviewProps) => {
             <TaskDetails
               displayName={name}
               executionId={executionId}
-              componentSpec={componentSpec}
+              componentRef={taskSpec.componentRef}
               taskId={taskId}
               componentDigest={taskSpec.componentRef.digest}
               url={taskSpec.componentRef.url}

--- a/src/components/shared/TaskDetails/Actions.tsx
+++ b/src/components/shared/TaskDetails/Actions.tsx
@@ -2,12 +2,11 @@ import { type ReactNode } from "react";
 import { FaPython } from "react-icons/fa";
 
 import useToastNotification from "@/hooks/useToastNotification";
-import type { ComponentSpec } from "@/utils/componentSpec";
+import type { HydratedComponentReference } from "@/utils/componentSpec";
 import {
   downloadStringAsFile,
   downloadYamlFromComponentText,
 } from "@/utils/URL";
-import { componentSpecToText } from "@/utils/yaml";
 
 import {
   ActionBlock,
@@ -16,7 +15,7 @@ import {
 
 interface TaskActionsProps {
   displayName: string;
-  componentSpec: ComponentSpec;
+  componentRef: HydratedComponentReference;
   actions?: ReactNode[];
   onDelete?: () => void;
   readOnly?: boolean;
@@ -25,7 +24,7 @@ interface TaskActionsProps {
 
 const TaskActions = ({
   displayName,
-  componentSpec,
+  componentRef,
   actions = [],
   onDelete,
   readOnly = false,
@@ -34,24 +33,24 @@ const TaskActions = ({
   const notify = useToastNotification();
 
   const pythonOriginalCode =
-    componentSpec?.metadata?.annotations?.original_python_code;
+    componentRef.spec.metadata?.annotations?.original_python_code;
 
   const stringToPythonCodeDownload = () => {
     if (!pythonOriginalCode) return;
 
     downloadStringAsFile(
       pythonOriginalCode,
-      `${componentSpec?.name || displayName}.py`,
+      `${componentRef.name || displayName}.py`,
       "text/x-python",
     );
   };
 
   const handleDownloadYaml = () => {
-    downloadYamlFromComponentText(componentSpec, displayName);
+    downloadYamlFromComponentText(componentRef.text, displayName);
   };
 
   const handleCopyYaml = () => {
-    const code = componentSpecToText(componentSpec);
+    const code = componentRef.text;
 
     navigator.clipboard.writeText(code).then(
       () => notify("YAML copied to clipboard", "success"),

--- a/src/utils/URL.test.ts
+++ b/src/utils/URL.test.ts
@@ -154,7 +154,7 @@ describe("downloadYamlFromComponentText", () => {
   });
 
   it("creates a downloadable yaml file with correct name", () => {
-    const mockComponentSpec = { name: "testComponent", foo: "bar" };
+    const codeText = "name: testComponent\nfoo: bar";
     const displayName = "displayName";
     const createObjectURLSpy = vi
       .spyOn(URL, "createObjectURL")
@@ -179,7 +179,7 @@ describe("downloadYamlFromComponentText", () => {
         }) as any,
     );
 
-    downloadYamlFromComponentText(mockComponentSpec as any, displayName);
+    downloadYamlFromComponentText(codeText, displayName);
 
     expect(createObjectURLSpy).toHaveBeenCalled();
     expect(revokeObjectURLSpy).toHaveBeenCalledWith("blob:url");

--- a/src/utils/URL.ts
+++ b/src/utils/URL.ts
@@ -1,8 +1,5 @@
 import { RUNS_BASE_PATH } from "@/routes/router";
 
-import type { ComponentSpec } from "./componentSpec";
-import { componentSpecToText } from "./yaml";
-
 const convertGcsUrlToBrowserUrl = (
   url: string,
   isDirectory: boolean,
@@ -130,12 +127,8 @@ const downloadStringAsFile = (
   URL.revokeObjectURL(url);
 };
 
-const downloadYamlFromComponentText = (
-  componentSpec: ComponentSpec,
-  displayName: string,
-) => {
-  const code = componentSpecToText(componentSpec);
-  downloadStringAsFile(code, `${displayName}.yaml`, "text/yaml");
+const downloadYamlFromComponentText = (text: string, displayName: string) => {
+  downloadStringAsFile(text, `${displayName}.yaml`, "text/yaml");
 };
 
 const getIdOrTitleFromPath = (


### PR DESCRIPTION
## Description

Closes https://github.com/TangleML/tangle-ui/issues/1530

Refactored the `TaskDetails` component to use component references instead of directly passing component specs. This change improves component hydration by:

1. Replacing `componentSpec` prop with `componentRef` in `TaskDetails` and related components
2. Adding `useHydrateComponentReference` hook to properly load component data
3. Wrapping `TaskDetails` with `withSuspenseWrapper` for better loading handling
4. Updating YAML download and copy functions to work with text directly instead of component specs

## Type of Change

- [x] Improvement
- [x] Cleanup/Refactor

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

[Screen Recording 2025-12-15 at 3.05.14 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/183e2f34-0b8f-4ec6-b9af-4b07301e12be.mov" />](https://app.graphite.com/user-attachments/video/183e2f34-0b8f-4ec6-b9af-4b07301e12be.mov)

1. To verify functionality - create new component via Component Editor, ensure to put some YAML comment lines. Save and drop new component onto the canvas.
2. Open component details dialogs and verify component information displays correctly
3. Test YAML download and copy functionality to ensure it works with the new implementation. You should see YAML comments taken from the text. Previously (Staging) such comments were stripped. 
4. Verify task details are properly displayed in flow canvas nodes