### PR TITLE
perf: Refactor React Compiler - Manage Component - Publish Button

### DIFF
--- a/react-compiler.config.js
+++ b/react-compiler.config.js
@@ -37,6 +37,9 @@ export const REACT_COMPILER_ENABLED_DIRS = [
   "src/components/shared/Submitters/Oasis/OasisSubmitter.tsx",
   "src/components/shared/PipelineDescription",
   "src/components/shared/InlineEditor",
+  "src/components/shared/ManageComponent/PublishComponentButton.tsx",
+  "src/components/shared/ManageComponent/DeprecatePublishedComponentButton.tsx",
+
   // 11-20 useCallback/useMemo
   // "src/components/ui",                         // 12
   // "src/components/PipelineRun",                // 14

--- a/src/components/shared/ManageComponent/DeprecatePublishedComponentButton.tsx
+++ b/src/components/shared/ManageComponent/DeprecatePublishedComponentButton.tsx
@@ -1,5 +1,4 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useCallback, useMemo } from "react";
 
 import { Button } from "@/components/ui/button";
 import { BlockStack } from "@/components/ui/layout";
@@ -46,9 +45,8 @@ export const DeprecatePublishedComponentButton = ({
 
   // strings and content for the confirmation dialog
   const { title, description, content, successMessage, buttonLabel } =
-    useMemo(() => {
-      if (successorComponent) {
-        return {
+    successorComponent
+      ? {
           buttonLabel: "Release new version",
           title: predecessorComponent.name,
           description:
@@ -66,23 +64,20 @@ export const DeprecatePublishedComponentButton = ({
               <ComponentQualityCard component={successorComponent} />
             </BlockStack>
           ),
+        }
+      : {
+          buttonLabel: "Deprecate component",
+          title: predecessorComponent.name,
+          description: "Are you sure you want to deprecate this component?",
+          successMessage: "Component deprecated successfully",
+          content: (
+            <Text as="p" size="sm">
+              This will deprecate the component and it will no longer be
+              available in search results. The component will still be available
+              in the component library for users who have already used it.
+            </Text>
+          ),
         };
-      }
-
-      return {
-        buttonLabel: "Deprecate component",
-        title: predecessorComponent.name,
-        description: "Are you sure you want to deprecate this component?",
-        successMessage: "Component deprecated successfully",
-        content: (
-          <Text as="p" size="sm">
-            This will deprecate the component and it will no longer be available
-            in search results. The component will still be available in the
-            component library for users who have already used it.
-          </Text>
-        ),
-      };
-    }, [successorComponent, predecessorComponent]);
 
   const {
     mutate: deletePublishedComponent,
@@ -114,7 +109,7 @@ export const DeprecatePublishedComponentButton = ({
     },
   });
 
-  const confirmProcess = useCallback(async () => {
+  const confirmProcess = async () => {
     const confirmed = await triggerConfirmation({
       title,
       description,
@@ -124,13 +119,7 @@ export const DeprecatePublishedComponentButton = ({
     if (confirmed) {
       deletePublishedComponent();
     }
-  }, [
-    title,
-    description,
-    content,
-    triggerConfirmation,
-    deletePublishedComponent,
-  ]);
+  };
 
   return (
     <>

--- a/src/components/shared/ManageComponent/PublishComponentButton.tsx
+++ b/src/components/shared/ManageComponent/PublishComponentButton.tsx
@@ -1,5 +1,4 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useCallback, useMemo } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
@@ -61,12 +60,9 @@ export const PublishComponentButton = ({
     },
   });
 
-  const confirmationContent = useMemo(
-    () => <ComponentQualityCard component={component} />,
-    [component],
-  );
+  const confirmationContent = <ComponentQualityCard component={component} />;
 
-  const confirmProcess = useCallback(async () => {
+  const confirmProcess = async () => {
     const confirmed = await triggerConfirmation({
       title: "Publish component",
       description: "",
@@ -76,7 +72,7 @@ export const PublishComponentButton = ({
     if (confirmed) {
       publishComponent();
     }
-  }, [triggerConfirmation, publishComponent, confirmationContent]);
+  };
 
   return (
     <>


### PR DESCRIPTION
## Description

Added React Compiler support for `PublishComponentButton.tsx` and `DeprecatePublishedComponentButton.tsx` by removing unnecessary `useCallback` and `useMemo` hooks. The compiler will automatically optimize these components, eliminating the need for manual memoization.

## Type of Change

- [x] Improvement
- [x] Cleanup/Refactor

## Tests

- [x] Confirm Chrome React Extension shows `Memo` next to `PublishComponentButton`.
    - ![image.png](https://app.graphite.com/user-attachments/assets/6e664834-8f41-45c6-b1e7-682dc743c7ce.png)
- [x] Clicked `PublishComponentButton` several times in UI with no noticeable adverse symptoms.
    - ![image.png](https://app.graphite.com/user-attachments/assets/f00a474e-48ed-4e0c-bf01-ed8cebcf5e25.png)
    - Received a `404` error, however when copying the payload from developer tools to `POST http://localhost:8000/api/published_components/` it worked fine.
    - @maxy-shpfy is there some environment variable I'm missing to be able to publish the component in the UI?
- [x] Ran `npm run validate:test` and passed.

## Test Steps

- Click top right Settings button and toggle `Published Components Library` to be enabled.
- Click Add Component button on left panel (next to `Components` text) and select `New` tab.  Select `Python`.
- Change the function name from `def filter_text` to something noticeable/unique.  Change the parameters to be `str` type so that the YAML has a type for the input parameters.  Click Save on top right.
- Expand the User Components to see your added new component and click the blue "i" icon.  Select the Publish tab and press the publish button.