### PR TITLE
Redesign CreatedByFilter component and add hideFilters prop to RunSection

### DIFF
--- a/src/components/Home/RunSection/RunSection.tsx
+++ b/src/components/Home/RunSection/RunSection.tsx
@@ -38,7 +38,13 @@ const INCLUDE_EXECUTION_STATS_QUERY_KEY = "include_execution_stats";
 
 type RunSectionSearch = { page_token?: string; filter?: string };
 
-export const RunSection = ({ onEmptyList }: { onEmptyList?: () => void }) => {
+interface RunSectionProps {
+  onEmptyList?: () => void;
+  /** When true, hides the built-in filter UI (used when new filter bar is enabled) */
+  hideFilters?: boolean;
+}
+
+export const RunSection = ({ onEmptyList, hideFilters }: RunSectionProps) => {
   const { backendUrl, configured, available, ready } = useBackend();
   const navigate = useNavigate();
   const { pathname } = useLocation();
@@ -224,7 +230,7 @@ export const RunSection = ({ onEmptyList }: { onEmptyList?: () => void }) => {
     );
   }
 
-  const searchMarkup = (
+  const searchMarkup = hideFilters ? null : (
     <InlineStack gap="4">
       <InlineStack gap="2">
         <Switch

--- a/src/components/shared/PipelineRunFiltersBar/PipelineRunFiltersBar.tsx
+++ b/src/components/shared/PipelineRunFiltersBar/PipelineRunFiltersBar.tsx
@@ -225,12 +225,11 @@ export function PipelineRunFiltersBar({
           </div>
 
           {/* Created By Filter */}
-          <div className="shrink-0">
-            <CreatedByFilter
-              value={filters.created_by}
-              onChange={(value) => setFilter("created_by", value)}
-            />
-          </div>
+          <CreatedByFilter
+            value={filters.created_by}
+            onChange={(value) => setFilterDebounced("created_by", value)}
+            onClear={() => setFilter("created_by", undefined)}
+          />
 
           {/* Status Filter */}
           <Select

--- a/src/routes/Home/Home.tsx
+++ b/src/routes/Home/Home.tsx
@@ -46,7 +46,10 @@ const Home = () => {
               <PipelineRunFiltersBar />
             </BetaFeatureWrapper>
           )}
-          <RunSection onEmptyList={handlePipelineRunsEmpty} />
+          <RunSection
+            onEmptyList={handlePipelineRunsEmpty}
+            hideFilters={isFiltersBarEnabled}
+          />
         </TabsContent>
       </Tabs>
     </div>

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -13,8 +13,6 @@ export const PRIVACY_POLICY_URL =
 export const DOCUMENTATION_URL =
   import.meta.env.VITE_DOCUMENTATION_URL || "https://tangleml.com/docs/";
 
-export const DEFAULT_CREATED_BY_ME_FILTER_VALUE = "me";
-
 export const API_URL = import.meta.env.VITE_BACKEND_API_URL || "";
 export const BASE_URL = import.meta.env.VITE_BASE_URL || "/";
 export const IS_GITHUB_PAGES = import.meta.env.VITE_GITHUB_PAGES === "true";


### PR DESCRIPTION
## Description

Redesigned the `CreatedByFilter` component to be a simpler, more focused text input with improved UX. The new implementation removes the toggle switch in favour of a cleaner search input with an icon and clear button. This change supports the new filter bar UI by allowing the `RunSection` component to hide its built-in filters when the new filter bar is enabled.

## Type of Change

- [x] Improvement
- [x] Cleanup/Refactor

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Test Instructions

1. Navigate to the home page to see the updated user filter in the new filter bar
2. Test typing in the user filter and verify it updates results
3. Test clearing the filter using the X button
4. Verify that the old filters are hidden when the new filter bar is enabled