### PR TITLE
fix: classic search by non-name term

### DIFF
--- a/src/components/shared/ReactFlow/FlowSidebar/components/PublishedComponentsSearch.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/components/PublishedComponentsSearch.tsx
@@ -332,7 +332,7 @@ const Search = withSuspenseWrapper(
         const staticSearchResult = isValidFilterRequest(searchRequest, {
           includesFilter: "name",
         })
-          ? searchComponentLibrary(searchRequest.searchTerm, [
+          ? await searchComponentLibrary(searchRequest.searchTerm, [
               ComponentSearchFilter.NAME,
             ])
           : null;

--- a/tests/e2e/componentlib.spec.ts
+++ b/tests/e2e/componentlib.spec.ts
@@ -220,7 +220,7 @@ test.describe("Component Library", () => {
     await expect(inputConnection).toHaveAttribute("data-highlighted", "false");
     await expect(inputConnection).toHaveAttribute("data-selected", "true");
 
-    assertSearchState(page, {
+    await assertSearchState(page, {
       searchTerm: "CSV",
       searchFilterCount: "2",
       searchResultsCount: "*",
@@ -234,7 +234,7 @@ test.describe("Component Library", () => {
     await expect(outputConnection).toHaveAttribute("data-highlighted", "false");
 
     // search should be reset
-    assertSearchState(page, {
+    await assertSearchState(page, {
       searchTerm: "",
     });
 
@@ -270,7 +270,7 @@ test.describe("Component Library", () => {
     await expect(inputConnection).toHaveAttribute("data-highlighted", "true");
 
     // assert search inputs
-    assertSearchState(page, {
+    await assertSearchState(page, {
       searchTerm: "CSV",
       searchFilterCount: "2",
       // todo: this can be painful to maintain, find a better way to do this
@@ -285,7 +285,7 @@ test.describe("Component Library", () => {
     await expect(outputConnection).toHaveAttribute("data-selected", "false");
 
     // search should be reset
-    assertSearchState(page, {
+    await assertSearchState(page, {
       searchTerm: "",
     });
 

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -247,6 +247,7 @@ export async function removeComponentFromCanvas(
 
   // Wait for the node to be removed from the DOM
   await expect(node).toBeHidden();
+  await expect(confirmDialog).toBeHidden();
 }
 
 /**

--- a/tests/e2e/published-componentlib.spec.ts
+++ b/tests/e2e/published-componentlib.spec.ts
@@ -209,7 +209,7 @@ test.describe("Published Component Library", () => {
     await expect(outputConnection).toHaveAttribute("data-highlighted", "false");
 
     // search should be reset
-    assertSearchState(page, {
+    await assertSearchState(page, {
       searchTerm: "",
     });
 
@@ -252,7 +252,7 @@ test.describe("Published Component Library", () => {
     await expect(outputConnection).toHaveAttribute("data-selected", "false");
 
     // search should be reset
-    assertSearchState(page, {
+    await assertSearchState(page, {
       searchTerm: "",
     });
 


### PR DESCRIPTION
## Description

Closes https://github.com/Shopify/oasis-frontend/issues/403



Made the `searchComponentLibrary` function asynchronous to support hydrating component references when searching with filters other than just name. This allows for more comprehensive search capabilities across component specifications.



Also this PR fixes e2e flaky tests that used `assertSearchState` without `await`. 

## Type of Change

- [x] Improvement
- [x] Bug fix

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

1. [Screen Recording 2026-01-05 at 10.56.49 AM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/aa5ce96d-6d5d-435b-8e8b-305b80bc738a.mov" />](https://app.graphite.com/user-attachments/video/aa5ce96d-6d5d-435b-8e8b-305b80bc738a.mov)

    Ensure beta flag "Published libs" is turned off
2. Search for components using different filters
3. Verify that components are properly found when searching by criteria other than just name
4. Confirm that component specifications are properly loaded when needed for filtering
5. Confirm that clicking on INPUT and OUTPUT handles searches properly
6. Ensure e2e tests passing

Test Published lib search:

1. Ensure beta flag "Published libs" is turned on
2. Try to search by name (use >=3 symbols)
3. Ensure search returns results