### PR TITLE
fix: call rerun pipeline with actual task arguments

### DIFF
--- a/src/components/PipelineRun/components/RerunPipelineButton.tsx
+++ b/src/components/PipelineRun/components/RerunPipelineButton.tsx
@@ -9,6 +9,7 @@ import { useAwaitAuthorization } from "@/components/shared/Authentication/useAwa
 import TooltipButton from "@/components/shared/Buttons/TooltipButton";
 import useToastNotification from "@/hooks/useToastNotification";
 import { useBackend } from "@/providers/BackendProvider";
+import { useExecutionDataOptional } from "@/providers/ExecutionDataProvider";
 import { APP_ROUTES } from "@/routes/router";
 import type { PipelineRun } from "@/types/pipelineRun";
 import type { ComponentSpec } from "@/utils/componentSpec";
@@ -24,6 +25,7 @@ export const RerunPipelineButton = ({
   const { backendUrl } = useBackend();
   const navigate = useNavigate();
   const notify = useToastNotification();
+  const executionData = useExecutionDataOptional();
 
   const { awaitAuthorization, isAuthorized } = useAwaitAuthorization();
   const { getToken } = useAuthLocalStorage();
@@ -59,6 +61,7 @@ export const RerunPipelineButton = ({
 
       return new Promise<PipelineRun>((resolve, reject) => {
         submitPipelineRun(componentSpec, backendUrl, {
+          taskArguments: executionData?.rootDetails?.task_spec.arguments,
           authorizationToken,
           onSuccess: resolve,
           onError: reject,


### PR DESCRIPTION
## Description

Closes https://github.com/Shopify/oasis-frontend/issues/415

Added support for reusing task arguments when rerunning a pipeline. This enhancement allows the RerunPipelineButton component to pass the original task arguments to the new pipeline run, preserving the input parameters from the previous execution.

## Type of Change

- [x] New feature
- [x] Improvement

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

[Screen Recording 2026-01-12 at 1.39.54 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/cfd18e03-1b9e-43af-a767-bf6763ecd571.mov" />](https://app.graphite.com/user-attachments/video/cfd18e03-1b9e-43af-a767-bf6763ecd571.mov)

1. Run a pipeline with specific input parameters
2. Navigate to the pipeline run details page
3. Click the "Rerun" button
4. Verify that the new pipeline run is created with the same input parameters as the original run

## Note

This PR does NOT address the "clone" action - only rerun.