### PR TITLE
refactor: move favorite libs to indexdb library

### DIFF
--- a/src/components/shared/Dialogs/ComponentDuplicateDialog.test.tsx
+++ b/src/components/shared/Dialogs/ComponentDuplicateDialog.test.tsx
@@ -40,7 +40,6 @@ const createMockComponentLibraryContext = (
     componentLibrary: undefined,
     userComponentsFolder,
     usedComponentsFolder: { name: "Used", components: [] },
-    favoritesFolder: { name: "Favorites", components: [] },
     isLoading: false,
     error: null,
     existingComponentLibraries: undefined,
@@ -48,7 +47,6 @@ const createMockComponentLibraryContext = (
     searchComponentLibrary: vi.fn(),
     addToComponentLibrary: vi.fn(),
     removeFromComponentLibrary: vi.fn(),
-    setComponentFavorite: vi.fn(),
     checkIfUserComponent: vi.fn().mockReturnValue(false),
     getComponentLibrary: vi.fn(),
   };

--- a/src/components/shared/ReactFlow/FlowSidebar/sections/GraphComponents.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/sections/GraphComponents.tsx
@@ -39,7 +39,6 @@ const GraphComponents = ({ isOpen }: { isOpen: boolean }) => {
   const remoteComponentLibrarySearchEnabled = useFlagValue(
     "remote-component-library-search",
   );
-
   const { updateSearchFilter, currentSearchFilter } = useForcedSearchContext();
 
   const handleSearchChange = (e: ChangeEvent<HTMLInputElement>) => {
@@ -129,12 +128,13 @@ function ComponentLibrarySection() {
   const { getComponentLibrary, existingComponentLibraries } =
     useComponentLibrary();
 
+  const favoriteComponentsLibrary = getComponentLibrary("favorite_components");
+
   const { updateSearchFilter } = useForcedSearchContext();
   const {
     componentLibrary,
     usedComponentsFolder,
     userComponentsFolder,
-    favoritesFolder,
     isLoading,
     error,
     searchResult,
@@ -165,9 +165,6 @@ function ComponentLibrarySection() {
     usedComponentsFolder?.components &&
     usedComponentsFolder.components.length > 0;
 
-  const hasFavouriteComponents =
-    favoritesFolder?.components && favoritesFolder.components.length > 0;
-
   const hasUserComponents =
     userComponentsFolder?.components &&
     userComponentsFolder.components.length > 0;
@@ -184,13 +181,13 @@ function ComponentLibrarySection() {
             icon="LayoutGrid"
           />
         )}
-        {hasFavouriteComponents && (
-          <FolderItem
-            key="favorite-components-folder"
-            folder={favoritesFolder}
-            icon="Star"
-          />
-        )}
+
+        <LibraryFolderItem
+          key="favorite-components-folder-v2"
+          library={favoriteComponentsLibrary}
+          icon="Star"
+        />
+
         {hasUserComponents && (
           <FolderItem
             key="my-components-folder"

--- a/src/providers/ComponentLibraryProvider/ComponentLibraryProvider.test.tsx
+++ b/src/providers/ComponentLibraryProvider/ComponentLibraryProvider.test.tsx
@@ -67,14 +67,9 @@ const mockImportComponent = vi.mocked(componentStore.importComponent);
 const mockDeleteComponentFileFromList = vi.mocked(
   componentStore.deleteComponentFileFromList,
 );
-const mockUpdateComponentRefInList = vi.mocked(
-  componentStore.updateComponentRefInList,
-);
-const mockGetComponentByUrl = vi.mocked(localforage.getComponentByUrl);
 const mockGetUserComponentByName = vi.mocked(
   localforage.getUserComponentByName,
 );
-const mockSaveComponent = vi.mocked(localforage.saveComponent);
 const mockGetComponentName = vi.mocked(getComponentName.getComponentName);
 
 describe("ComponentLibraryProvider - Component Management", () => {
@@ -535,84 +530,6 @@ describe("ComponentLibraryProvider - Component Management", () => {
       const isUserComponent =
         result.current.checkIfUserComponent(standardComponent);
       expect(isUserComponent).toBe(false);
-    });
-  });
-
-  describe("Component Favoriting", () => {
-    it("should set component as favorite for user components", async () => {
-      const userComponent: ComponentReference = {
-        name: "user-component",
-        digest: "user-digest",
-        spec: mockComponentSpec,
-        text: "user yaml content",
-      };
-
-      mockUpdateComponentRefInList.mockResolvedValue({
-        componentRef: userComponent,
-        name: "user-component",
-        data: new ArrayBuffer(0),
-        creationTime: new Date(),
-        modificationTime: new Date(),
-      } as any);
-
-      const { result } = renderHook(() => useComponentLibrary(), {
-        wrapper: createWrapper,
-      });
-
-      await waitFor(() => {
-        expect(result.current.isLoading).toBe(false);
-      });
-
-      await act(async () => {
-        await result.current.setComponentFavorite(userComponent, true);
-      });
-
-      expect(mockUpdateComponentRefInList).toHaveBeenCalledWith(
-        USER_COMPONENTS_LIST_NAME,
-        expect.objectContaining({ favorited: true }),
-        "user-component",
-      );
-    });
-
-    it("should set component as favorite for standard components", async () => {
-      const standardComponent: ComponentReference = {
-        name: "standard-component",
-        digest: "standard-digest",
-        url: "https://example.com/standard.yaml",
-        spec: mockComponentSpec,
-      };
-
-      const mockStoredComponent = {
-        id: "stored-1",
-        url: "https://example.com/standard.yaml",
-        data: "stored yaml",
-        createdAt: Date.now(),
-        updatedAt: Date.now(),
-        favorited: false,
-      };
-
-      mockGetComponentByUrl.mockResolvedValue(mockStoredComponent);
-      mockSaveComponent.mockResolvedValue(mockStoredComponent as any);
-
-      const { result } = renderHook(() => useComponentLibrary(), {
-        wrapper: createWrapper,
-      });
-
-      await waitFor(() => {
-        expect(result.current.isLoading).toBe(false);
-      });
-
-      await act(async () => {
-        await result.current.setComponentFavorite(standardComponent, true);
-      });
-
-      expect(mockGetComponentByUrl).toHaveBeenCalledWith(
-        "https://example.com/standard.yaml",
-      );
-      expect(mockSaveComponent).toHaveBeenCalledWith({
-        ...mockStoredComponent,
-        favorited: true,
-      });
     });
   });
 });

--- a/src/providers/ComponentLibraryProvider/componentLibrary.ts
+++ b/src/providers/ComponentLibraryProvider/componentLibrary.ts
@@ -13,7 +13,7 @@ import {
   getAllComponentFilesFromList,
 } from "@/utils/componentStore";
 import { USER_COMPONENTS_LIST_NAME } from "@/utils/constants";
-import { getComponentById, getComponentByUrl } from "@/utils/localforage";
+import { getComponentByUrl } from "@/utils/localforage";
 import { componentSpecToYaml } from "@/utils/yaml";
 
 export const fetchUserComponents = async (): Promise<ComponentFolder> => {
@@ -79,16 +79,6 @@ export const fetchUsedComponents = (graphSpec: GraphSpec): ComponentFolder => {
     isUserFolder: false,
   };
 };
-
-export async function isFavoriteComponent(component: ComponentReference) {
-  if (!component.digest) return false;
-
-  const storedComponent = await getComponentById(
-    `component-${component.digest}`,
-  );
-
-  return storedComponent?.favorited ?? false;
-}
 
 export async function populateComponentRefs<
   T extends ComponentLibrary | ComponentFolder,

--- a/src/providers/ComponentLibraryProvider/libraries/favoriteLibrary.ts
+++ b/src/providers/ComponentLibraryProvider/libraries/favoriteLibrary.ts
@@ -1,0 +1,69 @@
+import { hydrateComponentReference } from "@/services/componentService";
+import { iterateOverAllComponents } from "@/utils/localforage";
+
+import { BrowserPersistedLibrary } from "./browserPersistedLibrary";
+import { LibraryDB, type StoredLibraryItem } from "./storage";
+
+const FAVORITE_COMPONENTS_LIBRARY_ID = "favorite_components";
+
+export class FavoriteLibrary extends BrowserPersistedLibrary {
+  constructor() {
+    super(FAVORITE_COMPONENTS_LIBRARY_ID, () => migrateLegacyFavoriteFolder());
+  }
+}
+
+/**
+ * Migrate the favorite components to the new database.
+ * This action supposed to happen only once.
+ *
+ * @returns
+ */
+async function migrateLegacyFavoriteFolder() {
+  /**
+   * Migrate the favorite components to the new database
+   */
+  const favoriteComponents: StoredLibraryItem[] = [];
+  await iterateOverAllComponents(async (component) => {
+    if (component.favorited) {
+      console.log(
+        `Migrating component ${component.id} to favorite library. Favorited: ${component.favorited}`,
+        component,
+      );
+
+      const hydratedComponent = await hydrateComponentReference({
+        url: component.url,
+        text: component.data,
+      });
+
+      if (!hydratedComponent) {
+        console.error(
+          `Failed to migrate component "${component.id}" to favorite library`,
+          component,
+        );
+        return;
+      }
+
+      favoriteComponents.push({
+        digest: hydratedComponent.digest,
+        name: hydratedComponent.name,
+        url: hydratedComponent.url,
+      } as StoredLibraryItem);
+    }
+  });
+
+  await LibraryDB.component_libraries.put({
+    id: FAVORITE_COMPONENTS_LIBRARY_ID,
+    name: "Favorite Components",
+    icon: "Star",
+    type: "indexdb",
+    knownDigests: favoriteComponents.map((component) => component.digest),
+    configuration: {
+      migrated_at: new Date().toISOString(),
+    },
+    components: favoriteComponents,
+  });
+
+  return await LibraryDB.component_libraries.get(
+    FAVORITE_COMPONENTS_LIBRARY_ID,
+  );
+}

--- a/src/providers/ComponentLibraryProvider/libraries/storage.ts
+++ b/src/providers/ComponentLibraryProvider/libraries/storage.ts
@@ -4,7 +4,7 @@ import { icons } from "lucide-react";
 const DB_NAME = "oasis-app";
 const DEXIE_EPOCH = 0;
 
-interface StoredLibraryItem {
+export interface StoredLibraryItem {
   digest: string;
   name: string;
   url?: string;

--- a/src/utils/componentStore.ts
+++ b/src/utils/componentStore.ts
@@ -274,7 +274,8 @@ interface FileEntry {
 }
 
 interface ComponentFileEntryV3
-  extends FileEntry, ComponentReferenceWithSpecPlusData {}
+  extends FileEntry,
+    ComponentReferenceWithSpecPlusData {}
 
 export type ComponentFileEntry = ComponentFileEntryV3;
 
@@ -476,22 +477,6 @@ const addComponentToListByTextWithDuplicateCheck = async (
   );
 
   return fileEntry;
-};
-
-export const updateComponentInListByText = async (
-  listName: string,
-  componentText: string | ArrayBuffer,
-  fileName: string,
-  additionalData?: {
-    [K: string]: any;
-  },
-) => {
-  const componentRef = await storeComponentText(componentText);
-  if (additionalData) {
-    // Merge additional data into the component reference
-    Object.assign(componentRef, additionalData);
-  }
-  return updateComponentRefInList(listName, componentRef, fileName);
 };
 
 export const writeComponentToFileListFromText = async (

--- a/src/utils/localforage.ts
+++ b/src/utils/localforage.ts
@@ -76,6 +76,16 @@ export async function getComponentById(id: string): Promise<Component | null> {
   return componentStore.getItem<Component>(id);
 }
 
+export async function iterateOverAllComponents(
+  visitorFn: (component: Component) => Promise<void>,
+): Promise<void> {
+  const promises: Promise<void>[] = [];
+  await componentStore.iterate<Component, void>((component) => {
+    promises.push(visitorFn(component));
+  });
+  await Promise.all(promises);
+}
+
 // Function to get a component by URL
 export async function getComponentByUrl(
   url: string,

--- a/vitest-setup.js
+++ b/vitest-setup.js
@@ -1,1 +1,2 @@
 import "@testing-library/jest-dom/vitest";
+import "fake-indexeddb/auto";


### PR DESCRIPTION
## Description

Refactored the component favorites system to use a dedicated IndexedDB-based library instead of the previous approach that stored favorite status directly on component objects. This change:

1. Introduces a new `FavoriteLibrary` class that extends `BrowserPersistedLibrary`
2. Migrates existing favorited components to the new storage system
3. Updates the UI components to use the new library for managing favorites
4. Removes the now-obsolete `setComponentFavorite` method and related code

## Type of Change

- [x] Improvement
- [x] Cleanup/Refactor

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Test Instructions

1. Verify that existing favorite components are migrated correctly
2. Test adding and removing components from favorites
3. Confirm that the favorites folder displays correctly in the component library