### PR TITLE
Add URL-based filtering and React Compiler support

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -22,11 +22,22 @@ This is a React + TypeScript application for building and running Machine Learni
 ### React Patterns
 
 - Use functional components with hooks exclusively
-- Use proper dependency arrays in useEffect and useMemo
+- Use proper dependency arrays in useEffect
 - Follow the existing component structure
 - Do not use barrel exports
 - Use React 19 features and patterns
 - **Import modules from React**: `import module from react`. Do not use inline `React.[module]`
+
+### React Compiler
+
+This project uses **React Compiler** for automatic memoization. Follow these rules:
+
+- **DO NOT use `useMemo`, `useCallback`, or `React.memo`** in new components - React Compiler handles memoization automatically
+- **When creating a new component file**, add its directory or file path to `react-compiler.config.js` in the `REACT_COMPILER_ENABLED_DIRS` array
+- For new files in directories already in the allow list (e.g., `src/components/Home`, `src/routes`), no action needed
+- If adding a file in a new directory, add the directory path to the config
+- Existing components with `useMemo`/`useCallback` should NOT be refactored unless explicitly requested
+
 
 ### File Structure & Imports
 

--- a/src/components/Home/PipelineSection/usePipelineFilters.ts
+++ b/src/components/Home/PipelineSection/usePipelineFilters.ts
@@ -1,10 +1,8 @@
-import { useState } from "react";
-
 import type { PipelineRunSummary } from "@/services/pipelineRunService";
 import type { ComponentFileEntry } from "@/utils/componentStore";
 
 export type SortField = "name" | "modified" | "lastRun";
