### PR TITLE
chore: Split Settings from Beta Flags

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,6 +67,7 @@
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^25.0.9",
         "@types/react": "^19.2.9",
@@ -4275,6 +4276,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tybys/wasm-util": {

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^25.0.9",
     "@types/react": "^19.2.9",
@@ -128,10 +129,10 @@
     "jsdom": "^27.4.0",
     "knip": "^5.82.1",
     "prettier": "^3.8.1",
+    "tsx": "^4.21.0",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.53.1",
     "vite": "^7.3.1",
-    "vitest": "^3.0.5",
-    "tsx": "^4.21.0"
+    "vitest": "^3.0.5"
   }
 }

--- a/src/betaFlags.ts
+++ b/src/betaFlags.ts
@@ -9,12 +9,14 @@ export const ExistingBetaFlags = {
     description:
       "Highlight the tasks on the Pipeline canvas when the component is hovered over in the component library.",
     default: false,
+    category: "beta",
   } as BetaFlag,
 
   ["remote-component-library-search"]: {
     name: "Published Components Library",
     description: "Enable the Published Components Library feature.",
     default: isRemoteComponentLibraryEnabled,
+    category: "beta",
   } as BetaFlag,
 
   ["github-component-library"]: {
@@ -22,12 +24,14 @@ export const ExistingBetaFlags = {
     description:
       "Enable the GitHub Component Library. All lib folders will be based on GitHub components",
     default: false,
+    category: "beta",
   } as BetaFlag,
 
   ["redirect-on-new-pipeline-run"]: {
     name: "Redirect on new pipeline run",
     description: "Automatically open a new tab after starting a new execution.",
     default: false,
+    category: "setting",
   } as BetaFlag,
 
   ["created-by-me-default"]: {
@@ -35,6 +39,7 @@ export const ExistingBetaFlags = {
     description:
       "Automatically select the 'Created by me' filter when viewing the pipeline run list.",
     default: false,
+    category: "setting",
   } as BetaFlag,
 
   ["in-app-component-editor"]: {
@@ -42,6 +47,7 @@ export const ExistingBetaFlags = {
     description:
       "Enable the in-app component editor for creating and editing pipeline components.",
     default: true,
+    category: "beta",
   } as BetaFlag,
 
   ["partial-selection"]: {
@@ -49,5 +55,6 @@ export const ExistingBetaFlags = {
     description:
       "Allow nodes to be selected when partially covered by the selection box. Use Shift+drag for full selection, or Shift+Cmd+drag (Shift+Ctrl on Windows) for partial selection.",
     default: false,
+    category: "beta",
   } as BetaFlag,
 };

--- a/src/components/shared/Settings/BetaFeatures.tsx
+++ b/src/components/shared/Settings/BetaFeatures.tsx
@@ -1,0 +1,28 @@
+import { BlockStack } from "@/components/ui/layout";
+import { Paragraph } from "@/components/ui/typography";
+import type { Flag } from "@/types/configuration";
+
+import { Setting } from "./Setting";
+
+interface BetaFeaturesProps {
+  betaFlags: Flag[];
+  onChange: (key: string, enabled: boolean) => void;
+}
+
+export function BetaFeatures({ betaFlags, onChange }: BetaFeaturesProps) {
+  return (
+    <BlockStack gap="4">
+      <Paragraph weight="semibold">Beta Features</Paragraph>
+      {betaFlags.length === 0 && (
+        <Paragraph>No beta features available.</Paragraph>
+      )}
+      {betaFlags.map((flag) => (
+        <Setting
+          key={flag.key}
+          setting={flag}
+          onChange={(enabled) => onChange(flag.key, enabled)}
+        />
+      ))}
+    </BlockStack>
+  );
+}

--- a/src/components/shared/Settings/PersonalPreferencesDialog.tsx
+++ b/src/components/shared/Settings/PersonalPreferencesDialog.tsx
@@ -9,10 +9,10 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { BlockStack } from "@/components/ui/layout";
-import { Paragraph } from "@/components/ui/typography";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
-import { Setting } from "./Setting";
+import { BetaFeatures } from "./BetaFeatures";
+import { Settings } from "./Settings";
 import { useBetaFlagsReducer } from "./useBetaFlagReducer";
 
 interface PersonalPreferencesDialogProps {
@@ -24,11 +24,18 @@ export function PersonalPreferencesDialog({
   open,
   setOpen,
 }: PersonalPreferencesDialogProps) {
-  const [betaFlags, dispatch] = useBetaFlagsReducer(ExistingBetaFlags);
+  const [allFlags, dispatch] = useBetaFlagsReducer(ExistingBetaFlags);
 
   const handleSetFlag = (flag: string, enabled: boolean) => {
     dispatch({ type: "setFlag", payload: { key: flag, enabled } });
   };
+
+  const betaFlags = Object.values(allFlags).filter(
+    (flag) => flag.category === "beta",
+  );
+  const settings = Object.values(allFlags).filter(
+    (flag) => flag.category === "setting",
+  );
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
@@ -45,16 +52,19 @@ export function PersonalPreferencesDialog({
           Configure your personal preferences.
         </DialogDescription>
 
-        <BlockStack gap="4">
-          <Paragraph weight="semibold">Beta Features</Paragraph>
-          {betaFlags.map((flag) => (
-            <Setting
-              key={flag.key}
-              setting={flag}
-              onChange={(enabled) => handleSetFlag(flag.key, enabled)}
-            />
-          ))}
-        </BlockStack>
+        <Tabs defaultValue="settings" className="w-full gap-4">
+          <TabsList>
+            <TabsTrigger value="settings">Settings</TabsTrigger>
+            <TabsTrigger value="betas">Beta Features</TabsTrigger>
+          </TabsList>
+          <TabsContent value="settings">
+            <Settings settings={settings} onChange={handleSetFlag} />
+          </TabsContent>
+          <TabsContent value="betas">
+            <BetaFeatures betaFlags={betaFlags} onChange={handleSetFlag} />
+          </TabsContent>
+        </Tabs>
+
         <DialogFooter>
           <DialogClose asChild>
             <Button

--- a/src/components/shared/Settings/Settings.tsx
+++ b/src/components/shared/Settings/Settings.tsx
@@ -1,0 +1,26 @@
+import { BlockStack } from "@/components/ui/layout";
+import { Paragraph } from "@/components/ui/typography";
+import type { Flag } from "@/types/configuration";
+
+import { Setting } from "./Setting";
+
+interface SettingsProps {
+  settings: Flag[];
+  onChange: (key: string, enabled: boolean) => void;
+}
+
+export function Settings({ settings, onChange }: SettingsProps) {
+  return (
+    <BlockStack gap="4">
+      <Paragraph weight="semibold">Settings</Paragraph>
+      {settings.length === 0 && <Paragraph>No settings available.</Paragraph>}
+      {settings.map((setting) => (
+        <Setting
+          key={setting.key}
+          setting={setting}
+          onChange={(enabled) => onChange(setting.key, enabled)}
+        />
+      ))}
+    </BlockStack>
+  );
+}

--- a/src/components/shared/Settings/tests/useBetaFlagReducer.test.ts
+++ b/src/components/shared/Settings/tests/useBetaFlagReducer.test.ts
@@ -20,16 +20,19 @@ describe("useBetaFlagsReducer", () => {
       name: "Feature 1",
       description: "First feature flag",
       default: false,
+      category: "beta",
     },
     feature2: {
       name: "Feature 2",
       description: "Second feature flag",
       default: true,
+      category: "beta",
     },
     feature3: {
       name: "Feature 3",
       description: "Third feature flag",
       default: false,
+      category: "setting",
     },
   };
 
@@ -44,6 +47,7 @@ describe("useBetaFlagsReducer", () => {
       description: "First feature flag",
       enabled: false,
       default: false,
+      category: "beta",
     });
     expect(state[1]).toEqual({
       key: "feature2",
@@ -51,6 +55,7 @@ describe("useBetaFlagsReducer", () => {
       description: "Second feature flag",
       enabled: true, // Should use default value
       default: true,
+      category: "beta",
     });
     expect(state[2]).toEqual({
       key: "feature3",
@@ -58,6 +63,7 @@ describe("useBetaFlagsReducer", () => {
       description: "Third feature flag",
       enabled: false,
       default: false,
+      category: "setting",
     });
   });
 

--- a/src/types/configuration.ts
+++ b/src/types/configuration.ts
@@ -2,6 +2,7 @@ export interface BetaFlag {
   name: string;
   description: string;
   default: boolean;
+  category: "beta" | "setting";
 }
 
 export type BetaFlags = Record<string, BetaFlag>;

--- a/tests/e2e/published-componentlib.spec.ts
+++ b/tests/e2e/published-componentlib.spec.ts
@@ -35,6 +35,8 @@ test.describe("Published Component Library", () => {
     const dialog = page.getByTestId("personal-preferences-dialog");
     await expect(dialog).toBeVisible();
 
+    await dialog.getByRole("tab", { name: "Beta Features" }).click();
+
     const switchElement = dialog.getByTestId(
       "remote-component-library-search-switch",
     );

--- a/tests/e2e/published-componentlifecycle.spec.ts
+++ b/tests/e2e/published-componentlifecycle.spec.ts
@@ -33,6 +33,8 @@ test.describe("Published Component Library - Lifecycle", () => {
     const dialog = page.getByTestId("personal-preferences-dialog");
     await expect(dialog).toBeVisible();
 
+    await dialog.getByRole("tab", { name: "Beta Features" }).click();
+
     const switchElement = dialog.getByTestId(
       "remote-component-library-search-switch",
     );


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Splits long-term settings and configurations from temporary beta flags. The two are now separated by a new tab system in the configuration dialog. This is achieved by a new `category` field on the `BetaFlag` type.

Notes:
- I don't like, at all, that the dialog changes height and the tabs move around when switching. But this is an issue with our dialog component and so this PR is not the place to address that.
- I am also not a fan of settings still being defined and saved as beta flags and running via the beta flag code. A more generic name would be preferable. I may stack a PR on top to avoid overloading this PR with changes (since some files will need to be renamed)

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

Closes https://github.com/Shopify/oasis-frontend/issues/370

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Improvement
- [x] Cleanup/Refactor

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

![image.png](https://app.graphite.com/user-attachments/assets/9f8cc935-1d8f-4206-8434-27a7f935b421.png)

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

Confirm all settings & betas toggle & work as expected.

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
