### PR TITLE
feat: top menu for mobile resolution with sheet menu

### DIFF
--- a/src/components/layout/AppMenu.tsx
+++ b/src/components/layout/AppMenu.tsx
@@ -1,10 +1,21 @@
+import { Menu } from "lucide-react";
+import { useState } from "react";
+
 import logo from "/Tangle_white.png";
 import { isAuthorizationRequired } from "@/components/shared/Authentication/helpers";
 import { TopBarAuthentication } from "@/components/shared/Authentication/TopBarAuthentication";
 import { CopyText } from "@/components/shared/CopyText/CopyText";
 import ImportPipeline from "@/components/shared/ImportPipeline";
-import { InlineStack } from "@/components/ui/layout";
+import { Button } from "@/components/ui/button";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Link } from "@/components/ui/link";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 import { TOP_NAV_HEIGHT } from "@/utils/constants";
 
@@ -17,6 +28,7 @@ const AppMenu = () => {
   const requiresAuthorization = isAuthorizationRequired();
   const { componentSpec } = useComponentSpec();
   const title = componentSpec?.name;
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 
   return (
     <div
@@ -41,17 +53,46 @@ const AppMenu = () => {
         </InlineStack>
 
         <InlineStack gap="2" wrap="nowrap" className="shrink-0">
-          <InlineStack gap="2" className="md:flex" wrap="nowrap">
+          {/* Desktop action buttons - hidden on mobile */}
+          <InlineStack gap="2" className="hidden md:flex" wrap="nowrap">
             <CloneRunButton componentSpec={componentSpec} />
             <ImportPipeline />
             <NewPipelineButton />
           </InlineStack>
 
+          {/* Always visible settings */}
           <InlineStack gap="2" wrap="nowrap">
             <BackendStatus />
             <PersonalPreferences />
             {requiresAuthorization && <TopBarAuthentication />}
           </InlineStack>
+
+          {/* Mobile hamburger menu - visible only on mobile */}
+          <Sheet open={mobileMenuOpen} onOpenChange={setMobileMenuOpen}>
+            <SheetTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="md:hidden text-white hover:bg-stone-800"
+                aria-label="Open menu"
+              >
+                <Menu className="h-5 w-5" />
+              </Button>
+            </SheetTrigger>
+            <SheetContent
+              side="right"
+              className="w-fit bg-stone-900 border-stone-700 px-4"
+            >
+              <SheetHeader>
+                <SheetTitle className="text-white">Actions</SheetTitle>
+              </SheetHeader>
+              <BlockStack gap="3" className="mt-6">
+                <CloneRunButton componentSpec={componentSpec} />
+                <ImportPipeline />
+                <NewPipelineButton />
+              </BlockStack>
+            </SheetContent>
+          </Sheet>
         </InlineStack>
       </InlineStack>
     </div>


### PR DESCRIPTION
## Description

Closes https://github.com/Shopify/oasis-frontend/issues/404

Added a responsive mobile menu to the application header. The PR implements a hamburger menu that appears on mobile devices, providing access to actions like Clone Run, Import Pipeline, and New Pipeline buttons that were previously only visible on desktop. The mobile menu is implemented using a Sheet component that slides in from the right side when activated.

## Type of Change

- [x] New feature
- [x] Improvement

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

[Screen Recording 2026-01-07 at 9.36.20 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/f32807e3-a9a9-4480-a40e-5921092651dc.mov" />](https://app.graphite.com/user-attachments/video/f32807e3-a9a9-4480-a40e-5921092651dc.mov)

1. Resize browser window to mobile dimensions (or use device emulation in dev tools)
2. Verify the hamburger menu icon appears in the top navigation
3. Click the hamburger menu and confirm the slide-out panel appears with all action buttons
4. Test each action button in the mobile menu to ensure functionality
5. Verify desktop view still shows action buttons directly in the navigation bar