### PR TITLE
refactor: remove unsused props from componentLibraryProvider

### DIFF
--- a/src/components/shared/Dialogs/ComponentDuplicateDialog.test.tsx
+++ b/src/components/shared/Dialogs/ComponentDuplicateDialog.test.tsx
@@ -48,8 +48,6 @@ const createMockComponentLibraryContext = (
     searchComponentLibrary: vi.fn(),
     addToComponentLibrary: vi.fn(),
     removeFromComponentLibrary: vi.fn(),
-    refetchLibrary: vi.fn(),
-    refetchUserComponents: vi.fn(),
     setComponentFavorite: vi.fn(),
     checkIfUserComponent: vi.fn().mockReturnValue(false),
     checkLibraryContainsComponent: vi.fn().mockReturnValue(false),

--- a/src/providers/ComponentLibraryProvider/ComponentLibraryProvider.tsx
+++ b/src/providers/ComponentLibraryProvider/ComponentLibraryProvider.tsx
@@ -84,9 +84,6 @@ type ComponentLibraryContextType = {
     component: HydratedComponentReference,
   ) => Promise<HydratedComponentReference | undefined>;
   removeFromComponentLibrary: (component: ComponentReference) => void;
-  refetchLibrary: () => void;
-  refetchUserComponents: () => void;
-
   setComponentFavorite: (
     component: ComponentReference,
     favorited: boolean,
@@ -593,8 +590,6 @@ export const ComponentLibraryProvider = ({
       getComponentLibrary,
       addToComponentLibrary,
       removeFromComponentLibrary,
-      refetchLibrary,
-      refetchUserComponents,
       setComponentFavorite,
       checkIfUserComponent,
       checkLibraryContainsComponent,
@@ -612,8 +607,6 @@ export const ComponentLibraryProvider = ({
       getComponentLibrary,
       addToComponentLibrary,
       removeFromComponentLibrary,
-      refetchLibrary,
-      refetchUserComponents,
       setComponentFavorite,
       checkIfUserComponent,
       checkLibraryContainsComponent,


### PR DESCRIPTION
## Description

Removed unused `refetchLibrary` and `refetchUserComponents` methods from the ComponentLibraryProvider context and its mock in tests. These methods were defined in the context type but are no longer needed.

## Type of Change

- [x] Cleanup/Refactor

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Test Instructions

Verify that component library functionality continues to work as expected without the removed refetch methods.