### PR TITLE
Disable edge highlighting during multi-node selection

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/Edges/SmoothEdge.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/Edges/SmoothEdge.tsx
@@ -1,5 +1,5 @@
 import type { EdgeProps } from "@xyflow/react";
-import { getBezierPath, useEdges } from "@xyflow/react";
+import { getBezierPath, useEdges, useNodes } from "@xyflow/react";
 
 import { EdgeColor } from "./utils";
 
@@ -15,7 +15,15 @@ const SmoothEdge = ({
   selected,
 }: EdgeProps) => {
   const edges = useEdges();
-  const hasAnySelectedEdge = edges.some((edge) => edge.selected);
+  const nodes = useNodes();
+
+  const selectedNodes = nodes.filter((node) => node.selected);
+  const isMultiSelect = selectedNodes.length > 1;
+
+  // Don't highlight edges during multi-select to avoid visual clutter
+  const effectiveSelected = selected && !isMultiSelect;
+  const hasAnySelectedEdge =
+    !isMultiSelect && edges.some((edge) => edge.selected);
 
   const [edgePath] = getBezierPath({
     sourceX,
@@ -27,13 +35,13 @@ const SmoothEdge = ({
   });
 
   const getEdgeColor = () => {
-    if (selected) return EdgeColor.Selected;
+    if (effectiveSelected) return EdgeColor.Selected;
     if (hasAnySelectedEdge) return EdgeColor.Muted;
     return EdgeColor.Neutral;
   };
 
   const edgeColor = getEdgeColor();
-  const markerIdSuffix = selected
+  const markerIdSuffix = effectiveSelected
     ? "selected"
     : hasAnySelectedEdge
       ? "muted"

--- a/src/hooks/useEdgeSelectionHighlight.ts
+++ b/src/hooks/useEdgeSelectionHighlight.ts
@@ -1,7 +1,16 @@
-import { useEdges } from "@xyflow/react";
+import { useEdges, useNodes } from "@xyflow/react";
 
 export function useEdgeSelectionHighlight(nodeId: string) {
   const edges = useEdges();
+  const nodes = useNodes();
+
+  const selectedNodes = nodes.filter((node) => node.selected);
+
+  // Disable edge highlighting when multiple nodes are selected (multi-select scenario)
+  // to avoid highlighting nodes outside the selection
+  if (selectedNodes.length > 1) {
+    return false;
+  }
 
   const selectedEdges = edges.filter((edge) => edge.selected);
   const hasAnySelectedEdge = selectedEdges.length > 0;


### PR DESCRIPTION
## Description

Improved edge highlighting behavior during multi-select operations in the flow canvas. When multiple nodes are selected, edge highlighting is now disabled to reduce visual clutter and improve the user experience when working with complex flows.

![Screenshot 2026-01-16 at 12.55.13 PM.png](https://app.graphite.com/user-attachments/assets/f4d297ba-61d8-4c10-868c-e98a20932671.png)

## Type of Change

- [x] Improvement
- [x] Bug fix

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Test Instructions

1. Open a Pipeline with multiple nodes and edges
2. Select a single node and verify that connected edges are highlighted
3. Select multiple nodes (using Shift+click or drag selection) and verify that edge highlighting is disabled
4. Return to single node selection and confirm edge highlighting works again