### PR TITLE
chore: Add Min Width to TaskStatusBar Segments

### DIFF
--- a/src/components/shared/Status/TaskStatusBar.tsx
+++ b/src/components/shared/Status/TaskStatusBar.tsx
@@ -52,7 +52,7 @@ const StatusSegment = ({
     <Tooltip>
       <TooltipTrigger asChild>
         <div
-          className={cn(colorClass, "h-full")}
+          className={cn(colorClass, "h-full min-w-1/20")}
           style={{ width }}
           aria-label={`${count} ${label}`}
         />


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
In a large execution with many tasks, if one task failed and hundreds of others succeeded, it can be difficult to see at a glance in the status bar. Now statuses have a minimum width so they will always be somewhat visible.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->
before

![image.png](https://app.graphite.com/user-attachments/assets/a45d5708-c1c5-486c-9818-58300e4fa903.png)

after

![image.png](https://app.graphite.com/user-attachments/assets/ef35aa0a-4a17-4337-9902-701821404079.png)

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
