### PR TITLE
fix: remove unsupported gpus from configuration

### DIFF
--- a/src/config/launcherTaskAnnotationSchema.json
+++ b/src/config/launcherTaskAnnotationSchema.json
@@ -75,11 +75,9 @@
           "description": "GPU type and quantity",
           "x-enable-quantity": true,
           "exclusiveMinimum": 0,
-          "enum": ["NVIDIA-H200", "NVIDIA-H100", "NVIDIA-A100"],
+          "enum": ["NVIDIA-H200"],
           "x-enum-labels": {
-            "NVIDIA-H200": "NVIDIA H200",
-            "NVIDIA-H100": "NVIDIA H100",
-            "NVIDIA-A100": "NVIDIA A100"
+            "NVIDIA-H200": "NVIDIA H200"
           }
         }
       }


### PR DESCRIPTION
## Description

Restricted GPU options in the launcher task annotation schema to only include NVIDIA H200, removing NVIDIA H100 and NVIDIA A100 options.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

![image.png](https://app.graphite.com/user-attachments/assets/09c0c80a-5865-4c89-86d9-10228c4e5f42.png)

Verify that only NVIDIA H200 appears as a GPU option in the launcher task interface.

## Additional Comments

This change simplifies GPU selection by limiting options to only the H200 model.
See https://vault.shopify.io/docs/craft/138-Data/data_handbook/ml_at_shopify/ml_infrastructure#shopify-gpu-policy