### PR TITLE
refactor: move checkLibraryContainsComponent out of ComponentLibraryProvider

### DIFF
--- a/src/components/shared/Dialogs/ComponentDuplicateDialog.test.tsx
+++ b/src/components/shared/Dialogs/ComponentDuplicateDialog.test.tsx
@@ -50,7 +50,6 @@ const createMockComponentLibraryContext = (
     removeFromComponentLibrary: vi.fn(),
     setComponentFavorite: vi.fn(),
     checkIfUserComponent: vi.fn().mockReturnValue(false),
-    checkLibraryContainsComponent: vi.fn().mockReturnValue(false),
     getComponentLibrary: vi.fn(),
   };
 };

--- a/src/providers/ComponentLibraryProvider/ComponentLibraryProvider.test.tsx
+++ b/src/providers/ComponentLibraryProvider/ComponentLibraryProvider.test.tsx
@@ -536,29 +536,6 @@ describe("ComponentLibraryProvider - Component Management", () => {
         result.current.checkIfUserComponent(standardComponent);
       expect(isUserComponent).toBe(false);
     });
-
-    it("should correctly check if library contains component", async () => {
-      const libraryComponent: ComponentReference = {
-        name: "library-component",
-        digest: "library-digest",
-        spec: mockComponentSpec,
-      };
-
-      mockFlattenFolders.mockReturnValue([libraryComponent]);
-      mockFilterToUniqueByDigest.mockReturnValue([libraryComponent]);
-
-      const { result } = renderHook(() => useComponentLibrary(), {
-        wrapper: createWrapper,
-      });
-
-      await waitFor(() => {
-        expect(result.current.isLoading).toBe(false);
-      });
-
-      const containsComponent =
-        result.current.checkLibraryContainsComponent(libraryComponent);
-      expect(containsComponent).toBe(true);
-    });
   });
 
   describe("Component Favoriting", () => {

--- a/src/providers/ComponentLibraryProvider/ComponentLibraryProvider.tsx
+++ b/src/providers/ComponentLibraryProvider/ComponentLibraryProvider.tsx
@@ -96,7 +96,6 @@ type ComponentLibraryContextType = {
     favorited: boolean,
   ) => void;
   checkIfUserComponent: (component: ComponentReference) => boolean;
-  checkLibraryContainsComponent: (component: ComponentReference) => boolean;
 
   getComponentLibrary: (libraryName: AvailableComponentLibraries) => Library;
 };
@@ -345,21 +344,6 @@ export const ComponentLibraryProvider = ({
       return uniqueUserComponents.some((c) => c.digest === component.digest);
     },
     [userComponentsFolder],
-  );
-
-  const checkLibraryContainsComponent = useCallback(
-    (component: ComponentReference) => {
-      if (!componentLibrary) return false;
-
-      if (checkIfUserComponent(component)) return true;
-
-      const uniqueComponents = filterToUniqueByDigest(
-        flattenFolders(componentLibrary),
-      );
-
-      return uniqueComponents.some((c) => c.digest === component.digest);
-    },
-    [componentLibrary, checkIfUserComponent],
   );
 
   /**
@@ -639,7 +623,6 @@ export const ComponentLibraryProvider = ({
       removeFromComponentLibrary,
       setComponentFavorite,
       checkIfUserComponent,
-      checkLibraryContainsComponent,
     }),
     [
       componentLibrary,
@@ -656,7 +639,6 @@ export const ComponentLibraryProvider = ({
       removeFromComponentLibrary,
       setComponentFavorite,
       checkIfUserComponent,
-      checkLibraryContainsComponent,
     ],
   );
 


### PR DESCRIPTION
## Description

Closes https://github.com/Shopify/oasis-frontend/issues/249

Refactored component library functionality by removing the `checkLibraryContainsComponent` method and replacing it with a more efficient approach using React Query. The new implementation:

1. Adds a `useComponentFlags` hook that uses `useSuspenseQuery` to determine if a component exists in the library
2. Wraps the `ComponentFavoriteToggle` with a suspense wrapper to handle loading states
3. Improves performance by adding stale time to the query and optimizing component comparison

## Type of Change

- [x] Improvement
- [x] Cleanup/Refactor

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Test Instructions

1. Verify that component favorites still work correctly
2. Check that components are properly identified as being in the library or not
3. Confirm that loading states are handled appropriately with the suspense wrapper