### PR TITLE
feat: show component details on list item hover

### DIFF
--- a/react-compiler.config.js
+++ b/react-compiler.config.js
@@ -47,6 +47,7 @@ export const REACT_COMPILER_ENABLED_DIRS = [
   "src/components/shared/ManageComponent/hooks/useForceUpdateTasks.ts",
   "src/components/shared/TaskDetails/DisplayNameEditor.tsx",
   "src/components/shared/TaskDetails/Actions/UnpackSubgraphButton.tsx",
+  "src/components/shared/ReactFlow/FlowSidebar/components/ComponentHoverPopover.tsx",
 
   // 11-20 useCallback/useMemo
   // "src/components/ui",                         // 12

--- a/src/components/shared/ContextPanel/Blocks/TextBlock.tsx
+++ b/src/components/shared/ContextPanel/Blocks/TextBlock.tsx
@@ -16,6 +16,7 @@ interface TextBlockProps {
   text?: string;
   copyable?: boolean;
   collapsible?: boolean;
+  defaultCollapsed?: boolean;
   mono?: boolean;
   wrap?: boolean;
   className?: string;
@@ -26,6 +27,7 @@ export const TextBlock = ({
   text,
   copyable,
   collapsible,
+  defaultCollapsed = true,
   mono,
   wrap = false,
   className,
@@ -55,7 +57,7 @@ export const TextBlock = ({
 
   return (
     <BlockStack className={className}>
-      <Collapsible className="w-full">
+      <Collapsible className="w-full" defaultOpen={!defaultCollapsed}>
         <InlineStack blockAlign="center" gap="1">
           {title && <Heading level={3}>{title}</Heading>}
           {collapsible && (

--- a/src/components/shared/Dialogs/ComponentDetailsDialog.tsx
+++ b/src/components/shared/Dialogs/ComponentDetailsDialog.tsx
@@ -33,6 +33,7 @@ interface ComponentDetailsProps {
   readOnly?: boolean;
   trigger?: ReactNode;
   onClose?: () => void;
+  onOpenChange?: (open: boolean) => void;
 }
 
 const ComponentDetailsDialogContentSkeleton = () => {
@@ -171,6 +172,7 @@ const ComponentDetails = ({
   trigger,
   readOnly,
   onClose,
+  onOpenChange: onOpenChangeProp,
 }: ComponentDetailsProps) => {
   const [open, setOpen] = useState(false);
   const dialogTriggerButton = trigger || <InfoIconButton />;
@@ -185,12 +187,16 @@ const ComponentDetails = ({
     [],
   );
 
-  const onOpenChange = useCallback((open: boolean) => {
-    setOpen(open);
-    if (!open) {
-      onClose?.();
-    }
-  }, []);
+  const onOpenChange = useCallback(
+    (open: boolean) => {
+      setOpen(open);
+      onOpenChangeProp?.(open);
+      if (!open) {
+        onClose?.();
+      }
+    },
+    [onOpenChangeProp, onClose],
+  );
 
   return (
     <Dialog modal={false} open={open} onOpenChange={onOpenChange}>

--- a/src/components/shared/ReactFlow/FlowSidebar/components/ComponentHoverPopover.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/components/ComponentHoverPopover.tsx
@@ -1,0 +1,85 @@
+import {
+  forwardRef,
+  type ReactNode,
+  useImperativeHandle,
+  useState,
+} from "react";
+
+import { TaskDetails } from "@/components/shared/TaskDetails";
+import { BlockStack } from "@/components/ui/layout";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Heading } from "@/components/ui/typography";
+import type { ComponentReference } from "@/utils/componentSpec";
+import { debounce } from "@/utils/debounce";
+
+interface ComponentHoverPopoverProps {
+  component: ComponentReference;
+  children: ReactNode;
+}
+
+export interface ComponentHoverPopoverHandle {
+  close: () => void;
+}
+
+const HOVER_DELAY_MS = 100;
+
+export const ComponentHoverPopover = forwardRef<
+  ComponentHoverPopoverHandle,
+  ComponentHoverPopoverProps
+>(({ component, children }, ref) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const delaySetIsOpen = debounce(
+    (value: boolean) => setIsOpen(value),
+    HOVER_DELAY_MS,
+  );
+
+  useImperativeHandle(ref, () => ({ close: () => setIsOpen(false) }), []);
+
+  const handleMouseEnter = () => delaySetIsOpen(true);
+  const handleMouseLeave = () => delaySetIsOpen(false);
+
+  const handleOpenChange = (open: boolean) => {
+    /**
+     * Only react to close requests - opening is controlled by hover handlers only.
+     * This prevents the popover from opening when a dialog is closed.
+     */
+    if (!open) {
+      setIsOpen(false);
+    }
+  };
+
+  return (
+    <Popover open={isOpen} onOpenChange={handleOpenChange}>
+      <PopoverTrigger
+        asChild
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+      >
+        {children}
+      </PopoverTrigger>
+      <PopoverContent
+        side="right"
+        align="start"
+        sideOffset={16}
+        className="w-80 max-h-96 overflow-auto p-0"
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+      >
+        <BlockStack gap="2" className="px-3 py-2">
+          <Heading level={2}>{component.name}</Heading>
+        </BlockStack>
+        <TaskDetails
+          componentRef={component}
+          readOnly
+          options={{ descriptionExpanded: true }}
+        />
+      </PopoverContent>
+    </Popover>
+  );
+});
+
+ComponentHoverPopover.displayName = "ComponentHoverPopover";

--- a/src/components/shared/ReactFlow/FlowSidebar/components/ComponentItem.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/components/ComponentItem.tsx
@@ -17,6 +17,10 @@ import { getComponentName } from "@/utils/getComponentName";
 import { isSubgraph } from "@/utils/subgraphUtils";
 
 import { useNodesOverlay } from "../../NodesOverlay/NodesOverlayProvider";
+import {
+  ComponentHoverPopover,
+  type ComponentHoverPopoverHandle,
+} from "./ComponentHoverPopover";
 
 interface ComponentMarkupProps {
   component: ComponentReference;
@@ -78,6 +82,8 @@ const ComponentMarkup = ({
   const isRemoteComponentLibrarySearchEnabled = useFlagValue(
     "remote-component-library-search",
   );
+
+  const popoverRef = useRef<ComponentHoverPopoverHandle>(null);
 
   // TODO: respect selected node as a starting point
   const carousel = useRef(0);
@@ -160,6 +166,12 @@ const ComponentMarkup = ({
     isHighlightTasksOnComponentHoverEnabled,
   ]);
 
+  const onComponentDetailsDialogOpenChange = useCallback((open: boolean) => {
+    if (open) {
+      popoverRef.current?.close();
+    }
+  }, []);
+
   const iconName = isSubgraphSpec ? "Workflow" : owned ? "FileBadge" : "File";
 
   const iconClass = cn(
@@ -225,12 +237,19 @@ const ComponentMarkup = ({
                 </span>
               </div>
             </InlineStack>
+
             <InlineStack align="end" wrap="nowrap">
               <ComponentFavoriteToggle component={component} />
-              <ComponentDetailsDialog
-                displayName={displayName}
-                component={component}
-              />
+
+              <ComponentHoverPopover ref={popoverRef} component={component}>
+                <InlineStack>
+                  <ComponentDetailsDialog
+                    displayName={displayName}
+                    component={component}
+                    onOpenChange={onComponentDetailsDialogOpenChange}
+                  />
+                </InlineStack>
+              </ComponentHoverPopover>
             </InlineStack>
           </InlineStack>
         )}

--- a/src/components/shared/ReactFlow/FlowSidebar/components/PublishedComponentsSearch.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/components/PublishedComponentsSearch.tsx
@@ -39,6 +39,7 @@ import {
 } from "@/providers/ComponentLibraryProvider/types";
 import type { ComponentFolder } from "@/types/componentLibrary";
 import { ComponentSearchFilter } from "@/utils/constants";
+import { debounce } from "@/utils/debounce";
 
 import { ComponentMarkup } from "./ComponentItem";
 
@@ -137,20 +138,6 @@ const SearchFilter = ({
       </PopoverContent>
     </Popover>
   );
-};
-
-const debounce = <F extends (...args: Parameters<F>) => ReturnType<F>>(
-  func: F,
-  waitFor: number,
-) => {
-  let timeout: ReturnType<typeof setTimeout>;
-
-  const debounced = (...args: Parameters<F>) => {
-    clearTimeout(timeout);
-    timeout = setTimeout(() => func(...args), waitFor);
-  };
-
-  return debounced;
 };
 
 const SearchRequestInput = ({ value, onChange }: SearchRequestProps) => {

--- a/src/components/shared/TaskDetails/Details.tsx
+++ b/src/components/shared/TaskDetails/Details.tsx
@@ -21,6 +21,9 @@ interface TaskDetailsProps {
   executionId?: string;
   status?: string;
   readOnly?: boolean;
+  options?: {
+    descriptionExpanded?: boolean;
+  };
   additionalSection?: {
     title: string;
     component: ReactNode;
@@ -36,6 +39,7 @@ const TaskDetailsInternal = ({
   executionId,
   status,
   readOnly = false,
+  options,
   additionalSection = [],
 }: TaskDetailsProps) => {
   const hydratedComponentRef =
@@ -138,6 +142,7 @@ const TaskDetailsInternal = ({
         title="Description"
         text={description}
         collapsible
+        defaultCollapsed={!options?.descriptionExpanded}
         className={BASE_BLOCK_CLASS}
         wrap
       />

--- a/src/utils/debounce.ts
+++ b/src/utils/debounce.ts
@@ -1,0 +1,13 @@
+export const debounce = <F extends (...args: Parameters<F>) => ReturnType<F>>(
+  func: F,
+  waitFor: number,
+) => {
+  let timeout: ReturnType<typeof setTimeout>;
+
+  const debounced = (...args: Parameters<F>) => {
+    clearTimeout(timeout);
+    timeout = setTimeout(() => func(...args), waitFor);
+  };
+
+  return debounced;
+};


### PR DESCRIPTION
## Description

Added a hover popover for components in the Flow Sidebar that displays component details. When hovering over a component (i) icon in the sidebar, a popover appears showing the component name and details.

## Type of Change

- [x] New feature
- [x] Improvement

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Changes

- Created new `ComponentHoverPopover` component that shows component details on hover
- Added debounce utility function to prevent rapid toggling of the popover
- Modified `TextBlock` component to accept a `defaultCollapsed` prop
- Updated `TaskDetails` to support expanded descriptions by default
- Added the new component to React compiler config

![image.png](https://app.graphite.com/user-attachments/assets/8ecda10f-9603-40d0-8050-a372ac52b221.png)

## Test Instructions

[Component Details on info hover.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/61641057-4097-477a-b097-cc5132b056ba.mov" />](https://app.graphite.com/user-attachments/video/61641057-4097-477a-b097-cc5132b056ba.mov)

1. Navigate to the Flow Sidebar
2. Hover over (i) icon of any component in the sidebar
3. Verify that a popover appears showing the component name and details
4. Verify that the popover disappears when moving the mouse away
5. Verify that Component Details dialog opens and operates properly. 
6. Verify that after closing the dialog ComponentHoverPopover displays properly. 