### PR TITLE
fix: Edges use zIndex from Connected Nodes

### DIFF
--- a/src/hooks/useComponentSpecToEdges.test.ts
+++ b/src/hooks/useComponentSpecToEdges.test.ts
@@ -42,15 +42,19 @@ describe("useComponentSpecToEdges", () => {
 
     const { result } = renderHook(() => useComponentSpecToEdges(componentSpec));
 
-    expect(result.current.edges).toContainEqual({
-      id: "task2_output1-task1_input1",
-      source: "task_task2",
-      sourceHandle: "output_output1",
-      target: "task_task1",
-      targetHandle: "input_input1",
-      markerEnd: { type: MarkerType.Arrow },
-      type: "customEdge",
-    });
+    expect(result.current.edges).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "task2_output1-task1_input1",
+          source: "task_task2",
+          sourceHandle: "output_output1",
+          target: "task_task1",
+          targetHandle: "input_input1",
+          markerEnd: { type: MarkerType.Arrow },
+          type: "customEdge",
+        }),
+      ]),
+    );
   });
 
   it("creates graph input edges correctly", () => {
@@ -70,15 +74,19 @@ describe("useComponentSpecToEdges", () => {
 
     const { result } = renderHook(() => useComponentSpecToEdges(componentSpec));
 
-    expect(result.current.edges).toContainEqual({
-      id: "Input_graphInput1-task1_input1",
-      source: "input_graphInput1",
-      sourceHandle: null,
-      target: "task_task1",
-      targetHandle: "input_input1",
-      markerEnd: { type: MarkerType.Arrow },
-      type: "customEdge",
-    });
+    expect(result.current.edges).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "Input_graphInput1-task1_input1",
+          source: "input_graphInput1",
+          sourceHandle: null,
+          target: "task_task1",
+          targetHandle: "input_input1",
+          markerEnd: { type: MarkerType.Arrow },
+          type: "customEdge",
+        }),
+      ]),
+    );
   });
 
   it("creates output edges correctly", () => {
@@ -100,15 +108,19 @@ describe("useComponentSpecToEdges", () => {
 
     const { result } = renderHook(() => useComponentSpecToEdges(componentSpec));
 
-    expect(result.current.edges).toContainEqual({
-      id: "task1_output1-Output_graphOutput1",
-      source: "task_task1",
-      sourceHandle: "output_output1",
-      target: "output_graphOutput1",
-      targetHandle: null,
-      markerEnd: { type: MarkerType.Arrow },
-      type: "customEdge",
-    });
+    expect(result.current.edges).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "task1_output1-Output_graphOutput1",
+          source: "task_task1",
+          sourceHandle: "output_output1",
+          target: "output_graphOutput1",
+          targetHandle: null,
+          markerEnd: { type: MarkerType.Arrow },
+          type: "customEdge",
+        }),
+      ]),
+    );
   });
 
   it("handles string arguments by returning no edges", () => {
@@ -172,34 +184,46 @@ describe("useComponentSpecToEdges", () => {
 
     expect(result.current.edges).toHaveLength(3);
 
-    expect(result.current.edges).toContainEqual({
-      id: "Input_graphInput1-task1_input1",
-      source: "input_graphInput1",
-      sourceHandle: null,
-      target: "task_task1",
-      targetHandle: "input_input1",
-      markerEnd: { type: MarkerType.Arrow },
-      type: "customEdge",
-    });
+    expect(result.current.edges).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "Input_graphInput1-task1_input1",
+          source: "input_graphInput1",
+          sourceHandle: null,
+          target: "task_task1",
+          targetHandle: "input_input1",
+          markerEnd: { type: MarkerType.Arrow },
+          type: "customEdge",
+        }),
+      ]),
+    );
 
-    expect(result.current.edges).toContainEqual({
-      id: "task1_output1-task2_input1",
-      source: "task_task1",
-      sourceHandle: "output_output1",
-      target: "task_task2",
-      targetHandle: "input_input1",
-      markerEnd: { type: MarkerType.Arrow },
-      type: "customEdge",
-    });
+    expect(result.current.edges).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "task1_output1-task2_input1",
+          source: "task_task1",
+          sourceHandle: "output_output1",
+          target: "task_task2",
+          targetHandle: "input_input1",
+          markerEnd: { type: MarkerType.Arrow },
+          type: "customEdge",
+        }),
+      ]),
+    );
 
