### PR TITLE
refactor: report errors to Bugsnag when using error boundary (ErrorPage fallback)

### DIFF
--- a/src/components/shared/ErrorPage.tsx
+++ b/src/components/shared/ErrorPage.tsx
@@ -1,20 +1,40 @@
+import Bugsnag, { type Event } from "@bugsnag/js";
 import { type ErrorComponentProps, useRouter } from "@tanstack/react-router";
+import { useEffect } from "react";
 
 import { InfoBox } from "@/components/shared/InfoBox";
 import { Button } from "@/components/ui/button";
 import { BlockStack } from "@/components/ui/layout";
 import { Paragraph, Text } from "@/components/ui/typography";
+import { isBugsnagEnabled } from "@/services/errorManagement/bugsnag";
 
-export default function ErrorPage({ error }: ErrorComponentProps) {
+const ERROR_HANDLER_METADATA_KEY = "error_handler";
+
+export const ErrorPage = ({ error, reset = () => {} }: ErrorComponentProps) => {
   const router = useRouter();
 
+  useEffect(() => {
+    if (isBugsnagEnabled() && error instanceof Error) {
+      Bugsnag.notify(error, (event: Event) => {
+        event.addMetadata(ERROR_HANDLER_METADATA_KEY, {
+          pathname: window.location.pathname,
+        });
+      });
+    }
+  }, [error]);
+
   const handleRefresh = () => {
+    reset();
     window.location.reload();
   };
 
   const handleGoHome = () => {
+    reset();
     router.navigate({ to: "/" });
   };
+
+  const errorMessage =
+    error instanceof Error ? error.message : "An unexpected error occurred";
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-background p-4">
@@ -31,7 +51,7 @@ export default function ErrorPage({ error }: ErrorComponentProps) {
 
           <InfoBox title="Error Details" variant="error">
             <Paragraph font="mono" size="xs">
-              {error?.message || "An unexpected error occurred"}
+              {errorMessage}
             </Paragraph>
           </InfoBox>
 
@@ -52,4 +72,4 @@ export default function ErrorPage({ error }: ErrorComponentProps) {
       </div>
     </div>
   );
-}
+};

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -6,13 +6,13 @@ import {
   Outlet,
 } from "@tanstack/react-router";
 
+import { ErrorPage } from "@/components/shared/ErrorPage";
 import { AuthorizationResultScreen as GitHubAuthorizationResultScreen } from "@/components/shared/GitHubAuth/AuthorizationResultScreen";
 import { AuthorizationResultScreen as HuggingFaceAuthorizationResultScreen } from "@/components/shared/HuggingFaceAuth/AuthorizationResultScreen";
 import { BASE_URL, IS_GITHUB_PAGES } from "@/utils/constants";
 
 import RootLayout from "../components/layout/RootLayout";
 import Editor from "./Editor";
-import ErrorPage from "./ErrorPage";
 import Home from "./Home";
 import NotFoundPage from "./NotFoundPage";
 import PipelineRun from "./PipelineRun";

--- a/src/services/errorManagement/bugsnag.ts
+++ b/src/services/errorManagement/bugsnag.ts
@@ -14,6 +14,8 @@ const BUGSNAG_CUSTOM_GROUPING_KEY = import.meta.env
 
 const GENERIC_ERROR_CLASS = "Error";
 
+export const isBugsnagEnabled = (): boolean => Boolean(BUGSNAG_API_KEY);
+
 const getBugsnagConfig = (): BrowserConfig => {
   return {
     apiKey: BUGSNAG_API_KEY,


### PR DESCRIPTION
## Description

**Note:** Some of these changes are in preparation for work that is upstack. We wouldn't normally do this but don't wish to change it at this point.

Enhanced error handling by moving `ErrorPage` from routes to shared components and adding Bugsnag integration. The component now automatically reports errors to Bugsnag when configured and includes the current pathname as metadata. Added support for error boundary reset functionality, allowing the component to properly reset when used with React error boundaries. Improved error message handling to better display different error types.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [x] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

1. Test the error display by navigating to a non-existent route
2. Verify that the error message is displayed correctly
3. Test the "Try Again" and "Go Home" buttons to ensure they work as expected
4. Confirm that errors are properly reported to Bugsnag when enabled