### PR TITLE
feat: display taskspec arguments values in run view

### DIFF
--- a/src/components/PipelineRun/RunDetails.tsx
+++ b/src/components/PipelineRun/RunDetails.tsx
@@ -177,7 +177,7 @@ export const RunDetails = () => {
         />
       )}
 
-      <PipelineIO readOnly />
+      <PipelineIO taskArguments={details.task_spec.arguments} />
     </BlockStack>
   );
 };

--- a/src/components/shared/Execution/PipelineIO.tsx
+++ b/src/components/shared/Execution/PipelineIO.tsx
@@ -1,5 +1,6 @@
 import { type ReactNode } from "react";
 
+import type { TaskSpecOutput } from "@/api/types.gen";
 import { Attribute } from "@/components/shared/ContextPanel/Blocks/Attribute";
 import { ContentBlock } from "@/components/shared/ContextPanel/Blocks/ContentBlock";
 import { typeSpecToString } from "@/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/utils";
@@ -15,9 +16,15 @@ import { InputValueEditor } from "../../Editor/IOEditor/InputValueEditor";
 import { OutputNameEditor } from "../../Editor/IOEditor/OutputNameEditor";
 import { getOutputConnectedDetails } from "../../Editor/utils/getOutputConnectedDetails";
 
-const PipelineIO = ({ readOnly }: { readOnly?: boolean }) => {
+const PipelineIO = ({
+  taskArguments,
+}: {
+  taskArguments?: TaskSpecOutput["arguments"] | null;
+}) => {
   const { setContent } = useContextPanel();
   const { componentSpec, graphSpec } = useComponentSpec();
+
+  const readOnly = !!taskArguments;
 
   const handleInputEdit = (input: InputSpec) => {
     setContent(<InputValueEditor key={input.name} input={input} />);
@@ -57,13 +64,18 @@ const PipelineIO = ({ readOnly }: { readOnly?: boolean }) => {
 
   return (
     <BlockStack gap="4">
-      <ContentBlock title="Inputs">
+      <ContentBlock title={taskArguments ? "Arguments" : "Inputs"}>
         {componentSpec.inputs && componentSpec.inputs.length > 0 ? (
           <BlockStack>
             {componentSpec.inputs.map((input) => (
               <IORow
                 key={input.name}
-                value={input.value || input.default || "—"}
+                value={
+                  getArgumentValue(taskArguments, input.name) ||
+                  input.value ||
+                  input.default ||
+                  "—"
+                }
                 type={typeSpecToString(input?.type)}
                 spec={input}
                 actions={inputActions}
@@ -161,4 +173,15 @@ function IORow({ spec, value, type, actions }: IORowProps) {
       </InlineStack>
     </InlineStack>
   );
+}
+
+function getArgumentValue(
+  taskArguments: TaskSpecOutput["arguments"] | undefined,
+  inputName: string,
+) {
+  const argument = taskArguments?.[inputName];
+  if (typeof argument === "string") {
+    return argument;
+  }
+  return undefined;
 }


### PR DESCRIPTION
## Description

Closes https://github.com/Shopify/oasis-frontend/issues/413

Enhanced the `PipelineIO` component to display task arguments in the run details view. The component now accepts a `taskArguments` prop and displays the actual argument values when viewing pipeline run details.

## Type of Change

- [x] Improvement
- [x] New feature

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions


[Screen Recording 2026-01-09 at 4.29.50 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/776afa03-d259-4207-92d9-5a83f99b07e1.mov" />](https://app.graphite.com/user-attachments/video/776afa03-d259-4207-92d9-5a83f99b07e1.mov)

1. Create and run a pipeline with various input arguments - you can use http://localhost:8000/docs#/pipelineRuns/create_api_pipeline_runs__post (or replace origin with proper host/port)
2. Navigate to the run details page
3. Verify that the "Arguments" section displays the actual values passed to the pipeline run as TaskSpec arguments and not from the ComponentSpec input values/default values.