### PR TITLE
feat: Add Sticky Notes to Canvas

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -11,7 +11,7 @@
     "src/components/shared/ReactFlow/FlowCanvas/utils/zIndex.ts",
     "src/components/shared/ReactFlow/FlowControls/StackingControls.tsx",
     "src/components/shared/ReactFlow/FlowCanvas/types.ts",
-    "src/components/shared/ReactFlow/FlowCanvas/FlexNode/**"
+    "src/components/shared/ReactFlow/FlowCanvas/FlexNode/interface.ts"
   ],
   "ignoreDependencies": [
     "@radix-ui/react-accordion",

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "js-yaml": "^4.1.1",
         "localforage": "^1.10.0",
         "lucide-react": "^0.574.0",
+        "nanoid": "^5.1.6",
         "pyodide": "^0.29.3",
         "random-words": "^2.0.1",
         "react": "^19.2.4",
@@ -9072,9 +9073,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.6.tgz",
+      "integrity": "sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg==",
       "funding": [
         {
           "type": "github",
@@ -9083,10 +9084,10 @@
       ],
       "license": "MIT",
       "bin": {
-        "nanoid": "bin/nanoid.cjs"
+        "nanoid": "bin/nanoid.js"
       },
       "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+        "node": "^18 || >=20"
       }
     },
     "node_modules/natural-compare": {
@@ -9661,6 +9662,24 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss/node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/powershell-utils": {

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "js-yaml": "^4.1.1",
     "localforage": "^1.10.0",
     "lucide-react": "^0.574.0",
+    "nanoid": "^5.1.6",
     "pyodide": "^0.29.3",
     "random-words": "^2.0.1",
     "react": "^19.2.4",

--- a/src/components/shared/ReactFlow/FlowCanvas/FlexNode/utils.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlexNode/utils.ts
@@ -2,6 +2,14 @@ import { type Node } from "@xyflow/react";
 
 import type { FlexNodeData } from "./types";
 
+export const DEFAULT_STICKY_NOTE = {
+  title: "Sticky Note",
+  content: "",
+  color: "#FFF9C4",
+};
+
+export const DEFAULT_FLEX_NODE_SIZE = { width: 150, height: 100 };
+
 export const createFlexNode = (
   flexNode: FlexNodeData,
   readOnly: boolean = false,

--- a/src/components/shared/ReactFlow/FlowCanvas/utils/addFlexNode.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/utils/addFlexNode.ts
@@ -1,0 +1,59 @@
+import type { XYPosition } from "@xyflow/react";
+import { nanoid } from "nanoid";
+
+import { type ComponentSpec } from "@/utils/componentSpec";
+
+import { updateFlexNodeInComponentSpec } from "../FlexNode/interface";
+import type { FlexNodeData } from "../FlexNode/types";
+import { DEFAULT_FLEX_NODE_SIZE, DEFAULT_STICKY_NOTE } from "../FlexNode/utils";
+
+interface AddFlexNodeResult {
+  spec: ComponentSpec;
+  nodeId: string;
+}
+
+/**
+ * Creates a flex node (sticky note) and adds it to the component annotations.
+ *
+ * Nodes are created with default properties which can be edited later.
+ *
+ * @param position - Canvas position {x, y} where the node should be visually placed
+ * @param componentSpec - The component specification to modify (will be cloned, not mutated)
+ * @returns Object containing the updated spec and nodeId
+ *
+ * @example
+ * // Create a flex node
+ * const result = addFlexNode({ x: 100, y: 200 }, componentSpec);
+ *
+ */
+
+const addFlexNode = (
+  position: XYPosition,
+  author: string,
+  componentSpec: ComponentSpec,
+): AddFlexNodeResult => {
+  const nodeId = nanoid();
+
+  const metadata = {
+    createdAt: new Date().toISOString(),
+    createdBy: author,
+  };
+
+  const flexNode: FlexNodeData = {
+    id: nodeId,
+    properties: DEFAULT_STICKY_NOTE,
+    metadata,
+    size: DEFAULT_FLEX_NODE_SIZE,
+    position: position,
+    zIndex: 0,
+  };
+
+  const newComponentSpec = updateFlexNodeInComponentSpec(
+    componentSpec,
+    flexNode,
+  );
+
+  return { spec: newComponentSpec, nodeId };
+};
+
+export default addFlexNode;

--- a/src/components/shared/ReactFlow/FlowSidebar/components/ComponentItem.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/components/ComponentItem.tsx
@@ -10,6 +10,7 @@ import { Icon } from "@/components/ui/icon";
 import { InlineStack } from "@/components/ui/layout";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
+import { Text } from "@/components/ui/typography";
 import { useHydrateComponentReference } from "@/hooks/useHydrateComponentReference";
 import { cn } from "@/lib/utils";
 import { type ComponentReference, type TaskSpec } from "@/utils/componentSpec";
@@ -318,6 +319,38 @@ export const IONodeSidebarItem = ({ nodeType }: IONodeSidebarItemProps) => {
           {nodeType === "input" ? "Input Node" : "Output Node"}
         </span>
       </div>
+    </li>
+  );
+};
+
+export const StickyNoteSidebarItem = () => {
+  const onDragStart = useCallback((event: DragEvent) => {
+    event.dataTransfer.setData(
+      "application/reactflow",
+      JSON.stringify({ ["flex"]: null }),
+    );
+    event.dataTransfer.setData(
+      "DragStart.offset",
+      JSON.stringify({
+        offsetX: event.nativeEvent.offsetX,
+        offsetY: event.nativeEvent.offsetY,
+      }),
+    );
+    event.dataTransfer.effectAllowed = "move";
+  }, []);
+
+  return (
+    <li
+      className="pl-2 py-1.5 cursor-grab hover:bg-gray-100 active:bg-gray-200"
+      draggable
+      onDragStart={onDragStart}
+    >
+      <InlineStack blockAlign="center" gap="2">
+        <Icon name="StickyNote" className="text-gray-400 shrink-0" />
+        <Text size="sm" className="truncate">
+          Sticky Note
+        </Text>
+      </InlineStack>
     </li>
   );
 };

--- a/src/components/shared/ReactFlow/FlowSidebar/sections/GraphComponents.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/sections/GraphComponents.tsx
@@ -20,7 +20,10 @@ import {
   SearchInput,
   SearchResults,
 } from "../components";
-import { IONodeSidebarItem } from "../components/ComponentItem";
+import {
+  IONodeSidebarItem,
+  StickyNoteSidebarItem,
+} from "../components/ComponentItem";
 import { LibraryFolderItem } from "../components/FolderItem";
 import PublishedComponentsSearch from "../components/PublishedComponentsSearch";
 import { SidebarSection } from "../components/SidebarSection";
@@ -95,6 +98,18 @@ const GraphComponents = () => {
         {remoteComponentLibrarySearchEnabled && <UpgradeAvailableAlertBox />}
 
         <BlockStack>
+          <FolderItem
+            key="canvas-tools-folder"
+            folder={
+              {
+                name: "Canvas Tools",
+                components: [<StickyNoteSidebarItem key="sticky-note" />],
+                folders: [],
+              } as UIComponentFolder
+            }
+            icon="ToolCase"
+          />
+          <Separator />
           {hasUsedComponents && (
             <FolderItem
               key="used-components-folder"


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

Add a new folder to the component library `Canvas Tools`. From here users can now drag a sticky note onto their canvas.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

Progresses https://github.com/Shopify/oasis-frontend/issues/118

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] New feature

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

![image.png](https://app.graphite.com/user-attachments/assets/09503bdb-8b30-4a0c-a104-f6afe04ed7c4.png)

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

- Confirm that sticky note can be dragged from component library onto canvas
- Confirm they also appear on a run executed from that pipeline

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
