### PR TITLE
perf: Refactor React Compiler - Manage Component - Published Component Details

### DIFF
--- a/react-compiler.config.js
+++ b/react-compiler.config.js
@@ -42,6 +42,8 @@ export const REACT_COMPILER_ENABLED_DIRS = [
   "src/components/shared/ManageComponent/DeprecatePublishedComponentButton.tsx",
   "src/components/shared/ManageComponent/PublishComponent.tsx",
   "src/components/shared/ManageComponent/hooks/useComponentCanvasTasks.ts",
+  "src/components/shared/ManageComponent/PublishedComponentDetails.tsx",
+  "src/components/shared/ManageComponent/hooks/useForceUpdateTasks.ts",
   "src/components/shared/TaskDetails/DisplayNameEditor.tsx",
   "src/components/shared/TaskDetails/Actions/UnpackSubgraphButton.tsx",
 

--- a/src/components/shared/ManageComponent/PublishedComponentDetails.tsx
+++ b/src/components/shared/ManageComponent/PublishedComponentDetails.tsx
@@ -1,5 +1,3 @@
-import { useCallback, useMemo } from "react";
-
 import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
@@ -35,18 +33,17 @@ function PublishedComponentDetailsContent({
   const { data: isPublished } = useHasPublishedComponent(component);
   const { data: outdatedComponents } = useOutdatedComponents([component]);
 
-  const outdatedComponentIndex = useMemo(
-    () => new Map(outdatedComponents.map(([c, m]) => [c.digest, m])),
-    [outdatedComponents],
+  const outdatedComponentIndex = new Map(
+    outdatedComponents.map(([c, m]) => [c.digest, m]),
   );
 
   const onForceUpdate = useForceUpdateTasks(
     outdatedComponentIndex.get(component.digest) ?? null,
   );
 
-  const onUpdateTasks = useCallback(() => {
+  const onUpdateTasks = () => {
     onForceUpdate(component.digest);
-  }, [onForceUpdate, component.digest]);
+  };
 
   if (!isPublished) {
     return null;

--- a/src/components/shared/ManageComponent/hooks/useForceUpdateTasks.ts
+++ b/src/components/shared/ManageComponent/hooks/useForceUpdateTasks.ts
@@ -1,5 +1,3 @@
-import { useCallback } from "react";
-
 import type { HydratedComponentReference } from "@/utils/componentSpec";
 
 import { useDialogContext } from "../../Dialogs/dialog.context";
@@ -11,43 +9,34 @@ export function useForceUpdateTasks(
   const dialogContext = useDialogContext();
   const { notifyNode, getNodeIdsByDigest, fitNodeIntoView } = useNodesOverlay();
 
-  return useCallback(
-    async (digest: string) => {
-      if (!currentComponent) {
-        return;
-      }
+  return async (digest: string) => {
+    if (!currentComponent) {
+      return;
+    }
 
-      const nodeIds = getNodeIdsByDigest(digest);
+    const nodeIds = getNodeIdsByDigest(digest);
 
-      if (nodeIds.length === 0) {
-        return;
-      }
+    if (nodeIds.length === 0) {
+      return;
+    }
 
-      const nodeId = nodeIds.pop();
+    const nodeId = nodeIds.pop();
 
-      if (!nodeId) {
-        return;
-      }
+    if (!nodeId) {
+      return;
+    }
 
-      // close current dialog?
-      dialogContext?.close();
+    // close current dialog?
+    dialogContext?.close();
 
-      await fitNodeIntoView(nodeId);
+    await fitNodeIntoView(nodeId);
 
-      notifyNode(nodeId, {
-        type: "update-overlay",
-        data: {
-          replaceWith: new Map([[digest, currentComponent]]),
-          ids: nodeIds,
-        },
-      });
-    },
-    [
-      dialogContext,
-      getNodeIdsByDigest,
-      fitNodeIntoView,
-      notifyNode,
-      currentComponent,
-    ],
-  );
+    notifyNode(nodeId, {
+      type: "update-overlay",
+      data: {
+        replaceWith: new Map([[digest, currentComponent]]),
+        ids: nodeIds,
+      },
+    });
+  };
 }


### PR DESCRIPTION
## Description

Enabled React Compiler for two additional files in the ManageComponent directory: `PublishedComponentDetails.tsx` and `useForceUpdateTasks.ts`. Removed unnecessary `useCallback` and `useMemo` hooks from these files to make them compatible with the React Compiler optimization.

## Related Issue and Pull requests

## Type of Change

- [x] Improvement
- [x] Cleanup/Refactor

## Tests

- [x] Confirm `Memo` is displayed in the Chrome React Dev Tool.
  - ![image.png](https://app.graphite.com/user-attachments/assets/19c8c73c-a9d9-4989-9e44-c09a807d5888.png)

