### PR TITLE
feat: clone pipeline from run with arguments

### DIFF
--- a/src/components/shared/Submitters/Oasis/components/SubmitTaskArgumentsDialog.tsx
+++ b/src/components/shared/Submitters/Oasis/components/SubmitTaskArgumentsDialog.tsx
@@ -34,7 +34,7 @@ import {
 } from "@/services/executionService";
 import type { PipelineRun } from "@/types/pipelineRun";
 import type { ComponentSpec, InputSpec } from "@/utils/componentSpec";
-import { getArgumentValue } from "@/utils/nodes/taskArguments";
+import { extractTaskArguments } from "@/utils/nodes/taskArguments";
 
 type TaskArguments = TaskSpecOutput["arguments"];
 
@@ -193,22 +193,7 @@ const CopyFromRunPopover = ({
     },
     onSuccess: (runArguments: TaskArguments) => {
       if (runArguments) {
-        const componentSpecInputs = new Set(
-          componentSpec.inputs?.map((input) => input.name) ?? [],
-        );
-
-        const newArgs = Object.fromEntries(
-          Object.entries(runArguments)
-            .map(
-              ([name, _]) =>
-                [name, getArgumentValue(runArguments, name)] as const,
-            )
-            .filter(
-              (entry): entry is [string, string] =>
-                entry[1] !== undefined && componentSpecInputs.has(entry[0]),
-            ),
-        );
-
+        const newArgs = extractTaskArguments(runArguments, componentSpec);
         onCopy(newArgs);
       }
       setPopoverOpen(false);

--- a/src/services/pipelineRunService.ts
+++ b/src/services/pipelineRunService.ts
@@ -77,6 +77,7 @@ export const copyRunToPipeline = async (
   componentSpec: ComponentSpec,
   runId?: string | null,
   name?: string,
+  taskArguments?: Record<string, string>,
 ) => {
   if (!componentSpec) {
     console.error("No component spec found to copy");
@@ -98,6 +99,15 @@ export const copyRunToPipeline = async (
       "left-to-right";
     if (runId) {
       cleanComponentSpec.metadata.annotations["cloned_from_run_id"] = runId;
+    }
+
+    if (taskArguments) {
+      // update all  values of inputs with the task arguments
+      cleanComponentSpec.inputs?.forEach((input) => {
+        if (taskArguments[input.name]) {
+          input.value = taskArguments[input.name];
+        }
+      });
     }
 
     // Remove caching strategy from all tasks

--- a/src/utils/nodes/taskArguments.test.ts
+++ b/src/utils/nodes/taskArguments.test.ts
@@ -1,0 +1,260 @@
+import { describe, expect, it } from "vitest";
+
+import type { GraphInputArgument, TaskOutputArgument } from "@/api/types.gen";
+import type { ComponentSpec } from "@/utils/componentSpec";
+
+import { extractTaskArguments, getArgumentValue } from "./taskArguments";
+
+describe("taskArguments", () => {
+  describe("getArgumentValue", () => {
+    it("should return undefined when inputName is undefined", () => {
+      const taskArguments = { input1: "value1" };
+
+      expect(getArgumentValue(taskArguments, undefined)).toBeUndefined();
+    });
+
+    it("should return undefined when inputName is empty string", () => {
+      const taskArguments = { input1: "value1" };
+
+      expect(getArgumentValue(taskArguments, "")).toBeUndefined();
+    });
+
+    it("should return undefined when taskArguments is undefined", () => {
+      expect(getArgumentValue(undefined, "input1")).toBeUndefined();
+    });
+
+    it("should return undefined when argument does not exist", () => {
+      const taskArguments = { input1: "value1" };
+
+      expect(getArgumentValue(taskArguments, "nonexistent")).toBeUndefined();
+    });
+
+    it("should return the string value when argument is a string", () => {
+      const taskArguments = {
+        input1: "value1",
+        input2: "value2",
+      };
+
+      expect(getArgumentValue(taskArguments, "input1")).toBe("value1");
+      expect(getArgumentValue(taskArguments, "input2")).toBe("value2");
+    });
+
+    it("should return undefined when argument is a GraphInputArgument", () => {
+      const graphInputArgument: GraphInputArgument = {
+        graphInput: { inputName: "pipeline_input" },
+      };
+      const taskArguments = {
+        input1: graphInputArgument,
+      };
+
+      expect(getArgumentValue(taskArguments, "input1")).toBeUndefined();
+    });
+
+    it("should return undefined when argument is a TaskOutputArgument", () => {
+      const taskOutputArgument: TaskOutputArgument = {
+        taskOutput: { outputName: "output", taskId: "task1" },
+      };
+      const taskArguments = {
+        input1: taskOutputArgument,
+      };
+
+      expect(getArgumentValue(taskArguments, "input1")).toBeUndefined();
+    });
+
+    it("should handle mixed argument types and return only string values", () => {
+      const graphInputArgument: GraphInputArgument = {
+        graphInput: { inputName: "pipeline_input" },
+      };
+      const taskOutputArgument: TaskOutputArgument = {
+        taskOutput: { outputName: "output", taskId: "task1" },
+      };
+      const taskArguments = {
+        stringArg: "string_value",
+        graphArg: graphInputArgument,
+        taskArg: taskOutputArgument,
+      };
+
+      expect(getArgumentValue(taskArguments, "stringArg")).toBe("string_value");
+      expect(getArgumentValue(taskArguments, "graphArg")).toBeUndefined();
+      expect(getArgumentValue(taskArguments, "taskArg")).toBeUndefined();
+    });
+  });
+
+  describe("extractTaskArguments", () => {
+    it("should return empty object when taskArguments is undefined", () => {
+      expect(extractTaskArguments(undefined)).toEqual({});
+    });
+
+    it("should return empty object when taskArguments is null", () => {
+      expect(extractTaskArguments(null)).toEqual({});
+    });
+
+    it("should return empty object when taskArguments is empty", () => {
+      expect(extractTaskArguments({})).toEqual({});
+    });
+
+    it("should return all string arguments", () => {
+      const taskArguments = {
+        input1: "value1",
+        input2: "value2",
+        input3: "value3",
+      };
+
+      expect(extractTaskArguments(taskArguments)).toEqual({
+        input1: "value1",
+        input2: "value2",
+        input3: "value3",
+      });
+    });
+
+    it("should filter out GraphInputArgument values", () => {
+      const graphInputArgument: GraphInputArgument = {
+        graphInput: { inputName: "pipeline_input" },
+      };
+      const taskArguments = {
+        stringArg: "value1",
+        graphArg: graphInputArgument,
+      };
+
+      expect(extractTaskArguments(taskArguments)).toEqual({
+        stringArg: "value1",
+      });
+    });
+
+    it("should filter out TaskOutputArgument values", () => {
+      const taskOutputArgument: TaskOutputArgument = {
+        taskOutput: { outputName: "output", taskId: "task1" },
+      };
+      const taskArguments = {
+        stringArg: "value1",
+        taskArg: taskOutputArgument,
+      };
+
+      expect(extractTaskArguments(taskArguments)).toEqual({
+        stringArg: "value1",
+      });
+    });
+
+    it("should filter out all non-string arguments", () => {
+      const graphInputArgument: GraphInputArgument = {
+        graphInput: { inputName: "pipeline_input" },
+      };
+      const taskOutputArgument: TaskOutputArgument = {
+        taskOutput: { outputName: "output", taskId: "task1" },
+      };
+      const taskArguments = {
+        stringArg1: "value1",
+        graphArg: graphInputArgument,
+        stringArg2: "value2",
+        taskArg: taskOutputArgument,
+      };
+
+      expect(extractTaskArguments(taskArguments)).toEqual({
+        stringArg1: "value1",
+        stringArg2: "value2",
+      });
+    });
+
+    describe("with componentSpec", () => {
+      const minimalImplementation: ComponentSpec["implementation"] = {
+        container: { image: "test-image", command: ["echo"] },
+      };
+
+      it("should only include arguments that match component inputs", () => {
+        const taskArguments = {
+          input1: "value1",
+          input2: "value2",
+          extraArg: "extraValue",
+        };
+        const componentSpec: ComponentSpec = {
+          name: "test-component",
+          inputs: [{ name: "input1" }, { name: "input2" }],
+          implementation: minimalImplementation,
+        };
+
+        expect(extractTaskArguments(taskArguments, componentSpec)).toEqual({
+          input1: "value1",
+          input2: "value2",
+        });
+      });
+
+      it("should exclude arguments not in component inputs", () => {
+        const taskArguments = {
+          input1: "value1",
+          unknownArg: "unknownValue",
+        };
+        const componentSpec: ComponentSpec = {
+          name: "test-component",
+          inputs: [{ name: "input1" }],
+          implementation: minimalImplementation,
+        };
+
+        expect(extractTaskArguments(taskArguments, componentSpec)).toEqual({
+          input1: "value1",
+        });
+      });
+
+      it("should return empty object when componentSpec has no inputs", () => {
+        const taskArguments = {
+          input1: "value1",
+          input2: "value2",
+        };
+        const componentSpec: ComponentSpec = {
+          name: "test-component",
+          implementation: minimalImplementation,
+        };
+
+        expect(extractTaskArguments(taskArguments, componentSpec)).toEqual({});
+      });
+
+      it("should return empty object when componentSpec has empty inputs array", () => {
+        const taskArguments = {
+          input1: "value1",
+          input2: "value2",
+        };
+        const componentSpec: ComponentSpec = {
+          name: "test-component",
+          inputs: [],
+          implementation: minimalImplementation,
+        };
+
+        expect(extractTaskArguments(taskArguments, componentSpec)).toEqual({});
+      });
+
+      it("should filter both by componentSpec inputs and non-string values", () => {
+        const graphInputArgument: GraphInputArgument = {
+          graphInput: { inputName: "pipeline_input" },
+        };
+        const taskArguments = {
+          validInput: "validValue",
+          graphArg: graphInputArgument,
+          unknownArg: "unknownValue",
+        };
+        const componentSpec: ComponentSpec = {
+          name: "test-component",
+          inputs: [{ name: "validInput" }, { name: "graphArg" }],
+          implementation: minimalImplementation,
+        };
+
+        expect(extractTaskArguments(taskArguments, componentSpec)).toEqual({
+          validInput: "validValue",
+        });
+      });
+
+      it("should return matching arguments when only some exist in taskArguments", () => {
+        const taskArguments = {
+          input1: "value1",
+        };
+        const componentSpec: ComponentSpec = {
+          name: "test-component",
+          inputs: [{ name: "input1" }, { name: "input2" }, { name: "input3" }],
+          implementation: minimalImplementation,
+        };
+
+        expect(extractTaskArguments(taskArguments, componentSpec)).toEqual({
+          input1: "value1",
+        });
+      });
+    });
+  });
+});

--- a/src/utils/nodes/taskArguments.ts
+++ b/src/utils/nodes/taskArguments.ts
@@ -1,5 +1,7 @@
 import type { TaskSpecOutput } from "@/api/types.gen";
 
+import type { ComponentSpec } from "../componentSpec";
+
 /**
  * Gets the string value of a task argument.
  *
@@ -21,4 +23,30 @@ export function getArgumentValue(
   }
 
   return undefined;
+}
+
+/**
+ * Returns a record of task arguments with the value as a string.
+ *
+ * @param taskArguments
+ * @param componentSpec - Optional component specification to filter arguments by.
+ * @returns
+ */
+export function extractTaskArguments(
+  taskArguments: TaskSpecOutput["arguments"],
+  componentSpec?: ComponentSpec,
+): Record<string, string> {
+  const componentSpecInputs = componentSpec
+    ? new Set(componentSpec.inputs?.map((input) => input.name) ?? [])
+    : undefined;
+
+  return Object.fromEntries(
+    Object.entries(taskArguments ?? {})
+      .map(([key, _]) => [key, getArgumentValue(taskArguments, key)] as const)
+      .filter(
+        (entry): entry is [string, string] =>
+          entry[1] !== undefined &&
+          Boolean(!componentSpecInputs || componentSpecInputs.has(entry[0])),
+      ),
+  );
 }

--- a/src/utils/submitPipeline.ts
+++ b/src/utils/submitPipeline.ts
@@ -10,7 +10,7 @@ import {
 import type { PipelineRun } from "@/types/pipelineRun";
 
 import type { ComponentReference, ComponentSpec } from "./componentSpec";
-import { getArgumentValue } from "./nodes/taskArguments";
+import { extractTaskArguments } from "./nodes/taskArguments";
 import { componentSpecFromYaml } from "./yaml";
 
 export async function submitPipelineRun(
@@ -37,12 +37,7 @@ export async function submitPipelineRun(
     );
     const argumentsFromInputs = getArgumentsFromInputs(fullyLoadedSpec);
     const normalizedTaskArguments = options?.taskArguments
-      ? Object.fromEntries(
-          Object.entries(options.taskArguments).map(([key, _]) => [
-            key,
-            getArgumentValue(options.taskArguments, key),
-          ]),
-        )
+      ? extractTaskArguments(options.taskArguments)
       : {};
     const payloadArguments = {
       ...argumentsFromInputs,


### PR DESCRIPTION
## Description

Closes https://github.com/Shopify/oasis-frontend/issues/411

Updated behavior for "Clone Pipeline" button on the Pipeline Run Details page. This button clones a pipeline while preserving the arguments used in the original run, allowing users to quickly create a new pipeline with the same parameter values.

Following decisions made in sync meeting:

> Where to hold arguments  
> In short-term it’s OK to store them anywhere as long as this implementation detail does not leak into submitted and exported pipelines.  
> Currently, UI code stores pipeline-level arguments inside pipeline-level inputs (InputSpec.value).

To keep behavior consistent former "Clone Pipeline" button should be removed - https://app.graphite.com/github/pr/TangleML/tangle-ui/1628/fix-remove-redundant-clone-pipeline-from-the-top-menu

## Type of Change

- [x] New feature
- [x] Improvement

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

[Screen Recording 2026-01-13 at 10.39.45 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/4dab8000-916b-4b16-bbab-971912d9b2dc.mov" />](https://app.graphite.com/user-attachments/video/4dab8000-916b-4b16-bbab-971912d9b2dc.mov)

1. Navigate to a completed pipeline run
2. Verify that both clone buttons are visible:
    - The original "Clone Pipeline" button
    - The new "Clone Pipeline with Arguments" button
3. Click the "Clone Pipeline with Arguments" button
4. Verify that the new pipeline opens in the editor with all input parameters pre-filled with values from the original run argumentsFol