### PR TITLE
feat: Delete Flex Nodes

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/FlexNode/interface.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlexNode/interface.ts
@@ -92,3 +92,24 @@ export const updateFlexNodeInComponentSpec = (
 
   return newComponentSpec;
 };
+
+export const removeFlexNodeFromComponentSpec = (
+  componentSpec: ComponentSpec,
+  flexNodeId: string,
+): ComponentSpec => {
+  const clonedComponentSpec = deepClone(componentSpec);
+  const newComponentSpec = ensureAnnotations(clonedComponentSpec);
+
+  const flexNodesAnnotations = getFlexNodeAnnotations(newComponentSpec);
+
+  const updatedFlexNodes = flexNodesAnnotations.filter(
+    (node) => node.id !== flexNodeId,
+  );
+
+  newComponentSpec.metadata.annotations = {
+    ...newComponentSpec.metadata.annotations,
+    [FLEX_NODES_ANNOTATION]: serializeFlexNodes(updatedFlexNodes),
+  };
+
+  return newComponentSpec;
+};

--- a/src/components/shared/ReactFlow/FlowCanvas/types.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/types.ts
@@ -5,6 +5,7 @@ import type { TaskType } from "@/types/taskNode";
 
 import SmoothEdge from "./Edges/SmoothEdge";
 import FlexNode from "./FlexNode/FlexNode";
+import type { FlexNodeData } from "./FlexNode/types";
 import GhostNode from "./GhostNode/GhostNode";
 import IONode from "./IONode/IONode";
 import TaskNode from "./TaskNode/TaskNode";
@@ -34,4 +35,8 @@ export function isDefinedNode(node: Node): node is Node & { type: NodeType } {
 
 export function isTaskNodeType(type: string): type is TaskType {
   return type === "task" || type === "input" || type === "output";
+}
+
+export function isFlexNode(node: Node): node is Node<FlexNodeData> {
+  return node.type === "flex";
 }

--- a/src/components/shared/ReactFlow/FlowCanvas/utils/removeNode.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/utils/removeNode.ts
@@ -1,5 +1,6 @@
 import { type Node } from "@xyflow/react";
 
+import { FLEX_NODES_ANNOTATION } from "@/utils/annotations";
 import {
   type ComponentSpec,
   isGraphImplementation,
@@ -12,6 +13,7 @@ import {
   nodeIdToTaskId,
 } from "@/utils/nodes/nodeIdUtils";
 
+import { removeFlexNodeFromComponentSpec } from "../FlexNode/interface";
 import { setGraphOutputValue } from "./setGraphOutputValue";
 import { setTaskArgument } from "./setTaskArgument";
 
@@ -29,6 +31,10 @@ export const removeNode = (node: Node, componentSpec: ComponentSpec) => {
   if (node.type === "output") {
     const outputName = nodeIdToOutputName(node.id);
     return removeGraphOutput(outputName, componentSpec);
+  }
+
+  if (node.type === "flex") {
+    return removeFlexNode(node.id, componentSpec);
   }
 
   return componentSpec;
@@ -143,6 +149,19 @@ export const removeTask = (
         },
       }),
     };
+  }
+
+  return componentSpec;
+};
+
+const removeFlexNode = (
+  nodeIdToRemove: string,
+  componentSpec: ComponentSpec,
+) => {
+  const annotations = componentSpec.metadata?.annotations;
+
+  if (annotations && annotations[FLEX_NODES_ANNOTATION]) {
+    return removeFlexNodeFromComponentSpec(componentSpec, nodeIdToRemove);
   }
 
   return componentSpec;

--- a/src/utils/string.test.ts
+++ b/src/utils/string.test.ts
@@ -7,6 +7,7 @@ import {
   formatJsonValue,
   getValue,
   removeTrailingDateFromTitle,
+  truncate,
 } from "./string";
 
 describe("formatBytes", () => {
@@ -173,5 +174,69 @@ describe("createStringList", () => {
     expect(createStringList(fruits, 10, label)).toBe(
       '"apple", "banana", "cherry", "mango" & "strawberry"',
     );
+  });
+});
+
+describe("truncate", () => {
+  it("returns original string if shorter than maxLength", () => {
+    expect(truncate("hello", 10)).toBe("hello");
+  });
+
+  it("returns original string if equal to maxLength", () => {
+    expect(truncate("hello", 5)).toBe("hello");
+  });
+
+  it("truncates string with ellipsis when longer than maxLength", () => {
+    expect(truncate("hello world", 8)).toBe("hello wo...");
+  });
+
+  it("breaks words by default", () => {
+    expect(truncate("hello world", 8, { breakWords: true })).toBe(
+      "hello wo...",
+    );
+  });
+
+  it("does not break words when breakWords is false", () => {
+    expect(truncate("hello world", 8, { breakWords: false })).toBe("hello...");
+  });
+
+  it("breaks at last space when breakWords is false", () => {
+    expect(truncate("the quick brown fox", 12, { breakWords: false })).toBe(
+      "the quick...",
+    );
+  });
+
+  it("breaks at last newline when breakWords is false", () => {
+    expect(truncate("hello\nworld\ntest", 12, { breakWords: false })).toBe(
+      "hello\nworld...",
+    );
+  });
+
+  it("prefers newline over space when both present", () => {
+    expect(truncate("hello world\ntest", 14, { breakWords: false })).toBe(
+      "hello world...",
+    );
+  });
+
+  it("breaks words if no space or newline found when breakWords is false", () => {
+    expect(truncate("helloworld", 5, { breakWords: false })).toBe("hello...");
+  });
+
+  it("trims whitespace before adding ellipsis", () => {
+    expect(truncate("hello   ", 5)).toBe("hello...");
+    expect(truncate("hello world   ", 10)).toBe("hello worl...");
+  });
+
+  it("handles empty string", () => {
+    expect(truncate("", 5)).toBe("");
+  });
+
+  it("handles single character", () => {
+    expect(truncate("a", 0)).toBe("...");
+  });
+
+  it("handles multiline text with breakWords false", () => {
+    const text = "Line one\nLine two\nLine three";
+    expect(truncate(text, 15, { breakWords: false })).toBe("Line one\nLine...");
   });
 });

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -115,6 +115,29 @@ export function getStringFromData(data: string | ArrayBuffer): string {
   return data;
 }
 
+export const truncate = (
+  str: string,
+  maxLength: number,
+  options: { breakWords?: boolean } = { breakWords: true },
+): string => {
+  if (str.length <= maxLength) {
+    return str;
+  }
+
+  if (!options.breakWords) {
+    const truncated = str.slice(0, maxLength);
+    const lastSpaceIndex = truncated.lastIndexOf(" ");
+    const lastNewlineIndex = truncated.lastIndexOf("\n");
+    const lastBreakIndex = Math.max(lastSpaceIndex, lastNewlineIndex);
+
+    if (lastBreakIndex > 0) {
+      return truncated.slice(0, lastBreakIndex).trim() + "...";
+    }
+  }
+
+  return `${str.slice(0, maxLength).trim()}...`;
+};
+
 export {
   copyToClipboard,
   createStringList,


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

Can now delete a sticky note from the canvas using the DELETE key.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

Progresses https://github.com/Shopify/oasis-frontend/issues/118

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] New feature

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

![image.png](https://app.graphite.com/user-attachments/assets/559fea6c-2c40-4a49-8c20-e5b16b7e56de.png)

![image.png](https://app.graphite.com/user-attachments/assets/b7ec61fb-742d-4d02-93e2-b65e84421c5f.png)

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

- Can delete sticky notes via the DELETE key
- Can delete multiple sticky notes at once

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
