### PR TITLE
feat: add Bugsnag error reporting service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,3 +34,22 @@ VITE_DEFAULT_REMOTE_COMPONENT_LIBRARY_BETA=<boolean>
 
 # Dev Tools
 VITE_ENABLE_DEBUG_MODE=<boolean>
+
+# =============================================================================
+# BUGSNAG ERROR REPORTING (OPTIONAL)
+# =============================================================================
+# Bugsnag error reporting is disabled by default. To enable, set your API key
+# below.
+
+# Required: Your Bugsnag API key
+# Get this from your Bugsnag project settings
+# VITE_BUGSNAG_API_KEY=
+
+# Optional: Custom endpoints (defaults to Bugsnag)
+# VITE_BUGSNAG_NOTIFY_ENDPOINT=https://notify.bugsnag.com
+# VITE_BUGSNAG_SESSIONS_ENDPOINT=https://sessions.bugsnag.com
+
+# Optional: Custom grouping key for metadata
+# If set, the normalized error message will also be added to metadata.custom[key]
+# Useful for integration with platforms that use custom grouping keys
+# VITE_BUGSNAG_CUSTOM_GROUPING_KEY=

--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ If you find you are blocked by CORS, you will, for now, need to use the manual s
 
 If you complete these steps the app will launch on `127.0.0.1:8000` with the latest build you've created on the frontend.
 
+### Reporting errors to Bugsnag (Optional)
+
+To enable error reporting, add your API key to your `.env` file:
+
+```bash
+VITE_BUGSNAG_API_KEY=your-api-key
+```
+
 ## App features:
 
 - Build and edit pipelines using drag and drop visual editor

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@bugsnag/js": "^8.8.1",
+        "@bugsnag/plugin-react": "^8.8.0",
         "@dnd-kit/core": "^6.3.1",
         "@hey-api/client-fetch": "^0.13.1",
         "@hyperjump/browser": "^1.3.1",
@@ -604,6 +606,78 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@bugsnag/browser": {
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/@bugsnag/browser/-/browser-8.8.1.tgz",
+      "integrity": "sha512-wdDFZQtZBKlVkNWx57VWuOf+NKF3Pp+INn8E2SdYNwN42PQdsgsx7NliSMqY5MPiW0GeE9mgc7QMIMixOWp8Lw==",
+      "license": "MIT",
+      "dependencies": {
+        "@bugsnag/core": "^8.8.0"
+      }
+    },
+    "node_modules/@bugsnag/core": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/core/-/core-8.8.0.tgz",
+      "integrity": "sha512-N9Z1znQ2EnhKlGNrxYx0XZ87IhcJ0V9NO9lmxOmOq0g8XMMaEnnqFj5f/YSO5H/NPFF/eVAyzDGDeuxsDWdK+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@bugsnag/cuid": "^3.0.0",
+        "@bugsnag/safe-json-stringify": "^6.0.0",
+        "error-stack-parser": "^2.0.3",
+        "iserror": "^0.0.2",
+        "stack-generator": "^2.0.3"
+      }
+    },
+    "node_modules/@bugsnag/cuid": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@bugsnag/cuid/-/cuid-3.2.1.tgz",
+      "integrity": "sha512-zpvN8xQ5rdRWakMd/BcVkdn2F8HKlDSbM3l7duueK590WmI1T0ObTLc1V/1e55r14WNjPd5AJTYX4yPEAFVi+Q==",
+      "license": "MIT"
+    },
+    "node_modules/@bugsnag/js": {
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/@bugsnag/js/-/js-8.8.1.tgz",
+      "integrity": "sha512-qjio+9OxHXXG75ywWy156kUmqcqqyLBzOIKs+kFgLK4znx8pXBjtpFBo8e1Y/IXrbCJjFetn+TdFy+P4yYZM5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@bugsnag/browser": "^8.8.1",
+        "@bugsnag/node": "^8.8.0"
+      }
+    },
+    "node_modules/@bugsnag/node": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/node/-/node-8.8.0.tgz",
+      "integrity": "sha512-ODajeAIRAICO8JXnrWkjzBmA0Qslt6n7aMEZQ3OJXDTsgXgdK1qoLjlScJqOoeQNR/kXUXl2allvJdrB4u2pdg==",
+      "license": "MIT",
+      "dependencies": {
+        "@bugsnag/core": "^8.8.0",
+        "byline": "^5.0.0",
+        "error-stack-parser": "^2.0.3",
+        "iserror": "^0.0.2",
+        "pump": "^3.0.0",
+        "stack-generator": "^2.0.3"
+      }
+    },
+    "node_modules/@bugsnag/plugin-react": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/plugin-react/-/plugin-react-8.8.0.tgz",
+      "integrity": "sha512-8XsurLzcFlpu+xBMzlXQqxvLJsVsim8X4BD53phWiFQXelUxfm8BjCHROBLl3pC8wtyONTwDpuSACTtxAo/2WA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@bugsnag/core": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@bugsnag/core": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@bugsnag/safe-json-stringify": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/safe-json-stringify/-/safe-json-stringify-6.1.0.tgz",
+      "integrity": "sha512-ImA35rnM7bGr+J30R979FQ95BhRB4UO1KfJA0J2sVqc8nwnrS9hhE5mkTmQWMs8Vh1Da+hkLKs5jJB4JjNZp4A==",
+      "license": "MIT"
     },
     "node_modules/@clack/core": {
       "version": "0.3.5",
@@ -5363,6 +5437,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/byline": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
+      "integrity": "sha512-s6webAy+R4SR8XVuJWt2V2rGvhnrhxN+9S15GNuTK3wKPOXFF6RNc+8ug2XhH+2s4f+uudG4kUVYmYOQWL2g0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/c12": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/c12/-/c12-3.3.3.tgz",
@@ -6158,9 +6241,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.283",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.283.tgz",
-      "integrity": "sha512-3vifjt1HgrGW/h76UEeny+adYApveS9dH2h3p57JYzBSXJIKUJAvtmIytDKjcSCt9xHfrNCFJ7gts6vkhuq++w==",
+      "version": "1.5.286",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz",
+      "integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
       "license": "ISC"
     },
     "node_modules/email-addresses": {
@@ -6175,6 +6258,15 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
     },
     "node_modules/enhanced-resolve": {
       "version": "5.18.4",
@@ -6200,6 +6292,15 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/error-stack-parser": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
+      "integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "stackframe": "^1.3.4"
       }
     },
     "node_modules/es-abstract": {
@@ -8116,6 +8217,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/iserror": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/iserror/-/iserror-0.0.2.tgz",
+      "integrity": "sha512-oKGGrFVaWwETimP3SiWwjDeY27ovZoyZPHtxblC4hCq9fXxed/jasx+ATWFFjCVSRZng8VTMsN1nDnGo6zMBSw==",
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -9163,6 +9270,15 @@
       "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
       "license": "MIT"
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/open": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
@@ -9655,6 +9771,16 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -10217,18 +10343,18 @@
       }
     },
     "node_modules/seroval": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.4.2.tgz",
