### PR TITLE
refactor: remove highlighted state from componentLibraryProvider

### DIFF
--- a/src/components/shared/Dialogs/ComponentDuplicateDialog.test.tsx
+++ b/src/components/shared/Dialogs/ComponentDuplicateDialog.test.tsx
@@ -45,17 +45,14 @@ const createMockComponentLibraryContext = (
     error: null,
     existingComponentLibraries: undefined,
     searchResult: null,
-    highlightedComponentDigest: null,
     searchComponentLibrary: vi.fn(),
     addToComponentLibrary: vi.fn(),
     removeFromComponentLibrary: vi.fn(),
     refetchLibrary: vi.fn(),
     refetchUserComponents: vi.fn(),
-    setHighlightedComponentDigest: vi.fn(),
     setComponentFavorite: vi.fn(),
     checkIfUserComponent: vi.fn().mockReturnValue(false),
     checkLibraryContainsComponent: vi.fn().mockReturnValue(false),
-    checkIfHighlighted: vi.fn().mockReturnValue(false),
     getComponentLibrary: vi.fn(),
   };
 };

--- a/src/components/shared/ReactFlow/FlowSidebar/components/ComponentItem.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/components/ComponentItem.tsx
@@ -13,7 +13,6 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { useHydrateComponentReference } from "@/hooks/useHydrateComponentReference";
 import { cn } from "@/lib/utils";
-import { useComponentLibrary } from "@/providers/ComponentLibraryProvider";
 import { type ComponentReference, type TaskSpec } from "@/utils/componentSpec";
 import { getComponentName } from "@/utils/getComponentName";
 import { isSubgraph } from "@/utils/subgraphUtils";
@@ -83,7 +82,6 @@ const ComponentMarkup = ({
 
   // TODO: respect selected node as a starting point
   const carousel = useRef(0);
-  const { checkIfHighlighted } = useComponentLibrary();
   const { notifyNode, getNodeIdsByDigest, fitNodeIntoView } = useNodesOverlay();
 
   const { spec, digest, url, name, published_by: author, owned } = component;
@@ -177,7 +175,6 @@ const ComponentMarkup = ({
         error
           ? "cursor-not-allowed opacity-60"
           : "cursor-grab hover:bg-gray-100 active:bg-gray-200",
-        checkIfHighlighted(component) && "bg-orange-100",
       )}
       draggable={!error && !isLoading}
       onDragStart={onDragStart}

--- a/src/providers/ComponentLibraryProvider/ComponentLibraryProvider.tsx
+++ b/src/providers/ComponentLibraryProvider/ComponentLibraryProvider.tsx
@@ -76,7 +76,6 @@ type ComponentLibraryContextType = {
   existingComponentLibraries: StoredLibrary[] | undefined;
   searchResult: SearchResult | null;
 
-  highlightedComponentDigest: string | null;
   searchComponentLibrary: (
     search: string,
     filters: string[],
@@ -88,14 +87,12 @@ type ComponentLibraryContextType = {
   refetchLibrary: () => void;
   refetchUserComponents: () => void;
 
-  setHighlightedComponentDigest: (digest: string | null) => void;
   setComponentFavorite: (
     component: ComponentReference,
     favorited: boolean,
   ) => void;
   checkIfUserComponent: (component: ComponentReference) => boolean;
   checkLibraryContainsComponent: (component: ComponentReference) => boolean;
-  checkIfHighlighted: (component: ComponentReference) => boolean;
 
   getComponentLibrary: (libraryName: AvailableComponentLibraries) => Library;
 };
@@ -178,10 +175,6 @@ export const ComponentLibraryProvider = ({
   const [componentLibrary, setComponentLibrary] = useState<ComponentLibrary>();
   const [userComponentsFolder, setUserComponentsFolder] =
     useState<ComponentFolder>();
-
-  const [highlightedComponentDigest, setHighlightedComponentDigest] = useState<
-    string | null
-  >(null);
 
   const [existingComponent, setExistingComponent] =
     useState<UserComponent | null>(null);
@@ -363,13 +356,6 @@ export const ComponentLibraryProvider = ({
       return uniqueComponents.some((c) => c.digest === component.digest);
     },
     [componentLibrary, checkIfUserComponent],
-  );
-
-  const checkIfHighlighted = useCallback(
-    (component: ComponentReference) => {
-      return component.digest === highlightedComponentDigest;
-    },
-    [highlightedComponentDigest],
   );
 
   /**
@@ -602,7 +588,6 @@ export const ComponentLibraryProvider = ({
       isLoading,
       error,
       searchResult,
-      highlightedComponentDigest,
       existingComponentLibraries,
       searchComponentLibrary,
       getComponentLibrary,
@@ -610,11 +595,9 @@ export const ComponentLibraryProvider = ({
       removeFromComponentLibrary,
       refetchLibrary,
       refetchUserComponents,
-      setHighlightedComponentDigest,
       setComponentFavorite,
       checkIfUserComponent,
       checkLibraryContainsComponent,
-      checkIfHighlighted,
     }),
     [
       componentLibrary,
@@ -624,7 +607,6 @@ export const ComponentLibraryProvider = ({
       isLoading,
       error,
       searchResult,
-      highlightedComponentDigest,
       existingComponentLibraries,
       searchComponentLibrary,
       getComponentLibrary,
@@ -632,11 +614,9 @@ export const ComponentLibraryProvider = ({
       removeFromComponentLibrary,
       refetchLibrary,
       refetchUserComponents,
-      setHighlightedComponentDigest,
       setComponentFavorite,
       checkIfUserComponent,
       checkLibraryContainsComponent,
-      checkIfHighlighted,
     ],
   );
 


### PR DESCRIPTION
## Description

Removed the component highlighting functionality from the ComponentLibraryProvider. This includes removing the `highlightedComponentDigest` state, `setHighlightedComponentDigest` method, and `checkIfHighlighted` function. Also removed the highlighting-related CSS class from ComponentItem and updated the mock in ComponentDuplicateDialog test.

## Type of Change

- [x] Cleanup/Refactor

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging