### PR TITLE
refactor: react compiler in GraphComponents

### DIFF
--- a/react-compiler.config.js
+++ b/react-compiler.config.js
@@ -42,6 +42,7 @@ export const REACT_COMPILER_ENABLED_DIRS = [
   "src/components/shared/ManageComponent/DeprecatePublishedComponentButton.tsx",
   "src/components/shared/ManageComponent/PublishComponent.tsx",
   "src/components/shared/ManageComponent/hooks/useComponentCanvasTasks.ts",
+  "src/components/shared/ReactFlow/FlowSidebar/sections/GraphComponents.tsx",
 
   // 11-20 useCallback/useMemo
   // "src/components/ui",                         // 12


### PR DESCRIPTION
## Description

Refactored the GraphComponents component by extracting the component library section into a separate `ComponentLibrarySection` function component. This improves code organization by:

1. Removing the `useMemo` and `useCallback` hooks in favor of a more straightforward component structure
2. Moving related functionality into a dedicated component
3. Simplifying the main component's render logic

## Type of Change

- [x] Cleanup/Refactor

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

Verify that the component library sidebar displays correctly and that all functionality (search, filtering, component selection) works as expected.