### PR TITLE
Condensed Node Bugfixes

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeCard.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeCard.tsx
@@ -230,7 +230,12 @@ const TaskNodeCard = () => {
   }, []);
 
   useEffect(() => {
-    if (contentRef.current && scrollHeight > 0 && dimensions.h) {
+    if (!dimensions.h) {
+      setCondensed(false);
+      return;
+    }
+
+    if (contentRef.current && scrollHeight > 0) {
       setCondensed(scrollHeight > dimensions.h);
     }
   }, [scrollHeight, dimensions.h]);
@@ -328,6 +333,7 @@ const TaskNodeCard = () => {
                   ? `${dimensions.h}px`
                   : "100%",
             }}
+            className="min-h-fit"
             ref={contentRef}
           >
             <TaskNodeInputs

--- a/src/utils/nodes/setPositionInAnnotations.ts
+++ b/src/utils/nodes/setPositionInAnnotations.ts
@@ -5,6 +5,23 @@ export const setPositionInAnnotations = (
   position: XYPosition,
 ): Record<string, unknown> => {
   const updatedAnnotations = { ...annotations };
-  updatedAnnotations["editor.position"] = JSON.stringify(position);
+
+  let existingPosition: Record<string, number> = {};
+  const editorPosition = annotations["editor.position"];
+  if (typeof editorPosition === "string") {
+    try {
+      existingPosition = JSON.parse(editorPosition);
+    } catch {
+      existingPosition = {};
+    }
+  }
+
+  const newPosition = {
+    ...existingPosition,
+    x: position.x,
+    y: position.y,
+  };
+
+  updatedAnnotations["editor.position"] = JSON.stringify(newPosition);
   return updatedAnnotations;
 };


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Fixes a couple of bugs with condensed nodes:
- Condensed nodes will no longer overflow the task card
- Condensed nodes will remain condensed when moved on the canvas
- Condensing a node will now correctly undo/redo as appropriate
- Input connections from an input node will no longer be (visually) lost upon condensing
- Condensed nodes will remain condensed when cloning or rerunning a pipeline

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->
Closes https://github.com/Shopify/oasis-frontend/issues/140
Closes https://github.com/Shopify/oasis-frontend/issues/371


## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->
1. Select a task
2. Configuration -> edit the node position annotation to a "h" property (e.g. {"x":0, "y":0,"h":100}
3. If "h" is smaller that than current node height, it will condense
4. Confirm that the condensed node can be moved, copied etc without uncondensing
5. Confirm the node stays condensed when cloning or running the pipeline
6. Confirm that any connections to or from the node stay visible and connected when condensing happens
7. Confirm you can use the undo/redo feature to uncondense/recondense

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
