### PR TITLE
chore: Hide Flex Node annotation from Context Panel

### DIFF
--- a/src/components/Editor/Context/PipelineDetails.tsx
+++ b/src/components/Editor/Context/PipelineDetails.tsx
@@ -13,7 +13,10 @@ import { useFlagValue } from "@/components/shared/Settings/useFlags";
 import { BlockStack } from "@/components/ui/layout";
 import useToastNotification from "@/hooks/useToastNotification";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
-import { PIPELINE_NOTES_ANNOTATION } from "@/utils/annotations";
+import {
+  FLEX_NODES_ANNOTATION,
+  PIPELINE_NOTES_ANNOTATION,
+} from "@/utils/annotations";
 import { getComponentFileFromList } from "@/utils/componentStore";
 import { USER_PIPELINES_LIST_NAME } from "@/utils/constants";
 
@@ -22,7 +25,7 @@ import { PipelineNotesEditor } from "./PipelineNotesEditor";
 import { PipelineValidationList } from "./PipelineValidationList";
 import RenamePipeline from "./RenamePipeline";
 
-const EXCLUDED_ANNOTATIONS = [PIPELINE_NOTES_ANNOTATION];
+const EXCLUDED_ANNOTATIONS = [PIPELINE_NOTES_ANNOTATION, FLEX_NODES_ANNOTATION];
 
 const PipelineDetails = () => {
   const notify = useToastNotification();

--- a/src/components/PipelineRun/RunDetails.tsx
+++ b/src/components/PipelineRun/RunDetails.tsx
@@ -13,6 +13,7 @@ import { useBackend } from "@/providers/BackendProvider";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 import { useExecutionData } from "@/providers/ExecutionDataProvider";
 import {
+  FLEX_NODES_ANNOTATION,
   getAnnotationValue,
   PIPELINE_NOTES_ANNOTATION,
 } from "@/utils/annotations";
@@ -24,7 +25,7 @@ import {
 
 import { RunNotesEditor } from "./RunNotesEditor";
 
-const EXCLUDED_ANNOTATIONS = [PIPELINE_NOTES_ANNOTATION];
+const EXCLUDED_ANNOTATIONS = [PIPELINE_NOTES_ANNOTATION, FLEX_NODES_ANNOTATION];
 
 export const RunDetails = () => {
   const { configured } = useBackend();


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
The pipeline & run context panels will no longer render the `flex-nodes` annotation text.

I made this a separate PR in the off-chance we actually want them to keep them there.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

Progresses https://github.com/Shopify/oasis-frontend/issues/118

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

Before

![image.png](https://app.graphite.com/user-attachments/assets/0047913b-4657-4b7d-bbf8-14d9c14bbbb3.png)

After

![image.png](https://app.graphite.com/user-attachments/assets/6a657e1d-3d3b-424d-a4ba-54e378355d52.png)

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
