### PR TITLE
fix: do not crash ui if argument is not a string

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/ArgumentInputField.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/ArgumentInputField.tsx
@@ -32,6 +32,7 @@ import { ArgumentInputDialog } from "./ArgumentInputDialog";
 import {
   getDefaultValue,
   getInputValue,
+  getInputValueAsString,
   getPlaceholder,
   typeSpecToString,
 } from "./utils";
@@ -63,7 +64,7 @@ export const ArgumentInputField = ({
   };
 
   const handleBlur = () => {
-    const value = inputValue.trim();
+    const value = getInputValueAsString(inputValue);
     handleSubmit(value);
   };
 
@@ -86,7 +87,7 @@ export const ArgumentInputField = ({
   const handleRemove = () => {
     const updatedArgument = {
       ...argument,
-      value: inputValue.trim(),
+      value: getInputValueAsString(inputValue),
       isRemoved: !argument.isRemoved,
     };
 

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/utils.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/utils.ts
@@ -4,6 +4,7 @@ import type {
   TaskSpec,
   TypeSpecType,
 } from "@/utils/componentSpec";
+import { isScalar } from "@/utils/types";
 
 export const getArgumentInputs = (taskSpec: TaskSpec) => {
   const componentSpec = taskSpec.componentRef.spec;
@@ -51,7 +52,7 @@ export const typeSpecToString = (typeSpec?: TypeSpecType): string => {
 };
 
 export const getPlaceholder = (argument: ArgumentType) => {
-  if (typeof argument === "string" || !argument) {
+  if (isScalar(argument) || !argument) {
     return null;
   }
 
@@ -71,10 +72,17 @@ export const getInputValue = (argumentInput: ArgumentInput) => {
     return argumentInput.inputSpec.default;
   }
 
-  if (typeof argument === "string") {
+  if (isScalar(argument)) {
     return argument;
   }
 
+  return "";
+};
+
+export const getInputValueAsString = (value: string) => {
+  if (isScalar(value)) {
+    return value.toString().trim();
+  }
   return "";
 };
 

--- a/src/hooks/useComponentSpecToEdges.ts
+++ b/src/hooks/useComponentSpecToEdges.ts
@@ -19,6 +19,7 @@ import {
   outputNameToNodeId,
   taskIdToNodeId,
 } from "@/utils/nodes/nodeIdUtils";
+import { isScalar } from "@/utils/types";
 
 const useComponentSpecToEdges = (
   componentSpec: ComponentSpec,
@@ -71,7 +72,7 @@ const createEdgeForArgument = (
   inputName: string,
   argument: ArgumentType,
 ): Edge[] => {
-  if (typeof argument === "string") {
+  if (isScalar(argument)) {
     return [];
   }
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,0 +1,11 @@
+export const isScalar = (
+  argument: unknown,
+): argument is string | number | boolean | null | undefined => {
+  return (
+    typeof argument === "string" ||
+    typeof argument === "number" ||
+    typeof argument === "boolean" ||
+    argument === null ||
+    argument === undefined
+  );
+};


### PR DESCRIPTION
## Description

closes https://github.com/Shopify/oasis-frontend/issues/408

Added a new `isScalar()` utility function to properly handle different scalar types (string, number, boolean, null, undefined) in argument handling. This replaces the previous approach that only checked for string types. Also added a new `getInputValueAsString()` helper function to consistently handle input value conversion to strings.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Improvement
- [x] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Test Instructions

[Screen Recording 2025-12-19 at 12.04.40 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/4e46549c-52f0-40f6-9891-ae37672a7924.mov" />](https://app.graphite.com/user-attachments/video/4e46549c-52f0-40f6-9891-ae37672a7924.mov)

You can drop component [Sft train (1).yaml](https://github.com/user-attachments/files/24265379/Sft.train.1.yaml) onto the canvas and check if UI fails. It is still not possible to RUN the component - server will return an error. But at least UI not crashes. Next step: add validation to notify user that component is malformed.

Test argument handling with different scalar types (strings, numbers, booleans) to ensure they are properly processed in the ArgumentInputField component.