### PR TITLE
feat: Add Pipeline Run Toolbar

### DIFF
--- a/src/components/PipelineRun/PipelineRunPage.tsx
+++ b/src/components/PipelineRun/PipelineRunPage.tsx
@@ -8,6 +8,7 @@ import { ContextPanelProvider } from "@/providers/ContextPanelProvider";
 
 import { CollapsibleContextPanel } from "../shared/ContextPanel/CollapsibleContextPanel";
 import { RunDetails } from "./RunDetails";
+import { RunToolbar } from "./RunToolbar";
 
 const GRID_SIZE = 10;
 
@@ -37,6 +38,7 @@ const PipelineRunPage = () => {
           <BlockStack fill className="flex-1">
             <FlowCanvas {...flowConfig} readOnly>
               <MiniMap position="bottom-left" pannable />
+              <RunToolbar />
               <FlowControls
                 className="ml-56! mb-6!"
                 config={flowConfig}

--- a/src/components/PipelineRun/RunToolbar.tsx
+++ b/src/components/PipelineRun/RunToolbar.tsx
@@ -1,0 +1,78 @@
+import { InlineStack } from "@/components/ui/layout";
+import { useCheckComponentSpecFromPath } from "@/hooks/useCheckComponentSpecFromPath";
+import { useUserDetails } from "@/hooks/useUserDetails";
+import { cn } from "@/lib/utils";
+import { useComponentSpec } from "@/providers/ComponentSpecProvider";
+import { useExecutionData } from "@/providers/ExecutionDataProvider";
+import {
+  countInProgressFromStats,
+  flattenExecutionStatusStats,
+  isExecutionComplete,
+} from "@/utils/executionStatus";
+
+import { ViewYamlButton } from "../shared/Buttons/ViewYamlButton";
+import { CancelPipelineRunButton } from "./components/CancelPipelineRunButton";
+import { ClonePipelineButton } from "./components/ClonePipelineButton";
+import { InspectPipelineButton } from "./components/InspectPipelineButton";
+import { RerunPipelineButton } from "./components/RerunPipelineButton";
+
+export const RunToolbar = () => {
+  const { componentSpec, currentSubgraphPath } = useComponentSpec();
+  const { rootState: state, runId, metadata } = useExecutionData();
+  const { data: currentUserDetails } = useUserDetails();
+
+  const editorRoute = componentSpec.name
+    ? `/editor/${encodeURIComponent(componentSpec.name)}`
+    : "";
+
+  const canAccessEditorSpec = useCheckComponentSpecFromPath(
+    editorRoute,
+    !componentSpec.name,
+  );
+
+  const isRunCreator =
+    currentUserDetails?.id && metadata?.created_by === currentUserDetails.id;
+
+  if (!componentSpec || !state) {
+    return null;
+  }
+
+  const executionStatusStats =
+    metadata?.execution_status_stats ??
+    flattenExecutionStatusStats(state.child_execution_status_stats);
+
+  const isInProgress = countInProgressFromStats(executionStatusStats) > 0;
+  const isComplete = isExecutionComplete(executionStatusStats);
+
+  const isViewingSubgraph = currentSubgraphPath.length > 1;
+
+  return (
+    <InlineStack
+      gap="2"
+      className={cn(
+        "fixed left-0 p-2 z-50 bg-background border rounded-br-lg",
+        isViewingSubgraph ? "top-23" : "top-14",
+      )}
+    >
+      <ViewYamlButton componentSpec={componentSpec} displayLabel="View" />
+
+      {canAccessEditorSpec && componentSpec.name && (
+        <InspectPipelineButton pipelineName={componentSpec.name} showLabel />
+      )}
+
+      <ClonePipelineButton
+        componentSpec={componentSpec}
+        runId={runId}
+        showLabel
+      />
+
+      {isInProgress && isRunCreator && (
+        <CancelPipelineRunButton runId={runId} showLabel />
+      )}
+
+      {isComplete && (
+        <RerunPipelineButton componentSpec={componentSpec} showLabel />
+      )}
+    </InlineStack>
+  );
+};

--- a/src/components/PipelineRun/components/CancelPipelineRunButton.tsx
+++ b/src/components/PipelineRun/components/CancelPipelineRunButton.tsx
@@ -1,9 +1,9 @@
 import { useMutation } from "@tanstack/react-query";
-import { CircleSlash, CircleX } from "lucide-react";
 import { useCallback, useState } from "react";
 
 import TooltipButton from "@/components/shared/Buttons/TooltipButton";
 import ConfirmationDialog from "@/components/shared/Dialogs/ConfirmationDialog";
+import { Icon } from "@/components/ui/icon";
 import { Spinner } from "@/components/ui/spinner";
 import useToastNotification from "@/hooks/useToastNotification";
 import { useBackend } from "@/providers/BackendProvider";
@@ -11,10 +11,12 @@ import { cancelPipelineRun } from "@/services/pipelineRunService";
 
 interface CancelPipelineRunButtonProps {
   runId: string | null | undefined;
+  showLabel?: boolean;
 }
 
 export const CancelPipelineRunButton = ({
   runId,
+  showLabel,
 }: CancelPipelineRunButtonProps) => {
   const { backendUrl, available } = useBackend();
   const notify = useToastNotification();
@@ -66,7 +68,8 @@ export const CancelPipelineRunButton = ({
   if (isSuccess) {
     return (
       <TooltipButton disabled tooltip="Run cancelled">
-        <CircleSlash className="w-4 h-4" />
+        <Icon name="CircleSlash" />
+        {showLabel && "Cancelled"}
       </TooltipButton>
     );
   }
@@ -84,9 +87,10 @@ export const CancelPipelineRunButton = ({
           <Spinner className="mr-2" />
         ) : (
           <div className="flex items-center gap-2">
-            <CircleX className="w-4 h-4" />
+            <Icon name="CircleX" />
           </div>
         )}
+        {showLabel && "Cancel"}
       </TooltipButton>
 
       <ConfirmationDialog

--- a/src/components/PipelineRun/components/ClonePipelineButton.tsx
+++ b/src/components/PipelineRun/components/ClonePipelineButton.tsx
@@ -14,11 +14,13 @@ import { extractTaskArguments } from "@/utils/nodes/taskArguments";
 type ClonePipelineButtonProps = {
   componentSpec: ComponentSpec;
   runId?: string | null;
+  showLabel?: boolean;
 };
 
 export const ClonePipelineButton = ({
   componentSpec,
   runId,
+  showLabel,
 }: ClonePipelineButtonProps) => {
   const navigate = useNavigate();
   const notify = useToastNotification();
@@ -62,6 +64,7 @@ export const ClonePipelineButton = ({
       data-testid="clone-pipeline-run-button"
     >
       <Icon name="CopyPlus" />
+      {showLabel && "Clone"}
     </TooltipButton>
   );
 };

--- a/src/components/PipelineRun/components/InspectPipelineButton.tsx
+++ b/src/components/PipelineRun/components/InspectPipelineButton.tsx
@@ -6,10 +6,12 @@ import { Icon } from "@/components/ui/icon";
 
 type InspectPipelineButtonProps = {
   pipelineName: string;
+  showLabel?: boolean;
 };
 
 export const InspectPipelineButton = ({
   pipelineName,
+  showLabel,
 }: InspectPipelineButtonProps) => {
   const navigate = useNavigate();
 
@@ -25,6 +27,7 @@ export const InspectPipelineButton = ({
       data-testid="inspect-pipeline-button"
     >
       <Icon name="Network" className="rotate-270" />
+      {showLabel && "Inspect"}
     </TooltipButton>
   );
 };

--- a/src/components/PipelineRun/components/RerunPipelineButton.tsx
+++ b/src/components/PipelineRun/components/RerunPipelineButton.tsx
@@ -1,12 +1,12 @@
 import { useMutation } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
-import { RefreshCcw } from "lucide-react";
 import { useCallback } from "react";
 
 import { isAuthorizationRequired } from "@/components/shared/Authentication/helpers";
 import { useAuthLocalStorage } from "@/components/shared/Authentication/useAuthLocalStorage";
 import { useAwaitAuthorization } from "@/components/shared/Authentication/useAwaitAuthorization";
 import TooltipButton from "@/components/shared/Buttons/TooltipButton";
+import { Icon } from "@/components/ui/icon";
 import useToastNotification from "@/hooks/useToastNotification";
 import { useBackend } from "@/providers/BackendProvider";
 import { useExecutionDataOptional } from "@/providers/ExecutionDataProvider";
@@ -17,10 +17,12 @@ import { submitPipelineRun } from "@/utils/submitPipeline";
 
 type RerunPipelineButtonProps = {
   componentSpec: ComponentSpec;
+  showLabel?: boolean;
 };
 
 export const RerunPipelineButton = ({
   componentSpec,
+  showLabel,
 }: RerunPipelineButtonProps) => {
   const { backendUrl } = useBackend();
   const navigate = useNavigate();
@@ -80,7 +82,8 @@ export const RerunPipelineButton = ({
       disabled={isPending}
       data-testid="rerun-pipeline-button"
     >
-      <RefreshCcw className="w-4 h-4" />
+      <Icon name="RefreshCcw" />
+      {showLabel && "Rerun"}
     </TooltipButton>
   );
 };

--- a/src/components/shared/Buttons/ActionButton.tsx
+++ b/src/components/shared/Buttons/ActionButton.tsx
@@ -1,24 +1,31 @@
 import { type ReactNode } from "react";
 
 import { Icon, type IconName } from "@/components/ui/icon";
+import { Paragraph } from "@/components/ui/typography";
 
 import TooltipButton from "./TooltipButton";
 
+type IconOrChildren =
+  | { icon: IconName; children?: never }
+  | { children: ReactNode; icon?: never };
+
+type AlwaysTooltipOrLabel =
+  | { tooltip: string; label?: string }
+  | { tooltip?: string; label: string };
+
 type ActionButtonProps = {
-  label: string;
   destructive?: boolean;
   disabled?: boolean;
   onClick: () => void;
   className?: string;
-} & (
-  | { icon: IconName; children?: never }
-  | { children: ReactNode; icon?: never }
-);
+} & IconOrChildren &
+  AlwaysTooltipOrLabel;
 
 export const ActionButton = ({
-  label,
+  tooltip,
   destructive,
   disabled,
+  label,
   onClick,
   className,
   icon,
@@ -26,14 +33,15 @@ export const ActionButton = ({
 }: ActionButtonProps) => {
   return (
     <TooltipButton
-      data-testid={`action-${label}`}
+      data-testid={`action-${label ?? tooltip}`}
       variant={destructive ? "destructive" : "outline"}
-      tooltip={label}
+      tooltip={tooltip}
       onClick={onClick}
       disabled={disabled}
       className={className}
     >
       {children === undefined && icon ? <Icon name={icon} /> : children}
+      {label && <Paragraph>{label}</Paragraph>}
     </TooltipButton>
   );
 };

--- a/src/components/shared/Buttons/ViewYamlButton.tsx
+++ b/src/components/shared/Buttons/ViewYamlButton.tsx
@@ -9,13 +9,17 @@ import { getComponentName } from "@/utils/getComponentName";
 import TaskImplementation from "../TaskDetails/Implementation";
 import { ActionButton } from "./ActionButton";
 
-type ViewYamlButtonProps =
+type ViewYamlButtonProps = {
+  displayLabel?: string;
+} & (
   | { componentRef: HydratedComponentReference; componentSpec?: never }
-  | { componentSpec: ComponentSpec; componentRef?: never };
+  | { componentSpec: ComponentSpec; componentRef?: never }
+);
 
 export const ViewYamlButton = ({
   componentRef,
   componentSpec,
+  displayLabel,
 }: ViewYamlButtonProps) => {
   const [showCodeViewer, setShowCodeViewer] = useState(false);
 
@@ -34,9 +38,10 @@ export const ViewYamlButton = ({
   return (
     <>
       <ActionButton
-        label="View YAML"
+        tooltip="View YAML"
         icon="FileCodeCorner"
         onClick={handleClick}
+        label={displayLabel}
       />
 
       {showCodeViewer && (


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

Follows #1628 to add a new Run Actions toolbar in the top left of the pipeline run view. This allows consistent access to pipeline-level actions (such as cancel, clone, rerun) in lieu of using the top nave or context panel.

TBD if we will keep the existing actions defined in the context panel. Removal will be scheduled for a future PR.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

Supersedes #1656 

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] New feature
- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

![image.png](https://app.graphite.com/user-attachments/assets/a6b2746a-96c4-4e87-826c-b498e5e9f246.png)

![image.png](https://app.graphite.com/user-attachments/assets/ccce18b3-10bc-4f07-af08-5dd9402fddc6.png)

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

Confirm that the pipeline run actions are displayed in the top left of the run view.
Confirm that they work as expected.

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
