### PR TITLE
Make SubmitTaskArgumentsDialog React compiler compatible

### DIFF
--- a/react-compiler.config.js
+++ b/react-compiler.config.js
@@ -33,6 +33,7 @@ export const REACT_COMPILER_ENABLED_DIRS = [
   "src/components/shared/Submitters/GoogleCloud/ConfigInput.tsx",
   "src/components/shared/Submitters/GoogleCloud/GoogleCloudSubmitter.tsx",
   "src/components/shared/Submitters/GoogleCloud/RegionInput.tsx",
+  "src/components/shared/Submitters/Oasis/components/SubmitTaskArgumentsDialog.tsx",
 
   // 11-20 useCallback/useMemo
   // "src/components/ui",                         // 12


### PR DESCRIPTION
## Description

Added Oasis SubmitTaskArgumentsDialog component to the React Compiler enabled directories list.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

Verify that the Oasis SubmitTaskArgumentsDialog component works correctly with React Compiler enabled.

## Additional Comments

This change enables React Compiler optimizations for the Oasis SubmitTaskArgumentsDialog component, which should improve its performance.