### PR TITLE
Add task status list with node focus navigation in pipeline run view

### DIFF
--- a/src/components/PipelineRun/PipelineRunPage.tsx
+++ b/src/components/PipelineRun/PipelineRunPage.tsx
@@ -3,6 +3,7 @@ import { useCallback, useState } from "react";
 
 import { FlowCanvas, FlowControls } from "@/components/shared/ReactFlow";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { useNodeFocus } from "@/hooks/useNodeFocus";
 import { ComponentLibraryProvider } from "@/providers/ComponentLibraryProvider";
 import { ContextPanelProvider } from "@/providers/ContextPanelProvider";
 
@@ -12,6 +13,8 @@ import { RunDetails } from "./RunDetails";
 const GRID_SIZE = 10;
 
 const PipelineRunPage = () => {
+  useNodeFocus();
+
   const [flowConfig, setFlowConfig] = useState<ReactFlowProps>({
     snapGrid: [GRID_SIZE, GRID_SIZE],
     snapToGrid: true,

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeCard.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeCard.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from "@tanstack/react-router";
+import { useLocation, useNavigate } from "@tanstack/react-router";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import type { TooltipButtonProps } from "@/components/shared/Buttons/TooltipButton";
@@ -13,6 +13,7 @@ import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { QuickTooltip } from "@/components/ui/tooltip";
 import { Text } from "@/components/ui/typography";
 import { useEdgeSelectionHighlight } from "@/hooks/useEdgeSelectionHighlight";
+import { getFocusParam } from "@/hooks/useNodeFocus";
 import { buildExecutionUrl } from "@/hooks/useSubgraphBreadcrumbs";
 import { cn } from "@/lib/utils";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
@@ -35,6 +36,8 @@ import { UpgradeNodePopover } from "./UpgradeNodePopover";
 
 const TaskNodeCard = () => {
   const navigate = useNavigate();
+  const { search } = useLocation();
+  const focusParam = getFocusParam(search);
   const isRemoteComponentLibrarySearchEnabled = useBetaFlagValue(
     "remote-component-library-search",
   );
@@ -42,6 +45,7 @@ const TaskNodeCard = () => {
   const isInAppEditorEnabled = useBetaFlagValue("in-app-component-editor");
   const { registerNode } = useNodesOverlay();
   const taskNode = useTaskNode();
+  const isFocusedByUrl = focusParam === taskNode.nodeId;
   const {
     setContent,
     clearContent,
@@ -281,7 +285,8 @@ const TaskNodeCard = () => {
         className={cn(
           "rounded-2xl border-gray-200 border-2 wrap-break-word p-0 drop-shadow-none gap-2",
           selected ? "border-gray-500" : "hover:border-slate-200",
-          (highlighted || highlightedState) && "border-orange-500!",
+          (highlighted || highlightedState || isFocusedByUrl) &&
+            "border-orange-500!",
           isConnectedToSelectedEdge &&
             "border-edge-selected! ring-2 ring-edge-selected/30",
           isSubgraphNode && "cursor-pointer",

--- a/src/components/shared/Status/TaskStatusList.tsx
+++ b/src/components/shared/Status/TaskStatusList.tsx
@@ -1,0 +1,227 @@
+import { useState } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { Icon } from "@/components/ui/icon";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
+import { useTaskNavigation } from "@/hooks/useTaskNavigation";
+import { cn } from "@/lib/utils";
+import type { TaskStatusInfo } from "@/utils/collectTaskStatuses";
+import {
+  EXECUTION_STATUS_BG_COLORS,
+  getExecutionStatusLabel,
+} from "@/utils/executionStatus";
+
+const STATUS_GROUP_ORDER = [
+  "FAILED",
+  "SYSTEM_ERROR",
+  "INVALID",
+  "CANCELLED",
+  "CANCELLING",
+  "RUNNING",
+  "PENDING",
+  "QUEUED",
+  "WAITING_FOR_UPSTREAM",
+  "UNINITIALIZED",
+  "SUCCEEDED",
+  "SKIPPED",
+  "UNKNOWN",
+];
+
+const DEFAULT_EXPANDED_STATUSES = new Set([
+  "FAILED",
+  "SYSTEM_ERROR",
+  "INVALID",
+]);
+
+const shouldDefaultExpandStatus = (status: string): boolean =>
+  DEFAULT_EXPANDED_STATUSES.has(status);
+
+const getStatusDotColor = (status: string): string => {
+  return EXECUTION_STATUS_BG_COLORS[status] ?? "bg-slate-400";
+};
+
+const isKnownStatus = (status: string): boolean => {
+  return STATUS_GROUP_ORDER.includes(status);
+};
+
+interface TaskStatusItemProps {
+  task: TaskStatusInfo;
+  onClick: () => void;
+}
+
+const TaskStatusItem = ({ task, onClick }: TaskStatusItemProps) => {
+  const pathDisplay =
+    task.subgraphPath.length > 1
+      ? task.subgraphPath.slice(1).join(" → ")
+      : null;
+
+  const showTaskId = task.taskId !== task.taskName;
+
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      className="w-full justify-start h-auto py-1 px-1"
+      onClick={onClick}
+    >
+      <BlockStack gap="0" className="min-w-0">
+        <Text as="span" size="xs" className="truncate block">
+          <Text as="span" weight="semibold">
+            {task.taskName}
+          </Text>
+          {showTaskId && (
+            <Text as="span" tone="subdued">
+              {" - "}
+              {task.taskId}
+            </Text>
+          )}
+        </Text>
+        {pathDisplay && (
+          <Text as="span" size="xs" tone="subdued" className="truncate block">
+            in {pathDisplay}
+          </Text>
+        )}
+      </BlockStack>
+    </Button>
+  );
+};
+
+interface StatusGroupProps {
+  status: string;
+  tasks: TaskStatusInfo[];
+  onTaskClick: (task: TaskStatusInfo) => void;
+  defaultExpanded?: boolean;
+}
+
+const StatusGroup = ({
+  status,
+  tasks,
+  onTaskClick,
+  defaultExpanded = false,
+}: StatusGroupProps) => {
+  const [isExpanded, setIsExpanded] = useState(defaultExpanded);
+  const statusLabel = getExecutionStatusLabel(status);
+  const statusColor = getStatusDotColor(status);
+
+  return (
+    <Collapsible
+      open={isExpanded}
+      onOpenChange={setIsExpanded}
+      className="w-full border-t border-border/40 first:border-t-0"
+    >
+      <CollapsibleTrigger asChild>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="w-full justify-between h-auto py-1 px-1"
+          aria-expanded={isExpanded}
+        >
+          <InlineStack gap="2" blockAlign="center">
+            <Badge variant="dot" className={statusColor} />
+            <Text as="span" size="xs">
+              {statusLabel}
+            </Text>
+            <Badge size="sm" variant="secondary" className="rounded-full">
+              {tasks.length}
+            </Badge>
+          </InlineStack>
+          <Icon
+            name="ChevronRight"
+            size="xs"
+            className={cn(
+              "text-muted-foreground transition-transform duration-200",
+              isExpanded && "rotate-90",
+            )}
+          />
+        </Button>
+      </CollapsibleTrigger>
+      <CollapsibleContent className="w-full">
+        <BlockStack gap="0" className="pl-4 w-full divide-y divide-border/40">
+          {tasks.map((task) => (
+            <TaskStatusItem
+              key={`${task.subgraphPath.join(".")}.${task.taskId}`}
+              task={task}
+              onClick={() => onTaskClick(task)}
+            />
+          ))}
+        </BlockStack>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+};
+
+const groupTasksByStatus = (
+  tasks: TaskStatusInfo[],
+): Array<{ status: string; tasks: TaskStatusInfo[] }> => {
+  const groups = new Map<string, TaskStatusInfo[]>();
+
+  for (const task of tasks) {
+    const existing = groups.get(task.status);
+    if (existing) {
+      existing.push(task);
+    } else {
+      groups.set(task.status, [task]);
+    }
+  }
+
+  const result: Array<{ status: string; tasks: TaskStatusInfo[] }> = [];
+
+  for (const status of STATUS_GROUP_ORDER) {
+    const groupTasks = groups.get(status);
+    if (groupTasks && groupTasks.length > 0) {
+      result.push({ status, tasks: groupTasks });
+    }
+  }
+
+  for (const [status, groupTasks] of groups.entries()) {
+    if (!isKnownStatus(status)) {
+      result.push({ status, tasks: groupTasks });
+    }
+  }
+
+  return result;
+};
+
+interface TaskStatusListProps {
+  tasks: TaskStatusInfo[];
+  rootExecutionId?: string;
+}
+
+export const TaskStatusList = ({
+  tasks,
+  rootExecutionId,
+}: TaskStatusListProps) => {
+  const { navigateToTask } = useTaskNavigation({ rootExecutionId });
+  const groupedTasks = groupTasksByStatus(tasks);
+
+  if (groupedTasks.length === 0) {
+    return (
+      <BlockStack className="py-2 px-1">
+        <Text size="xs" tone="subdued">
+          No tasks found
+        </Text>
+      </BlockStack>
+    );
+  }
+
+  return (
+    <BlockStack gap="1" className="w-full" data-task-status-list>
+      {groupedTasks.map(({ status, tasks: groupTasks }) => (
+        <StatusGroup
+          key={status}
+          status={status}
+          tasks={groupTasks}
+          onTaskClick={navigateToTask}
+          defaultExpanded={shouldDefaultExpandStatus(status)}
+        />
+      ))}
+    </BlockStack>
+  );
+};

--- a/src/hooks/useNodeFocus.ts
+++ b/src/hooks/useNodeFocus.ts
@@ -1,0 +1,44 @@
+import { useLocation, useNavigate } from "@tanstack/react-router";
+import { useEffect } from "react";
+
+export const getFocusParam = (
+  search: Record<string, unknown>,
+): string | undefined => {
+  if (typeof search.focus === "string") {
+    return search.focus;
+  }
+  return undefined;
+};
+
+export const useNodeFocus = () => {
+  const navigate = useNavigate();
+  const { pathname, search } = useLocation();
+  const focusParam = getFocusParam(search);
+
+  useEffect(() => {
+    if (!focusParam) return;
+
+    const handleClick = (event: MouseEvent) => {
+      const target = event.target;
+      if (
+        target instanceof HTMLElement &&
+        target.closest("[data-task-status-list]")
+      ) {
+        return;
+      }
+
+      const { focus: _, ...rest } = search;
+      navigate({
+        to: pathname,
+        search: rest,
+        replace: true,
+      });
+    };
+
+    document.addEventListener("click", handleClick, { capture: true });
+
+    return () => {
+      document.removeEventListener("click", handleClick, { capture: true });
+    };
+  }, [focusParam, navigate, pathname, search]);
+};

--- a/src/hooks/useTaskNavigation.ts
+++ b/src/hooks/useTaskNavigation.ts
@@ -1,0 +1,60 @@
+import { useLocation, useNavigate } from "@tanstack/react-router";
+import equal from "fast-deep-equal";
+import { useCallback } from "react";
+
+import { buildExecutionUrl } from "@/hooks/useSubgraphBreadcrumbs";
+import { useComponentSpec } from "@/providers/ComponentSpecProvider";
+import type { TaskStatusInfo } from "@/utils/collectTaskStatuses";
+import { taskIdToNodeId } from "@/utils/nodes/nodeIdUtils";
+
+interface UseTaskNavigationOptions {
+  rootExecutionId?: string;
+}
+
+/**
+ * Hook for navigating to a task from the status list.
+ * Updates the URL with `?focus=nodeId` to trigger node highlighting.
+ */
+export const useTaskNavigation = ({
+  rootExecutionId,
+}: UseTaskNavigationOptions = {}) => {
+  const navigate = useNavigate();
+  const { pathname, search } = useLocation();
+  const { currentSubgraphPath, navigateToPath } = useComponentSpec();
+
+  const navigateToTask = useCallback(
+    (task: TaskStatusInfo) => {
+      const nodeId = taskIdToNodeId(task.taskId);
+      if (!nodeId) return;
+
+      if (!equal(task.subgraphPath, currentSubgraphPath)) {
+        navigateToPath(task.subgraphPath);
+
+        if (rootExecutionId && task.parentExecutionId) {
+          const url = buildExecutionUrl(
+            rootExecutionId,
+            task.parentExecutionId,
+          );
+          navigate({ to: url, search: { focus: nodeId } });
+        }
+        return;
+      }
+
+      navigate({
+        to: pathname,
+        search: { ...search, focus: nodeId },
+        replace: true,
+      });
+    },
+    [
+      currentSubgraphPath,
+      navigate,
+      navigateToPath,
+      pathname,
+      rootExecutionId,
+      search,
+    ],
+  );
+
+  return { navigateToTask };
+};

--- a/src/routes/PipelineRun/PipelineRun.tsx
+++ b/src/routes/PipelineRun/PipelineRun.tsx
@@ -6,6 +6,7 @@ import { useEffect } from "react";
 import PipelineRunPage from "@/components/PipelineRun";
 import { InfoBox } from "@/components/shared/InfoBox";
 import { LoadingScreen } from "@/components/shared/LoadingScreen";
+import { NodesOverlayProvider } from "@/components/shared/ReactFlow/NodesOverlay/NodesOverlayProvider";
 import { BlockStack } from "@/components/ui/layout";
 import { Paragraph } from "@/components/ui/typography";
 import { faviconManager } from "@/favicon";
@@ -17,7 +18,7 @@ import {
   useExecutionData,
 } from "@/providers/ExecutionDataProvider";
 import { getBackendStatusString } from "@/utils/backend";
-import type { ComponentSpec } from "@/utils/componentSpec";
+import { isValidComponentSpec } from "@/utils/componentSpec";
 import {
   flattenExecutionStatusStats,
   getOverallExecutionStatusFromStats,
@@ -59,10 +60,9 @@ const PipelineRunContent = () => {
   }, [details, state]);
 
   useEffect(() => {
-    if (rootDetails?.task_spec.componentRef.spec) {
-      setComponentSpec(
-        rootDetails.task_spec.componentRef.spec as ComponentSpec,
-      );
+    const spec = rootDetails?.task_spec.componentRef.spec;
+    if (spec && isValidComponentSpec(spec)) {
+      setComponentSpec(spec);
     }
 
     return () => {
@@ -141,12 +141,14 @@ const PipelineRun = () => {
   return (
     <DndContext>
       <ReactFlowProvider>
-        <ExecutionDataProvider
-          pipelineRunId={id}
-          subgraphExecutionId={subgraphExecutionId}
-        >
-          <PipelineRunContent />
-        </ExecutionDataProvider>
+        <NodesOverlayProvider>
+          <ExecutionDataProvider
+            pipelineRunId={id}
+            subgraphExecutionId={subgraphExecutionId}
+          >
+            <PipelineRunContent />
+          </ExecutionDataProvider>
+        </NodesOverlayProvider>
       </ReactFlowProvider>
     </DndContext>
   );

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -50,10 +50,24 @@ const mainLayout = createRoute({
   component: RootLayout,
 });
 
+type HomeSearchParams = {
+  page_token?: string;
+  filter?: string;
+};
+
+const validateHomeSearch = (
+  search: Record<string, unknown>,
+): HomeSearchParams => ({
+  page_token:
+    typeof search.page_token === "string" ? search.page_token : undefined,
+  filter: typeof search.filter === "string" ? search.filter : undefined,
+});
+
 const indexRoute = createRoute({
   getParentRoute: () => mainLayout,
   path: APP_ROUTES.HOME,
   component: Home,
+  validateSearch: validateHomeSearch,
 });
 
 const quickStartRoute = createRoute({
@@ -84,16 +98,28 @@ const huggingFaceAuthCallbackRoute = createRoute({
   component: HuggingFaceAuthorizationResultScreen,
 });
 
+type RunSearchParams = {
+  focus?: string;
+};
+
+const validateRunSearch = (
+  search: Record<string, unknown>,
+): RunSearchParams => ({
+  focus: typeof search.focus === "string" ? search.focus : undefined,
+});
+
 const runDetailRoute = createRoute({
   getParentRoute: () => mainLayout,
   path: APP_ROUTES.RUN_DETAIL,
   component: PipelineRun,
+  validateSearch: validateRunSearch,
 });
 
 const runDetailWithSubgraphRoute = createRoute({
   getParentRoute: () => mainLayout,
   path: APP_ROUTES.RUN_DETAIL_WITH_SUBGRAPH,
   component: PipelineRun,
+  validateSearch: validateRunSearch,
 });
 
 const appRouteTree = mainLayout.addChildren([

--- a/src/utils/collectTaskStatuses.ts
+++ b/src/utils/collectTaskStatuses.ts
@@ -1,0 +1,132 @@
+import type {
+  GetExecutionInfoResponse,
+  GetGraphExecutionStateResponse,
+} from "@/api/types.gen";
+import {
+  fetchExecutionDetails,
+  fetchExecutionState,
+} from "@/services/executionService";
+
+import type { ComponentSpec, TaskSpec } from "./componentSpec";
+import { isGraphImplementation } from "./componentSpec";
+import { ROOT_TASK_ID } from "./constants";
+import { getOverallExecutionStatusFromStats } from "./executionStatus";
+import { isSubgraph } from "./subgraphUtils";
+
+export interface TaskStatusInfo {
+  taskId: string;
+  taskName: string;
+  status: string;
+  subgraphPath: string[];
+  /** Execution ID of the innermost subgraph containing this task (for URL navigation) */
+  parentExecutionId?: string;
+}
+
+interface CollectContext {
+  subgraphPath: string[];
+  visitedSpecs: Set<ComponentSpec>;
+  executionState?: GetGraphExecutionStateResponse;
+  executionDetails?: GetExecutionInfoResponse;
+  backendUrl: string;
+  /** Execution ID of the current subgraph level */
+  currentExecutionId?: string;
+}
+
+const getTaskDisplayName = (taskId: string, taskSpec: TaskSpec): string => {
+  return (
+    taskSpec.componentRef?.spec?.name ?? taskSpec.componentRef?.name ?? taskId
+  );
+};
+
+/**
+ * Recursively collects all LEAF tasks (non-subgraph tasks) with their execution statuses.
+ * This traverses into subgraphs to find the actual tasks.
+ */
+export const collectAllTaskStatuses = async (
+  componentSpec: ComponentSpec,
+  executionState: GetGraphExecutionStateResponse | undefined,
+  executionDetails: GetExecutionInfoResponse | undefined,
+  backendUrl: string,
+  rootExecutionId?: string,
+): Promise<TaskStatusInfo[]> => {
+  return collectTasksRecursive(componentSpec, {
+    subgraphPath: [ROOT_TASK_ID],
+    visitedSpecs: new Set(),
+    executionState,
+    executionDetails,
+    backendUrl,
+    currentExecutionId: rootExecutionId,
+  });
+};
+
+const collectTasksRecursive = async (
+  componentSpec: ComponentSpec,
+  context: CollectContext,
+): Promise<TaskStatusInfo[]> => {
+  if (context.visitedSpecs.has(componentSpec)) {
+    return [];
+  }
+  context.visitedSpecs.add(componentSpec);
+
+  if (!isGraphImplementation(componentSpec.implementation)) {
+    return [];
+  }
+
+  const tasks = componentSpec.implementation.graph.tasks;
+  const results: TaskStatusInfo[] = [];
+
+  for (const [taskId, taskSpec] of Object.entries(tasks)) {
+    const isSubgraphTask = isSubgraph(taskSpec);
+
+    if (isSubgraphTask && taskSpec.componentRef?.spec) {
+      const subgraphExecutionId =
+        context.executionDetails?.child_task_execution_ids?.[taskId];
+
+      let nestedState: GetGraphExecutionStateResponse | undefined;
+      let nestedDetails: GetExecutionInfoResponse | undefined;
+
+      if (subgraphExecutionId && context.backendUrl) {
+        try {
+          [nestedDetails, nestedState] = await Promise.all([
+            fetchExecutionDetails(subgraphExecutionId, context.backendUrl),
+            fetchExecutionState(subgraphExecutionId, context.backendUrl),
+          ]);
+        } catch {
+          // If fetching fails, continue without nested execution data
+        }
+      }
+
+      const nestedResults = await collectTasksRecursive(
+        taskSpec.componentRef.spec,
+        {
+          subgraphPath: [...context.subgraphPath, taskId],
+          visitedSpecs: context.visitedSpecs,
+          executionState: nestedState,
+          executionDetails: nestedDetails,
+          backendUrl: context.backendUrl,
+          currentExecutionId: subgraphExecutionId,
+        },
+      );
+      results.push(...nestedResults);
+    } else {
+      const executionId =
+        context.executionDetails?.child_task_execution_ids?.[taskId];
+      const statusStats =
+        context.executionState?.child_execution_status_stats?.[
+          executionId ?? ""
+        ];
+      const status =
+        getOverallExecutionStatusFromStats(statusStats) ?? "UNKNOWN";
+
+      results.push({
+        taskId,
+        taskName: getTaskDisplayName(taskId, taskSpec),
+        status,
+        subgraphPath: context.subgraphPath,
+        parentExecutionId: context.currentExecutionId,
+      });
+    }
+  }
+
+  return results;
+};


### PR DESCRIPTION
## Description

Added a task status list feature that allows users to view and navigate to individual tasks in a pipeline run. The implementation includes:

- A collapsible status bar that shows task statuses grouped by their execution state
- Ability to navigate to specific tasks in the pipeline graph
- Automatic highlighting of tasks when selected
- Task grouping by status with expandable sections
- Integration with the existing status bar component

## Type of Change

- [x] New feature
- [x] Improvement

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Test Instructions

1. Open any pipeline run with multiple tasks
2. Click "View all" under the status bar
3. Expand status groups and click on individual tasks to navigate to them
4. Verify that the graph focuses on the selected task and highlights it

## [status_click.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/c1ce94b2-79b9-49df-b134-a89a64765476.mov" />](https://app.graphite.com/user-attachments/video/c1ce94b2-79b9-49df-b134-a89a64765476.mov)



## Additional Comments

This feature improves pipeline run debugging by making it easier to find and navigate to specific tasks, especially in complex pipelines with many nested components.