### PR TITLE
fix: responsive top menu

### DIFF
--- a/src/components/layout/AppMenu.tsx
+++ b/src/components/layout/AppMenu.tsx
@@ -17,14 +17,15 @@ const AppMenu = () => {
   const requiresAuthorization = isAuthorizationRequired();
   const { componentSpec } = useComponentSpec();
   const title = componentSpec?.name;
+
   return (
     <div
-      className="w-full bg-stone-900 p-2 pt-2.5"
+      className="w-full bg-stone-900 px-3 py-2.5 md:px-4"
       style={{ height: `${TOP_NAV_HEIGHT}px` }}
     >
-      <InlineStack align="space-between" className="pl-12 pr-2">
-        <InlineStack>
-          <Link href="/" aria-label="Home" variant="block">
+      <InlineStack align="space-between" wrap="nowrap">
+        <InlineStack gap="3" wrap="nowrap" className="min-w-0 flex-1">
+          <Link href="/" aria-label="Home" variant="block" className="shrink-0">
             <img
               src={logo}
               alt="logo"
@@ -33,20 +34,20 @@ const AppMenu = () => {
           </Link>
 
           {title && (
-            <CopyText className="text-white text-md font-bold truncate max-w-lg ml-22">
+            <CopyText className="text-white text-md font-bold truncate max-w-32 sm:max-w-48 md:max-w-64 lg:max-w-md">
               {title}
             </CopyText>
           )}
         </InlineStack>
 
-        <InlineStack>
-          <InlineStack gap="4" className="mr-42">
+        <InlineStack gap="2" wrap="nowrap" className="shrink-0">
+          <InlineStack gap="2" className="md:flex" wrap="nowrap">
             <CloneRunButton componentSpec={componentSpec} />
             <ImportPipeline />
             <NewPipelineButton />
           </InlineStack>
 
-          <InlineStack gap="2">
+          <InlineStack gap="2" wrap="nowrap">
             <BackendStatus />
             <PersonalPreferences />
             {requiresAuthorization && <TopBarAuthentication />}


### PR DESCRIPTION
## Description

Improved the responsive design of the AppMenu component by:

- Adjusting padding to be more consistent across device sizes
- Adding proper wrapping behavior to prevent overflow
- Implementing responsive text truncation with appropriate max-width constraints
- Ensuring proper shrinking and growing behavior of flex items
- Improving spacing between menu elements

## Type of Change

- [x] Improvement
- [x] Cleanup/Refactor

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

[Screen Recording 2026-01-07 at 9.34.29 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/07647725-ab91-40d1-bece-d7819c5be11c.mov" />](https://app.graphite.com/user-attachments/video/07647725-ab91-40d1-bece-d7819c5be11c.mov)

Verify the AppMenu displays correctly across different screen sizes:

1. Check that the component title truncates appropriately on small screens
2. Confirm that menu items remain accessible and properly spaced on mobile devices
3. Ensure the layout adjusts smoothly between breakpoints