### PR TITLE
Add BetaFeatureWrapper and pipeline run filters bar UI

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -3,10 +3,8 @@
   "ignore": [
     ".git/**",
     "src/api/**",
-    "node_modules/**",
     "src/components/ui/**",
-    "openapi-ts.config.ts",
-    "vite.config.ghpages.js"
+    "openapi-ts.config.ts"
   ],
   "ignoreDependencies": [
     "@radix-ui/react-accordion",

--- a/src/components/shared/BetaFeatureWrapper/BetaFeatureWrapper.tsx
+++ b/src/components/shared/BetaFeatureWrapper/BetaFeatureWrapper.tsx
@@ -1,0 +1,61 @@
+import type { ReactNode } from "react";
+
+import { Icon } from "@/components/ui/icon";
+import { BlockStack } from "@/components/ui/layout";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { Paragraph } from "@/components/ui/typography";
+import { ExistingFlags } from "@/flags";
+import { cn } from "@/lib/utils";
+
+interface BetaFeatureWrapperProps {
+  flagKey: keyof typeof ExistingFlags;
+  children: ReactNode;
+  className?: string;
+}
+
+export function BetaFeatureWrapper({
+  flagKey,
+  children,
+  className,
+}: BetaFeatureWrapperProps) {
+  const flag = ExistingFlags[flagKey];
+
+  if (!flag) {
+    return <>{children}</>;
+  }
+
+  return (
+    <div
+      className={cn(
+        "relative rounded-lg border-2 border-amber-400/50 bg-amber-50/30",
+        className,
+      )}
+    >
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div className="absolute -right-2 -top-2 flex size-6 cursor-help items-center justify-center rounded-full border border-amber-400 bg-amber-100">
+            <Icon name="FlaskConical" size="sm" className="text-amber-600" />
+          </div>
+        </TooltipTrigger>
+        <TooltipContent side="top" className="max-w-xs">
+          <BlockStack gap="1">
+            <Paragraph weight="semibold" className="text-white">
+              {flag.name}
+            </Paragraph>
+            <Paragraph size="xs" className="text-white opacity-90">
+              {flag.description}
+            </Paragraph>
+            <Paragraph size="xs" className="italic text-white opacity-70">
+              Beta feature
+            </Paragraph>
+          </BlockStack>
+        </TooltipContent>
+      </Tooltip>
+      <div className="p-3">{children}</div>
+    </div>
+  );
+}

--- a/src/routes/Home/Home.tsx
+++ b/src/routes/Home/Home.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState } from "react";
 
 import { PipelineSection, RunSection } from "@/components/Home";
+import { BetaFeatureWrapper } from "@/components/shared/BetaFeatureWrapper/BetaFeatureWrapper";
 import { PipelineRunFiltersBar } from "@/components/shared/PipelineRunFiltersBar/PipelineRunFiltersBar";
 import { useFlagValue } from "@/components/shared/Settings/useFlags";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -40,7 +41,11 @@ const Home = () => {
           <PipelineSection />
         </TabsContent>
         <TabsContent value="runs" className="flex flex-col gap-4">
-          {isFiltersBarEnabled && <PipelineRunFiltersBar />}
+          {isFiltersBarEnabled && (
+            <BetaFeatureWrapper flagKey="pipeline-run-filters-bar">
+              <PipelineRunFiltersBar />
+            </BetaFeatureWrapper>
+          )}
           <RunSection onEmptyList={handlePipelineRunsEmpty} />
         </TabsContent>
       </Tabs>

--- a/src/types/pipelineRunFilters.ts
+++ b/src/types/pipelineRunFilters.ts
@@ -25,3 +25,4 @@ export interface PipelineRunFilters {
 }
 
 export type SortField = NonNullable<PipelineRunFilters["sort_field"]>;
+export type SortDirection = NonNullable<PipelineRunFilters["sort_direction"]>;

--- a/src/utils/pipelineRunFilterUtils.ts
+++ b/src/utils/pipelineRunFilterUtils.ts
@@ -1,8 +1,13 @@
 import type {
   AnnotationFilter,
   PipelineRunFilters,
+  SortDirection,
+  SortField,
 } from "@/types/pipelineRunFilters";
 import { isValidExecutionStatus } from "@/utils/executionStatus";
+
+const VALID_SORT_FIELDS = new Set<string>(["created_at", "pipeline_name"]);
+const VALID_SORT_DIRECTIONS = new Set<string>(["asc", "desc"]);
 
 export function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -14,6 +19,14 @@ function isValidAnnotationFilter(value: unknown): value is AnnotationFilter {
     typeof value.key === "string" &&
     (value.value === undefined || typeof value.value === "string")
   );
+}
+
+function isValidSortField(value: string): value is SortField {
+  return VALID_SORT_FIELDS.has(value);
+}
+
+function isValidSortDirection(value: string): value is SortDirection {
+  return VALID_SORT_DIRECTIONS.has(value);
 }
 
 /**
@@ -49,6 +62,18 @@ export function validateFilters(parsed: unknown): PipelineRunFilters {
       filters.annotations = validAnnotations;
     }
   }
+  if (
+    typeof parsed.sort_field === "string" &&
+    isValidSortField(parsed.sort_field)
+  ) {
+    filters.sort_field = parsed.sort_field;
+  }
+  if (
+    typeof parsed.sort_direction === "string" &&
+    isValidSortDirection(parsed.sort_direction)
+  ) {
+    filters.sort_direction = parsed.sort_direction;
+  }
 
   return filters;
 }
@@ -78,6 +103,8 @@ const SPECIAL_FILTER_KEYS = new Set([
   "annotations",
   "created_after",
   "created_before",
+  "sort_field",
+  "sort_direction",
 ]);
 
 /**


### PR DESCRIPTION
## Description

Added a new `BetaFeatureWrapper` component that visually highlights beta features with an amber border and a flask icon tooltip. This component displays the feature name, description, and "Beta feature" label when users hover over the icon.

Also added a new feature flag `pipeline-run-filters-bar` for a non-functional UI preview of pipeline run filters, and implemented it on the Home page within the runs tab.

## Related Issue and Pull requests

## Type of Change

- [x] New feature
- [x] Improvement

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Enable the `pipeline-run-filters-bar` feature flag in settings
2. Navigate to the Home page and select the "Runs" tab
3. Verify the filters bar appears with the beta feature styling (amber border and flask icon)
4. Hover over the flask icon to confirm the tooltip displays correctly with feature name and description

## Additional Comments

The filters bar is currently non-functional and is only for UI preview purposes. The actual functionality will be implemented in a future PR.