### PR TITLE
Refactor TaskStatusBar to apply hatched pattern overlay to the root component

### DIFF
--- a/src/components/shared/Status/TaskStatusBar.tsx
+++ b/src/components/shared/Status/TaskStatusBar.tsx
@@ -1,4 +1,4 @@
-import { InlineStack } from "@/components/ui/layout";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
 import {
   Tooltip,
   TooltipContent,
@@ -39,12 +39,10 @@ const StatusSegment = ({
   status,
   count,
   total,
-  hatched,
 }: {
   status: string;
   count: number;
   total: number;
-  hatched: boolean;
 }) => {
   const label = getExecutionStatusLabel(status);
   const colorClass = EXECUTION_STATUS_BG_COLORS[status] ?? "bg-slate-300";
@@ -54,7 +52,7 @@ const StatusSegment = ({
     <Tooltip>
       <TooltipTrigger asChild>
         <div
-          className={cn(colorClass, "h-full", hatched && HATCHED_SEGMENT_CLASS)}
+          className={cn(colorClass, "h-full")}
           style={{ width }}
           aria-label={`${count} ${label}`}
         />
@@ -102,17 +100,26 @@ const TaskStatusBar = ({
   });
 
   return (
-    <InlineStack wrap="nowrap" gap="0" className={BAR_CLASS}>
-      {sortedEntries.map(([status, count]) => (
-        <StatusSegment
-          key={status}
-          status={status}
-          count={count ?? 0}
-          total={total}
-          hatched={hasCancelled}
+    <BlockStack className="relative">
+      <InlineStack wrap="nowrap" gap="0" className={BAR_CLASS}>
+        {sortedEntries.map(([status, count]) => (
+          <StatusSegment
+            key={status}
+            status={status}
+            count={count ?? 0}
+            total={total}
+          />
+        ))}
+      </InlineStack>
+      {hasCancelled && (
+        <div
+          className={cn(
+            "pointer-events-none absolute inset-0 rounded",
+            HATCHED_SEGMENT_CLASS,
+          )}
         />
-      ))}
-    </InlineStack>
+      )}
+    </BlockStack>
   );
 };
 


### PR DESCRIPTION
## Description

Refactored the `TaskStatusBar` component to improve the visual representation of cancelled tasks. Instead of applying the hatched pattern to individual segments, the pattern is now applied as an overlay to the entire status bar when tasks are cancelled. This change provides a clearer visual indication of cancelled status while maintaining the underlying status information.

## Type of Change

- [x] Improvement
- [x] Cleanup/Refactor

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Test Instructions  
  
Before

![Screenshot 2026-01-06 at 3.38.35 PM.png](https://app.graphite.com/user-attachments/assets/43e45e29-ac77-4212-9218-f094282953d9.png)

  


  
After:

![Screenshot 2026-01-06 at 3.37.42 PM.png](https://app.graphite.com/user-attachments/assets/7a328c2e-cebf-4aa7-b7af-64d9a577108b.png)



Verify that the status bar correctly displays the hatched pattern overlay when tasks are cancelled, and that the individual status segments remain visible underneath.