### PR TITLE
fix: add label to clone pipeline button

### DIFF
--- a/src/components/PipelineRun/RunDetails.tsx
+++ b/src/components/PipelineRun/RunDetails.tsx
@@ -93,6 +93,14 @@ export const RunDetails = () => {
   const actions = [];
 
   actions.push(
+    <ClonePipelineButton
+      key="clone"
+      componentSpec={componentSpec}
+      runId={runId}
+    />,
+  );
+
+  actions.push(
     <ViewYamlButton key="view-pipeline-yaml" componentSpec={componentSpec} />,
   );
 
@@ -101,14 +109,6 @@ export const RunDetails = () => {
       <InspectPipelineButton key="inspect" pipelineName={componentSpec.name} />,
     );
   }
-
-  actions.push(
-    <ClonePipelineButton
-      key="clone"
-      componentSpec={componentSpec}
-      runId={runId}
-    />,
-  );
 
   if (isInProgress && isRunCreator) {
     actions.push(<CancelPipelineRunButton key="cancel" runId={runId} />);

--- a/src/components/PipelineRun/components/ClonePipelineButton.tsx
+++ b/src/components/PipelineRun/components/ClonePipelineButton.tsx
@@ -62,6 +62,7 @@ export const ClonePipelineButton = ({
       data-testid="clone-pipeline-run-button"
     >
       <Icon name="CopyPlus" />
+      Clone Pipeline
     </TooltipButton>
   );
 };


### PR DESCRIPTION
## Description

This PR makes two changes to the pipeline run interface:

1. Reorders the action buttons in the RunDetails component, moving the "Clone Pipeline" button to the first position.
2. Adds the text "Clone Pipeline" to the ClonePipelineButton component, making its purpose clearer to users.

![image.png](https://app.graphite.com/user-attachments/assets/19e26cc0-c138-4101-99f5-16a0b4b5e8b1.png)

## Motivation

The main technical issue with the top-menu button is that it’s global and sits outside the necessary context, which creates divergent behavior compared to the Clone Pipeline button in the right panel. Because the top-menu button can’t access arguments, cloning with arguments isn’t possible.

We discussed alternatives internally; one option is adding a label to the right-panel action button. That said, placement is partly a matter of habit - over time, people adapt to the correctly positioned button.

## Type of Change

- [x] Improvement
- [x] User Interface Enhancement

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

![image.png](https://app.graphite.com/user-attachments/assets/759c99af-fddb-4863-9936-051577b338f1.png)

1. Navigate to any pipeline run details page
2. Verify that the Clone Pipeline button appears first in the action buttons
3. Confirm that the Clone Pipeline button now displays the text "Clone Pipeline" alongside its icon