### PR TITLE
feat: zIndex Management for Task Nodes

### DIFF
--- a/react-compiler.config.js
+++ b/react-compiler.config.js
@@ -50,6 +50,7 @@ export const REACT_COMPILER_ENABLED_DIRS = [
   "src/components/shared/ReactFlow/FlowSidebar/components/ComponentHoverPopover.tsx",
   "src/components/shared/ReactFlow/FlowControls/StackingControls.tsx",
   "src/components/shared/ReactFlow/FlowCanvas/FlexNode",
+  "src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/ZIndexEditor.tsx",
   "src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/DynamicDataDropdown.tsx",
   "src/components/shared/HighlightText.tsx",
 

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/TaskOverview.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/TaskOverview.tsx
@@ -26,6 +26,7 @@ import IOSection from "./IOSection/IOSection";
 import Logs, { OpenLogsInNewWindowLink } from "./logs";
 import OutputsList from "./OutputsList";
 import RenameTask from "./RenameTask";
+import { ZIndexEditor } from "./ZIndexEditor";
 
 interface TaskOverviewProps {
   taskNode: TaskNodeContextType;
@@ -165,6 +166,8 @@ const TaskOverview = ({ taskNode }: TaskOverviewProps) => {
           )}
         </Tabs>
       </div>
+
+      <ZIndexEditor taskNode={taskNode} />
     </BlockStack>
   );
 };

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/ZIndexEditor.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/ZIndexEditor.tsx
@@ -1,0 +1,29 @@
+import { ContentBlock } from "@/components/shared/ContextPanel/Blocks/ContentBlock";
+import type { TaskNodeContextType } from "@/providers/TaskNodeProvider";
+import { ZINDEX_ANNOTATION } from "@/utils/annotations";
+
+import { StackingControls } from "../../../FlowControls/StackingControls";
+
+interface ZIndexEditorProps {
+  taskNode: TaskNodeContextType;
+}
+
+export const ZIndexEditor = ({ taskNode }: ZIndexEditorProps) => {
+  const handleStackingControlChange = (newZIndex: number) => {
+    const updatedAnnotations = {
+      ...taskNode.taskSpec?.annotations,
+      [ZINDEX_ANNOTATION]: `${newZIndex}`,
+    };
+
+    taskNode.callbacks.setAnnotations(updatedAnnotations);
+  };
+
+  return (
+    <ContentBlock className="border rounded-lg p-2 bg-background w-fit mx-auto">
+      <StackingControls
+        nodeId={taskNode.nodeId}
+        onChange={handleStackingControlChange}
+      />
+    </ContentBlock>
+  );
+};

--- a/src/components/shared/ReactFlow/FlowCanvas/utils/addTask.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/utils/addTask.ts
@@ -1,7 +1,10 @@
 import type { XYPosition } from "@xyflow/react";
 
 import type { TaskType } from "@/types/taskNode";
