### PR TITLE
Add useRunSearchParams hook for pipeline run filtering

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,4 +1,4 @@
-# Cursor AI Rules for Pipeline Studio App
+# Cursor AI Rules for Pipeline Studio App.
 
 ## Project Overview
 
@@ -303,21 +303,23 @@ This project uses the React Compiler for automatic memoization. Files/directorie
 **For new files**, ensure they follow React Compiler rules from the start:
 
 1. **Don't mutate values during render**
+
    ```typescript
    // ❌ Bad - mutating during render
    const items = props.items;
    items.push(newItem);
-   
+
    // ✅ Good - create new reference
    const items = [...props.items, newItem];
    ```
 
 2. **Don't read/write refs during render**
+
    ```typescript
    // ❌ Bad - reading ref during render
    const value = myRef.current;
    return <div>{value}</div>;
-   
+
    // ✅ Good - read refs in effects or callbacks
    useEffect(() => {
      const value = myRef.current;
@@ -337,6 +339,7 @@ This project uses the React Compiler for automatic memoization. Files/directorie
 #### Adding Files to React Compiler
 
 When a file is added to `react-compiler.config.js`:
+
 - Remove unnecessary `useCallback` and `useMemo` (compiler handles this)
 - Verify no compiler violations with `npm run validate`
 - Test the component still works correctly
@@ -344,8 +347,9 @@ When a file is added to `react-compiler.config.js`:
 #### React Compiler Config Structure
 
 Files are organized by cleanup effort in `react-compiler.config.js`:
+
 - Top section: Already enabled directories/files
-- Middle: Ready to enable (0 useCallback/useMemo)  
+- Middle: Ready to enable (0 useCallback/useMemo)
 - Bottom (commented): Need cleanup before enabling
 
 ## Component Architecture
@@ -508,6 +512,7 @@ Present findings in a clear, actionable format:
 ## Issues Found
 
 ### 1. **[Issue Title]** - [File:Line]
+
 [Code snippet showing the problem]
 **Why**: [Brief explanation]
 **Fix**: [Suggested solution]
@@ -515,15 +520,17 @@ Present findings in a clear, actionable format:
 ---
 
 ## What's Good
+
 - [Positive observations about the code]
 - Note if file was added to `react-compiler.config.js` (React Compiler enabled)
 
 ---
 
 ## Summary Table
-| Issue | Severity | Location |
-|-------|----------|----------|
-| ... | High/Medium/Low | file:line |
+
+| Issue | Severity        | Location  |
+| ----- | --------------- | --------- |
+| ...   | High/Medium/Low | file:line |
 ```
 
 ### Review Principles
@@ -553,12 +560,14 @@ After completing a code generation task, scan the surrounding area for small, lo
 4. **Clear benefit**: Improves readability, removes dead code, or fixes obvious issues
 
 **Examples of good "while we're here" suggestions:**
+
 - Removing an unused import in the file you just edited
 - Fixing a typo in a comment nearby
 - Removing an unused variable in the same function
 - Updating a deprecated pattern you noticed (e.g., `lucide-react` → `Icon` component)
 
 **Do NOT suggest cleanup for:**
+
 - Complex refactors (> 30 lines)
 - Logic changes
 - Files you didn't touch
@@ -566,6 +575,7 @@ After completing a code generation task, scan the surrounding area for small, lo
 - Anything that could break functionality
 
 **How to offer:**
+
 ```
 ---
 While we're here, I noticed a small cleanup opportunity:
@@ -585,6 +595,7 @@ When asked to create planning documents, architecture decisions, or investigatio
 - These files persist locally but won't be committed to the repo
 
 **Example use cases:**
+
 - Feature planning and design docs
 - Bug investigation notes
 - Architecture decision records (local drafts)
@@ -592,6 +603,7 @@ When asked to create planning documents, architecture decisions, or investigatio
 - Research and exploration notes
 
 **File naming convention:**
+
 ```
 .local/[feature-or-task]-[type].md
 

