### PR TITLE
perf: Refactor React Compiler - Manage Component - Component Usage Count

### DIFF
--- a/react-compiler.config.js
+++ b/react-compiler.config.js
@@ -41,6 +41,7 @@ export const REACT_COMPILER_ENABLED_DIRS = [
   "src/components/shared/ManageComponent/PublishComponentButton.tsx",
   "src/components/shared/ManageComponent/DeprecatePublishedComponentButton.tsx",
   "src/components/shared/ManageComponent/PublishComponent.tsx",
+  "src/components/shared/ManageComponent/hooks/useComponentCanvasTasks.ts",
 
   // 11-20 useCallback/useMemo
   // "src/components/ui",                         // 12

--- a/src/components/shared/ManageComponent/hooks/useComponentCanvasTasks.ts
+++ b/src/components/shared/ManageComponent/hooks/useComponentCanvasTasks.ts
@@ -1,5 +1,3 @@
-import { useMemo } from "react";
-
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 
 /**
@@ -11,11 +9,7 @@ import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 export function useComponentCanvasTasks(digest: string) {
   const { graphSpec } = useComponentSpec();
 
-  return useMemo(
-    () =>
-      Object.values(graphSpec?.tasks).filter(
-        (task) => task.componentRef.digest === digest,
-      ),
-    [graphSpec, digest],
+  return Object.values(graphSpec?.tasks).filter(
+    (task) => task.componentRef.digest === digest,
   );
 }


### PR DESCRIPTION
## Description

Enabled React Compiler for `useComponentCanvasTasks.ts` hook by adding it to the `REACT_COMPILER_ENABLED_DIRS` list in the config file. Also removed the unnecessary `useMemo` wrapper in the hook implementation, as the React Compiler will handle memoization automatically.

## Type of Change

- [x] Improvement
- [x] Performance optimization

## Tests

- [x] Confirm Chrome React Extension shows `Memo` next to `ComponentUsageCount`.
  - Confirmed that Anonymous is the correct component and it has `Memo` next to it because I compared before/after changes.
  - ![image.png](https://app.graphite.com/user-attachments/assets/4ba87851-e293-478e-a4a9-ee1ce01627c1.png)
- [x] Ran `npm run validate:test` and passed.