### PR TITLE
Make ConfigInput React compiler compatible

### DIFF
--- a/react-compiler.config.js
+++ b/react-compiler.config.js
@@ -30,6 +30,7 @@ export const REACT_COMPILER_ENABLED_DIRS = [
   "src/hooks/useEdgeSelectionHighlight.ts",
 
   "src/components/shared/Submitters/Oasis/components",
+  "src/components/shared/Submitters/GoogleCloud/ConfigInput.tsx",
 
   // 11-20 useCallback/useMemo
   // "src/components/ui",                         // 12

--- a/src/components/shared/Submitters/GoogleCloud/ConfigInput.tsx
+++ b/src/components/shared/Submitters/GoogleCloud/ConfigInput.tsx
@@ -1,11 +1,5 @@
 import { RefreshCcw } from "lucide-react";
-import {
-  type KeyboardEvent,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-} from "react";
+import { type KeyboardEvent, useEffect, useRef, useState } from "react";
 
 import {
   Command,
@@ -35,26 +29,20 @@ export const ConfigInput = ({
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
 
-  const handleInputChange = useCallback(
-    (value: string) => {
-      onChange({ projectId: value });
-    },
-    [onChange],
-  );
+  const handleInputChange = (value: string) => {
+    onChange({ projectId: value });
+  };
 
-  const handleSelect = useCallback(
-    (projectId: string) => {
-      onChange({ projectId });
-      setOpen(false);
-    },
-    [onChange],
-  );
+  const handleSelect = (projectId: string) => {
+    onChange({ projectId });
+    setOpen(false);
+  };
 
-  const handleKeyDown = useCallback((e: KeyboardEvent<HTMLInputElement>) => {
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Tab") {
       setOpen(false);
     }
-  }, []);
+  };
 
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {


### PR DESCRIPTION
## Description

Removed unnecessary `useCallback` hooks from the GoogleCloud ConfigInput component. The component now uses regular function declarations for event handlers, which simplifies the code without affecting functionality.

## Type of Change

- [x] Cleanup/Refactor

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

Verify that the Google Cloud submitter configuration input still functions correctly:
1. Open the Google Cloud submitter configuration
2. Check that project ID input works properly
3. Verify that selection from dropdown and keyboard navigation still function as expected