--- a/knip.json
+++ b/knip.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://unpkg.com/knip@5/schema.json",
   "ignore": [
+    ".git/**",
     "src/api/**",
     "node_modules/**",
     "src/components/ui/**",

--- a/react-compiler.config.js
+++ b/react-compiler.config.js
@@ -28,6 +28,7 @@ export const REACT_COMPILER_ENABLED_DIRS = [
   "src/components/shared/GitHubLibrary",
   "src/hooks/useHandleEdgeSelection.ts",
   "src/hooks/useEdgeSelectionHighlight.ts",
+  "src/hooks/useRunSearchParams.ts",
 
   "src/components/shared/Submitters/Oasis/components",
   "src/components/shared/Submitters/GoogleCloud/ConfigInput.tsx",

--- a/src/components/shared/GitHubLibrary/utils/githubApiClient.ts
+++ b/src/components/shared/GitHubLibrary/utils/githubApiClient.ts
@@ -81,7 +81,7 @@ interface GitHubApiConfig {
 /**
  * GitHub API Client class
  */
-export class GitHubApiClient {
+class GitHubApiClient {
   private readonly accessToken: string;
   private readonly apiBase: string;
   private readonly apiVersion: string;

--- a/src/hooks/useRunSearchParams.test.ts
+++ b/src/hooks/useRunSearchParams.test.ts
@@ -1,0 +1,181 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { PipelineRunFilters } from "@/types/pipelineRunFilters";
+
+import { useRunSearchParams } from "./useRunSearchParams";
+
+const mockNavigate = vi.fn();
+let mockSearchParams: Record<string, unknown> = {};
+
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => mockNavigate,
+  useLocation: () => ({ pathname: "/test-path" }),
+  useSearch: () => mockSearchParams,
+}));
+
+const expectNavigatedTo = (filters: PipelineRunFilters | undefined) => {
+  const search = filters ? { filter: filters } : {};
+  expect(mockNavigate).toHaveBeenCalledWith({ to: "/test-path", search });
+};
+
+describe("useRunSearchParams", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    mockSearchParams = {};
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("parsing", () => {
+    it("returns empty filters when no URL params exist", () => {
+      const { result } = renderHook(() => useRunSearchParams());
+
+      expect(result.current.filters).toEqual({});
+      expect(result.current.hasActiveFilters).toBe(false);
+      expect(result.current.activeFilterCount).toBe(0);
+    });
+
+    it("parses filter object from URL (router-parsed)", () => {
+      mockSearchParams = {
+        filter: {
+          status: "FAILED",
+          pipeline_name: "test",
+          created_by: "user@test.com",
+          created_after: "2024-01-01",
+          created_before: "2024-12-31",
+        },
+      };
+
+      const { result } = renderHook(() => useRunSearchParams());
+
+      expect(result.current.filters).toEqual({
+        status: "FAILED",
+        pipeline_name: "test",
+        created_by: "user@test.com",
+        created_after: "2024-01-01",
+        created_before: "2024-12-31",
+      });
+      expect(result.current.activeFilterCount).toBe(4); // date range counts as 1
+    });
+
+    it("parses legacy JSON string format", () => {
+      mockSearchParams = {
+        filter: JSON.stringify({ status: "FAILED", pipeline_name: "test" }),
+      };
+
+      const { result } = renderHook(() => useRunSearchParams());
+
+      expect(result.current.filters).toEqual({
+        status: "FAILED",
+        pipeline_name: "test",
+      });
+    });
+
+    it("returns empty filters for invalid JSON string", () => {
+      mockSearchParams = { filter: "{invalid" };
+      const { result } = renderHook(() => useRunSearchParams());
+      expect(result.current.filters).toEqual({});
+    });
+  });
+
+  describe("setFilter", () => {
+    it("adds a new filter to URL", () => {
+      const { result } = renderHook(() => useRunSearchParams());
+
+      act(() => result.current.setFilter("status", "RUNNING"));
+
+      expectNavigatedTo({ status: "RUNNING" });
+    });
+
+    it.each([undefined, "", null] as const)(
+      "removes filter when value is %s",
+      (value) => {
+        mockSearchParams = {
+          filter: { status: "FAILED", pipeline_name: "test" },
+        };
+        const { result } = renderHook(() => useRunSearchParams());
+
+        act(() =>
+          result.current.setFilter(
+            "status",
+            value as PipelineRunFilters["status"],
+          ),
+        );
+
+        expectNavigatedTo({ pipeline_name: "test" });
+      },
+    );
+  });
+
+  describe("setFilters", () => {
+    it("sets multiple filters and merges with existing", () => {
+      mockSearchParams = { filter: { status: "RUNNING" } };
+      const { result } = renderHook(() => useRunSearchParams());
+
+      act(() => {
+        result.current.setFilters({
+          created_after: "2024-01-01",
+          created_before: "2024-12-31",
+        });
+      });
+
+      expectNavigatedTo({
+        status: "RUNNING",
+        created_after: "2024-01-01",
+        created_before: "2024-12-31",
+      });
+    });
+  });
+
+  describe("setFilterDebounced", () => {
+    it("debounces updates and uses latest value", () => {
+      const { result } = renderHook(() => useRunSearchParams());
+
+      act(() => result.current.setFilterDebounced("pipeline_name", "t"));
+      act(() => {
+        vi.advanceTimersByTime(100);
+        result.current.setFilterDebounced("pipeline_name", "test");
+      });
+
+      expect(mockNavigate).not.toHaveBeenCalled();
+
+      act(() => vi.advanceTimersByTime(500));
+
+      expect(mockNavigate).toHaveBeenCalledTimes(1);
+      expectNavigatedTo({ pipeline_name: "test" });
+    });
+  });
+
+  describe("clearFilters", () => {
+    it("removes all filters from URL", () => {
+      mockSearchParams = {
+        filter: { status: "FAILED", pipeline_name: "test" },
+      };
+      const { result } = renderHook(() => useRunSearchParams());
+
+      act(() => result.current.clearFilters());
+
+      expectNavigatedTo(undefined);
+    });
+  });
+
+  describe("activeFilterCount", () => {
+    it.each([
+      [{ status: "FAILED" as const }, 1],
+      [{ created_after: "2024-01-01", created_before: "2024-12-31" }, 1],
+      [{ created_after: "2024-01-01" }, 1],
+      [
+        { status: "FAILED" as const, pipeline_name: "test", created_by: "u" },
+        3,
+      ],
+    ])("counts %o as %i", (filters, expected) => {
+      mockSearchParams = { filter: filters };
+      const { result } = renderHook(() => useRunSearchParams());
+      expect(result.current.activeFilterCount).toBe(expected);
+    });
+  });
+});

--- a/src/hooks/useRunSearchParams.ts
+++ b/src/hooks/useRunSearchParams.ts
@@ -1,0 +1,123 @@
+import { useLocation, useNavigate, useSearch } from "@tanstack/react-router";
+import { useEffect, useRef } from "react";
+
+import type { PipelineRunFilters } from "@/types/pipelineRunFilters";
+import {
+  countActiveFilters,
+  isRecord,
+  serializeFiltersToUrl,
+  validateFilters,
+} from "@/utils/pipelineRunFilterUtils";
+
+const DEBOUNCE_MS = 500;
+
+function parseFilterString(value: string): PipelineRunFilters {
+  try {
+    return validateFilters(JSON.parse(value));
+  } catch {
+    return {};
+  }
+}
+
+function getFiltersFromSearch(search: unknown): PipelineRunFilters {
+  const rawFilter = isRecord(search) ? search.filter : undefined;
+  if (typeof rawFilter === "string") return parseFilterString(rawFilter);
+  if (isRecord(rawFilter)) return validateFilters(rawFilter);
+  return {};
+}
+
+function withFilterChange<K extends keyof PipelineRunFilters>(
+  current: PipelineRunFilters,
+  key: K,
+  value: PipelineRunFilters[K],
+): PipelineRunFilters {
+  const next = { ...current };
+  if (value === undefined || value === null || value === "") {
+    delete next[key];
+  } else {
+    next[key] = value;
+  }
+  return next;
+}
+
+interface UseRunSearchParamsReturn {
+  filters: PipelineRunFilters;
+  setFilter: <K extends keyof PipelineRunFilters>(
+    key: K,
+    value: PipelineRunFilters[K],
+  ) => void;
+  setFilters: (filters: Partial<PipelineRunFilters>) => void;
+  setFilterDebounced: <K extends keyof PipelineRunFilters>(
+    key: K,
+    value: PipelineRunFilters[K],
+  ) => void;
+  clearFilters: () => void;
+  hasActiveFilters: boolean;
+  activeFilterCount: number;
+}
+
+/**
+ * Hook to manage pipeline run search/filter state with URL synchronization.
+ */
+export function useRunSearchParams(): UseRunSearchParamsReturn {
+  const navigate = useNavigate();
+  const { pathname } = useLocation();
+  const search: unknown = useSearch({ strict: false });
+  const debounceTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (debounceTimeoutRef.current) {
+        clearTimeout(debounceTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  const filters = getFiltersFromSearch(search);
+  const filtersRef = useRef(filters);
+  filtersRef.current = filters;
+
+  const updateUrl = (newFilters: PipelineRunFilters) => {
+    const filter = serializeFiltersToUrl(newFilters);
+    navigate({ to: pathname, search: filter ? { filter } : {} });
+  };
+
+  const setFilter = <K extends keyof PipelineRunFilters>(
+    key: K,
+    value: PipelineRunFilters[K],
+  ) => {
+    updateUrl(withFilterChange(filters, key, value));
+  };
+
+  const setFilters = (newFilters: Partial<PipelineRunFilters>) => {
+    updateUrl({ ...filters, ...newFilters });
+  };
+
+  const setFilterDebounced = <K extends keyof PipelineRunFilters>(
+    key: K,
+    value: PipelineRunFilters[K],
+  ) => {
+    if (debounceTimeoutRef.current) {
+      clearTimeout(debounceTimeoutRef.current);
+    }
+    debounceTimeoutRef.current = setTimeout(() => {
+      updateUrl(withFilterChange(filtersRef.current, key, value));
+      debounceTimeoutRef.current = null;
+    }, DEBOUNCE_MS);
+  };
+
+  const clearFilters = () => updateUrl({});
+
+  const activeFilterCount = countActiveFilters(filters);
+  const hasActiveFilters = activeFilterCount > 0;
+
+  return {
+    filters,
+    setFilter,
+    setFilters,
+    setFilterDebounced,
+    clearFilters,
+    hasActiveFilters,
+    activeFilterCount,
+  };
+}

--- a/src/types/pipelineRunFilters.ts
+++ b/src/types/pipelineRunFilters.ts
@@ -1,0 +1,13 @@
+import type { ContainerExecutionStatus } from "@/api/types.gen";
+
+/**
+ * Filters for searching and filtering pipeline runs.
+ * All filters combine with AND logic.
+ */
+export interface PipelineRunFilters {
+  status?: ContainerExecutionStatus;
+  created_by?: string;
+  created_after?: string; // ISO datetime
+  created_before?: string; // ISO datetime
+  pipeline_name?: string;
+}

--- a/src/utils/executionStatus.ts
+++ b/src/utils/executionStatus.ts
@@ -84,6 +84,12 @@ export function getExecutionStatusLabel(status: string | undefined): string {
   return EXECUTION_STATUS_LABELS[status] ?? status;
 }
 
+export function isValidExecutionStatus(
+  value: string,
+): value is ContainerExecutionStatus {
+  return value in EXECUTION_STATUS_LABELS;
+}
+
 /**
  * Flatten nested child_execution_status_stats into a single aggregated stats object.
  */

--- a/src/utils/pipelineRunFilterUtils.ts
+++ b/src/utils/pipelineRunFilterUtils.ts
@@ -1,0 +1,71 @@
+import type { PipelineRunFilters } from "@/types/pipelineRunFilters";
+import { isValidExecutionStatus } from "@/utils/executionStatus";
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Validates and extracts filter fields from an unknown object.
+ * Used for both parsed JSON and router-provided objects.
+ */
+export function validateFilters(parsed: unknown): PipelineRunFilters {
+  if (!isRecord(parsed)) return {};
+
+  const filters: PipelineRunFilters = {};
+
+  if (
+    typeof parsed.status === "string" &&
+    isValidExecutionStatus(parsed.status)
+  ) {
+    filters.status = parsed.status;
+  }
+  if (typeof parsed.created_by === "string") {
+    filters.created_by = parsed.created_by;
+  }
+  if (typeof parsed.created_after === "string") {
+    filters.created_after = parsed.created_after;
+  }
+  if (typeof parsed.created_before === "string") {
+    filters.created_before = parsed.created_before;
+  }
+  if (typeof parsed.pipeline_name === "string") {
+    filters.pipeline_name = parsed.pipeline_name;
+  }
+
+  return filters;
+}
+
+/**
+ * Strips empty values from filters for clean URL serialization.
+ * Returns undefined when no filters are active to keep the URL clean.
+ */
+export function serializeFiltersToUrl(
+  filters: PipelineRunFilters,
+): PipelineRunFilters | undefined {
+  const result = Object.fromEntries(
+    Object.entries(filters).filter(([, v]) => {
+      if (v === undefined || v === null || v === "") return false;
+      if (Array.isArray(v) && v.length === 0) return false;
+      return true;
+    }),
+  );
+
+  return Object.keys(result).length > 0
+    ? (result as PipelineRunFilters)
+    : undefined;
+}
+
+/**
+ * Count the number of active filters.
+ */
+export function countActiveFilters(filters: PipelineRunFilters): number {
+  let count = 0;
+
+  if (filters.status) count++;
+  if (filters.created_by) count++;
+  if (filters.created_after || filters.created_before) count++;
+  if (filters.pipeline_name) count++;
+
+  return count;
+}


### PR DESCRIPTION
Resolves: https://github.com/Shopify/oasis-frontend/issues/456

## Description

Adds a new `useRunSearchParams` hook to manage pipeline run filter state with URL synchronization. This hook provides a clean interface for components to read and update filter parameters while keeping them persisted in the URL.

## Type of Change

- [x] New feature

## Changes

- Added `useRunSearchParams` hook with:
    - `filters` - Current filter state parsed from URL
    - `setFilter` / `setFilters` - Update individual or multiple filters
    - `setFilterDebounced` - Debounced filter updates (300ms) for text inputs
    - `clearFilters` - Reset all filters
    - `hasActiveFilters` / `activeFilterCount` - Helper state for UI
- Added `PipelineRunFilters` and `AnnotationFilter` types
- Enabled React Compiler for the new hook

## Checklist

- [x] I have tested this does not break current pipelines/runs functionality

## Test Instructions

This feature has no UI so we can't test yet. If you want to validate it you can use any of the branches above to confirm.  
Run the test suite:

```bash
npm test src/hooks/useRunSearchParams.test.ts
```