### PR TITLE
Test filter route

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -6,7 +6,11 @@
     "node_modules/**",
     "src/components/ui/**",
     "openapi-ts.config.ts",
-    "vite.config.ghpages.js"
+    "vite.config.ghpages.js",
+    "src/types/pipelineRunFilters.ts",
+    "src/components/shared/PipelineRunFiltersBar/PipelineRunFiltersBar.tsx",
+    "src/hooks/useRunSearchParams.ts",
+    "src/components/shared/PipelineRunFiltersBar/**"
   ],
   "ignoreDependencies": [
     "@radix-ui/react-accordion",

--- a/src/routes/FilterTest/FilterTest.tsx
+++ b/src/routes/FilterTest/FilterTest.tsx
@@ -1,0 +1,144 @@
+import { useState } from "react";
+import type { DateRange } from "react-day-picker";
+
+import type { ContainerExecutionStatus } from "@/api/types.gen";
+import { AnnotationFilterInput } from "@/components/shared/AnnotationFilterInput/AnnotationFilterInput";
+import { PipelineRunFiltersBar } from "@/components/shared/PipelineRunFiltersBar/PipelineRunFiltersBar";
+import { StatusFilterSelect } from "@/components/shared/StatusFilterSelect/StatusFilterSelect";
+import { DatePickerWithRange } from "@/components/ui/date-picker";
+import { BlockStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
+import { useRunSearchParams } from "@/hooks/useRunSearchParams";
+import type { AnnotationFilter } from "@/types/pipelineRunFilters";
+
+const FilterTest = () => {
+  const { filters } = useRunSearchParams();
+
+  // Local state for individual component demos
+  const [demoAnnotations, setDemoAnnotations] = useState<AnnotationFilter[]>([
+    { key: "team", value: "ml" },
+  ]);
+  const [demoDateRange, setDemoDateRange] = useState<DateRange | undefined>();
+  const [demoStatus, setDemoStatus] = useState<
+    ContainerExecutionStatus | undefined
+  >();
+
+  return (
+    <div className="container mx-auto max-w-5xl p-6">
+      <BlockStack gap="8">
+        <BlockStack gap="2">
+          <Text as="h1" size="xl" weight="bold">
+            Filter Test Page
+          </Text>
+          <Text tone="subdued">
+            Testing filter components and URL synchronization
+          </Text>
+        </BlockStack>
+
+        {/* Section 1: Full Filter Bar */}
+        <BlockStack gap="3">
+          <Text as="h2" size="lg" weight="semibold">
+            Full Filter Bar
+          </Text>
+          <Text size="sm" tone="subdued">
+            Integrated component with all filters and URL sync
+          </Text>
+          <PipelineRunFiltersBar totalCount={128} filteredCount={42} />
+        </BlockStack>
+
+        {/* Debug: Current URL State */}
+        <div className="rounded-lg border bg-muted/50 p-4">
+          <BlockStack gap="2">
+            <Text size="sm" weight="semibold">
+              Current URL Filter State
+            </Text>
+            <pre className="text-xs break-all whitespace-pre-wrap bg-background p-2 rounded">
+              {JSON.stringify(filters, null, 2)}
+            </pre>
+          </BlockStack>
+        </div>
+
+        {/* Section 2: Individual Components */}
+        <BlockStack gap="6">
+          <BlockStack gap="2">
+            <Text as="h2" size="lg" weight="semibold">
+              Individual Components
+            </Text>
+            <Text size="sm" tone="subdued">
+              Standalone components with local state (not synced to URL)
+            </Text>
+          </BlockStack>
+
+          {/* Status Filter Select */}
+          <div className="rounded-lg border p-4">
+            <BlockStack gap="3">
+              <BlockStack gap="1">
+                <Text weight="semibold">StatusFilterSelect</Text>
+                <Text size="sm" tone="subdued">
+                  Filter by pipeline run execution status
+                </Text>
+              </BlockStack>
+              <StatusFilterSelect value={demoStatus} onChange={setDemoStatus} />
+              <div className="bg-muted/50 p-2 rounded">
+                <Text size="xs" tone="subdued">
+                  State: {demoStatus ?? "undefined"}
+                </Text>
+              </div>
+            </BlockStack>
+          </div>
+
+          {/* Date Picker */}
+          <div className="rounded-lg border p-4">
+            <BlockStack gap="3">
+              <BlockStack gap="1">
+                <Text weight="semibold">DatePickerWithRange</Text>
+                <Text size="sm" tone="subdued">
+                  Select a date range with two-month calendar
+                </Text>
+              </BlockStack>
+              <DatePickerWithRange
+                value={demoDateRange}
+                onChange={setDemoDateRange}
+                placeholder="Select date range"
+              />
+              <div className="bg-muted/50 p-2 rounded">
+                <Text size="xs" tone="subdued">
+                  State:{" "}
+                  {demoDateRange
+                    ? JSON.stringify({
+                        from: demoDateRange.from?.toISOString(),
+                        to: demoDateRange.to?.toISOString(),
+                      })
+                    : "undefined"}
+                </Text>
+              </div>
+            </BlockStack>
+          </div>
+
+          {/* Annotation Filter Input */}
+          <div className="rounded-lg border p-4">
+            <BlockStack gap="3">
+              <BlockStack gap="1">
+                <Text weight="semibold">AnnotationFilterInput</Text>
+                <Text size="sm" tone="subdued">
+                  Add/remove key-value annotation filters
+                </Text>
+              </BlockStack>
+              <AnnotationFilterInput
+                filters={demoAnnotations}
+                onChange={setDemoAnnotations}
+              />
+              <div className="bg-muted/50 p-2 rounded">
+                <Text size="xs" tone="subdued">
+                  State: {JSON.stringify(demoAnnotations)}
+                </Text>
+              </div>
+            </BlockStack>
+          </div>
+        </BlockStack>
+      </BlockStack>
+    </div>
+  );
+};
+
+export default FilterTest;

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -13,6 +13,7 @@ import { BASE_URL, IS_GITHUB_PAGES } from "@/utils/constants";
 
 import RootLayout from "../components/layout/RootLayout";
 import Editor from "./Editor";
+import FilterTest from "./FilterTest/FilterTest";
 import Home from "./Home";
 import NotFoundPage from "./NotFoundPage";
 import PipelineRun from "./PipelineRun";
@@ -27,6 +28,7 @@ declare module "@tanstack/react-router" {
 export const EDITOR_PATH = "/editor";
 export const RUNS_BASE_PATH = "/runs";
 export const QUICK_START_PATH = "/quick-start";
+export const FILTER_TEST_PATH = "/filter-test";
 export const APP_ROUTES = {
   HOME: "/",
   QUICK_START: QUICK_START_PATH,
@@ -34,6 +36,7 @@ export const APP_ROUTES = {
   RUN_DETAIL: `${RUNS_BASE_PATH}/$id`,
   RUN_DETAIL_WITH_SUBGRAPH: `${RUNS_BASE_PATH}/$id/$subgraphExecutionId`,
   RUNS: RUNS_BASE_PATH,
+  FILTER_TEST: FILTER_TEST_PATH,
   GITHUB_AUTH_CALLBACK: "/authorize/github",
   HUGGINGFACE_AUTH_CALLBACK: "/authorize/huggingface",
 };
@@ -96,12 +99,19 @@ const runDetailWithSubgraphRoute = createRoute({
   component: PipelineRun,
 });
 
+const filterTestRoute = createRoute({
+  getParentRoute: () => mainLayout,
+  path: APP_ROUTES.FILTER_TEST,
+  component: FilterTest,
+});
+
 const appRouteTree = mainLayout.addChildren([
   indexRoute,
   quickStartRoute,
   editorRoute,
   runDetailRoute,
   runDetailWithSubgraphRoute,
+  filterTestRoute,
 ]);
 
 const rootRouteTree = rootRoute.addChildren([


### PR DESCRIPTION
## Description

Added a new Filter Test page to showcase and test pipeline run filter components. This page demonstrates both the integrated `PipelineRunFiltersBar` and individual filter components with local state management. Updated `knip.json` to ignore the filter-related components and hooks from unused code analysis.

## Type of Change

- [x] New feature
- [x] Documentation update

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Screenshots (if applicable)

N/A

## Test Instructions

1. Navigate to `/filter-test` to view the new test page
2. Test the integrated filter bar with URL synchronization
3. Try the individual filter components (status filter, date picker, annotation filter)
4. Verify that the URL parameters update correctly when using the filter bar

## Additional Comments

This page serves as both a testing ground and documentation for our filter components, making it easier to develop and debug filter functionality.