### PR TITLE
refactor: remove usercomponents from componentLibraryProvider

### DIFF
--- a/src/components/shared/Dialogs/ComponentDuplicateDialog.test.tsx
+++ b/src/components/shared/Dialogs/ComponentDuplicateDialog.test.tsx
@@ -47,7 +47,6 @@ const createMockComponentLibraryContext = (
     searchComponentLibrary: vi.fn(),
     addToComponentLibrary: vi.fn(),
     removeFromComponentLibrary: vi.fn(),
-    checkIfUserComponent: vi.fn().mockReturnValue(false),
     getComponentLibrary: vi.fn(),
   };
 };

--- a/src/components/shared/FavoriteComponentToggle.tsx
+++ b/src/components/shared/FavoriteComponentToggle.tsx
@@ -142,25 +142,28 @@ const FavoriteToggleButton = withSuspenseWrapper(
 );
 
 const useComponentFlags = (component: ComponentReference) => {
-  const { checkIfUserComponent, getComponentLibrary } = useComponentLibrary();
+  const { getComponentLibrary } = useComponentLibrary();
   const componentLibrary = getComponentLibrary("standard_components");
+  const userComponentsLibrary = getComponentLibrary("user_components");
 
-  const isUserComponent = useMemo(
-    () => checkIfUserComponent(component),
-    [checkIfUserComponent],
-  );
-
-  const { data: isInLibrary } = useSuspenseQuery({
+  const { data } = useSuspenseQuery({
     queryKey: ["component", "flags", component.digest],
     queryFn: async () => {
-      if (!componentLibrary) return false;
+      if (!componentLibrary)
+        return { isInLibrary: false, isUserComponent: false };
 
-      return componentLibrary.hasComponent(component);
+      const isUserComponent =
+        await userComponentsLibrary.hasComponent(component);
+
+      return {
+        isInLibrary: await componentLibrary.hasComponent(component),
+        isUserComponent,
+      };
     },
     staleTime: 10 * MINUTES,
   });
 
-  return { isInLibrary, isUserComponent };
+  return data;
 };
 
 const ComponentFavoriteToggleInternal = ({

--- a/src/components/shared/ReactFlow/FlowSidebar/sections/GraphComponents.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/sections/GraphComponents.tsx
@@ -128,15 +128,11 @@ function ComponentLibrarySection() {
     useComponentLibrary();
 
   const favoriteComponentsLibrary = getComponentLibrary("favorite_components");
+  const userComponentsLibrary = getComponentLibrary("user_components");
 
   const { updateSearchFilter } = useForcedSearchContext();
-  const {
-    usedComponentsFolder,
-    userComponentsFolder,
-    isLoading,
-    error,
-    searchResult,
-  } = useComponentLibrary();
+  const { usedComponentsFolder, isLoading, error, searchResult } =
+    useComponentLibrary();
 
   const standardComponentsLibrary = getComponentLibrary("standard_components");
 
@@ -164,10 +160,6 @@ function ComponentLibrarySection() {
     usedComponentsFolder?.components &&
     usedComponentsFolder.components.length > 0;
 
-  const hasUserComponents =
-    userComponentsFolder?.components &&
-    userComponentsFolder.components.length > 0;
-
   return (
     <BlockStack gap="2">
       {remoteComponentLibrarySearchEnabled && <UpgradeAvailableAlertBox />}
@@ -187,13 +179,11 @@ function ComponentLibrarySection() {
           icon="Star"
         />
 
-        {hasUserComponents && (
-          <FolderItem
-            key="my-components-folder"
-            folder={userComponentsFolder}
-            icon="Puzzle"
-          />
-        )}
+        <LibraryFolderItem
+          key="my-components-library-folder"
+          library={userComponentsLibrary}
+          icon="Puzzle"
+        />
         <Separator />
         <FolderItem
           key="graph-inputs-outputs-folder"

--- a/src/providers/ComponentLibraryProvider/componentLibrary.test.ts
+++ b/src/providers/ComponentLibraryProvider/componentLibrary.test.ts
@@ -17,7 +17,6 @@ import * as yamlUtils from "@/utils/yaml";
 
 import {
   fetchUsedComponents,
-  fetchUserComponents,
   filterToUniqueByDigest,
   flattenFolders,
   populateComponentRefs,
@@ -40,128 +39,6 @@ describe("componentLibrary", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
-  });
-
-  describe("fetchUserComponents", () => {
-    it("should return user components folder with components from store", async () => {
-      // Arrange
-      const mockComponentFiles = new Map([
-        [
-          "component1",
-          {
-            name: "Test Component 1",
-            creationTime: new Date(),
-            modificationTime: new Date(),
-            data: new ArrayBuffer(0),
-            componentRef: {
-              name: "test-component-1",
-              digest: "digest1",
-              url: "https://example.com/component1.yaml",
-              spec: {} as ComponentSpec,
-              text: "test-yaml",
-            },
-          },
-        ],
-        [
-          "component2",
-          {
-            name: "Test Component 2",
-            creationTime: new Date(),
-            modificationTime: new Date(),
-            data: new ArrayBuffer(0),
-            componentRef: {
-              name: "test-component-2",
-              digest: "digest2",
-              url: "https://example.com/component2.yaml",
-              spec: {} as ComponentSpec,
-              text: "test-yaml",
-            },
-          },
-        ],
-      ]);
-
-      mockComponentStore.getAllComponentFilesFromList.mockResolvedValue(
-        mockComponentFiles,
-      );
-
-      // Act
-      const result = await fetchUserComponents();
-
-      // Assert
-      expect(result).toEqual({
-        name: "User Components",
-        components: [
-          {
-            name: "Test Component 1",
-            digest: "digest1",
-            url: "https://example.com/component1.yaml",
-            spec: {},
-            text: "test-yaml",
-            owned: true,
-          },
-          {
-            name: "Test Component 2",
-            digest: "digest2",
-            url: "https://example.com/component2.yaml",
-            spec: {},
-            text: "test-yaml",
-            owned: true,
-          },
-        ],
-        folders: [],
-        isUserFolder: true,
-      });
-      expect(
-        mockComponentStore.getAllComponentFilesFromList,
-      ).toHaveBeenCalledWith("user_components");
-    });
-
-    it("should return empty user components folder when no components exist", async () => {
-      // Arrange
-      mockComponentStore.getAllComponentFilesFromList.mockResolvedValue(
-        new Map(),
-      );
-
-      // Act
-      const result = await fetchUserComponents();
-
-      // Assert
-      expect(result).toEqual({
-        name: "User Components",
-        components: [],
-        folders: [],
-        isUserFolder: true,
-      });
-    });
-
-    it("should return empty folder on error", async () => {
-      // Arrange
-      mockComponentStore.getAllComponentFilesFromList.mockRejectedValue(
-        new Error("Storage error"),
-      );
-      const consoleSpy = vi
-        .spyOn(console, "error")
-        .mockImplementation(() => {});
-
-      // Act
-      const result = await fetchUserComponents();
-
-      // Assert
-      expect(result).toEqual({
-        name: "User Components",
-        components: [],
-        folders: [],
-        isUserFolder: true,
-      });
-      expect(consoleSpy).toHaveBeenCalledWith(
-        "Error fetching user components:",
-        expect.any(Error),
-      );
-
-      consoleSpy.mockRestore();
-    });
-
-    // todo: test edge cases with malformed component files
   });
 
   describe("fetchUsedComponents", () => {

--- a/src/providers/ComponentLibraryProvider/libraries/userComponentLibrary.ts
+++ b/src/providers/ComponentLibraryProvider/libraries/userComponentLibrary.ts
@@ -1,0 +1,54 @@
+import { hydrateComponentReference } from "@/services/componentService";
+import { isHydratedComponentReference } from "@/utils/componentSpec";
+import { getAllUserComponents } from "@/utils/localforage";
+
+import { BrowserPersistedLibrary } from "./browserPersistedLibrary";
+import { LibraryDB, type StoredLibraryItem } from "./storage";
+
+const USER_COMPONENTS_LIBRARY_ID = "user_components";
+
+export class UserComponentsLibrary extends BrowserPersistedLibrary {
+  constructor() {
+    super(USER_COMPONENTS_LIBRARY_ID, () =>
+      migrateLegacyUserComponentsFolder(),
+    );
+  }
+}
+
+/**
+ * Migrate the favorite components to the new database.
+ * This action supposed to happen only once.
+ *
+ * @returns
+ */
+async function migrateLegacyUserComponentsFolder() {
+  /**
+   * Migrate the favorite components to the new database
+   */
+  const allComponents = await getAllUserComponents();
+  const userComponents: StoredLibraryItem[] = (
+    await Promise.all([
+      ...allComponents.map((c) => hydrateComponentReference(c.componentRef)),
+    ])
+  )
+    .filter(isHydratedComponentReference)
+    .map((component) => ({
+      digest: component.digest,
+      name: component.name,
+      url: component.url,
+    }));
+
+  await LibraryDB.component_libraries.put({
+    id: USER_COMPONENTS_LIBRARY_ID,
+    name: "User Components",
+    icon: "Puzzle",
+    type: "indexdb",
+    knownDigests: userComponents.map((component) => component.digest),
+    configuration: {
+      migrated_at: new Date().toISOString(),
+    },
+    components: userComponents,
+  });
+
+  return await LibraryDB.component_libraries.get(USER_COMPONENTS_LIBRARY_ID);
+}

--- a/src/utils/localforage.ts
+++ b/src/utils/localforage.ts
@@ -107,12 +107,6 @@ export async function getAllUserComponents(): Promise<UserComponent[]> {
   return userComponents;
 }
 
-export async function getUserComponentByName(
-  name: string,
-): Promise<UserComponent | null> {
-  return await userComponentStore.getItem<UserComponent>(name);
-}
-
 // App Settings
 export const getUserBackendUrl = async () => {
   return (await settingsStore.getItem<string>("userBackendUrl")) ?? "";


### PR DESCRIPTION
## Description

Refactored the component library system to improve how user components are managed. This PR replaces the old approach of checking if a component is owned by a user with a more reliable method using the user components library.

Key changes:
- Added a dedicated `UserComponentsLibrary` class to handle user components
- Replaced the `checkIfUserComponent` function with direct library queries
- Updated component flags to use suspense queries for determining component ownership
- Modified the component details dialog to properly check if a component belongs to the user

## Type of Change

- [x] Improvement
- [x] Cleanup/Refactor

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

1. Create a new component and verify it appears in your user components
2. Check that the component details dialog correctly identifies user-owned components
3. Verify that favorite component functionality still works as expected
4. Test that component library search functions properly