### PR TITLE
feat: Open some pages in a new tab with CMD + Click

### DIFF
--- a/src/components/Home/PipelineSection/PipelineRow.tsx
+++ b/src/components/Home/PipelineSection/PipelineRow.tsx
@@ -47,6 +47,11 @@ const PipelineRow = withSuspenseWrapper(
       if ((e.target as HTMLElement).closest("[data-popover-trigger]")) {
         return;
       }
+
+      if (e.ctrlKey || e.metaKey) {
+        window.open(`${EDITOR_PATH}/${name}`, "_blank");
+        return;
+      }
       navigate({ to: `${EDITOR_PATH}/${name}` });
     };
 

--- a/src/components/Home/PipelineSection/PipelineSection.tsx
+++ b/src/components/Home/PipelineSection/PipelineSection.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from "@tanstack/react-router";
+import { Link } from "@tanstack/react-router";
 import { type ChangeEvent, useEffect, useState } from "react";
 
 import { LoadingScreen } from "@/components/shared/LoadingScreen";
@@ -323,16 +323,12 @@ export const PipelineSection = withSuspenseWrapper(() => {
 }, PipelineSectionSkeleton);
 
 function QuickStartButton() {
-  const navigate = useNavigate();
   return (
-    <Button
-      variant="secondary"
-      onClick={() =>
-        navigate({ to: QUICK_START_PATH as string /* todo: fix this */ })
-      }
-    >
-      <Icon name="Sparkles" />
-      Example Pipelines
+    <Button variant="secondary" asChild>
+      <Link to={QUICK_START_PATH as string}>
+        <Icon name="Sparkles" />
+        Example Pipelines
+      </Link>
     </Button>
   );
 }

