### PR TITLE
fix: use componentRef.text when possible to view task implementation

### DIFF
--- a/src/components/shared/Dialogs/ComponentDetailsDialog.tsx
+++ b/src/components/shared/Dialogs/ComponentDetailsDialog.tsx
@@ -150,7 +150,7 @@ const ComponentDetailsDialogContent = withSuspenseWrapper(
               <TabsContent value="implementation" className="h-full">
                 <TaskImplementation
                   displayName={displayName}
-                  componentSpec={componentSpec}
+                  componentRef={componentRef}
                 />
               </TabsContent>
 

--- a/src/components/shared/ManageComponent/ComponentQuickDetailsDialog.tsx
+++ b/src/components/shared/ManageComponent/ComponentQuickDetailsDialog.tsx
@@ -97,7 +97,7 @@ const ComponentQuickDetailsDialog = withSuspenseWrapper(
 
             <TaskImplementation
               displayName={displayName}
-              componentSpec={hydratedComponent.spec}
+              componentRef={hydratedComponent}
             />
           </BlockStack>
           <DialogFooter>

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/TaskOverview.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/TaskOverview.tsx
@@ -69,7 +69,7 @@ const TaskOverview = ({ taskNode, actions }: TaskOverviewProps) => {
     <TaskImplementation
       key="task-implementation-action"
       displayName={name}
-      componentSpec={componentSpec}
+      componentRef={taskSpec.componentRef}
       showInlineContent={false}
     />,
   ];

--- a/src/components/shared/TaskDetails/Implementation.tsx
+++ b/src/components/shared/TaskDetails/Implementation.tsx
@@ -1,27 +1,85 @@
 import { CodeViewer } from "@/components/shared/CodeViewer";
-import type { ComponentSpec } from "@/utils/componentSpec";
+import { useHydrateComponentReference } from "@/hooks/useHydrateComponentReference";
+import type { ComponentReference, ComponentSpec } from "@/utils/componentSpec";
 import { componentSpecToText } from "@/utils/yaml";
+
+import { withSuspenseWrapper } from "../SuspenseWrapper";
 
 interface TaskImplementationProps {
   displayName: string;
-  componentSpec: ComponentSpec;
+  componentRef?: ComponentReference;
+  componentSpec?: ComponentSpec;
   showInlineContent?: boolean;
 }
 
-const TaskImplementation = ({
-  displayName,
-  componentSpec,
-  showInlineContent = true,
-}: TaskImplementationProps) => {
-  const code = componentSpecToText(componentSpec);
+const TaskImplementation = withSuspenseWrapper(
+  ({
+    displayName,
+    componentRef,
+    componentSpec,
+    showInlineContent = true,
+  }: TaskImplementationProps) => {
+    if (componentRef) {
+      return (
+        <ComponentRefCodeViewer
+          componentRef={componentRef}
+          displayName={displayName}
+          showInlineContent={showInlineContent}
+        />
+      );
+    }
 
-  if (!componentSpec?.implementation) {
+    if (componentSpec) {
+      return (
+        <ComponentSpecCodeViewer
+          componentSpec={componentSpec}
+          displayName={displayName}
+          showInlineContent={showInlineContent}
+        />
+      );
+    }
+
     return (
       <div className="text-sm text-gray-500 p-4 border rounded-md">
         No implementation code found for this component.
       </div>
     );
-  }
+  },
+);
+
+const ComponentRefCodeViewer = withSuspenseWrapper(
+  ({
+    componentRef,
+    displayName,
+    showInlineContent = true,
+  }: Pick<TaskImplementationProps, "displayName" | "showInlineContent"> & {
+    componentRef: ComponentReference;
+  }) => {
+    const hydratedComponentRef = useHydrateComponentReference(componentRef);
+
+    if (!hydratedComponentRef) {
+      return null;
+    }
+
+    return (
+      <CodeViewer
+        code={hydratedComponentRef.text}
+        language="yaml"
+        filename={displayName}
+        showInlineContent={showInlineContent}
+      />
+    );
+  },
+);
+
+const ComponentSpecCodeViewer = ({
+  componentSpec,
+  displayName,
+  showInlineContent = true,
+}: Pick<TaskImplementationProps, "displayName" | "showInlineContent"> & {
+  componentSpec: ComponentSpec;
+}) => {
+  const code = componentSpecToText(componentSpec);
 
   return (
     <CodeViewer


### PR DESCRIPTION
## Description

Refactored the `TaskImplementation` component to accept a `componentRef` prop instead of directly using `componentSpec`. This change improves component hydration by using the new `useHydrateComponentReference` hook to properly load component references.

The implementation now handles both cases:

- When a `componentRef` is provided, it hydrates and displays the reference
- When a `componentSpec` is provided directly, it uses the existing functionality

Updated all component imports in:

- ComponentDetailsDialog
- ComponentQuickDetailsDialog
- TaskNode/TaskOverview

## Type of Change

- [x] Improvement
- [x] Refactor

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

[Screen Recording 2025-12-15 at 3.22.17 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/58adbad5-bf57-43b7-98a6-3694999e7ee6.mov" />](https://app.graphite.com/user-attachments/video/58adbad5-bf57-43b7-98a6-3694999e7ee6.mov)

1. Open component details for various components
2. Verify that implementation code is correctly displayed (e.g. comments in YAML)
3. Check that both referenced components and inline component specs render properly