### PR TITLE
feat: add error message normalization utility

### DIFF
--- a/src/services/errorManagement/normalizeErrorMessage.test.ts
+++ b/src/services/errorManagement/normalizeErrorMessage.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeErrorMessage } from "./normalizeErrorMessage";
+
+describe("normalizeErrorMessage", () => {
+  it("should extract UUIDs from error messages", () => {
+    const message =
+      "HTTP 404 Not Found: Resource not found (URL: http://localhost:8000/api/executions/019b3428-a0f0-d259-b764-ae0efbf37a64/status)";
+    const result = normalizeErrorMessage(message);
+
+    expect(result.normalizedMessage).toBe(
+      "HTTP 404 Not Found: Resource not found (URL: http://localhost:{var2}/api/executions/{var1}/status)",
+    );
+    expect(result.extractedValues["{var1}"]).toBe(
+      "019b3428-a0f0-d259-b764-ae0efbf37a64",
+    );
+    expect(result.extractedValues["{var2}"]).toBe("8000");
+  });
+
+  it("should extract numeric IDs from paths", () => {
+    const message =
+      "HTTP 500 Internal Server Error (URL: /api/runs/12345/tasks)";
+    const result = normalizeErrorMessage(message);
+
+    expect(result.normalizedMessage).toBe(
+      "HTTP 500 Internal Server Error (URL: /api/runs/{var1}/tasks)",
+    );
+    expect(result.extractedValues["{var1}"]).toBe("12345");
+  });
+
+  it("should preserve HTTP status codes", () => {
+    const message = "HTTP 502 Bad Gateway: Gateway timeout";
+    const result = normalizeErrorMessage(message);
+
+    expect(result.normalizedMessage).toBe(
+      "HTTP 502 Bad Gateway: Gateway timeout",
+    );
+    expect(result.extractedValues).toEqual({});
+  });
+
+  it("should extract alphanumeric IDs", () => {
+    const message = "Error fetching /api/resources/abc123def456/details";
+    const result = normalizeErrorMessage(message);
+
+    expect(result.normalizedMessage).toBe(
+      "Error fetching /api/resources/{var1}/details",
+    );
+    expect(result.extractedValues["{var1}"]).toBe("abc123def456");
+  });
+
+  it("should extract query parameters with IDs", () => {
+    const message = "Failed to load /api/data?id=abc123&status=pending";
+    const result = normalizeErrorMessage(message);
+
+    expect(result.normalizedMessage).toBe(
+      "Failed to load /api/data?id={var1}&status=pending",
+    );
+    expect(result.extractedValues["{var1}"]).toBe("abc123");
+  });
+
+  it("should extract hash values (MD5, SHA-1, SHA-256)", () => {
+    // Test MD5 hash (32 characters)
+    const md5Message =
+      "Validation failed for hash a1b2c3d4e5f67890123456789abcdef0";
+    const md5Result = normalizeErrorMessage(md5Message);
+
+    expect(md5Result.normalizedMessage).toBe(
+      "Validation failed for hash {var1}",
+    );
+    expect(md5Result.extractedValues["{var1}"]).toBe(
+      "a1b2c3d4e5f67890123456789abcdef0",
+    );
+
+    // Test SHA-1 hash (40 characters)
+    const sha1Message =
+      "Error: checksum mismatch abc123def4567890abcdef1234567890abcdef12";
+    const sha1Result = normalizeErrorMessage(sha1Message);
+
+    expect(sha1Result.normalizedMessage).toBe(
+      "Error: checksum mismatch {var1}",
+    );
+    expect(sha1Result.extractedValues["{var1}"]).toBe(
+      "abc123def4567890abcdef1234567890abcdef12",
+    );
+
+    // Test SHA-256 hash (64 characters)
+    const sha256Message =
+      "Failed to verify 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    const sha256Result = normalizeErrorMessage(sha256Message);
+
+    expect(sha256Result.normalizedMessage).toBe("Failed to verify {var1}");
+    expect(sha256Result.extractedValues["{var1}"]).toBe(
+      "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    );
+  });
+
+  it("should extract quoted strings", () => {
+    const message = 'Error: File "document.pdf" not found';
+    const result = normalizeErrorMessage(message);
+
+    expect(result.normalizedMessage).toBe("Error: File {var1} not found");
+    expect(result.extractedValues["{var1}"]).toBe("document.pdf");
+  });
+
+  it("should truncate long messages to 200 characters", () => {
+    const longMessage = "Error: " + "a".repeat(300);
+    const result = normalizeErrorMessage(longMessage);
+
+    // After normalization, all 'a's get extracted as a quoted string placeholder
+    // So the message becomes much shorter
+    expect(result.normalizedMessage.length).toBeLessThanOrEqual(200);
+  });
+
+  it("should handle multiple dynamic values", () => {
+    const message =
+      "Failed to copy /files/abc123defghi/item to /files/xyz789ghijkl/backup";
+    const result = normalizeErrorMessage(message);
+
+    expect(result.normalizedMessage).toBe(
+      "Failed to copy /files/{var1}/item to /files/{var2}/backup",
+    );
+    expect(result.extractedValues["{var1}"]).toBe("abc123defghi");
+    expect(result.extractedValues["{var2}"]).toBe("xyz789ghijkl");
+  });
+
+  it("should clean up multiple spaces and empty parentheses", () => {
+    const message = "Error:   Multiple   spaces   and  ()  empty  parens  ()";
+    const result = normalizeErrorMessage(message);
+
+    // The function cleans up multiple spaces to single spaces and removes empty parens
+    expect(result.normalizedMessage).toContain("Error:");
+    expect(result.normalizedMessage).toContain("Multiple");
+    expect(result.normalizedMessage).not.toContain("()");
+    expect(result.normalizedMessage.trim()).toBe(result.normalizedMessage);
+  });
+
+  it("should NOT extract short hex strings that are not real hashes", () => {
+    // 26 characters - too short to be a real hash, should not be extracted
+    const message = "Error with value a1b2c3d4e5f6789012345678 in system";
+    const result = normalizeErrorMessage(message);
+
+    expect(result.normalizedMessage).toBe(
+      "Error with value a1b2c3d4e5f6789012345678 in system",
+    );
+    expect(result.extractedValues).toEqual({});
+  });
+
+  it("should preserve HTTP status codes with multiple spaces", () => {
+    const message = "HTTP  502 Bad Gateway: Gateway timeout";
+    const result = normalizeErrorMessage(message);
+
+    expect(result.normalizedMessage).toContain("HTTP 502");
+    expect(result.normalizedMessage).toContain("Gateway timeout");
+    // The 502 should NOT be extracted as a variable
+    expect(result.normalizedMessage).not.toContain("{var");
+  });
+});

--- a/src/services/errorManagement/normalizeErrorMessage.ts
+++ b/src/services/errorManagement/normalizeErrorMessage.ts
@@ -1,0 +1,171 @@
+// Message length constraints
+const MAX_MESSAGE_LENGTH = 200;
+const MAX_MESSAGE_TRUNCATED_LENGTH = 197;
+const ELLIPSIS = "...";
+
+// HTTP status code detection
+const HTTP_LOOKBACK_LENGTH = 10;
+
+/**
+ * Normalization pattern configuration.
+ * Each pattern extracts dynamic values and replaces them with placeholders.
+ *
+ * @param match - The full matched string
+ * @param ...groups - Capture groups from the regex
+ * @param offset - The offset of the match in the string
+ * @param fullString - The full string being matched against
+ * @param placeholder - The placeholder to use for this match
+ * @returns Object with extracted value and replacement string, or null to skip extraction
+ */
+type NormalizationReplacer = (
+  match: string,
+  ...args: any[]
+) => { value: string; replacement: string } | null;
+
+interface NormalizationPattern {
+  name: string;
+  pattern: RegExp;
+  replacer: NormalizationReplacer;
+}
+
+const NORMALIZATION_PATTERNS: NormalizationPattern[] = [
+  {
+    name: "uuid",
+    pattern:
+      /\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(\/|$|\)|\s)/gi,
+    replacer: (_match, uuid, after, _offset, _fullString, placeholder) => ({
+      value: uuid,
+      replacement: `/${placeholder}${after}`,
+    }),
+  },
+  {
+    name: "numericPathId",
+    pattern: /\/(\d+)(\/|$|\)|\s)/g,
+    replacer: (_match, num, after, _offset, _fullString, placeholder) => ({
+      value: num,
+      replacement: `/${placeholder}${after}`,
+    }),
+  },
+  {
+    name: "alphanumericPathId",
+    pattern:
+      /\/([a-zA-Z0-9]*\d[a-zA-Z0-9]*[a-zA-Z][a-zA-Z0-9]{6,}|[a-zA-Z0-9]*[a-zA-Z][a-zA-Z0-9]*\d[a-zA-Z0-9]{6,})(\/|$|\)|\s)/g,
+    replacer: (_match, id, after, _offset, _fullString, placeholder) => ({
+      value: id,
+      replacement: `/${placeholder}${after}`,
+    }),
+  },
+  {
+    name: "queryParamId",
+    pattern: /([?&][a-zA-Z_]+)=([0-9a-zA-Z-]{6,})/g,
+    replacer: (_match, key, value, _offset, _fullString, placeholder) => {
+      // Only extract if value contains digits or is hexadecimal
+      if (/\d/.test(value) || /^[a-f0-9]+$/i.test(value)) {
+        return {
+          value,
+          replacement: `${key}=${placeholder}`,
+        };
+      }
+      return null; // Skip this match
+    },
+  },
+  {
+    name: "hashOrDigest",
+    // Match common hash lengths: MD5 (32), SHA-1 (40), SHA-256 (64)
+    // More specific than 16+ to avoid false positives with sequential numbers
+    pattern: /\b([a-f0-9]{32}|[a-f0-9]{40}|[a-f0-9]{64})\b/gi,
+    replacer: (_match, hash, _offset, _fullString, placeholder) => ({
+      value: hash,
+      replacement: placeholder,
+    }),
+  },
+  {
+    name: "doubleQuotedString",
+    pattern: /"([^"]+)"/g,
+    replacer: (_match, content, _offset, _fullString, placeholder) => ({
+      value: content,
+      replacement: placeholder,
+    }),
+  },
+  {
+    name: "singleQuotedString",
+    pattern: /'([^']+)'/g,
+    replacer: (_match, content, _offset, _fullString, placeholder) => ({
+      value: content,
+      replacement: placeholder,
+    }),
+  },
+  {
+    name: "largeNumber",
+    pattern: /\b\d{3,}\b/g,
+    replacer: (match, offset, fullString, placeholder) => {
+      const beforeMatch = fullString.substring(
+        Math.max(0, offset - HTTP_LOOKBACK_LENGTH),
+        offset,
+      );
+      // Preserve HTTP status codes (handle multiple spaces)
+      if (/HTTP\s+$/.test(beforeMatch)) {
+        return null; // Skip this match
+      }
+      return {
+        value: match,
+        replacement: placeholder,
+      };
+    },
+  },
+];
+
+const CLEANUP_PATTERNS: Array<{ pattern: RegExp; replacement: string }> = [
+  { pattern: /\s+/g, replacement: " " },
+  { pattern: /\(\s*\)/g, replacement: "" },
+];
+
+/**
+ * Extract dynamic values from error message and replace with numbered placeholders.
+ * Returns both the normalized message and a metadata object with extracted values.
+ *
+ * This normalization helps group similar errors together (e.g., errors with different
+ * IDs, UUIDs, or dynamic values that are otherwise the same error).
+ */
+export function normalizeErrorMessage(message: string): {
+  normalizedMessage: string;
+  extractedValues: Record<string, string>;
+} {
+  const extractedValues: Record<string, string> = {};
+  let extractedValueIndex = 1;
+  let normalized = message;
+
+  // Apply all normalization patterns
+  for (const { pattern, replacer } of NORMALIZATION_PATTERNS) {
+    normalized = normalized.replace(pattern, (...args) => {
+      const placeholder = `{var${extractedValueIndex}}`;
+      // Call the replacer with all match args plus the placeholder
+      const result = replacer(...args, placeholder);
+
+      // If replacer returns null, skip this match
+      if (result === null) {
+        return args[0]; // Return the original match
+      }
+
+      // Extract the value and use the replacement
+      extractedValues[placeholder] = result.value;
+      extractedValueIndex++;
+      return result.replacement;
+    });
+  }
+
+  // Apply cleanup patterns (these don't extract values)
+  for (const { pattern, replacement } of CLEANUP_PATTERNS) {
+    normalized = normalized.replace(pattern, replacement);
+  }
+
+  normalized = normalized.trim();
+
+  // Limit length
+  if (normalized.length > MAX_MESSAGE_LENGTH) {
+    normalized =
+      normalized.substring(0, MAX_MESSAGE_TRUNCATED_LENGTH) + ELLIPSIS;
+  }
+
+  return { normalizedMessage: normalized, extractedValues };
+}


### PR DESCRIPTION
## Description

Added error message normalization functionality to standardize error messages by extracting dynamic values (UUIDs, IDs, hashes, etc.) and replacing them with placeholders. This helps group similar errors that differ only in their dynamic values.

The implementation includes:

- A `normalizeErrorMessage` function that extracts various types of dynamic values
- Comprehensive test coverage for different error message patterns
- Support for extracting UUIDs, numeric IDs, alphanumeric IDs, query parameters, hash values, and quoted strings
- Message truncation for very long error messages

## Type of Change

- [x] New feature
- [x] Improvement

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

Run the test suite with `npm test src/services/errorManagement/normalizeErrorMessage.test.ts` to verify the functionality works as expected.