### PR TITLE
feat: zIndex Management for IO Nodes

### DIFF
--- a/react-compiler.config.js
+++ b/react-compiler.config.js
@@ -51,6 +51,7 @@ export const REACT_COMPILER_ENABLED_DIRS = [
   "src/components/shared/ReactFlow/FlowControls/StackingControls.tsx",
   "src/components/shared/ReactFlow/FlowCanvas/FlexNode",
   "src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/ZIndexEditor.tsx",
+  "src/components/Editor/IOEditor/IOZIndexEditor.tsx",
   "src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/DynamicDataDropdown.tsx",
   "src/components/shared/HighlightText.tsx",
 

--- a/src/components/Editor/IOEditor/IOZIndexEditor.tsx
+++ b/src/components/Editor/IOEditor/IOZIndexEditor.tsx
@@ -1,0 +1,116 @@
+import { ContentBlock } from "@/components/shared/ContextPanel/Blocks/ContentBlock";
+import { StackingControls } from "@/components/shared/ReactFlow/FlowControls/StackingControls";
+import { useComponentSpec } from "@/providers/ComponentSpecProvider";
+import { ZINDEX_ANNOTATION } from "@/utils/annotations";
+import {
+  type ComponentSpec,
+  type InputSpec,
+  type OutputSpec,
+} from "@/utils/componentSpec";
+import {
+  inputNameToNodeId,
+  outputNameToNodeId,
+} from "@/utils/nodes/nodeIdUtils";
+import { updateSubgraphSpec } from "@/utils/subgraphUtils";
+
+interface IOZIndexEditorProps {
+  ioSpec: InputSpec | OutputSpec;
+  ioType: "input" | "output";
+}
+
+export const IOZIndexEditor = ({ ioSpec, ioType }: IOZIndexEditorProps) => {
+  const {
+    componentSpec,
+    currentSubgraphSpec,
+    currentSubgraphPath,
+    setComponentSpec,
+  } = useComponentSpec();
+
+  const isInput = ioType === "input";
+
+  const nodeId = isInput
+    ? inputNameToNodeId(ioSpec.name)
+    : outputNameToNodeId(ioSpec.name);
+
+  const handleStackingControlChange = (newZIndex: number) => {
+    const updatedSubgraphSpec = setZIndexInAnnotations(
+      currentSubgraphSpec,
+      ioSpec,
+      ioType,
+      newZIndex,
+    );
+
+    const newRootSpec = updateSubgraphSpec(
+      componentSpec,
+      currentSubgraphPath,
+      updatedSubgraphSpec,
+    );
+
+    setComponentSpec(newRootSpec);
+  };
+
+  return (
+    <ContentBlock className="border rounded-lg p-2 bg-background w-fit mx-auto">
+      <StackingControls
+        nodeId={nodeId}
+        onChange={handleStackingControlChange}
+      />
+    </ContentBlock>
+  );
+};
+
+function setZIndexInAnnotations(
+  componentSpec: ComponentSpec,
+  ioSpec: InputSpec | OutputSpec,
+  ioType: "input" | "output",
+  zIndex: number,
+): ComponentSpec {
+  const newComponentSpec = { ...componentSpec };
+
+  const isInput = ioType === "input";
+  const isOutput = ioType === "output";
+
+  if (isInput) {
+    const inputs = [...(newComponentSpec.inputs || [])];
+    const inputIndex = inputs.findIndex((input) => input.name === ioSpec.name);
+
+    if (inputIndex >= 0) {
+      const annotations = inputs[inputIndex].annotations || {};
+
+      const updatedAnnotations = {
+        ...annotations,
+        [ZINDEX_ANNOTATION]: `${zIndex}`,
+      };
+
+      inputs[inputIndex] = {
+        ...inputs[inputIndex],
+        annotations: updatedAnnotations,
+      };
+
+      newComponentSpec.inputs = inputs;
+    }
+  } else if (isOutput) {
+    const outputs = [...(newComponentSpec.outputs || [])];
+    const outputIndex = outputs.findIndex(
+      (output) => output.name === ioSpec.name,
+    );
+
+    if (outputIndex >= 0) {
+      const annotations = outputs[outputIndex].annotations || {};
+
+      const updatedAnnotations = {
+        ...annotations,
+        [ZINDEX_ANNOTATION]: `${zIndex}`,
+      };
+
+      outputs[outputIndex] = {
+        ...outputs[outputIndex],
+        annotations: updatedAnnotations,
+      };
+
+      newComponentSpec.outputs = outputs;
+    }
+  }
+
+  return newComponentSpec;
+}

--- a/src/components/Editor/IOEditor/InputValueEditor/InputValueEditor.test.tsx
+++ b/src/components/Editor/IOEditor/InputValueEditor/InputValueEditor.test.tsx
@@ -11,6 +11,10 @@ const mockTransferSelection = vi.fn();
 const mockNotify = vi.fn();
 const mockClearContent = vi.fn();
 
+vi.mock("@/components/Editor/IOEditor/IOZIndexEditor", () => ({
+  IOZIndexEditor: () => null,
+}));
+
 vi.mock("@/providers/ComponentSpecProvider", () => ({
   useComponentSpec: () => ({
     componentSpec: {

--- a/src/components/Editor/IOEditor/InputValueEditor/InputValueEditor.tsx
+++ b/src/components/Editor/IOEditor/InputValueEditor/InputValueEditor.tsx
@@ -6,7 +6,7 @@ import { InfoBox } from "@/components/shared/InfoBox";
 import { removeGraphInput } from "@/components/shared/ReactFlow/FlowCanvas/utils/removeNode";
 import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
-import { BlockStack } from "@/components/ui/layout";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Heading, Paragraph } from "@/components/ui/typography";
 import useConfirmationDialog from "@/hooks/useConfirmationDialog";
 import { useNodeSelectionTransfer } from "@/hooks/useNodeSelectionTransfer";
@@ -18,6 +18,7 @@ import { checkInputConnectionToRequiredFields } from "@/utils/inputConnectionUti
 import { inputNameToNodeId } from "@/utils/nodes/nodeIdUtils";
 import { updateSubgraphSpec } from "@/utils/subgraphUtils";
 
+import { IOZIndexEditor } from "../IOZIndexEditor";
 import {
   DescriptionField,
   NameField,
@@ -318,11 +319,15 @@ export const InputValueEditor = ({
         </InfoBox>
       )}
 
-      {!disabled && (
-        <Button onClick={deleteNode} variant="destructive" size="icon">
-          <Icon name="Trash2" />
-        </Button>
-      )}
+      <InlineStack gap="4">
+        {!disabled && (
+          <Button onClick={deleteNode} variant="destructive" size="icon">
+            <Icon name="Trash2" />
+          </Button>
+        )}
+
+        <IOZIndexEditor ioSpec={input} ioType="input" />
+      </InlineStack>
 
       <ConfirmationDialog
         {...confirmationProps}

--- a/src/components/Editor/IOEditor/OutputNameEditor/OutputNameEditor.tsx
+++ b/src/components/Editor/IOEditor/OutputNameEditor/OutputNameEditor.tsx
@@ -4,7 +4,7 @@ import ConfirmationDialog from "@/components/shared/Dialogs/ConfirmationDialog";
 import { removeGraphOutput } from "@/components/shared/ReactFlow/FlowCanvas/utils/removeNode";
 import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
-import { BlockStack } from "@/components/ui/layout";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Heading, Paragraph } from "@/components/ui/typography";
 import useConfirmationDialog from "@/hooks/useConfirmationDialog";
 import { useNodeSelectionTransfer } from "@/hooks/useNodeSelectionTransfer";
@@ -22,6 +22,7 @@ import {
   TypeField,
 } from "../InputValueEditor/FormFields";
 import { checkNameCollision } from "../InputValueEditor/FormFields/utils";
+import { IOZIndexEditor } from "../IOZIndexEditor";
 
 interface OutputNameEditorProps {
   output: OutputSpec;
@@ -206,11 +207,15 @@ export const OutputNameEditor = ({
         />
       </div>
 
-      {!disabled && (
-        <Button onClick={deleteNode} variant="destructive" size="icon">
-          <Icon name="Trash2" />
-        </Button>
-      )}
+      <InlineStack gap="4">
+        {!disabled && (
+          <Button onClick={deleteNode} variant="destructive" size="icon">
+            <Icon name="Trash2" />
+          </Button>
+        )}
+
+        <IOZIndexEditor ioSpec={output} ioType="output" />
+      </InlineStack>
 
       <ConfirmationDialog
         {...confirmationProps}

--- a/src/utils/nodes/createInputNode.ts
+++ b/src/utils/nodes/createInputNode.ts
@@ -2,7 +2,10 @@ import { type Node } from "@xyflow/react";
 
 import type { TaskNodeData } from "@/types/taskNode";
 
-import { extractPositionFromAnnotations } from "../annotations";
+import {
+  extractPositionFromAnnotations,
+  extractZIndexFromAnnotations,
+} from "../annotations";
 import type { InputSpec } from "../componentSpec";
 import { inputNameToNodeId } from "./nodeIdUtils";
 
@@ -11,9 +14,13 @@ export const createInputNode = (
   nodeData: TaskNodeData,
   readOnly: boolean = false,
 ) => {
+  const nodeType = "input";
+
   const { name, annotations, ...rest } = input;
 
   const position = extractPositionFromAnnotations(annotations);
+  const zIndex = extractZIndexFromAnnotations(input.annotations, nodeType);
+
   const nodeId = inputNameToNodeId(name);
 
   return {
@@ -25,6 +32,7 @@ export const createInputNode = (
       readOnly,
     },
     position: position,
-    type: "input",
+    type: nodeType,
+    zIndex,
   } as Node;
 };

--- a/src/utils/nodes/createNodesFromComponentSpec.test.ts
+++ b/src/utils/nodes/createNodesFromComponentSpec.test.ts
@@ -91,12 +91,16 @@ describe("createNodesFromComponentSpec", () => {
 
     const result = createNodesFromComponentSpec(componentSpec, mockNodeData);
 
-    expect(result).toContainEqual({
-      id: "input_input1",
-      data: expect.objectContaining({ label: "input1" }),
-      position: { x: 50, y: 100 },
-      type: "input",
-    });
+    expect(result).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "input_input1",
+          data: expect.objectContaining({ label: "input1" }),
+          position: { x: 50, y: 100 },
+          type: "input",
+        }),
+      ]),
+    );
   });
 
   it("creates output nodes correctly", () => {
@@ -116,12 +120,16 @@ describe("createNodesFromComponentSpec", () => {
 
     const result = createNodesFromComponentSpec(componentSpec, mockNodeData);
 
-    expect(result).toContainEqual({
-      id: "output_output1",
-      data: expect.objectContaining({ label: "output1" }),
-      position: { x: 300, y: 150 },
-      type: "output",
-    });
+    expect(result).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "output_output1",
+          data: expect.objectContaining({ label: "output1" }),
+          position: { x: 300, y: 150 },
+          type: "output",
+        }),
+      ]),
+    );
   });
 
   it("handles missing position annotations by using default position", () => {

--- a/src/utils/nodes/createOutputNode.ts
+++ b/src/utils/nodes/createOutputNode.ts
@@ -2,7 +2,10 @@ import { type Node } from "@xyflow/react";
 
 import type { TaskNodeData } from "@/types/taskNode";
 
-import { extractPositionFromAnnotations } from "../annotations";
+import {
+  extractPositionFromAnnotations,
+  extractZIndexFromAnnotations,
+} from "../annotations";
 import type { OutputSpec } from "../componentSpec";
 import { outputNameToNodeId } from "./nodeIdUtils";
 
@@ -11,9 +14,13 @@ export const createOutputNode = (
   nodeData: TaskNodeData,
   readOnly: boolean = false,
 ) => {
+  const nodeType = "output";
+
   const { name, annotations, ...rest } = output;
 
   const position = extractPositionFromAnnotations(annotations);
+  const zIndex = extractZIndexFromAnnotations(output.annotations, nodeType);
+
   const nodeId = outputNameToNodeId(name);
 
   return {
@@ -25,6 +32,7 @@ export const createOutputNode = (
       readOnly,
     },
     position: position,
-    type: "output",
+    type: nodeType,
+    zIndex,
   } as Node;
 };


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Add zIndex management via UI to Input and Output Nodes. This is managed via annotations.

Exact same as previous Task Nodes PR, but for IO Nodes.

This is a sidequest so UI/UX is just thrown in and can be iterated later.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

Progresses https://github.com/Shopify/oasis-frontend/issues/483

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] New feature

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

Input Nodes
![image.png](https://app.graphite.com/user-attachments/assets/08dc53f0-e426-4c6e-925c-45e34e305670.png)

Output Nodes
![image.png](https://app.graphite.com/user-attachments/assets/bd316100-f231-40d5-bb05-95540a1cd9fc.png)

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->
Stacking controls work as expected via new UI on IO Nodes context panel

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
