### PR TITLE
refactor: remove fetchFavoriteComponents method

### DIFF
--- a/src/providers/ComponentLibraryProvider/ComponentLibraryProvider.test.tsx
+++ b/src/providers/ComponentLibraryProvider/ComponentLibraryProvider.test.tsx
@@ -56,9 +56,6 @@ const mockFetchUserComponents = vi.mocked(
 const mockFetchUsedComponents = vi.mocked(
   componentLibraryUtils.fetchUsedComponents,
 );
-const mockFetchFavoriteComponents = vi.mocked(
-  componentLibraryUtils.fetchFavoriteComponents,
-);
 const mockPopulateComponentRefs = vi.mocked(
   componentLibraryUtils.populateComponentRefs,
 );
@@ -146,11 +143,6 @@ describe("ComponentLibraryProvider - Component Management", () => {
     mockFetchUserComponents.mockResolvedValue(mockUserComponentsFolder);
     mockFetchUsedComponents.mockReturnValue({
       name: "Used Components",
-      components: [],
-      folders: [],
-    });
-    mockFetchFavoriteComponents.mockReturnValue({
-      name: "Favorites",
       components: [],
       folders: [],
     });

--- a/src/providers/ComponentLibraryProvider/componentLibrary.test.ts
+++ b/src/providers/ComponentLibraryProvider/componentLibrary.test.ts
@@ -16,7 +16,6 @@ import * as localforage from "@/utils/localforage";
 import * as yamlUtils from "@/utils/yaml";
 
 import {
-  fetchFavoriteComponents,
   fetchUsedComponents,
   fetchUserComponents,
   filterToUniqueByDigest,
@@ -259,89 +258,6 @@ describe("componentLibrary", () => {
 
     // todo: test with components without digest
     // todo: test with deeply nested task structures
-  });
-
-  describe("fetchFavoriteComponents", () => {
-    const mockComponentLibrary: ComponentLibrary = {
-      folders: [
-        {
-          name: "Folder 1",
-          components: [
-            {
-              name: "component-1",
-              digest: "digest1",
-              favorited: true,
-            },
-            {
-              name: "component-2",
-              digest: "digest2",
-              favorited: false,
-            },
-          ],
-          folders: [
-            {
-              name: "Subfolder",
-              components: [
-                {
-                  name: "component-3",
-                  digest: "digest3",
-                  favorited: true,
-                },
-              ],
-              folders: [],
-            },
-          ],
-        },
-      ],
-    };
-
-    it("should return favorited components from library", () => {
-      // Act
-      const result = fetchFavoriteComponents(mockComponentLibrary);
-
-      // Assert
-      expect(result).toEqual({
-        name: "Favorite Components",
-        components: [
-          {
-            name: "component-1",
-            digest: "digest1",
-            favorited: true,
-          },
-          {
-            name: "component-3",
-            digest: "digest3",
-            favorited: true,
-          },
-        ],
-        folders: [],
-        isUserFolder: false,
-      });
-    });
-
-    it("should return empty folder when no component library provided", () => {
-      // Act
-      const result = fetchFavoriteComponents(undefined);
-
-      // Assert
-      expect(result).toEqual({
-        name: "Favorite Components",
-        components: [],
-        folders: [],
-        isUserFolder: false,
-      });
-    });
-
-    it("should work without user components", () => {
-      // Act
-      const result = fetchFavoriteComponents(mockComponentLibrary);
-
-      // Assert
-      expect(result.components).toHaveLength(2);
-      expect(result.components?.every((c) => c.favorited)).toBe(true);
-    });
-
-    // todo: test deduplication of favorites with same digest across library and user components
   });
 
   describe("populateComponentRefs", () => {

--- a/src/providers/ComponentLibraryProvider/componentLibrary.ts
+++ b/src/providers/ComponentLibraryProvider/componentLibrary.ts
@@ -90,36 +90,6 @@ export async function isFavoriteComponent(component: ComponentReference) {
   return storedComponent?.favorited ?? false;
 }
 
-/**
- * @deprecated
- */
-export const fetchFavoriteComponents = (
-  componentLibrary: ComponentLibrary | undefined,
-): ComponentFolder => {
-  const favoritesFolder = {
-    name: "Favorite Components",
-    components: [] as ComponentReference[],
-    folders: [],
-    isUserFolder: false,
-  };
-
-  if (!componentLibrary || !componentLibrary.folders) {
-    return favoritesFolder;
-  }
-
-  const uniqueLibraryComponents = filterToUniqueByDigest(
-    flattenFolders(componentLibrary),
-  );
-
-  uniqueLibraryComponents.forEach((component) => {
-    if (component?.favorited) {
-      favoritesFolder.components.push(component);
-    }
-  });
-
-  return favoritesFolder;
-};
-
 export async function populateComponentRefs<
   T extends ComponentLibrary | ComponentFolder,
 >(libraryOrFolder: T): Promise<T> {


### PR DESCRIPTION
## Description

Removed the deprecated `fetchFavoriteComponents` function and its related test cases. This function was previously marked as deprecated and is no longer needed in the codebase.

## Type of Change

- [x] Cleanup/Refactor

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Test Instructions

Verify that the application still functions correctly without the removed function, particularly in areas that might have previously used the favorites functionality.