### PR TITLE
fix: Larger gap between App Logo and Pipeline Name

### DIFF
--- a/src/components/layout/AppMenu.tsx
+++ b/src/components/layout/AppMenu.tsx
@@ -36,7 +36,7 @@ const AppMenu = () => {
       style={{ height: `${TOP_NAV_HEIGHT}px` }}
     >
       <InlineStack align="space-between" wrap="nowrap">
-        <InlineStack gap="3" wrap="nowrap" className="min-w-0 flex-1">
+        <InlineStack gap="8" wrap="nowrap" className="min-w-0 flex-1">
           <Link href="/" aria-label="Home" variant="block" className="shrink-0">
             <img
               src={logo}


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

This is pedantic but I felt like the gap between the app logo and the pipeline/run title was too small so I made it a bit larger.


## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

before
![image.png](https://app.graphite.com/user-attachments/assets/2e35ba86-51dc-4d1a-b6c6-82456fa4c15b.png)

after
![image.png](https://app.graphite.com/user-attachments/assets/65841154-4004-497e-ba22-0528c07e1f99.png)

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