-    expect(result.current.edges).toContainEqual({
-      id: "task2_output1-Output_graphOutput1",
-      source: "task_task2",
-      sourceHandle: "output_output1",
-      target: "output_graphOutput1",
-      targetHandle: null,
-      markerEnd: { type: MarkerType.Arrow },
-      type: "customEdge",
-    });
+    expect(result.current.edges).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "task2_output1-Output_graphOutput1",
+          source: "task_task2",
+          sourceHandle: "output_output1",
+          target: "output_graphOutput1",
+          targetHandle: null,
+          markerEnd: { type: MarkerType.Arrow },
+          type: "customEdge",
+        }),
+      ]),
+    );
   });
 });

--- a/src/hooks/useComponentSpecToEdges.ts
+++ b/src/hooks/useComponentSpecToEdges.ts
@@ -6,13 +6,17 @@ import {
 } from "@xyflow/react";
 import { useEffect } from "react";
 
+import { extractZIndexFromAnnotations } from "@/utils/annotations";
 import {
   type ArgumentType,
   type ComponentSpec,
   type GraphInputArgument,
   type GraphSpec,
   isDynamicDataArgument,
+  isGraphImplementation,
+  isGraphInputArgument,
   isSecretArgument,
+  isTaskOutputArgument,
   type TaskOutputArgument,
   type TaskSpec,
 } from "@/utils/componentSpec";
