### PR TITLE
poc: prototype of the compare pipeline runs

### DIFF
--- a/src/components/Compare/ComparePage.tsx
+++ b/src/components/Compare/ComparePage.tsx
@@ -1,0 +1,138 @@
+import { useLocation, useNavigate, useSearch } from "@tanstack/react-router";
+import { useMemo } from "react";
+
+import { LoadingScreen } from "@/components/shared/LoadingScreen";
+import { Icon } from "@/components/ui/icon";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
+import { useRunsById } from "@/hooks/useRunsById";
+import type { CompareSearchParams } from "@/routes/router";
+import type { PipelineRun } from "@/types/pipelineRun";
+
+import { ComparisonView } from "./Diff";
+import { RunSelector } from "./RunSelector";
+
+/**
+ * Parse run IDs from URL search param
+ */
+function parseRunIds(runsParam: string | undefined): string[] {
+  if (!runsParam) return [];
+  return runsParam
+    .split(",")
+    .map((id) => id.trim())
+    .filter((id) => id.length > 0);
+}
+
+/**
+ * Sort runs chronologically (earliest first).
+ * This ensures consistent diff semantics: newer runs show additions relative to older runs.
+ */
+function sortRunsChronologically(runs: PipelineRun[]): PipelineRun[] {
+  return [...runs].sort((a, b) => {
+    const dateA = a.created_at ? new Date(a.created_at).getTime() : 0;
+    const dateB = b.created_at ? new Date(b.created_at).getTime() : 0;
+    return dateA - dateB;
+  });
+}
+
+/**
+ * Main page for comparing pipeline runs.
+ * State is persisted in URL for shareability.
+ * URL format: /compare?runs=123,456,789&pipeline=MyPipeline
+ */
+export const ComparePage = () => {
+  const navigate = useNavigate();
+  const { pathname } = useLocation();
+  const search = useSearch({ strict: false }) as CompareSearchParams;
+
+  // Parse run IDs from URL
+  const runIdsFromUrl = useMemo(() => parseRunIds(search.runs), [search.runs]);
+
+  // Fetch runs by IDs if present in URL
+  const {
+    runs: fetchedRuns,
+    isLoading,
+    notFoundIds,
+    isReady,
+  } = useRunsById(runIdsFromUrl);
+
+  // Determine view state based on URL
+  const showComparison = runIdsFromUrl.length >= 2;
+
+  const handleCompare = (runs: PipelineRun[]) => {
+    // Sort runs chronologically before storing in URL
+    const sortedRuns = sortRunsChronologically(runs);
+    const runIds = sortedRuns.map((r) => String(r.id)).join(",");
+    const pipelineName = sortedRuns[0]?.pipeline_name;
+
+    navigate({
+      to: pathname,
+      search: {
+        runs: runIds,
+        pipeline: pipelineName,
+      } as CompareSearchParams,
+    });
+  };
+
+  const handleBack = () => {
+    // Clear runs from URL but keep pipeline for convenience
+    navigate({
+      to: pathname,
+      search: {
+        pipeline: search.pipeline,
+      } as CompareSearchParams,
+    });
+  };
+
+  // Loading state when fetching runs from URL
+  if (showComparison && isLoading) {
+    return <LoadingScreen message="Loading runs for comparison..." />;
+  }
+
+  // Error state if some runs weren't found
+  const hasNotFoundError = showComparison && notFoundIds.length > 0;
+
+  return (
+    <div className="container mx-auto w-3/4 p-4">
+      <BlockStack gap="4">
+        <BlockStack gap="1">
+          <Text as="h1" size="2xl" weight="bold">
+            Compare Runs
+          </Text>
+          {!showComparison && (
+            <Text as="p" tone="subdued">
+              Select a pipeline and compare up to 3 runs to see differences in
+              arguments and tasks.
+            </Text>
+          )}
+        </BlockStack>
+
+        {/* Warning if some runs weren't found */}
+        {hasNotFoundError && (
+          <div className="border border-yellow-500 bg-yellow-50 dark:bg-yellow-900/10 rounded-lg p-4">
+            <InlineStack gap="2" blockAlign="center">
+              <Icon name="TriangleAlert" className="w-5 h-5 text-yellow-600" />
+              <Text>
+                Could not find {notFoundIds.length === 1 ? "run" : "runs"}:{" "}
+                {notFoundIds.join(", ")}
+              </Text>
+            </InlineStack>
+          </div>
+        )}
+
+        {/* Show selector if not enough runs, or comparison if ready */}
+        {!showComparison || !isReady ? (
+          <RunSelector
+            onCompare={handleCompare}
+            initialPipelineName={search.pipeline}
+          />
+        ) : (
+          <ComparisonView
+            runs={sortRunsChronologically(fetchedRuns)}
+            onBack={handleBack}
+          />
+        )}
+      </BlockStack>
+    </div>
+  );
+};

--- a/src/components/Compare/Diff/ArgumentsDiff.tsx
+++ b/src/components/Compare/Diff/ArgumentsDiff.tsx
@@ -1,0 +1,74 @@
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
+import type { ValueDiff } from "@/utils/diff/types";
+
+import { ArgumentRow, ArgumentsTable } from "./ArgumentsTable";
+
+interface ArgumentsDiffProps {
+  arguments: ValueDiff[];
+  runLabels: string[];
+}
+
+export const ArgumentsDiff = ({
+  arguments: args,
+  runLabels,
+}: ArgumentsDiffProps) => {
+  const changedArgs = args.filter((a) => a.changeType !== "unchanged");
+  const unchangedArgs = args.filter((a) => a.changeType === "unchanged");
+
+  if (args.length === 0) {
+    return (
+      <div className="border border-dashed border-border rounded-md p-4">
+        <Text tone="subdued">No pipeline arguments to compare.</Text>
+      </div>
+    );
+  }
+
+  return (
+    <BlockStack gap="4">
+      <InlineStack align="space-between" blockAlign="center">
+        <Text as="h3" size="lg" weight="semibold">
+          Pipeline Arguments
+        </Text>
+        <Text size="sm" tone="subdued">
+          {changedArgs.length} changed, {unchangedArgs.length} unchanged
+        </Text>
+      </InlineStack>
+
+      {/* Changed arguments */}
+      {changedArgs.length > 0 && (
+        <ArgumentsTable runLabels={runLabels}>
+          {changedArgs.map((diff) => (
+            <ArgumentRow key={diff.key} diff={diff} />
+          ))}
+        </ArgumentsTable>
+      )}
+
+      {/* Unchanged arguments (collapsible) */}
+      {unchangedArgs.length > 0 && (
+        <Accordion type="single" collapsible>
+          <AccordionItem value="unchanged">
+            <AccordionTrigger>
+              <Text size="sm" tone="subdued">
+                {unchangedArgs.length} unchanged arguments
+              </Text>
+            </AccordionTrigger>
+            <AccordionContent>
+              <ArgumentsTable runLabels={runLabels} compact>
+                {unchangedArgs.map((diff) => (
+                  <ArgumentRow key={diff.key} diff={diff} compact />
+                ))}
+              </ArgumentsTable>
+            </AccordionContent>
+          </AccordionItem>
+        </Accordion>
+      )}
+    </BlockStack>
+  );
+};

--- a/src/components/Compare/Diff/ArgumentsTable.tsx
+++ b/src/components/Compare/Diff/ArgumentsTable.tsx
@@ -1,0 +1,154 @@
+import type { PropsWithChildren } from "react";
+
+import { Text } from "@/components/ui/typography";
+import { cn } from "@/lib/utils";
+import type { ChangeType, ValueDiff } from "@/utils/diff/types";
+
+const changeTypeStyles: Record<ChangeType, string> = {
+  added: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400",
+  removed: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400",
+  modified:
+    "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400",
+  unchanged: "",
+};
+
+const changeTypeIcons: Record<ChangeType, string> = {
+  added: "+",
+  removed: "-",
+  modified: "~",
+  unchanged: "",
+};
+
+interface ArgumentsTableProps extends PropsWithChildren {
+  runLabels: string[];
+  compact?: boolean;
+}
+
+/**
+ * Table container for arguments comparison with proper column alignment
+ */
+export const ArgumentsTable = ({
+  runLabels,
+  compact = false,
+  children,
+}: ArgumentsTableProps) => {
+  const columnCount = runLabels.length;
+
+  return (
+    <div className="w-full overflow-x-auto">
+      <div
+        className="grid gap-2 min-w-fit"
+        style={{
+          gridTemplateColumns: `auto 1.5rem repeat(${columnCount}, minmax(150px, 1fr))`,
+        }}
+      >
+        {/* Header row */}
+        {!compact && (
+          <>
+            <div className="py-2 px-1">
+              <Text size="sm" weight="semibold" tone="subdued">
+                Argument
+              </Text>
+            </div>
+            <div /> {/* Spacer for change indicator */}
+            {runLabels.map((label) => (
+              <div key={label} className="py-2 px-2">
+                <Text
+                  size="sm"
+                  weight="semibold"
+                  tone="subdued"
+                  className="truncate block"
+                  title={label}
+                >
+                  {label}
+                </Text>
+              </div>
+            ))}
+          </>
+        )}
+
+        {children}
+      </div>
+    </div>
+  );
+};
+
+interface ArgumentRowProps {
+  diff: ValueDiff;
+  compact?: boolean;
+}
+
+/**
+ * Single row in the arguments table
+ */
+export const ArgumentRow = ({ diff, compact = false }: ArgumentRowProps) => {
+  const { key, values, changeType } = diff;
+  const showChangeIndicator = changeType !== "unchanged";
+
+  return (
+    <>
+      {/* Key column */}
+      <div
+        className={cn(
+          "py-2 px-1 flex items-start",
+          compact ? "min-h-8" : "min-h-10",
+        )}
+      >
+        <Text
+          size="sm"
+          weight="semibold"
+          className="truncate"
+          title={key}
+        >
+          {key}
+        </Text>
+      </div>
+
+      {/* Change indicator column */}
+      <div className="py-2 flex items-start justify-center">
+        {showChangeIndicator && (
+          <span
+            className={cn(
+              "inline-flex items-center justify-center w-5 h-5 rounded text-xs font-mono shrink-0",
+              changeTypeStyles[changeType],
+            )}
+          >
+            {changeTypeIcons[changeType]}
+          </span>
+        )}
+      </div>
+
+      {/* Value columns */}
+      {values.map((value, index) => {
+        const isEmpty = value === undefined || value === "";
+        const isFirst = index === 0;
+        const showHighlight = changeType !== "unchanged" && !isFirst;
+
+        return (
+          <div
+            key={index}
+            className={cn(
+              "py-2 px-2 rounded border",
+              compact ? "min-h-8" : "min-h-10",
+              showHighlight && changeTypeStyles[changeType],
+              isEmpty && "bg-muted/50",
+              !showHighlight && !isEmpty && "border-border bg-muted/20",
+              isEmpty && "border-dashed",
+            )}
+          >
+            <Text
+              size="sm"
+              className={cn(
+                "break-words",
+                isEmpty && "text-muted-foreground italic",
+              )}
+            >
+              {isEmpty ? "(empty)" : value}
+            </Text>
+          </div>
+        );
+      })}
+    </>
+  );
+};
+

