### PR TITLE
fix: canonical name preservation on rerun action

### DIFF
--- a/src/components/PipelineRun/components/RerunPipelineButton.tsx
+++ b/src/components/PipelineRun/components/RerunPipelineButton.tsx
@@ -6,6 +6,7 @@ import { isAuthorizationRequired } from "@/components/shared/Authentication/help
 import { useAuthLocalStorage } from "@/components/shared/Authentication/useAuthLocalStorage";
 import { useAwaitAuthorization } from "@/components/shared/Authentication/useAwaitAuthorization";
 import TooltipButton from "@/components/shared/Buttons/TooltipButton";
+import { buildTakSpecShape } from "@/components/shared/PipelineRunNameTemplate/types";
 import { useFlagValue } from "@/components/shared/Settings/useFlags";
 import { Icon } from "@/components/ui/icon";
 import useToastNotification from "@/hooks/useToastNotification";
@@ -13,6 +14,7 @@ import { useBackend } from "@/providers/BackendProvider";
 import { useExecutionDataOptional } from "@/providers/ExecutionDataProvider";
 import { APP_ROUTES } from "@/routes/router";
 import type { PipelineRun } from "@/types/pipelineRun";
+import { extractCanonicalName } from "@/utils/canonicalPipelineName";
 import type { ComponentSpec } from "@/utils/componentSpec";
 import { submitPipelineRun } from "@/utils/submitPipeline";
 
@@ -65,6 +67,12 @@ export const RerunPipelineButton = ({
 
       return new Promise<PipelineRun>((resolve, reject) => {
         submitPipelineRun(componentSpec, backendUrl, {
+          canonicalName: extractCanonicalName(
+            buildTakSpecShape(
+              executionData?.rootDetails?.task_spec,
+              componentSpec,
+            ),
+          ),
           taskArguments: executionData?.rootDetails?.task_spec.arguments,
           authorizationToken,
           runNameOverride,

--- a/src/utils/submitPipeline.ts
+++ b/src/utils/submitPipeline.ts
@@ -24,11 +24,13 @@ export async function submitPipelineRun(
     taskArguments?: TaskSpecOutput["arguments"];
     authorizationToken?: string;
     runNameOverride?: boolean;
+    canonicalName?: string;
     onSuccess?: (data: PipelineRun) => void;
     onError?: (error: Error) => void;
   },
 ) {
-  const pipelineName = componentSpec.name ?? "Pipeline";
+  const pipelineName =
+    options?.canonicalName ?? componentSpec.name ?? "Pipeline";
 
   try {
     const specCopy = structuredClone(componentSpec);


### PR DESCRIPTION
## Description

Added support for canonical pipeline names when rerunning pipelines. The `RerunPipelineButton` component now extracts the canonical name from the task spec and passes it to the `submitPipelineRun` function, which uses this name instead of the component spec name when available.

## Type of Change

- [x] Improvement
- [x] New feature

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

1. Run a pipeline
2. Verify that when rerunning the pipeline, the canonical name is preserved
3. Check that the pipeline run name follows the expected format