### PR TITLE
Add RunID to Cloned Pipelines

### DIFF
--- a/src/components/PipelineRun/RunDetails.tsx
+++ b/src/components/PipelineRun/RunDetails.tsx
@@ -101,7 +101,7 @@ export const RunDetails = () => {
         {canAccessEditorSpec && componentSpec.name && (
           <InspectPipelineButton pipelineName={componentSpec.name} />
         )}
-        <ClonePipelineButton componentSpec={componentSpec} />
+        <ClonePipelineButton componentSpec={componentSpec} runId={runId} />
         {isInProgress && isRunCreator && (
           <CancelPipelineRunButton runId={runId} />
         )}

--- a/src/components/PipelineRun/components/ClonePipelineButton.tsx
+++ b/src/components/PipelineRun/components/ClonePipelineButton.tsx
@@ -11,10 +11,12 @@ import { getInitialName } from "@/utils/getComponentName";
 
 type ClonePipelineButtonProps = {
   componentSpec: ComponentSpec;
+  runId?: string | null;
 };
 
 export const ClonePipelineButton = ({
   componentSpec,
+  runId,
 }: ClonePipelineButtonProps) => {
   const navigate = useNavigate();
   const notify = useToastNotification();
@@ -22,7 +24,7 @@ export const ClonePipelineButton = ({
   const { isPending, mutate: clonePipeline } = useMutation({
     mutationFn: async () => {
       const name = getInitialName(componentSpec);
-      return copyRunToPipeline(componentSpec, name);
+      return copyRunToPipeline(componentSpec, runId, name);
     },
     onSuccess: (result) => {
       if (result?.url) {

--- a/src/components/shared/CloneRunButton.tsx
+++ b/src/components/shared/CloneRunButton.tsx
@@ -1,4 +1,4 @@
-import { useLocation, useNavigate } from "@tanstack/react-router";
+import { useLocation, useNavigate, useParams } from "@tanstack/react-router";
 import { Loader2 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -7,27 +7,39 @@ import { copyRunToPipeline } from "@/services/pipelineRunService";
 import type { ComponentSpec } from "@/utils/componentSpec";
 import { getInitialName } from "@/utils/getComponentName";
 
-const CloneRunButtonInner = ({
+const CloneRunButton = ({
   componentSpec,
 }: {
-  componentSpec: ComponentSpec;
+  componentSpec?: ComponentSpec;
 }) => {
+  const location = useLocation();
   const navigate = useNavigate();
+  const params = useParams({ strict: false });
+
+  const isRunDetailRoute = location.pathname.includes(RUNS_BASE_PATH);
+
+  const runId =
+    "id" in params && typeof params.id === "string" ? params.id : undefined;
 
   const handleClone = async () => {
-    const name = getInitialName(componentSpec);
     if (!componentSpec) {
       console.error("No component spec found");
       return;
     }
 
-    const result = await copyRunToPipeline(componentSpec, name);
+    const name = getInitialName(componentSpec);
+
+    const result = await copyRunToPipeline(componentSpec, runId, name);
     if (result?.url) {
       navigate({ to: result.url });
     } else {
       console.error("Failed to copy run to pipeline");
     }
   };
+
+  if (!isRunDetailRoute) {
+    return null;
+  }
 
   if (!componentSpec) {
     return (
@@ -42,21 +54,6 @@ const CloneRunButtonInner = ({
       Clone Pipeline
     </Button>
   );
-};
-
-const CloneRunButton = ({
-  componentSpec,
-}: {
-  componentSpec?: ComponentSpec;
-}) => {
-  const location = useLocation();
-
-  const isRunDetailRoute = location.pathname.includes(RUNS_BASE_PATH);
-
-  if (!isRunDetailRoute || !componentSpec) {
-    return null;
-  }
-  return <CloneRunButtonInner componentSpec={componentSpec} />;
 };
 
 export default CloneRunButton;

--- a/src/services/pipelineRunService.ts
+++ b/src/services/pipelineRunService.ts
@@ -75,6 +75,7 @@ export const savePipelineRun = async (
 
 export const copyRunToPipeline = async (
   componentSpec: ComponentSpec,
+  runId?: string | null,
   name?: string,
 ) => {
   if (!componentSpec) {
@@ -95,6 +96,9 @@ export const copyRunToPipeline = async (
     cleanComponentSpec.metadata.annotations ??= {};
     cleanComponentSpec.metadata.annotations["editor.flow-direction"] ??=
       "left-to-right";
+    if (runId) {
+      cleanComponentSpec.metadata.annotations["cloned_from_run_id"] = runId;
+    }
 
     // Remove caching strategy from all tasks
     if (isGraphImplementation(cleanComponentSpec.implementation)) {


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Cloning a pipeline from a run will now add a `cloned_from_run_id` annotation to the new pipeline.

Note: this is bugged for the "Clone Pipeline" button in the top menu bar when in a subgraph because the url params for a subgraph switch to execution id instead of run id. Not sure yet what the best solution is - in the past we've made a conscious effort to avoid API calls in the header (so we can't use the execution id to call for the run id)

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

Closes https://github.com/TangleML/tangle-ui/issues/260

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

![image.png](https://app.graphite.com/user-attachments/assets/92257e8d-caee-4408-b896-9169951fe2c6.png)

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->
verify that the annotation correctly appears when a run is cloned.

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
