### PR TITLE
fix: Task Actions have labels instead of tooltips

### DIFF
--- a/src/components/shared/Buttons/TooltipButton.tsx
+++ b/src/components/shared/Buttons/TooltipButton.tsx
@@ -34,9 +34,11 @@ const TooltipButton = React.forwardRef<HTMLButtonElement, TooltipButtonProps>(
             </Button>
           </div>
         </TooltipTrigger>
-        <TooltipContent side={tooltipSide} align={tooltipAlign}>
-          {tooltip}
-        </TooltipContent>
+        {!!tooltip && (
+          <TooltipContent side={tooltipSide} align={tooltipAlign}>
+            {tooltip}
+          </TooltipContent>
+        )}
       </Tooltip>
     </TooltipProvider>
   ),

--- a/src/components/shared/TaskDetails/Actions/CopyYamlButton.tsx
+++ b/src/components/shared/TaskDetails/Actions/CopyYamlButton.tsx
@@ -20,6 +20,6 @@ export const CopyYamlButton = ({ componentRef }: CopyYamlButtonProps) => {
   };
 
   return (
-    <ActionButton label="Copy YAML" icon="Clipboard" onClick={handleClick} />
+    <ActionButton tooltip="Copy YAML" icon="Clipboard" onClick={handleClick} />
   );
 };

--- a/src/components/shared/TaskDetails/Actions/DeleteComponentButton.tsx
+++ b/src/components/shared/TaskDetails/Actions/DeleteComponentButton.tsx
@@ -22,7 +22,7 @@ export const DeleteComponentButton = ({
 
   return (
     <ActionButton
-      label="Delete Component"
+      tooltip="Delete Component"
       icon="Trash"
       onClick={handleClick}
       destructive

--- a/src/components/shared/TaskDetails/Actions/DownloadPythonButton.tsx
+++ b/src/components/shared/TaskDetails/Actions/DownloadPythonButton.tsx
@@ -28,7 +28,7 @@ export const DownloadPythonButton = ({
   };
 
   return (
-    <ActionButton label="Download Python Code" onClick={handleClick}>
+    <ActionButton tooltip="Download Python Code" onClick={handleClick}>
       <FaPython />
     </ActionButton>
   );

--- a/src/components/shared/TaskDetails/Actions/DownloadYamlButton.tsx
+++ b/src/components/shared/TaskDetails/Actions/DownloadYamlButton.tsx
@@ -17,6 +17,10 @@ export const DownloadYamlButton = ({
   };
 
   return (
-    <ActionButton label="Download YAML" icon="Download" onClick={handleClick} />
+    <ActionButton
+      tooltip="Download YAML"
+      icon="Download"
+      onClick={handleClick}
+    />
   );
 };

--- a/src/components/shared/TaskDetails/Actions/DuplicateTaskButton.tsx
+++ b/src/components/shared/TaskDetails/Actions/DuplicateTaskButton.tsx
@@ -8,6 +8,6 @@ export const DuplicateTaskButton = ({
   onDuplicate,
 }: DuplicateTaskButtonProps) => {
   return (
-    <ActionButton label="Duplicate Task" icon="Copy" onClick={onDuplicate} />
+    <ActionButton tooltip="Duplicate Task" icon="Copy" onClick={onDuplicate} />
   );
 };

--- a/src/components/shared/TaskDetails/Actions/EditComponentButton.tsx
+++ b/src/components/shared/TaskDetails/Actions/EditComponentButton.tsx
@@ -25,7 +25,7 @@ export const EditComponentButton = ({
   return (
     <>
       <ActionButton
-        label="Edit Component Definition"
+        tooltip="Edit Component Definition"
         icon="FilePenLine"
         onClick={handleClick}
       />

--- a/src/components/shared/TaskDetails/Actions/NavigateToSubgraphButton.tsx
+++ b/src/components/shared/TaskDetails/Actions/NavigateToSubgraphButton.tsx
@@ -22,7 +22,7 @@ export const NavigateToSubgraphButton = ({
 
   return (
     <ActionButton
-      label={`Enter Subgraph: ${subgraphDescription}`}
+      tooltip={`Enter Subgraph: ${subgraphDescription}`}
       icon="Workflow"
       onClick={handleClick}
     />

--- a/src/components/shared/TaskDetails/Actions/UpgradeTaskButton.tsx
+++ b/src/components/shared/TaskDetails/Actions/UpgradeTaskButton.tsx
@@ -7,7 +7,7 @@ interface UpgradeTaskButtonProps {
 export const UpgradeTaskButton = ({ onUpgrade }: UpgradeTaskButtonProps) => {
   return (
     <ActionButton
-      label="Update Task from Source URL"
+      tooltip="Update Task from Source URL"
       icon="CircleFadingArrowUp"
       onClick={onUpgrade}
     />


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
In #1659 I forgot to switch all the task actions from the `label` prop to the new `tooltip` prop, causing them to all render with labels rather just the icon.

This PR fixes that.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

hotfix for #1659 

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->
currently

![image.png](https://app.graphite.com/user-attachments/assets/4bf14f42-67fd-4a1a-bc4b-e4919bdfd5a9.png)

after (how it used to be)

![image.png](https://app.graphite.com/user-attachments/assets/569f54c7-796f-450c-8fa8-f656787dcf57.png)

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
