### PR TITLE
fix: Clashing Queries Keys when Hydrating Component References

### DIFF
--- a/src/hooks/useHydrateComponentReference.test.tsx
+++ b/src/hooks/useHydrateComponentReference.test.tsx
@@ -1,133 +1,388 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderHook, waitFor } from "@testing-library/react";
-import type { ReactNode } from "react";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-
-import type { ComponentReference } from "@/utils/componentSpec";
-
-import { useHydrateComponentReference } from "./useHydrateComponentReference";
-
-// Mock only the hydrateComponentReference function from componentService
-vi.mock("@/services/componentService", () => ({
-  hydrateComponentReference: vi.fn(),
-}));
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { hydrateComponentReference } from "@/services/componentService";
-import type { HydratedComponentReference } from "@/utils/componentSpec";
+import type {
+  ComponentReference,
+  HydratedComponentReference,
+} from "@/utils/componentSpec";
+import * as yamlUtils from "@/utils/yaml";
 
-describe("useHydrateComponentReference", () => {
-  let queryClient: QueryClient;
+import {
+  useGuaranteedHydrateComponentReference,
+  useHydrateComponentReference,
+} from "./useHydrateComponentReference";
 
-  const createWrapper = ({ children }: { children: ReactNode }) => (
+vi.mock("@/services/componentService");
+vi.mock("@/utils/yaml", async () => {
+  const actual = await vi.importActual<typeof yamlUtils>("@/utils/yaml");
+  return {
+    ...actual,
+    componentSpecToText: vi.fn(),
+  };
+});
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
   );
+  Wrapper.displayName = "QueryClientWrapper";
 
+  return Wrapper;
+};
+
+describe("useHydrateComponentReference", () => {
   beforeEach(() => {
-    queryClient = new QueryClient({
-      defaultOptions: {
-        queries: {
-          retry: false,
-        },
-      },
-    });
     vi.clearAllMocks();
+    // Reset all mock implementations
+    vi.mocked(hydrateComponentReference).mockReset();
+    vi.mocked(yamlUtils.componentSpecToText).mockReset();
   });
 
-  afterEach(() => {
-    queryClient.clear();
-  });
-
-  it("should hydrate a component reference with URL", async () => {
+  it("should hydrate component with digest", async () => {
     const mockComponent: ComponentReference = {
-      name: "test-component",
-      url: "https://example.com/component.yaml",
-    };
-
-    const mockHydratedComponent: HydratedComponentReference = {
-      name: mockComponent.name || "test-component",
+      digest: "test-digest-123",
       spec: {
-        name: "test-component",
-        description: "Test component spec",
-        inputs: [],
-        outputs: [],
+        name: "Test Component",
         implementation: {
           container: {
-            image: "test:latest",
-            command: ["echo"],
-            args: ["hello"],
+            image: "test-image:latest",
           },
         },
       },
-      text: "component yaml content",
-      digest: "abc123",
-      url: mockComponent.url,
     };
 
-    vi.mocked(hydrateComponentReference).mockResolvedValue(
-      mockHydratedComponent,
-    );
+    const mockHydratedRef: HydratedComponentReference = {
+      digest: "test-digest-123",
+      name: "Test Component",
+      url: "https://example.com/component.yaml",
+      spec: mockComponent.spec!,
+      text: "name: Test Component\nimplementation:\n  container:\n    image: test-image:latest",
+    };
+
+    vi.mocked(hydrateComponentReference).mockResolvedValue(mockHydratedRef);
 
     const { result } = renderHook(
       () => useHydrateComponentReference(mockComponent),
-      { wrapper: createWrapper },
+      {
+        wrapper: createWrapper(),
+      },
     );
 
     await waitFor(() => {
-      expect(result.current).toEqual(mockHydratedComponent);
+      expect(result.current).toEqual(mockHydratedRef);
     });
 
     expect(hydrateComponentReference).toHaveBeenCalledWith(mockComponent);
-    expect(hydrateComponentReference).toHaveBeenCalledTimes(1);
+    // When digest is present, componentSpecToText should NOT be called
+    expect(yamlUtils.componentSpecToText).not.toHaveBeenCalled();
   });
 
-  it("should cache the result for 1 hour", async () => {
+  it("should hydrate component with URL", async () => {
     const mockComponent: ComponentReference = {
-      name: "cached-component",
-      digest: "cache-test",
-    };
-
-    const mockHydratedComponent: HydratedComponentReference = {
-      name: mockComponent.name || "cached-component",
-      digest: mockComponent.digest || "cache-test",
+      url: "https://example.com/component.yaml",
       spec: {
-        name: "cached",
-        inputs: [],
-        outputs: [],
+        name: "Test Component",
         implementation: {
           container: {
-            image: "test:latest",
-            command: ["cached"],
+            image: "test-image:latest",
           },
         },
       },
-      text: "cached content",
     };
 
-    vi.mocked(hydrateComponentReference).mockResolvedValue(
-      mockHydratedComponent,
+    const mockHydratedRef: HydratedComponentReference = {
+      digest: "computed-digest",
+      name: "Test Component",
+      url: "https://example.com/component.yaml",
+      spec: mockComponent.spec!,
+      text: "name: Test Component\nimplementation:\n  container:\n    image: test-image:latest",
+    };
+
+    vi.mocked(hydrateComponentReference).mockResolvedValue(mockHydratedRef);
+
+    const { result } = renderHook(
+      () => useHydrateComponentReference(mockComponent),
+      {
+        wrapper: createWrapper(),
+      },
     );
 
-    // First render
+    await waitFor(() => {
+      expect(result.current).toEqual(mockHydratedRef);
+    });
+
+    // When URL is present, componentSpecToText should NOT be called
+    expect(yamlUtils.componentSpecToText).not.toHaveBeenCalled();
+  });
+
+  it("should hydrate component with inline spec only", async () => {
+    const mockComponent: ComponentReference = {
+      spec: {
+        name: "Inline Component",
+        description: "Component with only inline spec",
+        implementation: {
+          container: {
+            image: "test-image:latest",
+            command: ["python", "script.py"],
+          },
+        },
+      },
+    };
+
+    // Mock componentSpecToText to return a predictable string
+    vi.mocked(yamlUtils.componentSpecToText).mockReturnValue(
+      "inline-component-yaml",
+    );
+
+    const mockHydratedRef: HydratedComponentReference = {
+      digest: "generated-digest",
+      name: "Inline Component",
+      spec: mockComponent.spec!,
+      text: "inline-component-yaml",
+    };
+
+    vi.mocked(hydrateComponentReference).mockResolvedValue(mockHydratedRef);
+
+    const { result } = renderHook(
+      () => useHydrateComponentReference(mockComponent),
+      {
+        wrapper: createWrapper(),
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current).toEqual(mockHydratedRef);
+    });
+
+    // Should have called componentSpecToText for inline spec
+    expect(yamlUtils.componentSpecToText).toHaveBeenCalledWith(
+      mockComponent.spec,
+    );
+  });
+
+  it("should use different cache keys for different inline specs", async () => {
+    const component1: ComponentReference = {
+      spec: {
+        name: "Component A",
+        description: "First component",
+        implementation: {
+          container: {
+            image: "component-a:latest",
+          },
+        },
+      },
+    };
+
+    const component2: ComponentReference = {
+      spec: {
+        name: "Component B",
+        description: "Second component",
+        implementation: {
+          container: {
+            image: "component-b:latest",
+          },
+        },
+      },
+    };
+
+    // Mock componentSpecToText to return DIFFERENT strings for different specs
+    vi.mocked(yamlUtils.componentSpecToText).mockImplementation((spec) => {
+      if (spec.name === "Component A") {
+        return "component-a-yaml";
+      } else if (spec.name === "Component B") {
+        return "component-b-yaml";
+      }
+      return "unknown-yaml";
+    });
+
+    const hydratedRef1: HydratedComponentReference = {
+      digest: "digest-a",
+      name: "Component A",
+      spec: component1.spec!,
+      text: "component-a-yaml",
+    };
+
+    const hydratedRef2: HydratedComponentReference = {
+      digest: "digest-b",
+      name: "Component B",
+      spec: component2.spec!,
+      text: "component-b-yaml",
+    };
+
+    vi.mocked(hydrateComponentReference).mockImplementation(async (ref) => {
+      if (ref.spec?.name === "Component A") {
+        return hydratedRef1;
+      } else if (ref.spec?.name === "Component B") {
+        return hydratedRef2;
+      }
+      return null;
+    });
+
+    const wrapper = createWrapper();
+
     const { result: result1 } = renderHook(
-      () => useHydrateComponentReference(mockComponent),
-      { wrapper: createWrapper },
+      () => useHydrateComponentReference(component1),
+      { wrapper },
     );
 
-    await waitFor(() => {
-      expect(result1.current).toEqual(mockHydratedComponent);
-    });
-
-    // Second render with same component
     const { result: result2 } = renderHook(
-      () => useHydrateComponentReference(mockComponent),
-      { wrapper: createWrapper },
+      () => useHydrateComponentReference(component2),
+      { wrapper },
     );
 
     await waitFor(() => {
-      expect(result2.current).toEqual(mockHydratedComponent);
+      expect(result1.current).toEqual(hydratedRef1);
+      expect(result2.current).toEqual(hydratedRef2);
     });
 
-    // Should only be called once due to caching
+    // Verify that hydrateComponentReference was called twice (different cache keys)
+    expect(hydrateComponentReference).toHaveBeenCalledTimes(2);
+  });
+
+  it("should use same cache key for identical inline specs", async () => {
+    const component1: ComponentReference = {
+      spec: {
+        name: "Same Component",
+        description: "Identical spec",
+        implementation: {
+          container: {
+            image: "same-image:latest",
+          },
+        },
+      },
+    };
+
+    const component2: ComponentReference = {
+      spec: {
+        name: "Same Component",
+        description: "Identical spec",
+        implementation: {
+          container: {
+            image: "same-image:latest",
+          },
+        },
+      },
+    };
+
+    // Mock componentSpecToText to return SAME string for identical specs
+    vi.mocked(yamlUtils.componentSpecToText).mockReturnValue(
+      "identical-yaml-string",
+    );
+
+    const hydratedRef: HydratedComponentReference = {
+      digest: "digest-same",
+      name: "Same Component",
+      spec: component1.spec!,
+      text: "identical-yaml-string",
+    };
+
+    vi.mocked(hydrateComponentReference).mockResolvedValue(hydratedRef);
+
+    const wrapper = createWrapper();
+
+    const { result: result1 } = renderHook(
+      () => useHydrateComponentReference(component1),
+      { wrapper },
+    );
+
+    const { result: result2 } = renderHook(
+      () => useHydrateComponentReference(component2),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result1.current).toEqual(hydratedRef);
+      expect(result2.current).toEqual(hydratedRef);
+    });
+
+    // Should only call hydration once (same cache key)
     expect(hydrateComponentReference).toHaveBeenCalledTimes(1);
+    // componentSpecToText might be called twice (once per hook call), but the result is the same
+    expect(yamlUtils.componentSpecToText).toHaveBeenCalled();
+  });
+
+  it("should handle component with text field", async () => {
+    const mockComponent: ComponentReference = {
+      text: "name: Text Component\nimplementation:\n  container:\n    image: text-image:latest",
+    };
+
+    const mockHydratedRef: HydratedComponentReference = {
+      digest: "digest-from-text",
+      name: "Text Component",
+      spec: {
+        name: "Text Component",
+        implementation: {
+          container: {
+            image: "text-image:latest",
+          },
+        },
+      },
+      text: mockComponent.text!,
+    };
+
+    vi.mocked(hydrateComponentReference).mockResolvedValue(mockHydratedRef);
+
+    const { result } = renderHook(
+      () => useHydrateComponentReference(mockComponent),
+      {
+        wrapper: createWrapper(),
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current).toEqual(mockHydratedRef);
+    });
+
+    // Should NOT call componentSpecToText when text is present
+    expect(yamlUtils.componentSpecToText).not.toHaveBeenCalled();
+  });
+});
+
+describe("useGuaranteedHydrateComponentReference", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(hydrateComponentReference).mockReset();
+  });
+
+  it("should return hydrated component when successful", async () => {
+    const mockComponent: ComponentReference = {
+      digest: "test-digest",
+      spec: {
+        name: "Test Component",
+        implementation: {
+          container: {
+            image: "test-image:latest",
+          },
+        },
+      },
+    };
+
+    const mockHydratedRef: HydratedComponentReference = {
+      digest: "test-digest",
+      name: "Test Component",
+      spec: mockComponent.spec!,
+      text: "name: Test Component\nimplementation:\n  container:\n    image: test-image:latest",
+    };
+
+    vi.mocked(hydrateComponentReference).mockResolvedValue(mockHydratedRef);
+
+    const { result } = renderHook(
+      () => useGuaranteedHydrateComponentReference(mockComponent),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => {
+      expect(result.current).toEqual(mockHydratedRef);
+    });
   });
 });


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

Fixes an unlikely bug that causes severe rendering issues with tasks.

The bug occurs when multiple component references in the spec are lacking both a `digest` and `url`. This, in turn, results in a fallback query key, which leads to all tasks trying to hydrate their component reference from the same cache. This, finally, causes a myriad of issues, such as edges not rendering, and tasks to change whenever clicking on the "Details" tab.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

The bug in action:

[task-info-mixed-up.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/c6bf99ad-21d1-4108-b8da-1a6807107d53.mov" />](https://app.graphite.com/user-attachments/video/c6bf99ad-21d1-4108-b8da-1a6807107d53.mov)

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->
before:

![image.png](https://app.graphite.com/user-attachments/assets/02fa4299-a442-4bc0-8e7b-b9446872a3cd.png)

after:

![image.png](https://app.graphite.com/user-attachments/assets/1f1f1836-7ebc-4a62-8d2b-dd4379337b5f.png)

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->
1. Clone this pipeline: https://oasis.shopify.io/runs/019c2f50e081f2769823 and download the yaml
2. Import the pipeline into your local dev with this branch running
3. The pipeline should be fixed.
4. Confirm that nothing else broke (i.e. other pipelines still work as expected)

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
