### PR TITLE
feat: display task annotations in pipeline run - task details context panel

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/TaskOverview.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/TaskOverview.tsx
@@ -124,6 +124,7 @@ const TaskOverview = ({ taskNode, actions }: TaskOverviewProps) => {
               displayName={name}
               executionId={executionId}
               componentRef={taskSpec.componentRef}
+              taskSpec={taskSpec}
               taskId={taskId}
               componentDigest={taskSpec.componentRef.digest}
               url={taskSpec.componentRef.url}

--- a/src/components/shared/TaskDetails/Details.tsx
+++ b/src/components/shared/TaskDetails/Details.tsx
@@ -2,10 +2,11 @@ import { type ReactNode } from "react";
 
 import { BlockStack } from "@/components/ui/layout";
 import { useGuaranteedHydrateComponentReference } from "@/hooks/useHydrateComponentReference";
-import type { ComponentReference } from "@/utils/componentSpec";
+import type { ComponentReference, TaskSpec } from "@/utils/componentSpec";
 import { getExecutionStatusLabel } from "@/utils/executionStatus";
 
 import { ContentBlock } from "../ContextPanel/Blocks/ContentBlock";
+import { ListBlock } from "../ContextPanel/Blocks/ListBlock";
 import { TextBlock } from "../ContextPanel/Blocks/TextBlock";
 import { withSuspenseWrapper } from "../SuspenseWrapper";
 import TaskActions from "./Actions";
@@ -17,6 +18,7 @@ interface TaskDetailsProps {
   componentRef: ComponentReference;
   executionId?: string;
   taskId?: string;
+  taskSpec?: TaskSpec;
   componentDigest?: string;
   url?: string;
   actions?: ReactNode[];
@@ -37,6 +39,7 @@ const TaskDetailsInternal = ({
   componentRef,
   executionId,
   taskId,
+  taskSpec,
   componentDigest,
   url,
   actions = [],
@@ -135,6 +138,27 @@ const TaskDetailsInternal = ({
           {section.component}
         </ContentBlock>
       ))}
+
+      {Object.keys(taskSpec?.annotations || {}).length > 0 && (
+        <ContentBlock
+          key="annotations"
+          title="Task Annotations"
+          collapsible
+          defaultOpen={false}
+          className={BASE_BLOCK_CLASS}
+        >
+          <ListBlock
+            items={Object.entries(taskSpec?.annotations || {}).map(
+              ([key, value]) => ({
+                label: key,
+                value: String(value),
+                copyable: true,
+              }),
+            )}
+            marker="none"
+          />
+        </ContentBlock>
+      )}
 
       <TaskActions
         displayName={displayName}


### PR DESCRIPTION
## Description

Closes https://github.com/Shopify/oasis-frontend/issues/418

Added support for displaying task annotations in the Task Details panel. This enhancement allows users to view task-specific annotations in a collapsible section, with each annotation key-value pair being copyable.

![image.png](https://app.graphite.com/user-attachments/assets/de87b3d2-70bd-4e24-8f65-6e94a7620116.png)

## Type of Change

- [x] New feature
- [x] Improvement

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions


[Screen Recording 2026-01-12 at 2.51.24 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/863ac4bd-a11d-44d8-a8d9-6953e141d57c.mov" />](https://app.graphite.com/user-attachments/video/863ac4bd-a11d-44d8-a8d9-6953e141d57c.mov)

1. Create a task with annotations in your pipeline
2. Open the Task Details panel for that task
3. Verify that a "Task Annotations" section appears
4. Expand the section to see the key-value pairs
5. Test the copy functionality for annotation values