### PR TITLE
feat: lazy load of the yaml library components

### DIFF
--- a/src/providers/ComponentLibraryProvider/componentLibrary.ts
+++ b/src/providers/ComponentLibraryProvider/componentLibrary.ts
@@ -13,7 +13,7 @@ import {
   getAllComponentFilesFromList,
 } from "@/utils/componentStore";
 import { USER_COMPONENTS_LIST_NAME } from "@/utils/constants";
-import { getComponentByUrl } from "@/utils/localforage";
+import { getComponentById, getComponentByUrl } from "@/utils/localforage";
 import { componentSpecToYaml } from "@/utils/yaml";
 
 export const fetchUserComponents = async (): Promise<ComponentFolder> => {
@@ -80,6 +80,19 @@ export const fetchUsedComponents = (graphSpec: GraphSpec): ComponentFolder => {
   };
 };
 
+export async function isFavoriteComponent(component: ComponentReference) {
+  if (!component.digest) return false;
+
+  const storedComponent = await getComponentById(
+    `component-${component.digest}`,
+  );
+
+  return storedComponent?.favorited ?? false;
+}
+
+/**
+ * @deprecated
+ */
 export const fetchFavoriteComponents = (
   componentLibrary: ComponentLibrary | undefined,
 ): ComponentFolder => {

--- a/src/services/componentService.ts
+++ b/src/services/componentService.ts
@@ -1,6 +1,5 @@
 import { getAppSettings } from "@/appSettings";
 import {
-  type ComponentFolder,
   type ComponentLibrary,
   isValidComponentLibrary,
 } from "@/types/componentLibrary";
@@ -112,35 +111,8 @@ export const fetchAndStoreComponentLibrary =
       updatedAt: Date.now(),
     });
 
-    // Also store individual components for future reference
-    await storeComponentsFromLibrary(obj);
-
     return obj;
   };
-
-/**
- * Store all components from the library in local storage
- */
-const storeComponentsFromLibrary = async (
-  library: ComponentLibrary,
-): Promise<void> => {
-  const processFolder = async (folder: ComponentFolder) => {
-    // Store each component in the folder
-    for (const component of folder.components || []) {
-      await fetchAndStoreComponent(component);
-    }
-
-    // Process subfolders recursively
-    for (const subfolder of folder.folders || []) {
-      await processFolder(subfolder);
-    }
-  };
-
-  // Process all top-level folders
-  for (const folder of library.folders) {
-    await processFolder(folder);
-  }
-};
 
 /**
  * Fetch and store a single component by URL


### PR DESCRIPTION
## Description

Closes https://github.com/TangleML/tangle-ui/issues/1306

Contributes to https://github.com/Shopify/oasis-frontend/issues/249

Removed the `populateComponentRefs` function call when setting the component library state. Also removed the `storeComponentsFromLibrary` function and its associated logic that was storing individual components in local storage.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [x] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

[Screen Recording 2025-12-15 at 4.42.24 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/56c6fa34-3963-4dc9-828f-3a761dee6e2e.mov" />](https://app.graphite.com/user-attachments/video/56c6fa34-3963-4dc9-828f-3a761dee6e2e.mov)

1. Open Tangle in "Incokgnito" browser mode. Ensure no lib is available in Application / IndexedDB / components.
2. Create "New Pipeline".
3. Ensure, that Component Library is available almost instantly.
4. Ensure, that Components can be dropped on canvas.
5. Ensure, that you can open "Info" dialog from left panel.

In the video I manually removed "hydration" info (name, author, digest) from the "Quick start" folder to ensure, that Left panel can display "not loaded" libraries.

## Additional Comments

This change simplifies the component library loading process by removing unnecessary processing steps.