### PR TITLE
feat: Extend `useNavigate` hook to allow opening urls in a new tab

### DIFF
--- a/react-compiler.config.js
+++ b/react-compiler.config.js
@@ -28,6 +28,7 @@ export const REACT_COMPILER_ENABLED_DIRS = [
   "src/components/shared/GitHubLibrary",
   "src/hooks/useHandleEdgeSelection.ts",
   "src/hooks/useEdgeSelectionHighlight.ts",
+  "src/hooks/useNavigate.ts",
 
   "src/components/shared/Submitters/Oasis/components",
 

--- a/src/components/Home/PipelineSection/PipelineRow.tsx
+++ b/src/components/Home/PipelineSection/PipelineRow.tsx
@@ -1,4 +1,3 @@
-import { useNavigate } from "@tanstack/react-router";
 import { type MouseEvent } from "react";
 
 import { ConfirmationDialog } from "@/components/shared/Dialogs";
@@ -17,6 +16,7 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 import { TableCell, TableRow } from "@/components/ui/table";
 import { Paragraph } from "@/components/ui/typography";
+import { useNavigate } from "@/hooks/useNavigate";
 import { EDITOR_PATH } from "@/routes/router";
 import { deletePipeline } from "@/services/pipelineService";
 import type { ComponentReferenceWithSpec } from "@/utils/componentStore";

--- a/src/components/Home/PipelineSection/PipelineSection.tsx
+++ b/src/components/Home/PipelineSection/PipelineSection.tsx
@@ -1,4 +1,3 @@
-import { useNavigate } from "@tanstack/react-router";
 import { type ChangeEvent, useEffect, useState } from "react";
 
 import { LoadingScreen } from "@/components/shared/LoadingScreen";
@@ -21,6 +20,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Paragraph, Text } from "@/components/ui/typography";
+import { useNavigate } from "@/hooks/useNavigate";
 import { QUICK_START_PATH } from "@/routes/router";
 import {
   type ComponentFileEntry,
@@ -327,9 +327,7 @@ function QuickStartButton() {
   return (
     <Button
       variant="secondary"
-      onClick={() =>
-        navigate({ to: QUICK_START_PATH as string /* todo: fix this */ })
-      }
+      onClick={() => navigate({ to: QUICK_START_PATH })}
     >
       <Icon name="Sparkles" />
       Example Pipelines

--- a/src/components/Home/RunSection/RunRow.tsx
+++ b/src/components/Home/RunSection/RunRow.tsx
@@ -1,4 +1,3 @@
-import { useNavigate } from "@tanstack/react-router";
 import { type MouseEvent } from "react";
 
 import type { PipelineRunResponse } from "@/api/types.gen";
@@ -11,6 +10,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { Paragraph } from "@/components/ui/typography";
+import { useNavigate } from "@/hooks/useNavigate";
 import useToastNotification from "@/hooks/useToastNotification";
 import { APP_ROUTES } from "@/routes/router";
 import { convertUTCToLocalTime, formatDate } from "@/utils/date";

--- a/src/components/PipelineRun/components/ClonePipelineButton.tsx
+++ b/src/components/PipelineRun/components/ClonePipelineButton.tsx
@@ -1,9 +1,9 @@
 import { useMutation } from "@tanstack/react-query";
-import { useNavigate } from "@tanstack/react-router";
 import { useCallback } from "react";
 
 import TooltipButton from "@/components/shared/Buttons/TooltipButton";
 import { Icon } from "@/components/ui/icon";
+import { useNavigate } from "@/hooks/useNavigate";
 import useToastNotification from "@/hooks/useToastNotification";
 import { useExecutionDataOptional } from "@/providers/ExecutionDataProvider";
 import { copyRunToPipeline } from "@/services/pipelineRunService";

--- a/src/components/PipelineRun/components/InspectPipelineButton.tsx
+++ b/src/components/PipelineRun/components/InspectPipelineButton.tsx
@@ -1,8 +1,8 @@
-import { useNavigate } from "@tanstack/react-router";
 import { useCallback } from "react";
 
 import TooltipButton from "@/components/shared/Buttons/TooltipButton";
 import { Icon } from "@/components/ui/icon";
+import { useNavigate } from "@/hooks/useNavigate";
 
 type InspectPipelineButtonProps = {
   pipelineName: string;

--- a/src/components/PipelineRun/components/RerunPipelineButton.tsx
+++ b/src/components/PipelineRun/components/RerunPipelineButton.tsx
@@ -1,5 +1,4 @@
 import { useMutation } from "@tanstack/react-query";
-import { useNavigate } from "@tanstack/react-router";
 import { RefreshCcw } from "lucide-react";
 import { useCallback } from "react";
 
@@ -7,6 +6,7 @@ import { isAuthorizationRequired } from "@/components/shared/Authentication/help
 import { useAuthLocalStorage } from "@/components/shared/Authentication/useAuthLocalStorage";
 import { useAwaitAuthorization } from "@/components/shared/Authentication/useAwaitAuthorization";
 import TooltipButton from "@/components/shared/Buttons/TooltipButton";
+import { useNavigate } from "@/hooks/useNavigate";
 import useToastNotification from "@/hooks/useToastNotification";
 import { useBackend } from "@/providers/BackendProvider";
 import { useExecutionDataOptional } from "@/providers/ExecutionDataProvider";

--- a/src/components/shared/NewPipelineButton.tsx
+++ b/src/components/shared/NewPipelineButton.tsx
@@ -1,7 +1,7 @@
-import { useNavigate } from "@tanstack/react-router";
 import { generate } from "random-words";
 
 import { Button } from "@/components/ui/button";
+import { useNavigate } from "@/hooks/useNavigate";
 import { EDITOR_PATH } from "@/routes/router";
 import { writeComponentToFileListFromText } from "@/utils/componentStore";
 import {

--- a/src/components/shared/PipelineRunDisplay/RunOverview.tsx
+++ b/src/components/shared/PipelineRunDisplay/RunOverview.tsx
@@ -1,7 +1,7 @@
-import { useNavigate } from "@tanstack/react-router";
 import type { MouseEvent } from "react";
 
 import { StatusBar, StatusText } from "@/components/shared/Status/";
+import { useNavigate } from "@/hooks/useNavigate";
 import { cn } from "@/lib/utils";
 import { APP_ROUTES } from "@/routes/router";
 import type { PipelineRun, TaskStatusCounts } from "@/types/pipelineRun";

--- a/src/components/shared/QuickStart/QuickStartCards.tsx
+++ b/src/components/shared/QuickStart/QuickStartCards.tsx
@@ -1,5 +1,4 @@
 import { useMutation } from "@tanstack/react-query";
-import { useNavigate } from "@tanstack/react-router";
 
 import { InfoBox } from "@/components/shared/InfoBox";
 import { Badge } from "@/components/ui/badge";
@@ -13,6 +12,7 @@ import {
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Spinner } from "@/components/ui/spinner";
 import { Paragraph } from "@/components/ui/typography";
+import { useNavigate } from "@/hooks/useNavigate";
 import useToastNotification from "@/hooks/useToastNotification";
 import { cn } from "@/lib/utils";
 import { EDITOR_PATH } from "@/routes/router";

--- a/src/components/shared/Submitters/Oasis/OasisSubmitter.tsx
+++ b/src/components/shared/Submitters/Oasis/OasisSubmitter.tsx
@@ -1,5 +1,4 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useNavigate } from "@tanstack/react-router";
 import { AlertCircle, CheckCircle, Loader2, SendHorizonal } from "lucide-react";
 import { useCallback, useMemo, useRef, useState } from "react";
 
@@ -10,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
 import { InlineStack } from "@/components/ui/layout";
 import useCooldownTimer from "@/hooks/useCooldownTimer";
+import { useNavigate } from "@/hooks/useNavigate";
 import useToastNotification from "@/hooks/useToastNotification";
 import { cn } from "@/lib/utils";
 import { useBackend } from "@/providers/BackendProvider";
@@ -106,12 +106,8 @@ const OasisSubmitter = ({
 
   const handleViewRun = useCallback(
     (runId: number, newTab = false) => {
-      const href = `${APP_ROUTES.RUNS}/${runId}`;
-      if (newTab) {
-        window.open(href, "_blank");
-      } else {
-        navigate({ to: href });
-      }
+      const to = `${APP_ROUTES.RUNS}/${runId}`;
+      navigate({ to, newTab });
     },
     [navigate],
   );

--- a/src/hooks/useNavigate.ts
+++ b/src/hooks/useNavigate.ts
@@ -1,0 +1,68 @@
+import { useNavigate as useReactRouterNavigation } from "@tanstack/react-router";
+import { useEffect, useRef } from "react";
+
+type NavigateOptions = Parameters<
+  ReturnType<typeof useReactRouterNavigation>
+>[0];
+
+type AdvancedNavigationOptions = NavigateOptions & {
+  /**
+   * Force the navigation target to open in a new tab.
+   * Target will always open in a new tab when CMD (Mac) or CTRL (Windows/Linux) key is held.
+   */
+  newTab?: boolean;
+};
+
+export const useNavigate = () => {
+  const navigate = useReactRouterNavigation();
+  const isMetaKeyPressedRef = useRef(false);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Meta" || e.key === "Control") {
+        isMetaKeyPressedRef.current = true;
+      }
+    };
+
+    const handleKeyUp = (e: KeyboardEvent) => {
+      if (e.key === "Meta" || e.key === "Control") {
+        isMetaKeyPressedRef.current = false;
+      }
+    };
+
+    const handleBlur = () => {
+      isMetaKeyPressedRef.current = false;
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    window.addEventListener("keyup", handleKeyUp);
+    window.addEventListener("blur", handleBlur);
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+      window.removeEventListener("keyup", handleKeyUp);
+      window.removeEventListener("blur", handleBlur);
+    };
+  }, []);
+
+  const handleNavigate = (options: AdvancedNavigationOptions) => {
+    const { newTab, ...navigateOptions } = options;
+    const shouldOpenNewTab = newTab || isMetaKeyPressedRef.current;
+
+    if (shouldOpenNewTab) {
+      const url =
+        navigateOptions.href ??
+        (typeof navigateOptions.to === "string" ? navigateOptions.to : null);
+      if (url === null) {
+        console.warn("useNavigate 'newTab' argument requires a string URL");
+        return;
+      }
+
+      window.open(url, "_blank");
+    } else {
+      navigate(navigateOptions as NavigateOptions);
+    }
+  };
+
+  return handleNavigate;
+};


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
This adds a custom hook `useNavigate` that extends the existing React Router `useNavigate` to allow navigation to open in new tabs.

Specifically, it adds:
1. a `newTab` prop to the `navigate` function. If true the url will open in a new tab. If false current behaviour is maintained.
2. the hook tracks whether `cmd`/`meta` is held down when the `navigate` function executes and will open in a new tab as expected by usual link-clicking behaviour.

The PR then propagates this to all the places where I judged this additionally functionality would be desired. Implementation of the hook is as simple as replacing the import path for `useNavigate`, since the hook extends the React Router base hook (and thus the behaviour is unchanged when not opening in a new tab).

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

Closes https://github.com/Shopify/oasis-frontend/issues/423

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] New feature
- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->
No visible change to ui

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->
For the areas where this hook has been implemented check that:
- clicking as usual opens the url in the same tab (current behaviour)
- you can now cmd + click to open in a new tab

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
