### PR TITLE
Status filter

### DIFF
--- a/src/components/shared/PipelineRunFiltersBar/PipelineRunFiltersBar.tsx
+++ b/src/components/shared/PipelineRunFiltersBar/PipelineRunFiltersBar.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import type { DateRange } from "react-day-picker";
 
 import { AnnotationFilterInput } from "@/components/shared/AnnotationFilterInput/AnnotationFilterInput";
+import { StatusFilterSelect } from "@/components/shared/StatusFilterSelect/StatusFilterSelect";
 import { Button } from "@/components/ui/button";
 import { DatePickerWithRange } from "@/components/ui/date-picker";
 import { Icon } from "@/components/ui/icon";
@@ -70,6 +71,13 @@ export function PipelineRunFiltersBar() {
               <Icon name="X" size="sm" />
             </Button>
           )}
+        </div>
+
+        <div className="shrink-0">
+          <StatusFilterSelect
+            value={filters.status}
+            onChange={(value) => setFilter("status", value)}
+          />
         </div>
 
         <div className="shrink-0">

--- a/src/components/shared/StatusFilterSelect/StatusFilterSelect.test.tsx
+++ b/src/components/shared/StatusFilterSelect/StatusFilterSelect.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { StatusFilterSelect } from "./StatusFilterSelect";
+
+describe("StatusFilterSelect", () => {
+  describe("rendering", () => {
+    it("should render with default placeholder when no value", () => {
+      render(<StatusFilterSelect value={undefined} onChange={vi.fn()} />);
+
+      expect(screen.getByRole("combobox")).toBeInTheDocument();
+      expect(screen.getByText("All statuses")).toBeInTheDocument();
+    });
+
+    it("should render with Running status", () => {
+      render(<StatusFilterSelect value="RUNNING" onChange={vi.fn()} />);
+
+      expect(screen.getByText("Running")).toBeInTheDocument();
+    });
+
+    it("should render with Succeeded status", () => {
+      render(<StatusFilterSelect value="SUCCEEDED" onChange={vi.fn()} />);
+
+      expect(screen.getByText("Succeeded")).toBeInTheDocument();
+    });
+
+    it("should render with Failed status", () => {
+      render(<StatusFilterSelect value="FAILED" onChange={vi.fn()} />);
+
+      expect(screen.getByText("Failed")).toBeInTheDocument();
+    });
+
+    it("should render with Pending status", () => {
+      render(<StatusFilterSelect value="PENDING" onChange={vi.fn()} />);
+
+      expect(screen.getByText("Pending")).toBeInTheDocument();
+    });
+
+    it("should render with Cancelled status", () => {
+      render(<StatusFilterSelect value="CANCELLED" onChange={vi.fn()} />);
+
+      expect(screen.getByText("Cancelled")).toBeInTheDocument();
+    });
+
+    it("should render with System error status", () => {
+      render(<StatusFilterSelect value="SYSTEM_ERROR" onChange={vi.fn()} />);
+
+      expect(screen.getByText("System error")).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/shared/StatusFilterSelect/StatusFilterSelect.tsx
+++ b/src/components/shared/StatusFilterSelect/StatusFilterSelect.tsx
@@ -1,0 +1,65 @@
+import type { ContainerExecutionStatus } from "@/api/types.gen";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+import {
+  EXECUTION_STATUS_LABELS,
+  getExecutionStatusLabel,
+  isValidExecutionStatus,
+} from "@/utils/executionStatus";
+
+const STATUS_OPTIONS = (
+  Object.keys(EXECUTION_STATUS_LABELS) as string[]
+).filter((s): s is ContainerExecutionStatus => isValidExecutionStatus(s));
+
+interface StatusFilterSelectProps {
+  value: ContainerExecutionStatus | undefined;
+  onChange: (value: ContainerExecutionStatus | undefined) => void;
+  className?: string;
+}
+
+export function StatusFilterSelect({
+  value,
+  onChange,
+  className,
+}: StatusFilterSelectProps) {
+  const handleValueChange = (newValue: string) => {
+    if (newValue === "all") {
+      onChange(undefined);
+    } else if (isValidExecutionStatus(newValue)) {
+      onChange(newValue);
+    }
+  };
+
+  const hasActiveFilter = value !== undefined;
+
+  return (
+    <Select value={value ?? "all"} onValueChange={handleValueChange}>
+      <SelectTrigger
+        className={cn(
+          "w-40",
+          hasActiveFilter && "ring-2 ring-primary/20",
+          className,
+        )}
+      >
+        <SelectValue placeholder="Status" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="all">All statuses</SelectItem>
+        {STATUS_OPTIONS.map((status) => (
+          <StatusOption key={status} status={status} />
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
+
+function StatusOption({ status }: { status: ContainerExecutionStatus }) {
+  const label = getExecutionStatusLabel(status);
+  return <SelectItem value={status}>{label}</SelectItem>;
+}

--- a/src/utils/executionStatus.ts
+++ b/src/utils/executionStatus.ts
@@ -9,7 +9,7 @@ import type {
  * Note: The mapping is intentionally aligned to the status table from:
  * https://github.com/TangleML/tangle-ui/issues/1540
  */
-const EXECUTION_STATUS_LABELS: Record<string, string> = {
+export const EXECUTION_STATUS_LABELS: Record<string, string> = {
   CANCELLED: "Cancelled",
   CANCELLING: "Cancelling",
   FAILED: "Failed",


### PR DESCRIPTION
## Description

Added a status filter dropdown to the Pipeline Run Filters Bar, allowing users to filter pipeline runs by execution status (Running, Succeeded, Failed, Pending, Cancelled, System error).

## Related Issue and Pull requests

## Type of Change

- [x] New feature
- [x] Improvement

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Navigate to the Pipeline Runs page
2. Verify the new status filter dropdown appears in the filters bar
3. Test selecting different status options and confirm the filter works correctly
4. Verify "All statuses" option resets the filter

## Additional Comments

The implementation includes comprehensive tests for the new StatusFilterSelect component and integrates with the existing filter system.