### PR TITLE
fix: Querying data unreliable with custom backend

### DIFF
--- a/src/components/Home/RunSection/RunSection.tsx
+++ b/src/components/Home/RunSection/RunSection.tsx
@@ -75,7 +75,7 @@ export const RunSection = ({ onEmptyList }: { onEmptyList?: () => void }) => {
 
   const { data, isLoading, isFetching, error, isFetched } =
     useQuery<ListPipelineJobsResponse>({
-      queryKey: ["runs", backendUrl, pageToken, search.filter],
+      queryKey: ["runs", pageToken, search.filter],
       refetchOnWindowFocus: false,
       enabled: configured && available,
       queryFn: async () => {

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOSection.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOSection.tsx
@@ -8,6 +8,7 @@ import { useBackend } from "@/providers/BackendProvider";
 import { getExecutionArtifacts } from "@/services/executionService";
 import { getBackendStatusString } from "@/utils/backend";
 import type { TaskSpec } from "@/utils/componentSpec";
+import { BACKEND_QUERY_KEY } from "@/utils/constants";
 
 import IOExtras from "./IOExtras";
 import IOInputs from "./IOInputs";
@@ -28,9 +29,9 @@ const IOSection = ({ taskSpec, executionId, readOnly }: IOSectionProps) => {
     isFetching,
     error,
   } = useQuery({
-    queryKey: ["artifacts", executionId],
+    queryKey: [BACKEND_QUERY_KEY, "artifacts", executionId],
     queryFn: () => getExecutionArtifacts(String(executionId), backendUrl),
-    enabled: !!executionId,
+    enabled: !!executionId && configured,
   });
 
   if (!configured) {

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/logs.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/logs.tsx
@@ -7,6 +7,7 @@ import { Link } from "@/components/ui/link";
 import { Spinner } from "@/components/ui/spinner";
 import { useBackend } from "@/providers/BackendProvider";
 import { getBackendStatusString } from "@/utils/backend";
+import { BACKEND_QUERY_KEY } from "@/utils/constants";
 
 const LogDisplay = ({
   logs,
@@ -108,10 +109,10 @@ const Logs = ({
     log_text?: string;
     system_error_exception_full?: string;
   }>();
-  const { data, isLoading, error, refetch } = useQuery({
-    queryKey: ["logs", executionId],
+  const { data, isLoading, error } = useQuery({
+    queryKey: [BACKEND_QUERY_KEY, "logs", executionId],
     queryFn: () => getLogs(String(executionId), backendUrl),
-    enabled: isLogging,
+    enabled: isLogging && configured,
     refetchInterval: 5000,
     refetchIntervalInBackground: false,
   });
@@ -135,10 +136,6 @@ const Logs = ({
       setLogs({ log_text: "No logs available" });
     }
   }, [data, error]);
-
-  useEffect(() => {
-    refetch();
-  }, [backendUrl, refetch]);
 
   if (!configured) {
     return (

--- a/src/services/executionService.ts
+++ b/src/services/executionService.ts
@@ -9,6 +9,7 @@ import type {
 } from "@/api/types.gen";
 import { useBackend } from "@/providers/BackendProvider";
 import {
+  BACKEND_QUERY_KEY,
   DEFAULT_RATE_LIMIT_RPS,
   TWENTY_FOUR_HOURS_IN_MS,
 } from "@/utils/constants";
@@ -47,12 +48,12 @@ export const fetchPipelineRun = async (
 };
 
 export const useFetchPipelineRunMetadata = (runId: string | undefined) => {
-  const { backendUrl } = useBackend();
+  const { backendUrl, configured } = useBackend();
 
   return useQuery<PipelineRunResponse>({
-    queryKey: ["pipeline-run-metadata", runId],
+    queryKey: [BACKEND_QUERY_KEY, "pipeline-run-metadata", runId],
     queryFn: () => fetchPipelineRun(runId!, backendUrl),
-    enabled: !!runId,
+    enabled: !!runId && configured,
     refetchOnWindowFocus: false,
     staleTime: TWENTY_FOUR_HOURS_IN_MS,
   });
@@ -70,10 +71,12 @@ export const useFetchContainerExecutionState = (
   executionId: string | undefined,
   backendUrl: string,
 ) => {
+  const { configured } = useBackend();
+
   return useQuery<GetContainerExecutionStateResponse>({
-    queryKey: ["container-execution-state", executionId],
+    queryKey: [BACKEND_QUERY_KEY, "container-execution-state", executionId],
     queryFn: () => fetchContainerExecutionState(executionId!, backendUrl),
-    enabled: !!executionId,
+    enabled: !!executionId && configured,
     refetchOnWindowFocus: false,
   });
 };

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -80,3 +80,7 @@ export const ISO8601_DURATION_ZERO_DAYS = "P0D";
 export const DEFAULT_RATE_LIMIT_RPS = 10; // requests per second
 
 export const MINUTES = 60 * 1000;
+
+// Query key prefix for backend-dependent queries
+// All queries with this prefix are invalidated when the backend URL changes
+export const BACKEND_QUERY_KEY = "backend";


### PR DESCRIPTION
## Description

Added `BACKEND_QUERY_KEY` to React Query hooks and updated query keys to ensure proper cache invalidation when the backend URL changes. This fixes issues where data wasn't being properly fetched when using a custom backend URL instead of the default one.

The changes include:
- Removing `backendUrl` from query keys to ensure cache is shared regardless of URL
- Adding `BACKEND_QUERY_KEY` prefix to backend-dependent queries
- Adding `!!configured` to query enabled conditions to prevent fetching before backend is configured
- Implementing cache invalidation when backend URL changes
- Adding tests to verify backend configuration behavior

## Related issue

https://github.com/TangleML/tangle-ui/issues/1575

### To Reproduce the bug on master

1. Open your database / backend connection preferences in the top right of the page
2. Set a custom backend to http://localhost:8000
3. Save.
4. Reload the homepage.
5. Select a run.
6. Reload the page when the URL is /runs/{id}
    - At this point, you should see an error.

### Before fix

![image.png](https://app.graphite.com/user-attachments/assets/d86f49fa-90e6-492e-81cc-e7663c4465b1.png)

### After fix

![image.png](https://app.graphite.com/user-attachments/assets/85bcf0ff-c90a-4503-8b75-347966de6f46.png)

## Type of Change

- [x] Bug fix
- [x] Improvement
- [x] Cleanup/Refactor

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Test Instructions

1. Configure multiple backend URLs in settings
2. Regression test submitting runs, and loading run pages using the refresh button of the browser (as well as coming from the homepage)
3. Verify that data is properly fetched with and without custom backend enabled