### PR TITLE
feat: Add Color Picker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "pyodide": "^0.29.3",
         "random-words": "^2.0.1",
         "react": "^19.2.4",
+        "react-colorful": "^5.6.1",
         "react-day-picker": "^9.13.2",
         "react-dom": "^19.2.4",
         "react-error-boundary": "^6.1.1",
@@ -9867,6 +9868,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-colorful": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.6.1.tgz",
+      "integrity": "sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/react-day-picker": {

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "pyodide": "^0.29.3",
     "random-words": "^2.0.1",
     "react": "^19.2.4",
+    "react-colorful": "^5.6.1",
     "react-day-picker": "^9.13.2",
     "react-dom": "^19.2.4",
     "react-error-boundary": "^6.1.1",

--- a/src/components/shared/ReactFlow/FlowCanvas/FlexNode/FlexNodeEditor.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlexNode/FlexNodeEditor.tsx
@@ -3,6 +3,7 @@ import { type ChangeEvent, useEffect, useState } from "react";
 import { ContentBlock } from "@/components/shared/ContextPanel/Blocks/ContentBlock";
 import { KeyValueList } from "@/components/shared/ContextPanel/Blocks/KeyValueList";
 import { CopyText } from "@/components/shared/CopyText/CopyText";
+import { ColorPicker } from "@/components/ui/color";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
@@ -199,7 +200,46 @@ const ColorEditor = ({
   flexNode: FlexNodeData;
   readOnly: boolean;
 }) => {
+  const {
+    componentSpec,
+    currentSubgraphSpec,
+    currentSubgraphPath,
+    setComponentSpec,
+  } = useComponentSpec();
+
   const { properties } = flexNode;
+
+  const [backgroundColor, setBackgroundColor] = useState(properties.color);
+
+  const handleBackgroundColorChange = (newColor: string) => {
+    setBackgroundColor(newColor);
+    saveColors(newColor);
+  };
+
+  const saveColors = (newBackgroundColor: string) => {
+    const updatedSubgraphSpec = updateFlexNodeInComponentSpec(
+      currentSubgraphSpec,
+      {
+        ...flexNode,
+        properties: {
+          ...properties,
+          color: newBackgroundColor,
+        },
+      },
+    );
+
+    const newRootSpec = updateSubgraphSpec(
+      componentSpec,
+      currentSubgraphPath,
+      updatedSubgraphSpec,
+    );
+
+    setComponentSpec(newRootSpec);
+  };
+
+  useEffect(() => {
+    setBackgroundColor(properties.color);
+  }, [properties]);
 
   if (readOnly) {
     return (
@@ -221,9 +261,10 @@ const ColorEditor = ({
       <BlockStack gap="1">
         <InlineStack gap="4" blockAlign="center">
           <Paragraph size="xs">Background</Paragraph>
-          <div
-            className="aspect-square h-4 rounded-full border border-muted-foreground"
-            style={{ backgroundColor: properties.color }}
+          <ColorPicker
+            title="Background Color"
+            color={backgroundColor}
+            setColor={handleBackgroundColorChange}
           />
           <CopyText className="text-xs font-mono">{properties.color}</CopyText>
         </InlineStack>

--- a/src/components/ui/color.tsx
+++ b/src/components/ui/color.tsx
@@ -1,0 +1,137 @@
+import { useState } from "react";
+import { HexColorPicker } from "react-colorful";
+
+import { useDebouncedState } from "@/hooks/useDebouncedState";
+import { cn } from "@/lib/utils";
+
+import { Button } from "./button";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "./collapsible";
+import { Icon } from "./icon";
+import { Input } from "./input";
+import { BlockStack, InlineStack } from "./layout";
+import { Popover, PopoverContent, PopoverTrigger } from "./popover";
+import { Heading } from "./typography";
+
+const PRESET_COLORS = [
+  "#FFF9C4",
+  "#C8E6C9",
+  "#BBDEFB",
+  "#D1C4E9",
+  "#FFE0B2",
+  "#EF9A9A",
+  "#FFCCBC",
+  "#D7CCC8",
+  "#F5F5F5",
+  "#CFD8DC",
+  "#B0BEC5",
+  "transparent",
+];
+
+interface ColorPickerProps {
+  title?: string;
+  color: string;
+  debounceMs?: number;
+  setColor: (color: string) => void;
+  onClose?: () => void;
+}
+
+export const ColorPicker = ({
+  color,
+  title,
+  debounceMs = 300,
+  setColor,
+  onClose,
+}: ColorPickerProps) => {
+  const [open, setOpen] = useState(false);
+  const [localColor, setLocalColor] = useState(color);
+
+  const { clearDebounce, updatePreviousState } = useDebouncedState(
+    localColor,
+    setColor,
+    () => false,
+    { debounceMs },
+  );
+
+  const handleOpenChange = (isOpen: boolean) => {
+    setOpen(isOpen);
+    if (!isOpen) {
+      onClose?.();
+    }
+  };
+
+  const handlePresetClick = (preset: string) => {
+    clearDebounce();
+    setLocalColor(preset);
+    setColor(preset);
+    updatePreviousState(preset);
+  };
+
+  return (
+    <Popover open={open} onOpenChange={handleOpenChange}>
+      <PopoverTrigger>
+        <div
+          className="aspect-square h-4 rounded-full border border-muted-foreground cursor-pointer"
+          style={{ backgroundColor: color }}
+        />
+      </PopoverTrigger>
+      <PopoverContent className="w-fit">
+        <BlockStack gap="4" align="center">
+          <Heading level={3}>{title ?? "Pick a color"}</Heading>
+          <InlineStack gap="2" className="grid grid-cols-6 px-2">
+            {PRESET_COLORS.map((preset) => (
+              <div
+                key={preset}
+                className={cn(
+                  "aspect-square w-6 rounded-sm border border-muted-foreground cursor-pointer relative overflow-hidden",
+                  {
+                    "ring-2 ring-offset-2 ring-black": preset === color,
+                  },
+                )}
+                style={{ backgroundColor: preset }}
+                onClick={() => handlePresetClick(preset)}
+              >
+                {preset === "transparent" && (
+                  <div className="absolute inset-0 flex items-center justify-center">
+                    <div className="h-px w-full bg-red-500 rotate-45 origin-center" />
+                  </div>
+                )}
+              </div>
+            ))}
+          </InlineStack>
+          <div className="relative w-full">
+            <Input
+              value={localColor}
+              onChange={(e) => setLocalColor(e.target.value)}
+            />
+            <Collapsible>
+              <InlineStack blockAlign="center" gap="1">
+                <CollapsibleTrigger asChild>
+                  <Button
+                    size="icon"
+                    variant="ghost"
+                    className="absolute right-2 top-0 hover:bg-transparent hover:text-black!"
+                    style={{
+                      color:
+                        localColor === "transparent" ? "lightgray" : localColor,
+                      filter: "brightness(0.8)",
+                    }}
+                  >
+                    <Icon name="Palette" />
+                    <span className="sr-only">Toggle</span>
+                  </Button>
+                </CollapsibleTrigger>
+              </InlineStack>
+              <CollapsibleContent className="mt-2">
+                <HexColorPicker color={localColor} onChange={setLocalColor} />
+              </CollapsibleContent>
+            </Collapsible>
+          </div>
+        </BlockStack>
+      </PopoverContent>
+    </Popover>
+  );
+};


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

Uses `react-colorful` to add a (debounced) colorpicker for sticky notes. This applies to sticky note background color only.

https://www.npmjs.com/package/react-colorful


If the sticky note has no background color and no text content it will have an orange dashed border around it so it doesn't get permanently lost.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

Progresses https://github.com/Shopify/oasis-frontend/issues/118

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] New feature

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

![image.png](https://app.graphite.com/user-attachments/assets/8f594cd6-b7c9-45ec-a099-a412bce33cbf.png)

![image.png](https://app.graphite.com/user-attachments/assets/56d3719a-f7cb-43bd-94b3-fe991f3fdf82.png)

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

Confirm:
- The color circle in the flex node context panel is clickable
- When clicked the color circle opens a popover with color selection options
- A preset color can be selected
- A color can be typed
- A custom color can be picked from the color picker, activated by the pallete icon in the right of the input box
- When a color is selected the sticky note updates on-canvas
- Transparent color can be selected
- If a sticky note has transparent background and no text content it shows an orange border

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
Don't forget to `npm i` before testing.
