### PR TITLE
chore: Side Panel Collapse Buttons at top of view when not looking at a Subgraph

### DIFF
--- a/src/components/shared/ContextPanel/CollapsibleContextPanel.tsx
+++ b/src/components/shared/ContextPanel/CollapsibleContextPanel.tsx
@@ -6,6 +6,8 @@ import {
 } from "@/components/ui/collapsible";
 import { Icon } from "@/components/ui/icon";
 import { VerticalResizeHandle } from "@/components/ui/resize-handle";
+import { cn } from "@/lib/utils";
+import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 import { useContextPanel } from "@/providers/ContextPanelProvider";
 
 import { ContextPanel } from "./ContextPanel";
@@ -17,13 +19,20 @@ const DEFAULT_WIDTH = 400;
 export function CollapsibleContextPanel() {
   const { open, setOpen } = useContextPanel();
 
+  const { currentSubgraphPath } = useComponentSpec();
+
+  const isViewingSubgraph = currentSubgraphPath.length > 1;
+
   return (
     <Collapsible open={open} onOpenChange={setOpen} className="h-full">
       <CollapsibleTrigger asChild>
         <Button
           variant="ghost"
           size="icon"
-          className="absolute top-[95px] z-0 transition-all duration-300 bg-white rounded-r-none shadow-md -translate-x-9"
+          className={cn(
+            "absolute z-0 transition-all duration-300 bg-white rounded-r-none shadow-md -translate-x-9",
+            isViewingSubgraph ? "top-23.75" : "top-14",
+          )}
           aria-label={open ? "Collapse context panel" : "Expand context panel"}
         >
           <Icon name={open ? "PanelRightClose" : "PanelRightOpen"} />

--- a/src/components/shared/ReactFlow/FlowSidebar/FlowSidebar.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/FlowSidebar.tsx
@@ -5,6 +5,7 @@ import {
   useSidebar,
 } from "@/components/ui/sidebar";
 import { cn } from "@/lib/utils";
+import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 
 import FileActions from "./sections/FileActions";
 import GraphComponents from "./sections/GraphComponents";
@@ -12,10 +13,14 @@ import RunsAndSubmission from "./sections/RunsAndSubmission";
 
 const FlowSidebar = () => {
   const { open, setOpen } = useSidebar();
+  const { currentSubgraphPath } = useComponentSpec();
+
+  const isViewingSubgraph = currentSubgraphPath.length > 1;
 
   const sidebarTriggerClasses = cn(
-    "absolute top-[65px] z-1 transition-all duration-300 bg-white mt-8 rounded-r-md shadow-md p-0.5 pr-1",
+    "absolute z-1 transition-all duration-300 bg-white mt-8 rounded-r-md shadow-md p-0.5 pr-1",
     open ? "left-[255px]" : "left-[47px]",
+    isViewingSubgraph ? "top-[65px]" : "top-6",
   );
 
   return (


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
A simple change to make the collapse buttons for the sidebar & context panel push up to the top of the viewport when not looking at a subgraph. They will remain below the subgraph bar when looking at a subgraph (current behaviour).

This behaviour is similar to the new Run Toolbar.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->
Not looking at subgraph

![image.png](https://app.graphite.com/user-attachments/assets/6dacae68-eebd-4971-a651-d32e2aa11784.png)

Looking at subgraph (current)

![image.png](https://app.graphite.com/user-attachments/assets/b8e6e2d2-fa60-4f2d-9948-29cd1440d9a0.png)

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

Confirm buttons still work as expected and are not in weird places.

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->

[Existing Behaviour] On very narrow screens (aka mobile) viewing a subgraph can cause the subgraph nav bar to spill over multiple lines which covers up these collapse buttons. This is something to look into and fix later.
