### PR TITLE
fix: Center title text in RunRow

### DIFF
--- a/src/components/Home/RunSection/RunRow.tsx
+++ b/src/components/Home/RunSection/RunRow.tsx
@@ -4,6 +4,7 @@ import { type MouseEvent } from "react";
 import type { PipelineRunResponse } from "@/api/types.gen";
 import { StatusBar, StatusIcon } from "@/components/shared/Status";
 import { Button } from "@/components/ui/button";
+import { InlineStack } from "@/components/ui/layout";
 import { TableCell, TableRow } from "@/components/ui/table";
 import {
   Tooltip,
@@ -68,12 +69,16 @@ const RunRow = ({ run }: { run: PipelineRunResponse }) => {
       }}
       className="cursor-pointer text-gray-500 text-xs"
     >
-      <TableCell className="text-sm flex items-center gap-2">
-        <StatusIcon status={overallStatus} />
-        <Paragraph className="truncate max-w-[400px]" title={name}>
-          {name}
-        </Paragraph>
-        <span>{`#${runId}`}</span>
+      <TableCell>
+        <InlineStack gap="2" blockAlign="center" wrap="nowrap">
+          <StatusIcon status={overallStatus} />
+          <Paragraph className="truncate max-w-[400px] text-sm" title={name}>
+            {name}
+          </Paragraph>
+          <Paragraph tone="subdued" className="text-sm" title={runId}>
+            #{runId}
+          </Paragraph>
+        </InlineStack>
       </TableCell>
       <TableCell>
         <div className="w-2/3">


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
A simple visual fix to vertically centre content within each row of the runs table

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

Related: https://github.com/Shopify/oasis-frontend/issues/416

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

before:

![image.png](https://app.graphite.com/user-attachments/assets/b619537e-a2b2-4f6c-9fcf-92a4f638fc44.png)

after:

![image.png](https://app.graphite.com/user-attachments/assets/fac40808-1a69-4996-b249-447fedf1cc6e.png)

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->
Row table on homepage -> title & status icon should be vertically centred in the row

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
