### PR TITLE
feat: add error message normalization and integration

### DIFF
--- a/src/services/errorManagement/bugsnag.test.ts
+++ b/src/services/errorManagement/bugsnag.test.ts
@@ -15,18 +15,13 @@ const createTestEvent = (errorClass: string, errorMessage: string): Event => {
   const testClient = Bugsnag.createClient({
     apiKey: "0123456789abcdef0123456789abcdef",
     onError: (event) => {
+      event.errors[0].errorClass = errorClass;
       capturedEvent = event;
       return false;
     },
   });
 
-  testClient.notify(
-    new Error(errorMessage),
-    (event) => {
-      event.errors[0].errorClass = errorClass;
-    },
-    () => {},
-  );
+  testClient.notify(new Error(errorMessage));
 
   if (!capturedEvent) {
     throw new Error("Failed to capture test event");
@@ -36,6 +31,109 @@ const createTestEvent = (errorClass: string, errorMessage: string): Event => {
 };
 
 describe("handleBugsnagError", () => {
+  it("should normalize generic Error instances", () => {
+    const event = createTestEvent(
+      "Error",
+      "HTTP 404 Not Found: /api/executions/019b3428-a0f0-d259-b764-ae0efbf37a64/status",
+    );
+
+    const addMetadataSpy = vi.spyOn(event, "addMetadata");
+    handleBugsnagError(event);
+
+    expect(event.groupingHash).toBe(
+      "HTTP 404 Not Found: /api/executions/{var1}/status",
+    );
+    expect(event.errors[0].errorClass).toBe(
+      "HTTP 404 Not Found: /api/executions/{var1}/status",
+    );
+    expect(addMetadataSpy).toHaveBeenCalledWith("context", {
+      pathname: mockPathname,
+    });
+    expect(addMetadataSpy).toHaveBeenCalledWith("extracted_values", {
+      "{var1}": "019b3428-a0f0-d259-b764-ae0efbf37a64",
+    });
+  });
+
+  it("should NOT normalize custom error classes", () => {
+    const errorMessage = "Network timeout after 30 seconds";
+    const event = createTestEvent("NetworkError", errorMessage);
+    const originalErrorClass = event.errors[0].errorClass;
+
+    const addMetadataSpy = vi.spyOn(event, "addMetadata");
+    handleBugsnagError(event);
+
+    expect(event.errors[0].errorClass).toBe(originalErrorClass);
+    expect(event.errors[0].errorClass).toBe("NetworkError");
+    expect(event.groupingHash).toBeUndefined();
+    expect(addMetadataSpy).toHaveBeenCalledWith("context", {
+      pathname: mockPathname,
+    });
+    expect(addMetadataSpy).not.toHaveBeenCalledWith(
+      "extracted_values",
+      expect.anything(),
+    );
+  });
+
+  it("should NOT add extracted_values metadata when no values are extracted", () => {
+    const event = createTestEvent("Error", "Simple error message");
+
+    const addMetadataSpy = vi.spyOn(event, "addMetadata");
+    handleBugsnagError(event);
+
+    expect(addMetadataSpy).not.toHaveBeenCalledWith(
+      "extracted_values",
+      expect.anything(),
+    );
+    expect(addMetadataSpy).toHaveBeenCalledWith("context", {
+      pathname: mockPathname,
+    });
+  });
+
+  it("should handle multiple dynamic values in error message", () => {
+    const event = createTestEvent(
+      "Error",
+      "Failed to copy /files/abc123defghi/item to /files/xyz789ghijkl/backup",
+    );
+
+    const addMetadataSpy = vi.spyOn(event, "addMetadata");
+    handleBugsnagError(event);
+
+    expect(event.groupingHash).toBe(
+      "Failed to copy /files/{var1}/item to /files/{var2}/backup",
+    );
+    expect(addMetadataSpy).toHaveBeenCalledWith("extracted_values", {
+      "{var1}": "abc123defghi",
+      "{var2}": "xyz789ghijkl",
+    });
+  });
+
+  it("should preserve HTTP status codes in error messages", () => {
+    const event = createTestEvent(
+      "Error",
+      "HTTP 502 Bad Gateway: Gateway timeout",
+    );
+
+    handleBugsnagError(event);
+
+    expect(event.groupingHash).toBe("HTTP 502 Bad Gateway: Gateway timeout");
+    expect(event.groupingHash).not.toContain("{var");
+  });
+
+  it("should extract hash values from error messages", () => {
+    const event = createTestEvent(
+      "Error",
+      "Checksum mismatch: expected a1b2c3d4e5f67890123456789abcdef0",
+    );
+
+    const addMetadataSpy = vi.spyOn(event, "addMetadata");
+    handleBugsnagError(event);
+
+    expect(event.groupingHash).toBe("Checksum mismatch: expected {var1}");
+    expect(addMetadataSpy).toHaveBeenCalledWith("extracted_values", {
+      "{var1}": "a1b2c3d4e5f67890123456789abcdef0",
+    });
+  });
+
   it("should add pathname context for all errors", () => {
     const genericError = createTestEvent("Error", "Generic error");
     const customError = createTestEvent("ValidationError", "Validation failed");

--- a/src/services/errorManagement/bugsnag.ts
+++ b/src/services/errorManagement/bugsnag.ts
@@ -1,12 +1,18 @@
 import Bugsnag, { type BrowserConfig, type Event } from "@bugsnag/js";
 import BugsnagPluginReact from "@bugsnag/plugin-react";
 
+import { normalizeErrorMessage } from "./normalizeErrorMessage";
+
 const BUGSNAG_API_KEY = import.meta.env.VITE_BUGSNAG_API_KEY || "";
 const BUGSNAG_NOTIFY_ENDPOINT =
   import.meta.env.VITE_BUGSNAG_NOTIFY_ENDPOINT || "https://notify.bugsnag.com";
 const BUGSNAG_SESSIONS_ENDPOINT =
   import.meta.env.VITE_BUGSNAG_SESSIONS_ENDPOINT ||
   "https://sessions.bugsnag.com";
+const BUGSNAG_CUSTOM_GROUPING_KEY = import.meta.env
+  .VITE_BUGSNAG_CUSTOM_GROUPING_KEY;
+
+const GENERIC_ERROR_CLASS = "Error";
 
 const getBugsnagConfig = (): BrowserConfig => {
   return {
@@ -21,6 +27,28 @@ const getBugsnagConfig = (): BrowserConfig => {
 };
 
 export const handleBugsnagError = (event: Event): void => {
+  if (
+    event.errors.length > 0 &&
+    event.errors[0].errorClass === GENERIC_ERROR_CLASS
+  ) {
+    const errorMessage = event.errors[0].errorMessage;
+    const { normalizedMessage, extractedValues } =
+      normalizeErrorMessage(errorMessage);
+
+    event.groupingHash = normalizedMessage;
+    event.errors[0].errorClass = normalizedMessage;
+
+    if (BUGSNAG_CUSTOM_GROUPING_KEY) {
+      event.addMetadata("custom", {
+        [BUGSNAG_CUSTOM_GROUPING_KEY]: normalizedMessage,
+      });
+    }
+
+    if (Object.keys(extractedValues).length > 0) {
+      event.addMetadata("extracted_values", extractedValues);
+    }
+  }
+
   event.addMetadata("context", { pathname: window.location.pathname });
 };
 

--- a/src/services/errorManagement/normalizeErrorMessage.test.ts
+++ b/src/services/errorManagement/normalizeErrorMessage.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeErrorMessage } from "./normalizeErrorMessage";
+
+describe("normalizeErrorMessage", () => {
+  it("should extract UUIDs from error messages", () => {
+    const message =
+      "HTTP 404 Not Found: Resource not found (URL: http://localhost:8000/api/executions/019b3428-a0f0-d259-b764-ae0efbf37a64/status)";
+    const result = normalizeErrorMessage(message);
+
+    expect(result.normalizedMessage).toBe(
+      "HTTP 404 Not Found: Resource not found (URL: http://localhost:{var2}/api/executions/{var1}/status)",
+    );
+    expect(result.extractedValues["{var1}"]).toBe(
+      "019b3428-a0f0-d259-b764-ae0efbf37a64",
+    );
+    expect(result.extractedValues["{var2}"]).toBe("8000");
+  });
+
+  it("should extract numeric IDs from paths", () => {
+    const message =
+      "HTTP 500 Internal Server Error (URL: /api/runs/12345/tasks)";
+    const result = normalizeErrorMessage(message);
+
+    expect(result.normalizedMessage).toBe(
+      "HTTP 500 Internal Server Error (URL: /api/runs/{var1}/tasks)",
+    );
+    expect(result.extractedValues["{var1}"]).toBe("12345");
+  });
+
+  it("should preserve HTTP status codes", () => {
+    const message = "HTTP 502 Bad Gateway: Gateway timeout";
+    const result = normalizeErrorMessage(message);
+
+    expect(result.normalizedMessage).toBe(
+      "HTTP 502 Bad Gateway: Gateway timeout",
+    );
+    expect(result.extractedValues).toEqual({});
+  });
+
+  it("should extract alphanumeric IDs", () => {
+    const message = "Error fetching /api/resources/abc123def456/details";
+    const result = normalizeErrorMessage(message);
+
+    expect(result.normalizedMessage).toBe(
+      "Error fetching /api/resources/{var1}/details",
+    );
+    expect(result.extractedValues["{var1}"]).toBe("abc123def456");
+  });
+
+  it("should extract query parameters with IDs", () => {
+    const message = "Failed to load /api/data?id=abc123&status=pending";
+    const result = normalizeErrorMessage(message);
+
+    expect(result.normalizedMessage).toBe(
+      "Failed to load /api/data?id={var1}&status=pending",
+    );
+    expect(result.extractedValues["{var1}"]).toBe("abc123");
+  });
+
+  it("should extract hash values (MD5, SHA-1, SHA-256)", () => {
+    // Test MD5 hash (32 characters)
+    const md5Message =
+      "Validation failed for hash a1b2c3d4e5f67890123456789abcdef0";
+    const md5Result = normalizeErrorMessage(md5Message);
+
+    expect(md5Result.normalizedMessage).toBe(
+      "Validation failed for hash {var1}",
+    );
+    expect(md5Result.extractedValues["{var1}"]).toBe(
+      "a1b2c3d4e5f67890123456789abcdef0",
+    );
+
+    // Test SHA-1 hash (40 characters)
+    const sha1Message =
+      "Error: checksum mismatch abc123def4567890abcdef1234567890abcdef12";
+    const sha1Result = normalizeErrorMessage(sha1Message);
+
+    expect(sha1Result.normalizedMessage).toBe(
+      "Error: checksum mismatch {var1}",
+    );
+    expect(sha1Result.extractedValues["{var1}"]).toBe(
+      "abc123def4567890abcdef1234567890abcdef12",
+    );
+
+    // Test SHA-256 hash (64 characters)
+    const sha256Message =
+      "Failed to verify 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    const sha256Result = normalizeErrorMessage(sha256Message);
+
+    expect(sha256Result.normalizedMessage).toBe("Failed to verify {var1}");
+    expect(sha256Result.extractedValues["{var1}"]).toBe(
+      "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    );
+  });
+
+  it("should extract quoted strings", () => {
+    const message = 'Error: File "document.pdf" not found';
+    const result = normalizeErrorMessage(message);
+
+    expect(result.normalizedMessage).toBe("Error: File {var1} not found");
+    expect(result.extractedValues["{var1}"]).toBe("document.pdf");
+  });
+
+  it("should truncate long messages to 200 characters", () => {
+    const longMessage = "Error: " + "a".repeat(300);
+    const result = normalizeErrorMessage(longMessage);
+
+    // After normalization, all 'a's get extracted as a quoted string placeholder
+    // So the message becomes much shorter
+    expect(result.normalizedMessage.length).toBeLessThanOrEqual(200);
+  });
+
+  it("should handle multiple dynamic values", () => {
+    const message =
+      "Failed to copy /files/abc123defghi/item to /files/xyz789ghijkl/backup";
+    const result = normalizeErrorMessage(message);
+
+    expect(result.normalizedMessage).toBe(
+      "Failed to copy /files/{var1}/item to /files/{var2}/backup",
+    );
+    expect(result.extractedValues["{var1}"]).toBe("abc123defghi");
+    expect(result.extractedValues["{var2}"]).toBe("xyz789ghijkl");
+  });
+
+  it("should clean up multiple spaces and empty parentheses", () => {
+    const message = "Error:   Multiple   spaces   and  ()  empty  parens  ()";
+    const result = normalizeErrorMessage(message);
+
+    // The function cleans up multiple spaces to single spaces and removes empty parens
+    expect(result.normalizedMessage).toContain("Error:");
+    expect(result.normalizedMessage).toContain("Multiple");
+    expect(result.normalizedMessage).not.toContain("()");
+    expect(result.normalizedMessage.trim()).toBe(result.normalizedMessage);
+  });
+
+  it("should NOT extract short hex strings that are not real hashes", () => {
+    // 26 characters - too short to be a real hash, should not be extracted
+    const message = "Error with value a1b2c3d4e5f6789012345678 in system";
+    const result = normalizeErrorMessage(message);
+
+    expect(result.normalizedMessage).toBe(
+      "Error with value a1b2c3d4e5f6789012345678 in system",
+    );
+    expect(result.extractedValues).toEqual({});
+  });
+
+  it("should preserve HTTP status codes with multiple spaces", () => {
+    const message = "HTTP  502 Bad Gateway: Gateway timeout";
+    const result = normalizeErrorMessage(message);
+
+    expect(result.normalizedMessage).toContain("HTTP 502");
+    expect(result.normalizedMessage).toContain("Gateway timeout");
+    // The 502 should NOT be extracted as a variable
+    expect(result.normalizedMessage).not.toContain("{var");
+  });
+});

--- a/src/services/errorManagement/normalizeErrorMessage.ts
+++ b/src/services/errorManagement/normalizeErrorMessage.ts
@@ -1,0 +1,207 @@
+const MAX_MESSAGE_LENGTH = 200;
+const MAX_MESSAGE_TRUNCATED_LENGTH = 197;
+const ELLIPSIS = "...";
+const HTTP_LOOKBACK_LENGTH = 10;
+
+// Regex patterns for normalizing error messages
+const UUID_PATH_SEGMENT_PATTERN =
+  /\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(\/|$|\)|\s)/gi;
+
+const NUMERIC_PATH_SEGMENT_PATTERN = /\/(\d+)(\/|$|\)|\s)/g;
+
+const ALPHANUMERIC_PATH_ID_MIN_6_CHARS_WITH_LETTERS_AND_DIGITS_PATTERN =
+  /\/([a-zA-Z0-9]*\d[a-zA-Z0-9]*[a-zA-Z][a-zA-Z0-9]{6,}|[a-zA-Z0-9]*[a-zA-Z][a-zA-Z0-9]*\d[a-zA-Z0-9]{6,})(\/|$|\)|\s)/g;
+
+const QUERY_PARAM_VALUE_WITH_DIGITS_OR_HEX_PATTERN =
+  /([?&][a-zA-Z_]+)=([0-9a-zA-Z-]{6,})/g;
+
+const CRYPTOGRAPHIC_HASH_MD5_SHA1_SHA256_PATTERN =
+  /\b([a-f0-9]{32}|[a-f0-9]{40}|[a-f0-9]{64})\b/gi;
+
+const CONTENT_IN_DOUBLE_QUOTES_PATTERN = /"([^"]+)"/g;
+
+const CONTENT_IN_SINGLE_QUOTES_PATTERN = /'([^']+)'/g;
+
+const THREE_OR_MORE_DIGIT_NUMBER_PATTERN = /\b\d{3,}\b/g;
+
+const HTTP_STATUS_CODE_PREFIX_PATTERN = /HTTP\s+$/;
+
+const HAS_DIGIT_PATTERN = /\d/;
+
+const IS_ALL_HEXADECIMAL_PATTERN = /^[a-f0-9]+$/i;
+
+type NormalizationResult = { value: string; replacement: string } | null;
+
+// Replacer for patterns with 2 capture groups (e.g., /users/123/profile → captures "123" and "/")
+type TwoGroupReplacer = (
+  match: string,
+  group1: string,
+  group2: string,
+  offset: number,
+  fullString: string,
+  placeholder: string,
+) => NormalizationResult;
+
+// Replacer for patterns with 1 capture group (e.g., "error message" → captures "error message")
+type OneGroupReplacer = (
+  match: string,
+  group1: string,
+  offset: number,
+  fullString: string,
+  placeholder: string,
+) => NormalizationResult;
+
+// Replacer for patterns with no capture groups (e.g., matches 12345 as a whole)
+type NoGroupReplacer = (
+  match: string,
+  offset: number,
+  fullString: string,
+  placeholder: string,
+) => NormalizationResult;
+
+interface NormalizationPattern<
+  T extends TwoGroupReplacer | OneGroupReplacer | NoGroupReplacer,
+> {
+  name: string;
+  pattern: RegExp;
+  replacer: T;
+}
+
+const NORMALIZATION_PATTERNS: Array<
+  | NormalizationPattern<TwoGroupReplacer>
+  | NormalizationPattern<OneGroupReplacer>
+  | NormalizationPattern<NoGroupReplacer>
+> = [
+  {
+    name: "uuid",
+    pattern: UUID_PATH_SEGMENT_PATTERN,
+    replacer: (_match, uuid, after, _offset, _fullString, placeholder) => ({
+      value: uuid,
+      replacement: `/${placeholder}${after}`,
+    }),
+  } satisfies NormalizationPattern<TwoGroupReplacer>,
+  {
+    name: "numericPathId",
+    pattern: NUMERIC_PATH_SEGMENT_PATTERN,
+    replacer: (_match, num, after, _offset, _fullString, placeholder) => ({
+      value: num,
+      replacement: `/${placeholder}${after}`,
+    }),
+  } satisfies NormalizationPattern<TwoGroupReplacer>,
+  {
+    name: "alphanumericPathId",
+    pattern: ALPHANUMERIC_PATH_ID_MIN_6_CHARS_WITH_LETTERS_AND_DIGITS_PATTERN,
+    replacer: (_match, id, after, _offset, _fullString, placeholder) => ({
+      value: id,
+      replacement: `/${placeholder}${after}`,
+    }),
+  } satisfies NormalizationPattern<TwoGroupReplacer>,
+  {
+    name: "queryParamId",
+    pattern: QUERY_PARAM_VALUE_WITH_DIGITS_OR_HEX_PATTERN,
+    replacer: (_match, key, value, _offset, _fullString, placeholder) => {
+      if (
+        HAS_DIGIT_PATTERN.test(value) ||
+        IS_ALL_HEXADECIMAL_PATTERN.test(value)
+      ) {
+        return {
+          value,
+          replacement: `${key}=${placeholder}`,
+        };
+      }
+      return null;
+    },
+  } satisfies NormalizationPattern<TwoGroupReplacer>,
+  {
+    name: "hashOrDigest",
+    pattern: CRYPTOGRAPHIC_HASH_MD5_SHA1_SHA256_PATTERN,
+    replacer: (_match, hash, _offset, _fullString, placeholder) => ({
+      value: hash,
+      replacement: placeholder,
+    }),
+  } satisfies NormalizationPattern<OneGroupReplacer>,
+  {
+    name: "doubleQuotedString",
+    pattern: CONTENT_IN_DOUBLE_QUOTES_PATTERN,
+    replacer: (_match, content, _offset, _fullString, placeholder) => ({
+      value: content,
+      replacement: placeholder,
+    }),
+  } satisfies NormalizationPattern<OneGroupReplacer>,
+  {
+    name: "singleQuotedString",
+    pattern: CONTENT_IN_SINGLE_QUOTES_PATTERN,
+    replacer: (_match, content, _offset, _fullString, placeholder) => ({
+      value: content,
+      replacement: placeholder,
+    }),
+  } satisfies NormalizationPattern<OneGroupReplacer>,
+  {
+    name: "largeNumber",
+    pattern: THREE_OR_MORE_DIGIT_NUMBER_PATTERN,
+    replacer: (match, offset, fullString, placeholder) => {
+      const beforeMatch = fullString.substring(
+        Math.max(0, offset - HTTP_LOOKBACK_LENGTH),
+        offset,
+      );
+      // Preserve HTTP status codes (handle multiple spaces)
+      if (HTTP_STATUS_CODE_PREFIX_PATTERN.test(beforeMatch)) {
+        return null;
+      }
+      return {
+        value: match,
+        replacement: placeholder,
+      };
+    },
+  } satisfies NormalizationPattern<NoGroupReplacer>,
+];
+
+const CLEANUP_PATTERNS: Array<{ pattern: RegExp; replacement: string }> = [
+  { pattern: /\s+/g, replacement: " " },
+  { pattern: /\(\s*\)/g, replacement: "" },
+];
+
+export function normalizeErrorMessage(message: string): {
+  normalizedMessage: string;
+  extractedValues: Record<string, string>;
+} {
+  const extractedValues: Record<string, string> = {};
+  let extractedValueIndex = 1;
+  let normalized = message;
+
+  for (const { pattern, replacer } of NORMALIZATION_PATTERNS) {
+    normalized = normalized.replace(
+      pattern,
+      (match: string, ...args: (string | number)[]) => {
+        const placeholder = `{var${extractedValueIndex}}`;
+        // Call the replacer with the match and remaining args + placeholder
+        const result = (replacer as (...args: any[]) => NormalizationResult)(
+          match,
+          ...args,
+          placeholder,
+        );
+
+        if (result === null) {
+          return match;
+        }
+
+        extractedValues[placeholder] = result.value;
+        extractedValueIndex++;
+        return result.replacement;
+      },
+    );
+  }
+
+  for (const { pattern, replacement } of CLEANUP_PATTERNS) {
+    normalized = normalized.replace(pattern, replacement);
+  }
+
+  normalized = normalized.trim();
+
+  if (normalized.length > MAX_MESSAGE_LENGTH) {
+    normalized =
+      normalized.substring(0, MAX_MESSAGE_TRUNCATED_LENGTH) + ELLIPSIS;
+  }
+
+  return { normalizedMessage: normalized, extractedValues };
+}


### PR DESCRIPTION
## Description

Implemented error message normalization for Bugsnag to improve error grouping. This enhancement extracts dynamic values (UUIDs, IDs, hashes) from error messages and replaces them with placeholders, allowing similar errors with different dynamic values to be grouped together.

The implementation includes:
- A new `normalizeErrorMessage` utility that identifies and extracts common patterns
- Enhanced Bugsnag error handling that applies normalization to generic Error instances
- Custom grouping hash generation for better error categorization
- Preservation of extracted values as metadata for debugging

## Type of Change

- [x] Improvement
- [x] New feature

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Test Instructions

1. Verify that similar errors with different IDs/UUIDs are grouped together in Bugsnag
2. Check that the extracted values are available in the error metadata
3. Confirm that HTTP status codes are preserved and not normalized
4. Ensure custom error classes (NetworkError, ValidationError, etc.) are not affected by normalization