### PR TITLE
feat: User Notes on Pipelines

### DIFF
--- a/src/components/Editor/Context/PipelineDetails.tsx
+++ b/src/components/Editor/Context/PipelineDetails.tsx
@@ -13,12 +13,16 @@ import { useFlagValue } from "@/components/shared/Settings/useFlags";
 import { BlockStack } from "@/components/ui/layout";
 import useToastNotification from "@/hooks/useToastNotification";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
+import { PIPELINE_NOTES_ANNOTATION } from "@/utils/annotations";
 import { getComponentFileFromList } from "@/utils/componentStore";
 import { USER_PIPELINES_LIST_NAME } from "@/utils/constants";
 
 import PipelineIO from "../../shared/Execution/PipelineIO";
+import { PipelineNotesEditor } from "./PipelineNotesEditor";
 import { PipelineValidationList } from "./PipelineValidationList";
 import RenamePipeline from "./RenamePipeline";
+
+const EXCLUDED_ANNOTATIONS = [PIPELINE_NOTES_ANNOTATION];
 
 const PipelineDetails = () => {
   const notify = useToastNotification();
@@ -79,12 +83,12 @@ const PipelineDetails = () => {
     },
   ];
 
-  const annotations = Object.entries(
-    componentSpec.metadata?.annotations || {},
-  ).map(([key, value]) => ({
-    label: key,
-    value: String(value),
-  }));
+  const annotations = Object.entries(componentSpec.metadata?.annotations || {})
+    .filter(([key]) => !EXCLUDED_ANNOTATIONS.includes(key))
+    .map(([key, value]) => ({
+      label: key,
+      value: String(value),
+    }));
 
   const actions = [
     <RenamePipeline key="rename-pipeline-action" />,
@@ -135,6 +139,10 @@ const PipelineDetails = () => {
           globalValidationIssues={globalValidationIssues}
           onIssueSelect={handleIssueClick}
         />
+      </ContentBlock>
+
+      <ContentBlock title="Notes">
+        <PipelineNotesEditor />
       </ContentBlock>
     </BlockStack>
   );

--- a/src/components/Editor/Context/PipelineNotesEditor.tsx
+++ b/src/components/Editor/Context/PipelineNotesEditor.tsx
@@ -1,0 +1,45 @@
+import { useState } from "react";
+
+import { Textarea } from "@/components/ui/textarea";
+import { useComponentSpec } from "@/providers/ComponentSpecProvider";
+import {
+  getAnnotationValue,
+  PIPELINE_NOTES_ANNOTATION,
+} from "@/utils/annotations";
+
+export const PipelineNotesEditor = () => {
+  const { componentSpec, setComponentSpec } = useComponentSpec();
+
+  const annotations = componentSpec.metadata?.annotations;
+  const notes =
+    getAnnotationValue(annotations, PIPELINE_NOTES_ANNOTATION) ?? "";
+
+  const [value, setValue] = useState(notes);
+
+  const onInputChange = (value: string) => {
+    setValue(value);
+  };
+
+  const onBlur = () => {
+    setComponentSpec({
+      ...componentSpec,
+      metadata: {
+        ...componentSpec.metadata,
+        annotations: {
+          ...annotations,
+          [PIPELINE_NOTES_ANNOTATION]: value,
+        },
+      },
+    });
+  };
+
+  return (
+    <Textarea
+      value={value}
+      onChange={(e) => onInputChange(e.target.value)}
+      onBlur={onBlur}
+      placeholder="Share context about this pipeline..."
+      className="text-xs"
+    />
+  );
+};

--- a/src/utils/annotations.ts
+++ b/src/utils/annotations.ts
@@ -52,3 +52,4 @@ function hasAnnotation(
 
 export const DISPLAY_NAME_MAX_LENGTH = 100;
 export const TASK_DISPLAY_NAME_ANNOTATION = "display_name";
+export const PIPELINE_NOTES_ANNOTATION = "notes";


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Adds a free text field to the pipeline context panel so users can save notes, thoughts and comments. These will then be visible to anyone who clones the pipeline or on any Runs submitted on the pipeline.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

Progresses https://github.com/Shopify/oasis-frontend/issues/157

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] New feature

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

![image.png](https://app.graphite.com/user-attachments/assets/fafabeba-a165-4d58-9968-0a1001117800.png)

![image.png](https://app.graphite.com/user-attachments/assets/c6e07a0b-ae97-4b75-a850-09bdbb775b4d.png)

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->
- Can add & edit notes on the pipeline in edit mode
- Can READONLY pipeline notes in run mode
- Pipeline notes are copied over when a pipeline is cloned

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