--- a/src/components/Home/RunSection/RunRow.tsx
+++ b/src/components/Home/RunSection/RunRow.tsx
@@ -41,6 +41,19 @@ const RunRow = ({ run }: { run: PipelineRunResponse }) => {
 
   const clickThroughUrl = `${APP_ROUTES.RUNS}/${runId}`;
 
+  const handleRowClick = (e: MouseEvent<HTMLElement>) => {
+    if (e.target instanceof HTMLElement && e.target.closest("button")) {
+      return;
+    }
+
+    if (e.ctrlKey || e.metaKey) {
+      window.open(clickThroughUrl, "_blank");
+      return;
+    }
+
+    navigate({ to: clickThroughUrl });
+  };
+
   const createdByButton = (
     <Button
       className="truncate underline"
@@ -63,10 +76,7 @@ const RunRow = ({ run }: { run: PipelineRunResponse }) => {
 
   return (
     <TableRow
-      onClick={(e) => {
-        e.stopPropagation();
-        navigate({ to: clickThroughUrl });
-      }}
+      onClick={handleRowClick}
       className="cursor-pointer text-gray-500 text-xs"
     >
       <TableCell>

--- a/src/components/PipelineRun/components/InspectPipelineButton.tsx
+++ b/src/components/PipelineRun/components/InspectPipelineButton.tsx
@@ -1,5 +1,5 @@
 import { useNavigate } from "@tanstack/react-router";
-import { useCallback } from "react";
+import { type MouseEvent, useCallback } from "react";
 
 import TooltipButton from "@/components/shared/Buttons/TooltipButton";
 import { Icon } from "@/components/ui/icon";
@@ -15,9 +15,19 @@ export const InspectPipelineButton = ({
 }: InspectPipelineButtonProps) => {
   const navigate = useNavigate();
 
-  const handleInspect = useCallback(() => {
-    navigate({ to: `/editor/${encodeURIComponent(pipelineName)}` });
-  }, [pipelineName, navigate]);
+  const handleInspect = useCallback(
+    (e: MouseEvent<HTMLButtonElement>) => {
+      const clickThroughUrl = `/editor/${encodeURIComponent(pipelineName)}`;
+
+      if (e.ctrlKey || e.metaKey) {
+        window.open(clickThroughUrl, "_blank");
+        return;
+      }
+
+      navigate({ to: clickThroughUrl });
+    },
+    [navigate, pipelineName],
+  );
 
   return (
     <TooltipButton

--- a/src/components/shared/NewPipelineButton.tsx
+++ b/src/components/shared/NewPipelineButton.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from "@tanstack/react-router";
 import { generate } from "random-words";
+import type { MouseEvent } from "react";
 
 import { Button } from "@/components/ui/button";
 import { EDITOR_PATH } from "@/routes/router";
@@ -15,7 +16,7 @@ const randomName = () => (generate(4) as string[]).join(" ");
 const NewPipelineButton = () => {
   const navigate = useNavigate();
 
-  const handleCreate = async () => {
+  const handleCreate = async (e: MouseEvent<HTMLButtonElement>) => {
     const name = randomName();
     const componentText = defaultPipelineYamlWithName(name);
     await writeComponentToFileListFromText(
@@ -24,8 +25,15 @@ const NewPipelineButton = () => {
       componentText,
     );
 
-    await navigate({
-      to: `${EDITOR_PATH}/${name}`,
+    const clickThroughUrl = `${EDITOR_PATH}/${encodeURIComponent(name)}`;
+
+    if (e.ctrlKey || e.metaKey) {
+      window.open(clickThroughUrl, "_blank");
+      return;
+    }
+
+    navigate({
+      to: clickThroughUrl,
       reloadDocument: !IS_GITHUB_PAGES,
     });
   };

--- a/src/components/shared/PipelineRunDisplay/RunOverview.tsx
+++ b/src/components/shared/PipelineRunDisplay/RunOverview.tsx
@@ -73,7 +73,14 @@ const RunOverview = ({
     if (onClick) {
       onClick(run);
     } else {
-      navigate({ to: `${APP_ROUTES.RUNS}/${run.id}` });
+      const clickThroughUrl = `${APP_ROUTES.RUNS}/${run.id}`;
+
+      if (e.ctrlKey || e.metaKey) {
+        window.open(clickThroughUrl, "_blank");
+        return;
+      }
+
+      navigate({ to: clickThroughUrl });
     }
   };
 

--- a/src/components/shared/Submitters/Oasis/OasisSubmitter.tsx
+++ b/src/components/shared/Submitters/Oasis/OasisSubmitter.tsx
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { AlertCircle, CheckCircle, Loader2, SendHorizonal } from "lucide-react";
-import { useRef, useState } from "react";
+import { type MouseEvent, useRef, useState } from "react";
 
 import type { TaskSpecOutput } from "@/api/types.gen";
 import { useAwaitAuthorization } from "@/components/shared/Authentication/useAwaitAuthorization";
@@ -101,9 +101,9 @@ const OasisSubmitter = ({
     notify(message, "error");
   };
 
-  const handleViewRun = (runId: number, newTab = false) => {
+  const handleViewRun = (runId: number, e: MouseEvent) => {
     const href = `${APP_ROUTES.RUNS}/${runId}`;
-    if (newTab) {
+    if (e.ctrlKey || e.metaKey) {
       window.open(href, "_blank");
     } else {
       navigate({ to: href });
@@ -116,7 +116,10 @@ const OasisSubmitter = ({
         <div className="flex items-center gap-2">
           <span className="font-semibold">Pipeline successfully submitted</span>
         </div>
-        <Button onClick={() => handleViewRun(runId)} className="w-full">
+        <Button
+          onClick={(e: MouseEvent) => handleViewRun(runId, e)}
+          className="w-full"
+        >
           View Run
         </Button>
       </div>
@@ -131,7 +134,8 @@ const OasisSubmitter = ({
     showSuccessNotification(response.id);
 
     if (isAutoRedirect) {
-      handleViewRun(response.id, true);
+      const href = `${APP_ROUTES.RUNS}/${response.id}`;
+      window.open(href, "_blank");
     }
   };
 


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

Add support for `cmd + click` to open pages in a new tab where doing so is triggered by a click action on a UI component.

Notably, this affects:
- Row Row
- Pipeline Row
- Inspect Pipeline
- Quick Start
- View Run (after submission)

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->
Closes https://github.com/Shopify/oasis-frontend/issues/423

Supersedes #1627 

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] New feature
- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

no UI changes

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

Check the places where navigation has been updated that existing behaviour persists, and cmd + click opens in a new tab.

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