--- a/src/components/Compare/Diff/ComparisonView.tsx
+++ b/src/components/Compare/Diff/ComparisonView.tsx
@@ -1,0 +1,175 @@
+import { useMemo } from "react";
+
+import { LoadingScreen } from "@/components/shared/LoadingScreen";
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icon";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Separator } from "@/components/ui/separator";
+import { Text } from "@/components/ui/typography";
+import { useRunComparisonData } from "@/hooks/useRunComparisonData";
+import { useBackend } from "@/providers/BackendProvider";
+import { APP_ROUTES } from "@/routes/router";
+import type { PipelineRun } from "@/types/pipelineRun";
+import { formatDate } from "@/utils/date";
+import { compareRuns } from "@/utils/diff/compareRuns";
+
+import { ArgumentsDiff } from "./ArgumentsDiff";
+import { TasksVisualDiff } from "./TasksVisualDiff";
+
+interface ComparisonViewProps {
+  runs: PipelineRun[];
+  onBack: () => void;
+}
+
+/**
+ * Generate run labels for display (e.g., "Run #123 (Jan 1)")
+ */
+function generateRunLabels(runs: PipelineRun[]): string[] {
+  return runs.map((run) => {
+    const date = run.created_at ? formatDate(run.created_at) : "Unknown date";
+    return `Run #${run.id} (${date})`;
+  });
+}
+
+export const ComparisonView = ({ runs, onBack }: ComparisonViewProps) => {
+  const { ready } = useBackend();
+  const { comparisonData, isLoading, error, isReady } =
+    useRunComparisonData(runs);
+
+  const runLabels = useMemo(() => generateRunLabels(runs), [runs]);
+
+  const diffResult = useMemo(() => {
+    if (!isReady || comparisonData.length < 2) {
+      return null;
+    }
+    try {
+      return compareRuns(comparisonData);
+    } catch (e) {
+      console.error("Failed to compute diff:", e);
+      return null;
+    }
+  }, [comparisonData, isReady]);
+
+  if (!ready) {
+    return (
+      <BlockStack gap="4" className="p-4">
+        <Button variant="ghost" onClick={onBack}>
+          <Icon name="ArrowLeft" className="w-4 h-4 mr-2" />
+          Back to selection
+        </Button>
+        <div className="border border-yellow-500 bg-yellow-50 dark:bg-yellow-900/10 rounded-lg p-4">
+          <InlineStack gap="2" blockAlign="center">
+            <Icon name="TriangleAlert" className="w-5 h-5 text-yellow-600" />
+            <Text>
+              Backend is not configured. Full comparison requires a connected
+              backend to fetch execution details.
+            </Text>
+          </InlineStack>
+        </div>
+        <Text tone="subdued">
+          Basic metadata comparison is shown below based on locally available
+          data.
+        </Text>
+      </BlockStack>
+    );
+  }
+
+  if (isLoading) {
+    return <LoadingScreen message="Loading run details for comparison..." />;
+  }
+
+  if (error) {
+    return (
+      <BlockStack gap="4" className="p-4">
+        <Button variant="ghost" onClick={onBack}>
+          <Icon name="ArrowLeft" className="w-4 h-4 mr-2" />
+          Back to selection
+        </Button>
+        <div className="border border-red-500 bg-red-50 dark:bg-red-900/10 rounded-lg p-4">
+          <InlineStack gap="2" blockAlign="center">
+            <Icon name="CircleAlert" className="w-5 h-5 text-red-600" />
+            <Text>Failed to load run details: {String(error)}</Text>
+          </InlineStack>
+        </div>
+      </BlockStack>
+    );
+  }
+
+  if (!diffResult) {
+    return (
+      <BlockStack gap="4" className="p-4">
+        <Button variant="ghost" onClick={onBack}>
+          <Icon name="ArrowLeft" className="w-4 h-4 mr-2" />
+          Back to selection
+        </Button>
+        <div className="border border-dashed border-border rounded-lg p-4">
+          <Text tone="subdued">Unable to compute comparison.</Text>
+        </div>
+      </BlockStack>
+    );
+  }
+
+  return (
+    <BlockStack gap="6" className="w-full">
+      {/* Header */}
+      <InlineStack align="space-between" blockAlign="center">
+        <Button variant="ghost" onClick={onBack}>
+          <Icon name="ArrowLeft" className="w-4 h-4 mr-2" />
+          Back to selection
+        </Button>
+        <Text size="sm" tone="subdued">
+          Comparing {runs.length} runs
+        </Text>
+      </InlineStack>
+
+      {/* Run info cards */}
+      <div
+        className="grid gap-4"
+        style={{
+          gridTemplateColumns: `repeat(${runs.length}, minmax(200px, 1fr))`,
+        }}
+      >
+        {runs.map((run, index) => (
+          <div
+            key={run.id}
+            className="border rounded-lg p-3 bg-muted/30 h-full"
+          >
+            <BlockStack gap="1">
+              <a
+                href={`${APP_ROUTES.RUNS}/${run.id}`}
+                className="text-sm font-semibold hover:underline text-primary"
+              >
+                {runLabels[index]}
+              </a>
+              <Text
+                size="xs"
+                tone="subdued"
+                className="truncate"
+                title={run.pipeline_name}
+              >
+                {run.pipeline_name}
+              </Text>
+              <Text size="xs" tone="subdued">
+                Status: {run.status || "Unknown"}
+              </Text>
+            </BlockStack>
+          </div>
+        ))}
+      </div>
+
+      <Separator />
+
+      {/* Arguments Diff */}
+      <ArgumentsDiff arguments={diffResult.arguments} runLabels={runLabels} />
+
+      <Separator />
+
+      {/* Tasks Visual Diff */}
+      <TasksVisualDiff
+        comparisonData={comparisonData}
+        tasksDiff={diffResult.tasks}
+        runLabels={runLabels}
+      />
+    </BlockStack>
+  );
+};

--- a/src/components/Compare/Diff/DiffSummary.tsx
+++ b/src/components/Compare/Diff/DiffSummary.tsx
@@ -1,0 +1,112 @@
+import { Icon } from "@/components/ui/icon";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
+import { cn } from "@/lib/utils";
+import type { RunDiffResult } from "@/utils/diff/types";
+import { pluralize } from "@/utils/string";
+
+interface DiffSummaryProps {
+  diff: RunDiffResult;
+}
+
+interface SummaryCardProps {
+  title: string;
+  count: number;
+  icon: string;
+  variant: "default" | "success" | "warning" | "error";
+}
+
+const SummaryCard = ({ title, count, icon, variant }: SummaryCardProps) => {
+  const variantStyles = {
+    default: "border-border bg-card",
+    success: "border-green-500 bg-green-50 dark:bg-green-900/10",
+    warning: "border-yellow-500 bg-yellow-50 dark:bg-yellow-900/10",
+    error: "border-red-500 bg-red-50 dark:bg-red-900/10",
+  };
+
+  return (
+    <div
+      className={cn(
+        "border rounded-lg p-4 h-full",
+        variantStyles[variant],
+      )}
+    >
+      <BlockStack gap="2" className="h-full">
+        <InlineStack gap="2" blockAlign="center">
+          <Icon name={icon as any} className="w-4 h-4 shrink-0" />
+          <Text size="sm" tone="subdued" className="truncate">
+            {title}
+          </Text>
+        </InlineStack>
+        <Text size="2xl" weight="bold">
+          {count}
+        </Text>
+      </BlockStack>
+    </div>
+  );
+};
+
+export const DiffSummary = ({ diff }: DiffSummaryProps) => {
+  const { tasks, summary } = diff;
+
+  const taskChanges = tasks.added.length + tasks.removed.length + tasks.modified.length;
+
+  if (!summary.hasChanges) {
+    return (
+      <div className="border border-green-500 bg-green-50 dark:bg-green-900/10 rounded-lg p-4">
+        <InlineStack gap="2" blockAlign="center">
+          <Icon name="Check" className="w-5 h-5 text-green-600" />
+          <Text weight="semibold">No differences found between runs</Text>
+        </InlineStack>
+      </div>
+    );
+  }
+
+  return (
+    <BlockStack gap="4">
+      <Text as="h3" size="lg" weight="semibold">
+        Summary
+      </Text>
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <SummaryCard
+          title="Argument Changes"
+          count={summary.totalArgumentChanges}
+          icon="Settings"
+          variant={summary.totalArgumentChanges > 0 ? "warning" : "default"}
+        />
+
+        <SummaryCard
+          title="Task Changes"
+          count={taskChanges}
+          icon="Workflow"
+          variant={taskChanges > 0 ? "warning" : "default"}
+        />
+
+        <SummaryCard
+          title="Tasks Added"
+          count={tasks.added.length}
+          icon="Plus"
+          variant={tasks.added.length > 0 ? "success" : "default"}
+        />
+
+        <SummaryCard
+          title="Tasks Removed"
+          count={tasks.removed.length}
+          icon="Minus"
+          variant={tasks.removed.length > 0 ? "error" : "default"}
+        />
+      </div>
+
+      {summary.hasChanges && (
+        <Text size="sm" tone="subdued">
+          Found {summary.totalArgumentChanges}{" "}
+          {pluralize(summary.totalArgumentChanges, "argument change")} and{" "}
+          {taskChanges} {pluralize(taskChanges, "task change")} across{" "}
+          {diff.runIds.length} runs.
+        </Text>
+      )}
+    </BlockStack>
+  );
+};
+

