### PR TITLE
Add edge selection highlighting and connected node visualization

### DIFF
--- a/react-compiler.config.js
+++ b/react-compiler.config.js
@@ -26,6 +26,8 @@ export const REACT_COMPILER_ENABLED_DIRS = [
   "src/components/shared/Settings",
   "src/components/shared/HuggingFaceAuth",
   "src/components/shared/GitHubLibrary",
+  "src/hooks/useHandleEdgeSelection.ts",
+  "src/hooks/useEdgeSelectionHighlight.ts",
 
   "src/components/shared/Submitters/Oasis/components",
 

--- a/src/components/shared/ReactFlow/FlowCanvas/Edges/SmoothEdge.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/Edges/SmoothEdge.tsx
@@ -1,5 +1,5 @@
 import type { EdgeProps } from "@xyflow/react";
-import { getBezierPath } from "@xyflow/react";
+import { getBezierPath, useEdges } from "@xyflow/react";
 
 import { EdgeColor } from "./utils";
 
@@ -14,6 +14,9 @@ const SmoothEdge = ({
   style = {},
   selected,
 }: EdgeProps) => {
+  const edges = useEdges();
+  const hasAnySelectedEdge = edges.some((edge) => edge.selected);
+
   const [edgePath] = getBezierPath({
     sourceX,
     sourceY,
@@ -23,8 +26,18 @@ const SmoothEdge = ({
     targetPosition,
   });
 
-  const edgeColor = selected ? EdgeColor.Selected : EdgeColor.Neutral;
-  const markerIdSuffix = selected ? "selected" : "default";
+  const getEdgeColor = () => {
+    if (selected) return EdgeColor.Selected;
+    if (hasAnySelectedEdge) return EdgeColor.Muted;
+    return EdgeColor.Neutral;
+  };
+
+  const edgeColor = getEdgeColor();
+  const markerIdSuffix = selected
+    ? "selected"
+    : hasAnySelectedEdge
+      ? "muted"
+      : "default";
 
   return (
     <>

--- a/src/components/shared/ReactFlow/FlowCanvas/Edges/utils.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/Edges/utils.ts
@@ -1,9 +1,11 @@
+// Note: Selected color is also defined as --edge-selected CSS variable in global.css
 export enum EdgeColor {
   Incomplete = "#b1b1b7",
   Neutral = "#6b7280",
+  Muted = "#d1d5db",
   Valid = "#8db88d",
   Invalid = "#d47a7a",
   Input = "#3b82f6",
   Output = "#a855f7",
-  Selected = "#38bdf8",
+  Selected = "#5b2ef4",
 }

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/Handles.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/Handles.tsx
@@ -11,6 +11,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { useHandleEdgeSelection } from "@/hooks/useHandleEdgeSelection";
 import { cn } from "@/lib/utils";
 import { useTaskNode } from "@/providers/TaskNodeProvider";
 import type { InputSpec, OutputSpec } from "@/utils/componentSpec";
@@ -33,6 +34,8 @@ export const InputHandle = ({
   onHandleSelectionChange,
 }: InputHandleProps) => {
   const { nodeId, state } = useTaskNode();
+  const { selectEdgesForHandle, clearEdgeSelection } =
+    useHandleEdgeSelection(nodeId);
 
   const fromHandle = useConnection((connection) => connection.fromHandle?.id);
   const toHandle = useConnection((connection) => connection.toHandle?.id);
@@ -53,9 +56,15 @@ export const InputHandle = ({
   const handleHandleClick = useCallback(
     (e: ReactMouseEvent<HTMLDivElement>) => {
       e.stopPropagation();
-      setSelected(!selected);
+      const newSelected = !selected;
+      setSelected(newSelected);
+      if (newSelected) {
+        selectEdgesForHandle(handleId, "target");
+      } else {
+        clearEdgeSelection();
+      }
     },
-    [selected],
+    [selected, selectEdgesForHandle, clearEdgeSelection, handleId],
   );
 
   const handleLabelClick = useCallback(
@@ -219,6 +228,8 @@ export const OutputHandle = ({
   onHandleSelectionChange,
 }: OutputHandleProps) => {
   const { nodeId, state } = useTaskNode();
+  const { selectEdgesForHandle, clearEdgeSelection } =
+    useHandleEdgeSelection(nodeId);
 
   const fromHandle = useConnection((connection) => connection.fromHandle?.id);
   const toHandle = useConnection((connection) => connection.toHandle?.id);
@@ -236,9 +247,15 @@ export const OutputHandle = ({
   const handleHandleClick = useCallback(
     (e: ReactMouseEvent<HTMLDivElement>) => {
       e.stopPropagation();
-      setSelected(!selected);
+      const newSelected = !selected;
+      setSelected(newSelected);
+      if (newSelected) {
+        selectEdgesForHandle(handleId, "source");
+      } else {
+        clearEdgeSelection();
+      }
     },
-    [selected],
+    [selected, selectEdgesForHandle, clearEdgeSelection, handleId],
   );
 
   const handleLabelClick = useCallback(

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeCard.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeCard.tsx
@@ -12,6 +12,7 @@ import { Icon } from "@/components/ui/icon";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { QuickTooltip } from "@/components/ui/tooltip";
 import { Text } from "@/components/ui/typography";
+import { useEdgeSelectionHighlight } from "@/hooks/useEdgeSelectionHighlight";
 import { buildExecutionUrl } from "@/hooks/useSubgraphBreadcrumbs";
 import { cn } from "@/lib/utils";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
@@ -69,6 +70,8 @@ const TaskNodeCard = () => {
   const { name, state, callbacks, nodeId, taskSpec, taskId } = taskNode;
   const { dimensions, selected, highlighted, isCustomComponent, readOnly } =
     state;
+
+  const isConnectedToSelectedEdge = useEdgeSelectionHighlight(nodeId);
 
   const isSubgraphNode = useMemo(() => {
     if (!taskSpec) return false;
@@ -279,6 +282,8 @@ const TaskNodeCard = () => {
           "rounded-2xl border-gray-200 border-2 wrap-break-word p-0 drop-shadow-none gap-2",
           selected ? "border-gray-500" : "hover:border-slate-200",
           (highlighted || highlightedState) && "border-orange-500!",
+          isConnectedToSelectedEdge &&
+            "border-edge-selected! ring-2 ring-edge-selected/30",
           isSubgraphNode && "cursor-pointer",
         )}
         style={{

--- a/src/hooks/useEdgeSelectionHighlight.ts
+++ b/src/hooks/useEdgeSelectionHighlight.ts
@@ -1,0 +1,14 @@
+import { useEdges } from "@xyflow/react";
+
+export function useEdgeSelectionHighlight(nodeId: string) {
+  const edges = useEdges();
+
+  const selectedEdges = edges.filter((edge) => edge.selected);
+  const isConnectedToSelectedEdge =
+    selectedEdges.length > 0 &&
+    selectedEdges.some(
+      (edge) => edge.source === nodeId || edge.target === nodeId,
+    );
+
+  return isConnectedToSelectedEdge;
+}

--- a/src/hooks/useHandleEdgeSelection.ts
+++ b/src/hooks/useHandleEdgeSelection.ts
@@ -1,0 +1,42 @@
+import { useEdges, useReactFlow } from "@xyflow/react";
+
+export function useHandleEdgeSelection(nodeId: string) {
+  const edges = useEdges();
+  const { setEdges } = useReactFlow();
+
+  const selectEdgesForHandle = (
+    handleId: string,
+    handleType: "source" | "target",
+  ) => {
+    const connectedEdgeIds = new Set<string>();
+
+    for (const edge of edges) {
+      const isMatch =
+        handleType === "source"
+          ? edge.source === nodeId && edge.sourceHandle === handleId
+          : edge.target === nodeId && edge.targetHandle === handleId;
+
+      if (isMatch) connectedEdgeIds.add(edge.id);
+    }
+
+    if (connectedEdgeIds.size === 0) return;
+
+    setEdges((eds) =>
+      eds.map((edge) => ({
+        ...edge,
+        selected: connectedEdgeIds.has(edge.id),
+      })),
+    );
+  };
+
+  const clearEdgeSelection = () => {
+    setEdges((eds) =>
+      eds.map((edge) => ({
+        ...edge,
+        selected: false,
+      })),
+    );
+  };
+
+  return { selectEdgesForHandle, clearEdgeSelection };
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -58,6 +58,7 @@ code {
   --sidebar-accent-foreground: oklch(0.205 0 0);
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.708 0 0);
+  --edge-selected: #5b2ef4;
 }
 
 .dark {
@@ -99,6 +100,7 @@ code {
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(0.269 0 0);
   --sidebar-ring: oklch(0.439 0 0);
+  --edge-selected: #5b2ef4;
 }
 
 @theme inline {
@@ -144,6 +146,7 @@ code {
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-ring: var(--sidebar-ring);
+  --color-edge-selected: var(--edge-selected);
 
   /* Custom animations */
   --animate-revert-copied: revert-copied 0.5s ease-in-out forwards;


### PR DESCRIPTION
## Description

Enhanced edge selection and highlighting in the flow canvas to improve visual feedback when working with connections. This PR adds:

1. Visual highlighting of nodes connected to selected edges
2. Handle-based edge selection (clicking an input/output handle selects all connected edges)
3. Improved edge styling with muted appearance for non-selected edges when any edge is selected
4. Updated edge colors for better visibility and contrast
5. Edge rendering order optimization to ensure selected edges appear on top

## Type of Change

- [x] New feature
- [x] Improvement

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## ![Screenshot 2026-01-14 at 4.44.52 PM.png](https://app.graphite.com/user-attachments/assets/7bce7404-9a8c-48f2-b15e-309318df58f5.png)

![Screenshot 2026-01-14 at 4.45.19 PM.png](https://app.graphite.com/user-attachments/assets/9896ae4f-9ef0-4ad0-b01e-e7d18aca256c.png)



## Test Instructions

1. Create a pipeline with multiple connected nodes
2. Click on an edge to select it and observe:
    - Connected nodes highlight with a purple border and ring
    - Other edges appear muted
3. Click on an input or output handle to select all edges connected to that handle
4. Verify that selected edges appear on top of other edges