### PR TITLE
feat: canonical name poc

### DIFF
--- a/src/components/Home/PipelineSection/PipelineRow.tsx
+++ b/src/components/Home/PipelineSection/PipelineRow.tsx
@@ -184,6 +184,7 @@ const PipelineRunsButton = withSuspenseWrapper(
             showMoreButton={false}
             overviewConfig={{
               showName: false,
+              showDescription: true,
             }}
           />
         </PopoverContent>

--- a/src/components/PipelineRun/RunToolbar.tsx
+++ b/src/components/PipelineRun/RunToolbar.tsx
@@ -4,6 +4,7 @@ import { useUserDetails } from "@/hooks/useUserDetails";
 import { cn } from "@/lib/utils";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 import { useExecutionData } from "@/providers/ExecutionDataProvider";
+import { extractCanonicalName } from "@/utils/canonicalPipelineName";
 import {
   countInProgressFromStats,
   flattenExecutionStatusStats,
@@ -11,6 +12,7 @@ import {
 } from "@/utils/executionStatus";
 
 import { ViewYamlButton } from "../shared/Buttons/ViewYamlButton";
+import { buildTakSpecShape } from "../shared/PipelineRunNameTemplate/types";
 import { CancelPipelineRunButton } from "./components/CancelPipelineRunButton";
 import { ClonePipelineButton } from "./components/ClonePipelineButton";
 import { InspectPipelineButton } from "./components/InspectPipelineButton";
@@ -18,7 +20,12 @@ import { RerunPipelineButton } from "./components/RerunPipelineButton";
 
 export const RunToolbar = () => {
   const { componentSpec, currentSubgraphPath } = useComponentSpec();
-  const { rootState: state, runId, metadata } = useExecutionData();
+  const {
+    rootState: state,
+    runId,
+    metadata,
+    rootDetails: details,
+  } = useExecutionData();
   const { data: currentUserDetails } = useUserDetails();
 
   const editorRoute = componentSpec.name
@@ -27,7 +34,7 @@ export const RunToolbar = () => {
 
   const canAccessEditorSpec = useCheckComponentSpecFromPath(
     editorRoute,
-    !componentSpec.name,
+    componentSpec,
   );
 
   const isRunCreator =
@@ -46,6 +53,11 @@ export const RunToolbar = () => {
 
   const isViewingSubgraph = currentSubgraphPath.length > 1;
 
+  const pipelineName =
+    extractCanonicalName(
+      buildTakSpecShape(details?.task_spec, componentSpec),
+    ) ?? componentSpec.name;
+
   return (
     <InlineStack
       gap="2"
@@ -56,8 +68,8 @@ export const RunToolbar = () => {
     >
       <ViewYamlButton componentSpec={componentSpec} displayLabel="View" />
 
-      {canAccessEditorSpec && componentSpec.name && (
-        <InspectPipelineButton pipelineName={componentSpec.name} showLabel />
+      {canAccessEditorSpec && pipelineName && (
+        <InspectPipelineButton pipelineName={pipelineName} showLabel />
       )}
 
       <ClonePipelineButton

--- a/src/components/PipelineRun/components/ClonePipelineButton.tsx
+++ b/src/components/PipelineRun/components/ClonePipelineButton.tsx
@@ -3,10 +3,12 @@ import { useNavigate } from "@tanstack/react-router";
 import { useCallback } from "react";
 
 import TooltipButton from "@/components/shared/Buttons/TooltipButton";
+import { buildTakSpecShape } from "@/components/shared/PipelineRunNameTemplate/types";
 import { Icon } from "@/components/ui/icon";
 import useToastNotification from "@/hooks/useToastNotification";
 import { useExecutionDataOptional } from "@/providers/ExecutionDataProvider";
 import { copyRunToPipeline } from "@/services/pipelineRunService";
+import { extractCanonicalName } from "@/utils/canonicalPipelineName";
 import type { ComponentSpec } from "@/utils/componentSpec";
 import { getInitialName } from "@/utils/getComponentName";
 import { extractTaskArguments } from "@/utils/nodes/taskArguments";
@@ -32,8 +34,11 @@ export const ClonePipelineButton = ({
     }: {
       taskArguments?: Record<string, string>;
     }) => {
-      const name = getInitialName(componentSpec);
+      const canonicalName = extractCanonicalName(
+        buildTakSpecShape(runDetails?.rootDetails?.task_spec, componentSpec),
+      );
 
+      const name = getInitialName(componentSpec, canonicalName);
       return copyRunToPipeline(componentSpec, runId, name, taskArguments);
     },
     onSuccess: (result) => {

--- a/src/components/PipelineRun/components/RerunPipelineButton.tsx
+++ b/src/components/PipelineRun/components/RerunPipelineButton.tsx
@@ -6,6 +6,7 @@ import { isAuthorizationRequired } from "@/components/shared/Authentication/help
 import { useAuthLocalStorage } from "@/components/shared/Authentication/useAuthLocalStorage";
 import { useAwaitAuthorization } from "@/components/shared/Authentication/useAwaitAuthorization";
 import TooltipButton from "@/components/shared/Buttons/TooltipButton";
+import { useFlagValue } from "@/components/shared/Settings/useFlags";
 import { Icon } from "@/components/ui/icon";
 import useToastNotification from "@/hooks/useToastNotification";
 import { useBackend } from "@/providers/BackendProvider";
@@ -24,6 +25,7 @@ export const RerunPipelineButton = ({
   componentSpec,
   showLabel,
 }: RerunPipelineButtonProps) => {
+  const runNameOverride = useFlagValue("templatized-pipeline-run-name");
   const { backendUrl } = useBackend();
   const navigate = useNavigate();
   const notify = useToastNotification();
@@ -65,6 +67,7 @@ export const RerunPipelineButton = ({
         submitPipelineRun(componentSpec, backendUrl, {
           taskArguments: executionData?.rootDetails?.task_spec.arguments,
           authorizationToken,
+          runNameOverride,
           onSuccess: resolve,
           onError: reject,
         });

--- a/src/components/shared/PipelineRunDisplay/RunOverview.tsx
+++ b/src/components/shared/PipelineRunDisplay/RunOverview.tsx
@@ -2,6 +2,7 @@ import { useNavigate } from "@tanstack/react-router";
 import type { MouseEvent } from "react";
 
 import { StatusBar, StatusText } from "@/components/shared/Status/";
+import { Text } from "@/components/ui/typography";
 import { cn } from "@/lib/utils";
 import { APP_ROUTES } from "@/routes/router";
 import type { PipelineRun, TaskStatusCounts } from "@/types/pipelineRun";
@@ -9,7 +10,6 @@ import { formatDate } from "@/utils/date";
 import type { ExecutionStatusStats } from "@/utils/executionStatus";
 
 import { PipelineRunStatus } from "./components/PipelineRunStatus";
-
 /**
  * Convert TaskStatusCounts (lowercase keys) to ExecutionStatusStats (uppercase keys)
  * for use with the simplified StatusBar component.
@@ -35,6 +35,7 @@ interface RunOverviewProps {
   config?: {
     showStatus?: boolean;
     showName?: boolean;
+    showDescription?: boolean;
     showExecutionId?: boolean;
     showCreatedAt?: boolean;
     showTaskStatusBar?: boolean;
@@ -49,6 +50,7 @@ const defaultConfig = {
   showStatus: true,
   showName: true,
   showExecutionId: true,
+  showDescription: false,
   showCreatedAt: true,
   showTaskStatusBar: true,
   showStatusCounts: undefined,
@@ -95,11 +97,25 @@ const RunOverview = ({
       <div className="flex items-center justify-between mb-1">
         <div className="flex items-center gap-2">
           {combinedConfig?.showName && <span>{run.pipeline_name}</span>}
+
           <div className="flex items-center gap-3">
             {combinedConfig?.showStatus && <PipelineRunStatus run={run} />}
-            {combinedConfig?.showExecutionId && (
-              <div className="text-xs">{`#${run.id}`}</div>
-            )}
+            {combinedConfig?.showExecutionId &&
+              !combinedConfig?.showDescription && (
+                <div className="text-xs">{`#${run.id}`}</div>
+              )}
+            {combinedConfig?.showDescription &&
+              !combinedConfig?.showExecutionId && (
+                <Text size="xs">{run.pipeline_description}</Text>
+              )}
+            {combinedConfig?.showDescription &&
+              combinedConfig?.showExecutionId && (
+                <div className="flex items-center gap-2">
+                  <Text size="xs">
+                    {run.pipeline_description ?? `#${run.id}`}
+                  </Text>
+                </div>
+              )}
           </div>
           {combinedConfig?.showCreatedAt && run.created_at && (
             <div className="flex items-center gap-2">

--- a/src/components/shared/PipelineRunNameTemplate/types.ts
+++ b/src/components/shared/PipelineRunNameTemplate/types.ts
@@ -1,4 +1,6 @@
+import type { TaskSpecOutput } from "@/api/types.gen";
 import type { ComponentReference, ComponentSpec } from "@/utils/componentSpec";
+import { extractTaskArguments } from "@/utils/nodes/taskArguments";
 
 export interface TaskSpecShape {
   componentRef: Omit<ComponentReference, "spec"> & {
@@ -6,4 +8,21 @@ export interface TaskSpecShape {
   };
   arguments?: Record<string, string> | null;
   annotations?: Record<string, unknown> | null;
+}
+
+export function buildTakSpecShape(
+  taskSpecOutput: TaskSpecOutput | undefined,
+  componentSpec: ComponentSpec,
+): TaskSpecShape | undefined {
+  if (!taskSpecOutput) {
+    return undefined;
+  }
+
+  return {
+    componentRef: {
+      spec: componentSpec,
+    },
+    arguments: extractTaskArguments(taskSpecOutput.arguments),
+    annotations: taskSpecOutput.annotations,
+  };
 }

--- a/src/components/shared/ReactFlow/FlowSidebar/components/RecentExecutionsButton.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/components/RecentExecutionsButton.tsx
@@ -34,7 +34,7 @@ export const RecentExecutionsButton = withSuspenseWrapper(
         <PopoverContent className="w-[500px]">
           <PipelineRunsList
             pipelineName={componentSpec.name}
-            overviewConfig={{ showName: false }}
+            overviewConfig={{ showName: false, showDescription: true }}
           />
         </PopoverContent>
       </Popover>

--- a/src/components/shared/Submitters/Oasis/OasisSubmitter.tsx
+++ b/src/components/shared/Submitters/Oasis/OasisSubmitter.tsx
@@ -30,6 +30,7 @@ interface OasisSubmitterProps {
 }
 
 function useSubmitPipeline() {
+  const runNameOverride = useFlagValue("templatized-pipeline-run-name");
   const { awaitAuthorization, isAuthorized } = useAwaitAuthorization();
   const queryClient = useQueryClient();
   const { getToken } = useAuthLocalStorage();
@@ -62,6 +63,7 @@ function useSubmitPipeline() {
         submitPipelineRun(componentSpec, backendUrl, {
           authorizationToken: authorizationToken.current,
           taskArguments,
+          runNameOverride,
           onSuccess: (data) => {
             resolve(data);
             onSuccess(data);

--- a/src/components/shared/Submitters/Oasis/components/SubmitTaskArgumentsDialog.tsx
+++ b/src/components/shared/Submitters/Oasis/components/SubmitTaskArgumentsDialog.tsx
@@ -266,6 +266,7 @@ const CopyFromRunPopover = ({
               showMoreButton={true}
               overviewConfig={{
                 showName: false,
+                showDescription: true,
                 showTaskStatusBar: false,
               }}
               disabled={isCopyingFromRun}

--- a/src/hooks/useCheckComponentSpecFromPath.ts
+++ b/src/hooks/useCheckComponentSpecFromPath.ts
@@ -1,28 +1,40 @@
 import { useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
 
+import { buildTakSpecShape } from "@/components/shared/PipelineRunNameTemplate/types";
+import { useExecutionDataOptional } from "@/providers/ExecutionDataProvider";
 import { RUNS_BASE_PATH } from "@/routes/router";
 import { loadPipelineByName } from "@/services/pipelineService";
-import { TWENTY_FOUR_HOURS_IN_MS } from "@/utils/constants";
+import { extractCanonicalName } from "@/utils/canonicalPipelineName";
+import type { ComponentSpec } from "@/utils/componentSpec";
+import { HOURS } from "@/utils/constants";
 import { getIdOrTitleFromPath } from "@/utils/URL";
 
 export const useCheckComponentSpecFromPath = (
   url: string,
-  disabled: boolean = false,
+  componentSpec: ComponentSpec,
 ) => {
+  const details = useExecutionDataOptional();
   const isRunPath = url.includes(RUNS_BASE_PATH);
   const isEmptyPath = url.trim() === "" || url.trim() === "/";
 
   const { title } = useMemo(() => getIdOrTitleFromPath(url), [url]);
 
+  const pipelineName =
+    extractCanonicalName(
+      buildTakSpecShape(details?.rootDetails?.task_spec, componentSpec),
+    ) ?? title;
+
+  const disabled = !componentSpec.name;
+
   const { data: existsLocal } = useQuery({
     queryKey: ["component-spec-local", url],
     queryFn: async () =>
-      loadPipelineByName(title as string).then(
+      loadPipelineByName(pipelineName as string).then(
         (result) => !!result.experiment?.componentRef?.spec,
       ),
     enabled: !disabled && !isRunPath && !!title && !isEmptyPath,
-    staleTime: TWENTY_FOUR_HOURS_IN_MS,
+    staleTime: 24 * HOURS,
   });
 
   return existsLocal ?? false;

--- a/src/services/pipelineRunService.ts
+++ b/src/services/pipelineRunService.ts
@@ -54,6 +54,7 @@ export const savePipelineRun = async (
   },
   pipelineName: string,
   pipelineDigest?: string,
+  pipelineDescription?: string,
 ): Promise<PipelineRun> => {
   const pipelineRunsDb = localForage.createInstance({
     name: DB_NAME,
@@ -67,6 +68,7 @@ export const savePipelineRun = async (
     created_by: responseData.created_by,
     pipeline_name: pipelineName || "Untitled Pipeline",
     pipeline_digest: pipelineDigest,
+    pipeline_description: pipelineDescription,
   };
 
   await pipelineRunsDb.setItem(String(responseData.id), pipelineRun);

--- a/src/types/pipelineRun.ts
+++ b/src/types/pipelineRun.ts
@@ -4,6 +4,7 @@ export interface PipelineRun {
   created_at: string;
   created_by: string;
   pipeline_name: string;
+  pipeline_description?: string;
   pipeline_digest?: string;
   status?: string;
   statusCounts?: TaskStatusCounts;

--- a/src/utils/canonicalPipelineName.ts
+++ b/src/utils/canonicalPipelineName.ts
@@ -1,0 +1,35 @@
+import type { TaskSpecShape } from "@/components/shared/PipelineRunNameTemplate/types";
+
+import { getAnnotationValue } from "./annotations";
+
+/**
+ * Extracts the canonical name from the task spec
+ * @param taskSpec - The task spec to extract the canonical name from
+ * @returns The canonical name
+ */
+export function extractCanonicalName(
+  taskSpec: TaskSpecShape | undefined,
+): string | undefined {
+  return taskSpec
+    ? getAnnotationValue(taskSpec.annotations, CANONICAL_NAME_ANNOTATION)
+    : undefined;
+}
+
+/**
+ * Builds annotations with the canonical name
+ * @param canonicalName - The canonical name to build annotations with
+ * @returns The annotations with the canonical name
+ */
+export function buildAnnotationsWithCanonicalName(
+  canonicalName: string | undefined,
+): Record<string, string> {
+  if (!canonicalName) {
+    return {};
+  }
+
+  return {
+    [CANONICAL_NAME_ANNOTATION]: canonicalName,
+  };
+}
+
+const CANONICAL_NAME_ANNOTATION = "canonical-pipeline-name";

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -80,3 +80,4 @@ export const ISO8601_DURATION_ZERO_DAYS = "P0D";
 export const DEFAULT_RATE_LIMIT_RPS = 10; // requests per second
 
 export const MINUTES = 60 * 1000;
+export const HOURS = 60 * MINUTES;

--- a/src/utils/getComponentName.ts
+++ b/src/utils/getComponentName.ts
@@ -9,9 +9,12 @@ export const getComponentName = (component: ComponentReference): string => {
   );
 };
 
-export function getInitialName(componentSpec: ComponentSpec): string {
+export function getInitialName(
+  componentSpec: ComponentSpec,
+  canonicalName?: string,
+): string {
   const dateTime = new Date().toISOString();
-  const baseName = componentSpec?.name || "Pipeline";
+  const baseName = canonicalName ?? componentSpec.name ?? "Pipeline";
 
   return `${removeTrailingDateFromTitle(baseName)} (${dateTime})`;
 }

--- a/src/utils/submitPipeline.test.ts
+++ b/src/utils/submitPipeline.test.ts
@@ -87,6 +87,7 @@ describe("submitPipelineRun", () => {
         mockPipelineRun,
         "simple-component",
         undefined,
+        undefined,
       );
       expect(mockOnSuccess).toHaveBeenCalledWith(mockPipelineRun);
       expect(mockOnError).not.toHaveBeenCalled();
@@ -151,6 +152,7 @@ describe("submitPipelineRun", () => {
       expect(pipelineRunService.savePipelineRun).toHaveBeenCalledWith(
         mockPipelineRun,
         "Pipeline",
+        undefined,
         undefined,
       );
     });
@@ -921,6 +923,7 @@ describe("submitPipelineRun", () => {
         expect.any(Object),
         "digest-component",
         testDigest,
+        undefined,
       );
     });
 


### PR DESCRIPTION
## Description

Added pipeline descriptions to the UI, showing them in pipeline run lists and execution details. This enhances the user experience by providing more context about pipeline runs directly in the interface.

Key changes:

- Added description display in pipeline run lists and popover components
- Created utility functions to extract and set canonical pipeline names
- Implemented description processing for pipeline submissions
- Added support for showing descriptions instead of or alongside execution IDs

### Canonical Name

- The original pipeline name that uniquely identifies the pipeline template
- Stored in the TaskSpec annotations under `canonical-pipeline-name`
- Used for looking up the pipeline definition, inspecting the source pipeline, and linking runs to their originating pipeline

### Data Flow

1. **On Pipeline Submission:**
    - The original pipeline name is stored as the canonical name in annotations
    - The run name is processed with placeholder substitution
    - The processed name becomes the run's display name
2. **On Pipeline Run Display:**
    - The `pipeline_description` field is shown in run lists and overviews
    - Falls back to execution ID (`#<id>`) if no description exists
3. **On Pipeline Inspection:**
    - The canonical name is used to look up the original pipeline definition
    - Enables "Inspect Pipeline" functionality even with dynamic run names

## Type of Change

- [x] New feature
- [x] Improvement

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

[Screen Recording 2026-01-22 at 12.09.23 AM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/6e46133a-236a-4fcc-9c74-94f79083031c.mov" />](https://app.graphite.com/user-attachments/video/6e46133a-236a-4fcc-9c74-94f79083031c.mov)



1. Create a pipeline with a run name
2. Run the pipeline and verify the run name appears in the run list
3. Check that the description is visible in the pipeline run details view
4. Verify that descriptions appear in recent executions popover