--- a/src/components/Compare/Diff/TasksDiff.tsx
+++ b/src/components/Compare/Diff/TasksDiff.tsx
@@ -1,0 +1,188 @@
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+import { Icon } from "@/components/ui/icon";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
+import { cn } from "@/lib/utils";
+import type { RunDiffResult, TaskDiff as TaskDiffType } from "@/utils/diff/types";
+
+import { ValueDiffInline } from "./ValueDiffDisplay";
+
+interface TasksDiffProps {
+  tasks: RunDiffResult["tasks"];
+}
+
+const TaskBadge = ({
+  taskId,
+  type,
+}: {
+  taskId: string;
+  type: "added" | "removed" | "modified" | "unchanged";
+}) => {
+  const styles = {
+    added: "bg-green-100 text-green-800 border-green-300 dark:bg-green-900/30 dark:text-green-400 dark:border-green-700",
+    removed: "bg-red-100 text-red-800 border-red-300 dark:bg-red-900/30 dark:text-red-400 dark:border-red-700",
+    modified: "bg-yellow-100 text-yellow-800 border-yellow-300 dark:bg-yellow-900/30 dark:text-yellow-400 dark:border-yellow-700",
+    unchanged: "bg-muted text-muted-foreground border-border",
+  };
+
+  const icons = {
+    added: "Plus",
+    removed: "Minus",
+    modified: "Pencil",
+    unchanged: "Check",
+  };
+
+  return (
+    <InlineStack
+      gap="2"
+      blockAlign="center"
+      className={cn("px-2 py-1 rounded border text-sm", styles[type])}
+    >
+      <Icon name={icons[type] as any} className="w-3 h-3" />
+      <span className="font-mono">{taskId}</span>
+    </InlineStack>
+  );
+};
+
+const TaskDetailDiff = ({
+  task,
+}: {
+  task: TaskDiffType;
+}) => {
+  const hasDetails =
+    task.digestDiff || task.componentNameDiff || task.argumentsDiff.length > 0;
+
+  if (!hasDetails) {
+    return null;
+  }
+
+  return (
+    <BlockStack gap="2" className="pl-4 border-l-2 border-yellow-400">
+      {task.componentNameDiff && (
+        <ValueDiffInline diff={task.componentNameDiff} />
+      )}
+      {task.digestDiff && <ValueDiffInline diff={task.digestDiff} />}
+      {task.argumentsDiff.length > 0 && (
+        <BlockStack gap="1">
+          <Text size="sm" weight="semibold">
+            Changed Arguments:
+          </Text>
+          {task.argumentsDiff.map((argDiff) => (
+            <ValueDiffInline key={argDiff.key} diff={argDiff} />
+          ))}
+        </BlockStack>
+      )}
+    </BlockStack>
+  );
+};
+
+export const TasksDiff = ({ tasks }: TasksDiffProps) => {
+  const { added, removed, modified, unchanged } = tasks;
+  const hasChanges = added.length > 0 || removed.length > 0 || modified.length > 0;
+
+  if (!hasChanges && unchanged.length === 0) {
+    return (
+      <div className="border border-dashed border-border rounded-md p-4">
+        <Text tone="subdued">No tasks to compare.</Text>
+      </div>
+    );
+  }
+
+  return (
+    <BlockStack gap="4">
+      <InlineStack align="space-between" blockAlign="center">
+        <Text as="h3" size="lg" weight="semibold">
+          Tasks
+        </Text>
+        <Text size="sm" tone="subdued">
+          {added.length + removed.length + modified.length} changed,{" "}
+          {unchanged.length} unchanged
+        </Text>
+      </InlineStack>
+
+      {/* Added tasks */}
+      {added.length > 0 && (
+        <BlockStack gap="2">
+          <InlineStack gap="2" blockAlign="center">
+            <Icon name="Plus" className="w-4 h-4 text-green-600" />
+            <Text size="sm" weight="semibold">
+              Added Tasks ({added.length})
+            </Text>
+          </InlineStack>
+          <InlineStack gap="2" wrap="wrap">
+            {added.map((taskId) => (
+              <TaskBadge key={taskId} taskId={taskId} type="added" />
+            ))}
+          </InlineStack>
+        </BlockStack>
+      )}
+
+      {/* Removed tasks */}
+      {removed.length > 0 && (
+        <BlockStack gap="2">
+          <InlineStack gap="2" blockAlign="center">
+            <Icon name="Minus" className="w-4 h-4 text-red-600" />
+            <Text size="sm" weight="semibold">
+              Removed Tasks ({removed.length})
+            </Text>
+          </InlineStack>
+          <InlineStack gap="2" wrap="wrap">
+            {removed.map((taskId) => (
+              <TaskBadge key={taskId} taskId={taskId} type="removed" />
+            ))}
+          </InlineStack>
+        </BlockStack>
+      )}
+
+      {/* Modified tasks */}
+      {modified.length > 0 && (
+        <BlockStack gap="2">
+          <InlineStack gap="2" blockAlign="center">
+            <Icon name="Pencil" className="w-4 h-4 text-yellow-600" />
+            <Text size="sm" weight="semibold">
+              Modified Tasks ({modified.length})
+            </Text>
+          </InlineStack>
+          <Accordion type="multiple" className="w-full">
+            {modified.map((task) => (
+              <AccordionItem key={task.taskId} value={task.taskId}>
+                <AccordionTrigger>
+                  <TaskBadge taskId={task.taskId} type="modified" />
+                </AccordionTrigger>
+                <AccordionContent>
+                  <TaskDetailDiff task={task} />
+                </AccordionContent>
+              </AccordionItem>
+            ))}
+          </Accordion>
+        </BlockStack>
+      )}
+
+      {/* Unchanged tasks (collapsible) */}
+      {unchanged.length > 0 && (
+        <Accordion type="single" collapsible>
+          <AccordionItem value="unchanged">
+            <AccordionTrigger>
+              <Text size="sm" tone="subdued">
+                {unchanged.length} unchanged tasks
+              </Text>
+            </AccordionTrigger>
+            <AccordionContent>
+              <InlineStack gap="2" wrap="wrap">
+                {unchanged.map((taskId) => (
+                  <TaskBadge key={taskId} taskId={taskId} type="unchanged" />
+                ))}
+              </InlineStack>
+            </AccordionContent>
+          </AccordionItem>
+        </Accordion>
+      )}
+    </BlockStack>
+  );
+};
+

