### PR TITLE
Make GoogleCloudSubmitter React compiler compatible

### DIFF
--- a/react-compiler.config.js
+++ b/react-compiler.config.js
@@ -31,6 +31,7 @@ export const REACT_COMPILER_ENABLED_DIRS = [
 
   "src/components/shared/Submitters/Oasis/components",
   "src/components/shared/Submitters/GoogleCloud/ConfigInput.tsx",
+  "src/components/shared/Submitters/GoogleCloud/GoogleCloudSubmitter.tsx",
 
   // 11-20 useCallback/useMemo
   // "src/components/ui",                         // 12

--- a/src/components/shared/Submitters/GoogleCloud/GoogleCloudSubmitter.tsx
+++ b/src/components/shared/Submitters/GoogleCloud/GoogleCloudSubmitter.tsx
@@ -1,4 +1,4 @@
-import { type ChangeEvent, useCallback } from "react";
+import type { ChangeEvent } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -28,19 +28,13 @@ const GoogleCloudSubmitter = ({ componentSpec }: GoogleCloudSubmitterProps) => {
     componentSpec,
   });
 
-  const handleOAuthClientIdChange = useCallback(
-    (e: ChangeEvent<HTMLInputElement>) => {
-      updateConfig({ googleCloudOAuthClientId: e.target.value });
-    },
-    [],
-  );
+  const handleOAuthClientIdChange = (e: ChangeEvent<HTMLInputElement>) => {
+    updateConfig({ googleCloudOAuthClientId: e.target.value });
+  };
 
-  const handleDirectoryInputChange = useCallback(
-    (e: ChangeEvent<HTMLInputElement>) => {
-      updateConfig({ gcsOutputDirectory: e.target.value });
-    },
-    [],
-  );
+  const handleDirectoryInputChange = (e: ChangeEvent<HTMLInputElement>) => {
+    updateConfig({ gcsOutputDirectory: e.target.value });
+  };
 
   return (
     <div className="flex flex-col gap-4">


### PR DESCRIPTION
## Description

Added `GoogleCloudSubmitter.tsx` to the React Compiler enabled directories and simplified the component by removing unnecessary `useCallback` hooks from event handlers.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [x] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

Verify that the Google Cloud submitter component functions correctly after removing the `useCallback` hooks.

## Additional Comments

This change is part of our ongoing effort to optimize React components for the React Compiler by removing unnecessary memoization where it's not needed.