### PR TITLE
Hook up filters to API where availiable

### DIFF
--- a/src/components/shared/CreatedByFilter/CreatedByFilter.tsx
+++ b/src/components/shared/CreatedByFilter/CreatedByFilter.tsx
@@ -1,5 +1,5 @@
 import type { KeyboardEvent } from "react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -22,6 +22,16 @@ interface CreatedByFilterProps {
 export function CreatedByFilter({ value, onChange }: CreatedByFilterProps) {
   const [searchUser, setSearchUser] = useState(value ?? "");
 
+  // Sync internal state when value prop changes externally (e.g., URL navigation, badge removal)
+  useEffect(() => {
+    // Only sync if value is different and not "me" (don't populate input with "me")
+    if (value !== undefined && value !== DEFAULT_CREATED_BY_ME_FILTER_VALUE) {
+      setSearchUser(value);
+    } else if (value === undefined) {
+      setSearchUser("");
+    }
+  }, [value]);
+
   const isFilterActive = value !== undefined;
   const toggleText = value ? `Created by ${value}` : "Created by me";
 
@@ -33,7 +43,6 @@ export function CreatedByFilter({ value, onChange }: CreatedByFilterProps) {
         setSearchUser("");
       }
     } else {
-      // Disable filter
       onChange(undefined);
     }
   };

--- a/src/components/shared/StatusFilterSelect/StatusFilterSelect.tsx
+++ b/src/components/shared/StatusFilterSelect/StatusFilterSelect.tsx
@@ -13,9 +13,9 @@ import {
   isValidExecutionStatus,
 } from "@/utils/executionStatus";
 
-const STATUS_OPTIONS = (
-  Object.keys(EXECUTION_STATUS_LABELS) as string[]
-).filter((s): s is ContainerExecutionStatus => isValidExecutionStatus(s));
+const STATUS_OPTIONS = Object.keys(EXECUTION_STATUS_LABELS).filter(
+  (s): s is ContainerExecutionStatus => isValidExecutionStatus(s),
+);
 
 interface StatusFilterSelectProps {
   value: ContainerExecutionStatus | undefined;

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -48,9 +48,9 @@ export const ExistingFlags: ConfigFlags = {
   },
 
   ["pipeline-run-filters-bar"]: {
-    name: "Pipeline run filters bar (UI only)",
+    name: "Pipeline run filters bar (Experimental)",
     description:
-      "Non-functional UI preview. This filter bar is not connected to the API and is for testing/development purposes only.",
+      "Enable the advanced pipeline run filters bar. Note: Only 'Created by' filter is currently functional. Other filters are UI previews.",
     default: false,
     category: "beta",
   },

--- a/src/utils/pipelineRunFilterUtils.ts
+++ b/src/utils/pipelineRunFilterUtils.ts
@@ -9,6 +9,12 @@ import { isValidExecutionStatus } from "@/utils/executionStatus";
 const VALID_SORT_FIELDS = new Set<string>(["created_at", "pipeline_name"]);
 const VALID_SORT_DIRECTIONS = new Set<string>(["asc", "desc"]);
 
+/**
+ * List of filter keys that the API currently supports.
+ * Add keys here as the backend adds support for more filters.
+ */
+const SUPPORTED_API_FILTERS: (keyof PipelineRunFilters)[] = ["created_by"];
+
 export function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -79,8 +85,83 @@ export function validateFilters(parsed: unknown): PipelineRunFilters {
 }
 
 /**
- * Strips empty values from filters for clean URL serialization.
- * Returns undefined when no filters are active to keep the URL clean.
+ * Converts PipelineRunFilters to the API's key:value string format.
+ * Only includes filters that the API actually supports.
+ *
+ * @example
+ * // Input: { created_by: "me", status: "FAILED", annotations: [...] }
+ * // Output: "created_by:me" (status and annotations are stripped as unsupported)
+ */
+export function filtersToApiString(
+  filters: PipelineRunFilters,
+): string | undefined {
+  const parts: string[] = [];
+
+  for (const key of SUPPORTED_API_FILTERS) {
+    const value = filters[key];
+    if (value) {
+      parts.push(`${key}:${value}`);
+    }
+  }
+
+  return parts.length > 0 ? parts.join(",") : undefined;
+}
+
+/**
+ * Parses the legacy key:value,key2:value2 format into a filter object.
+ * Used for backwards compatibility with existing URLs.
+ */
+function parseApiStringToFilters(
+  filterString: string | undefined,
+): PipelineRunFilters {
+  if (!filterString) return {};
+
+  const filters: PipelineRunFilters = {};
+  const parts = filterString.split(",");
+
+  for (const part of parts) {
+    const colonIndex = part.indexOf(":");
+    if (colonIndex === -1) continue;
+
+    const key = part.slice(0, colonIndex).trim();
+    const value = part.slice(colonIndex + 1).trim();
+
+    if (key && value) {
+      // Must be kept in sync with SUPPORTED_API_FILTERS as new filters are added
+      if (key === "created_by") {
+        filters.created_by = value;
+      }
+    }
+  }
+
+  return filters;
+}
+
+/**
+ * Parses the filter URL param, handling both JSON format (new) and key:value format (legacy).
+ */
+export function parseFilterParam(
+  filterParam: string | Record<string, unknown> | undefined,
+): PipelineRunFilters {
+  if (!filterParam) return {};
+
+  // Already an object (parsed by router) - validate and return
+  if (isRecord(filterParam)) {
+    return validateFilters(filterParam);
+  }
+
+  try {
+    return validateFilters(JSON.parse(filterParam));
+  } catch {
+    // Invalid JSON - try legacy key:value format for backwards compatibility
+    return parseApiStringToFilters(filterParam);
+  }
+}
+
+/**
+ * Clean and prepare PipelineRunFilters for URL serialization.
+ * Returns the filter object - let TanStack Router handle JSON serialization.
+ * Must include all filter keys that should persist in the URL (including annotations).
  */
 export function serializeFiltersToUrl(
   filters: PipelineRunFilters,


### PR DESCRIPTION
## Description

Implemented support for advanced pipeline run filters with a new JSON-based filter format while maintaining backward compatibility with the legacy key:value format. This change enables the pipeline run filters bar feature flag to be more than just a UI preview.

## Type of Change

- [x] New feature
- [x] Improvement
- [x] Refactor

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Test Instructions

1. Enable the "pipeline-run-filters-bar" feature flag
2. Verify that the "Created by" filter works correctly in both the new UI and via URL parameters
3. Test that both JSON format filters and legacy key:value format filters work in the URL
4. Confirm that only supported filters (currently only "created_by") are sent to the API

## Additional Comments

This PR adds a new utility file `pipelineRunFilterUtils.ts` that handles parsing and serializing filter formats. The flag description has been updated to clarify that only the "Created by" filter is currently functional, while other filters are UI previews that will be connected to the API in future PRs.