-import { EDITOR_POSITION_ANNOTATION } from "@/utils/annotations";
+import {
+  EDITOR_POSITION_ANNOTATION,
+  ZINDEX_ANNOTATION,
+} from "@/utils/annotations";
 import {
   type ComponentSpec,
   type GraphSpec,
@@ -16,6 +19,8 @@ import {
   getUniqueOutputName,
   getUniqueTaskName,
 } from "@/utils/unique";
+
+import { getNodeTypeZIndexDefault } from "./zIndex";
 
 interface AddTaskResult {
   spec: ComponentSpec;
@@ -75,8 +80,9 @@ const addTask = (
   const graphSpec = newComponentSpec.implementation.graph;
 
   const nodePosition = { x: position.x, y: position.y };
-  const positionAnnotations = {
+  const annotations = {
     [EDITOR_POSITION_ANNOTATION]: JSON.stringify(nodePosition),
+    [ZINDEX_ANNOTATION]: getNodeTypeZIndexDefault(taskType),
   };
 
   if (taskType === "task") {
@@ -103,7 +109,7 @@ const addTask = (
 
     const mergedAnnotations = {
       ...taskSpec.annotations,
-      ...positionAnnotations,
+      ...annotations,
     };
 
     const updatedTaskSpec: TaskSpec = {
@@ -133,7 +139,7 @@ const addTask = (
     const inputSpec: InputSpec = {
       ...options,
       name: inputId,
-      annotations: positionAnnotations,
+      annotations,
     };
 
     const inputs = (newComponentSpec.inputs ?? []).concat([inputSpec]);
@@ -146,7 +152,7 @@ const addTask = (
     const outputSpec: OutputSpec = {
       ...options,
       name: outputId,
-      annotations: positionAnnotations,
+      annotations,
     };
 
     const outputs = (newComponentSpec.outputs ?? []).concat([outputSpec]);

--- a/src/components/shared/ReactFlow/FlowCanvas/utils/zIndex.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/utils/zIndex.ts
@@ -36,6 +36,10 @@ export const Z_INDEX_RANGES: Record<NodeType, ZIndexDefinition> = {
   },
 };
 
+export const getNodeTypeZIndexDefault = (nodeType: NodeType): number => {
+  return Z_INDEX_RANGES[nodeType].default;
+};
+
 const getNodeZIndexProp = (
   node: Node,
   prop: keyof ZIndexDefinition,

--- a/src/config/launcherTaskAnnotationSchema.json
+++ b/src/config/launcherTaskAnnotationSchema.json
@@ -17,6 +17,13 @@
         "title": "Display Name",
         "x-type": "string",
         "exclusiveMaximum": 100
+      },
+      "zIndex": {
+        "type": "integer",
+        "title": "Z-Index",
+        "x-type": "string",
+        "exclusiveMinimum": -100,
+        "exclusiveMaximum": 100
       }
     }
   }

--- a/src/utils/annotations.ts
+++ b/src/utils/annotations.ts
@@ -1,5 +1,6 @@
 import type { XYPosition } from "@xyflow/react";
 
+import { getNodeTypeZIndexDefault } from "@/components/shared/ReactFlow/FlowCanvas/utils/zIndex";
 import type { AnnotationConfig } from "@/types/annotations";
 
 import type { ComponentSpec } from "./componentSpec";
@@ -13,6 +14,7 @@ export const RUN_NAME_TEMPLATE_ANNOTATION = "run-name-template";
 export const EDITOR_POSITION_ANNOTATION = "editor.position";
 export const EDITOR_COLLAPSED_ANNOTATION = "editor.collapsed";
 export const FLEX_NODES_ANNOTATION = "flex-nodes";
+export const ZINDEX_ANNOTATION = "zIndex";
 
 export const DEFAULT_COMMON_ANNOTATIONS: AnnotationConfig[] = [
   {
@@ -230,3 +232,32 @@ export function removeAnnotation(
   const { [key]: _, ...rest } = annotations;
   return rest;
 }
+
+/**
+ * Gets the z-index from annotations.
+ * @param annotations - The annotations object
+ * @returns z-index number
+ */
+export const extractZIndexFromAnnotations = (
+  annotations: Annotations,
+  nodeType: string,
+): number => {
+  const defaultZIndex = getNodeTypeZIndexDefault(nodeType);
+
+  if (!annotations) return defaultZIndex;
+
+  const zIndex = annotations[ZINDEX_ANNOTATION];
+
+  if (typeof zIndex === "number") {
+    return Math.round(zIndex);
+  }
+
+  if (typeof zIndex === "string") {
+    const parsedZIndex = parseInt(zIndex, 10);
+    if (!isNaN(parsedZIndex)) {
+      return Math.round(parsedZIndex);
+    }
+  }
+
+  return defaultZIndex;
+};

--- a/src/utils/nodes/createTaskNode.ts
+++ b/src/utils/nodes/createTaskNode.ts
@@ -2,7 +2,10 @@ import { type Node } from "@xyflow/react";
 
 import type { TaskNodeData } from "@/types/taskNode";
 
-import { extractPositionFromAnnotations } from "../annotations";
+import {
+  extractPositionFromAnnotations,
+  extractZIndexFromAnnotations,
+} from "../annotations";
 import type { TaskSpec } from "../componentSpec";
 import { generateDynamicNodeCallbacks } from "./generateDynamicNodeCallbacks";
 import { taskIdToNodeId } from "./nodeIdUtils";
@@ -12,9 +15,13 @@ export const createTaskNode = (
   nodeData: TaskNodeData,
   readOnly: boolean = false,
 ) => {
+  const nodeType = "task";
+
   const [taskId, taskSpec] = task;
 
   const position = extractPositionFromAnnotations(taskSpec.annotations);
+  const zIndex = extractZIndexFromAnnotations(taskSpec.annotations, nodeType);
+
   const nodeId = taskIdToNodeId(taskId);
 
   // Inject the taskId and nodeId into the callbacks
@@ -32,6 +39,7 @@ export const createTaskNode = (
       readOnly,
     },
     position: position,
-    type: "task",
+    type: nodeType,
+    zIndex,
   } as Node;
 };


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

zIndex management for Task Nodes, accessible in UI via Context Panel & Configuration. zIndex is saved in annotations as `annotations: { zIndex: number.toString() }`

I didn't know where to stick the UI for it so just shoved it at the bottom of the Context Panel. It'd be nice to have a little floating toolbar above the node, but this is a sidequest, so it's something we can iterate on later.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

Progresses https://github.com/Shopify/oasis-frontend/issues/483

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] New feature

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

![image.png](https://app.graphite.com/user-attachments/assets/3cf51e8b-6596-4ad2-ac19-2e09a7eb48f6.png)

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->
- Add a bunch of tasks to the Canvas
- Click on one of them. In the Context Panel you will see Stacking Controls at the bottom of the panel.
- Confirm that each of these buttons works as expected.
- Go to the Configuration Tab on a Task. Confirm that manually editing the zIndex annotation also works as expected.

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
