### PR TITLE
fix: return clone pipeline button back to the top menu

### DIFF
--- a/react-compiler.config.js
+++ b/react-compiler.config.js
@@ -29,6 +29,9 @@ export const REACT_COMPILER_ENABLED_DIRS = [
   "src/hooks/useHandleEdgeSelection.ts",
   "src/hooks/useEdgeSelectionHighlight.ts",
 
+  "src/providers/TopNavActionsProvider.tsx",
+  "src/components/PipelineRun/components/ClonePipelineButton.tsx",
+
   "src/components/shared/Submitters/Oasis/components",
 
   // 11-20 useCallback/useMemo

--- a/src/components/PipelineRun/PipelineRunPage.tsx
+++ b/src/components/PipelineRun/PipelineRunPage.tsx
@@ -7,6 +7,7 @@ import { ComponentLibraryProvider } from "@/providers/ComponentLibraryProvider";
 import { ContextPanelProvider } from "@/providers/ContextPanelProvider";
 
 import { CollapsibleContextPanel } from "../shared/ContextPanel/CollapsibleContextPanel";
+import { ClonePipelineButtonTopNav } from "./components/ClonePipelineButton";
 import { RunDetails } from "./RunDetails";
 
 const GRID_SIZE = 10;
@@ -33,6 +34,7 @@ const PipelineRunPage = () => {
   return (
     <ContextPanelProvider defaultContent={<RunDetails />}>
       <ComponentLibraryProvider>
+        <ClonePipelineButtonTopNav />
         <InlineStack fill>
           <BlockStack fill className="flex-1">
             <FlowCanvas {...flowConfig} readOnly>

--- a/src/components/PipelineRun/components/ClonePipelineButton.test.tsx
+++ b/src/components/PipelineRun/components/ClonePipelineButton.test.tsx
@@ -3,11 +3,19 @@ import { screen, waitFor } from "@testing-library/dom";
 import { act, fireEvent, render } from "@testing-library/react";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
+import {
+  TopNavActionsProvider,
+  TopNavActionsRenderer,
+} from "@/components/layout/TopNavActionsProvider";
 import useToastNotification from "@/hooks/useToastNotification";
+import * as ComponentSpecProvider from "@/providers/ComponentSpecProvider";
 import * as ExecutionDataProvider from "@/providers/ExecutionDataProvider";
 import * as pipelineRunService from "@/services/pipelineRunService";
 
-import { ClonePipelineButton } from "./ClonePipelineButton";
+import {
+  ClonePipelineButton,
+  ClonePipelineButtonTopNav,
+} from "./ClonePipelineButton";
 
 vi.mock("@tanstack/react-router", async (importOriginal) => ({
   ...(await importOriginal()),
@@ -28,6 +36,9 @@ describe("<ClonePipelineButton/>", () => {
       url: "/editor/cloned-pipeline",
       name: "Cloned Pipeline",
     });
+    vi.spyOn(ExecutionDataProvider, "useExecutionData").mockReturnValue({
+      rootDetails: undefined,
+    } as unknown as ReturnType<typeof ExecutionDataProvider.useExecutionData>);
   });
 
   const componentSpec = { name: "Test Pipeline" } as any;
@@ -52,17 +63,13 @@ describe("<ClonePipelineButton/>", () => {
       another_param: "another_value",
     };
 
-    vi.spyOn(ExecutionDataProvider, "useExecutionDataOptional").mockReturnValue(
-      {
-        rootDetails: {
-          task_spec: {
-            arguments: mockTaskArguments,
-          },
+    vi.spyOn(ExecutionDataProvider, "useExecutionData").mockReturnValue({
+      rootDetails: {
+        task_spec: {
+          arguments: mockTaskArguments,
         },
-      } as unknown as ReturnType<
-        typeof ExecutionDataProvider.useExecutionDataOptional
-      >,
-    );
+      },
+    } as unknown as ReturnType<typeof ExecutionDataProvider.useExecutionData>);
 
     renderWithClient(<ClonePipelineButton componentSpec={componentSpec} />);
 
@@ -73,6 +80,80 @@ describe("<ClonePipelineButton/>", () => {
       expect(pipelineRunService.copyRunToPipeline).toHaveBeenCalledWith(
         componentSpec,
         undefined,
+        expect.stringContaining("Test Pipeline"),
+        mockTaskArguments,
+      );
+    });
+
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.stringContaining("cloned"),
+      "success",
+    );
+  });
+});
+
+describe("<ClonePipelineButtonTopNav/>", () => {
+  const queryClient = new QueryClient();
+  const mockNotify = vi.fn();
+  const mockComponentSpec = { name: "Test Pipeline" } as any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+    vi.mocked(useToastNotification).mockReturnValue(mockNotify);
+    vi.mocked(pipelineRunService.copyRunToPipeline).mockResolvedValue({
+      url: "/editor/cloned-pipeline",
+      name: "Cloned Pipeline",
+    });
+    vi.spyOn(ComponentSpecProvider, "useComponentSpec").mockReturnValue({
+      componentSpec: mockComponentSpec,
+    } as unknown as ReturnType<typeof ComponentSpecProvider.useComponentSpec>);
+    vi.spyOn(ExecutionDataProvider, "useExecutionData").mockReturnValue({
+      runId: "run-123",
+      rootDetails: undefined,
+    } as unknown as ReturnType<typeof ExecutionDataProvider.useExecutionData>);
+  });
+
+  const renderWithProviders = (component: React.ReactElement) =>
+    render(
+      <QueryClientProvider client={queryClient}>
+        <TopNavActionsProvider>
+          {component}
+          <TopNavActionsRenderer />
+        </TopNavActionsProvider>
+      </QueryClientProvider>,
+    );
+
+  test("registers clone button in top nav", () => {
+    renderWithProviders(<ClonePipelineButtonTopNav />);
+    expect(
+      screen.queryByTestId("global-clone-pipeline-run-button"),
+    ).toBeInTheDocument();
+  });
+
+  test("calls copyRunToPipeline with componentSpec and runId from context", async () => {
+    const mockTaskArguments = {
+      input_param: "input_value",
+    };
+
+    vi.spyOn(ExecutionDataProvider, "useExecutionData").mockReturnValue({
+      runId: "run-456",
+      rootDetails: {
+        task_spec: {
+          arguments: mockTaskArguments,
+        },
+      },
+    } as unknown as ReturnType<typeof ExecutionDataProvider.useExecutionData>);
+
+    renderWithProviders(<ClonePipelineButtonTopNav />);
+
+    const cloneButton = screen.getByTestId("global-clone-pipeline-run-button");
+    act(() => fireEvent.click(cloneButton));
+
+    await waitFor(() => {
+      expect(pipelineRunService.copyRunToPipeline).toHaveBeenCalledWith(
+        mockComponentSpec,
+        "run-456",
         expect.stringContaining("Test Pipeline"),
         mockTaskArguments,
       );

--- a/src/components/layout/AppMenu.tsx
+++ b/src/components/layout/AppMenu.tsx
@@ -2,6 +2,7 @@ import { Menu } from "lucide-react";
 import { useState } from "react";
 
 import logo from "/Tangle_white.png";
+import { TopNavActionsRenderer } from "@/components/layout/TopNavActionsProvider";
 import { isAuthorizationRequired } from "@/components/shared/Authentication/helpers";
 import { TopBarAuthentication } from "@/components/shared/Authentication/TopBarAuthentication";
 import { CopyText } from "@/components/shared/CopyText/CopyText";
@@ -54,6 +55,7 @@ const AppMenu = () => {
         <InlineStack gap="2" wrap="nowrap" className="shrink-0">
           {/* Desktop action buttons - hidden on mobile */}
           <InlineStack gap="2" className="hidden md:flex" wrap="nowrap">
+            <TopNavActionsRenderer />
             <ImportPipeline />
             <NewPipelineButton />
           </InlineStack>
@@ -85,6 +87,7 @@ const AppMenu = () => {
                 <SheetTitle className="text-white">Actions</SheetTitle>
               </SheetHeader>
               <BlockStack gap="3" className="mt-6">
+                <TopNavActionsRenderer />
                 <ImportPipeline />
                 <NewPipelineButton />
               </BlockStack>

--- a/src/components/layout/RootLayout.tsx
+++ b/src/components/layout/RootLayout.tsx
@@ -2,6 +2,7 @@ import { Outlet } from "@tanstack/react-router";
 import { TanStackRouterDevtools } from "@tanstack/router-devtools";
 import { ToastContainer } from "react-toastify";
 
+import { TopNavActionsProvider } from "@/components/layout/TopNavActionsProvider";
 import { SidebarProvider } from "@/components/ui/sidebar";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 import { BackendProvider } from "@/providers/BackendProvider";
@@ -16,23 +17,25 @@ const RootLayout = () => {
   return (
     <BackendProvider>
       <SidebarProvider>
-        <ComponentSpecProvider>
-          <ToastContainer />
+        <TopNavActionsProvider>
+          <ComponentSpecProvider>
+            <ToastContainer />
 
-          <div className="App flex flex-col min-h-screen w-full">
-            <AppMenu />
+            <div className="App flex flex-col min-h-screen w-full">
+              <AppMenu />
 
-            <main className="flex-1 grid">
-              <Outlet />
-            </main>
+              <main className="flex-1 grid">
+                <Outlet />
+              </main>
 
-            <AppFooter />
+              <AppFooter />
 
-            {import.meta.env.VITE_ENABLE_ROUTER_DEVTOOLS === "true" && (
-              <TanStackRouterDevtools />
-            )}
-          </div>
-        </ComponentSpecProvider>
+              {import.meta.env.VITE_ENABLE_ROUTER_DEVTOOLS === "true" && (
+                <TanStackRouterDevtools />
+              )}
+            </div>
+          </ComponentSpecProvider>
+        </TopNavActionsProvider>
       </SidebarProvider>
     </BackendProvider>
   );

--- a/src/components/layout/TopNavActionsProvider.tsx
+++ b/src/components/layout/TopNavActionsProvider.tsx
@@ -1,0 +1,93 @@
+import { type ReactNode, useId, useLayoutEffect, useState } from "react";
+
+import {
+  createRequiredContext,
+  useRequiredContext,
+} from "@/hooks/useRequiredContext";
+
+type ActionEntry = {
+  id: string;
+  node: ReactNode;
+  priority?: number;
+};
+
+type TopNavActionsContextValue = {
+  actions: ActionEntry[];
+  registerAction: (id: string, node: ReactNode, priority?: number) => void;
+  unregisterAction: (id: string) => void;
+};
+
+const TopNavActionsContext = createRequiredContext<TopNavActionsContextValue>(
+  "TopNavActionsContext",
+);
+
+export const TopNavActionsProvider = ({
+  children,
+}: {
+  children: ReactNode;
+}) => {
+  const [actions, setActions] = useState<ActionEntry[]>([]);
+
+  const registerAction = (id: string, node: ReactNode, priority = 0) => {
+    setActions((prev) => {
+      const filtered = prev.filter((a) => a.id !== id);
+      const newActions = [...filtered, { id, node, priority }];
+      return newActions.sort((a, b) => (a.priority ?? 0) - (b.priority ?? 0));
+    });
+  };
+
+  const unregisterAction = (id: string) => {
+    setActions((prev) => prev.filter((a) => a.id !== id));
+  };
+
+  const value = { actions, registerAction, unregisterAction };
+
+  return (
+    <TopNavActionsContext.Provider value={value}>
+      {children}
+    </TopNavActionsContext.Provider>
+  );
+};
+
+const useTopNavActions = () => useRequiredContext(TopNavActionsContext);
+
+/**
+ * Hook to register an action in the top nav.
+ * The action will be automatically unregistered when the component unmounts.
+ */
+export const useRegisterTopNavAction = (
+  node: ReactNode,
+  options?: { priority?: number },
+) => {
+  const id = useId();
+  const { registerAction, unregisterAction } = useTopNavActions();
+
+  useLayoutEffect(() => {
+    registerAction(id, node, options?.priority);
+    return () => unregisterAction(id);
+  }, [id, node, options?.priority, registerAction, unregisterAction]);
+};
+
+/**
+ * Renders all registered top nav actions.
+ * Can be placed in multiple locations (desktop menu, mobile drawer, etc.)
+ */
+export const TopNavActionsRenderer = () => {
+  const { actions } = useTopNavActions();
+
+  if (actions.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      {actions.map((action) => (
+        <ActionWrapper key={action.id}>{action.node}</ActionWrapper>
+      ))}
+    </>
+  );
+};
+
+function ActionWrapper({ children }: { children: ReactNode }) {
+  return <>{children}</>;
+}


### PR DESCRIPTION
## Description

Added a new TopNavActionsProvider system that allows components to register actions in the top navigation bar. This enables context-specific actions to appear in the global navigation.

Implemented a "Clone Pipeline" button in the top navigation bar for the Pipeline Run page, making this functionality more discoverable while maintaining the existing inline button.

## Alternatives

### Option A: React Portal

Use `createPortal` to render content into a designated DOM node in the menu.

**Pros:**
- Built-in React API
- Simple for single-target scenarios

**Cons:**
- **Only supports a single target DOM node** — cannot render to both desktop and mobile locations simultaneously
- Using two portals would require duplicate state management and event handlers
- Mobile Sheet content only exists in DOM when open, causing `document.getElementById()` to return `null`
- Not designed for "render same content in multiple places" use case

**Verdict:** ❌ Not suitable for this requirement

### Option B: Module-Level Store (useSyncExternalStore)

Lightweight pub/sub pattern without React Context.

**Pros:**
- No Provider required
- Works from anywhere in the app
- Minimal boilerplate

**Cons:**
- Global mutable state
- Less idiomatic React
- Manual subscription management
- High risk of state desync due to implementation complexity

### Option C: Route-Based Conditional Rendering

Check current route in AppMenu and render appropriate actions.

**Pros:**
- Explicit and simple
- No additional abstractions

**Cons:**
- AppMenu must know about all routes and their actions
- Tight coupling, harder to maintain as app grows
- Would require to place Providers on a higher level increasing complexity.

**Verdict:** ❌ Not suitable for this requirement

### Option D: Render Component Twice (Simplest)

Render the same component in both locations; use CSS to control visibility.

**Pros:**
- Simplest implementation, no additional abstractions
- Easy to understand and debug

**Cons:**
- Component exists twice in React tree (minor overhead)
- Requires optional context hooks to handle cases where context isn't available
- Slightly more coupling between AppMenu and page-specific actions
- Would require to place Providers on a higher level increasing complexity.

**Verdict:** ❌ Not suitable for this requirement

---

## Type of Change

- [x] New feature
- [x] Improvement

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions


[Screen Recording 2026-01-16 at 12.51.19 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/e45a9f6c-db24-411a-96e9-c42690dc56cf.mov" />](https://app.graphite.com/user-attachments/video/e45a9f6c-db24-411a-96e9-c42690dc56cf.mov)

1. Navigate to a Pipeline Run page
2. Verify the "Clone Pipeline" button appears in the top navigation bar
3. Click the button and confirm it creates a clone of the pipeline
4. Verify the button appears in both desktop and mobile views

## Additional Comments

The TopNavActionsProvider is designed to be reusable for other context-specific actions that should appear in the global navigation. Actions can be prioritized to control their order in the navigation bar.