### PR TITLE
feat: display warnings and errors separately in Pipeline validations

### DIFF
--- a/src/components/Editor/Context/PipelineValidationList.tsx
+++ b/src/components/Editor/Context/PipelineValidationList.tsx
@@ -31,15 +31,40 @@ interface PipelineValidationListProps {
   onIssueSelect: (issue: ComponentValidationIssue) => void;
 }
 
-const groupTriggerStyles = cn(
+const levelToTone = (
+  level: ValidationIssueGroup["issues"][number]["level"],
+): "critical" | "warning" => {
+  if (level === "error") {
+    return "critical";
+  }
+  return "warning";
+};
+
+const isGroupWarningOnly = (group: ValidationIssueGroup): boolean => {
+  return group.issues.every((issue) => issue.level === "warning");
+};
+
+const groupTriggerWarningStyles = cn(
+  "w-full justify-start gap-2 rounded-lg font-medium",
+  "bg-warning/10 text-warning-foreground hover:bg-warning/15",
+);
+
+const groupTriggerErrorStyles = cn(
   "w-full justify-start gap-2 rounded-lg font-medium",
   "bg-destructive/10 text-destructive-foreground hover:bg-destructive/15",
 );
 
-const issueButtonStyles = cn(
+const warningButtonStyles = cn(
   "h-auto w-full flex-col items-start justify-start gap-1 rounded-lg",
-  "whitespace-normal border-destructive/20 bg-white/80 px-3 py-2 text-left",
-  "hover:border-destructive/40 hover:bg-destructive/5",
+  "whitespace-normal border-warning/20 bg-warning/5 px-3 py-2 text-left",
+  "hover:border-warning/80 hover:bg-warning/15",
+  "focus-visible:ring-warning/40",
+);
+
+const errorButtonStyles = cn(
+  "h-auto w-full flex-col items-start justify-start gap-1 rounded-lg",
+  "whitespace-normal border-destructive/20 bg-destructive/5 px-3 py-2 text-left",
+  "hover:border-destructive/40 hover:bg-destructive/10",
   "focus-visible:ring-destructive/40",
 );
 
@@ -53,7 +78,7 @@ export const PipelineValidationList = ({
     globalValidationIssues.filter(isFixableIssue).length;
   const nonFixableIssueCount = totalIssueCount - fixableIssueCount;
 
-  const isValid = nonFixableIssueCount === 0;
+  const isValid = totalIssueCount === 0;
 
   const [openGroups, setOpenGroups] = useState<Set<string>>(new Set());
 
@@ -77,10 +102,22 @@ export const PipelineValidationList = ({
     );
   }
 
+  const errorTitle =
+    nonFixableIssueCount > 0
+      ? `${nonFixableIssueCount} ${pluralize(nonFixableIssueCount, "error")}`
+      : "";
+  const warningTitle =
+    fixableIssueCount > 0
+      ? `${fixableIssueCount} ${pluralize(fixableIssueCount, "warning")}`
+      : "";
+  const totalIssuesTitle = [errorTitle, warningTitle]
+    .filter(Boolean)
+    .join(" and ");
+
   return (
     <InfoBox
-      variant="error"
-      title={`${nonFixableIssueCount} ${pluralize(nonFixableIssueCount, "issue")} detected`}
+      variant={nonFixableIssueCount > 0 ? "error" : "warning"}
+      title={`${totalIssuesTitle} detected`}
     >
       <Paragraph size="sm" className="mb-4">
         Select an item to jump to its location in the pipeline.
@@ -89,6 +126,7 @@ export const PipelineValidationList = ({
       <BlockStack gap="2">
         {groupedIssues.map((group) => {
           const isOpen = openGroups.has(group.pathKey);
+          const isWarningOnly = isGroupWarningOnly(group);
 
           return (
             <Collapsible
@@ -100,7 +138,14 @@ export const PipelineValidationList = ({
               <Tooltip>
                 <TooltipTrigger asChild className="w-full">
                   <CollapsibleTrigger asChild>
-                    <Button variant="ghost" className={groupTriggerStyles}>
+                    <Button
+                      variant="ghost"
+                      className={
+                        isWarningOnly
+                          ? groupTriggerWarningStyles
+                          : groupTriggerErrorStyles
+                      }
+                    >
                       <Icon
                         name="ChevronRight"
                         size="sm"
@@ -116,7 +161,8 @@ export const PipelineValidationList = ({
                       </Text>
                       <Badge
                         size="sm"
-                        className="rounded-full bg-destructive/20 text-destructive"
+                        shape="rounded"
+                        variant={isWarningOnly ? "outline" : "destructive"}
                       >
                         {group.issues.length}
                       </Badge>
@@ -131,26 +177,43 @@ export const PipelineValidationList = ({
               <CollapsibleContent>
                 <BlockStack gap="1" className="mt-1 pl-2">
                   {group.issues.map(
-                    ({ issue, displayName, typeLabel, displayMessage }) => (
+                    ({
+                      issue,
+                      displayName,
+                      typeLabel,
+                      displayMessage,
+                      level,
+                    }) => (
                       <Button
                         key={issue.id}
                         variant="outline"
                         onClick={() => onIssueSelect(issue)}
-                        className={issueButtonStyles}
+                        className={
+                          level === "error"
+                            ? errorButtonStyles
+                            : warningButtonStyles
+                        }
                       >
                         <InlineStack gap="1" wrap="nowrap">
                           <Text
                             size="xs"
                             weight="semibold"
-                            tone="critical"
+                            tone={levelToTone(level)}
                             className="shrink-0 uppercase tracking-wide"
                           >
                             {typeLabel}
                           </Text>
-                          <Text tone="critical" className="shrink-0 opacity-40">
+                          <Text
+                            tone={levelToTone(level)}
+                            className="shrink-0 opacity-40"
+                          >
                             •
                           </Text>
-                          <Text size="xs" tone="subdued" className="truncate">
+                          <Text
+                            size="xs"
+                            tone={levelToTone(level)}
+                            className="truncate"
+                          >
                             {displayName}
                           </Text>
                         </InlineStack>

--- a/src/components/Editor/hooks/useValidationIssueNavigation.ts
+++ b/src/components/Editor/hooks/useValidationIssueNavigation.ts
@@ -21,6 +21,15 @@ const ISSUE_TYPE_LABELS: Record<ComponentValidationIssue["type"], string> = {
   output: "Output",
 };
 
+type IssueLevel = "error" | "warning";
+
+const getIssueLevel = (issue: ComponentValidationIssue): IssueLevel => {
+  if (isFixableIssue(issue)) {
+    return "warning";
+  }
+  return "error";
+};
+
 const getIssueNodeId = (issue: ComponentValidationIssue): string | null => {
   if (issue.taskId) return taskIdToNodeId(issue.taskId);
   if (issue.inputName) return inputNameToNodeId(issue.inputName);
@@ -33,6 +42,7 @@ interface ValidationIssueListItem {
   displayName: string;
   displayMessage: string;
   typeLabel: string;
+  level: IssueLevel;
 }
 
 export interface ValidationIssueGroup {
@@ -130,9 +140,8 @@ export const useValidationIssueNavigation = (
     return () => cancelAnimationFrame(frameId);
   }, [currentSubgraphPath, focusIssue, pendingIssue]);
 
-  const issueItems: ValidationIssueListItem[] = validationIssues
-    .filter((issue) => !isFixableIssue(issue))
-    .map((issue) => {
+  const issueItems: ValidationIssueListItem[] = validationIssues.map(
+    (issue) => {
       const nodeLabel =
         issue.taskId ?? issue.inputName ?? issue.outputName ?? null;
       const fallbackName =
@@ -144,10 +153,12 @@ export const useValidationIssueNavigation = (
       return {
         issue,
         displayName,
+        level: getIssueLevel(issue),
         typeLabel: ISSUE_TYPE_LABELS[issue.type],
         displayMessage: issue.message,
       };
-    });
+    },
+  );
 
   const groupedIssues = groupIssuesByPath(issueItems);
 

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -5,7 +5,7 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 
 const badgeVariants = cva(
-  "inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",
+  "inline-flex items-center justify-center border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",
   {
     variants: {
       size: {
@@ -18,6 +18,10 @@ const badgeVariants = cva(
         block: "block",
         topright: "absolute -top-1 -right-1",
         topleft: "absolute -top-2 -left-2",
+      },
+      shape: {
+        rectangle: "rounded-md",
+        rounded: "rounded-full",
       },
       variant: {
         default: "border-transparent bg-primary text-primary-foreground",
@@ -32,6 +36,7 @@ const badgeVariants = cva(
       },
     },
     defaultVariants: {
+      shape: "rectangle",
       variant: "default",
       position: "inline",
       size: "md",
@@ -43,6 +48,7 @@ function Badge({
   className,
   variant,
   position,
+  shape,
   size,
   asChild = false,
   ...props
@@ -53,7 +59,10 @@ function Badge({
   return (
     <Comp
       data-slot="badge"
-      className={cn(badgeVariants({ variant, position, size }), className)}
+      className={cn(
+        badgeVariants({ variant, position, size, shape }),
+        className,
+      )}
       {...props}
     />
   );


### PR DESCRIPTION
## Description

Enhanced the validation UI to distinguish between errors and warnings. Errors are now displayed with red styling, while warnings use amber/yellow styling. The validation list now shows a more accurate count of "errors and warnings" instead of just "issues", and groups can be visually identified as containing only warnings or a mix of errors and warnings.

## Type of Change

- [x] Improvement
- [x] New feature

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging


## Test Instructions


[Screen Recording 2026-02-03 at 12.09.16 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/40788711-ef5c-480a-b580-3e90ab78e3fe.mov" />](https://app.graphite.com/user-attachments/video/40788711-ef5c-480a-b580-3e90ab78e3fe.mov)

1. Create a pipeline with both errors (e.g., missing required connections) and warnings (fixable issues)
2. Verify that errors display with red styling and warnings with amber/yellow styling
3. Check that the validation summary correctly counts and labels errors vs warnings
4. Confirm that groups containing only warnings have amber styling, while groups with errors have red styling