### PR TITLE
feat: add pipeline run name template with placeholders

### DIFF
--- a/react-compiler.config.js
+++ b/react-compiler.config.js
@@ -35,6 +35,7 @@ export const REACT_COMPILER_ENABLED_DIRS = [
   "src/components/shared/Submitters/GoogleCloud/RegionInput.tsx",
   "src/components/shared/Submitters/Oasis/components/SubmitTaskArgumentsDialog.tsx",
   "src/components/shared/Submitters/Oasis/OasisSubmitter.tsx",
+  "src/components/shared/PipelineRunNameTemplate",
   "src/components/shared/PipelineDescription",
   "src/components/shared/InlineEditor",
   "src/components/shared/ManageComponent/PublishComponentButton.tsx",

--- a/src/components/Editor/Context/PipelineDetails.tsx
+++ b/src/components/Editor/Context/PipelineDetails.tsx
@@ -8,6 +8,8 @@ import { ListBlock } from "@/components/shared/ContextPanel/Blocks/ListBlock";
 import { TextBlock } from "@/components/shared/ContextPanel/Blocks/TextBlock";
 import { CopyText } from "@/components/shared/CopyText/CopyText";
 import { PipelineDescription } from "@/components/shared/PipelineDescription/PipelineDescription";
+import { PipelineRunNameTemplateEditor } from "@/components/shared/PipelineRunNameTemplate/PipelineRunNameTemplateEditor";
+import { useFlagValue } from "@/components/shared/Settings/useFlags";
 import { BlockStack } from "@/components/ui/layout";
 import useToastNotification from "@/hooks/useToastNotification";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
@@ -26,6 +28,10 @@ const PipelineDetails = () => {
     isComponentTreeValid,
     globalValidationIssues,
   } = useComponentSpec();
+
+  const templatizedRunNameEnabled = useFlagValue(
+    "templatized-pipeline-run-name",
+  );
 
   const { handleIssueClick, groupedIssues } = useValidationIssueNavigation(
     globalValidationIssues,
@@ -102,6 +108,12 @@ const PipelineDetails = () => {
       <ListBlock items={metadata} marker="none" />
 
       <PipelineDescription componentSpec={componentSpec} />
+
+      {templatizedRunNameEnabled && (
+        <ContentBlock title="Run Name Template">
+          <PipelineRunNameTemplateEditor />
+        </ContentBlock>
+      )}
 
       {digest && (
         <TextBlock

--- a/src/components/PipelineRun/RunDetails.tsx
+++ b/src/components/PipelineRun/RunDetails.tsx
@@ -1,6 +1,5 @@
 import { ContentBlock } from "@/components/shared/ContextPanel/Blocks/ContentBlock";
 import { ListBlock } from "@/components/shared/ContextPanel/Blocks/ListBlock";
-import { TextBlock } from "@/components/shared/ContextPanel/Blocks/TextBlock";
 import { CopyText } from "@/components/shared/CopyText/CopyText";
 import PipelineIO from "@/components/shared/Execution/PipelineIO";
 import { InfoBox } from "@/components/shared/InfoBox";
@@ -16,6 +15,8 @@ import {
   getExecutionStatusLabel,
   getOverallExecutionStatusFromStats,
 } from "@/utils/executionStatus";
+
+import { TextBlock } from "../shared/ContextPanel/Blocks/TextBlock";
 
 export const RunDetails = () => {
   const { configured } = useBackend();

--- a/src/components/shared/PipelineRunNameTemplate/PipelineRunNameTemplateEditor.tsx
+++ b/src/components/shared/PipelineRunNameTemplate/PipelineRunNameTemplateEditor.tsx
@@ -1,0 +1,39 @@
+import { useState } from "react";
+
+import { Textarea } from "@/components/ui/textarea";
+import { useComponentSpec } from "@/providers/ComponentSpecProvider";
+
+import { getRunNameTemplate, setRunNameTemplate } from "./utils";
+
+interface PipelineRunNameTemplateEditorProps {
+  autoFocus?: boolean;
+}
+
+export const PipelineRunNameTemplateEditor = ({
+  autoFocus,
+}: PipelineRunNameTemplateEditorProps) => {
+  const { componentSpec, setComponentSpec } = useComponentSpec();
+  const [localValue, setLocalValue] = useState(
+    getRunNameTemplate(componentSpec),
+  );
+
+  const updateRunNameTemplate = (runNameTemplate: string | undefined) => {
+    if (runNameTemplate === undefined) {
+      return;
+    }
+
+    setComponentSpec(setRunNameTemplate(componentSpec, runNameTemplate));
+  };
+
+  return (
+    <Textarea
+      value={localValue}
+      onChange={(event) => setLocalValue(event.target.value)}
+      onBlur={() => updateRunNameTemplate(localValue)}
+      placeholder="Add a pipeline run name template..."
+      className="min-h-5 resize-y"
+      data-testid="pipeline-description-editor"
+      autoFocus={autoFocus}
+    />
+  );
+};

--- a/src/components/shared/PipelineRunNameTemplate/processTemplate.test.ts
+++ b/src/components/shared/PipelineRunNameTemplate/processTemplate.test.ts
@@ -1,0 +1,413 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { ComponentSpec } from "@/utils/componentSpec";
+
+import { processTemplate } from "./processTemplate";
+import type { TaskSpecShape } from "./types";
+
+/**
+ * Creates a minimal ComponentSpec for testing.
+ */
+const createMinimalComponentSpec = (
+  overrides: Partial<ComponentSpec> = {},
+): ComponentSpec => ({
+  name: "test-component",
+  implementation: {
+    container: { image: "test-image", command: ["echo"] },
+  },
+  ...overrides,
+});
+
+/**
+ * Creates a minimal TaskSpecShape for testing.
+ */
+const createTaskSpecShape = (
+  overrides: Partial<{
+    componentSpec: Partial<ComponentSpec>;
+    arguments: Record<string, string>;
+    annotations: Record<string, unknown>;
+  }> = {},
+): TaskSpecShape => ({
+  componentRef: {
+    spec: createMinimalComponentSpec(overrides.componentSpec),
+  },
+  arguments: overrides.arguments ?? null,
+  annotations: overrides.annotations ?? null,
+});
+
+describe("processTemplate", () => {
+  describe("basic template handling", () => {
+    it("returns empty string when template is empty", () => {
+      const taskSpec = createTaskSpecShape();
+
+      const result = processTemplate("", taskSpec);
+
+      expect(result).toBe("");
+    });
+
+    it("returns template unchanged when no placeholders exist", () => {
+      const taskSpec = createTaskSpecShape();
+      const template = "Simple text without placeholders";
+
+      const result = processTemplate(template, taskSpec);
+
+      expect(result).toBe("Simple text without placeholders");
+    });
+
+    it("preserves special characters in template", () => {
+      const taskSpec = createTaskSpecShape();
+      const template = "Text with special chars: !@#%^&*()[]{}|\\;':\",./<>?";
+
+      const result = processTemplate(template, taskSpec);
+
+      expect(result).toBe(template);
+    });
+  });
+
+  describe("arguments source", () => {
+    it("resolves placeholder from taskSpec.arguments", () => {
+      const taskSpec = createTaskSpecShape({
+        arguments: { "Dataset Path": "/data/training" },
+      });
+      const template = "Training on ${arguments.Dataset Path}";
+
+      const result = processTemplate(template, taskSpec);
+
+      expect(result).toBe("Training on /data/training");
+    });
+
+    it("falls back to componentSpec input value when argument not in taskSpec", () => {
+      const taskSpec = createTaskSpecShape({
+        componentSpec: {
+          inputs: [{ name: "Dataset Path", value: "/default/data" }],
+        },
+      });
+      const template = "Training on ${arguments.Dataset Path}";
+
+      const result = processTemplate(template, taskSpec);
+
+      expect(result).toBe("Training on /default/data");
+    });
+
+    it("falls back to componentSpec input default when no value set", () => {
+      const taskSpec = createTaskSpecShape({
+        componentSpec: {
+          inputs: [{ name: "Learning Rate", default: "0.001" }],
+        },
+      });
+      const template = "LR: ${arguments.Learning Rate}";
+
+      const result = processTemplate(template, taskSpec);
+
+      expect(result).toBe("LR: 0.001");
+    });
+
+    it("prioritizes taskSpec.arguments over componentSpec input value", () => {
+      const taskSpec = createTaskSpecShape({
+        componentSpec: {
+          inputs: [{ name: "Epochs", value: "50", default: "10" }],
+        },
+        arguments: { Epochs: "100" },
+      });
+      const template = "Training for ${arguments.Epochs} epochs";
+
+      const result = processTemplate(template, taskSpec);
+
+      expect(result).toBe("Training for 100 epochs");
+    });
+
+    it("leaves placeholder unchanged when argument not found anywhere", () => {
+      const taskSpec = createTaskSpecShape();
+      const template = "Missing: ${arguments.Unknown Argument}";
+
+      const result = processTemplate(template, taskSpec);
+
+      expect(result).toBe("Missing: ${arguments.Unknown Argument}");
+    });
+
+    it("handles arguments with special characters in names", () => {
+      const taskSpec = createTaskSpecShape({
+        arguments: { "input-with-dashes_and_underscores": "value123" },
+      });
+      const template = "Value: ${arguments.input-with-dashes_and_underscores}";
+
+      const result = processTemplate(template, taskSpec);
+
+      expect(result).toBe("Value: value123");
+    });
+  });
+
+  describe("annotations source", () => {
+    it("resolves string annotation value", () => {
+      const taskSpec = createTaskSpecShape({
+        annotations: { environment: "production" },
+      });
+      const template = "Environment: ${annotations.environment}";
+
+      const result = processTemplate(template, taskSpec);
+
+      expect(result).toBe("Environment: production");
+    });
+
+    it("converts number annotation to string", () => {
+      const taskSpec = createTaskSpecShape({
+        annotations: { version: 42 },
+      });
+      const template = "Version: ${annotations.version}";
+
+      const result = processTemplate(template, taskSpec);
+
+      expect(result).toBe("Version: 42");
+    });
+
+    it("converts boolean annotation to string", () => {
+      const taskSpec = createTaskSpecShape({
+        annotations: { debug: true },
+      });
+      const template = "Debug: ${annotations.debug}";
+
+      const result = processTemplate(template, taskSpec);
+
+      expect(result).toBe("Debug: true");
+    });
+
+    it("leaves placeholder unchanged when annotation not found", () => {
+      const taskSpec = createTaskSpecShape({
+        annotations: { existing: "value" },
+      });
+      const template = "Missing: ${annotations.nonexistent}";
+
+      const result = processTemplate(template, taskSpec);
+
+      expect(result).toBe("Missing: ${annotations.nonexistent}");
+    });
+
+    it("leaves placeholder unchanged when annotations is null", () => {
+      const taskSpec = createTaskSpecShape({ annotations: {} });
+      taskSpec.annotations = null;
+      const template = "Annotation: ${annotations.key}";
+
+      const result = processTemplate(template, taskSpec);
+
+      expect(result).toBe("Annotation: ${annotations.key}");
+    });
+  });
+
+  describe("date source", () => {
+    it("resolves timestamp format to Unix timestamp in seconds", () => {
+      vi.useFakeTimers();
+      const testDate = new Date("2026-01-21T15:30:45.000Z");
+      vi.setSystemTime(testDate);
+
+      const taskSpec = createTaskSpecShape();
+      const template = "Run at ${date.timestamp}";
+
+      const result = processTemplate(template, taskSpec);
+
+      const expectedTimestamp = Math.floor(
+        testDate.getTime() / 1000,
+      ).toString();
+      expect(result).toBe(`Run at ${expectedTimestamp}`);
+
+      vi.useRealTimers();
+    });
+
+    it("resolves short date format", () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-01-21T15:30:45.000Z"));
+
+      const taskSpec = createTaskSpecShape();
+      const template = "Created: ${date.short}";
+
+      const result = processTemplate(template, taskSpec);
+
+      // Short format varies by locale, so we just check it's not the placeholder
+      expect(result).not.toBe("Created: ${date.short}");
+      expect(result).toMatch(/Created: .+/);
+
+      vi.useRealTimers();
+    });
+
+    it("resolves long date format", () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-01-21T15:30:45.000Z"));
+
+      const taskSpec = createTaskSpecShape();
+      const template = "Created: ${date.long}";
+
+      const result = processTemplate(template, taskSpec);
+
+      // Long format varies by locale, so we just check it's not the placeholder
+      expect(result).not.toBe("Created: ${date.long}");
+      expect(result).toMatch(/Created: .+/);
+
+      vi.useRealTimers();
+    });
+
+    it("leaves placeholder unchanged for unknown date format", () => {
+      const taskSpec = createTaskSpecShape();
+      const template = "Date: ${date.unknownFormat}";
+
+      const result = processTemplate(template, taskSpec);
+
+      expect(result).toBe("Date: ${date.unknownFormat}");
+    });
+  });
+
+  describe("invalid placeholders", () => {
+    it("leaves placeholder unchanged for unknown source", () => {
+      const taskSpec = createTaskSpecShape();
+      const template = "Value: ${unknown.key}";
+
+      const result = processTemplate(template, taskSpec);
+
+      expect(result).toBe("Value: ${unknown.key}");
+    });
+
+    it("leaves placeholder unchanged when missing dot separator", () => {
+      const taskSpec = createTaskSpecShape({
+        arguments: { arguments: "value" },
+      });
+      const template = "Value: ${arguments}";
+
+      const result = processTemplate(template, taskSpec);
+
+      expect(result).toBe("Value: ${arguments}");
+    });
+
+    it("leaves placeholder unchanged when key is empty", () => {
+      const taskSpec = createTaskSpecShape();
+      const template = "Value: ${arguments.}";
+
+      const result = processTemplate(template, taskSpec);
+
+      expect(result).toBe("Value: ${arguments.}");
+    });
+
+    it("handles whitespace around placeholder content", () => {
+      const taskSpec = createTaskSpecShape({
+        arguments: { key: "value" },
+      });
+      const template = "Value: ${ arguments.key }";
+
+      const result = processTemplate(template, taskSpec);
+
+      expect(result).toBe("Value: value");
+    });
+  });
+
+  describe("multiple placeholders", () => {
+    it("resolves multiple different placeholders", () => {
+      vi.useFakeTimers();
+      const testDate = new Date("2026-01-21T15:30:45.000Z");
+      vi.setSystemTime(testDate);
+
+      const taskSpec = createTaskSpecShape({
+        arguments: { model: "bert-large" },
+        annotations: { version: "v2" },
+      });
+      const template =
+        "${arguments.model}-${annotations.version}-${date.timestamp}";
+
+      const result = processTemplate(template, taskSpec);
+
+      const expectedTimestamp = Math.floor(
+        testDate.getTime() / 1000,
+      ).toString();
+      expect(result).toBe(`bert-large-v2-${expectedTimestamp}`);
+
+      vi.useRealTimers();
+    });
+
+    it("resolves same placeholder appearing multiple times", () => {
+      const taskSpec = createTaskSpecShape({
+        arguments: { name: "experiment" },
+      });
+      const template =
+        "${arguments.name}: Start ${arguments.name}, End ${arguments.name}";
+
+      const result = processTemplate(template, taskSpec);
+
+      expect(result).toBe("experiment: Start experiment, End experiment");
+    });
+
+    it("handles mix of resolved and unresolved placeholders", () => {
+      const taskSpec = createTaskSpecShape({
+        arguments: { found: "exists" },
+      });
+      const template = "${arguments.found} and ${arguments.missing}";
+
+      const result = processTemplate(template, taskSpec);
+
+      expect(result).toBe("exists and ${arguments.missing}");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("handles placeholder with nested braces in surrounding text", () => {
+      const taskSpec = createTaskSpecShape({
+        arguments: { key: "value" },
+      });
+      const template = "{prefix}${arguments.key}{suffix}";
+
+      const result = processTemplate(template, taskSpec);
+
+      expect(result).toBe("{prefix}value{suffix}");
+    });
+
+    it("handles placeholder at start of template", () => {
+      const taskSpec = createTaskSpecShape({
+        arguments: { key: "value" },
+      });
+      const template = "${arguments.key} is at the start";
+
+      const result = processTemplate(template, taskSpec);
+
+      expect(result).toBe("value is at the start");
+    });
+
+    it("handles placeholder at end of template", () => {
+      const taskSpec = createTaskSpecShape({
+        arguments: { key: "value" },
+      });
+      const template = "Ends with ${arguments.key}";
+
+      const result = processTemplate(template, taskSpec);
+
+      expect(result).toBe("Ends with value");
+    });
+
+    it("handles template that is just a placeholder", () => {
+      const taskSpec = createTaskSpecShape({
+        arguments: { key: "value" },
+      });
+      const template = "${arguments.key}";
+
+      const result = processTemplate(template, taskSpec);
+
+      expect(result).toBe("value");
+    });
+
+    it("handles empty argument value", () => {
+      const taskSpec = createTaskSpecShape({
+        arguments: { empty: "" },
+      });
+      const template = "Value: [${arguments.empty}]";
+
+      const result = processTemplate(template, taskSpec);
+
+      expect(result).toBe("Value: []");
+    });
+
+    it("handles key with dots in the name", () => {
+      const taskSpec = createTaskSpecShape({
+        arguments: { "config.learning.rate": "0.01" },
+      });
+      const template = "Rate: ${arguments.config.learning.rate}";
+
+      const result = processTemplate(template, taskSpec);
+
+      expect(result).toBe("Rate: 0.01");
+    });
+  });
+});

--- a/src/components/shared/PipelineRunNameTemplate/processTemplate.ts
+++ b/src/components/shared/PipelineRunNameTemplate/processTemplate.ts
@@ -1,0 +1,163 @@
+import { getArgumentValue } from "@/utils/nodes/taskArguments";
+
+import type { TaskSpecShape } from "./types";
+
+/**
+ * Regex pattern for matching placeholders in the format ${...}
+ * Captures the content between ${ and }
+ */
+const PLACEHOLDER_PATTERN = /\$\{([^}]+)\}/g;
+
+/**
+ * Supported placeholder prefixes and their source paths
+ */
+const PLACEHOLDER_SOURCES = {
+  arguments: "arguments",
+  date: "date",
+  /**
+   * TaskSpec annotations
+   */
+  annotations: "annotations",
+} as const;
+
+/**
+ * Supported date format keys
+ */
+type DateFormatKey = "timestamp" | "short" | "long";
+
+type PlaceholderSource = keyof typeof PLACEHOLDER_SOURCES;
+
+/**
+ * Parses a placeholder string to extract the source and key
+ * @param placeholder - The content inside ${...}, e.g., "arguments.Input Name"
+ * @returns An object with source and key, or null if invalid format
+ */
+function parsePlaceholder(
+  placeholder: string,
+): { source: PlaceholderSource; key: string } | null {
+  const trimmed = placeholder.trim();
+  const dotIndex = trimmed.indexOf(".");
+
+  if (dotIndex === -1) {
+    return null;
+  }
+
+  const source = trimmed.slice(0, dotIndex) as PlaceholderSource;
+  const key = trimmed.slice(dotIndex + 1);
+
+  if (!(source in PLACEHOLDER_SOURCES) || !key) {
+    return null;
+  }
+
+  return { source, key };
+}
+
+/**
+ * Formats the current date according to the specified format key
+ * @param formatKey - The date format key (timestamp, short, long)
+ * @returns The formatted date string or undefined if invalid key
+ */
+function formatDate(formatKey: string): string | undefined {
+  const now = new Date();
+
+  switch (formatKey as DateFormatKey) {
+    case "timestamp":
+      return Math.floor(now.getTime() / 1000).toString();
+    case "short":
+      return now.toLocaleString(undefined, {
+        dateStyle: "short",
+        timeStyle: "short",
+      });
+    case "long":
+      return now.toLocaleString(undefined, {
+        dateStyle: "long",
+        timeStyle: "long",
+      });
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Resolves a placeholder value from taskArguments or ComponentSpec
+ * @param source - The source type (e.g., "arguments", "date")
+ * @param key - The key to look up (e.g., input name, date format)
+ * @param componentSpec - The ComponentSpec to resolve values from
+ * @param taskArguments - Optional task arguments from execution data (takes priority)
+ * @returns The resolved value or undefined if not found
+ */
+function resolvePlaceholderValue(
+  source: PlaceholderSource,
+  key: string,
+  taskSpec: TaskSpecShape,
+): string | undefined {
+  switch (source) {
+    case "arguments": {
+      // First, try to get the value from taskArguments if provided
+      const taskArgumentValue = getArgumentValue(taskSpec?.arguments, key);
+      if (taskArgumentValue !== undefined) {
+        return taskArgumentValue;
+      }
+
+      // Fall back to ComponentSpec input value or default
+      const input = taskSpec.componentRef.spec.inputs?.find(
+        (input) => input.name === key,
+      );
+      return input?.value ?? input?.default;
+    }
+    case "annotations": {
+      return taskSpec?.annotations &&
+        Object.prototype.hasOwnProperty.call(taskSpec?.annotations, key)
+        ? String(taskSpec?.annotations[key])
+        : undefined;
+    }
+    case "date":
+      return formatDate(key);
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Pure function that processes a template string by replacing placeholders
+ * with values from taskArguments or ComponentSpec.
+ *
+ * Placeholder format: ${source.key}
+ * Currently supported sources:
+ * - arguments: Resolves to argument values by name
+ *   - First checks taskArguments if provided
+ *   - Falls back to ComponentSpec.inputs value or default
+ *   Example: ${arguments.Dataset Path} -> value of argument named "Dataset Path"
+ * - date: Resolves to current date/time in various formats
+ *   - timestamp: Unix timestamp in seconds (e.g., "1705257600")
+ *   - short: Short date/time format (e.g., "1/14/26, 3:00 PM")
+ *   - long: Long date/time format (e.g., "January 14, 2026 at 3:00:00 PM EST")
+ *   Example: ${date.timestamp}, ${date.short}, ${date.long}
+ *
+ * Unresolved placeholders are left unchanged.
+ *
+ * @param template - The description string containing placeholders
+ * @param componentSpec - The ComponentSpec to resolve placeholder values from
+ * @param taskArguments - Optional task arguments from execution data (takes priority)
+ * @returns The description with resolved placeholders
+ */
+export function processTemplate(
+  template: string,
+  taskSpec: TaskSpecShape,
+): string {
+  if (!template) {
+    return template;
+  }
+
+  return template.replace(PLACEHOLDER_PATTERN, (match, placeholder) => {
+    const parsed = parsePlaceholder(placeholder);
+
+    if (!parsed) {
+      return match;
+    }
+
+    const value = resolvePlaceholderValue(parsed.source, parsed.key, taskSpec);
+
+    return value !== undefined ? value : match;
+  });
+}

--- a/src/components/shared/PipelineRunNameTemplate/types.ts
+++ b/src/components/shared/PipelineRunNameTemplate/types.ts
@@ -1,0 +1,9 @@
+import type { ComponentReference, ComponentSpec } from "@/utils/componentSpec";
+
+export interface TaskSpecShape {
+  componentRef: Omit<ComponentReference, "spec"> & {
+    spec: ComponentSpec;
+  };
+  arguments?: Record<string, string> | null;
+  annotations?: Record<string, unknown> | null;
+}

--- a/src/components/shared/PipelineRunNameTemplate/useProcessedRunName.test.ts
+++ b/src/components/shared/PipelineRunNameTemplate/useProcessedRunName.test.ts
@@ -1,0 +1,145 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ComponentSpec } from "@/utils/componentSpec";
+
+import { useProcessedRunName } from "./useProcessedRunName";
+
+// Mock the providers
+vi.mock("@/providers/ComponentSpecProvider", () => ({
+  useComponentSpec: vi.fn(),
+}));
+
+vi.mock("@/providers/ExecutionDataProvider", () => ({
+  useExecutionDataOptional: vi.fn(),
+}));
+
+// Import mocked modules
+import { useComponentSpec } from "@/providers/ComponentSpecProvider";
+import { useExecutionDataOptional } from "@/providers/ExecutionDataProvider";
+
+const mockedUseComponentSpec = vi.mocked(useComponentSpec);
+const mockedUseExecutionDataOptional = vi.mocked(useExecutionDataOptional);
+
+/**
+ * Helper to create a mock return value for useComponentSpec.
+ * Only the componentSpec property is used by useProcessedRunName.
+ */
+function mockComponentSpecContext(componentSpec: ComponentSpec) {
+  return { componentSpec } as ReturnType<typeof useComponentSpec>;
+}
+
+/**
+ * Helper to create a mock return value for useExecutionDataOptional.
+ */
+function mockExecutionDataContext(
+  taskSpec: {
+    arguments?: Record<string, unknown>;
+    annotations?: Record<string, unknown> | null;
+  } | null,
+): ReturnType<typeof useExecutionDataOptional> {
+  if (taskSpec === null) {
+    return undefined;
+  }
+  return {
+    rootDetails: {
+      task_spec: taskSpec,
+    },
+  } as ReturnType<typeof useExecutionDataOptional>;
+}
+
+const createMinimalComponentSpec = (
+  overrides: Partial<ComponentSpec> = {},
+): ComponentSpec => ({
+  name: "test-component",
+  implementation: {
+    container: { image: "test-image", command: ["echo"] },
+  },
+  ...overrides,
+});
+
+describe("useProcessedRunName", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("argument placeholders", () => {
+    it("should resolve argument from execution data task arguments", () => {
+      mockedUseComponentSpec.mockReturnValue(
+        mockComponentSpecContext(
+          createMinimalComponentSpec({
+            inputs: [{ name: "Dataset Path" }],
+            metadata: {
+              annotations: {
+                "run-name-template": "Training on ${arguments.Dataset Path}",
+              },
+            },
+          }),
+        ),
+      );
+      mockedUseExecutionDataOptional.mockReturnValue(
+        mockExecutionDataContext({
+          arguments: {
+            "Dataset Path": "/data/train.csv",
+          },
+        }),
+      );
+
+      const { result } = renderHook(() => useProcessedRunName());
+
+      expect(result.current).toBe("Training on /data/train.csv");
+    });
+  });
+
+  describe("annotation placeholders", () => {
+    it("should resolve annotation from task spec", () => {
+      mockedUseComponentSpec.mockReturnValue(
+        mockComponentSpecContext(
+          createMinimalComponentSpec({
+            metadata: {
+              annotations: {
+                "run-name-template": "Run by ${annotations.author}",
+              },
+            },
+          }),
+        ),
+      );
+      mockedUseExecutionDataOptional.mockReturnValue(
+        mockExecutionDataContext({
+          annotations: {
+            author: "John Doe",
+          },
+        }),
+      );
+
+      const { result } = renderHook(() => useProcessedRunName());
+
+      expect(result.current).toBe("Run by John Doe");
+    });
+
+    it("should convert non-string annotation values to string", () => {
+      mockedUseComponentSpec.mockReturnValue(
+        mockComponentSpecContext(
+          createMinimalComponentSpec({
+            metadata: {
+              annotations: {
+                "run-name-template": "Version ${annotations.version}",
+              },
+            },
+          }),
+        ),
+      );
+      mockedUseExecutionDataOptional.mockReturnValue(
+        mockExecutionDataContext({
+          annotations: {
+            version: 42,
+          },
+        }),
+      );
+
+      const { result } = renderHook(() => useProcessedRunName());
+
+      expect(result.current).toBe("Version 42");
+    });
+  });
+});

--- a/src/components/shared/PipelineRunNameTemplate/useProcessedRunName.ts
+++ b/src/components/shared/PipelineRunNameTemplate/useProcessedRunName.ts
@@ -1,0 +1,34 @@
+import { useComponentSpec } from "@/providers/ComponentSpecProvider";
+import { useExecutionDataOptional } from "@/providers/ExecutionDataProvider";
+import { extractTaskArguments } from "@/utils/nodes/taskArguments";
+
+import { processTemplate } from "./processTemplate";
+import { getRunNameTemplate } from "./utils";
+
+/**
+ * Hook that returns the processed run name from the ComponentSpec
+ * with all placeholders resolved.
+ *
+ * Uses taskArguments from execution data if available, otherwise falls back
+ * to ComponentSpec input values or defaults.
+ *
+ * @returns The processed run name string, or undefined if no run name template exists
+ */
+export function useProcessedRunName(): string | undefined {
+  const { componentSpec } = useComponentSpec();
+  const executionData = useExecutionDataOptional();
+  const taskSpec = executionData?.rootDetails?.task_spec;
+
+  const runNameTemplate = getRunNameTemplate(componentSpec);
+  if (!runNameTemplate) {
+    return undefined;
+  }
+
+  return processTemplate(runNameTemplate, {
+    componentRef: {
+      spec: componentSpec,
+    },
+    arguments: extractTaskArguments(taskSpec?.arguments),
+    annotations: taskSpec?.annotations ?? {},
+  });
+}

--- a/src/components/shared/PipelineRunNameTemplate/utils.ts
+++ b/src/components/shared/PipelineRunNameTemplate/utils.ts
@@ -1,0 +1,28 @@
+import { getAnnotationValue, setAnnotation } from "@/utils/annotations";
+import type { ComponentSpec } from "@/utils/componentSpec";
+
+export const getRunNameTemplate = (componentSpec: ComponentSpec) => {
+  return getAnnotationValue(
+    componentSpec.metadata?.annotations,
+    RUN_NAME_TEMPLATE_ANNOTATION,
+  );
+};
+
+export const setRunNameTemplate = (
+  componentSpec: ComponentSpec,
+  runNameTemplate: string | undefined,
+) => {
+  return {
+    ...componentSpec,
+    metadata: {
+      ...componentSpec.metadata,
+      annotations: setAnnotation(
+        componentSpec.metadata?.annotations,
+        RUN_NAME_TEMPLATE_ANNOTATION,
+        runNameTemplate,
+      ),
+    },
+  };
+};
+
+const RUN_NAME_TEMPLATE_ANNOTATION = "run-name-template";

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -57,4 +57,12 @@ export const ExistingFlags: ConfigFlags = {
     default: false,
     category: "beta",
   },
+
+  ["templatized-pipeline-run-name"]: {
+    name: "Templatized pipeline run name",
+    description:
+      "Enable the templatized pipeline run name feature. This will generate a run name for each pipeline run based on the template with placeholders.",
+    default: false,
+    category: "beta",
+  },
 };

--- a/src/utils/annotations.ts
+++ b/src/utils/annotations.ts
@@ -1,0 +1,51 @@
+/**
+ * Gets the value of an annotation.
+ * @param annotations - The annotations object
+ * @param key
+ * @param defaultValue
+ * @returns
+ */
+export function getAnnotationValue(
+  annotations: Record<string, unknown> | undefined | null,
+  key: string,
+  defaultValue?: string,
+) {
+  return hasAnnotation(annotations, key)
+    ? String(annotations[key])
+    : defaultValue;
+}
+
+/**
+ * Sets the value of an annotation.
+ * @param annotations - The annotations object
+ * @param key - The key of the annotation
+ * @param value - The value to set
+ * @returns
+ */
+export function setAnnotation(
+  annotations: Record<string, unknown> | undefined | null,
+  key: string,
+  value: string | undefined,
+) {
+  return {
+    ...(annotations ?? {}),
+    [key]: value,
+  };
+}
+
+/**
+ * Checks if an annotation exists.
+ * @param annotations - The annotations object
+ * @param key - The key of the annotation
+ * @returns boolean
+ */
+function hasAnnotation(
+  annotations: Record<string, unknown> | undefined | null,
+  key: string,
+): annotations is { [key: string]: unknown } {
+  if (!annotations) {
+    return false;
+  }
+
+  return Object.prototype.hasOwnProperty.call(annotations, key);
+}


### PR DESCRIPTION
## Description

Change is behind the beta flag.

Added a new `PipelineRunNameTemplate` component that edits annotation with dynamic placeholder support.

In future this component allows users to include variables in run names that get resolved at runtime, such as `${arguments.InputName}` and date formats like `${date.timestamp}`.

### Pipeline Run Name Template

- A dynamic, user-facing name for each pipeline run
- Supports placeholder substitution with runtime values
- Displayed in pipeline run lists, recent executions, and run details

### Placeholder Syntax

The pipeline description supports dynamic placeholders that are resolved at submission time:

| Placeholder Format | Description | Example |
| --- | --- | --- |
| `${arguments.<input_name>}` | Resolves to the value of a pipeline input argument | `${arguments.Dataset Path}` → `/data/train.csv` |
| `${date.timestamp}` | Unix timestamp in seconds | `1705257600` |
| `${date.short}` | Localized short date/time | `1/14/26, 3:00 PM` |
| `${date.long}` | Localized long date/time | `January 14, 2026 at 3:00:00 PM EST` |

### Example

If a pipeline has:

- **Pipeline Name:** `Training Pipeline`
- **Run Name:** `Training on ${arguments.Dataset} - ${date.short}`

When submitted with argument `Dataset = "ImageNet"`, the run will display:

> **Training on ImageNet - 1/14/26, 3:00 PM**

## Type of Change

- [x] New feature
- [x] Improvement

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

[Screen Recording 2026-01-22 at 12.06.00 AM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/96c3cabc-6389-487a-a0df-1e4a2e905398.mov" />](https://app.graphite.com/user-attachments/video/96c3cabc-6389-487a-a0df-1e4a2e905398.mov)

1. Create a pipeline with a Run Name containing placeholders like `${arguments.InputName}` or `${date.short}`
2. Ensure the pipeline annotation was properly handled