### PR TITLE
chore: Refactoring of Preferences Dialog

### DIFF
--- a/src/betaFlags.ts
+++ b/src/betaFlags.ts
@@ -1,4 +1,4 @@
-import type { BetaFlag } from "@/types/betaFlags";
+import type { BetaFlag } from "@/types/configuration";
 
 const isRemoteComponentLibraryEnabled =
   import.meta.env.VITE_DEFAULT_REMOTE_COMPONENT_LIBRARY_BETA === "true";

--- a/src/components/shared/Settings/PersonalPreferencesDialog.tsx
+++ b/src/components/shared/Settings/PersonalPreferencesDialog.tsx
@@ -9,8 +9,10 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { Switch } from "@/components/ui/switch";
+import { BlockStack } from "@/components/ui/layout";
+import { Paragraph } from "@/components/ui/typography";
 
+import { Setting } from "./Setting";
 import { useBetaFlagsReducer } from "./useBetaFlagReducer";
 
 interface PersonalPreferencesDialogProps {
@@ -43,24 +45,16 @@ export function PersonalPreferencesDialog({
           Configure your personal preferences.
         </DialogDescription>
 
-        <div className="flex flex-col gap-4">
-          <p className="font-semibold">Beta Features</p>
+        <BlockStack gap="4">
+          <Paragraph weight="semibold">Beta Features</Paragraph>
           {betaFlags.map((flag) => (
-            <div key={flag.name} className="flex items-center gap-2">
-              <Switch
-                checked={flag.enabled}
-                onCheckedChange={(checked) => handleSetFlag(flag.key, checked)}
-                data-testid={`${flag.key}-switch`}
-              />
-              <div className="flex flex-col items-start">
-                <span>{flag.name}</span>
-                <p className="text-sm text-muted-foreground">
-                  {flag.description}
-                </p>
-              </div>
-            </div>
+            <Setting
+              key={flag.key}
+              setting={flag}
+              onChange={(enabled) => handleSetFlag(flag.key, enabled)}
+            />
           ))}
-        </div>
+        </BlockStack>
         <DialogFooter>
           <DialogClose asChild>
             <Button

--- a/src/components/shared/Settings/Setting.tsx
+++ b/src/components/shared/Settings/Setting.tsx
@@ -1,0 +1,27 @@
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Switch } from "@/components/ui/switch";
+import { Paragraph } from "@/components/ui/typography";
+import type { Flag } from "@/types/configuration";
+
+interface SettingProps {
+  setting: Flag;
+  onChange?: (enabled: boolean) => void;
+}
+
+export function Setting({ setting, onChange }: SettingProps) {
+  return (
+    <InlineStack gap="2" blockAlign="center" key={setting.name} wrap="nowrap">
+      <Switch
+        checked={setting.enabled}
+        onCheckedChange={onChange}
+        data-testid={`${setting.key}-switch`}
+      />
+      <BlockStack>
+        <Paragraph>{setting.name}</Paragraph>
+        <Paragraph size="sm" tone="subdued">
+          {setting.description}
+        </Paragraph>
+      </BlockStack>
+    </InlineStack>
+  );
+}

--- a/src/components/shared/Settings/tests/useBetaFlagReducer.test.ts
+++ b/src/components/shared/Settings/tests/useBetaFlagReducer.test.ts
@@ -1,7 +1,7 @@
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import type { BetaFlags } from "@/types/betaFlags";
+import type { BetaFlags } from "@/types/configuration";
 
 import { useBetaFlagsReducer } from "../useBetaFlagReducer";
 

--- a/src/components/shared/Settings/tests/useBetaFlags.test.ts
+++ b/src/components/shared/Settings/tests/useBetaFlags.test.ts
@@ -60,12 +60,12 @@ describe("useBetaFlagValue", () => {
     expect(result.current).toBe(false);
   });
 
-  it("should react to localStorage changes and update the returned value", () => {
+  it("should react to localStorage changes and update the returned value", async () => {
     const { result } = renderHook(() => useBetaFlagValue("codeViewer" as any));
 
     expect(result.current).toBe(false);
 
-    act(() => {
+    await act(async () => {
       localStorage.setItem("betaFlags", JSON.stringify({ codeViewer: true }));
       // Manually dispatch storage event to simulate the behavior from getStorage
       window.dispatchEvent(
@@ -80,7 +80,7 @@ describe("useBetaFlagValue", () => {
     expect(result.current).toBe(true);
   });
 
-  it("should react to localStorage changes and update from true to false", () => {
+  it("should react to localStorage changes and update from true to false", async () => {
     // Start with flag set to true
     localStorage.setItem("betaFlags", JSON.stringify({ codeViewer: true }));
 
@@ -88,7 +88,7 @@ describe("useBetaFlagValue", () => {
 
     expect(result.current).toBe(true);
 
-    act(() => {
+    await act(async () => {
       localStorage.setItem("betaFlags", JSON.stringify({ codeViewer: false }));
       // Manually dispatch storage event
       window.dispatchEvent(

--- a/src/components/shared/Settings/useBetaFlagReducer.ts
+++ b/src/components/shared/Settings/useBetaFlagReducer.ts
@@ -1,6 +1,6 @@
 import { useEffect, useReducer } from "react";
 
-import type { BetaFlag, BetaFlags } from "@/types/betaFlags";
+import type { BetaFlags, Flag } from "@/types/configuration";
 
 import { useBetaFlags } from "./useBetaFlags";
 
@@ -13,7 +13,7 @@ interface SetFlagAction {
 }
 
 type Action = SetFlagAction;
-type State = (BetaFlag & { key: string; enabled: boolean })[];
+type State = Flag[];
 
 export function useBetaFlagsReducer(betaFlags: BetaFlags) {
   const { getFlag, setFlag, getFlags, removeFlag } = useBetaFlags();

--- a/src/components/shared/Settings/useBetaFlags.ts
+++ b/src/components/shared/Settings/useBetaFlags.ts
@@ -40,7 +40,7 @@ export function useBetaFlags() {
     subscribe: (listener: () => void) => {
       function handleStorageChange(event: StorageEvent) {
         if (event.key === "betaFlags") {
-          listener();
+          queueMicrotask(listener);
         }
       }
       window.addEventListener("storage", handleStorageChange);

--- a/src/types/configuration.ts
+++ b/src/types/configuration.ts
@@ -5,3 +5,8 @@ export interface BetaFlag {
 }
 
 export type BetaFlags = Record<string, BetaFlag>;
+
+export type Flag = BetaFlag & {
+  key: string;
+  enabled: boolean;
+};


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Groundwork for splitting preferences from beta flags.

Also, fix a longstanding React Error that would show in the console whenever a beta flag was toggled. Fix is to use `queueMicrotask(listener)`.

No change to UI.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Cleanup/Refactor

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
