### PR TITLE
fix: Scroll for component dialog details tab

### DIFF
--- a/src/components/shared/Dialogs/ComponentDetailsDialog.tsx
+++ b/src/components/shared/Dialogs/ComponentDetailsDialog.tsx
@@ -118,7 +118,7 @@ const ComponentDetailsDialogContent = withSuspenseWrapper(
               ) : null}
             </TabsList>
 
-            <div className="overflow-hidden h-[40vh]">
+            <div className="overflow-auto h-[40vh]">
               <TabsContent value="details" className="h-full">
                 {remoteComponentLibrarySearchEnabled ? (
                   <PublishedComponentDetails component={componentRef} />


### PR DESCRIPTION
## Description

Changed the overflow behavior in the ComponentDetailsDialog from `overflow-hidden` to `overflow-auto` to enable scrolling within the component details section.

## Type of Change

- [x] Bug fix

## Tests

### Reproduce error on production

- Go to production https://oasis.shopify.io/
- Open up a pipeline with components in the pipeline
- Click the info next to the pipeline and in the Details tab note you cannot scroll.  You can expand the description section to get some more heigh real estate.

### Video of local fix vs. production

[Screen Recording 2026-01-16 at 2.41.55 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/02feefdc-f74b-43de-af07-524b4a78f2b5.mov" />](https://app.graphite.com/user-attachments/video/02feefdc-f74b-43de-af07-524b4a78f2b5.mov)