@@ -45,27 +49,32 @@ const useComponentSpecToEdges = (
 };
 
 const getEdges = (componentSpec: ComponentSpec) => {
-  if (!("graph" in componentSpec.implementation)) {
+  const taskEdges = createEdgesFromTaskSpec(componentSpec);
+  const outputEdges = createOutputEdgesFromComponentSpec(componentSpec);
+  return [...taskEdges, ...outputEdges];
+};
+
+const createEdgesFromTaskSpec = (componentSpec: ComponentSpec) => {
+  if (!isGraphImplementation(componentSpec.implementation)) {
     return [];
   }
 
   const graphSpec = componentSpec.implementation.graph;
-  const taskEdges = createEdgesFromTaskSpec(graphSpec);
-  const outputEdges = createOutputEdgesFromGraphSpec(graphSpec);
-  return [...taskEdges, ...outputEdges];
-};
 
-const createEdgesFromTaskSpec = (graphSpec: GraphSpec) => {
   const edges: Edge[] = Object.entries(graphSpec.tasks).flatMap(
-    ([taskId, taskSpec]) => createEdgesForTask(taskId, taskSpec),
+    ([taskId, taskSpec]) => createEdgesForTask(taskId, taskSpec, componentSpec),
   );
   return edges;
 };
 
-const createEdgesForTask = (taskId: string, taskSpec: TaskSpec): Edge[] => {
+const createEdgesForTask = (
+  taskId: string,
+  taskSpec: TaskSpec,
+  componentSpec: ComponentSpec,
+): Edge[] => {
   return Object.entries(taskSpec.arguments ?? {}).flatMap(
     ([inputName, argument]) =>
-      createEdgeForArgument(taskId, inputName, argument),
+      createEdgeForArgument(taskId, inputName, argument, componentSpec),
   );
 };
 
@@ -73,17 +82,33 @@ const createEdgeForArgument = (
   taskId: string,
   inputName: string,
   argument: ArgumentType,
+  componentSpec: ComponentSpec,
 ): Edge[] => {
   if (isScalar(argument)) {
     return [];
   }
 
-  if ("taskOutput" in argument) {
-    return [createTaskOutputEdge(taskId, inputName, argument.taskOutput)];
+  if (!isGraphImplementation(componentSpec.implementation)) {
+    throw new Error("ComponentSpec is not a graph implementation");
   }
 
-  if ("graphInput" in argument) {
-    return [createGraphInputEdge(taskId, inputName, argument.graphInput)];
+  const graphSpec = componentSpec.implementation.graph;
+
+  if (isTaskOutputArgument(argument)) {
+    return [
+      createTaskOutputEdge(taskId, inputName, argument.taskOutput, graphSpec),
+    ];
+  }
+
+  if (isGraphInputArgument(argument)) {
+    return [
+      createGraphInputEdge(
+        taskId,
+        inputName,
+        argument.graphInput,
+        componentSpec,
+      ),
+    ];
   }
 
   if (isSecretArgument(argument) || isDynamicDataArgument(argument)) {
@@ -98,7 +123,21 @@ const createTaskOutputEdge = (
   taskId: string,
   inputName: string,
   taskOutput: TaskOutputArgument["taskOutput"],
+  graphSpec: GraphSpec,
 ): Edge => {
+  const targetTaskSpec = graphSpec.tasks[taskId];
+
+  const sourceTaskSpec = graphSpec.tasks[taskOutput.taskId];
+  const sourceZIndex = extractZIndexFromAnnotations(
+    sourceTaskSpec?.annotations,
+    "task",
+  );
+  const targetZIndex = extractZIndexFromAnnotations(
+    targetTaskSpec.annotations,
+    "task",
+  );
+  const edgeZIndex = Math.max(sourceZIndex, targetZIndex);
+
   return {
     id: `${taskOutput.taskId}_${taskOutput.outputName}-${taskId}_${inputName}`,
     source: taskIdToNodeId(taskOutput.taskId),
@@ -107,6 +146,7 @@ const createTaskOutputEdge = (
     targetHandle: inputNameToNodeId(inputName),
     markerEnd: { type: MarkerType.Arrow },
     type: "customEdge",
+    zIndex: edgeZIndex,
   };
 };
 
@@ -114,7 +154,28 @@ const createGraphInputEdge = (
   taskId: string,
   inputName: string,
   graphInput: GraphInputArgument["graphInput"],
+  componentSpec: ComponentSpec,
 ): Edge => {
+  if (!isGraphImplementation(componentSpec.implementation)) {
+    throw new Error("ComponentSpec is not a graph implementation");
+  }
+
+  const graphSpec = componentSpec.implementation.graph;
+  const targetTaskSpec = graphSpec.tasks[taskId];
+
+  const inputSpec = componentSpec.inputs?.find(
+    (input) => input.name === graphInput.inputName,
+  );
+  const sourceZIndex = extractZIndexFromAnnotations(
+    inputSpec?.annotations,
+    "input",
+  );
+  const targetZIndex = extractZIndexFromAnnotations(
+    targetTaskSpec.annotations,
+    "task",
+  );
+  const edgeZIndex = Math.max(sourceZIndex, targetZIndex);
+
   return {
     id: `Input_${graphInput.inputName}-${taskId}_${inputName}`,
     source: inputNameToNodeId(graphInput.inputName),
@@ -123,13 +184,35 @@ const createGraphInputEdge = (
     targetHandle: inputNameToNodeId(inputName),
     type: "customEdge",
     markerEnd: { type: MarkerType.Arrow },
+    zIndex: edgeZIndex,
   };
 };
 
-const createOutputEdgesFromGraphSpec = (graphSpec: GraphSpec) => {
+const createOutputEdgesFromComponentSpec = (componentSpec: ComponentSpec) => {
+  if (!isGraphImplementation(componentSpec.implementation)) {
+    return [];
+  }
+
+  const graphSpec = componentSpec.implementation.graph;
+
   const outputEdges: Edge[] = Object.entries(graphSpec.outputValues ?? {}).map(
     ([outputName, argument]) => {
       const taskOutput = argument.taskOutput;
+      const sourceTaskSpec = graphSpec.tasks[taskOutput.taskId];
+      const outputSpec = componentSpec.outputs?.find(
+        (output) => output.name === outputName,
+      );
+
+      const sourceZIndex = extractZIndexFromAnnotations(
+        sourceTaskSpec?.annotations,
+        "task",
+      );
+      const targetZIndex = extractZIndexFromAnnotations(
+        outputSpec?.annotations,
+        "output",
+      );
+      const edgeZIndex = Math.max(sourceZIndex, targetZIndex);
+
       const edge: Edge = {
         id: `${taskOutput.taskId}_${taskOutput.outputName}-Output_${outputName}`,
         source: taskIdToNodeId(taskOutput.taskId),
@@ -138,6 +221,7 @@ const createOutputEdgesFromGraphSpec = (graphSpec: GraphSpec) => {
         targetHandle: null,
         type: "customEdge",
         markerEnd: { type: MarkerType.Arrow },
+        zIndex: edgeZIndex,
       };
       return edge;
     },


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

Edges will automatically use the maximum zIndex of the two connected nodes.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

Closes https://github.com/Shopify/oasis-frontend/issues/483

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->
Before:

[edge-bring-to-front-notfixed.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/321a25f3-42ec-4fca-b4b8-31fbe44d40a8.mov" />](https://app.graphite.com/user-attachments/video/321a25f3-42ec-4fca-b4b8-31fbe44d40a8.mov)

After:

[edge-bring-to-front-fixed.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/5ebdffac-cf9b-49cb-9d78-55008ebef0dd.mov" />](https://app.graphite.com/user-attachments/video/5ebdffac-cf9b-49cb-9d78-55008ebef0dd.mov)

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

- Put three tasks on the canvas. Link two of them together.
- The unlinked task "Bring to Front" and drag it over the other two.
- On one of the two linked tasks now "Bring to Front" one of them.
- You should see the task come to front, as well as the edges connected to it.

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
