### PR TITLE
Annotation Filter input

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -5,6 +5,7 @@
     "src/api/**",
     "node_modules/**",
     "src/components/ui/**",
+    "src/components/shared/StatusFilterSelect/**",
     "openapi-ts.config.ts",
     "vite.config.ghpages.js"
   ],

--- a/src/components/shared/AnnotationFilterInput/AnnotationFilterInput.test.tsx
+++ b/src/components/shared/AnnotationFilterInput/AnnotationFilterInput.test.tsx
@@ -1,0 +1,397 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { AnnotationFilterInput } from "./AnnotationFilterInput";
+
+describe("AnnotationFilterInput", () => {
+  describe("empty state", () => {
+    it("should show add filter button when no filters", () => {
+      render(<AnnotationFilterInput filters={[]} onChange={vi.fn()} />);
+
+      expect(screen.getByText("Annotations:")).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /add filter/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("should not show any badges when no filters", () => {
+      render(<AnnotationFilterInput filters={[]} onChange={vi.fn()} />);
+
+      expect(
+        screen.queryByRole("button", { name: /remove/i }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("expanding input form", () => {
+    it("should show input fields when add filter is clicked", async () => {
+      const user = userEvent.setup();
+      render(<AnnotationFilterInput filters={[]} onChange={vi.fn()} />);
+
+      await user.click(screen.getByRole("button", { name: /add filter/i }));
+
+      expect(screen.getByPlaceholderText("Key")).toBeInTheDocument();
+      expect(
+        screen.getByPlaceholderText("Value (optional)"),
+      ).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Add" })).toBeInTheDocument();
+    });
+
+    it("should focus key input when expanded", async () => {
+      const user = userEvent.setup();
+      render(<AnnotationFilterInput filters={[]} onChange={vi.fn()} />);
+
+      await user.click(screen.getByRole("button", { name: /add filter/i }));
+
+      expect(screen.getByPlaceholderText("Key")).toHaveFocus();
+    });
+
+    it("should collapse when cancel button is clicked", async () => {
+      const user = userEvent.setup();
+      render(<AnnotationFilterInput filters={[]} onChange={vi.fn()} />);
+
+      await user.click(screen.getByRole("button", { name: /add filter/i }));
+      expect(screen.getByPlaceholderText("Key")).toBeInTheDocument();
+
+      await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+      expect(screen.queryByPlaceholderText("Key")).not.toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /add filter/i }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("adding filters", () => {
+    it("should add filter with key only", async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      render(<AnnotationFilterInput filters={[]} onChange={onChange} />);
+
+      await user.click(screen.getByRole("button", { name: /add filter/i }));
+      await user.type(screen.getByPlaceholderText("Key"), "env");
+      await user.click(screen.getByRole("button", { name: "Add" }));
+
+      expect(onChange).toHaveBeenCalledWith([{ key: "env" }]);
+    });
+
+    it("should add filter with key and value", async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      render(<AnnotationFilterInput filters={[]} onChange={onChange} />);
+
+      await user.click(screen.getByRole("button", { name: /add filter/i }));
+      await user.type(screen.getByPlaceholderText("Key"), "team");
+      await user.type(screen.getByPlaceholderText("Value (optional)"), "ml");
+      await user.click(screen.getByRole("button", { name: "Add" }));
+
+      expect(onChange).toHaveBeenCalledWith([{ key: "team", value: "ml" }]);
+    });
+
+    it("should trim whitespace from key and value", async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      render(<AnnotationFilterInput filters={[]} onChange={onChange} />);
+
+      await user.click(screen.getByRole("button", { name: /add filter/i }));
+      await user.type(screen.getByPlaceholderText("Key"), "  team  ");
+      await user.type(
+        screen.getByPlaceholderText("Value (optional)"),
+        "  ml  ",
+      );
+      await user.click(screen.getByRole("button", { name: "Add" }));
+
+      expect(onChange).toHaveBeenCalledWith([{ key: "team", value: "ml" }]);
+    });
+
+    it("should disable add button when key is empty", async () => {
+      const user = userEvent.setup();
+      render(<AnnotationFilterInput filters={[]} onChange={vi.fn()} />);
+
+      await user.click(screen.getByRole("button", { name: /add filter/i }));
+
+      expect(screen.getByRole("button", { name: "Add" })).toBeDisabled();
+    });
+
+    it("should clear inputs after adding", async () => {
+      const user = userEvent.setup();
+      render(<AnnotationFilterInput filters={[]} onChange={vi.fn()} />);
+
+      await user.click(screen.getByRole("button", { name: /add filter/i }));
+      await user.type(screen.getByPlaceholderText("Key"), "team");
+      await user.type(screen.getByPlaceholderText("Value (optional)"), "ml");
+      await user.click(screen.getByRole("button", { name: "Add" }));
+
+      expect(screen.queryByPlaceholderText("Key")).not.toBeInTheDocument();
+    });
+
+    it("should add filter on Enter key press", async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      render(<AnnotationFilterInput filters={[]} onChange={onChange} />);
+
+      await user.click(screen.getByRole("button", { name: /add filter/i }));
+      await user.type(screen.getByPlaceholderText("Key"), "team");
+      await user.keyboard("{Enter}");
+
+      expect(onChange).toHaveBeenCalledWith([{ key: "team" }]);
+    });
+
+    it("should collapse on Escape key press", async () => {
+      const user = userEvent.setup();
+      render(<AnnotationFilterInput filters={[]} onChange={vi.fn()} />);
+
+      await user.click(screen.getByRole("button", { name: /add filter/i }));
+      await user.keyboard("{Escape}");
+
+      expect(screen.queryByPlaceholderText("Key")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("displaying filters", () => {
+    it("should display filter with key only", () => {
+      render(
+        <AnnotationFilterInput filters={[{ key: "env" }]} onChange={vi.fn()} />,
+      );
+
+      expect(screen.getByText("env")).toBeInTheDocument();
+    });
+
+    it("should display filter with key and value", () => {
+      render(
+        <AnnotationFilterInput
+          filters={[{ key: "team", value: "ml" }]}
+          onChange={vi.fn()}
+        />,
+      );
+
+      expect(screen.getByText("team: ml")).toBeInTheDocument();
+    });
+
+    it("should display multiple filters", () => {
+      render(
+        <AnnotationFilterInput
+          filters={[
+            { key: "team", value: "ml" },
+            { key: "env", value: "prod" },
+            { key: "priority" },
+          ]}
+          onChange={vi.fn()}
+        />,
+      );
+
+      expect(screen.getByText("team: ml")).toBeInTheDocument();
+      expect(screen.getByText("env: prod")).toBeInTheDocument();
+      expect(screen.getByText("priority")).toBeInTheDocument();
+    });
+  });
+
+  describe("removing filters", () => {
+    it("should remove filter when remove button is clicked", async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      render(
+        <AnnotationFilterInput
+          filters={[
+            { key: "team", value: "ml" },
+            { key: "env", value: "prod" },
+          ]}
+          onChange={onChange}
+        />,
+      );
+
+      const removeButton = screen.getByRole("button", {
+        name: /remove team filter/i,
+      });
+      await user.click(removeButton);
+
+      expect(onChange).toHaveBeenCalledWith([{ key: "env", value: "prod" }]);
+    });
+
+    it("should have accessible remove button", () => {
+      render(
+        <AnnotationFilterInput
+          filters={[{ key: "team", value: "ml" }]}
+          onChange={vi.fn()}
+        />,
+      );
+
+      expect(
+        screen.getByRole("button", { name: /remove team filter/i }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("editing filters", () => {
+    it("should enter edit mode on double-click", async () => {
+      const user = userEvent.setup();
+      render(
+        <AnnotationFilterInput
+          filters={[{ key: "team", value: "ml" }]}
+          onChange={vi.fn()}
+        />,
+      );
+
+      const badge = screen.getByText("team: ml");
+      await user.dblClick(badge);
+
+      expect(screen.getByDisplayValue("team")).toBeInTheDocument();
+      expect(screen.getByDisplayValue("ml")).toBeInTheDocument();
+    });
+
+    it("should focus key input when entering edit mode", async () => {
+      const user = userEvent.setup();
+      render(
+        <AnnotationFilterInput
+          filters={[{ key: "team", value: "ml" }]}
+          onChange={vi.fn()}
+        />,
+      );
+
+      const badge = screen.getByText("team: ml");
+      await user.dblClick(badge);
+
+      expect(screen.getByDisplayValue("team")).toHaveFocus();
+    });
+
+    it("should save changes on Enter", async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      render(
+        <AnnotationFilterInput
+          filters={[{ key: "team", value: "ml" }]}
+          onChange={onChange}
+        />,
+      );
+
+      const badge = screen.getByText("team: ml");
+      await user.dblClick(badge);
+
+      const keyInput = screen.getByDisplayValue("team");
+      await user.clear(keyInput);
+      await user.type(keyInput, "department");
+      await user.keyboard("{Enter}");
+
+      expect(onChange).toHaveBeenCalledWith([
+        { key: "department", value: "ml" },
+      ]);
+    });
+
+    it("should cancel edit on Escape", async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      render(
+        <AnnotationFilterInput
+          filters={[{ key: "team", value: "ml" }]}
+          onChange={onChange}
+        />,
+      );
+
+      const badge = screen.getByText("team: ml");
+      await user.dblClick(badge);
+
+      const keyInput = screen.getByDisplayValue("team");
+      await user.clear(keyInput);
+      await user.type(keyInput, "different");
+      await user.keyboard("{Escape}");
+
+      expect(onChange).not.toHaveBeenCalled();
+      expect(screen.getByText("team: ml")).toBeInTheDocument();
+    });
+
+    it("should save changes when clicking save button", async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      render(
+        <AnnotationFilterInput
+          filters={[{ key: "team", value: "ml" }]}
+          onChange={onChange}
+        />,
+      );
+
+      const badge = screen.getByText("team: ml");
+      await user.dblClick(badge);
+
+      const valueInput = screen.getByDisplayValue("ml");
+      await user.clear(valueInput);
+      await user.type(valueInput, "data");
+
+      await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+      expect(onChange).toHaveBeenCalledWith([{ key: "team", value: "data" }]);
+    });
+
+    it("should cancel edit when clicking cancel button", async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      render(
+        <AnnotationFilterInput
+          filters={[{ key: "team", value: "ml" }]}
+          onChange={onChange}
+        />,
+      );
+
+      const badge = screen.getByText("team: ml");
+      await user.dblClick(badge);
+
+      await user.click(screen.getByRole("button", { name: /cancel editing/i }));
+
+      expect(onChange).not.toHaveBeenCalled();
+      expect(screen.getByText("team: ml")).toBeInTheDocument();
+    });
+
+    it("should remove value if cleared during edit", async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      render(
+        <AnnotationFilterInput
+          filters={[{ key: "team", value: "ml" }]}
+          onChange={onChange}
+        />,
+      );
+
+      const badge = screen.getByText("team: ml");
+      await user.dblClick(badge);
+
+      const valueInput = screen.getByDisplayValue("ml");
+      await user.clear(valueInput);
+      await user.keyboard("{Enter}");
+
+      expect(onChange).toHaveBeenCalledWith([{ key: "team" }]);
+    });
+
+    it("should cancel if key is cleared during edit", async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      render(
+        <AnnotationFilterInput
+          filters={[{ key: "team", value: "ml" }]}
+          onChange={onChange}
+        />,
+      );
+
+      const badge = screen.getByText("team: ml");
+      await user.dblClick(badge);
+
+      const keyInput = screen.getByDisplayValue("team");
+      await user.clear(keyInput);
+      await user.keyboard("{Enter}");
+
+      expect(onChange).not.toHaveBeenCalled();
+      expect(screen.getByText("team: ml")).toBeInTheDocument();
+    });
+
+    it("should show tooltip hint on badge", () => {
+      render(
+        <AnnotationFilterInput
+          filters={[{ key: "team", value: "ml" }]}
+          onChange={vi.fn()}
+        />,
+      );
+
+      const badge = screen.getByText("team: ml").closest("[title]");
+      expect(badge).toHaveAttribute("title", "Double-click to edit");
+    });
+  });
+});

--- a/src/components/shared/AnnotationFilterInput/AnnotationFilterInput.tsx
+++ b/src/components/shared/AnnotationFilterInput/AnnotationFilterInput.tsx
@@ -1,0 +1,124 @@
+import type { KeyboardEvent } from "react";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icon";
+import { Input } from "@/components/ui/input";
+import { InlineStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
+import type { AnnotationFilter } from "@/types/pipelineRunFilters";
+
+import { EditableAnnotationBadge } from "./EditableAnnotationBadge";
+
+interface AnnotationFilterInputProps {
+  filters: AnnotationFilter[];
+  onChange: (filters: AnnotationFilter[]) => void;
+}
+
+export function AnnotationFilterInput({
+  filters,
+  onChange,
+}: AnnotationFilterInputProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [keyInput, setKeyInput] = useState("");
+  const [valueInput, setValueInput] = useState("");
+
+  const handleAdd = () => {
+    const trimmedKey = keyInput.trim();
+
+    if (!trimmedKey) return;
+    const newFilter: AnnotationFilter = {
+      key: trimmedKey,
+      value: valueInput.trim() || undefined,
+    };
+
+    onChange([...filters, newFilter]);
+    setKeyInput("");
+    setValueInput("");
+    setIsExpanded(false);
+  };
+
+  const handleRemove = (index: number) => {
+    onChange(filters.filter((_, i) => i !== index));
+  };
+
+  const handleUpdate = (index: number, updatedFilter: AnnotationFilter) => {
+    const newFilters = [...filters];
+    newFilters[index] = updatedFilter;
+    onChange(newFilters);
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter" && keyInput.trim()) {
+      e.preventDefault();
+      handleAdd();
+    }
+    if (e.key === "Escape") {
+      setIsExpanded(false);
+      setKeyInput("");
+      setValueInput("");
+    }
+  };
+
+  return (
+    <InlineStack gap="2" align="start" blockAlign="center">
+      <Text size="sm" tone="subdued">
+        Annotations:
+      </Text>
+
+      {!isExpanded ? (
+        <Button variant="outline" size="sm" onClick={() => setIsExpanded(true)}>
+          <Icon name="Plus" size="xs" className="mr-1" />
+          Add filter
+        </Button>
+      ) : (
+        <InlineStack gap="1" align="center">
+          <Input
+            placeholder="Key"
+            value={keyInput}
+            onChange={(e) => setKeyInput(e.target.value)}
+            onKeyDown={handleKeyDown}
+            className="w-28 h-8 text-sm"
+            autoFocus
+          />
+          <Input
+            placeholder="Value (optional)"
+            value={valueInput}
+            onChange={(e) => setValueInput(e.target.value)}
+            onKeyDown={handleKeyDown}
+            className="w-36 h-8 text-sm"
+          />
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleAdd}
+            disabled={!keyInput.trim()}
+          >
+            Add
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => {
+              setIsExpanded(false);
+              setKeyInput("");
+              setValueInput("");
+            }}
+            aria-label="Cancel"
+          >
+            <Icon name="X" size="xs" />
+          </Button>
+        </InlineStack>
+      )}
+
+      {filters.map((filter, index) => (
+        <EditableAnnotationBadge
+          key={`annotation-${index}-${filter.key}`}
+          filter={filter}
+          onUpdate={(updated) => handleUpdate(index, updated)}
+          onRemove={() => handleRemove(index)}
+        />
+      ))}
+    </InlineStack>
+  );
+}

--- a/src/components/shared/AnnotationFilterInput/EditableAnnotationBadge.tsx
+++ b/src/components/shared/AnnotationFilterInput/EditableAnnotationBadge.tsx
@@ -1,0 +1,140 @@
+import type { KeyboardEvent, MouseEvent } from "react";
+import { useEffect, useRef, useState } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icon";
+import { Input } from "@/components/ui/input";
+import { InlineStack } from "@/components/ui/layout";
+import { cn } from "@/lib/utils";
+import type { AnnotationFilter } from "@/types/pipelineRunFilters";
+
+interface EditableAnnotationBadgeProps {
+  filter: AnnotationFilter;
+  onUpdate: (filter: AnnotationFilter) => void;
+  onRemove: () => void;
+}
+
+export function EditableAnnotationBadge({
+  filter,
+  onUpdate,
+  onRemove,
+}: EditableAnnotationBadgeProps) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [editKey, setEditKey] = useState(filter.key);
+  const [editValue, setEditValue] = useState(filter.value ?? "");
+  const keyInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (isEditing) {
+      keyInputRef.current?.focus();
+      keyInputRef.current?.select();
+    }
+  }, [isEditing]);
+
+  const handleSave = () => {
+    const trimmedKey = editKey.trim();
+    if (!trimmedKey) {
+      handleCancel();
+      return;
+    }
+
+    const trimmedValue = editValue.trim();
+    onUpdate(
+      trimmedValue
+        ? { key: trimmedKey, value: trimmedValue }
+        : { key: trimmedKey },
+    );
+    setIsEditing(false);
+  };
+
+  const handleCancel = () => {
+    setEditKey(filter.key);
+    setEditValue(filter.value ?? "");
+    setIsEditing(false);
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      handleSave();
+    }
+    if (e.key === "Escape") {
+      e.preventDefault();
+      handleCancel();
+    }
+  };
+
+  const handleDoubleClick = (e: MouseEvent<HTMLElement>) => {
+    e.preventDefault();
+    setIsEditing(true);
+  };
+
+  if (isEditing) {
+    return (
+      <InlineStack
+        gap="1"
+        align="center"
+        className="animate-in fade-in-0 zoom-in-95"
+      >
+        <Input
+          ref={keyInputRef}
+          value={editKey}
+          onChange={(e) => setEditKey(e.target.value)}
+          onKeyDown={handleKeyDown}
+          className="h-6 w-20 px-1.5 text-xs"
+          placeholder="Key"
+        />
+        <Input
+          value={editValue}
+          onChange={(e) => setEditValue(e.target.value)}
+          onKeyDown={handleKeyDown}
+          className="h-6 w-24 px-1.5 text-xs"
+          placeholder="Value"
+        />
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={handleSave}
+          className="size-5"
+          aria-label="Save changes"
+        >
+          <Icon name="Check" size="xs" />
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={handleCancel}
+          className="size-5 hover:text-destructive"
+          aria-label="Cancel editing"
+        >
+          <Icon name="X" size="xs" />
+        </Button>
+      </InlineStack>
+    );
+  }
+
+  return (
+    <Badge
+      variant="secondary"
+      className={cn(
+        "cursor-default select-none transition-colors pr-1",
+        "hover:bg-secondary/80",
+      )}
+      onDoubleClick={handleDoubleClick}
+      title="Double-click to edit"
+    >
+      {filter.key}
+      {filter.value && `: ${filter.value}`}
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={onRemove}
+        className="ml-0.5 size-4 hover:text-destructive hover:bg-transparent"
+        aria-label={`Remove ${filter.key} filter`}
+      >
+        <Icon name="X" size="xs" />
+      </Button>
+    </Badge>
+  );
+}

--- a/src/components/shared/PipelineRunFiltersBar/PipelineRunFiltersBar.tsx
+++ b/src/components/shared/PipelineRunFiltersBar/PipelineRunFiltersBar.tsx
@@ -1,12 +1,14 @@
 import { useState } from "react";
 import type { DateRange } from "react-day-picker";
 
+import { AnnotationFilterInput } from "@/components/shared/AnnotationFilterInput/AnnotationFilterInput";
 import { Button } from "@/components/ui/button";
 import { DatePickerWithRange } from "@/components/ui/date-picker";
 import { Icon } from "@/components/ui/icon";
 import { Input } from "@/components/ui/input";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { useRunSearchParams } from "@/hooks/useRunSearchParams";
+import type { AnnotationFilter } from "@/types/pipelineRunFilters";
 
 export function PipelineRunFiltersBar() {
   const { filters, setFilter, setFilters, setFilterDebounced } =
@@ -31,6 +33,10 @@ export function PipelineRunFiltersBar() {
       created_after: range?.from?.toISOString(),
       created_before: range?.to?.toISOString(),
     });
+  };
+
+  const handleAnnotationsChange = (annotations: AnnotationFilter[]) => {
+    setFilter("annotations", annotations.length > 0 ? annotations : undefined);
   };
 
   return (
@@ -74,6 +80,11 @@ export function PipelineRunFiltersBar() {
           />
         </div>
       </InlineStack>
+
+      <AnnotationFilterInput
+        filters={filters.annotations ?? []}
+        onChange={handleAnnotationsChange}
+      />
     </BlockStack>
   );
 }

--- a/src/types/pipelineRunFilters.ts
+++ b/src/types/pipelineRunFilters.ts
@@ -1,6 +1,15 @@
 import type { ContainerExecutionStatus } from "@/api/types.gen";
 
 /**
+ * Filter for annotation key-value pairs.
+ * If value is omitted, matches any run with this annotation key.
+ */
+export interface AnnotationFilter {
+  key: string;
+  value?: string;
+}
+
+/**
  * Filters for searching and filtering pipeline runs.
  * All filters combine with AND logic.
  */
@@ -10,4 +19,5 @@ export interface PipelineRunFilters {
   created_after?: string; // ISO datetime
   created_before?: string; // ISO datetime
   pipeline_name?: string;
+  annotations?: AnnotationFilter[];
 }


### PR DESCRIPTION
## 

Resolves: https://github.com/Shopify/oasis-frontend/issues/458

## Description

Adds an annotation filter input component for filtering pipeline runs by key-value annotation pairs.

**Note:** This is a UI-only preview. The filters update the URL but are not properly connected to the API, causing a broken search state. This is resolved in a later PR in the stack.

## Type of Change

- [x] New feature

## Changes

- Added `AnnotationFilterInput` component with:
    - Add annotation filters with key and optional value
    - Inline editing of existing filters (double-click to edit)
    - Remove filters with X button
    - Keyboard support (Enter to add/save, Escape to cancel)
- Integrated annotation filters into `PipelineRunFiltersBar`

## Checklist

- [x] I have tested this does not break current pipelines/runs functionality

## Test Instructions

1. Enable the feature flag: Settings → Beta → "Pipeline run filters bar (UI only)"
2. Navigate to the Runs tab on the home page
3. Click "Add filter" in the Annotations row
4. Enter a key and optional value, press Enter or click Add
5. Double-click a badge to edit, click X to remove