### PR TITLE
Add enhanced run filtering with advanced search, sort, and filter options

### DIFF
--- a/src/betaFlags.ts
+++ b/src/betaFlags.ts
@@ -50,4 +50,11 @@ export const ExistingBetaFlags = {
       "Allow nodes to be selected when partially covered by the selection box. Use Shift+drag for full selection, or Shift+Cmd+drag (Shift+Ctrl on Windows) for partial selection.",
     default: false,
   } as BetaFlag,
+
+  ["enhanced-run-filtering"]: {
+    name: "Enhanced Run Filtering",
+    description:
+      "Enable advanced filtering and sorting for pipeline runs. Some filters are placeholders pending backend support.",
+    default: false,
+  } as BetaFlag,
 };

--- a/src/components/Home/RunSection/RunFiltersBar.tsx
+++ b/src/components/Home/RunSection/RunFiltersBar.tsx
@@ -1,0 +1,231 @@
+import type { ChangeEvent } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icon";
+import { Input } from "@/components/ui/input";
+import { InlineStack } from "@/components/ui/layout";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select";
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { Text } from "@/components/ui/typography";
+import { cn } from "@/lib/utils";
+
+import type {
+    RunDateFilter,
+    RunFilters,
+    RunSortField,
+    RunStatusFilter,
+} from "./useRunFilters";
+
+interface RunFiltersBarProps {
+    filters: RunFilters;
+    hasActiveFilters: boolean;
+    activeFilterCount: number;
+    onUpdateFilter: <K extends keyof RunFilters>(key: K, value: RunFilters[K]) => void;
+    onClearFilters: () => void;
+    totalCount: number;
+    filteredCount: number;
+}
+
+const SORT_OPTIONS: { value: RunSortField; label: string }[] = [
+    { value: "date", label: "Date" },
+    { value: "name", label: "Name" },
+    { value: "status", label: "Status" },
+];
+
+const DATE_FILTER_OPTIONS: { value: RunDateFilter; label: string }[] = [
+    { value: "all", label: "All time" },
+    { value: "today", label: "Today" },
+    { value: "week", label: "Last 7 days" },
+    { value: "month", label: "Last 30 days" },
+];
+
+const STATUS_FILTER_OPTIONS: { value: RunStatusFilter; label: string }[] = [
+    { value: "all", label: "All statuses" },
+    { value: "SUCCEEDED", label: "Succeeded" },
+    { value: "FAILED", label: "Failed" },
+    { value: "RUNNING", label: "Running" },
+    { value: "PENDING", label: "Pending" },
+    { value: "CANCELLED", label: "Cancelled" },
+    { value: "SYSTEM_ERROR", label: "System error" },
+];
+
+const TRAPDOOR_TOOLTIP = "Preview: Filters current page only. Full API support coming soon.";
+
+interface TrapdoorWrapperProps {
+    children: React.ReactNode;
+    className?: string;
+}
+
+function TrapdoorWrapper({ children, className }: TrapdoorWrapperProps) {
+    return (
+        <Tooltip>
+            <TooltipTrigger asChild>
+                <div
+                    className={cn(
+                        "relative border border-dashed border-amber-500/50 rounded-md p-0.5 bg-amber-500/5",
+                        className,
+                    )}
+                >
+                    <div className="absolute -top-1.5 -right-1.5 z-10">
+                        <Badge
+                            variant="outline"
+                            size="xs"
+                            className="bg-amber-100 border-amber-300 text-amber-700"
+                        >
+                            <Icon name="FlaskConical" className="w-2.5 h-2.5" />
+                        </Badge>
+                    </div>
+                    {children}
+                </div>
+            </TooltipTrigger>
+            <TooltipContent sideOffset={8} className="max-w-xs">
+                {TRAPDOOR_TOOLTIP}
+            </TooltipContent>
+        </Tooltip>
+    );
+}
+
+export function RunFiltersBar({
+    filters,
+    hasActiveFilters,
+    activeFilterCount,
+    onUpdateFilter,
+    onClearFilters,
+    totalCount,
+    filteredCount,
+}: RunFiltersBarProps) {
+    const handleSearchChange = (e: ChangeEvent<HTMLInputElement>) => {
+        onUpdateFilter("searchQuery", e.target.value);
+    };
+
+    const handleSortChange = (value: string) => {
+        onUpdateFilter("sortField", value as RunSortField);
+    };
+
+    const handleSortDirectionToggle = () => {
+        onUpdateFilter(
+            "sortDirection",
+            filters.sortDirection === "asc" ? "desc" : "asc",
+        );
+    };
+
+    const handleDateFilterChange = (value: string) => {
+        onUpdateFilter("dateFilter", value as RunDateFilter);
+    };
+
+    const handleStatusFilterChange = (value: string) => {
+        onUpdateFilter("statusFilter", value as RunStatusFilter);
+    };
+
+    const sortDirectionIcon: "ArrowUp" | "ArrowDown" =
+        filters.sortDirection === "asc" ? "ArrowUp" : "ArrowDown";
+
+    const isFiltered = filteredCount < totalCount;
+
+    return (
+        <InlineStack gap="3" blockAlign="center" wrap="wrap" className="mb-4">
+            <TrapdoorWrapper>
+                <InlineStack gap="1" wrap="nowrap">
+                    <Input
+                        type="text"
+                        placeholder="Search name or ID..."
+                        value={filters.searchQuery}
+                        onChange={handleSearchChange}
+                        className="w-44"
+                        data-testid="run-search-input"
+                    />
+                    {filters.searchQuery && (
+                        <Button
+                            variant="ghost"
+                            size="icon"
+                            onClick={() => onUpdateFilter("searchQuery", "")}
+                        >
+                            <Icon name="CircleX" />
+                        </Button>
+                    )}
+                </InlineStack>
+            </TrapdoorWrapper>
+
+            <TrapdoorWrapper>
+                <InlineStack gap="1" wrap="nowrap" blockAlign="center">
+                    <Select value={filters.sortField} onValueChange={handleSortChange}>
+                        <SelectTrigger className="w-24" data-testid="run-sort-select">
+                            <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                            {SORT_OPTIONS.map((option) => (
+                                <SelectItem key={option.value} value={option.value}>
+                                    {option.label}
+                                </SelectItem>
+                            ))}
+                        </SelectContent>
+                    </Select>
+                    <Button
+                        variant="outline"
+                        size="icon"
+                        onClick={handleSortDirectionToggle}
+                        title={filters.sortDirection === "asc" ? "Ascending" : "Descending"}
+                    >
+                        <Icon name={sortDirectionIcon} />
+                    </Button>
+                </InlineStack>
+            </TrapdoorWrapper>
+
+            <TrapdoorWrapper>
+                <Select value={filters.dateFilter} onValueChange={handleDateFilterChange}>
+                    <SelectTrigger className="w-28" data-testid="run-date-filter-select">
+                        <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                        {DATE_FILTER_OPTIONS.map((option) => (
+                            <SelectItem key={option.value} value={option.value}>
+                                {option.label}
+                            </SelectItem>
+                        ))}
+                    </SelectContent>
+                </Select>
+            </TrapdoorWrapper>
+
+            <TrapdoorWrapper>
+                <Select value={filters.statusFilter} onValueChange={handleStatusFilterChange}>
+                    <SelectTrigger className="w-32" data-testid="run-status-filter-select">
+                        <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                        {STATUS_FILTER_OPTIONS.map((option) => (
+                            <SelectItem key={option.value} value={option.value}>
+                                {option.label}
+                            </SelectItem>
+                        ))}
+                    </SelectContent>
+                </Select>
+            </TrapdoorWrapper>
+
+            {hasActiveFilters && (
+                <Button variant="ghost" size="sm" onClick={onClearFilters} data-testid="run-clear-filters">
+                    <Icon name="X" />
+                    <Text as="span" size="xs" className="bg-muted px-1.5 py-0.5 rounded-full">
+                        {activeFilterCount}
+                    </Text>
+                </Button>
+            )}
+
+            {isFiltered && (
+                <Text as="span" size="xs" tone="subdued">
+                    Showing {filteredCount} of {totalCount} on this page
+                </Text>
+            )}
+        </InlineStack>
+    );
+}