-      "integrity": "sha512-N3HEHRCZYn3cQbsC4B5ldj9j+tHdf4JZoYPlcI4rRYu0Xy4qN8MQf1Z08EibzB0WpgRG5BGK08FTrmM66eSzKQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.0.tgz",
+      "integrity": "sha512-OE4cvmJ1uSPrKorFIH9/w/Qwuvi/IMcGbv5RKgcJ/zjA/IohDLU6SVaxFN9FwajbP7nsX0dQqMDes1whk3y+yw==",
       "license": "MIT",
       "engines": {
         "node": ">=10"
       }
     },
     "node_modules/seroval-plugins": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/seroval-plugins/-/seroval-plugins-1.4.2.tgz",
-      "integrity": "sha512-X7p4MEDTi+60o2sXZ4bnDBhgsUYDSkQEvzYZuJyFqWg9jcoPsHts5nrg5O956py2wyt28lUrBxk0M0/wU8URpA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/seroval-plugins/-/seroval-plugins-1.5.0.tgz",
+      "integrity": "sha512-EAHqADIQondwRZIdeW2I636zgsODzoBDwb3PT/+7TLDWyw1Dy/Xv7iGUIEXXav7usHDE9HVhOU61irI3EnyyHA==",
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -10440,11 +10566,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stack-generator": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.10.tgz",
+      "integrity": "sha512-mwnua/hkqM6pF4k8SnmZ2zfETsRUpWXREfA/goT8SLCV4iOFa4bzOX2nDipWAZFPTjLvQB82f5yaodMVhK0yJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "stackframe": "^1.3.4"
+      }
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stackframe": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
+      "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
       "license": "MIT"
     },
     "node_modules/state-local": {
@@ -12658,6 +12799,12 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
     },
     "node_modules/ws": {
       "version": "8.18.3",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,8 @@
     "hydrate-component-library": "tsx scripts/hydrate-component-library.ts public/component_library.original.yaml public/component_library.yaml"
   },
   "dependencies": {
+    "@bugsnag/js": "^8.8.1",
+    "@bugsnag/plugin-react": "^8.8.0",
     "@dnd-kit/core": "^6.3.1",
     "@hey-api/client-fetch": "^0.13.1",
     "@hyperjump/browser": "^1.3.1",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,6 +8,9 @@ import ReactDOM from "react-dom/client";
 import { scan } from "react-scan";
 
 import { router } from "./routes/router";
+import { initializeBugsnag } from "./services/errorManagement/bugsnag";
+
+initializeBugsnag();
 
 const queryClient = new QueryClient();
 

--- a/src/services/errorManagement/bugsnag.test.ts
+++ b/src/services/errorManagement/bugsnag.test.ts
@@ -1,0 +1,84 @@
+import Bugsnag, { type Event } from "@bugsnag/js";
+import { describe, expect, it, vi } from "vitest";
+
+import { handleBugsnagError } from "./bugsnag";
+
+const mockPathname = "/test/path";
+Object.defineProperty(window, "location", {
+  value: { pathname: mockPathname },
+  writable: true,
+});
+
+const createTestEvent = (errorClass: string, errorMessage: string): Event => {
+  let capturedEvent: Event | null = null;
+
+  const testClient = Bugsnag.createClient({
+    apiKey: "0123456789abcdef0123456789abcdef",
+    onError: (event) => {
+      capturedEvent = event;
+      return false;
+    },
+  });
+
+  testClient.notify(
+    new Error(errorMessage),
+    (event) => {
+      event.errors[0].errorClass = errorClass;
+    },
+    () => {},
+  );
+
+  if (!capturedEvent) {
+    throw new Error("Failed to capture test event");
+  }
+
+  return capturedEvent;
+};
+
+describe("handleBugsnagError", () => {
+  it("should add pathname context for all errors", () => {
+    const genericError = createTestEvent("Error", "Generic error");
+    const customError = createTestEvent("ValidationError", "Validation failed");
+
+    const addMetadataSpy1 = vi.spyOn(genericError, "addMetadata");
+    const addMetadataSpy2 = vi.spyOn(customError, "addMetadata");
+
+    handleBugsnagError(genericError);
+    handleBugsnagError(customError);
+
+    expect(addMetadataSpy1).toHaveBeenCalledWith("context", {
+      pathname: mockPathname,
+    });
+    expect(addMetadataSpy2).toHaveBeenCalledWith("context", {
+      pathname: mockPathname,
+    });
+  });
+
+  it("should handle errors without throwing", () => {
+    const event = createTestEvent("Error", "Test error");
+
+    expect(() => handleBugsnagError(event)).not.toThrow();
+  });
+});
+
+describe("createTestEvent", () => {
+  it("should use onError callback that returns false to prevent sending", () => {
+    let onErrorCalled = false;
+
+    const testClient = Bugsnag.createClient({
+      apiKey: "0123456789abcdef0123456789abcdef",
+      onError: () => {
+        onErrorCalled = true;
+        return false;
+      },
+    });
+
+    testClient.notify(
+      new Error("Test error"),
+      () => {},
+      () => {},
+    );
+
+    expect(onErrorCalled).toBe(true);
+  });
+});

--- a/src/services/errorManagement/bugsnag.ts
+++ b/src/services/errorManagement/bugsnag.ts
@@ -1,0 +1,37 @@
+import Bugsnag, { type BrowserConfig, type Event } from "@bugsnag/js";
+import BugsnagPluginReact from "@bugsnag/plugin-react";
+
+const BUGSNAG_API_KEY = import.meta.env.VITE_BUGSNAG_API_KEY || "";
+const BUGSNAG_NOTIFY_ENDPOINT =
+  import.meta.env.VITE_BUGSNAG_NOTIFY_ENDPOINT || "https://notify.bugsnag.com";
+const BUGSNAG_SESSIONS_ENDPOINT =
+  import.meta.env.VITE_BUGSNAG_SESSIONS_ENDPOINT ||
+  "https://sessions.bugsnag.com";
+
+const getBugsnagConfig = (): BrowserConfig => {
+  return {
+    apiKey: BUGSNAG_API_KEY,
+    endpoints: {
+      notify: BUGSNAG_NOTIFY_ENDPOINT,
+      sessions: BUGSNAG_SESSIONS_ENDPOINT,
+    },
+    plugins: [new BugsnagPluginReact()],
+    onError: handleBugsnagError,
+  };
+};
+
+export const handleBugsnagError = (event: Event): void => {
+  event.addMetadata("context", { pathname: window.location.pathname });
+};
+
+export const initializeBugsnag = (): void => {
+  if (!BUGSNAG_API_KEY) {
+    return;
+  }
+
+  try {
+    Bugsnag.start(getBugsnagConfig());
+  } catch (error) {
+    console.error("Failed to initialize Bugsnag:", error);
+  }
+};


### PR DESCRIPTION
## Description

Added Bugsnag error reporting integration to the application. This allows for optional error tracking and monitoring when configured with an API key.

## Type of Change

- [x] New feature
- [x] Documentation update

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Test Instructions

1. Add a Bugsnag API key to your `.env` file:
   ```
   VITE_BUGSNAG_API_KEY=your-api-key
   ```
2. Errors will now be reported to your Bugsnag dashboard
3. Verify that the application works normally without a key (error reporting remains disabled)

## Additional Comments

- Error reporting is completely optional and disabled by default
- Added unit tests for the error handling functionality
- Updated documentation in README and .env.example with configuration instructions
- Custom endpoints and grouping keys can be configured if needed