### PR TITLE
feat: edit pipeline description

### DIFF
--- a/react-compiler.config.js
+++ b/react-compiler.config.js
@@ -35,7 +35,8 @@ export const REACT_COMPILER_ENABLED_DIRS = [
   "src/components/shared/Submitters/GoogleCloud/RegionInput.tsx",
   "src/components/shared/Submitters/Oasis/components/SubmitTaskArgumentsDialog.tsx",
   "src/components/shared/Submitters/Oasis/OasisSubmitter.tsx",
-
+  "src/components/shared/PipelineDescription",
+  "src/components/shared/InlineEditor",
   // 11-20 useCallback/useMemo
   // "src/components/ui",                         // 12
   // "src/components/PipelineRun",                // 14

--- a/src/components/Editor/Context/PipelineDetails.tsx
+++ b/src/components/Editor/Context/PipelineDetails.tsx
@@ -7,6 +7,7 @@ import { ContentBlock } from "@/components/shared/ContextPanel/Blocks/ContentBlo
 import { ListBlock } from "@/components/shared/ContextPanel/Blocks/ListBlock";
 import { TextBlock } from "@/components/shared/ContextPanel/Blocks/TextBlock";
 import { CopyText } from "@/components/shared/CopyText/CopyText";
+import { PipelineDescription } from "@/components/shared/PipelineDescription/PipelineDescription";
 import { BlockStack } from "@/components/ui/layout";
 import useToastNotification from "@/hooks/useToastNotification";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
@@ -100,9 +101,7 @@ const PipelineDetails = () => {
 
       <ListBlock items={metadata} marker="none" />
 
-      {componentSpec.description && (
-        <TextBlock title="Description" text={componentSpec.description} />
-      )}
+      <PipelineDescription componentSpec={componentSpec} />
 
       {digest && (
         <TextBlock

--- a/src/components/shared/InlineEditor/InlineEditor.tsx
+++ b/src/components/shared/InlineEditor/InlineEditor.tsx
@@ -1,0 +1,52 @@
+import {
+  type FocusEvent,
+  type KeyboardEvent,
+  type ReactNode,
+  useRef,
+  useState,
+} from "react";
+
+export const InlineEditor = ({
+  value,
+  editor,
+}: {
+  value: ReactNode;
+  editor: ReactNode;
+}) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const onKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === "Enter" || event.key === " ") {
+      setIsEditing(true);
+    }
+  };
+
+  const onBlur = (event: FocusEvent<HTMLDivElement>) => {
+    // Only exit edit mode if focus moves outside the container
+    if (!containerRef.current?.contains(event.relatedTarget)) {
+      setIsEditing(false);
+    }
+  };
+
+  if (isEditing) {
+    return (
+      <div className="w-full" ref={containerRef} onBlur={onBlur}>
+        {editor}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="w-full cursor-pointer whitespace-pre-wrap rounded-md border border-transparent px-3 py-2 text-sm hover:border-input hover:bg-muted/50"
+      onClick={() => setIsEditing(true)}
+      onKeyDown={onKeyDown}
+      role="button"
+      tabIndex={0}
+      title="Click to edit"
+    >
+      {value}
+    </div>
+  );
+};

--- a/src/components/shared/PipelineDescription/PipelineDescription.tsx
+++ b/src/components/shared/PipelineDescription/PipelineDescription.tsx
@@ -1,0 +1,32 @@
+import type { ComponentSpec } from "@/utils/componentSpec";
+
+import { ContentBlock } from "../ContextPanel/Blocks/ContentBlock";
+import { InlineEditor } from "../InlineEditor/InlineEditor";
+import { PipelineDescriptionEditor } from "./PipelineDescriptionEditor";
+
+export const PipelineDescription = ({
+  componentSpec,
+}: {
+  componentSpec: ComponentSpec;
+}) => {
+  const hasDescription = Boolean(
+    componentSpec.description && componentSpec.description.trim(),
+  );
+
+  if (!hasDescription) {
+    return (
+      <ContentBlock title="Description">
+        <PipelineDescriptionEditor />
+      </ContentBlock>
+    );
+  }
+
+  return (
+    <ContentBlock title="Description">
+      <InlineEditor
+        value={componentSpec.description}
+        editor={<PipelineDescriptionEditor autoFocus />}
+      />
+    </ContentBlock>
+  );
+};

--- a/src/components/shared/PipelineDescription/PipelineDescriptionEditor.tsx
+++ b/src/components/shared/PipelineDescription/PipelineDescriptionEditor.tsx
@@ -1,0 +1,39 @@
+import { useEffect, useState } from "react";
+
+import { Textarea } from "@/components/ui/textarea";
+import { useComponentSpec } from "@/providers/ComponentSpecProvider";
+
+interface PipelineDescriptionEditorProps {
+  autoFocus?: boolean;
+}
+
+export const PipelineDescriptionEditor = ({
+  autoFocus,
+}: PipelineDescriptionEditorProps) => {
+  const { componentSpec, setComponentSpec } = useComponentSpec();
+  const [localValue, setLocalValue] = useState(componentSpec.description ?? "");
+
+  const setDescription = (description: string) => {
+    setComponentSpec({
+      ...componentSpec,
+      description: description || undefined,
+    });
+  };
+
+  // Sync local value when componentSpec.description changes externally
+  useEffect(() => {
+    setLocalValue(componentSpec.description ?? "");
+  }, [componentSpec.description]);
+
+  return (
+    <Textarea
+      value={localValue}
+      onChange={(event) => setLocalValue(event.target.value)}
+      onBlur={() => setDescription(localValue)}
+      placeholder="Add a pipeline description..."
+      className="min-h-5 resize-y"
+      data-testid="pipeline-description-editor"
+      autoFocus={autoFocus}
+    />
+  );
+};


### PR DESCRIPTION
## Description

Closes https://github.com/TangleML/tangle-ui/issues/605

Added an inline editor for pipeline descriptions, allowing users to edit descriptions directly from the pipeline details panel. This includes:

1. A new `InlineEditor` component that toggles between view and edit modes
2. A dedicated `PipelineDescription` component that handles displaying and editing pipeline descriptions
3. A `PipelineDescriptionEditor` component for editing the description text

Also enabled React Compiler for the new PipelineDescription and InlineEditor components.

## Type of Change

- [x] New feature
- [x] Improvement

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

[Screen Recording 2026-01-21 at 11.45.14 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/08141ac9-5f87-4c81-a7af-3d17b280b5fc.mov" />](https://app.graphite.com/user-attachments/video/08141ac9-5f87-4c81-a7af-3d17b280b5fc.mov)

1. Open a pipeline in the editor
2. Check the pipeline details panel for the description section
3. Click on an existing description to edit it inline
4. For pipelines without descriptions, verify you can add one directly

## Note

I decided to experiment with switching to edit mode on click,  which could be a questionable UX - since it is a new pattern without visual clues. I tried to mitigate it by making "edit" mode active by default for empty descriptions. If you see better way of representing the "edit on click" - I'm open. If you think this pattern is not something we want - I can easily remove it.