-type SortDirection = "asc" | "desc";
+export type SortDirection = "asc" | "desc";
 
 export interface DateRange {
   from: Date | undefined;
@@ -25,13 +23,18 @@ interface PipelineWithRunInfo {
   runSummary: PipelineRunSummary | null;
 }
 
-const DEFAULT_FILTERS: PipelineFilters = {
+export const DEFAULT_FILTERS: PipelineFilters = {
   searchQuery: "",
   sortField: "modified",
   sortDirection: "desc",
   dateRange: undefined,
   hasRunsOnly: false,
 };
+
+interface UsePipelineFiltersOptions {
+  filters: PipelineFilters;
+  onFiltersChange: (filters: PipelineFilters) => void;
+}
 
 function isWithinDateRange(date: Date, range: DateRange | undefined): boolean {
   if (!range || !range.from) return true;
@@ -90,8 +93,9 @@ function comparePipelines(
 export function usePipelineFilters(
   pipelines: Map<string, ComponentFileEntry>,
   runSummaries: Map<string, PipelineRunSummary>,
+  options: UsePipelineFiltersOptions,
 ) {
-  const [filters, setFilters] = useState<PipelineFilters>(DEFAULT_FILTERS);
+  const { filters, onFiltersChange } = options;
 
   const pipelinesWithRunInfo: PipelineWithRunInfo[] = Array.from(
     pipelines.entries(),
@@ -143,14 +147,14 @@ export function usePipelineFilters(
   const filterKey = `${filters.searchQuery}-${filters.sortField}-${filters.sortDirection}-${filters.dateRange?.from?.toISOString()}-${filters.dateRange?.to?.toISOString()}-${filters.hasRunsOnly}`;
 
   const clearFilters = () => {
-    setFilters(DEFAULT_FILTERS);
+    onFiltersChange(DEFAULT_FILTERS);
   };
 
   const updateFilter = <K extends keyof PipelineFilters>(
     key: K,
     value: PipelineFilters[K],
   ) => {
-    setFilters((prev) => ({ ...prev, [key]: value }));
+    onFiltersChange({ ...filters, [key]: value });
   };
 
   return {

--- a/src/routes/Home/Home.tsx
+++ b/src/routes/Home/Home.tsx
@@ -1,18 +1,44 @@
-import { useRef, useState } from "react";
+import { useNavigate, useSearch } from "@tanstack/react-router";
+import { useRef } from "react";
 
 import { PipelineSection, RunSection } from "@/components/Home";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  type HomeSearchParams,
+  type HomeTab,
+  indexRoute,
+} from "@/routes/router";
 
 const Home = () => {
-  const [activeTab, setActiveTab] = useState("runs");
+  const navigate = useNavigate({ from: indexRoute.fullPath });
+  const search = useSearch({ strict: false }) as Partial<HomeSearchParams>;
+  const activeTab = search.tab ?? "runs";
+
   const handleTabSelect = (value: string) => {
-    setActiveTab(value);
+    const newTab = value as HomeTab;
+    navigate({
+      search: (prev) => ({
+        ...prev,
+        tab: newTab,
+        // Clear pipeline filters when switching to runs tab
+        ...(newTab === "runs" && {
+          q: undefined,
+          sort: undefined,
+          dir: undefined,
+          from: undefined,
+          to: undefined,
+          hasRuns: undefined,
+        }),
+      }),
+    });
   };
 
   const handledPipelineRunsEmpty = useRef(false);
   const handlePipelineRunsEmpty = () => {
     if (!handledPipelineRunsEmpty.current) {
-      setActiveTab("pipelines");
+      navigate({
+        search: (prev) => ({ ...prev, tab: "pipelines" }),
+      });
       handledPipelineRunsEmpty.current = true;
     }
   };
@@ -23,7 +49,6 @@ const Home = () => {
         <h1 className="text-2xl font-bold">Pipelines</h1>
       </div>
       <Tabs
-        defaultValue="runs"
         className="w-full"
         value={activeTab}
         onValueChange={handleTabSelect}

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -27,6 +27,52 @@ declare module "@tanstack/react-router" {
 export const EDITOR_PATH = "/editor";
 export const RUNS_BASE_PATH = "/runs";
 export const QUICK_START_PATH = "/quick-start";
+
+// Home page search params types
+export type HomeTab = "runs" | "pipelines";
+export type SortField = "name" | "modified" | "lastRun";
+export type SortDirection = "asc" | "desc";
+
+export interface HomeSearchParams {
+  tab: HomeTab;
+  // Pipeline filters
+  q?: string;
+  sort?: SortField;
+  dir?: SortDirection;
+  from?: string;
+  to?: string;
+  hasRuns?: boolean;
+  // Run section params
+  page_token?: string;
+  filter?: string;
+}
+
+function validateHomeSearch(search: Record<string, unknown>): HomeSearchParams {
+  const tab = search.tab === "pipelines" ? "pipelines" : "runs";
+  const q = typeof search.q === "string" && search.q ? search.q : undefined;
+  const sort =
+    search.sort === "name" ||
+    search.sort === "modified" ||
+    search.sort === "lastRun"
+      ? search.sort
+      : undefined;
+  const dir =
+    search.dir === "asc" || search.dir === "desc" ? search.dir : undefined;
+  const from =
+    typeof search.from === "string" && search.from ? search.from : undefined;
+  const to = typeof search.to === "string" && search.to ? search.to : undefined;
+  const hasRuns =
+    search.hasRuns === "true" || search.hasRuns === true ? true : undefined;
+  // Run section params
+  const page_token =
+    typeof search.page_token === "string" && search.page_token
+      ? search.page_token
+      : undefined;
+  const filter = typeof search.filter === "string" ? search.filter : undefined;
+
+  return { tab, q, sort, dir, from, to, hasRuns, page_token, filter };
+}
+
 export const APP_ROUTES = {
   HOME: "/",
   QUICK_START: QUICK_START_PATH,
@@ -50,10 +96,11 @@ const mainLayout = createRoute({
   component: RootLayout,
 });
 
-const indexRoute = createRoute({
+export const indexRoute = createRoute({
   getParentRoute: () => mainLayout,
   path: APP_ROUTES.HOME,
   component: Home,
+  validateSearch: validateHomeSearch,
 });
 
 const quickStartRoute = createRoute({


### PR DESCRIPTION
## Description

Added URL persistence for pipeline filters on the Home page, allowing users to share filtered views via URLs. This PR implements:

1. Updated `.cursorrules` to document React Compiler usage and memoization guidelines
2. Added URL parameter support for pipeline filters (search query, sort field/direction, date range, etc.)
3. Refactored `usePipelineFilters` to accept initial filters and handle filter changes
4. Created type definitions for Home page search parameters
5. Implemented tab state persistence in URLs
6. Improved navigation between tabs while preserving appropriate filter states

## Type of Change

- [x] New feature
- [x] Improvement
- [x] Cleanup/Refactor

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Test Instructions

1. Navigate to the Home page and switch between "Runs" and "Pipelines" tabs
2. Apply various filters in the Pipelines tab (search, sort, date range)
3. Verify the URL updates with appropriate parameters
4. Copy the URL and open in a new tab to confirm filters are preserved
5. Test navigation between tabs and verify filter state is maintained correctly