### PR TITLE
feat: Unpacked Subgraphs Retain External Connections

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/utils/replaceTaskArgumentsInGraphSpec.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/utils/replaceTaskArgumentsInGraphSpec.ts
@@ -1,20 +1,23 @@
 import type { ArgumentType, GraphSpec } from "@/utils/componentSpec";
+import { deepClone } from "@/utils/deepClone";
 
 const replaceTaskArgumentsInGraphSpec = (
   taskId: string,
   graphSpec: GraphSpec,
   taskArguments?: Record<string, ArgumentType>,
 ) => {
+  const cleanGraphSpec = deepClone(graphSpec);
+
   if (!taskArguments) {
     return graphSpec;
   }
 
   const newGraphSpec: GraphSpec = {
-    ...graphSpec,
+    ...cleanGraphSpec,
     tasks: {
-      ...graphSpec.tasks,
+      ...cleanGraphSpec.tasks,
       [taskId]: {
-        ...graphSpec.tasks[taskId],
+        ...cleanGraphSpec.tasks[taskId],
         arguments: taskArguments,
       },
     },


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

Expands the new Subgraph Unpacking feature to ensure existing connections to the subgraph are not broken when unpacked - those connections will instead be routed to the relevant internal tasks based on the subgraph's internal IO nodes.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

[unpacking-subgraphs-retain-connections.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/dd93f338-17ca-4160-9604-95d534be127c.mov" />](https://app.graphite.com/user-attachments/video/dd93f338-17ca-4160-9604-95d534be127c.mov)


[unpacking-subgraphs-all-the-way-down.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/aeb76cb4-54b1-4335-bf02-9729b2bf729c.mov" />](https://app.graphite.com/user-attachments/video/aeb76cb4-54b1-4335-bf02-9729b2bf729c.mov)

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->
- confirm that basic subgraph unpacking still works as expected
- confirm that input nodes connected to a subgraph that is then unpacked has its connections rerouted to the correct internal subgraph tasks
- ^ same for connected tasks
- ^ same for connected outputs

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->

I am going to do tests as a separate PR, to avoid overwhelming things.
