### PR TITLE
feat: Add Basic FlexNode

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -10,7 +10,8 @@
     "vite.config.ghpages.js",
     "src/components/shared/ReactFlow/FlowCanvas/utils/zIndex.ts",
     "src/components/shared/ReactFlow/FlowControls/StackingControls.tsx",
-    "src/components/shared/ReactFlow/FlowCanvas/types.ts"
+    "src/components/shared/ReactFlow/FlowCanvas/types.ts",
+    "src/components/shared/ReactFlow/FlowCanvas/FlexNode/**"
   ],
   "ignoreDependencies": [
     "@radix-ui/react-accordion",

--- a/react-compiler.config.js
+++ b/react-compiler.config.js
@@ -49,6 +49,7 @@ export const REACT_COMPILER_ENABLED_DIRS = [
   "src/components/shared/TaskDetails/Actions/UnpackSubgraphButton.tsx",
   "src/components/shared/ReactFlow/FlowSidebar/components/ComponentHoverPopover.tsx",
   "src/components/shared/ReactFlow/FlowControls/StackingControls.tsx",
+  "src/components/shared/ReactFlow/FlowCanvas/FlexNode",
 
   // 11-20 useCallback/useMemo
   // "src/components/ui",                         // 12

--- a/src/components/Editor/Context/PipelineDetails.tsx
+++ b/src/components/Editor/Context/PipelineDetails.tsx
@@ -13,7 +13,10 @@ import { useFlagValue } from "@/components/shared/Settings/useFlags";
 import { BlockStack } from "@/components/ui/layout";
 import useToastNotification from "@/hooks/useToastNotification";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
-import { PIPELINE_NOTES_ANNOTATION } from "@/utils/annotations";
+import {
+  FLEX_NODES_ANNOTATION,
+  PIPELINE_NOTES_ANNOTATION,
+} from "@/utils/annotations";
 import { getComponentFileFromList } from "@/utils/componentStore";
 import { USER_PIPELINES_LIST_NAME } from "@/utils/constants";
 
@@ -22,7 +25,7 @@ import { PipelineNotesEditor } from "./PipelineNotesEditor";
 import { PipelineValidationList } from "./PipelineValidationList";
 import RenamePipeline from "./RenamePipeline";
 
-const EXCLUDED_ANNOTATIONS = [PIPELINE_NOTES_ANNOTATION];
+const EXCLUDED_ANNOTATIONS = [PIPELINE_NOTES_ANNOTATION, FLEX_NODES_ANNOTATION];
 
 const PipelineDetails = () => {
   const notify = useToastNotification();

--- a/src/components/PipelineRun/RunDetails.tsx
+++ b/src/components/PipelineRun/RunDetails.tsx
@@ -13,6 +13,7 @@ import { useBackend } from "@/providers/BackendProvider";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 import { useExecutionData } from "@/providers/ExecutionDataProvider";
 import {
+  FLEX_NODES_ANNOTATION,
   getAnnotationValue,
   PIPELINE_NOTES_ANNOTATION,
 } from "@/utils/annotations";
@@ -24,7 +25,7 @@ import {
 
 import { RunNotesEditor } from "./RunNotesEditor";
 
-const EXCLUDED_ANNOTATIONS = [PIPELINE_NOTES_ANNOTATION];
+const EXCLUDED_ANNOTATIONS = [PIPELINE_NOTES_ANNOTATION, FLEX_NODES_ANNOTATION];
 
 export const RunDetails = () => {
   const { configured } = useBackend();

--- a/src/components/shared/ReactFlow/FlowCanvas/FlexNode/FlexNode.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlexNode/FlexNode.tsx
@@ -1,0 +1,44 @@
+import { type Node, type NodeProps } from "@xyflow/react";
+
+import { BlockStack } from "@/components/ui/layout";
+import { Paragraph } from "@/components/ui/typography";
+import { cn } from "@/lib/utils";
+
+import type { FlexNodeData } from "./types";
+
+type FlexNodeProps = NodeProps<Node<FlexNodeData>>;
+
+const FlexNode = ({ data, id, selected }: FlexNodeProps) => {
+  const { properties } = data;
+  const { title, content, color } = properties;
+
+  const isTransparent = color === "transparent";
+
+  return (
+    <div
+      key={id}
+      className={cn(
+        "p-1 rounded-lg border-2 border-transparent h-full w-full",
+        isTransparent && !title && !content && "border-dashed border-warning",
+        selected && "border-gray-500 border-solid",
+      )}
+      style={{ backgroundColor: color }}
+    >
+      <div
+        className={cn(
+          "rounded-sm p-1 h-full w-full overflow-hidden",
+          isTransparent ? "bg-transparent" : "bg-white/40",
+        )}
+      >
+        <BlockStack gap="1">
+          <Paragraph size="sm" weight="semibold">
+            {title}
+          </Paragraph>
+          <Paragraph size="xs">{content}</Paragraph>
+        </BlockStack>
+      </div>
+    </div>
+  );
+};
+
+export default FlexNode;

--- a/src/components/shared/ReactFlow/FlowCanvas/FlexNode/interface.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlexNode/interface.ts
@@ -1,0 +1,94 @@
+import { ensureAnnotations, FLEX_NODES_ANNOTATION } from "@/utils/annotations";
+import type { ComponentSpec, MetadataSpec } from "@/utils/componentSpec";
+import { deepClone } from "@/utils/deepClone";
+
+import { type FlexNodeData, isFlexNodeData } from "./types";
+
+export function serializeFlexNodes(data: FlexNodeData[]): string {
+  return JSON.stringify(data);
+}
+
+export function deserializeFlexNodes(
+  serializedData: string | undefined,
+): FlexNodeData[] {
+  if (!serializedData) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(serializedData);
+
+    if (!Array.isArray(parsed) || !parsed.every(isFlexNodeData)) {
+      throw new Error("Invalid FlexNode data format");
+    }
+
+    return parsed;
+  } catch (error) {
+    console.error("Failed to deserialize FlexNodes:", error);
+    return [];
+  }
+}
+
+export const getFlexNode = (id: string, componentSpec: ComponentSpec) => {
+  const flexNodes = getFlexNodeAnnotations(componentSpec);
+  return flexNodes.find((node) => node.id === id);
+};
+
+export const getFlexNodeAnnotations = (
+  componentSpec: ComponentSpec,
+): FlexNodeData[] => {
+  if (!componentSpec.metadata?.annotations) {
+    return [];
+  }
+
+  const flexNodesAnnotations = deserializeFlexNodes(
+    componentSpec.metadata.annotations[FLEX_NODES_ANNOTATION],
+  );
+
+  return flexNodesAnnotations;
+};
+
+export const updateFlexNodeInAnnotations = (
+  annotations: MetadataSpec["annotations"],
+  flexNode: FlexNodeData,
+): MetadataSpec["annotations"] => {
+  const clonedAnnotations = { ...annotations };
+  const flexNodesAnnotations = deserializeFlexNodes(
+    clonedAnnotations[FLEX_NODES_ANNOTATION],
+  );
+
+  const existingNodeIndex = flexNodesAnnotations.findIndex(
+    (node) => node.id === flexNode.id,
+  );
+
+  if (existingNodeIndex === -1) {
+    // Add a new Flex Node
+    flexNodesAnnotations.push(flexNode);
+  } else {
+    // Update an existing Flex Node
+    flexNodesAnnotations[existingNodeIndex] = flexNode;
+  }
+
+  clonedAnnotations[FLEX_NODES_ANNOTATION] =
+    serializeFlexNodes(flexNodesAnnotations);
+
+  return clonedAnnotations;
+};
+
+export const updateFlexNodeInComponentSpec = (
+  componentSpec: ComponentSpec,
+  flexNode: FlexNodeData,
+): ComponentSpec => {
+  const clonedComponentSpec = deepClone(componentSpec);
+  const newComponentSpec = ensureAnnotations(clonedComponentSpec);
+  const annotations = newComponentSpec.metadata.annotations;
+
+  const updatedAnnotations = updateFlexNodeInAnnotations(annotations, flexNode);
+
+  newComponentSpec.metadata.annotations = {
+    ...newComponentSpec.metadata.annotations,
+    ...updatedAnnotations,
+  };
+
+  return newComponentSpec;
+};

--- a/src/components/shared/ReactFlow/FlowCanvas/FlexNode/types.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlexNode/types.ts
@@ -1,0 +1,35 @@
+import type { XYPosition } from "@xyflow/react";
+
+export interface FlexNodeData extends Record<string, unknown> {
+  id: string;
+  properties: FlexNodeProperties;
+  metadata: FlexNodeMetadata;
+  size: { width: number; height: number };
+  position: XYPosition;
+  zIndex: number;
+  readOnly?: boolean;
+}
+
+type FlexNodeProperties = {
+  title: string;
+  content: string;
+  color: string;
+};
+
+type FlexNodeMetadata = {
+  createdAt: string;
+  createdBy: string;
+};
+
+export function isFlexNodeData(obj: any): obj is FlexNodeData {
+  return (
+    obj &&
+    typeof obj === "object" &&
+    "id" in obj &&
+    "properties" in obj &&
+    "metadata" in obj &&
+    "size" in obj &&
+    "position" in obj &&
+    "zIndex" in obj
+  );
+}

--- a/src/components/shared/ReactFlow/FlowCanvas/FlexNode/utils.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlexNode/utils.ts
@@ -1,0 +1,20 @@
+import { type Node } from "@xyflow/react";
+
+import type { FlexNodeData } from "./types";
+
+export const createFlexNode = (
+  flexNode: FlexNodeData,
+  readOnly: boolean = false,
+) => {
+  const { id, position, size, zIndex } = flexNode;
+
+  return {
+    id,
+    data: { ...flexNode, readOnly },
+    ...size,
+    position,
+    type: "flex",
+    connectable: false,
+    zIndex,
+  } as Node;
+};

--- a/src/components/shared/ReactFlow/FlowCanvas/types.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/types.ts
@@ -4,6 +4,7 @@ import type { ComponentType } from "react";
 import type { TaskType } from "@/types/taskNode";
 
 import SmoothEdge from "./Edges/SmoothEdge";
+import FlexNode from "./FlexNode/FlexNode";
 import GhostNode from "./GhostNode/GhostNode";
 import IONode from "./IONode/IONode";
 import TaskNode from "./TaskNode/TaskNode";
@@ -18,6 +19,7 @@ export const nodeTypes: Record<string, ComponentType<any>> = {
   input: IONode,
   output: IONode,
   ghost: GhostNode,
+  flex: FlexNode,
 };
 
 export type NodeType = keyof typeof nodeTypes;

--- a/src/utils/annotations.ts
+++ b/src/utils/annotations.ts
@@ -11,6 +11,7 @@ export const PIPELINE_RUN_NOTES_ANNOTATION = "notes";
 export const PIPELINE_CANONICAL_NAME_ANNOTATION = "canonical-pipeline-name";
 export const RUN_NAME_TEMPLATE_ANNOTATION = "run-name-template";
 export const EDITOR_POSITION_ANNOTATION = "editor.position";
+export const FLEX_NODES_ANNOTATION = "flex-nodes";
 
 export const DEFAULT_COMMON_ANNOTATIONS: AnnotationConfig[] = [
   {
@@ -185,3 +186,24 @@ export const extractPositionFromAnnotations = (
     return defaultPosition;
   }
 };
+
+/*
+ * Ensures that the componentSpec has metadata and annotations objects.
+ * @param componentSpec - The component specification
+ * @returns The component specification with ensured metadata and annotations
+ */
+export function ensureAnnotations(
+  componentSpec: ComponentSpec,
+): ComponentSpec & {
+  metadata: { annotations: Record<string, unknown> };
+} {
+  return {
+    ...componentSpec,
+    metadata: {
+      ...componentSpec.metadata,
+      annotations: {
+        ...(componentSpec.metadata?.annotations ?? {}),
+      },
+    },
+  };
+}

--- a/src/utils/componentSpec.ts
+++ b/src/utils/componentSpec.ts
@@ -3,6 +3,8 @@ import type {
   GraphImplementationOutput,
 } from "@/api/types.gen";
 
+import type { FLEX_NODES_ANNOTATION } from "./annotations";
+
 export type TypeSpecType =
   | string
   | {
@@ -142,6 +144,7 @@ export interface MetadataSpec {
     canonical_location?: string;
     author?: string;
     python_original_code?: string;
+    [FLEX_NODES_ANNOTATION]?: string;
   };
 }
 /**

--- a/src/utils/nodes/createNodesFromComponentSpec.ts
+++ b/src/utils/nodes/createNodesFromComponentSpec.ts
@@ -1,5 +1,7 @@
 import { type Node } from "@xyflow/react";
 
+import { getFlexNodeAnnotations } from "@/components/shared/ReactFlow/FlowCanvas/FlexNode/interface";
+import { createFlexNode } from "@/components/shared/ReactFlow/FlowCanvas/FlexNode/utils";
 import type { TaskNodeData } from "@/types/taskNode";
 import {
   type ComponentSpec,
@@ -24,8 +26,9 @@ const createNodesFromComponentSpec = (
   const taskNodes = createTaskNodes(graphSpec, nodeData, readOnly);
   const inputNodes = createInputNodes(componentSpec, nodeData, readOnly);
   const outputNodes = createOutputNodes(componentSpec, nodeData, readOnly);
+  const flexNodes = createFlexNodes(componentSpec, readOnly);
 
-  return [...taskNodes, ...inputNodes, ...outputNodes];
+  return [...taskNodes, ...inputNodes, ...outputNodes, ...flexNodes];
 };
 
 const createTaskNodes = (
@@ -55,6 +58,13 @@ const createOutputNodes = (
 ) => {
   return (componentSpec.outputs ?? []).map((outputSpec) =>
     createOutputNode(outputSpec, nodeData, readOnly),
+  );
+};
+
+const createFlexNodes = (componentSpec: ComponentSpec, readOnly: boolean) => {
+  const flexNodeAnnotations = getFlexNodeAnnotations(componentSpec);
+  return flexNodeAnnotations.map((flexNode) =>
+    createFlexNode(flexNode, readOnly),
   );
 };
 


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Adds a basic static FlexNode component to the canvas when the `flex-nodes` annotation has appropriate data (saved as a JSON string). The flex node cannot be interacted with beyond moving it around.

Flex Nodes (aka "Sticky Notes") have the following attributes:
- Id
- Properties
    - Title
    - Content
    - Color
    - Border Colour (later)
- Metadata
    - Created At
    - Created By
- Size (width, height)
- Position (x, y)
- Z-Index
- Read Only

Flex Nodes can be found & defined directly in the component spec at `spec.metadata.annotations["flex-nodes"] = JSON.stringify(FlexNode[])` 


Note this PR does not include a method of adding Flex Nodes to the canvas via UI. Nor does it add editing & basic canvas operations (e.g. delete). These features are added further upstack.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

Progresses https://github.com/Shopify/oasis-frontend/issues/118

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] New feature

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

![image.png](https://app.graphite.com/user-attachments/assets/f38fb604-a5e1-499b-b917-74abf38b50ad.png)

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

Create a component spec and define one ore more Sticky Notes via `spec.metadata.annotations["flex-nodes"]`, using the type structure provided. The created sticky notes should render on the canvas when the pipeline is imported.

Note! Flex Nodes are saved in the spec as a JSON string. Remember to stringify the entire Flex Node array when defining them in the spec.

Alternatively, go upstack to test via a UI-based solution.

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
