### PR TITLE
chore: vscode formatting on save fix

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,5 +18,14 @@
     "typescriptreact"
   ],
   "editor.defaultFormatter": "esbenp.prettier-vscode",
-  "editor.formatOnSave": true
+  "editor.formatOnSave": true,
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  }
 }


### PR DESCRIPTION
## Description

Updated VS Code settings to specify default formatters for different file types. Added configurations for TypeScript React files to use Prettier, TypeScript files to use Prettier, and JSON files to use VS Code's built-in JSON language features.

## Type of Change

- [x] Improvement

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Additional Comments

This change ensures consistent formatting across the codebase by explicitly defining which formatter to use for each file type, rather than relying on global defaults.