### PR TITLE
feat: allow run submission with missed pipeline input values

### DIFF
--- a/src/components/Editor/Context/PipelineDetails.tsx
+++ b/src/components/Editor/Context/PipelineDetails.tsx
@@ -22,12 +22,7 @@ import RenamePipeline from "./RenamePipeline";
 
 const PipelineDetails = () => {
   const notify = useToastNotification();
-  const {
-    componentSpec,
-    digest,
-    isComponentTreeValid,
-    globalValidationIssues,
-  } = useComponentSpec();
+  const { componentSpec, digest, globalValidationIssues } = useComponentSpec();
 
   const templatizedRunNameEnabled = useFlagValue(
     "templatized-pipeline-run-name",
@@ -136,9 +131,8 @@ const PipelineDetails = () => {
 
       <ContentBlock title="Validations">
         <PipelineValidationList
-          isComponentTreeValid={isComponentTreeValid}
           groupedIssues={groupedIssues}
-          totalIssueCount={globalValidationIssues.length}
+          globalValidationIssues={globalValidationIssues}
           onIssueSelect={handleIssueClick}
         />
       </ContentBlock>

--- a/src/components/Editor/Context/PipelineValidationList.tsx
+++ b/src/components/Editor/Context/PipelineValidationList.tsx
@@ -18,14 +18,16 @@ import {
 import { Paragraph, Text } from "@/components/ui/typography";
 import { cn } from "@/lib/utils";
 import { pluralize } from "@/utils/string";
-import type { ComponentValidationIssue } from "@/utils/validations";
+import {
+  type ComponentValidationIssue,
+  isFixableIssue,
+} from "@/utils/validations";
 
 import type { ValidationIssueGroup } from "../hooks/useValidationIssueNavigation";
 
 interface PipelineValidationListProps {
-  isComponentTreeValid: boolean;
   groupedIssues: ValidationIssueGroup[];
-  totalIssueCount: number;
+  globalValidationIssues: ComponentValidationIssue[];
   onIssueSelect: (issue: ComponentValidationIssue) => void;
 }
 
@@ -42,11 +44,17 @@ const issueButtonStyles = cn(
 );
 
 export const PipelineValidationList = ({
-  isComponentTreeValid,
+  globalValidationIssues,
   groupedIssues,
-  totalIssueCount,
   onIssueSelect,
 }: PipelineValidationListProps) => {
+  const totalIssueCount = globalValidationIssues.length;
+  const fixableIssueCount =
+    globalValidationIssues.filter(isFixableIssue).length;
+  const nonFixableIssueCount = totalIssueCount - fixableIssueCount;
+
+  const isValid = nonFixableIssueCount === 0;
+
   const [openGroups, setOpenGroups] = useState<Set<string>>(new Set());
 
   const toggleGroup = (pathKey: string) => {
@@ -61,7 +69,7 @@ export const PipelineValidationList = ({
     });
   };
 
-  if (isComponentTreeValid) {
+  if (isValid) {
     return (
       <InfoBox variant="success" title="No validation issues found">
         Pipeline is ready for submission
@@ -72,7 +80,7 @@ export const PipelineValidationList = ({
   return (
     <InfoBox
       variant="error"
-      title={`${totalIssueCount} ${pluralize(totalIssueCount, "issue")} detected`}
+      title={`${nonFixableIssueCount} ${pluralize(nonFixableIssueCount, "issue")} detected`}
     >
       <Paragraph size="sm" className="mb-4">
         Select an item to jump to its location in the pipeline.

--- a/src/components/Editor/IOEditor/InputValueEditor/InputValueEditor.tsx
+++ b/src/components/Editor/IOEditor/InputValueEditor/InputValueEditor.tsx
@@ -312,8 +312,9 @@ export const InputValueEditor = ({
       />
 
       {!initialInputValue && !inputOptional && !isInSubgraph && (
-        <InfoBox title="Missing value" variant="error">
-          Input is not optional. Value is required.
+        <InfoBox title="Missing value" variant="warning">
+          Input is not optional. Value is required to submit the run. You may
+          provide a value while submitting the run.
         </InfoBox>
       )}
 

--- a/src/components/Editor/hooks/useValidationIssueNavigation.ts
+++ b/src/components/Editor/hooks/useValidationIssueNavigation.ts
@@ -8,12 +8,16 @@ import {
   outputNameToNodeId,
   taskIdToNodeId,
 } from "@/utils/nodes/nodeIdUtils";
-import type { ComponentValidationIssue } from "@/utils/validations";
+import {
+  type ComponentValidationIssue,
+  isFixableIssue,
+} from "@/utils/validations";
 
 const ISSUE_TYPE_LABELS: Record<ComponentValidationIssue["type"], string> = {
   graph: "Graph",
   task: "Task",
   input: "Input",
+  argument: "Argument",
   output: "Output",
 };
 
@@ -126,8 +130,9 @@ export const useValidationIssueNavigation = (
     return () => cancelAnimationFrame(frameId);
   }, [currentSubgraphPath, focusIssue, pendingIssue]);
 
-  const issueItems: ValidationIssueListItem[] = validationIssues.map(
-    (issue) => {
+  const issueItems: ValidationIssueListItem[] = validationIssues
+    .filter((issue) => !isFixableIssue(issue))
+    .map((issue) => {
       const nodeLabel =
         issue.taskId ?? issue.inputName ?? issue.outputName ?? null;
       const fallbackName =
@@ -142,8 +147,7 @@ export const useValidationIssueNavigation = (
         typeLabel: ISSUE_TYPE_LABELS[issue.type],
         displayMessage: issue.message,
       };
-    },
-  );
+    });
 
   const groupedIssues = groupIssuesByPath(issueItems);
 

--- a/src/components/shared/ReactFlow/FlowSidebar/sections/RunsAndSubmission.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/sections/RunsAndSubmission.tsx
@@ -11,12 +11,18 @@ import {
 } from "@/components/ui/sidebar";
 import { cn } from "@/lib/utils";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
+import { isFixableIssue } from "@/utils/validations";
 
 import { RecentExecutionsButton } from "../components/RecentExecutionsButton";
 
 const RunsAndSubmission = ({ isOpen }: { isOpen: boolean }) => {
   const { isAuthorized } = useAwaitAuthorization();
-  const { componentSpec, isComponentTreeValid } = useComponentSpec();
+  const { componentSpec, isComponentTreeValid, globalValidationIssues } =
+    useComponentSpec();
+
+  const onlyFixableIssues =
+    globalValidationIssues.filter(isFixableIssue).length ===
+    globalValidationIssues.length;
 
   const showGoogleSubmitter =
     import.meta.env.VITE_ENABLE_GOOGLE_CLOUD_SUBMITTER === "true";
@@ -32,6 +38,7 @@ const RunsAndSubmission = ({ isOpen }: { isOpen: boolean }) => {
                 <OasisSubmitter
                   componentSpec={componentSpec}
                   isComponentTreeValid={isComponentTreeValid}
+                  onlyFixableIssues={onlyFixableIssues}
                 />
               ) : (
                 <HuggingFaceAuthButton title="Sign in to Submit Runs" />
@@ -66,6 +73,7 @@ const RunsAndSubmission = ({ isOpen }: { isOpen: boolean }) => {
               <OasisSubmitter
                 componentSpec={componentSpec}
                 isComponentTreeValid={isComponentTreeValid}
+                onlyFixableIssues={onlyFixableIssues}
               />
             ) : (
               <HuggingFaceAuthButton

--- a/src/components/shared/Submitters/Oasis/components/SubmitTaskArgumentsDialog.tsx
+++ b/src/components/shared/Submitters/Oasis/components/SubmitTaskArgumentsDialog.tsx
@@ -1,5 +1,10 @@
 import { useMutation } from "@tanstack/react-query";
-import { type ChangeEvent, type KeyboardEvent, useState } from "react";
+import {
+  type ChangeEvent,
+  type KeyboardEvent,
+  useEffect,
+  useState,
+} from "react";
 
 import type { TaskSpecOutput } from "@/api/types.gen";
 import { PipelineRunsList } from "@/components/shared/PipelineRunDisplay/PipelineRunsList";
@@ -35,6 +40,7 @@ import {
 import type { PipelineRun } from "@/types/pipelineRun";
 import type { ComponentSpec, InputSpec } from "@/utils/componentSpec";
 import { extractTaskArguments } from "@/utils/nodes/taskArguments";
+import { validateArguments } from "@/utils/validations";
 
 type TaskArguments = TaskSpecOutput["arguments"];
 
@@ -64,6 +70,10 @@ export const SubmitTaskArgumentsDialog = ({
 
   const inputs = componentSpec.inputs ?? [];
 
+  const [isValidToSubmit, setIsValidToSubmit] = useState(
+    validateArguments(inputs, taskArguments),
+  );
+
   const handleCopyFromRun = (args: Record<string, string>) => {
     const diff = Object.entries(args).filter(
       ([key, value]) => taskArguments[key] !== value,
@@ -86,6 +96,10 @@ export const SubmitTaskArgumentsDialog = ({
       [name]: value,
     }));
   };
+
+  useEffect(() => {
+    setIsValidToSubmit(validateArguments(inputs, taskArguments));
+  }, [inputs, taskArguments]);
 
   const handleConfirm = () => onConfirm(taskArguments);
 
@@ -150,7 +164,9 @@ export const SubmitTaskArgumentsDialog = ({
           <Button variant="outline" onClick={handleCancel}>
             Cancel
           </Button>
-          <Button onClick={handleConfirm}>Submit Run</Button>
+          <Button onClick={handleConfirm} disabled={!isValidToSubmit}>
+            Submit Run
+          </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/src/utils/validations.ts
+++ b/src/utils/validations.ts
@@ -14,7 +14,7 @@ interface ValidationOptions {
   skipInputValueValidation?: boolean;
 }
 
-type ValidationIssueType = "graph" | "task" | "input" | "output";
+type ValidationIssueType = "graph" | "task" | "input" | "argument" | "output";
 
 export interface ValidationError {
   type: ValidationIssueType;
@@ -22,6 +22,24 @@ export interface ValidationError {
   taskId?: string;
   inputName?: string;
   outputName?: string;
+}
+
+export function isFixableIssue(issue: ComponentValidationIssue): boolean {
+  return issue.type === "argument";
+}
+
+export function validateArguments(
+  inputs: InputSpec[],
+  taskArguments: Record<string, string>,
+): boolean {
+  const normalizedValues = inputs
+    .filter((input) => !input.optional)
+    .map((input) =>
+      String(
+        taskArguments[input.name] || input.value || input.default || "",
+      ).trim(),
+    );
+  return normalizedValues.every(Boolean);
 }
 
 export interface ComponentValidationIssue extends ValidationError {
@@ -141,7 +159,7 @@ const validateInputsAndOutputs = (
         !input.value
       ) {
         errors.push({
-          type: "input",
+          type: "argument",
           message: `Required input missing value`,
           inputName: input.name,
         });


### PR DESCRIPTION
## Description

Improved pipeline validation by distinguishing between fixable and non-fixable issues. Missing input values are now treated as fixable issues that can be resolved during run submission rather than blocking errors. The validation UI now shows a warning for missing inputs instead of an error, and the submit button remains enabled when only fixable issues exist, allowing users to provide values at submission time.

## Type of Change

- [x] Improvement

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

[Screen Recording 2026-02-02 at 2.59.34 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/3f03b879-f20d-42f8-961c-36629adc6b22.mov" />](https://app.graphite.com/user-attachments/video/3f03b879-f20d-42f8-961c-36629adc6b22.mov)

1. Create a pipeline with required inputs but no default values
2. Verify that missing inputs show as warnings rather than errors
3. Confirm you can still submit the pipeline and provide values at submission time
4. Verify that non-fixable validation issues still block submission

## Additional Comments

This change improves user experience by allowing pipeline submission even when required inputs are missing, as these can be provided during the submission process.