### PR TITLE
[Chore] CMD-Click to open Runs in a New Tab

### DIFF
--- a/src/components/Home/RunSection/RunRow.tsx
+++ b/src/components/Home/RunSection/RunRow.tsx
@@ -40,6 +40,15 @@ const RunRow = ({ run }: { run: PipelineRunResponse }) => {
 
   const clickThroughUrl = `${APP_ROUTES.RUNS}/${runId}`;
 
+  const handleRowClick = (e: MouseEvent) => {
+    e.stopPropagation();
+    if (e.metaKey || e.ctrlKey) {
+      window.open(clickThroughUrl, "_blank");
+    } else {
+      navigate({ to: clickThroughUrl });
+    }
+  };
+
   const createdByButton = (
     <Button
       className="truncate underline"
@@ -62,18 +71,19 @@ const RunRow = ({ run }: { run: PipelineRunResponse }) => {
 
   return (
     <TableRow
-      onClick={(e) => {
-        e.stopPropagation();
-        navigate({ to: clickThroughUrl });
-      }}
+      onClick={(e) => handleRowClick(e)}
       className="cursor-pointer text-gray-500 text-xs"
     >
-      <TableCell className="text-sm flex items-center gap-2">
-        <StatusIcon status={overallStatus} />
-        <Paragraph className="truncate max-w-[400px]" title={name}>
-          {name}
-        </Paragraph>
-        <span>{`#${runId}`}</span>
+      <TableCell>
+        <div className="flex items-center gap-2">
+          <StatusIcon status={overallStatus} />
+          <Paragraph className="truncate max-w-[400px] text-sm" title={name}>
+            {name}
+          </Paragraph>
+          <Paragraph tone="subdued" className="text-sm" title={runId}>
+            #{runId}
+          </Paragraph>
+        </div>
       </TableCell>
       <TableCell>
         <div className="w-2/3">


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Enable opening runs in a new tab using `cmd + click` on the row.

I also fixed the row name being off-centre horizontally from the rest of the row.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

This is off the back of a quick [user-request in Slack](https://shopify.slack.com/archives/C08HUHQU0Q2/p1768159030997279).

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix
- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

Go to homepage -> cmd + click on a run to open it in a new tab

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