--- a/src/components/Home/RunSection/useRunFilters.ts
+++ b/src/components/Home/RunSection/useRunFilters.ts
@@ -1,0 +1,243 @@
+import { useMemo, useState } from "react";
+
+import type {
+  ContainerExecutionStatus,
+  PipelineRunResponse,
+} from "@/api/types.gen";
+import { convertUTCToLocalTime } from "@/utils/date";
+import { getOverallExecutionStatusFromStats } from "@/utils/executionStatus";
+
+export type RunSortField = "date" | "name" | "status";
+type SortDirection = "asc" | "desc";
+export type RunDateFilter = "all" | "today" | "week" | "month";
+
+/**
+ * Subset of ContainerExecutionStatus values that represent overall run states
+ * (simplified for filtering purposes).
+ */
+export type RunStatusFilter =
+  | "all"
+  | "SUCCEEDED"
+  | "FAILED"
+  | "RUNNING"
+  | "PENDING"
+  | "CANCELLED"
+  | "SYSTEM_ERROR";
+
+export interface RunFilters {
+  searchQuery: string;
+  sortField: RunSortField;
+  sortDirection: SortDirection;
+  dateFilter: RunDateFilter;
+  statusFilter: RunStatusFilter;
+}
+
+const DEFAULT_FILTERS: RunFilters = {
+  searchQuery: "",
+  sortField: "date",
+  sortDirection: "desc",
+  dateFilter: "all",
+  statusFilter: "all",
+};
+
+/**
+ * Filter capability metadata - indicates what can be done server-side vs client-side.
+ * "trapdoor" filters only work on the current page of results.
+ */
+export const FILTER_CAPABILITIES = {
+  searchQuery: { isTrapdoor: true, label: "Search" },
+  sortField: { isTrapdoor: true, label: "Sort" },
+  dateFilter: { isTrapdoor: true, label: "Date range" },
+  statusFilter: { isTrapdoor: true, label: "Status" },
+  createdBy: { isTrapdoor: false, label: "Created by" },
+} as const;
+
+function isWithinDateRange(
+  dateString: string | null | undefined,
+  filter: RunDateFilter,
+): boolean {
+  if (filter === "all" || !dateString) return true;
+
+  const date = convertUTCToLocalTime(dateString);
+  const now = new Date();
+  const startOfToday = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate(),
+  );
+
+  switch (filter) {
+    case "today":
+      return date >= startOfToday;
+    case "week": {
+      const startOfWeek = new Date(startOfToday);
+      startOfWeek.setDate(startOfWeek.getDate() - 7);
+      return date >= startOfWeek;
+    }
+    case "month": {
+      const startOfMonth = new Date(startOfToday);
+      startOfMonth.setDate(startOfMonth.getDate() - 30);
+      return date >= startOfMonth;
+    }
+    default:
+      return true;
+  }
+}
+
+function matchesStatusFilter(
+  executionStatusStats: Record<string, number> | null | undefined,
+  filter: RunStatusFilter,
+): boolean {
+  if (filter === "all") return true;
+
+  const overallStatus =
+    getOverallExecutionStatusFromStats(executionStatusStats);
+  if (!overallStatus) return false;
+
+  // Map "in progress" statuses to RUNNING or PENDING for simplified filtering
+  const inProgressStatuses: ContainerExecutionStatus[] = [
+    "RUNNING",
+    "PENDING",
+    "QUEUED",
+    "WAITING_FOR_UPSTREAM",
+    "CANCELLING",
+    "UNINITIALIZED",
+  ];
+
+  if (filter === "RUNNING") {
+    return inProgressStatuses.includes(
+      overallStatus as ContainerExecutionStatus,
+    );
+  }
+
+  if (filter === "PENDING") {
+    return (
+      overallStatus === "PENDING" ||
+      overallStatus === "QUEUED" ||
+      overallStatus === "WAITING_FOR_UPSTREAM"
+    );
+  }
+
+  return overallStatus === filter;
+}
+
+function matchesSearchQuery(run: PipelineRunResponse, query: string): boolean {
+  if (!query) return true;
+
+  const lowerQuery = query.toLowerCase();
+  const name = run.pipeline_name?.toLowerCase() ?? "";
+  const id = run.id.toLowerCase();
+
+  return name.includes(lowerQuery) || id.includes(lowerQuery);
+}
+
+const STATUS_PRIORITY: Record<string, number> = {
+  SYSTEM_ERROR: 0,
+  FAILED: 1,
+  CANCELLING: 2,
+  CANCELLED: 3,
+  RUNNING: 4,
+  PENDING: 5,
+  QUEUED: 6,
+  WAITING_FOR_UPSTREAM: 7,
+  UNINITIALIZED: 8,
+  SKIPPED: 9,
+  SUCCEEDED: 10,
+};
+
+function compareRuns(
+  a: PipelineRunResponse,
+  b: PipelineRunResponse,
+  sortField: RunSortField,
+  sortDirection: SortDirection,
+): number {
+  let comparison = 0;
+
+  switch (sortField) {
+    case "name": {
+      const aName = a.pipeline_name ?? "";
+      const bName = b.pipeline_name ?? "";
+      comparison = aName.localeCompare(bName);
+      break;
+    }
+    case "date": {
+      const aDate = a.created_at ? new Date(a.created_at).getTime() : 0;
+      const bDate = b.created_at ? new Date(b.created_at).getTime() : 0;
+      comparison = aDate - bDate;
+      break;
+    }
+    case "status": {
+      const aStatus =
+        getOverallExecutionStatusFromStats(a.execution_status_stats) ??
+        "UNKNOWN";
+      const bStatus =
+        getOverallExecutionStatusFromStats(b.execution_status_stats) ??
+        "UNKNOWN";
+      const aPriority = STATUS_PRIORITY[aStatus] ?? 99;
+      const bPriority = STATUS_PRIORITY[bStatus] ?? 99;
+      comparison = aPriority - bPriority;
+      break;
+    }
+  }
+
+  return sortDirection === "asc" ? comparison : -comparison;
+}
+
+export function useRunFilters(runs: PipelineRunResponse[]) {
+  const [filters, setFilters] = useState<RunFilters>(DEFAULT_FILTERS);
+
+  const filteredAndSortedRuns = useMemo(() => {
+    return runs
+      .filter((run) => {
+        if (!matchesSearchQuery(run, filters.searchQuery)) {
+          return false;
+        }
+
+        if (!isWithinDateRange(run.created_at, filters.dateFilter)) {
+          return false;
+        }
+
+        if (
+          !matchesStatusFilter(run.execution_status_stats, filters.statusFilter)
+        ) {
+          return false;
+        }
+
+        return true;
+      })
+      .sort((a, b) =>
+        compareRuns(a, b, filters.sortField, filters.sortDirection),
+      );
+  }, [runs, filters]);
+
+  const hasActiveFilters =
+    filters.searchQuery !== "" ||
+    filters.dateFilter !== "all" ||
+    filters.statusFilter !== "all";
+
+  const activeFilterCount = [
+    filters.searchQuery !== "",
+    filters.dateFilter !== "all",
+    filters.statusFilter !== "all",
+  ].filter(Boolean).length;
+
+  const clearFilters = () => {
+    setFilters(DEFAULT_FILTERS);
+  };
+
+  const updateFilter = <K extends keyof RunFilters>(
+    key: K,
+    value: RunFilters[K],
+  ) => {
+    setFilters((prev) => ({ ...prev, [key]: value }));
+  };
+
+  return {
+    filters,
+    filteredAndSortedRuns,
+    hasActiveFilters,
+    activeFilterCount,
+    clearFilters,
+    updateFilter,
+  };
+}


### PR DESCRIPTION
## Description

Added an enhanced run filtering feature behind a beta flag. This introduces a new UI for filtering and sorting pipeline runs with capabilities for:

- Text search by name or ID
- Sorting by date, name, or status
- Filtering by date range (today, last 7 days, last 30 days)
- Filtering by run status (succeeded, failed, running, etc.)

The filters are currently client-side only (marked as "trapdoor" with visual indicators) with full API support planned for the future.

## Type of Change

- [x] New feature
- [x] Improvement

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Test Instructions

1. Enable the "Enhanced Run Filtering" beta flag
2. Navigate to the pipeline runs section
3. Test the various filtering and sorting options:
   - Search for runs by name or ID
   - Sort by different fields and directions
   - Filter by date ranges
   - Filter by run status
4. Verify that the filter counts and indicators work correctly
5. Ensure the legacy view still works when the beta flag is disabled

## Additional Comments

The enhanced filtering is currently client-side only, with visual indicators showing which features are pending backend support. The implementation includes a "trapdoor" pattern to clearly indicate which features are in preview mode.