### PR TITLE
Dim unconnected nodes when edges are selected

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/IONode/IONode.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/IONode/IONode.tsx
@@ -49,7 +49,10 @@ const IONode = ({ id, type, data, selected = false }: IONodeProps) => {
 
   const edges = useEdges();
   const { setEdges } = useReactFlow();
-  const isConnectedToSelectedEdge = useEdgeSelectionHighlight(id);
+  const { isConnectedToSelectedEdge, hasAnySelectedEdge } =
+    useEdgeSelectionHighlight(id);
+
+  const isDimmed = hasAnySelectedEdge && !isConnectedToSelectedEdge;
 
   const isInput = type === "input";
   const isOutput = type === "output";
@@ -182,7 +185,13 @@ const IONode = ({ id, type, data, selected = false }: IONodeProps) => {
   const handleId = id === GHOST_NODE_ID ? getGhostHandleId() : undefined;
 
   return (
-    <Card className={cn("border-2 max-w-[300px] p-0", borderColor)}>
+    <Card
+      className={cn(
+        "border-2 max-w-[300px] p-0 transition-opacity duration-200",
+        borderColor,
+        isDimmed && "opacity-40",
+      )}
+    >
       <CardHeader className="px-2 py-2.5">
         <CardTitle className="wrap-break-word text-sm">{data.label}</CardTitle>
       </CardHeader>

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNode.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNode.tsx
@@ -1,6 +1,8 @@
 import { type NodeProps } from "@xyflow/react";
 import { memo, useMemo } from "react";
 
+import { useEdgeSelectionHighlight } from "@/hooks/useEdgeSelectionHighlight";
+import { cn } from "@/lib/utils";
 import { useExecutionDataOptional } from "@/providers/ExecutionDataProvider";
 import { TaskNodeProvider } from "@/providers/TaskNodeProvider";
 import type { TaskNodeData } from "@/types/taskNode";
@@ -9,7 +11,7 @@ import { isCacheDisabled } from "@/utils/cache";
 import { StatusIndicator } from "./StatusIndicator";
 import { TaskNodeCard } from "./TaskNodeCard";
 
-const TaskNode = ({ data, selected }: NodeProps) => {
+const TaskNode = ({ data, selected, id }: NodeProps) => {
   const executionData = useExecutionDataOptional();
 
   const typedData = useMemo(() => data as TaskNodeData, [data]);
@@ -21,12 +23,22 @@ const TaskNode = ({ data, selected }: NodeProps) => {
 
   const disabledCache = isCacheDisabled(typedData.taskSpec);
 
+  const { isConnectedToSelectedEdge, hasAnySelectedEdge } =
+    useEdgeSelectionHighlight(id);
+
   return (
     <TaskNodeProvider data={typedData} selected={selected} status={status}>
-      {!!status && (
-        <StatusIndicator status={status} disabledCache={disabledCache} />
-      )}
-      <TaskNodeCard />
+      <div
+        className={cn(
+          "transition-opacity duration-200",
+          hasAnySelectedEdge && !isConnectedToSelectedEdge && "opacity-40",
+        )}
+      >
+        {!!status && (
+          <StatusIndicator status={status} disabledCache={disabledCache} />
+        )}
+        <TaskNodeCard />
+      </div>
     </TaskNodeProvider>
   );
 };

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeCard.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeCard.tsx
@@ -66,7 +66,7 @@ const TaskNodeCard = () => {
   const { name, state, nodeId, taskSpec, taskId } = taskNode;
   const { dimensions, selected, highlighted, readOnly } = state;
 
-  const isConnectedToSelectedEdge = useEdgeSelectionHighlight(nodeId);
+  const { isConnectedToSelectedEdge } = useEdgeSelectionHighlight(nodeId);
 
   const isSubgraphNode = useMemo(() => {
     if (!taskSpec) return false;

--- a/src/hooks/useEdgeSelectionHighlight.ts
+++ b/src/hooks/useEdgeSelectionHighlight.ts
@@ -4,11 +4,12 @@ export function useEdgeSelectionHighlight(nodeId: string) {
   const edges = useEdges();
 
   const selectedEdges = edges.filter((edge) => edge.selected);
+  const hasAnySelectedEdge = selectedEdges.length > 0;
   const isConnectedToSelectedEdge =
-    selectedEdges.length > 0 &&
+    hasAnySelectedEdge &&
     selectedEdges.some(
       (edge) => edge.source === nodeId || edge.target === nodeId,
     );
 
-  return isConnectedToSelectedEdge;
+  return { isConnectedToSelectedEdge, hasAnySelectedEdge };
 }


### PR DESCRIPTION
## Description

Implemented visual dimming for nodes and handles that are not connected to selected edges in the flow canvas. When an edge is selected, nodes and handles that are not part of that connection will be dimmed to 40% opacity, creating a visual focus on the selected connection path.

## Type of Change

- [x] Improvement
- [x] New feature

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Screenshots (if applicable)

N/A![Screenshot 2026-01-19 at 4.35.35 PM.png](https://app.graphite.com/user-attachments/assets/094f817d-1655-46ab-b514-0e6e7afcf95a.png)![Screenshot 2026-01-19 at 4.35.50 PM.png](https://app.graphite.com/user-attachments/assets/40884d4c-ae50-4f37-b270-e0a22ca7ec3d.png)![Screenshot 2026-01-19 at 4.36.20 PM.png](https://app.graphite.com/user-attachments/assets/25f3379d-c505-4c6e-b71a-5d056e075b32.png)







## Test Instructions

1. Open a flow with multiple connected nodes
2. Click on an edge to select it
3. Verify that nodes and handles not connected to the selected edge are dimmed
4. Verify that connected nodes and handles maintain full opacity
5. Deselect the edge and confirm all nodes return to full opacity

## Additional Comments

This change enhances the visual feedback when exploring connections in complex flows, making it easier to trace data paths through the pipeline.