### PR TITLE
Remove "subgraph-navigation" beta flag as it's now a standard feature

### DIFF
--- a/src/betaFlags.ts
+++ b/src/betaFlags.ts
@@ -44,13 +44,6 @@ export const ExistingBetaFlags = {
     default: true,
   } as BetaFlag,
 
-  ["subgraph-navigation"]: {
-    name: "Subgraph Navigation",
-    description:
-      "⚠️ Experimental ⚠️ feature for viewing subgraphs. Navigate into nested pipeline components by double-clicking.",
-    default: true,
-  } as BetaFlag,
-
   ["partial-selection"]: {
     name: "Partial Node Selection",
     description:

--- a/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
@@ -135,7 +135,6 @@ const FlowCanvas = ({
   const { preserveIOSelectionOnSpecChange, resetPrevSpec } =
     useIOSelectionPersistence();
 
-  const isSubgraphNavigationEnabled = useBetaFlagValue("subgraph-navigation");
   const isPartialSelectionEnabled = useBetaFlagValue("partial-selection");
 
   const store = useStoreApi();
@@ -309,10 +308,7 @@ const FlowCanvas = ({
     (node) => node.type && UPGRADEABLE_NODES.has(node.type),
   );
 
-  const { canGroup } = canGroupNodes(
-    selectedNodes,
-    isSubgraphNavigationEnabled,
-  );
+  const { canGroup } = canGroupNodes(selectedNodes);
 
   const onElementsRemove = (params: NodesAndEdges) => {
     let updatedSubgraphSpec = { ...currentSubgraphSpec };

--- a/src/components/shared/ReactFlow/FlowCanvas/Subgraphs/create/NewSubgraphDialog.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/Subgraphs/create/NewSubgraphDialog.tsx
@@ -3,7 +3,6 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { InputDialog } from "@/components/shared/Dialogs/InputDialog";
 import { InfoBox } from "@/components/shared/InfoBox";
-import { useBetaFlagValue } from "@/components/shared/Settings/useBetaFlags";
 import { BlockStack } from "@/components/ui/layout";
 import {
   type ComponentSpec,
@@ -35,8 +34,6 @@ export const NewSubgraphDialog = ({
   onClose,
   onCreateSubgraph,
 }: NewSubgraphDialogProps) => {
-  const isSubgraphNavigationEnabled = useBetaFlagValue("subgraph-navigation");
-
   const [excludedNodeIds, setExcludedNodeIds] = useState<Set<string>>(
     new Set(),
   );
@@ -78,10 +75,7 @@ export const NewSubgraphDialog = ({
 
   const hasActiveOrphans = activeOrphanedNodes.length > 0;
 
-  const { canGroup, errorMessage } = canGroupNodes(
-    activeNodes,
-    isSubgraphNavigationEnabled,
-  );
+  const { canGroup, errorMessage } = canGroupNodes(activeNodes);
 
   const dialogContent = useMemo(() => {
     const allOrphans = orphanedNodes

--- a/src/components/shared/ReactFlow/FlowCanvas/Subgraphs/create/utils.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/Subgraphs/create/utils.ts
@@ -5,17 +5,7 @@ interface GroupingValidation {
   errorMessage?: string;
 }
 
-export const canGroupNodes = (
-  nodes: Node[],
-  isSubgraphNavigationEnabled: boolean = true,
-): GroupingValidation => {
-  if (!isSubgraphNavigationEnabled) {
-    return {
-      canGroup: false,
-      errorMessage: "Subgraph navigation is disabled.",
-    };
-  }
-
+export const canGroupNodes = (nodes: Node[]): GroupingValidation => {
   if (nodes.length <= 1) {
     return {
       canGroup: false,

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeCard.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeCard.tsx
@@ -36,7 +36,6 @@ const TaskNodeCard = () => {
   const isRemoteComponentLibrarySearchEnabled = useBetaFlagValue(
     "remote-component-library-search",
   );
-  const isSubgraphNavigationEnabled = useBetaFlagValue("subgraph-navigation");
 
   const { registerNode } = useNodesOverlay();
   const taskNode = useTaskNode();
@@ -141,7 +140,7 @@ const TaskNodeCard = () => {
   }, []);
 
   const handleDoubleClick = useCallback(() => {
-    if (isSubgraphNode && taskId && isSubgraphNavigationEnabled) {
+    if (isSubgraphNode && taskId) {
       navigateToSubgraph(taskId);
 
       if (rootExecutionId && details?.child_task_execution_ids) {
@@ -156,7 +155,6 @@ const TaskNodeCard = () => {
     isSubgraphNode,
     taskId,
     navigateToSubgraph,
-    isSubgraphNavigationEnabled,
     rootExecutionId,
     details,
     navigate,
@@ -231,7 +229,7 @@ const TaskNodeCard = () => {
       <CardHeader className="border-b border-slate-200 px-2 py-2.5 flex flex-row justify-between items-start">
         <BlockStack>
           <InlineStack gap="2" wrap="nowrap">
-            {isSubgraphNode && isSubgraphNavigationEnabled && (
+            {isSubgraphNode && (
               <QuickTooltip content={`Subgraph: ${subgraphDescription}`}>
                 <Icon name="Workflow" size="sm" className="text-blue-600" />
               </QuickTooltip>

--- a/src/components/shared/TaskDetails/Actions.tsx
+++ b/src/components/shared/TaskDetails/Actions.tsx
@@ -27,7 +27,6 @@ const TaskActions = ({
   readOnly = false,
   className,
 }: TaskActionsProps) => {
-  const isSubgraphNavigationEnabled = useBetaFlagValue("subgraph-navigation");
   const isInAppEditorEnabled = useBetaFlagValue("in-app-component-editor");
 
   const { taskId, taskSpec, state, callbacks } = taskNode || {};
@@ -57,10 +56,9 @@ const TaskActions = ({
   const upgradeTask = onUpgrade && !isCustomComponent && !readOnly && (
     <UpgradeTaskButton onUpgrade={onUpgrade} />
   );
-  const navigateToSubgraph = isSubgraphNavigationEnabled &&
-    isSubgraphNode &&
-    taskId &&
-    !readOnly && <NavigateToSubgraphButton taskId={taskId} />;
+  const navigateToSubgraph = isSubgraphNode && taskId && !readOnly && (
+    <NavigateToSubgraphButton taskId={taskId} />
+  );
   const deleteComponent = onDelete && !readOnly && (
     <DeleteComponentButton onDelete={onDelete} />
   );


### PR DESCRIPTION
## Description

Removed the "subgraph-navigation" beta flag and made subgraph navigation a standard feature. This change removes the conditional checks for the beta flag throughout the codebase, simplifying the logic for subgraph-related functionality.

## Type of Change

- [x] Improvement
- [x] Cleanup/Refactor

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Test Instructions

1. Verify that double-clicking on subgraph nodes still navigates into nested pipeline components
2. Confirm that subgraph icons and navigation buttons appear correctly
3. Ensure that creating new subgraphs works as expected