### PR TITLE
Chore: rename BetaFlag core systems to just 'Flag'

### DIFF
--- a/src/components/Home/RunSection/RunSection.tsx
+++ b/src/components/Home/RunSection/RunSection.tsx
@@ -5,7 +5,7 @@ import { useEffect, useRef, useState } from "react";
 
 import type { ListPipelineJobsResponse } from "@/api/types.gen";
 import { InfoBox } from "@/components/shared/InfoBox";
-import { useBetaFlagValue } from "@/components/shared/Settings/useBetaFlags";
+import { useFlagValue } from "@/components/shared/Settings/useFlags";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -39,7 +39,7 @@ export const RunSection = ({ onEmptyList }: { onEmptyList?: () => void }) => {
   const navigate = useNavigate();
   const { pathname } = useLocation();
   const search = useSearch({ strict: false }) as RunSectionSearch;
-  const isCreatedByMeDefault = useBetaFlagValue("created-by-me-default");
+  const isCreatedByMeDefault = useFlagValue("created-by-me-default");
   const dataVersion = useRef(0);
 
   // Parse filter into a dictionary

--- a/src/components/shared/Dialogs/ComponentDetailsDialog.tsx
+++ b/src/components/shared/Dialogs/ComponentDetailsDialog.tsx
@@ -21,7 +21,7 @@ import { ComponentFavoriteToggle } from "../FavoriteComponentToggle";
 import { InfoBox } from "../InfoBox";
 import { PublishComponent } from "../ManageComponent/PublishComponent";
 import { PublishedComponentDetails } from "../ManageComponent/PublishedComponentDetails";
-import { useBetaFlagValue } from "../Settings/useBetaFlags";
+import { useFlagValue } from "../Settings/useFlags";
 import { withSuspenseWrapper } from "../SuspenseWrapper";
 import { TaskDetails, TaskImplementation, TaskIO } from "../TaskDetails";
 import { DialogContext } from "./dialog.context";
@@ -61,7 +61,7 @@ const ComponentDetailsDialogContentSkeleton = () => {
 
 const ComponentDetailsDialogContent = withSuspenseWrapper(
   ({ component, displayName }: ComponentDetailsProps) => {
-    const remoteComponentLibrarySearchEnabled = useBetaFlagValue(
+    const remoteComponentLibrarySearchEnabled = useFlagValue(
       "remote-component-library-search",
     );
 

--- a/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
@@ -48,7 +48,7 @@ import {
   updateSubgraphSpec,
 } from "@/utils/subgraphUtils";
 
-import { useBetaFlagValue } from "../../Settings/useBetaFlags";
+import { useFlagValue } from "../../Settings/useFlags";
 import { useNodesOverlay } from "../NodesOverlay/NodesOverlayProvider";
 import { getBulkUpdateConfirmationDetails } from "./ConfirmationDialogs/BulkUpdateConfirmationDialog";
 import { getDeleteConfirmationDetails } from "./ConfirmationDialogs/DeleteConfirmation";
@@ -135,7 +135,7 @@ const FlowCanvas = ({
   const { preserveIOSelectionOnSpecChange, resetPrevSpec } =
     useIOSelectionPersistence();
 
-  const isPartialSelectionEnabled = useBetaFlagValue("partial-selection");
+  const isPartialSelectionEnabled = useFlagValue("partial-selection");
 
   const store = useStoreApi();
   const { edges: specEdges, onEdgesChange } =

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeCard.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeCard.tsx
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { PublishedComponentBadge } from "@/components/shared/ManageComponent/PublishedComponentBadge";
 import { trimDigest } from "@/components/shared/ManageComponent/utils/digest";
-import { useBetaFlagValue } from "@/components/shared/Settings/useBetaFlags";
+import { useFlagValue } from "@/components/shared/Settings/useFlags";
 import TaskStatusBar from "@/components/shared/Status/TaskStatusBar";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Icon } from "@/components/ui/icon";
@@ -33,7 +33,7 @@ import { UpgradeNodePopover } from "./UpgradeNodePopover";
 
 const TaskNodeCard = () => {
   const navigate = useNavigate();
-  const isRemoteComponentLibrarySearchEnabled = useBetaFlagValue(
+  const isRemoteComponentLibrarySearchEnabled = useFlagValue(
     "remote-component-library-search",
   );
 

--- a/src/components/shared/ReactFlow/FlowSidebar/components/ComponentItem.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/components/ComponentItem.tsx
@@ -4,7 +4,7 @@ import { useCallback, useMemo, useRef } from "react";
 import { ComponentDetailsDialog } from "@/components/shared/Dialogs";
 import { ComponentFavoriteToggle } from "@/components/shared/FavoriteComponentToggle";
 import { useOutdatedComponents } from "@/components/shared/ManageComponent/hooks/useOutdatedComponents";
-import { useBetaFlagValue } from "@/components/shared/Settings/useBetaFlags";
+import { useFlagValue } from "@/components/shared/Settings/useFlags";
 import { withSuspenseWrapper } from "@/components/shared/SuspenseWrapper";
 import { Icon } from "@/components/ui/icon";
 import { InlineStack } from "@/components/ui/layout";
@@ -73,10 +73,10 @@ const ComponentMarkup = ({
   isLoading,
   error,
 }: ComponentMarkupProps) => {
-  const isHighlightTasksOnComponentHoverEnabled = useBetaFlagValue(
+  const isHighlightTasksOnComponentHoverEnabled = useFlagValue(
     "highlight-node-on-component-hover",
   );
-  const isRemoteComponentLibrarySearchEnabled = useBetaFlagValue(
+  const isRemoteComponentLibrarySearchEnabled = useFlagValue(
     "remote-component-library-search",
   );
 

--- a/src/components/shared/ReactFlow/FlowSidebar/components/ImportComponent.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/components/ImportComponent.tsx
@@ -12,7 +12,7 @@ import {
 import { ComponentEditorDialog } from "@/components/shared/ComponentEditor/ComponentEditorDialog";
 import { NewComponentTemplateSelector } from "@/components/shared/ComponentEditor/components/NewComponentTemplateSelector";
 import type { SupportedTemplate } from "@/components/shared/ComponentEditor/types";
-import { useBetaFlagValue } from "@/components/shared/Settings/useBetaFlags";
+import { useFlagValue } from "@/components/shared/Settings/useFlags";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -48,7 +48,7 @@ const ImportComponent = ({
   const notify = useToastNotification();
   const { addToComponentLibrary } = useComponentLibrary();
 
-  const hasEnabledInAppEditor = useBetaFlagValue("in-app-component-editor");
+  const hasEnabledInAppEditor = useFlagValue("in-app-component-editor");
 
   const [url, setUrl] = useState("");
   const [tab, setTab] = useState<TabType>(TabType.File);

--- a/src/components/shared/ReactFlow/FlowSidebar/sections/GraphComponents.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/sections/GraphComponents.tsx
@@ -2,7 +2,7 @@ import { PackagePlus } from "lucide-react";
 import { type ChangeEvent, useCallback, useMemo } from "react";
 
 import { ManageLibrariesDialog } from "@/components/shared/GitHubLibrary/ManageLibrariesDialog";
-import { useBetaFlagValue } from "@/components/shared/Settings/useBetaFlags";
+import { useFlagValue } from "@/components/shared/Settings/useFlags";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Separator } from "@/components/ui/separator";
 import {
@@ -36,10 +36,10 @@ import PublishedComponentsSearch from "../components/PublishedComponentsSearch";
 import { UpgradeAvailableAlertBox } from "../components/UpgradeAvailableAlertBox";
 
 const GraphComponents = ({ isOpen }: { isOpen: boolean }) => {
-  const remoteComponentLibrarySearchEnabled = useBetaFlagValue(
+  const remoteComponentLibrarySearchEnabled = useFlagValue(
     "remote-component-library-search",
   );
-  const githubComponentLibraryEnabled = useBetaFlagValue(
+  const githubComponentLibraryEnabled = useFlagValue(
     "github-component-library",
   );
 

--- a/src/components/shared/Settings/PersonalPreferences.tsx
+++ b/src/components/shared/Settings/PersonalPreferences.tsx
@@ -1,17 +1,11 @@
 import { Settings } from "lucide-react";
 import { useState } from "react";
 
-import { ExistingBetaFlags } from "@/betaFlags";
-
 import TooltipButton from "../Buttons/TooltipButton";
 import { PersonalPreferencesDialog } from "./PersonalPreferencesDialog";
 
 export function PersonalPreferences() {
   const [open, setOpen] = useState(false);
-
-  if (Object.keys(ExistingBetaFlags).length === 0) {
-    return null;
-  }
 
   return (
     <>

--- a/src/components/shared/Settings/PersonalPreferencesDialog.tsx
+++ b/src/components/shared/Settings/PersonalPreferencesDialog.tsx
@@ -1,4 +1,3 @@
-import { ExistingBetaFlags } from "@/betaFlags";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -10,10 +9,11 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { ExistingFlags } from "@/flags";
 
 import { BetaFeatures } from "./BetaFeatures";
 import { Settings } from "./Settings";
-import { useBetaFlagsReducer } from "./useBetaFlagReducer";
+import { useFlagsReducer } from "./useFlagsReducer";
 
 interface PersonalPreferencesDialogProps {
   open: boolean;
@@ -24,16 +24,16 @@ export function PersonalPreferencesDialog({
   open,
   setOpen,
 }: PersonalPreferencesDialogProps) {
-  const [allFlags, dispatch] = useBetaFlagsReducer(ExistingBetaFlags);
+  const [flags, dispatch] = useFlagsReducer(ExistingFlags);
 
   const handleSetFlag = (flag: string, enabled: boolean) => {
     dispatch({ type: "setFlag", payload: { key: flag, enabled } });
   };
 
-  const betaFlags = Object.values(allFlags).filter(
+  const betaFlags = Object.values(flags).filter(
     (flag) => flag.category === "beta",
   );
-  const settings = Object.values(allFlags).filter(
+  const settings = Object.values(flags).filter(
     (flag) => flag.category === "setting",
   );
 

--- a/src/components/shared/Settings/tests/PersonalPreferencesDialog.test.tsx
+++ b/src/components/shared/Settings/tests/PersonalPreferencesDialog.test.tsx
@@ -5,10 +5,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Flag } from "@/types/configuration";
 
 import { PersonalPreferencesDialog } from "../PersonalPreferencesDialog";
-import { useBetaFlagsReducer } from "../useBetaFlagReducer";
+import { useFlagsReducer } from "../useFlagsReducer";
 
-// Mock the useBetaFlagsReducer hook
-vi.mock("../useBetaFlagReducer");
+// Mock the useFlagsReducer hook
+vi.mock("../useFlagsReducer");
 
 describe("PersonalPreferencesDialog", () => {
   const mockDispatch = vi.fn();
@@ -33,11 +33,11 @@ describe("PersonalPreferencesDialog", () => {
     },
   ];
 
-  const mockUseBetaFlagsReducer = vi.mocked(useBetaFlagsReducer);
+  const mockuseFlagsReducer = vi.mocked(useFlagsReducer);
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockUseBetaFlagsReducer.mockReturnValue([mockBetaFlags, mockDispatch]);
+    mockuseFlagsReducer.mockReturnValue([mockBetaFlags, mockDispatch]);
   });
 
   afterEach(() => {
@@ -213,7 +213,7 @@ describe("PersonalPreferencesDialog", () => {
 
   it("should handle empty flags arrays", async () => {
     const user = userEvent.setup();
-    mockUseBetaFlagsReducer.mockReturnValue([[], mockDispatch]);
+    mockuseFlagsReducer.mockReturnValue([[], mockDispatch]);
 
     render(<PersonalPreferencesDialog open={true} setOpen={mockSetOpen} />);
 

--- a/src/components/shared/Settings/tests/useFlags.test.ts
+++ b/src/components/shared/Settings/tests/useFlags.test.ts
@@ -1,19 +1,20 @@
 import { act, renderHook } from "@testing-library/react";
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { useBetaFlagValue } from "../useBetaFlags";
+import { useFlagValue } from "../useFlags";
 
-vi.mock("@/betaFlags", () => ({
-  ExistingBetaFlags: {
+vi.mock("@/flags", () => ({
+  ExistingFlags: {
     codeViewer: {
       name: "Code Viewer",
       description: "Code Viewer",
       default: false,
+      category: "beta",
     },
   },
 }));
 
-describe("useBetaFlagValue", () => {
+describe("useFlagValue", () => {
   beforeEach(() => {
     localStorage.clear();
   });
@@ -23,7 +24,7 @@ describe("useBetaFlagValue", () => {
   });
 
   it("should return false by default when no flag is stored", () => {
-    const { result } = renderHook(() => useBetaFlagValue("codeViewer" as any));
+    const { result } = renderHook(() => useFlagValue("codeViewer" as any));
 
     expect(result.current).toBe(false);
   });
@@ -31,7 +32,7 @@ describe("useBetaFlagValue", () => {
   it("should return stored flag value when flag exists in localStorage", () => {
     localStorage.setItem("betaFlags", JSON.stringify({ codeViewer: true }));
 
-    const { result } = renderHook(() => useBetaFlagValue("codeViewer" as any));
+    const { result } = renderHook(() => useFlagValue("codeViewer" as any));
 
     expect(result.current).toBe(true);
   });
@@ -39,7 +40,7 @@ describe("useBetaFlagValue", () => {
   it("should return stored flag value when flag is explicitly set to false", () => {
     localStorage.setItem("betaFlags", JSON.stringify({ codeViewer: false }));
 
-    const { result } = renderHook(() => useBetaFlagValue("codeViewer" as any));
+    const { result } = renderHook(() => useFlagValue("codeViewer" as any));
 
     expect(result.current).toBe(false);
   });
@@ -47,7 +48,7 @@ describe("useBetaFlagValue", () => {
   it("should return false when betaFlags exists but specific flag is not set", () => {
     localStorage.setItem("betaFlags", JSON.stringify({ otherFlag: true }));
 
-    const { result } = renderHook(() => useBetaFlagValue("codeViewer" as any));
+    const { result } = renderHook(() => useFlagValue("codeViewer" as any));
 
     expect(result.current).toBe(false);
   });
@@ -55,13 +56,13 @@ describe("useBetaFlagValue", () => {
   it("should return false when localStorage contains invalid JSON", () => {
     localStorage.setItem("betaFlags", "invalid-json");
 
-    const { result } = renderHook(() => useBetaFlagValue("codeViewer" as any));
+    const { result } = renderHook(() => useFlagValue("codeViewer" as any));
 
     expect(result.current).toBe(false);
   });
 
   it("should react to localStorage changes and update the returned value", async () => {
-    const { result } = renderHook(() => useBetaFlagValue("codeViewer" as any));
+    const { result } = renderHook(() => useFlagValue("codeViewer" as any));
 
     expect(result.current).toBe(false);
 
@@ -84,7 +85,7 @@ describe("useBetaFlagValue", () => {
     // Start with flag set to true
     localStorage.setItem("betaFlags", JSON.stringify({ codeViewer: true }));
 
-    const { result } = renderHook(() => useBetaFlagValue("codeViewer" as any));
+    const { result } = renderHook(() => useFlagValue("codeViewer" as any));
 
     expect(result.current).toBe(true);
 
@@ -113,7 +114,7 @@ describe("useBetaFlagValue", () => {
       }),
     );
 
-    const { result } = renderHook(() => useBetaFlagValue("codeViewer" as any));
+    const { result } = renderHook(() => useFlagValue("codeViewer" as any));
 
     expect(result.current).toBe(true);
   });

--- a/src/components/shared/Settings/tests/useFlagsReducer.test.ts
+++ b/src/components/shared/Settings/tests/useFlagsReducer.test.ts
@@ -1,11 +1,11 @@
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import type { BetaFlags } from "@/types/configuration";
+import type { ConfigFlags } from "@/types/configuration";
 
-import { useBetaFlagsReducer } from "../useBetaFlagReducer";
+import { useFlagsReducer } from "../useFlagsReducer";
 
-describe("useBetaFlagsReducer", () => {
+describe("useFlagsReducer", () => {
   beforeEach(() => {
     // Clear localStorage before each test
     localStorage.clear();
@@ -15,7 +15,7 @@ describe("useBetaFlagsReducer", () => {
     localStorage.clear();
   });
 
-  const mockBetaFlags: BetaFlags = {
+  const mockFlags: ConfigFlags = {
     feature1: {
       name: "Feature 1",
       description: "First feature flag",
@@ -37,7 +37,7 @@ describe("useBetaFlagsReducer", () => {
   };
 
   it("should initialize state with default values when no flags are stored", () => {
-    const { result } = renderHook(() => useBetaFlagsReducer(mockBetaFlags));
+    const { result } = renderHook(() => useFlagsReducer(mockFlags));
     const [state] = result.current;
 
     expect(state).toHaveLength(3);
@@ -78,7 +78,7 @@ describe("useBetaFlagsReducer", () => {
       }),
     );
 
-    const { result } = renderHook(() => useBetaFlagsReducer(mockBetaFlags));
+    const { result } = renderHook(() => useFlagsReducer(mockFlags));
     const [state] = result.current;
 
     expect(state).toHaveLength(3);
@@ -88,7 +88,7 @@ describe("useBetaFlagsReducer", () => {
   });
 
   it("should handle setFlag action correctly", () => {
-    const { result } = renderHook(() => useBetaFlagsReducer(mockBetaFlags));
+    const { result } = renderHook(() => useFlagsReducer(mockFlags));
     const [initialState, dispatch] = result.current;
 
     expect(initialState.find((f: any) => f.key === "feature1")?.enabled).toBe(
@@ -114,7 +114,7 @@ describe("useBetaFlagsReducer", () => {
   });
 
   it("should persist flag changes to localStorage", () => {
-    const { result } = renderHook(() => useBetaFlagsReducer(mockBetaFlags));
+    const { result } = renderHook(() => useFlagsReducer(mockFlags));
     const [, dispatch] = result.current;
 
     act(() => {
@@ -132,7 +132,7 @@ describe("useBetaFlagsReducer", () => {
   });
 
   it("should handle multiple flag updates correctly", () => {
-    const { result } = renderHook(() => useBetaFlagsReducer(mockBetaFlags));
+    const { result } = renderHook(() => useFlagsReducer(mockFlags));
     const [, dispatch] = result.current;
 
     act(() => {
@@ -190,7 +190,7 @@ describe("useBetaFlagsReducer", () => {
       }),
     );
 
-    renderHook(() => useBetaFlagsReducer(mockBetaFlags));
+    renderHook(() => useFlagsReducer(mockFlags));
 
     // Check that obsolete flags are removed
     const storedFlags = JSON.parse(localStorage.getItem("betaFlags") || "{}");
@@ -202,8 +202,8 @@ describe("useBetaFlagsReducer", () => {
     expect(storedFlags.anotherObsoleteFlag).toBeUndefined();
   });
 
-  it("should handle empty betaFlags object", () => {
-    const { result } = renderHook(() => useBetaFlagsReducer({}));
+  it("should handle empty ConfigFlags object", () => {
+    const { result } = renderHook(() => useFlagsReducer({}));
     const [state] = result.current;
 
     expect(state).toHaveLength(0);
@@ -220,7 +220,7 @@ describe("useBetaFlagsReducer", () => {
       }),
     );
 
-    const { result } = renderHook(() => useBetaFlagsReducer(mockBetaFlags));
+    const { result } = renderHook(() => useFlagsReducer(mockFlags));
     const [, dispatch] = result.current;
 
     act(() => {

--- a/src/components/shared/Settings/useFlags.ts
+++ b/src/components/shared/Settings/useFlags.ts
@@ -1,13 +1,13 @@
 import { useSyncExternalStore } from "react";
 
-import { ExistingBetaFlags } from "@/betaFlags";
+import { ExistingFlags } from "@/flags";
 import { getStorage } from "@/utils/typedStorage";
 
 import type { BetaFlagsStorage } from "./types";
 
 const storage = getStorage<keyof BetaFlagsStorage, BetaFlagsStorage>();
 
-export function useBetaFlags() {
+export function useFlags() {
   return {
     getFlags: () => storage.getItem("betaFlags"),
 
@@ -49,10 +49,10 @@ export function useBetaFlags() {
   };
 }
 
-export function useBetaFlagValue(betaFlagName: keyof typeof ExistingBetaFlags) {
-  const { getFlag, subscribe } = useBetaFlags();
+export function useFlagValue(flagName: keyof typeof ExistingFlags) {
+  const { getFlag, subscribe } = useFlags();
 
   return useSyncExternalStore(subscribe, () =>
-    getFlag(betaFlagName, ExistingBetaFlags[betaFlagName]?.default ?? false),
+    getFlag(flagName, ExistingFlags[flagName]?.default ?? false),
   );
 }

--- a/src/components/shared/Settings/useFlagsReducer.ts
+++ b/src/components/shared/Settings/useFlagsReducer.ts
@@ -1,8 +1,8 @@
 import { useEffect, useReducer } from "react";
 
-import type { BetaFlags, Flag } from "@/types/configuration";
+import type { ConfigFlags, Flag } from "@/types/configuration";
 
-import { useBetaFlags } from "./useBetaFlags";
+import { useFlags } from "./useFlags";
 
 interface SetFlagAction {
   type: "setFlag";
@@ -15,17 +15,17 @@ interface SetFlagAction {
 type Action = SetFlagAction;
 type State = Flag[];
 
-export function useBetaFlagsReducer(betaFlags: BetaFlags) {
-  const { getFlag, setFlag, getFlags, removeFlag } = useBetaFlags();
+export function useFlagsReducer(flags: ConfigFlags) {
+  const { getFlag, setFlag, getFlags, removeFlag } = useFlags();
 
   useEffect(() => {
     // clean up unexisting flags
-    const existingFlags = new Set(Object.keys(betaFlags));
+    const existingFlags = new Set(Object.keys(flags));
 
     Object.keys(getFlags() ?? {})
       .filter((flag) => !existingFlags.has(flag))
       .forEach((flag) => removeFlag(flag));
-  }, [betaFlags, getFlags, removeFlag]);
+  }, [flags, getFlags, removeFlag]);
 
   const reducer = (state: State, action: Action) => {
     switch (action.type) {
@@ -44,7 +44,7 @@ export function useBetaFlagsReducer(betaFlags: BetaFlags) {
 
   return useReducer(
     reducer,
-    Object.entries(betaFlags).map(([key, flag]) => ({
+    Object.entries(flags).map(([key, flag]) => ({
       ...flag,
       key,
       enabled: getFlag(key, flag.default),

--- a/src/components/shared/Submitters/Oasis/OasisSubmitter.tsx
+++ b/src/components/shared/Submitters/Oasis/OasisSubmitter.tsx
@@ -5,7 +5,7 @@ import { type MouseEvent, useRef, useState } from "react";
 
 import type { TaskSpecOutput } from "@/api/types.gen";
 import { useAwaitAuthorization } from "@/components/shared/Authentication/useAwaitAuthorization";
-import { useBetaFlagValue } from "@/components/shared/Settings/useBetaFlags";
+import { useFlagValue } from "@/components/shared/Settings/useFlags";
 import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
 import { InlineStack } from "@/components/ui/layout";
@@ -89,7 +89,7 @@ const OasisSubmitter = ({
   const { isAuthorized } = useAwaitAuthorization();
   const { configured, available } = useBackend();
   const { mutate: submit, isPending: isSubmitting } = useSubmitPipeline();
-  const isAutoRedirect = useBetaFlagValue("redirect-on-new-pipeline-run");
+  const isAutoRedirect = useFlagValue("redirect-on-new-pipeline-run");
 
   const [submitSuccess, setSubmitSuccess] = useState<boolean | null>(null);
   const [isArgumentsDialogOpen, setIsArgumentsDialogOpen] = useState(false);

--- a/src/components/shared/TaskDetails/Actions.tsx
+++ b/src/components/shared/TaskDetails/Actions.tsx
@@ -4,7 +4,7 @@ import { isSubgraph } from "@/utils/subgraphUtils";
 
 import { ViewYamlButton } from "../Buttons/ViewYamlButton";
 import { ActionBlock } from "../ContextPanel/Blocks/ActionBlock";
-import { useBetaFlagValue } from "../Settings/useBetaFlags";
+import { useFlagValue } from "../Settings/useFlags";
 import { CopyYamlButton } from "./Actions/CopyYamlButton";
 import { DeleteComponentButton } from "./Actions/DeleteComponentButton";
 import { DownloadPythonButton } from "./Actions/DownloadPythonButton";
@@ -27,7 +27,7 @@ const TaskActions = ({
   readOnly = false,
   className,
 }: TaskActionsProps) => {
-  const isInAppEditorEnabled = useBetaFlagValue("in-app-component-editor");
+  const isInAppEditorEnabled = useFlagValue("in-app-component-editor");
 
   const { taskId, taskSpec, state, callbacks } = taskNode || {};
   const { onDuplicate, onUpgrade, onDelete } = callbacks || {};

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -1,23 +1,23 @@
-import type { BetaFlag } from "@/types/configuration";
+import type { ConfigFlags } from "@/types/configuration";
 
 const isRemoteComponentLibraryEnabled =
   import.meta.env.VITE_DEFAULT_REMOTE_COMPONENT_LIBRARY_BETA === "true";
 
-export const ExistingBetaFlags = {
+export const ExistingFlags: ConfigFlags = {
   ["highlight-node-on-component-hover"]: {
     name: "Highlight tasks on component hover",
     description:
       "Highlight the tasks on the Pipeline canvas when the component is hovered over in the component library.",
     default: false,
     category: "beta",
-  } as BetaFlag,
+  },
 
   ["remote-component-library-search"]: {
     name: "Published Components Library",
     description: "Enable the Published Components Library feature.",
     default: isRemoteComponentLibraryEnabled,
     category: "beta",
-  } as BetaFlag,
+  },
 
   ["github-component-library"]: {
     name: "GitHub Component Library",
@@ -25,14 +25,14 @@ export const ExistingBetaFlags = {
       "Enable the GitHub Component Library. All lib folders will be based on GitHub components",
     default: false,
     category: "beta",
-  } as BetaFlag,
+  },
 
   ["redirect-on-new-pipeline-run"]: {
     name: "Redirect on new pipeline run",
     description: "Automatically open a new tab after starting a new execution.",
     default: false,
     category: "setting",
-  } as BetaFlag,
+  },
 
   ["created-by-me-default"]: {
     name: "Default created by me filter",
@@ -40,7 +40,7 @@ export const ExistingBetaFlags = {
       "Automatically select the 'Created by me' filter when viewing the pipeline run list.",
     default: false,
     category: "setting",
-  } as BetaFlag,
+  },
 
   ["in-app-component-editor"]: {
     name: "In-app component editor",
@@ -48,7 +48,7 @@ export const ExistingBetaFlags = {
       "Enable the in-app component editor for creating and editing pipeline components.",
     default: true,
     category: "beta",
-  } as BetaFlag,
+  },
 
   ["partial-selection"]: {
     name: "Partial Node Selection",
@@ -56,5 +56,5 @@ export const ExistingBetaFlags = {
       "Allow nodes to be selected when partially covered by the selection box. Use Shift+drag for full selection, or Shift+Cmd+drag (Shift+Ctrl on Windows) for partial selection.",
     default: false,
     category: "beta",
-  } as BetaFlag,
+  },
 };

--- a/src/types/configuration.ts
+++ b/src/types/configuration.ts
@@ -1,13 +1,13 @@
-export interface BetaFlag {
+interface ConfigFlag {
   name: string;
   description: string;
   default: boolean;
   category: "beta" | "setting";
 }
 
-export type BetaFlags = Record<string, BetaFlag>;
+export type ConfigFlags = Record<string, ConfigFlag>;
 
-export type Flag = BetaFlag & {
+export type Flag = ConfigFlag & {
   key: string;
   enabled: boolean;
 };


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Rename `betaFlags` -> `configFlags` and the betaflag logic & hooks `betaFlag` -> `flag`.

Syntactically it makes more sense given that flags are no longer limited to just betas. Note this PR does not change the storage location in local storage, so that users do not lose their existing settings. We should strongly consider making a migration for that before adding new flags.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Cleanup/Refactor

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

Confirm that all settings & betas work as expected

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
