### PR TITLE
perf: Refactor React Compiler - Manage Component - Publish Component

### DIFF
--- a/react-compiler.config.js
+++ b/react-compiler.config.js
@@ -39,6 +39,7 @@ export const REACT_COMPILER_ENABLED_DIRS = [
   "src/components/shared/InlineEditor",
   "src/components/shared/ManageComponent/PublishComponentButton.tsx",
   "src/components/shared/ManageComponent/DeprecatePublishedComponentButton.tsx",
+  "src/components/shared/ManageComponent/PublishComponent.tsx",
 
   // 11-20 useCallback/useMemo
   // "src/components/ui",                         // 12

--- a/src/components/shared/ManageComponent/PublishComponent.tsx
+++ b/src/components/shared/ManageComponent/PublishComponent.tsx
@@ -1,5 +1,4 @@
 import { Separator } from "@radix-ui/react-separator";
-import { useCallback } from "react";
 
 import { BlockStack } from "@/components/ui/layout";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -49,9 +48,9 @@ export const PublishComponent = withSuspenseWrapper(
     const { data: history, refetch: refetchHistory } =
       usePublishedComponentHistory(component, currentUserDetails?.id ?? "");
 
-    const onChange = useCallback(() => {
+    const onChange = () => {
       refetchHistory();
-    }, [refetchHistory]);
+    };
 
     return (
       <ScrollArea className="h-full">


### PR DESCRIPTION
## Description

Added `PublishComponent.tsx` to the React Compiler enabled directories and simplified the component by replacing `useCallback` with a regular function for the `onChange` handler.

## Type of Change

- [x] Improvement
- [x] Cleanup/Refactor

## Tests

- [x] Confirm Chrome React Extension shows `Memo` next to `PublishComponent`.
  - @Mbeaulne I wasn't able to search `PublishComponent`, but I believe the `Anonymous` is memoized which appears to be the component itself?
  - ![image.png](https://app.graphite.com/user-attachments/assets/810456e5-175c-41b8-b898-3dffd62772f9.png)
- [x] Ran `npm run validate:test` and passed.