### PR TITLE
chore: Remove Top Nav Buttons

### DIFF
--- a/src/components/Home/PipelineSection/PipelineSection.tsx
+++ b/src/components/Home/PipelineSection/PipelineSection.tsx
@@ -1,8 +1,8 @@
 import { Link } from "@tanstack/react-router";
 import { type ChangeEvent, useEffect, useState } from "react";
 
+import NewPipelineButton from "@/components/shared/Buttons/NewPipelineButton";
 import { LoadingScreen } from "@/components/shared/LoadingScreen";
-import NewPipelineButton from "@/components/shared/NewPipelineButton";
 import QuickStartCards from "@/components/shared/QuickStart/QuickStartCards";
 import { withSuspenseWrapper } from "@/components/shared/SuspenseWrapper";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
@@ -231,7 +231,10 @@ export const PipelineSection = withSuspenseWrapper(() => {
           </InlineStack>
         </BlockStack>
 
-        <QuickStartButton />
+        <InlineStack gap="2" wrap="nowrap">
+          <NewPipelineButton />
+          <QuickStartButton />
+        </InlineStack>
       </InlineStack>
 
       {pipelines.size > 0 && (
@@ -324,7 +327,7 @@ export const PipelineSection = withSuspenseWrapper(() => {
 
 function QuickStartButton() {
   return (
-    <Button variant="secondary" asChild>
+    <Button variant="outline" asChild>
       <Link to={QUICK_START_PATH as string}>
         <Icon name="Sparkles" />
         Example Pipelines

--- a/src/components/layout/AppMenu.tsx
+++ b/src/components/layout/AppMenu.tsx
@@ -1,33 +1,19 @@
-import { Menu } from "lucide-react";
-import { useState } from "react";
-
 import logo from "/Tangle_white.png";
 import { isAuthorizationRequired } from "@/components/shared/Authentication/helpers";
 import { TopBarAuthentication } from "@/components/shared/Authentication/TopBarAuthentication";
 import { CopyText } from "@/components/shared/CopyText/CopyText";
-import ImportPipeline from "@/components/shared/ImportPipeline";
-import { Button } from "@/components/ui/button";
-import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { InlineStack } from "@/components/ui/layout";
 import { Link } from "@/components/ui/link";
-import {
-  Sheet,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-  SheetTrigger,
-} from "@/components/ui/sheet";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 import { TOP_NAV_HEIGHT } from "@/utils/constants";
 
 import BackendStatus from "../shared/BackendStatus";
-import NewPipelineButton from "../shared/NewPipelineButton";
 import { PersonalPreferences } from "../shared/Settings/PersonalPreferences";
 
 const AppMenu = () => {
   const requiresAuthorization = isAuthorizationRequired();
   const { componentSpec } = useComponentSpec();
   const title = componentSpec?.name;
-  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 
   return (
     <div
@@ -52,44 +38,11 @@ const AppMenu = () => {
         </InlineStack>
 
         <InlineStack gap="2" wrap="nowrap" className="shrink-0">
-          {/* Desktop action buttons - hidden on mobile */}
-          <InlineStack gap="2" className="hidden md:flex" wrap="nowrap">
-            <ImportPipeline />
-            <NewPipelineButton />
-          </InlineStack>
-
-          {/* Always visible settings */}
           <InlineStack gap="2" wrap="nowrap">
             <BackendStatus />
             <PersonalPreferences />
             {requiresAuthorization && <TopBarAuthentication />}
           </InlineStack>
-
-          {/* Mobile hamburger menu - visible only on mobile */}
-          <Sheet open={mobileMenuOpen} onOpenChange={setMobileMenuOpen}>
-            <SheetTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="md:hidden text-white hover:bg-stone-800"
-                aria-label="Open menu"
-              >
-                <Menu className="h-5 w-5" />
-              </Button>
-            </SheetTrigger>
-            <SheetContent
-              side="right"
-              className="w-fit bg-stone-900 border-stone-700 px-4"
-            >
-              <SheetHeader>
-                <SheetTitle className="text-white">Actions</SheetTitle>
-              </SheetHeader>
-              <BlockStack gap="3" className="mt-6">
-                <ImportPipeline />
-                <NewPipelineButton />
-              </BlockStack>
-            </SheetContent>
-          </Sheet>
         </InlineStack>
       </InlineStack>
     </div>

--- a/src/components/shared/Buttons/NewPipelineButton.tsx
+++ b/src/components/shared/Buttons/NewPipelineButton.tsx
@@ -1,31 +1,16 @@
 import { useNavigate } from "@tanstack/react-router";
-import { generate } from "random-words";
 import type { MouseEvent } from "react";
 
 import { Button } from "@/components/ui/button";
-import { EDITOR_PATH } from "@/routes/router";
-import { writeComponentToFileListFromText } from "@/utils/componentStore";
-import {
-  defaultPipelineYamlWithName,
-  IS_GITHUB_PAGES,
-  USER_PIPELINES_LIST_NAME,
-} from "@/utils/constants";
-
-const randomName = () => (generate(4) as string[]).join(" ");
+import { Icon } from "@/components/ui/icon";
+import { IS_GITHUB_PAGES } from "@/utils/constants";
+import { createNewPipeline } from "@/utils/createNewPipeline";
 
 const NewPipelineButton = () => {
   const navigate = useNavigate();
 
   const handleCreate = async (e: MouseEvent<HTMLButtonElement>) => {
-    const name = randomName();
-    const componentText = defaultPipelineYamlWithName(name);
-    await writeComponentToFileListFromText(
-      USER_PIPELINES_LIST_NAME,
-      name,
-      componentText,
-    );
-
-    const clickThroughUrl = `${EDITOR_PATH}/${encodeURIComponent(name)}`;
+    const clickThroughUrl = await createNewPipeline();
 
     if (e.ctrlKey || e.metaKey) {
       window.open(clickThroughUrl, "_blank");
@@ -44,7 +29,7 @@ const NewPipelineButton = () => {
       onClick={handleCreate}
       data-testid="new-pipeline-button"
     >
-      New Pipeline
+      <Icon name="FilePlusCorner" /> New Pipeline
     </Button>
   );
 };

--- a/src/components/shared/ReactFlow/FlowSidebar/sections/FileActions.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/sections/FileActions.tsx
@@ -1,5 +1,11 @@
 import { useNavigate } from "@tanstack/react-router";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  type MouseEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 
 import { PipelineNameDialog } from "@/components/shared/Dialogs";
 import ImportPipeline from "@/components/shared/ImportPipeline";
@@ -22,6 +28,8 @@ import { useAutoSaveStatus } from "@/providers/AutoSaveProvider";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 import { EDITOR_PATH } from "@/routes/router";
 import { getPipelineFile, useSavePipeline } from "@/services/pipelineService";
+import { IS_GITHUB_PAGES } from "@/utils/constants";
+import { createNewPipeline } from "@/utils/createNewPipeline";
 import { formatRelativeTime } from "@/utils/date";
 import { componentSpecToYaml } from "@/utils/yaml";
 
@@ -49,6 +57,20 @@ const FileActions = ({ isOpen }: { isOpen: boolean }) => {
     },
     [notify],
   );
+
+  const handleNewPipeline = async (e: MouseEvent<HTMLButtonElement>) => {
+    const clickThroughUrl = await createNewPipeline();
+
+    if (e.ctrlKey || e.metaKey) {
+      window.open(clickThroughUrl, "_blank");
+      return;
+    }
+
+    navigate({
+      to: clickThroughUrl,
+      reloadDocument: !IS_GITHUB_PAGES,
+    });
+  };
 
   const handleSavePipeline = useCallback(async () => {
     await savePipeline();
@@ -127,6 +149,16 @@ const FileActions = ({ isOpen }: { isOpen: boolean }) => {
             "flex-col": !isOpen,
           })}
         >
+          <SidebarMenuItem>
+            <SidebarMenuButton
+              tooltip="New Pipeline"
+              forceTooltip
+              tooltipPosition={tooltipPosition}
+              onClick={handleNewPipeline}
+            >
+              <Icon name="FilePlusCorner" size="lg" className="stroke-[1.5]" />
+            </SidebarMenuButton>
+          </SidebarMenuItem>
           <SidebarMenuItem>
             <SidebarMenuButton
               tooltip="Save Pipeline"

--- a/src/utils/createNewPipeline.ts
+++ b/src/utils/createNewPipeline.ts
@@ -1,0 +1,25 @@
+import { generate } from "random-words";
+
+import { EDITOR_PATH } from "@/routes/router";
+
+import { writeComponentToFileListFromText } from "./componentStore";
+import {
+  defaultPipelineYamlWithName,
+  USER_PIPELINES_LIST_NAME,
+} from "./constants";
+
+const randomName = () => (generate(4) as string[]).join(" ");
+
+export const createNewPipeline = async () => {
+  const name = randomName();
+  const componentText = defaultPipelineYamlWithName(name);
+  await writeComponentToFileListFromText(
+    USER_PIPELINES_LIST_NAME,
+    name,
+    componentText,
+  );
+
+  const clickThroughUrl = `${EDITOR_PATH}/${encodeURIComponent(name)}`;
+
+  return clickThroughUrl;
+};


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

Remove the low-used "New Pipeline" and "Import Pipeline" buttons from the top nav.

The New Pipeline Button has been moved to two new locations: Editor Sidebar (next to save) and Pipeline List (next to Example Pipelines)

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->
Closes https://github.com/Shopify/oasis-frontend/issues/55

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->
new top nav

![image.png](https://app.graphite.com/user-attachments/assets/f6721987-f39a-4bcc-a77d-e52933323102.png)

new pipeline button on pipeline list

![image.png](https://app.graphite.com/user-attachments/assets/7d3eedca-e8bc-4e02-9106-93610680afab.png)

New pipeline button in editor sidebar

![image.png](https://app.graphite.com/user-attachments/assets/11d4a4b7-4214-4668-8be2-91366e8f8444.png)

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
