### PR TITLE
refactor: move standard library to yamllibrary

### DIFF
--- a/src/components/shared/ReactFlow/FlowSidebar/components/LibraryStates.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/components/LibraryStates.tsx
@@ -12,7 +12,3 @@ export const LoadingState = () => (
 export const ErrorState = ({ message }: { message: string }) => (
   <SidebarMenuItem className="text-red-500">Error: {message}</SidebarMenuItem>
 );
-
-export const EmptyState = () => (
-  <SidebarMenuItem>No components found</SidebarMenuItem>
-);

--- a/src/components/shared/ReactFlow/FlowSidebar/components/index.ts
+++ b/src/components/shared/ReactFlow/FlowSidebar/components/index.ts
@@ -1,5 +1,5 @@
 export { default as FolderItem } from "./FolderItem";
 export { default as ImportComponent } from "./ImportComponent";
-export { EmptyState, ErrorState, LoadingState } from "./LibraryStates";
+export { ErrorState, LoadingState } from "./LibraryStates";
 export { default as SearchInput } from "./SearchInput";
 export { default as SearchResults } from "./SearchResults";

--- a/src/components/shared/ReactFlow/FlowSidebar/sections/GraphComponents.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/sections/GraphComponents.tsx
@@ -22,7 +22,6 @@ import { useForcedSearchContext } from "@/providers/ComponentLibraryProvider/For
 import type { UIComponentFolder } from "@/types/componentLibrary";
 
 import {
-  EmptyState,
   ErrorState,
   FolderItem,
   ImportComponent,
@@ -132,13 +131,14 @@ function ComponentLibrarySection() {
 
   const { updateSearchFilter } = useForcedSearchContext();
   const {
-    componentLibrary,
     usedComponentsFolder,
     userComponentsFolder,
     isLoading,
     error,
     searchResult,
   } = useComponentLibrary();
+
+  const standardComponentsLibrary = getComponentLibrary("standard_components");
 
   const handleFiltersChange = (filters: string[]) => {
     updateSearchFilter({
@@ -148,7 +148,6 @@ function ComponentLibrarySection() {
 
   if (isLoading) return <LoadingState />;
   if (error) return <ErrorState message={(error as Error).message} />;
-  if (!componentLibrary) return <EmptyState />;
 
   if (!remoteComponentLibrarySearchEnabled && searchResult) {
     // If there's a search result, use the SearchResults component
@@ -211,15 +210,9 @@ function ComponentLibrarySection() {
           icon="Cable"
         />
         <Separator />
-        <FolderItem
-          key="standard-library-folder"
-          folder={
-            {
-              name: "Standard library",
-              components: [],
-              folders: componentLibrary.folders,
-            } as UIComponentFolder
-          }
+        <LibraryFolderItem
+          key="standard-library-folder-v2"
+          library={standardComponentsLibrary}
           icon="Folder"
         />
         {githubComponentLibraryEnabled && (

--- a/src/providers/ComponentLibraryProvider/ComponentLibraryProvider.test.tsx
+++ b/src/providers/ComponentLibraryProvider/ComponentLibraryProvider.test.tsx
@@ -41,15 +41,12 @@ vi.mock("./componentLibrary");
 
 // Import mocked modules
 import * as componentLibraryUtils from "@/providers/ComponentLibraryProvider/componentLibrary";
-import * as componentService from "@/services/componentService";
 import * as componentStore from "@/utils/componentStore";
 import * as getComponentName from "@/utils/getComponentName";
 import * as localforage from "@/utils/localforage";
 
 // Mock implementations
-const mockFetchAndStoreComponentLibrary = vi.mocked(
-  componentService.fetchAndStoreComponentLibrary,
-);
+
 const mockFetchUserComponents = vi.mocked(
   componentLibraryUtils.fetchUserComponents,
 );
@@ -134,7 +131,6 @@ describe("ComponentLibraryProvider - Component Management", () => {
     componentDuplicateDialogProps.handleImportComponent = undefined;
 
     // Setup default mock implementations
-    mockFetchAndStoreComponentLibrary.mockResolvedValue(mockComponentLibrary);
     mockFetchUserComponents.mockResolvedValue(mockUserComponentsFolder);
     mockFetchUsedComponents.mockReturnValue({
       name: "Used Components",

--- a/src/services/componentService.ts
+++ b/src/services/componentService.ts
@@ -1,10 +1,5 @@
 import { getAppSettings } from "@/appSettings";
 import {
-  type ComponentLibrary,
-  isValidComponentLibrary,
-} from "@/types/componentLibrary";
-import { loadObjectFromYamlData } from "@/utils/cache";
-import {
   type ComponentReference,
   type ComponentSpec,
   type ContentfulComponentReference,
@@ -42,77 +37,7 @@ interface ExistingAndNewComponent {
   newComponent: HydratedComponentReference | undefined;
 }
 
-const COMPONENT_LIBRARY_URL = getAppSettings().componentLibraryUrl;
-
-/**
- * Fetches the component library from local storage
- */
-const loadComponentLibraryFromLocalStorage =
-  async (): Promise<ComponentLibrary | null> => {
-    const libraryExists = await componentExistsByUrl(COMPONENT_LIBRARY_URL);
-
-    if (libraryExists) {
-      const storedLibrary = await getComponentByUrl(COMPONENT_LIBRARY_URL);
-      if (storedLibrary) {
-        try {
-          const parsedLibrary = JSON.parse(storedLibrary.data);
-          if (isValidComponentLibrary(parsedLibrary)) {
-            return parsedLibrary;
-          }
-        } catch (error) {
-          console.error("Error parsing stored component library:", error);
-        }
-      }
-    }
-
-    return null;
-  };
-
-/**
- * Fetches the component library and stores all components in local storage
- */
-export const fetchAndStoreComponentLibrary =
-  async (): Promise<ComponentLibrary> => {
-    // Try fetch from the URL
-    const response = await fetch(COMPONENT_LIBRARY_URL);
-    if (!response.ok) {
-      // Fallback to local storage
-      await loadComponentLibraryFromLocalStorage().then((library) => {
-        if (library) {
-          return library;
-        }
-      });
-
-      throw new Error(
-        `Failed to load component library: ${response.statusText}`,
-      );
-    }
-
-    const arrayBuffer = await response.arrayBuffer();
-    const obj = loadObjectFromYamlData(arrayBuffer);
-
-    if (!isValidComponentLibrary(obj)) {
-      // Fallback to local storage
-      await loadComponentLibraryFromLocalStorage().then((library) => {
-        if (library) {
-          return library;
-        }
-      });
-
-      throw new Error("Invalid component library structure");
-    }
-
-    // Store the fetched library in local storage
-    await saveComponent({
-      id: `library-${Date.now()}`,
-      url: COMPONENT_LIBRARY_URL,
-      data: JSON.stringify(obj),
-      createdAt: Date.now(),
-      updatedAt: Date.now(),
-    });
-
-    return obj;
-  };
+export const COMPONENT_LIBRARY_URL = getAppSettings().componentLibraryUrl;
 
 /**
  * Fetch and store a single component by URL


### PR DESCRIPTION
## Description

Refactored component library management to use a registry-based approach. This PR:

- Replaced the monolithic component library with a registry of library objects
- Implemented a `YamlFileLibrary` class for standard components
- Removed the deprecated `fetchAndStoreComponentLibrary` function
- Updated `FavoriteComponentToggle` to use the new library structure
- Simplified component lookup by using the library's `hasComponent` method
- Removed unused `EmptyState` component from FlowSidebar
- Updated GraphComponents to use the new library structure

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [x] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

1. Verify that the component library loads correctly in the sidebar
2. Check that favorite component toggling works as expected
3. Ensure component search functionality works properly