### PR TITLE
improvement: move Task Actions out of details tab

### DIFF
--- a/src/components/shared/Dialogs/ComponentDetailsDialog.tsx
+++ b/src/components/shared/Dialogs/ComponentDetailsDialog.tsx
@@ -24,6 +24,7 @@ import { PublishedComponentDetails } from "../ManageComponent/PublishedComponent
 import { useFlagValue } from "../Settings/useFlags";
 import { withSuspenseWrapper } from "../SuspenseWrapper";
 import { TaskDetails, TaskImplementation, TaskIO } from "../TaskDetails";
+import TaskActions from "../TaskDetails/Actions";
 import { DialogContext } from "./dialog.context";
 
 interface ComponentDetailsProps {
@@ -120,11 +121,12 @@ const ComponentDetailsDialogContent = withSuspenseWrapper(
 
             <div className="overflow-auto h-[40vh]">
               <TabsContent value="details" className="h-full">
-                {remoteComponentLibrarySearchEnabled ? (
+                {remoteComponentLibrarySearchEnabled && (
                   <PublishedComponentDetails component={componentRef} />
-                ) : null}
+                )}
 
                 <TaskDetails componentRef={componentRef} />
+                <TaskActions componentRef={componentRef} className="mt-2" />
               </TabsContent>
 
               <TabsContent value="io" className="h-full">

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/TaskOverview.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/TaskOverview.tsx
@@ -10,6 +10,7 @@ import { ComponentDetailsDialog } from "@/components/shared/Dialogs";
 import { ComponentFavoriteToggle } from "@/components/shared/FavoriteComponentToggle";
 import { StatusIcon } from "@/components/shared/Status";
 import { TaskDetails } from "@/components/shared/TaskDetails";
+import TaskActions from "@/components/shared/TaskDetails/Actions";
 import { Icon } from "@/components/ui/icon";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Separator } from "@/components/ui/separator";
@@ -31,7 +32,8 @@ interface TaskOverviewProps {
 }
 
 const TaskOverview = ({ taskNode }: TaskOverviewProps) => {
-  const { displayName, taskSpec, taskId, state, callbacks } = taskNode;
+  const { componentRef, displayName, taskSpec, taskId, state, callbacks } =
+    taskNode;
 
   const executionData = useExecutionDataOptional();
   const details = executionData?.details;
@@ -57,8 +59,12 @@ const TaskOverview = ({ taskNode }: TaskOverviewProps) => {
   const canRename = !readOnly && isSubgraph;
 
   return (
-    <BlockStack className="h-full" data-context-panel="task-overview">
-      <InlineStack gap="2" className="px-2 pb-2">
+    <BlockStack
+      gap="4"
+      className="h-full px-2"
+      data-context-panel="task-overview"
+    >
+      <InlineStack gap="2">
         {isSubgraph && <Icon name="Workflow" />}
         <Text size="lg" weight="semibold" className="wrap-anywhere">
           {displayName}
@@ -72,7 +78,15 @@ const TaskOverview = ({ taskNode }: TaskOverviewProps) => {
         {readOnly && <StatusIcon status={status} tooltip label="task" />}
       </InlineStack>
 
-      <div className="px-4 overflow-y-auto pb-4 h-full w-full">
+      {!!componentRef && (
+        <TaskActions
+          componentRef={componentRef}
+          taskNode={taskNode}
+          readOnly={readOnly}
+        />
+      )}
+
+      <div className="overflow-y-auto pb-4 h-full w-full">
         <Tabs defaultValue="io" className="h-full">
           <TabsList className="mb-2">
             <TabsTrigger value="io" className="flex-1">

--- a/src/components/shared/TaskDetails/Actions.tsx
+++ b/src/components/shared/TaskDetails/Actions.tsx
@@ -80,7 +80,13 @@ const TaskActions = ({
     deleteComponent,
   ].filter(Boolean);
 
-  return <ActionBlock actions={actions} className={className} />;
+  return (
+    <ActionBlock
+      actions={actions}
+      className={className}
+      data-testid="task-actions"
+    />
+  );
 };
 
 export default TaskActions;

--- a/src/components/shared/TaskDetails/Details.tsx
+++ b/src/components/shared/TaskDetails/Details.tsx
@@ -11,7 +11,6 @@ import { KeyValueList } from "../ContextPanel/Blocks/KeyValueList";
 import { TextBlock } from "../ContextPanel/Blocks/TextBlock";
 import { InlineEditor } from "../InlineEditor/InlineEditor";
 import { withSuspenseWrapper } from "../SuspenseWrapper";
-import TaskActions from "./Actions";
 import { DisplayNameEditor } from "./DisplayNameEditor";
 import { ExecutionDetails } from "./ExecutionDetails";
 import { GithubDetails } from "./GithubDetails";
@@ -180,13 +179,6 @@ const TaskDetailsInternal = ({
           />
         </ContentBlock>
       )}
-
-      <TaskActions
-        componentRef={hydratedComponentRef}
-        taskNode={taskNode}
-        readOnly={readOnly}
-        className={BASE_BLOCK_CLASS}
-      />
     </BlockStack>
   );
 };


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Now they are always visible, not just when in the Details Tab - similar to pipeline runs

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

![image.png](https://app.graphite.com/user-attachments/assets/8468baaa-ab58-4245-ae8a-66a861478058.png)

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
