### PR TITLE
chore: Add Integer Annotation Type

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/AnnotationsInput.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/AnnotationsInput.tsx
@@ -1,4 +1,10 @@
-import { type ChangeEvent, useCallback, useEffect, useState } from "react";
+import {
+  type ChangeEvent,
+  type KeyboardEvent,
+  useCallback,
+  useEffect,
+  useState,
+} from "react";
 
 import { MultilineTextInputDialog } from "@/components/shared/Dialogs/MultilineTextInputDialog";
 import { Button } from "@/components/ui/button";
@@ -48,6 +54,8 @@ export const AnnotationsInput = ({
   const inputType = config?.type ?? "string";
   const placeholder = config?.label ?? "";
 
+  const isNumericType = inputType === "number" || inputType === "integer";
+
   const handleExpand = useCallback(() => {
     setIsDialogOpen(true);
   }, []);
@@ -87,6 +95,36 @@ export const AnnotationsInput = ({
       }
     }
   }, []);
+
+  const handleNumericInputChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      let newValue = e.target.value;
+
+      if (inputType === "integer") {
+        newValue = newValue.replace(/[.,]/g, "");
+      }
+
+      if (newValue === "") {
+        setInputValue(newValue);
+        return;
+      }
+
+      const numericValue = Number(newValue);
+      if (!isNaN(numericValue)) {
+        setInputValue(newValue);
+      }
+    },
+    [inputType],
+  );
+
+  const handleNumericInputKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLInputElement>) => {
+      if (inputType === "integer" && (e.key === "." || e.key === ",")) {
+        e.preventDefault();
+      }
+    },
+    [inputType],
+  );
 
   const handleQuantityKeyInputChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
@@ -186,12 +224,12 @@ export const AnnotationsInput = ({
 
     if (onBlur && lastSavedValue !== inputValue && !isInvalid) {
       let value = inputValue;
-      if (
-        config?.type === "number" &&
-        !isNaN(Number(inputValue)) &&
-        inputValue !== ""
-      ) {
-        value = clamp(Number(inputValue), config.min, config.max).toString();
+      if (isNumericType && !isNaN(Number(inputValue)) && inputValue !== "") {
+        value = clamp(Number(inputValue), config?.min, config?.max).toString();
+
+        if (inputType === "integer") {
+          value = Math.floor(Number(value)).toString();
+        }
       }
 
       onBlur(value);
@@ -201,6 +239,8 @@ export const AnnotationsInput = ({
     onBlur,
     shouldSaveQuantityField,
     isInvalid,
+    isNumericType,
+    inputType,
     lastSavedValue,
     inputValue,
     config,
@@ -262,7 +302,7 @@ export const AnnotationsInput = ({
         className={className}
       />
     );
-  } else if (inputType === "number") {
+  } else if (isNumericType) {
     inputElement = (
       <InlineStack gap="2" wrap="nowrap" className="grow">
         <Input
@@ -270,7 +310,8 @@ export const AnnotationsInput = ({
           value={inputValue}
           min={config?.min}
           max={config?.max}
-          onChange={(e) => setInputValue(e.target.value)}
+          onChange={handleNumericInputChange}
+          onKeyDown={handleNumericInputKeyDown}
           onBlur={handleBlur}
           autoFocus={autoFocus}
           className={className}
@@ -357,21 +398,19 @@ export const AnnotationsInput = ({
         )}
       </InlineStack>
 
-      {inputType !== "boolean" &&
-        inputType !== "number" &&
-        !config?.options && (
-          <MultilineTextInputDialog
-            title={dialogTitle}
-            description="Enter a value for this annotation."
-            placeholder={placeholder}
-            initialValue={inputValue}
-            open={isDialogOpen}
-            onCancel={handleDialogCancel}
-            onConfirm={handleDialogConfirm}
-            maxLength={config?.max}
-            required={config?.required}
-          />
-        )}
+      {inputType !== "boolean" && !isNumericType && !config?.options && (
+        <MultilineTextInputDialog
+          title={dialogTitle}
+          description="Enter a value for this annotation."
+          placeholder={placeholder}
+          initialValue={inputValue}
+          open={isDialogOpen}
+          onCancel={handleDialogCancel}
+          onConfirm={handleDialogConfirm}
+          maxLength={config?.max}
+          required={config?.required}
+        />
+      )}
     </>
   );
 };

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/utils.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/utils.ts
@@ -89,6 +89,8 @@ export function parseSchemaToAnnotationConfig(
       config.type = "json";
     } else if (property.type === "number") {
       config.type = "number";
+    } else if (property.type === "integer") {
+      config.type = "integer";
     } else if (property.type === "boolean") {
       config.type = "boolean";
     } else if (property.type === "string") {

--- a/src/types/annotations.ts
+++ b/src/types/annotations.ts
@@ -12,7 +12,7 @@ export type AnnotationConfig = {
   append?: string;
   options?: AnnotationOption[];
   enableQuantity?: boolean;
-  type?: "string" | "number" | "boolean" | "json";
+  type?: "string" | "number" | "integer" | "boolean" | "json";
   min?: number;
   max?: number;
   hidden?: boolean;


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

Adds `integer` as a supported annotation value type. An integer annotation will render as a numeric input, the same as `number`, but disallows the input of decimal values.

Enables us to add zIndex editing to Tasks and IO Nodes via annotations.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

- Add a new `common annotation` to the `launcherTaskAnnotationSchema.json` with type `integer`. Hard-restart the dev server (hmr won't pick up on static json changes).
- Go to a task. You should see your new annotation in the config panel.
- Confirm that it does not allow decimal input, including via copy and paste

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
