### PR TITLE
feat: zIndex Management for Flex Nodes

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -8,9 +8,6 @@
     "src/components/shared/StatusFilterSelect/**",
     "openapi-ts.config.ts",
     "vite.config.ghpages.js",
-    "src/components/shared/ReactFlow/FlowCanvas/utils/zIndex.ts",
-    "src/components/shared/ReactFlow/FlowControls/StackingControls.tsx",
-    "src/components/shared/ReactFlow/FlowCanvas/types.ts",
     "src/components/shared/ReactFlow/FlowCanvas/FlexNode/interface.ts"
   ],
   "ignoreDependencies": [

--- a/src/components/shared/ReactFlow/FlowCanvas/FlexNode/FlexNodeEditor.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlexNode/FlexNodeEditor.tsx
@@ -12,6 +12,7 @@ import { Paragraph, Text } from "@/components/ui/typography";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 import { updateSubgraphSpec } from "@/utils/subgraphUtils";
 
+import { StackingControls } from "../../FlowControls/StackingControls";
 import { updateFlexNodeInComponentSpec } from "./interface";
 import type { FlexNodeData } from "./types";
 
@@ -77,6 +78,8 @@ export const FlexNodeEditor = ({
           },
         ]}
       />
+
+      {!readOnly && <ZIndexEditor flexNode={flexNode} />}
     </BlockStack>
   );
 };
@@ -269,6 +272,42 @@ const ColorEditor = ({
           <CopyText className="text-xs font-mono">{properties.color}</CopyText>
         </InlineStack>
       </BlockStack>
+    </ContentBlock>
+  );
+};
+
+const ZIndexEditor = ({ flexNode }: { flexNode: FlexNodeData }) => {
+  const {
+    componentSpec,
+    currentSubgraphSpec,
+    currentSubgraphPath,
+    setComponentSpec,
+  } = useComponentSpec();
+
+  const handleStackingControlChange = (newZIndex: number) => {
+    const updatedSubgraphSpec = updateFlexNodeInComponentSpec(
+      currentSubgraphSpec,
+      {
+        ...flexNode,
+        zIndex: newZIndex,
+      },
+    );
+
+    const newRootSpec = updateSubgraphSpec(
+      componentSpec,
+      currentSubgraphPath,
+      updatedSubgraphSpec,
+    );
+
+    setComponentSpec(newRootSpec);
+  };
+
+  return (
+    <ContentBlock title="Stacking">
+      <StackingControls
+        nodeId={flexNode.id}
+        onChange={handleStackingControlChange}
+      />
     </ContentBlock>
   );
 };

--- a/src/components/shared/ReactFlow/FlowCanvas/utils/addFlexNode.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/utils/addFlexNode.ts
@@ -6,6 +6,7 @@ import { type ComponentSpec } from "@/utils/componentSpec";
 import { updateFlexNodeInComponentSpec } from "../FlexNode/interface";
 import type { FlexNodeData } from "../FlexNode/types";
 import { DEFAULT_FLEX_NODE_SIZE, DEFAULT_STICKY_NOTE } from "../FlexNode/utils";
+import { Z_INDEX_RANGES } from "./zIndex";
 
 interface AddFlexNodeResult {
   spec: ComponentSpec;
@@ -45,7 +46,7 @@ const addFlexNode = (
     metadata,
     size: DEFAULT_FLEX_NODE_SIZE,
     position: position,
-    zIndex: 0,
+    zIndex: Z_INDEX_RANGES.flex.default,
   };
 
   const newComponentSpec = updateFlexNodeInComponentSpec(

--- a/src/components/shared/ReactFlow/FlowCanvas/utils/zIndex.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/utils/zIndex.ts
@@ -29,6 +29,11 @@ export const Z_INDEX_RANGES: Record<NodeType, ZIndexDefinition> = {
     max: 100,
     default: 100,
   },
+  flex: {
+    min: -100,
+    max: 100,
+    default: 0,
+  },
 };
 
 const getNodeZIndexProp = (


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

Adds buttons to the flex node context panel to allow standard z-index management:
- Bring to Front
- Send to Back
- Move Forward
- Move Backward

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

Progresses https://github.com/Shopify/oasis-frontend/issues/118

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] New feature

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

![image.png](https://app.graphite.com/user-attachments/assets/9f8c63c4-d63d-439c-ac5f-fc8ec1284234.png)

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->
- Add a bunch of nodes to the canvas, including at least one sticky note
- Select the sticky note. In the context panel there should be options for managing the stacking order
- Confirm that each options works as expected and the z-index is updated accordingly

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