--- a/src/components/Compare/Diff/TasksVisualDiff.tsx
+++ b/src/components/Compare/Diff/TasksVisualDiff.tsx
@@ -1,0 +1,596 @@
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icon";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
+import { cn } from "@/lib/utils";
+import type { ComponentSpec, TaskSpec } from "@/utils/componentSpec";
+import type {
+  ChangeType,
+  RunComparisonData,
+  TaskDiff,
+} from "@/utils/diff/types";
+
+/**
+ * Extracted task data for visual display
+ */
+interface VisualTask {
+  taskId: string;
+  /** Full path for nested tasks (e.g., "parent/child/grandchild") */
+  fullPath: string;
+  changeType: ChangeType;
+  componentName?: string;
+  componentDigest?: string;
+  /** Arguments per run: [run1Args, run2Args, ...] */
+  argumentsByRun: (Record<string, string | undefined> | undefined)[];
+  /** Diff details if modified */
+  diff?: TaskDiff;
+  /** Nested tasks if this task has a graph implementation */
+  children: VisualTask[];
+  /** Nesting depth for indentation */
+  depth: number;
+  /** Whether this task is a subgraph */
+  isSubgraph: boolean;
+}
+
+interface TasksVisualDiffProps {
+  comparisonData: RunComparisonData[];
+  tasksDiff: {
+    added: string[];
+    removed: string[];
+    modified: TaskDiff[];
+    unchanged: string[];
+  };
+  runLabels: string[];
+}
+
+const changeColors: Record<ChangeType, string> = {
+  added: "border-l-green-500",
+  removed: "border-l-red-500",
+  modified: "border-l-yellow-500",
+  unchanged: "border-l-transparent",
+};
+
+const changeDotColors: Record<ChangeType, string> = {
+  added: "bg-green-500",
+  removed: "bg-red-500",
+  modified: "bg-yellow-500",
+  unchanged: "bg-muted-foreground/30",
+};
+
+/**
+ * Check if a component spec has a graph implementation
+ */
+function hasGraphImplementation(spec?: ComponentSpec): boolean {
+  return !!(spec?.implementation && "graph" in spec.implementation);
+}
+
+/**
+ * Get nested component spec from a task's componentRef
+ */
+function getNestedSpec(taskSpec?: TaskSpec): ComponentSpec | undefined {
+  return taskSpec?.componentRef?.spec as ComponentSpec | undefined;
+}
+
+/**
+ * Extract tasks from a graph implementation, handling nested subgraphs recursively
+ */
+function extractTasksFromGraph(
+  taskSpecs: (TaskSpec | undefined)[],
+  taskId: string,
+  parentPath: string,
+  depth: number,
+  changeTypeMap: Map<string, ChangeType>,
+  modifiedMap: Map<string, TaskDiff>,
+): VisualTask {
+  const fullPath = parentPath ? `${parentPath}/${taskId}` : taskId;
+  const changeType =
+    changeTypeMap.get(fullPath) ?? changeTypeMap.get(taskId) ?? "unchanged";
+  const diff = modifiedMap.get(fullPath) ?? modifiedMap.get(taskId);
+
+  // Extract arguments from each run
+  const argumentsByRun = taskSpecs.map((taskSpec) => {
+    if (!taskSpec?.arguments) return undefined;
+    const args: Record<string, string | undefined> = {};
+    for (const [key, value] of Object.entries(taskSpec.arguments)) {
+      args[key] = stringifyArgValue(value);
+    }
+    return args;
+  });
+
+  // Get component info from first available task spec
+  const firstTaskSpec = taskSpecs.find((ts) => ts !== undefined);
+  const componentName =
+    diff?.componentNameDiff?.values[0] ?? firstTaskSpec?.componentRef?.name;
+  const componentDigest =
+    diff?.digestDiff?.values[0] ?? firstTaskSpec?.componentRef?.digest;
+
+  // Check if any run has a nested graph implementation
+  const nestedSpecs = taskSpecs.map((ts) => getNestedSpec(ts));
+  const hasNestedGraph = nestedSpecs.some((spec) =>
+    hasGraphImplementation(spec),
+  );
+
+  // Extract children recursively if this is a subgraph
+  const children: VisualTask[] = [];
+  if (hasNestedGraph) {
+    // Collect all nested task IDs across runs
+    const nestedTaskIds: string[] = [];
+    const seenNestedIds = new Set<string>();
+
+    for (const spec of nestedSpecs) {
+      if (hasGraphImplementation(spec)) {
+        const nestedTasks = (
+          spec!.implementation as { graph: { tasks: Record<string, TaskSpec> } }
+        ).graph.tasks;
+        for (const nestedTaskId of Object.keys(nestedTasks)) {
+          if (!seenNestedIds.has(nestedTaskId)) {
+            seenNestedIds.add(nestedTaskId);
+            nestedTaskIds.push(nestedTaskId);
+          }
+        }
+      }
+    }
+
+    // Recursively extract each nested task
+    for (const nestedTaskId of nestedTaskIds) {
+      const nestedTaskSpecs = nestedSpecs.map((spec) => {
+        if (!hasGraphImplementation(spec)) return undefined;
+        return (
+          spec!.implementation as { graph: { tasks: Record<string, TaskSpec> } }
+        ).graph.tasks[nestedTaskId];
+      });
+
+      children.push(
+        extractTasksFromGraph(
+          nestedTaskSpecs,
+          nestedTaskId,
+          fullPath,
+          depth + 1,
+          changeTypeMap,
+          modifiedMap,
+        ),
+      );
+    }
+  }
+
+  return {
+    taskId,
+    fullPath,
+    changeType,
+    componentName,
+    componentDigest,
+    argumentsByRun,
+    diff,
+    children,
+    depth,
+    isSubgraph: hasNestedGraph,
+  };
+}
+
+/**
+ * Extract all tasks from comparison data for visual display,
+ * preserving the order as they appear in the YAML (first run's order as base,
+ * with new tasks from other runs appended at the end).
+ * Handles nested graph implementations recursively.
+ */
+function extractVisualTasks(
+  comparisonData: RunComparisonData[],
+  tasksDiff: TasksVisualDiffProps["tasksDiff"],
+): VisualTask[] {
+  // Build a map of change types for quick lookup
+  const changeTypeMap = new Map<string, ChangeType>();
+  const modifiedMap = new Map<string, TaskDiff>();
+
+  for (const taskId of tasksDiff.added) {
+    changeTypeMap.set(taskId, "added");
+  }
+  for (const taskId of tasksDiff.removed) {
+    changeTypeMap.set(taskId, "removed");
+  }
+  for (const diff of tasksDiff.modified) {
+    changeTypeMap.set(diff.taskId, "modified");
+    modifiedMap.set(diff.taskId, diff);
+  }
+  for (const taskId of tasksDiff.unchanged) {
+    changeTypeMap.set(taskId, "unchanged");
+  }
+
+  // Collect task IDs in YAML order from all runs, preserving first occurrence order
+  const orderedTaskIds: string[] = [];
+  const seenTaskIds = new Set<string>();
+
+  for (const run of comparisonData) {
+    const impl = run.componentSpec?.implementation;
+    if (impl && "graph" in impl && impl.graph.tasks) {
+      for (const taskId of Object.keys(impl.graph.tasks)) {
+        if (!seenTaskIds.has(taskId)) {
+          seenTaskIds.add(taskId);
+          orderedTaskIds.push(taskId);
+        }
+      }
+    }
+  }
+
+  // Build visual tasks in the preserved order with recursive subgraph extraction
+  const tasks: VisualTask[] = [];
+
+  for (const taskId of orderedTaskIds) {
+    // Get task specs from all runs
+    const taskSpecs = comparisonData.map((run) => {
+      const impl = run.componentSpec?.implementation;
+      if (impl && "graph" in impl) {
+        return impl.graph.tasks?.[taskId] as TaskSpec | undefined;
+      }
+      return undefined;
+    });
+
+    tasks.push(
+      extractTasksFromGraph(
+        taskSpecs,
+        taskId,
+        "",
+        0,
+        changeTypeMap,
+        modifiedMap,
+      ),
+    );
+  }
+
+  return tasks;
+}
+
+/**
+ * Convert argument value to display string
+ */
+function stringifyArgValue(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "string") return value;
+  if (typeof value === "object") {
+    // Handle taskOutput references
+    if ("taskOutput" in value) {
+      const ref = value as {
+        taskOutput: { taskId: string; outputName: string };
+      };
+      return `{{${ref.taskOutput.taskId}.${ref.taskOutput.outputName}}}`;
+    }
+    // Handle graphInput references
+    if ("graphInput" in value) {
+      const ref = value as { graphInput: { inputName: string } };
+      return `{{inputs.${ref.graphInput.inputName}}}`;
+    }
+    return JSON.stringify(value);
+  }
+  return String(value);
+}
+
+/**
+ * Single task node card - compact design with support for nested subgraphs
+ */
+const TaskNodeCard = ({
+  task,
+  runLabels,
+  expandedTasks,
+  onToggle,
+}: {
+  task: VisualTask;
+  runLabels: string[];
+  expandedTasks: Set<string>;
+  onToggle: (fullPath: string) => void;
+}) => {
+  // Collect all unique argument keys across runs
+  const allArgKeys = new Set<string>();
+  task.argumentsByRun.forEach((args) => {
+    if (args) Object.keys(args).forEach((k) => allArgKeys.add(k));
+  });
+
+  const hasArgs = allArgKeys.size > 0;
+  const changedCount = task.diff?.argumentsDiff?.length ?? 0;
+  const isExpanded = expandedTasks.has(task.fullPath);
+  const hasChildren = task.children.length > 0;
+
+  return (
+    <div
+      className="w-full"
+      style={{
+        paddingLeft: task.depth > 0 ? `${task.depth * 16}px` : undefined,
+      }}
+    >
+      <div
+        className={cn(
+          "border border-border rounded bg-card border-l-2 w-full transition-colors hover:bg-muted/50",
+          changeColors[task.changeType],
+        )}
+      >
+        {/* Header - compact */}
+        <button
+          onClick={() => onToggle(task.fullPath)}
+          className="w-full px-2 py-1.5 flex items-center gap-2 hover:bg-muted/30 transition-colors text-left"
+        >
+          {/* Status dot */}
+          <span
+            className={cn(
+              "w-2 h-2 rounded-full shrink-0",
+              changeDotColors[task.changeType],
+            )}
+          />
+
+          {/* Subgraph indicator */}
+          {task.isSubgraph && (
+            <Icon
+              name="GitBranch"
+              className="w-3 h-3 text-muted-foreground shrink-0"
+            />
+          )}
+
+          {/* Task ID */}
+          <span className="font-mono text-xs font-medium truncate">
+            {task.taskId}
+          </span>
+
+          {/* Component name - subdued */}
+          {task.componentName && (
+            <span className="text-xs text-muted-foreground truncate hidden sm:block">
+              · {task.componentName}
+            </span>
+          )}
+
+          {/* Spacer */}
+          <span className="flex-1" />
+
+          {/* Children count for subgraphs */}
+          {hasChildren && (
+            <span className="text-[10px] px-1.5 py-0.5 rounded bg-muted text-muted-foreground">
+              {task.children.length} tasks
+            </span>
+          )}
+
+          {/* Changed count badge */}
+          {changedCount > 0 && (
+            <span className="text-[10px] px-1.5 py-0.5 rounded bg-yellow-100 text-yellow-700 dark:bg-yellow-900/50 dark:text-yellow-300">
+              {changedCount}Δ
+            </span>
+          )}
+
+          {/* Expand icon */}
+          <Icon
+            name={isExpanded ? "ChevronUp" : "ChevronDown"}
+            className="w-3 h-3 text-muted-foreground shrink-0"
+          />
+        </button>
+
+        {/* Expanded content - arguments */}
+        {isExpanded && hasArgs && (
+          <div className="border-t border-border/50 bg-muted/20">
+            <table className="w-full text-xs">
+              <thead>
+                <tr className="border-b border-border/50">
+                  <th className="text-left py-1 px-2 font-medium text-muted-foreground w-1/4">
+                    arg
+                  </th>
+                  {runLabels.map((label, i) => (
+                    <th
+                      key={i}
+                      className="text-left py-1 px-2 font-medium text-muted-foreground"
+                    >
+                      {label.replace(/^Run #/, "#")}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {Array.from(allArgKeys)
+                  .sort()
+                  .map((argKey) => {
+                    const values = task.argumentsByRun.map(
+                      (args) => args?.[argKey],
+                    );
+                    const isChanged =
+                      task.diff?.argumentsDiff?.some((d) => d.key === argKey) ??
+                      false;
+
+                    return (
+                      <tr
+                        key={argKey}
+                        className={cn(
+                          "border-b border-border/30 last:border-b-0",
+                          isChanged && "bg-yellow-50/50 dark:bg-yellow-900/10",
+                        )}
+                      >
+                        <td className="py-1 px-2 font-mono text-muted-foreground">
+                          {argKey}
+                        </td>
+                        {values.map((val, i) => (
+                          <td
+                            key={i}
+                            className={cn(
+                              "py-1 px-2 font-mono break-all max-w-[200px] truncate",
+                              isChanged &&
+                                i > 0 &&
+                                val !== values[0] &&
+                                "text-yellow-700 dark:text-yellow-400",
+                            )}
+                            title={val || undefined}
+                          >
+                            {val || (
+                              <span className="text-muted-foreground">—</span>
+                            )}
+                          </td>
+                        ))}
+                      </tr>
+                    );
+                  })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      {/* Nested children (subgraph tasks) */}
+      {isExpanded && hasChildren && (
+        <BlockStack gap="1" className="mt-1">
+          {task.children.map((child) => (
+            <TaskNodeCard
+              key={child.fullPath}
+              task={child}
+              runLabels={runLabels}
+              expandedTasks={expandedTasks}
+              onToggle={onToggle}
+            />
+          ))}
+        </BlockStack>
+      )}
+    </div>
+  );
+};
+
+/**
+ * Collect all task paths recursively from visual tasks
+ */
+function collectAllPaths(tasks: VisualTask[]): string[] {
+  const paths: string[] = [];
+  for (const task of tasks) {
+    paths.push(task.fullPath);
+    if (task.children.length > 0) {
+      paths.push(...collectAllPaths(task.children));
+    }
+  }
+  return paths;
+}
+
+/**
+ * Collect paths of changed tasks (including nested)
+ */
+function collectChangedPaths(tasks: VisualTask[]): string[] {
+  const paths: string[] = [];
+  for (const task of tasks) {
+    if (task.changeType !== "unchanged") {
+      paths.push(task.fullPath);
+    }
+    if (task.children.length > 0) {
+      paths.push(...collectChangedPaths(task.children));
+    }
+  }
+  return paths;
+}
+
+/**
+ * Count total tasks including nested
+ */
+function countAllTasks(tasks: VisualTask[]): number {
+  let count = tasks.length;
+  for (const task of tasks) {
+    count += countAllTasks(task.children);
+  }
+  return count;
+}
+
+/**
+ * Visual DAG comparison showing tasks as node cards
+ */
+export const TasksVisualDiff = ({
+  comparisonData,
+  tasksDiff,
+  runLabels,
+}: TasksVisualDiffProps) => {
+  const visualTasks = extractVisualTasks(comparisonData, tasksDiff);
+
+  const [expandedTasks, setExpandedTasks] = useState<Set<string>>(() => {
+    // Auto-expand all changed tasks (including nested)
+    return new Set(collectChangedPaths(visualTasks));
+  });
+
+  const toggleTask = (fullPath: string) => {
+    setExpandedTasks((prev) => {
+      const next = new Set(prev);
+      if (next.has(fullPath)) {
+        next.delete(fullPath);
+      } else {
+        next.add(fullPath);
+      }
+      return next;
+    });
+  };
+
+  const expandAll = () => {
+    setExpandedTasks(new Set(collectAllPaths(visualTasks)));
+  };
+
+  const collapseAll = () => {
+    setExpandedTasks(new Set());
+  };
+
+  const totalTasks = countAllTasks(visualTasks);
+
+  if (visualTasks.length === 0) {
+    return (
+      <div className="border border-dashed border-border rounded-md p-4">
+        <Text tone="subdued">No tasks to compare.</Text>
+      </div>
+    );
+  }
+
+  return (
+    <BlockStack gap="3">
+      {/* Header - compact */}
+      <InlineStack align="space-between" blockAlign="center">
+        <InlineStack gap="3" blockAlign="center">
+          <Text as="h3" size="sm" weight="semibold">
+            Tasks ({totalTasks})
+          </Text>
+          {/* Inline legend */}
+          <InlineStack gap="2" className="text-[10px] text-muted-foreground">
+            <span className="flex items-center gap-1">
+              <span className="w-1.5 h-1.5 rounded-full bg-green-500" />
+              {tasksDiff.added.length}
+            </span>
+            <span className="flex items-center gap-1">
+              <span className="w-1.5 h-1.5 rounded-full bg-red-500" />
+              {tasksDiff.removed.length}
+            </span>
+            <span className="flex items-center gap-1">
+              <span className="w-1.5 h-1.5 rounded-full bg-yellow-500" />
+              {tasksDiff.modified.length}
+            </span>
+            <span className="flex items-center gap-1">
+              <span className="w-1.5 h-1.5 rounded-full bg-muted-foreground/30" />
+              {tasksDiff.unchanged.length}
+            </span>
+          </InlineStack>
+        </InlineStack>
+        <InlineStack gap="1">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-6 px-2 text-xs"
+            onClick={expandAll}
+          >
+            Expand
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-6 px-2 text-xs"
+            onClick={collapseAll}
+          >
+            Collapse
+          </Button>
+        </InlineStack>
+      </InlineStack>
+
+      {/* All tasks - tight spacing */}
+      <BlockStack gap="1">
+        {visualTasks.map((task) => (
+          <TaskNodeCard
+            key={task.fullPath}
+            task={task}
+            runLabels={runLabels}
+            expandedTasks={expandedTasks}
+            onToggle={toggleTask}
+          />
+        ))}
+      </BlockStack>
+    </BlockStack>
+  );
+};

--- a/src/components/Compare/Diff/ValueDiffDisplay.tsx
+++ b/src/components/Compare/Diff/ValueDiffDisplay.tsx
@@ -1,0 +1,75 @@
+import { InlineStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
+import { cn } from "@/lib/utils";
+import type { ChangeType, ValueDiff } from "@/utils/diff/types";
+
+const changeTypeStyles: Record<ChangeType, string> = {
+  added: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400",
+  removed: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400",
+  modified:
+    "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400",
+  unchanged: "",
+};
+
+const changeTypeIcons: Record<ChangeType, string> = {
+  added: "+",
+  removed: "-",
+  modified: "~",
+  unchanged: "",
+};
+
+/**
+ * Compact inline display for value diffs (used in task details)
+ */
+export const ValueDiffInline = ({ diff }: { diff: ValueDiff }) => {
+  const { key, values, changeType } = diff;
+  const showIndicator = changeType !== "unchanged";
+
+  return (
+    <div className="grid grid-cols-[auto_1.5rem_1fr] gap-2 items-center py-1">
+      {/* Key */}
+      <Text size="sm" weight="semibold" className="truncate" title={key}>
+        {key}
+      </Text>
+
+      {/* Change indicator */}
+      <div className="flex justify-center">
+        {showIndicator && (
+          <span
+            className={cn(
+              "inline-flex items-center justify-center w-5 h-5 rounded text-xs font-mono",
+              changeTypeStyles[changeType],
+            )}
+          >
+            {changeTypeIcons[changeType]}
+          </span>
+        )}
+      </div>
+
+      {/* Values */}
+      <InlineStack gap="2" wrap="wrap">
+        {values.map((value, index) => {
+          const isEmpty = value === undefined || value === "";
+          const isFirst = index === 0;
+          const showHighlight = changeType !== "unchanged" && !isFirst;
+
+          return (
+            <Text
+              key={index}
+              size="sm"
+              className={cn(
+                "px-2 py-0.5 rounded border max-w-48 truncate",
+                showHighlight && changeTypeStyles[changeType],
+                !showHighlight && "bg-muted/30 border-border",
+                isEmpty && "text-muted-foreground italic border-dashed",
+              )}
+              title={value || "(empty)"}
+            >
+              {isEmpty ? "(empty)" : value}
+            </Text>
+          );
+        })}
+      </InlineStack>
+    </div>
+  );
+};

--- a/src/components/Compare/Diff/index.ts
+++ b/src/components/Compare/Diff/index.ts
@@ -1,0 +1,2 @@
+export { ComparisonView } from "./ComparisonView";
+

--- a/src/components/Compare/RunSelector/RunSelectionList.tsx
+++ b/src/components/Compare/RunSelector/RunSelectionList.tsx
@@ -1,0 +1,108 @@
+import { usePipelineRuns } from "@/components/shared/PipelineRunDisplay/usePipelineRuns";
+import { Checkbox } from "@/components/ui/checkbox";
+import { InlineStack } from "@/components/ui/layout";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Text } from "@/components/ui/typography";
+import { cn } from "@/lib/utils";
+import type { PipelineRun } from "@/types/pipelineRun";
+import { formatDate } from "@/utils/date";
+
+import { PipelineRunStatus } from "../../shared/PipelineRunDisplay/components/PipelineRunStatus";
+
+interface RunSelectionListProps {
+  pipelineName: string;
+  selectedRuns: PipelineRun[];
+  onRunSelect: (run: PipelineRun, selected: boolean) => void;
+  maxSelections: number;
+}
+
+export const RunSelectionList = ({
+  pipelineName,
+  selectedRuns,
+  onRunSelect,
+  maxSelections,
+}: RunSelectionListProps) => {
+  const { data: runs } = usePipelineRuns(pipelineName);
+
+  if (!runs || runs.length === 0) {
+    return (
+      <InlineStack
+        className="border border-dashed border-border rounded-md p-8"
+        align="center"
+      >
+        <Text tone="subdued">No runs found for this pipeline.</Text>
+      </InlineStack>
+    );
+  }
+
+  const isRunSelected = (run: PipelineRun) =>
+    selectedRuns.some((r) => r.id === run.id);
+
+  const isMaxSelected = selectedRuns.length >= maxSelections;
+
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead className="w-12"></TableHead>
+          <TableHead>Run ID</TableHead>
+          <TableHead>Status</TableHead>
+          <TableHead>Created At</TableHead>
+          <TableHead>Created By</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {runs.map((run) => {
+          const selected = isRunSelected(run);
+          const disabled = !selected && isMaxSelected;
+
+          return (
+            <TableRow
+              key={run.id}
+              className={cn(
+                "cursor-pointer",
+                selected && "bg-accent/50",
+                disabled && "opacity-50",
+              )}
+              onClick={() => !disabled && onRunSelect(run, !selected)}
+            >
+              <TableCell onClick={(e) => e.stopPropagation()}>
+                <Checkbox
+                  checked={selected}
+                  disabled={disabled}
+                  onCheckedChange={(checked) =>
+                    onRunSelect(run, checked === true)
+                  }
+                />
+              </TableCell>
+              <TableCell>
+                <Text weight="semibold">#{run.id}</Text>
+              </TableCell>
+              <TableCell>
+                <PipelineRunStatus run={run} />
+              </TableCell>
+              <TableCell>
+                <Text size="sm" tone="subdued">
+                  {run.created_at ? formatDate(run.created_at) : "N/A"}
+                </Text>
+              </TableCell>
+              <TableCell>
+                <Text size="sm" tone="subdued" className="max-w-32 truncate">
+                  {run.created_by || "Unknown"}
+                </Text>
+              </TableCell>
+            </TableRow>
+          );
+        })}
+      </TableBody>
+    </Table>
+  );
+};
+

--- a/src/components/Compare/RunSelector/RunSelector.tsx
+++ b/src/components/Compare/RunSelector/RunSelector.tsx
@@ -1,0 +1,165 @@
+import { Suspense, useEffect, useState } from "react";
+
+import { withSuspenseWrapper } from "@/components/shared/SuspenseWrapper";
+import { Label } from "@/components/ui/label";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Text } from "@/components/ui/typography";
+import type { PipelineRun } from "@/types/pipelineRun";
+import {
+  type ComponentFileEntry,
+  getAllComponentFilesFromList,
+} from "@/utils/componentStore";
+import { USER_PIPELINES_LIST_NAME } from "@/utils/constants";
+
+import { RunSelectionList } from "./RunSelectionList";
+import { SelectionBar } from "./SelectionBar";
+
+const MAX_SELECTIONS = 3;
+
+interface RunSelectorProps {
+  onCompare: (runs: PipelineRun[]) => void;
+  /** Pre-select a pipeline from URL */
+  initialPipelineName?: string;
+}
+
+type Pipelines = Map<string, ComponentFileEntry>;
+
+const PipelineSelectorSkeleton = () => (
+  <BlockStack gap="2">
+    <Skeleton size="lg" shape="button" />
+    <Skeleton size="full" />
+  </BlockStack>
+);
+
+export const RunSelector = withSuspenseWrapper(
+  ({ onCompare, initialPipelineName }: RunSelectorProps) => {
+    const [pipelines, setPipelines] = useState<Pipelines>(new Map());
+    const [selectedPipeline, setSelectedPipeline] = useState<string>(
+      initialPipelineName ?? "",
+    );
+    const [selectedRuns, setSelectedRuns] = useState<PipelineRun[]>([]);
+    const [isLoading, setIsLoading] = useState(false);
+
+    useEffect(() => {
+      const fetchPipelines = async () => {
+        setIsLoading(true);
+        try {
+          const result = await getAllComponentFilesFromList(
+            USER_PIPELINES_LIST_NAME,
+          );
+          const sortedPipelines = new Map(
+            [...result.entries()].sort((a, b) => {
+              return (
+                new Date(b[1].modificationTime).getTime() -
+                new Date(a[1].modificationTime).getTime()
+              );
+            }),
+          );
+          setPipelines(sortedPipelines);
+
+          // If initialPipelineName was provided but not valid, clear selection
+          if (initialPipelineName && !result.has(initialPipelineName)) {
+            setSelectedPipeline("");
+          }
+        } catch (error) {
+          console.error("Failed to load pipelines:", error);
+        } finally {
+          setIsLoading(false);
+        }
+      };
+
+      fetchPipelines();
+    }, [initialPipelineName]);
+
+    const handlePipelineSelect = (value: string) => {
+      setSelectedPipeline(value);
+      setSelectedRuns([]);
+    };
+
+    const handleRunSelect = (run: PipelineRun, selected: boolean) => {
+      if (selected) {
+        if (selectedRuns.length < MAX_SELECTIONS) {
+          setSelectedRuns([...selectedRuns, run]);
+        }
+      } else {
+        setSelectedRuns(selectedRuns.filter((r) => r.id !== run.id));
+      }
+    };
+
+    const handleCompare = () => {
+      if (selectedRuns.length >= 2) {
+        onCompare(selectedRuns);
+      }
+    };
+
+    const handleClearSelection = () => {
+      setSelectedRuns([]);
+    };
+
+    if (isLoading) {
+      return <PipelineSelectorSkeleton />;
+    }
+
+    const pipelineNames = Array.from(pipelines.keys());
+
+    return (
+      <BlockStack gap="4" className="w-full">
+        <BlockStack gap="2">
+          <Label htmlFor="pipeline-select">Select Pipeline</Label>
+          <Select value={selectedPipeline} onValueChange={handlePipelineSelect}>
+            <SelectTrigger id="pipeline-select" className="w-full max-w-md">
+              <SelectValue placeholder="Choose a pipeline..." />
+            </SelectTrigger>
+            <SelectContent>
+              {pipelineNames.map((name) => (
+                <SelectItem key={name} value={name}>
+                  {name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </BlockStack>
+
+        {selectedPipeline && (
+          <BlockStack gap="2">
+            <InlineStack align="space-between" blockAlign="center">
+              <Text as="h3" size="lg" weight="semibold">
+                Select Runs to Compare
+              </Text>
+              <Text size="sm" tone="subdued">
+                Select 2-{MAX_SELECTIONS} runs
+              </Text>
+            </InlineStack>
+
+            <Suspense fallback={<Skeleton size="full" />}>
+              <RunSelectionList
+                pipelineName={selectedPipeline}
+                selectedRuns={selectedRuns}
+                onRunSelect={handleRunSelect}
+                maxSelections={MAX_SELECTIONS}
+              />
+            </Suspense>
+          </BlockStack>
+        )}
+
+        {selectedRuns.length > 0 && (
+          <SelectionBar
+            selectedRuns={selectedRuns}
+            onCompare={handleCompare}
+            onClearSelection={handleClearSelection}
+          />
+        )}
+      </BlockStack>
+    );
+  },
+  PipelineSelectorSkeleton,
+);
+

--- a/src/components/Compare/RunSelector/SelectionBar.tsx
+++ b/src/components/Compare/RunSelector/SelectionBar.tsx
@@ -1,0 +1,48 @@
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icon";
+import { InlineStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
+import type { PipelineRun } from "@/types/pipelineRun";
+import { pluralize } from "@/utils/string";
+
+interface SelectionBarProps {
+  selectedRuns: PipelineRun[];
+  onCompare: () => void;
+  onClearSelection: () => void;
+}
+
+export const SelectionBar = ({
+  selectedRuns,
+  onCompare,
+  onClearSelection,
+}: SelectionBarProps) => {
+  const canCompare = selectedRuns.length >= 2;
+
+  return (
+    <div className="fixed bottom-4 left-1/2 transform -translate-x-1/2 bg-background border border-border rounded-lg shadow-lg p-4 z-50">
+      <InlineStack gap="4" blockAlign="center">
+        <Text size="sm" weight="semibold">
+          {selectedRuns.length} {pluralize(selectedRuns.length, "run")} selected
+        </Text>
+
+        <InlineStack gap="2">
+          <Button
+            variant="default"
+            size="sm"
+            onClick={onCompare}
+            disabled={!canCompare}
+          >
+            <Icon name="GitCompareArrows" />
+            Compare {selectedRuns.length}{" "}
+            {pluralize(selectedRuns.length, "run")}
+          </Button>
+
+          <Button variant="ghost" size="sm" onClick={onClearSelection}>
+            <Icon name="X" />
+          </Button>
+        </InlineStack>
+      </InlineStack>
+    </div>
+  );
+};
+

--- a/src/components/Compare/RunSelector/index.ts
+++ b/src/components/Compare/RunSelector/index.ts
@@ -1,0 +1,2 @@
+export { RunSelector } from "./RunSelector";
+

--- a/src/components/Home/RunSection/RunSection.tsx
+++ b/src/components/Home/RunSection/RunSection.tsx
@@ -20,6 +20,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { useBackend } from "@/providers/BackendProvider";
+import type { HomeSearchParams } from "@/routes/router";
 import { getBackendStatusString } from "@/utils/backend";
 import { fetchWithErrorHandling } from "@/utils/fetchWithErrorHandling";
 
@@ -32,13 +33,11 @@ const CREATED_BY_ME_FILTER = "created_by:me";
 const INCLUDE_PIPELINE_NAME_QUERY_KEY = "include_pipeline_names";
 const INCLUDE_EXECUTION_STATS_QUERY_KEY = "include_execution_stats";
 
-type RunSectionSearch = { page_token?: string; filter?: string };
-
 export const RunSection = ({ onEmptyList }: { onEmptyList?: () => void }) => {
   const { backendUrl, configured, available, ready } = useBackend();
   const navigate = useNavigate();
   const { pathname } = useLocation();
-  const search = useSearch({ strict: false }) as RunSectionSearch;
+  const search = useSearch({ strict: false }) as HomeSearchParams;
   const isCreatedByMeDefault = useBetaFlagValue("created-by-me-default");
   const dataVersion = useRef(0);
 
@@ -103,7 +102,7 @@ export const RunSection = ({ onEmptyList }: { onEmptyList?: () => void }) => {
   }, [isCreatedByMeDefault]);
 
   const handleFilterChange = (value: boolean) => {
-    const nextSearch: RunSectionSearch = { ...search };
+    const nextSearch: HomeSearchParams = { ...search };
     delete nextSearch.page_token;
 
     if (value) {
@@ -140,7 +139,7 @@ export const RunSection = ({ onEmptyList }: { onEmptyList?: () => void }) => {
   const handleUserSearch = () => {
     if (!searchUser.trim()) return;
 
-    const nextSearch: RunSectionSearch = { ...search };
+    const nextSearch: HomeSearchParams = { ...search };
     delete nextSearch.page_token;
 
     // Create or update the created_by filter
@@ -171,7 +170,7 @@ export const RunSection = ({ onEmptyList }: { onEmptyList?: () => void }) => {
   const handlePreviousPage = () => {
     const previousToken = previousPageTokens[previousPageTokens.length - 1];
     setPreviousPageTokens(previousPageTokens.slice(0, -1));
-    const nextSearch: RunSectionSearch = { ...search };
+    const nextSearch: HomeSearchParams = { ...search };
     if (previousToken) {
       nextSearch.page_token = previousToken;
     } else {
@@ -182,7 +181,7 @@ export const RunSection = ({ onEmptyList }: { onEmptyList?: () => void }) => {
 
   const handleFirstPage = () => {
     setPreviousPageTokens([]);
-    const nextSearch: RunSectionSearch = { ...search };
+    const nextSearch: HomeSearchParams = { ...search };
     delete nextSearch.page_token;
     navigate({ to: pathname, search: nextSearch });
   };

--- a/src/hooks/useRunComparisonData.ts
+++ b/src/hooks/useRunComparisonData.ts
@@ -1,0 +1,165 @@
+import { useQueries } from "@tanstack/react-query";
+import yaml from "js-yaml";
+
+import type {
+  GetExecutionInfoResponse,
+  PipelineRunResponse,
+} from "@/api/types.gen";
+import { useBackend } from "@/providers/BackendProvider";
+import {
+  fetchExecutionDetails,
+  fetchPipelineRun,
+} from "@/services/executionService";
+import type { PipelineRun } from "@/types/pipelineRun";
+import { type ComponentSpec, isValidComponentSpec } from "@/utils/componentSpec";
+import type { RunComparisonData } from "@/utils/diff/types";
+import { getOverallExecutionStatusFromStats } from "@/utils/executionStatus";
+
+/**
+ * Extract ComponentSpec from execution details
+ */
+function extractComponentSpec(
+  details: GetExecutionInfoResponse | undefined,
+): ComponentSpec | undefined {
+  if (!details?.task_spec?.componentRef?.spec) {
+    return undefined;
+  }
+
+  const spec = details.task_spec.componentRef.spec;
+  if (isValidComponentSpec(spec)) {
+    return spec as ComponentSpec;
+  }
+
+  // Try parsing from text if spec is stored as string
+  const text = details.task_spec.componentRef.text;
+  if (text) {
+    try {
+      const parsed = yaml.load(text);
+      if (isValidComponentSpec(parsed)) {
+        return parsed as ComponentSpec;
+      }
+    } catch {
+      // Failed to parse
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Transform fetched data into RunComparisonData format
+ */
+function transformToComparisonData(
+  run: PipelineRun,
+  metadata: PipelineRunResponse | undefined,
+  details: GetExecutionInfoResponse | undefined,
+): RunComparisonData {
+  const componentSpec = extractComponentSpec(details);
+
+  // Get status from execution stats
+  let status: string | undefined;
+  if (metadata?.execution_status_stats) {
+    status = getOverallExecutionStatusFromStats(metadata.execution_status_stats);
+  } else if (details) {
+    // Try to derive from other data
+    status = run.status;
+  }
+
+  return {
+    runId: String(run.id),
+    pipelineName: run.pipeline_name,
+    createdAt: run.created_at,
+    createdBy: metadata?.created_by ?? run.created_by,
+    status,
+    arguments: details?.task_spec?.arguments as
+      | Record<string, import("@/utils/componentSpec").ArgumentType>
+      | undefined,
+    componentSpec,
+  };
+}
+
+/**
+ * Hook to fetch comparison data for multiple pipeline runs
+ */
+export function useRunComparisonData(runs: PipelineRun[]) {
+  const { backendUrl, ready } = useBackend();
+
+  // Fetch metadata for all runs
+  const metadataQueries = useQueries({
+    queries: runs.map((run) => ({
+      queryKey: ["comparison-metadata", run.id],
+      queryFn: () => fetchPipelineRun(String(run.id), backendUrl),
+      enabled: ready && runs.length > 0,
+      staleTime: Infinity,
+    })),
+  });
+
+  // Extract root execution IDs from metadata
+  const rootExecutionIds = metadataQueries.map((query) => ({
+    rootExecutionId: query.data?.root_execution_id,
+  }));
+
+  // Fetch execution details for all runs
+  const detailsQueries = useQueries({
+    queries: rootExecutionIds.map(({ rootExecutionId }) => ({
+      queryKey: ["comparison-details", rootExecutionId],
+      queryFn: () =>
+        rootExecutionId
+          ? fetchExecutionDetails(rootExecutionId, backendUrl)
+          : Promise.resolve(undefined),
+      enabled: ready && !!rootExecutionId,
+      staleTime: Infinity,
+    })),
+  });
+
+  // Combine all data
+  const isLoading =
+    metadataQueries.some((q) => q.isLoading) ||
+    detailsQueries.some((q) => q.isLoading);
+
+  const error =
+    metadataQueries.find((q) => q.error)?.error ||
+    detailsQueries.find((q) => q.error)?.error;
+
+  const comparisonData: RunComparisonData[] = runs.map((run, index) => {
+    const metadata = metadataQueries[index]?.data;
+    const details = detailsQueries[index]?.data;
+    return transformToComparisonData(run, metadata, details);
+  });
+
+  const isReady =
+    !isLoading &&
+    !error &&
+    comparisonData.every((data) => data.runId);
+
+  return {
+    comparisonData,
+    isLoading,
+    error,
+    isReady,
+  };
+}
+
+/**
+ * Simpler hook for when backend is not available - uses only local data
+ */
+export function useLocalRunComparisonData(runs: PipelineRun[]) {
+  // For local runs, we only have basic metadata
+  const comparisonData: RunComparisonData[] = runs.map((run) => ({
+    runId: String(run.id),
+    pipelineName: run.pipeline_name,
+    createdAt: run.created_at,
+    createdBy: run.created_by,
+    status: run.status,
+    arguments: undefined,
+    componentSpec: undefined,
+  }));
+
+  return {
+    comparisonData,
+    isLoading: false,
+    error: null,
+    isReady: runs.length > 0,
+  };
+}
+

--- a/src/hooks/useRunsById.ts
+++ b/src/hooks/useRunsById.ts
@@ -1,0 +1,90 @@
+import { useQueries } from "@tanstack/react-query";
+import localForage from "localforage";
+
+import type { PipelineRunResponse } from "@/api/types.gen";
+import { useBackend } from "@/providers/BackendProvider";
+import { fetchPipelineRun } from "@/services/executionService";
+import type { PipelineRun } from "@/types/pipelineRun";
+import { DB_NAME, PIPELINE_RUNS_STORE_NAME } from "@/utils/constants";
+import { getOverallExecutionStatusFromStats } from "@/utils/executionStatus";
+
+/**
+ * Fetch a run from local storage by ID
+ */
+async function fetchLocalRun(runId: string): Promise<PipelineRun | null> {
+  const pipelineRunsDb = localForage.createInstance({
+    name: DB_NAME,
+    storeName: PIPELINE_RUNS_STORE_NAME,
+  });
+
+  return pipelineRunsDb.getItem<PipelineRun>(runId);
+}
+
+/**
+ * Transform backend response to PipelineRun type
+ */
+function transformBackendResponse(response: PipelineRunResponse): PipelineRun {
+  // execution_status_stats in PipelineRunResponse is already flat { status: count }
+  const status = response.execution_status_stats
+    ? getOverallExecutionStatusFromStats(response.execution_status_stats)
+    : undefined;
+
+  return {
+    id: Number(response.id),
+    root_execution_id: Number(response.root_execution_id),
+    created_at: response.created_at ?? "",
+    created_by: response.created_by ?? "",
+    pipeline_name: response.pipeline_name ?? "Unknown Pipeline",
+    status,
+  };
+}
+
+/**
+ * Hook to fetch multiple pipeline runs by their IDs.
+ * First tries to fetch from backend, falls back to local storage.
+ */
+export function useRunsById(runIds: string[]) {
+  const { backendUrl, ready } = useBackend();
+
+  const queries = useQueries({
+    queries: runIds.map((runId) => ({
+      queryKey: ["run-by-id", runId, backendUrl],
+      queryFn: async (): Promise<PipelineRun | null> => {
+        // Try backend first
+        if (ready && backendUrl) {
+          try {
+            const response = await fetchPipelineRun(runId, backendUrl);
+            return transformBackendResponse(response);
+          } catch {
+            // Backend failed, try local storage
+          }
+        }
+
+        // Fallback to local storage
+        return fetchLocalRun(runId);
+      },
+      enabled: runIds.length > 0,
+      staleTime: Infinity,
+      retry: false,
+    })),
+  });
+
+  const isLoading = queries.some((q) => q.isLoading);
+  const error = queries.find((q) => q.error)?.error;
+
+  // Filter out null results and maintain order
+  const runs: PipelineRun[] = queries
+    .map((q) => q.data)
+    .filter((run): run is PipelineRun => run !== null && run !== undefined);
+
+  // Track which IDs were not found
+  const notFoundIds = runIds.filter((_, index) => !queries[index]?.data);
+
+  return {
+    runs,
+    isLoading,
+    error,
+    notFoundIds,
+    isReady: !isLoading && runs.length > 0,
+  };
+}

--- a/src/routes/Compare/Compare.tsx
+++ b/src/routes/Compare/Compare.tsx
@@ -1,0 +1,8 @@
+import { ComparePage } from "@/components/Compare/ComparePage";
+
+const Compare = () => {
+  return <ComparePage />;
+};
+
+export default Compare;
+

--- a/src/routes/Compare/index.ts
+++ b/src/routes/Compare/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./Compare";
+

--- a/src/routes/Home/Home.tsx
+++ b/src/routes/Home/Home.tsx
@@ -1,7 +1,12 @@
 import { useRef, useState } from "react";
 
 import { PipelineSection, RunSection } from "@/components/Home";
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icon";
+import { InlineStack } from "@/components/ui/layout";
+import { Link } from "@/components/ui/link";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { APP_ROUTES } from "@/routes/router";
 
 const Home = () => {
   const [activeTab, setActiveTab] = useState("runs");
@@ -19,9 +24,15 @@ const Home = () => {
 
   return (
     <div className="container mx-auto w-3/4 p-4 flex flex-col gap-4">
-      <div className="flex justify-between items-center">
+      <InlineStack align="space-between" blockAlign="center">
         <h1 className="text-2xl font-bold">Pipelines</h1>
-      </div>
+        <Link href={APP_ROUTES.COMPARE} variant="block">
+          <Button variant="outline">
+            <Icon name="GitCompareArrows" />
+            Compare Runs
+          </Button>
+        </Link>
+      </InlineStack>
       <Tabs
         defaultValue="runs"
         className="w-full"

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -11,6 +11,7 @@ import { AuthorizationResultScreen as HuggingFaceAuthorizationResultScreen } fro
 import { BASE_URL, IS_GITHUB_PAGES } from "@/utils/constants";
 
 import RootLayout from "../components/layout/RootLayout";
+import Compare from "./Compare";
 import Editor from "./Editor";
 import ErrorPage from "./ErrorPage";
 import Home from "./Home";
@@ -27,6 +28,7 @@ declare module "@tanstack/react-router" {
 export const EDITOR_PATH = "/editor";
 export const RUNS_BASE_PATH = "/runs";
 export const QUICK_START_PATH = "/quick-start";
+export const COMPARE_PATH = "/compare";
 export const APP_ROUTES = {
   HOME: "/",
   QUICK_START: QUICK_START_PATH,
@@ -34,6 +36,7 @@ export const APP_ROUTES = {
   RUN_DETAIL: `${RUNS_BASE_PATH}/$id`,
   RUN_DETAIL_WITH_SUBGRAPH: `${RUNS_BASE_PATH}/$id/$subgraphExecutionId`,
   RUNS: RUNS_BASE_PATH,
+  COMPARE: COMPARE_PATH,
   GITHUB_AUTH_CALLBACK: "/authorize/github",
   HUGGINGFACE_AUTH_CALLBACK: "/authorize/huggingface",
 };
@@ -50,10 +53,25 @@ const mainLayout = createRoute({
   component: RootLayout,
 });
 
+/**
+ * Search params for the home/index route.
+ * - page_token: Pagination token for runs list
+ * - filter: Filter string for runs (e.g., "created_by:me")
+ */
+export type HomeSearchParams = {
+  page_token?: string;
+  filter?: string;
+};
+
 const indexRoute = createRoute({
   getParentRoute: () => mainLayout,
   path: APP_ROUTES.HOME,
   component: Home,
+  validateSearch: (search: Record<string, unknown>): HomeSearchParams => ({
+    page_token:
+      typeof search.page_token === "string" ? search.page_token : undefined,
+    filter: typeof search.filter === "string" ? search.filter : undefined,
+  }),
 });
 
 const quickStartRoute = createRoute({
@@ -96,12 +114,33 @@ const runDetailWithSubgraphRoute = createRoute({
   component: PipelineRun,
 });
 
+/**
+ * Search params for the compare route.
+ * - runs: Comma-separated list of run IDs to compare
+ * - pipeline: Optional pipeline name to pre-select in the selector
+ */
+export type CompareSearchParams = {
+  runs?: string;
+  pipeline?: string;
+};
+
+const compareRoute = createRoute({
+  getParentRoute: () => mainLayout,
+  path: APP_ROUTES.COMPARE,
+  component: Compare,
+  validateSearch: (search: Record<string, unknown>): CompareSearchParams => ({
+    runs: typeof search.runs === "string" ? search.runs : undefined,
+    pipeline: typeof search.pipeline === "string" ? search.pipeline : undefined,
+  }),
+});
+
 const appRouteTree = mainLayout.addChildren([
   indexRoute,
   quickStartRoute,
   editorRoute,
   runDetailRoute,
   runDetailWithSubgraphRoute,
+  compareRoute,
 ]);
 
 const rootRouteTree = rootRoute.addChildren([

--- a/src/utils/diff/compareRuns.ts
+++ b/src/utils/diff/compareRuns.ts
@@ -1,0 +1,278 @@
+import type { ArgumentType } from "@/utils/componentSpec";
+import { isGraphImplementation } from "@/utils/componentSpec";
+
+import type {
+  ChangeType,
+  MetadataDiff,
+  RunComparisonData,
+  RunDiffResult,
+  TaskDiff,
+  TaskForComparison,
+  ValueDiff,
+} from "./types";
+
+/**
+ * Stringify an argument value for display and comparison
+ */
+export function stringifyArgumentValue(value: ArgumentType | undefined): string {
+  if (value === undefined || value === null) {
+    return "";
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  return JSON.stringify(value);
+}
+
+/**
+ * Determine the change type for a set of values across runs
+ */
+function getChangeType(values: (string | undefined)[]): ChangeType {
+  const definedValues = values.filter((v) => v !== undefined);
+
+  if (definedValues.length === 0) {
+    return "unchanged";
+  }
+
+  if (definedValues.length < values.length) {
+    // Some runs have the value, some don't
+    if (definedValues.length === values.length - 1) {
+      // Check if first run doesn't have it (added) or last run doesn't have it (removed)
+      if (values[0] === undefined) {
+        return "added";
+      }
+      if (values[values.length - 1] === undefined) {
+        return "removed";
+      }
+    }
+    return "modified";
+  }
+
+  // All runs have values - check if they're the same
+  const firstValue = definedValues[0];
+  const allSame = definedValues.every((v) => v === firstValue);
+
+  return allSame ? "unchanged" : "modified";
+}
+
+/**
+ * Create a ValueDiff from values across runs
+ */
+function createValueDiff(key: string, values: (string | undefined)[]): ValueDiff {
+  return {
+    key,
+    values,
+    changeType: getChangeType(values),
+  };
+}
+
+/**
+ * Extract tasks from a ComponentSpec for comparison
+ */
+function extractTasksForComparison(
+  run: RunComparisonData,
+): Map<string, TaskForComparison> {
+  const tasks = new Map<string, TaskForComparison>();
+
+  if (!run.componentSpec?.implementation) {
+    return tasks;
+  }
+
+  if (!isGraphImplementation(run.componentSpec.implementation)) {
+    return tasks;
+  }
+
+  const graphTasks = run.componentSpec.implementation.graph.tasks;
+
+  for (const [taskId, taskSpec] of Object.entries(graphTasks)) {
+    tasks.set(taskId, {
+      taskId,
+      componentName: taskSpec.componentRef.name,
+      componentDigest: taskSpec.componentRef.digest,
+      arguments: taskSpec.arguments ?? {},
+    });
+  }
+
+  return tasks;
+}
+
+/**
+ * Compare metadata between runs
+ */
+function compareMetadata(runs: RunComparisonData[]): MetadataDiff {
+  return {
+    createdAt: createValueDiff(
+      "Created At",
+      runs.map((r) => r.createdAt),
+    ),
+    createdBy: createValueDiff(
+      "Created By",
+      runs.map((r) => r.createdBy),
+    ),
+    status: createValueDiff(
+      "Status",
+      runs.map((r) => r.status),
+    ),
+  };
+}
+
+/**
+ * Compare pipeline arguments between runs
+ */
+function compareArguments(runs: RunComparisonData[]): ValueDiff[] {
+  // Collect all unique argument keys across all runs
+  const allKeys = new Set<string>();
+
+  for (const run of runs) {
+    if (run.arguments) {
+      Object.keys(run.arguments).forEach((key) => allKeys.add(key));
+    }
+  }
+
+  const diffs: ValueDiff[] = [];
+
+  for (const key of allKeys) {
+    const values = runs.map((run) =>
+      stringifyArgumentValue(run.arguments?.[key]),
+    );
+
+    // Only return non-empty or if at least one run has this argument
+    const hasAnyValue = values.some((v) => v !== "");
+    if (hasAnyValue) {
+      const diff = createValueDiff(key, values.map((v) => v || undefined));
+      diffs.push(diff);
+    }
+  }
+
+  // Sort by key name
+  return diffs.sort((a, b) => a.key.localeCompare(b.key));
+}
+
+/**
+ * Compare tasks between runs
+ */
+function compareTasks(runs: RunComparisonData[]): RunDiffResult["tasks"] {
+  const taskMaps = runs.map((run) => extractTasksForComparison(run));
+
+  // Collect all unique task IDs across all runs
+  const allTaskIds = new Set<string>();
+  taskMaps.forEach((map) => map.forEach((_, id) => allTaskIds.add(id)));
+
+  const added: string[] = [];
+  const removed: string[] = [];
+  const modified: TaskDiff[] = [];
+  const unchanged: string[] = [];
+
+  for (const taskId of allTaskIds) {
+    const tasksInRuns = taskMaps.map((map) => map.get(taskId));
+    const presentCount = tasksInRuns.filter(Boolean).length;
+
+    // Determine if task was added/removed
+    if (presentCount < runs.length) {
+      // Task doesn't exist in all runs
+      if (tasksInRuns[0] === undefined && tasksInRuns.some(Boolean)) {
+        added.push(taskId);
+      } else if (tasksInRuns[0] !== undefined && tasksInRuns.some((t) => !t)) {
+        removed.push(taskId);
+      }
+      continue;
+    }
+
+    // Task exists in all runs - compare details
+    const taskDiff = compareTask(taskId, tasksInRuns as TaskForComparison[]);
+
+    if (taskDiff.changeType === "unchanged") {
+      unchanged.push(taskId);
+    } else {
+      modified.push(taskDiff);
+    }
+  }
+
+  return { added, removed, modified, unchanged };
+}
+
+/**
+ * Compare a single task across runs
+ */
+function compareTask(
+  taskId: string,
+  tasks: TaskForComparison[],
+): TaskDiff {
+  const digestDiff = createValueDiff(
+    "Component Digest",
+    tasks.map((t) => t.componentDigest),
+  );
+
+  const componentNameDiff = createValueDiff(
+    "Component Name",
+    tasks.map((t) => t.componentName),
+  );
+
+  // Compare arguments
+  const allArgKeys = new Set<string>();
+  tasks.forEach((task) =>
+    Object.keys(task.arguments).forEach((key) => allArgKeys.add(key)),
+  );
+
+  const argumentsDiff: ValueDiff[] = [];
+
+  for (const key of allArgKeys) {
+    const values = tasks.map((task) =>
+      stringifyArgumentValue(task.arguments[key]),
+    );
+    const diff = createValueDiff(key, values.map((v) => v || undefined));
+
+    if (diff.changeType !== "unchanged") {
+      argumentsDiff.push(diff);
+    }
+  }
+
+  // Determine overall change type
+  const hasDigestChange = digestDiff.changeType !== "unchanged";
+  const hasArgumentChanges = argumentsDiff.length > 0;
+  const changeType: ChangeType =
+    hasDigestChange || hasArgumentChanges ? "modified" : "unchanged";
+
+  return {
+    taskId,
+    changeType,
+    digestDiff: hasDigestChange ? digestDiff : undefined,
+    componentNameDiff:
+      componentNameDiff.changeType !== "unchanged"
+        ? componentNameDiff
+        : undefined,
+    argumentsDiff,
+  };
+}
+
+/**
+ * Compare multiple pipeline runs and return a structured diff
+ */
+export function compareRuns(runs: RunComparisonData[]): RunDiffResult {
+  if (runs.length < 2) {
+    throw new Error("At least 2 runs are required for comparison");
+  }
+
+  const metadata = compareMetadata(runs);
+  const arguments_ = compareArguments(runs);
+  const tasks = compareTasks(runs);
+
+  const argumentChanges = arguments_.filter(
+    (a) => a.changeType !== "unchanged",
+  ).length;
+  const taskChanges =
+    tasks.added.length + tasks.removed.length + tasks.modified.length;
+
+  return {
+    runIds: runs.map((r) => r.runId),
+    metadata,
+    arguments: arguments_,
+    tasks,
+    summary: {
+      totalArgumentChanges: argumentChanges,
+      totalTaskChanges: taskChanges,
+      hasChanges: argumentChanges > 0 || taskChanges > 0,
+    },
+  };
+}
+

--- a/src/utils/diff/types.ts
+++ b/src/utils/diff/types.ts
@@ -1,0 +1,79 @@
+import type { ArgumentType, ComponentSpec } from "@/utils/componentSpec";
+
+/**
+ * Represents the data needed to compare runs
+ */
+export interface RunComparisonData {
+  runId: string;
+  pipelineName: string;
+  createdAt: string;
+  createdBy?: string;
+  status?: string;
+  arguments?: Record<string, ArgumentType>;
+  componentSpec?: ComponentSpec;
+}
+
+/**
+ * Change type for diff items
+ */
+export type ChangeType = "added" | "removed" | "modified" | "unchanged";
+
+/**
+ * Represents a single value difference between runs
+ */
+export interface ValueDiff {
+  key: string;
+  values: (string | undefined)[];
+  changeType: ChangeType;
+}
+
+/**
+ * Represents metadata differences between runs
+ */
+export interface MetadataDiff {
+  createdAt: ValueDiff;
+  createdBy: ValueDiff;
+  status: ValueDiff;
+}
+
+/**
+ * Represents differences in a task between runs
+ */
+export interface TaskDiff {
+  taskId: string;
+  changeType: ChangeType;
+  digestDiff?: ValueDiff;
+  componentNameDiff?: ValueDiff;
+  argumentsDiff: ValueDiff[];
+}
+
+/**
+ * Complete diff result between multiple runs
+ */
+export interface RunDiffResult {
+  runIds: string[];
+  metadata: MetadataDiff;
+  arguments: ValueDiff[];
+  tasks: {
+    added: string[];
+    removed: string[];
+    modified: TaskDiff[];
+    unchanged: string[];
+  };
+  summary: {
+    totalArgumentChanges: number;
+    totalTaskChanges: number;
+    hasChanges: boolean;
+  };
+}
+
+/**
+ * A simplified task representation for comparison
+ */
+export interface TaskForComparison {
+  taskId: string;
+  componentName?: string;
+  componentDigest?: string;
+  arguments: Record<string, ArgumentType>;
+}
+


### PR DESCRIPTION
## Description

Added a new run comparison feature that allows users to compare up to 3 pipeline runs side-by-side. The comparison shows differences in pipeline arguments and tasks, highlighting what was added, removed, or modified between runs.

The feature includes:

- A dedicated comparison page at `/compare`
- Run selection interface with pipeline filtering
- Visual diff of pipeline arguments with change highlighting
- Task comparison with nested subgraph support
- URL-based state for easy sharing of comparisons

## Type of Change

- [x] New feature
- [x] Improvement

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Run Comparison Feature

### Overview

Adds a new page for comparing 2-3 pipeline runs side-by-side, highlighting differences in arguments and task configurations.

### Features

- **Run Selection**: Select a pipeline and choose up to 3 runs to compare
- **URL State Persistence**: Comparison state is stored in URL (`/compare?runs=123,456&pipeline=MyPipeline`) for shareability and refresh persistence
- **Chronological Ordering**: Runs are automatically sorted by creation time for consistent diff semantics
- **Arguments Diff**: Tabular view of pipeline argument changes with change indicators (+/-/~)
- **Visual Task Diff**:
    - Compact node cards showing all tasks in YAML order
    - Color-coded change indicators (green=added, red=removed, yellow=modified)
    - Auto-expand changed tasks
    - Recursive subgraph visualization with indentation
    - Hover highlighting on task cards
- **Run Links**: Run labels link directly to run detail pages

### New Files

- `src/routes/Compare/` - New route for comparison page
- `src/components/Compare/` - ComparePage, RunSelector, and Diff components
- `src/hooks/useRunComparisonData.ts` - Fetches detailed run data for comparison
- `src/hooks/useRunsById.ts` - Fetches runs by ID from backend/local storage
- `src/utils/diff/` - Core diff logic for comparing run data

### Navigation

- Added "Compare Runs" button on the Home page

## Test Instructions

[Tangle - Run Diff.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/a9b0b523-5419-4ff6-932c-82d99c57ce20.mov" />](https://app.graphite.com/user-attachments/video/a9b0b523-5419-4ff6-932c-82d99c57ce20.mov)

1. Navigate to the home page and click "Compare Runs" in the top right
2. Select a pipeline from the dropdown
3. Choose 2-3 runs to compare
4. Click "Compare" to see the differences
5. Verify that arguments and tasks show proper highlighting for changes
6. Test that the URL can be shared and loads the same comparison

## Additional Comments

The comparison works with both backend-connected and local-only modes, though backend mode provides more detailed information for comparison.