### PR TITLE
Make RegionInput React compiler compatible

### DIFF
--- a/react-compiler.config.js
+++ b/react-compiler.config.js
@@ -32,6 +32,7 @@ export const REACT_COMPILER_ENABLED_DIRS = [
   "src/components/shared/Submitters/Oasis/components",
   "src/components/shared/Submitters/GoogleCloud/ConfigInput.tsx",
   "src/components/shared/Submitters/GoogleCloud/GoogleCloudSubmitter.tsx",
+  "src/components/shared/Submitters/GoogleCloud/RegionInput.tsx",
 
   // 11-20 useCallback/useMemo
   // "src/components/ui",                         // 12

--- a/src/components/shared/Submitters/GoogleCloud/RegionInput.tsx
+++ b/src/components/shared/Submitters/GoogleCloud/RegionInput.tsx
@@ -1,5 +1,3 @@
-import { useCallback } from "react";
-
 import {
   Select,
   SelectContent,
@@ -29,9 +27,9 @@ interface RegionInputProps {
 }
 
 export const RegionInput = ({ config, onChange }: RegionInputProps) => {
-  const handleSelectChange = useCallback((value: string) => {
+  const handleSelectChange = (value: string) => {
     onChange({ region: value });
-  }, []);
+  };
 
   return (
     <div className="flex flex-col gap-1">


### PR DESCRIPTION
## Description

Added `RegionInput.tsx` to the React Compiler enabled directories and simplified the component by removing unnecessary `useCallback` hook.

## Type of Change

- [x] Improvement
- [x] Cleanup/Refactor

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

Verify that the Google Cloud submitter's region selection functionality works correctly after removing the `useCallback` hook.