### PR TITLE
feat: Documentation URL in GithubDetails

### DIFF
--- a/src/components/shared/TaskDetails/GithubDetails.tsx
+++ b/src/components/shared/TaskDetails/GithubDetails.tsx
@@ -14,44 +14,73 @@ const linkProps = {
 export function GithubDetails({
   url,
   canonicalUrl,
+  documentationUrl,
   className,
 }: {
   url?: string;
   canonicalUrl?: string;
+  documentationUrl?: string;
   className?: string;
 }) {
-  if (!url && !canonicalUrl) return null;
+  const hasUrl = url || canonicalUrl;
+
+  if (!hasUrl && !documentationUrl) return null;
 
   return (
-    <BlockStack className={className}>
-      <Heading level={3}>URL</Heading>
-      {url && (
-        <>
-          <Link href={url} {...linkProps}>
-            View raw component.yaml
+    <BlockStack className={className} gap="2">
+      {!!hasUrl && (
+        <BlockStack>
+          <Heading level={3}>URL</Heading>
+          {!!url && (
+            <>
+              <Link href={url} {...linkProps}>
+                View raw component.yaml
+              </Link>
+
+              <Link
+                href={
+                  isGithubUrl(url) ? convertGithubUrlToDirectoryUrl(url) : url
+                }
+                {...linkProps}
+              >
+                View directory on GitHub
+              </Link>
+            </>
+          )}
+          {!!canonicalUrl && (
+            <>
+              <Link href={canonicalUrl} {...linkProps}>
+                View canonical URL
+              </Link>
+
+              <Link
+                href={convertGithubUrlToDirectoryUrl(canonicalUrl)}
+                {...linkProps}
+              >
+                View canonical URL on GitHub
+              </Link>
+            </>
+          )}
+        </BlockStack>
+      )}
+      {!!documentationUrl && (
+        <BlockStack>
+          <Heading level={3}>Documentation</Heading>
+          <Link href={documentationUrl} {...linkProps}>
+            View documentation
           </Link>
 
           <Link
-            href={isGithubUrl(url) ? convertGithubUrlToDirectoryUrl(url) : url}
+            href={
+              isGithubUrl(documentationUrl)
+                ? convertGithubUrlToDirectoryUrl(documentationUrl)
+                : documentationUrl
+            }
             {...linkProps}
           >
             View directory on GitHub
           </Link>
-        </>
-      )}
-      {canonicalUrl && (
-        <>
-          <Link href={canonicalUrl} {...linkProps}>
-            View canonical URL
-          </Link>
-
-          <Link
-            href={convertGithubUrlToDirectoryUrl(canonicalUrl)}
-            {...linkProps}
-          >
-            View canonical URL on GitHub
-          </Link>
-        </>
+        </BlockStack>
       )}
     </BlockStack>
   );


### PR DESCRIPTION
## Description

Added support for displaying documentation links in the component details panel. This enhancement allows users to access component documentation directly from the UI when the component's metadata includes a `documentation_path` annotation.

The changes refactor the URL reconstruction logic in the TaskDetails component to handle both component YAML paths and documentation paths. When a component includes the necessary Git metadata annotations and a documentation path, a new "Documentation" section appears in the details panel with links to view the documentation and its directory on GitHub.

See example:

![image.png](https://app.graphite.com/user-attachments/assets/ab3d0ca5-66b2-4424-9196-a205e4e9095a.png)

Based on the component with the following definition:
```
name: Scrape V2
description: Runs a query set against Shop Server (V2 - streamlined inputs)
inputs:
- name: env
  type: String
- name: query_set_name
  type: String
  optional: true
- name: access_route
  type: String
  optional: true
- name: template_params
  type: String
  optional: true
- name: execution_config
  type: String
  optional: true
- name: feature_flags
  type: String
  optional: true
- name: description
  type: String
  optional: true
- name: custom_run_id_prefix
  type: String
  optional: true
- name: external_query
  type: String
  optional: true
- name: parameter_overrides
  type: String
  optional: true
- name: flatten_products
  type: Boolean
  optional: true
- name: query_limit
  type: Integer
  optional: true
- name: export_to_parquet
  type: Boolean
  optional: true
  default: 'False'
- name: min_success_rate
  type: Float
  optional: true
- name: allow_partial_results
  type: Boolean
  optional: true
  default: 'False'
- name: output_raw_data
  type: Boolean
  optional: true
  default: 'False'
- name: env_vars
  type: String
  optional: true
- name: cache_bust_key
  type: String
  optional: true
outputs:
- name: run_id
  type: String
- name: run_results
  type: Parquet
- name: bsl_script
  type: String
- name: stats
  type: String
- name: raw_data
  type: Parquet
- name: evaluation_tool_link
  type: String
- name: scrape_date
  type: String
- name: timings
  type: String
implementation:
  container:
    image: us-docker.pkg.dev/shopify-docker-images/containers/apps/production/cloud-run-eval-slim-update:b580741f41463291a6197424f292ea87b6ad26b9
    command:
    - query-eval
    - query-v2
    - --env
    - inputValue: env
    - --run-id-path
    - outputPath: run_id
    - --results-path
    - outputPath: run_results
    - --bsl-script-path
    - outputPath: bsl_script
    - --stats-path
    - outputPath: stats
    - --raw-data-path
    - outputPath: raw_data
    - --evaluation-tool-link-path
    - outputPath: evaluation_tool_link
    - --scrape-date-path
    - outputPath: scrape_date
    - --timings-path
    - outputPath: timings
    - if:
        cond:
          isPresent: query_set_name
        then:
        - --query-set-name
        - inputValue: query_set_name
    - if:
        cond:
          isPresent: access_route
        then:
        - --access-route
        - inputValue: access_route
    - if:
        cond:
          isPresent: template_params
        then:
        - --template-params
        - inputValue: template_params
    - if:
        cond:
          isPresent: execution_config
        then:
        - --execution-config
        - inputValue: execution_config
    - if:
        cond:
          isPresent: feature_flags
        then:
        - --feature-flags
        - inputValue: feature_flags
    - if:
        cond:
          isPresent: description
        then:
        - --description
        - inputValue: description
    - if:
        cond:
          isPresent: custom_run_id_prefix
        then:
        - --custom-run-id-prefix
        - inputValue: custom_run_id_prefix
    - if:
        cond:
          isPresent: external_query
        then:
        - --external-query
        - inputValue: external_query
    - if:
        cond:
          isPresent: parameter_overrides
        then:
        - --parameter-overrides
        - inputValue: parameter_overrides
    - if:
        cond:
          isPresent: flatten_products
        then:
        - if:
            cond:
              inputValue: flatten_products
            then:
            - --flatten-products
    - if:
        cond:
          isPresent: query_limit
        then:
        - --query-limit
        - inputValue: query_limit
    - if:
        cond:
          isPresent: export_to_parquet
        then:
        - if:
            cond:
              inputValue: export_to_parquet
            then:
            - --export-to-parquet
    - if:
        cond:
          isPresent: min_success_rate
        then:
        - --min-success-rate
        - inputValue: min_success_rate
    - if:
        cond:
          isPresent: allow_partial_results
        then:
        - if:
            cond:
              inputValue: allow_partial_results
            then:
            - --allow-partial-results
    - if:
        cond:
          isPresent: output_raw_data
        then:
        - if:
            cond:
              inputValue: output_raw_data
            then:
            - --output-raw-data
    - if:
        cond:
          isPresent: env_vars
        then:
        - --env-vars
        - inputValue: env_vars
    - if:
        cond:
          isPresent: cache_bust_key
        then:
        - --cache-bust-key
        - inputValue: cache_bust_key
metadata:
  annotations:
    version: '1.27'
    updated_at: '2026-01-08T19:12:57Z'
    component_yaml_path: oasis/components/scrape-v2.yaml
    documentation_path: oasis/components/docs/scrape-v2.md
    git_remote_url: https://github.com/Shopify/discovery.git
    git_relative_dir: relevance-tools/src/relevance_tools
    published_at: '2026-01-08T19:44:55.266948+00:00'
    git_remote_sha: b580741f41463291a6197424f292ea87b6ad26b9
    git_remote_branch: volv/scrape-readme

```

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging