### PR TITLE
feat: Improve visual contrast between Pipelines and Runs

### DIFF
--- a/src/components/PipelineRun/PipelineRunPage.tsx
+++ b/src/components/PipelineRun/PipelineRunPage.tsx
@@ -1,4 +1,4 @@
-import { Background, MiniMap, type ReactFlowProps } from "@xyflow/react";
+import { MiniMap, type ReactFlowProps } from "@xyflow/react";
 import { useCallback, useState } from "react";
 
 import { FlowCanvas, FlowControls } from "@/components/shared/ReactFlow";
@@ -34,8 +34,12 @@ const PipelineRunPage = () => {
     <ContextPanelProvider defaultContent={<RunDetails />}>
       <ComponentLibraryProvider>
         <InlineStack fill>
-          <BlockStack fill className="flex-1">
-            <FlowCanvas {...flowConfig} readOnly>
+          <BlockStack fill className="flex-1 relative">
+            <FlowCanvas
+              {...flowConfig}
+              readOnly
+              style={{ backgroundColor: "#dbdbdb" }}
+            >
               <MiniMap position="bottom-left" pannable />
               <FlowControls
                 className="ml-56! mb-6!"
@@ -43,7 +47,6 @@ const PipelineRunPage = () => {
                 updateConfig={updateFlowConfig}
                 showInteractive={false}
               />
-              <Background gap={GRID_SIZE} className="bg-slate-50!" />
             </FlowCanvas>
           </BlockStack>
           <CollapsibleContextPanel />

--- a/src/components/PipelineRun/components/PipelineRunBreadcrumbs.tsx
+++ b/src/components/PipelineRun/components/PipelineRunBreadcrumbs.tsx
@@ -1,0 +1,195 @@
+import { useNavigate, useParams } from "@tanstack/react-router";
+import { Check, ChevronRight, Copy, Network } from "lucide-react";
+import { type MouseEvent, useCallback, useEffect, useState } from "react";
+
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { useComponentSpec } from "@/providers/ComponentSpecProvider";
+import { useExecutionDataOptional } from "@/providers/ExecutionDataProvider";
+import { loadPipelineByName } from "@/services/pipelineService";
+import { copyToClipboard } from "@/utils/string";
+
+interface PipelineRunBreadcrumbsProps {
+  variant?: "overlay" | "topbar";
+}
+
+export const PipelineRunBreadcrumbs = ({
+  variant = "overlay",
+}: PipelineRunBreadcrumbsProps) => {
+  const navigate = useNavigate();
+  const params = useParams({ strict: false });
+  const { componentSpec } = useComponentSpec();
+  const executionData = useExecutionDataOptional();
+
+  // Get run ID from execution data OR from URL params (fallback for when provider isn't loaded yet)
+  const runIdFromParams =
+    "id" in params && typeof params.id === "string" ? params.id : undefined;
+  const runId = executionData?.runId || runIdFromParams;
+  const metadata = executionData?.metadata;
+  const [isCopied, setIsCopied] = useState(false);
+  const [isHovered, setIsHovered] = useState(false);
+  const [pipelineExistsLocally, setPipelineExistsLocally] = useState<
+    boolean | null
+  >(null);
+
+  const pipelineName = componentSpec?.name || metadata?.pipeline_name;
+
+  // Check if the pipeline exists in local storage
+  useEffect(() => {
+    const checkPipelineExists = async () => {
+      if (!pipelineName) {
+        setPipelineExistsLocally(null);
+        return;
+      }
+
+      try {
+        const result = await loadPipelineByName(pipelineName);
+        setPipelineExistsLocally(!!result.experiment);
+      } catch (error) {
+        console.error("Error checking pipeline existence:", error);
+        setPipelineExistsLocally(false);
+      }
+    };
+
+    checkPipelineExists();
+  }, [pipelineName]);
+
+  const handleNavigateToPipeline = useCallback(() => {
+    if (pipelineName && pipelineExistsLocally) {
+      navigate({ to: `/editor/${encodeURIComponent(pipelineName)}` });
+    }
+  }, [pipelineName, pipelineExistsLocally, navigate]);
+
+  const handleCopyRunId = useCallback(
+    (e: MouseEvent) => {
+      e.stopPropagation();
+      if (runId) {
+        copyToClipboard(runId);
+        setIsCopied(true);
+      }
+    },
+    [runId],
+  );
+
+  useEffect(() => {
+    if (isCopied) {
+      const timer = setTimeout(() => {
+        setIsCopied(false);
+      }, 1500);
+      return () => clearTimeout(timer);
+    }
+  }, [isCopied]);
+
+  if (!pipelineName) {
+    return null;
+  }
+
+  // Styles for topbar variant (white text on dark background)
+  const isTopbar = variant === "topbar";
+  const textColorClass = isTopbar ? "text-white" : "text-foreground";
+  const mutedTextClass = isTopbar ? "text-gray-300" : "text-muted-foreground";
+  const buttonVariantClass = isTopbar
+    ? "h-7 px-2 gap-1.5 font-medium text-gray-300 hover:text-white hover:bg-stone-800"
+    : "h-7 px-2 gap-1.5 text-muted-foreground hover:text-foreground font-medium";
+
+  // Container for overlay variant
+  const containerClass = isTopbar
+    ? "flex items-center gap-1"
+    : "absolute top-0 left-0 z-10 bg-white/95 backdrop-blur-sm shadow-md rounded-br-xl border-b border-r border-gray-200";
+
+  return (
+    <div className={containerClass}>
+      <div className={isTopbar ? "" : "px-4 py-2.5"}>
+        <Breadcrumb>
+          <BreadcrumbList>
+            <BreadcrumbItem>
+              {pipelineExistsLocally ? (
+                <BreadcrumbLink asChild>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={handleNavigateToPipeline}
+                    title="Navigate to pipeline in editor"
+                    className={buttonVariantClass}
+                  >
+                    <Network className="w-4 h-4 rotate-270" />
+                    {pipelineName}
+                  </Button>
+                </BreadcrumbLink>
+              ) : (
+                <BreadcrumbPage
+                  title={
+                    pipelineExistsLocally === null
+                      ? "Checking if pipeline exists locally..."
+                      : "Pipeline not saved locally. Use 'Clone Pipeline' to edit."
+                  }
+                  className={cn(
+                    "flex items-center gap-1.5 h-7 px-2",
+                    mutedTextClass,
+                  )}
+                >
+                  <Network className="w-4 h-4 rotate-270" />
+                  {pipelineName}
+                </BreadcrumbPage>
+              )}
+            </BreadcrumbItem>
+            <BreadcrumbSeparator>
+              <ChevronRight className={cn("w-4 h-4", mutedTextClass)} />
+            </BreadcrumbSeparator>
+            <BreadcrumbItem>
+              {runId ? (
+                <div
+                  className="group flex items-center gap-1 cursor-pointer"
+                  onClick={handleCopyRunId}
+                  onMouseEnter={() => setIsHovered(true)}
+                  onMouseLeave={() => setIsHovered(false)}
+                  title={`Click to copy: ${runId}`}
+                >
+                  <span
+                    className={cn(
+                      "text-sm font-medium transition-colors duration-150",
+                      isCopied ? "text-emerald-500" : textColorClass,
+                    )}
+                  >
+                    Run {runId}
+                  </span>
+                  <span className="relative h-3.5 w-3.5">
+                    <Check
+                      className={cn(
+                        "absolute inset-0 h-3.5 w-3.5 text-emerald-500 transition-all duration-200",
+                        isCopied
+                          ? "rotate-0 scale-100 opacity-100"
+                          : "-rotate-90 scale-0 opacity-0",
+                      )}
+                    />
+                    <Copy
+                      className={cn(
+                        "absolute inset-0 h-3.5 w-3.5 transition-all duration-200",
+                        mutedTextClass,
+                        isHovered && !isCopied
+                          ? "rotate-0 scale-100 opacity-100"
+                          : "rotate-90 scale-0 opacity-0",
+                      )}
+                    />
+                  </span>
+                </div>
+              ) : (
+                <span className={cn("text-sm font-medium", textColorClass)}>
+                  Run
+                </span>
+              )}
+            </BreadcrumbItem>
+          </BreadcrumbList>
+        </Breadcrumb>
+      </div>
+    </div>
+  );
+};

--- a/src/components/layout/AppMenu.tsx
+++ b/src/components/layout/AppMenu.tsx
@@ -1,7 +1,9 @@
+import { useLocation } from "@tanstack/react-router";
 import { Menu } from "lucide-react";
 import { useState } from "react";
 
 import logo from "/Tangle_white.png";
+import { PipelineRunBreadcrumbs } from "@/components/PipelineRun/components/PipelineRunBreadcrumbs";
 import { isAuthorizationRequired } from "@/components/shared/Authentication/helpers";
 import { TopBarAuthentication } from "@/components/shared/Authentication/TopBarAuthentication";
 import { CopyText } from "@/components/shared/CopyText/CopyText";
@@ -17,6 +19,7 @@ import {
   SheetTrigger,
 } from "@/components/ui/sheet";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
+import { RUNS_BASE_PATH } from "@/routes/router";
 import { TOP_NAV_HEIGHT } from "@/utils/constants";
 
 import BackendStatus from "../shared/BackendStatus";
@@ -27,8 +30,12 @@ import { PersonalPreferences } from "../shared/Settings/PersonalPreferences";
 const AppMenu = () => {
   const requiresAuthorization = isAuthorizationRequired();
   const { componentSpec } = useComponentSpec();
+  const location = useLocation();
   const title = componentSpec?.name;
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+
+  // Check if we're on a run page
+  const isRunPage = location.pathname.includes(RUNS_BASE_PATH);
 
   return (
     <div
@@ -45,10 +52,15 @@ const AppMenu = () => {
             />
           </Link>
 
-          {title && (
-            <CopyText className="text-white text-md font-bold truncate max-w-32 sm:max-w-48 md:max-w-64 lg:max-w-md">
-              {title}
-            </CopyText>
+          {/* Show breadcrumbs on run pages, otherwise show simple title */}
+          {isRunPage ? (
+            <PipelineRunBreadcrumbs variant="topbar" />
+          ) : (
+            title && (
+              <CopyText className="text-white text-md font-bold truncate max-w-32 sm:max-w-48 md:max-w-64 lg:max-w-md">
+                {title}
+              </CopyText>
+            )
           )}
         </InlineStack>
 


### PR DESCRIPTION
## Description

Added breadcrumbs navigation to the Pipeline Run page, allowing users to navigate between pipeline runs and the editor. The breadcrumbs show the pipeline name and run ID, with the ability to:

1. Click on the pipeline name to navigate to the editor (if the pipeline exists locally)
2. Copy the run ID to clipboard with visual feedback

Also updated the flow canvas background from the previous `<Background>` component to a simple gray background color.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Screenshots (if applicable)

![image.png](https://app.graphite.com/user-attachments/assets/90995828-7e0b-42af-bc79-1c71c8a156f5.png)

[runs-contrast.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/96b229e5-53aa-43f7-ad8b-9afa7046d50b.mov" />](https://app.graphite.com/user-attachments/video/96b229e5-53aa-43f7-ad8b-9afa7046d50b.mov)

## Test Instructions

1. Navigate to a pipeline run page
2. Verify the breadcrumbs appear in the top-left corner
3. If the pipeline exists locally, click on the pipeline name to navigate to the editor
4. Click on the run ID to copy it to clipboard (verify the copy animation works)
5. Verify the background color of the flow canvas is gray (#dbdbdb)