### PR TITLE
refactor: remove checkIfFavorited from ComponentLibraryProvider

### DIFF
--- a/src/components/shared/Dialogs/ComponentDuplicateDialog.test.tsx
+++ b/src/components/shared/Dialogs/ComponentDuplicateDialog.test.tsx
@@ -53,7 +53,6 @@ const createMockComponentLibraryContext = (
     refetchUserComponents: vi.fn(),
     setHighlightedComponentDigest: vi.fn(),
     setComponentFavorite: vi.fn(),
-    checkIfFavorited: vi.fn().mockReturnValue(false),
     checkIfUserComponent: vi.fn().mockReturnValue(false),
     checkLibraryContainsComponent: vi.fn().mockReturnValue(false),
     checkIfHighlighted: vi.fn().mockReturnValue(false),

--- a/src/providers/ComponentLibraryProvider/ComponentLibraryProvider.test.tsx
+++ b/src/providers/ComponentLibraryProvider/ComponentLibraryProvider.test.tsx
@@ -645,28 +645,5 @@ describe("ComponentLibraryProvider - Component Management", () => {
         favorited: true,
       });
     });
-
-    it("should check if component is favorited correctly", async () => {
-      const favoritedComponent: ComponentReference = {
-        name: "favorited-component",
-        digest: "fav-digest",
-        spec: mockComponentSpec,
-        favorited: true,
-      };
-
-      mockFlattenFolders.mockReturnValue([favoritedComponent]);
-      mockFilterToUniqueByDigest.mockReturnValue([favoritedComponent]);
-
-      const { result } = renderHook(() => useComponentLibrary(), {
-        wrapper: createWrapper,
-      });
-
-      await waitFor(() => {
-        expect(result.current.isLoading).toBe(false);
-      });
-
-      const isFavorited = result.current.checkIfFavorited(favoritedComponent);
-      expect(isFavorited).toBe(true);
-    });
   });
 });

--- a/src/providers/ComponentLibraryProvider/ComponentLibraryProvider.tsx
+++ b/src/providers/ComponentLibraryProvider/ComponentLibraryProvider.tsx
@@ -93,10 +93,6 @@ type ComponentLibraryContextType = {
     component: ComponentReference,
     favorited: boolean,
   ) => void;
-  /**
-   * @deprecated
-   */
-  checkIfFavorited: (component: ComponentReference) => boolean;
   checkIfUserComponent: (component: ComponentReference) => boolean;
   checkLibraryContainsComponent: (component: ComponentReference) => boolean;
   checkIfHighlighted: (component: ComponentReference) => boolean;
@@ -339,41 +335,6 @@ export const ComponentLibraryProvider = ({
       }
     },
     [refreshComponentLibrary, refreshUserComponents],
-  );
-
-  const checkIfFavorited = useCallback(
-    (component: ComponentReference) => {
-      if (componentLibrary) {
-        const uniqueLibraryComponents = filterToUniqueByDigest(
-          flattenFolders(componentLibrary),
-        );
-
-        const isFavourited = uniqueLibraryComponents.some(
-          (c) => c.digest === component.digest && c.favorited,
-        );
-
-        if (isFavourited) {
-          return true;
-        }
-      }
-
-      if (userComponentsFolder) {
-        const uniqueUserComponents = filterToUniqueByDigest(
-          flattenFolders(userComponentsFolder),
-        );
-
-        const isFavourited = uniqueUserComponents.some(
-          (c) => c.digest === component.digest && c.favorited,
-        );
-
-        if (isFavourited) {
-          return true;
-        }
-      }
-
-      return false;
-    },
-    [componentLibrary, userComponentsFolder],
   );
 
   const checkIfUserComponent = useCallback(
@@ -651,7 +612,6 @@ export const ComponentLibraryProvider = ({
       refetchUserComponents,
       setHighlightedComponentDigest,
       setComponentFavorite,
-      checkIfFavorited,
       checkIfUserComponent,
       checkLibraryContainsComponent,
       checkIfHighlighted,
@@ -674,7 +634,6 @@ export const ComponentLibraryProvider = ({
       refetchUserComponents,
       setHighlightedComponentDigest,
       setComponentFavorite,
-      checkIfFavorited,
       checkIfUserComponent,
       checkLibraryContainsComponent,
       checkIfHighlighted,


### PR DESCRIPTION
## Description

Removed the deprecated `checkIfFavorited` method from the ComponentLibraryProvider. This includes:
- Removing the method implementation from the provider
- Removing the method from the context type definition
- Removing related tests
- Updating test mocks that referenced this method

## Type of Change

- [x] Cleanup/Refactor
- [x] Breaking change

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

Ensure that no components are using the deprecated `checkIfFavorited` method. All components should be updated to use alternative methods for checking if a component is favorited.