### PR TITLE
feat: secrets management ui

### DIFF
--- a/src/components/layout/AppMenu.tsx
+++ b/src/components/layout/AppMenu.tsx
@@ -23,6 +23,7 @@ import { DOCUMENTATION_URL, TOP_NAV_HEIGHT } from "@/utils/constants";
 import BackendStatus from "../shared/BackendStatus";
 import TooltipButton from "../shared/Buttons/TooltipButton";
 import NewPipelineButton from "../shared/NewPipelineButton";
+import { ManageSecretsButton } from "../shared/SecretsManagement/ManageSecretsButton";
 import { PersonalPreferences } from "../shared/Settings/PersonalPreferences";
 
 const AppMenu = () => {
@@ -72,6 +73,7 @@ const AppMenu = () => {
           <InlineStack gap="2" wrap="nowrap">
             <BackendStatus />
             <PersonalPreferences />
+            <ManageSecretsButton />
             {documentationButton}
             {requiresAuthorization && <TopBarAuthentication />}
           </InlineStack>

--- a/src/components/shared/SecretsManagement/ManageSecretsButton.tsx
+++ b/src/components/shared/SecretsManagement/ManageSecretsButton.tsx
@@ -1,0 +1,23 @@
+import { Icon } from "@/components/ui/icon";
+
+import TooltipButton from "../Buttons/TooltipButton";
+import { useFlagValue } from "../Settings/useFlags";
+import { ManageSecretsDialog } from "./ManageSecretsDialog";
+
+export function ManageSecretsButton() {
+  const isSecretsEnabled = useFlagValue("secrets");
+
+  if (!isSecretsEnabled) {
+    return null;
+  }
+
+  return (
+    <ManageSecretsDialog
+      trigger={
+        <TooltipButton tooltip="Manage Secrets">
+          <Icon name="Lock" />
+        </TooltipButton>
+      }
+    />
+  );
+}

--- a/src/components/shared/SecretsManagement/ManageSecretsDialog.tsx
+++ b/src/components/shared/SecretsManagement/ManageSecretsDialog.tsx
@@ -1,0 +1,179 @@
+import { type ReactNode, useState } from "react";
+
+import { withSuspenseWrapper } from "@/components/shared/SuspenseWrapper";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Icon } from "@/components/ui/icon";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Separator } from "@/components/ui/separator";
+import { Spinner } from "@/components/ui/spinner";
+import useToastNotification from "@/hooks/useToastNotification";
+
+import { AddSecretForm } from "./components/AddSecretForm";
+import { SecretsList } from "./components/SecretsList";
+import type { Secret } from "./types";
+
+type DialogMode = "list" | "add" | "replace";
+
+interface ManageSecretsDialogProps {
+  defaultMode?: DialogMode;
+  trigger?: ReactNode;
+}
+
+interface ManageSecretsDialogContentProps {
+  defaultMode: DialogMode;
+}
+
+function ManageSecretsDialogContentSkeleton() {
+  return <Spinner size={10} />;
+}
+
+function ManageSecretsDialogContentInternal({
+  defaultMode = "list",
+}: ManageSecretsDialogContentProps) {
+  const notify = useToastNotification();
+
+  const [mode, setMode] = useState<DialogMode>(defaultMode);
+  const [secretToReplace, setSecretToReplace] = useState<Secret | undefined>();
+
+  const handleAddSuccess = () => {
+    notify("Secret added successfully", "success");
+    setMode("list");
+  };
+
+  const handleReplaceSuccess = () => {
+    notify(`Secret "${secretToReplace?.name}" updated successfully`, "success");
+    setSecretToReplace(undefined);
+    setMode("list");
+  };
+
+  const handleRemoveSuccess = () => {
+    notify("Secret removed", "success");
+  };
+
+  const handleStartReplace = (secret: Secret) => {
+    setSecretToReplace(secret);
+    setMode("replace");
+  };
+
+  const handleCancelForm = () => {
+    setSecretToReplace(undefined);
+    setMode("list");
+  };
+
+  return (
+    <DialogContent
+      data-testid="manage-secrets-dialog"
+      key="manage-secrets-dialog"
+    >
+      {mode === "add" && (
+        <>
+          <DialogHeader>
+            <DialogTitle>
+              <InlineStack align="start" gap="1" blockAlign="center">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setMode("list")}
+                >
+                  <Icon name="ArrowLeft" />
+                </Button>
+                Add Secret
+              </InlineStack>
+            </DialogTitle>
+          </DialogHeader>
+          <AddSecretForm
+            onSuccess={handleAddSuccess}
+            onCancel={handleCancelForm}
+          />
+        </>
+      )}
+
+      {mode === "replace" && secretToReplace && (
+        <>
+          <DialogHeader>
+            <DialogTitle>
+              <InlineStack align="start" gap="1" blockAlign="center">
+                <Button variant="ghost" size="sm" onClick={handleCancelForm}>
+                  <Icon name="ArrowLeft" />
+                </Button>
+                Replace Secret
+              </InlineStack>
+            </DialogTitle>
+          </DialogHeader>
+          <DialogDescription>
+            {`Update the value for secret "${secretToReplace.name}"`}
+          </DialogDescription>
+          <AddSecretForm
+            existingSecret={secretToReplace}
+            onSuccess={handleReplaceSuccess}
+            onCancel={handleCancelForm}
+          />
+        </>
+      )}
+
+      {mode === "list" && (
+        <>
+          <DialogHeader>
+            <DialogTitle>Manage Secrets</DialogTitle>
+          </DialogHeader>
+          <DialogDescription>
+            Manage your secrets for use in pipelines. Secret values are stored
+            securely and injected at runtime.
+          </DialogDescription>
+          <BlockStack gap="4">
+            <SecretsList
+              onReplace={handleStartReplace}
+              onRemoveSuccess={handleRemoveSuccess}
+            />
+            <Separator />
+            <BlockStack gap="1" align="end">
+              <Button variant="secondary" onClick={() => setMode("add")}>
+                <InlineStack align="center" gap="1">
+                  <Icon name="Plus" />
+                  Add Secret
+                </InlineStack>
+              </Button>
+            </BlockStack>
+          </BlockStack>
+        </>
+      )}
+    </DialogContent>
+  );
+}
+
+const ManageSecretsDialogContent = withSuspenseWrapper(
+  ManageSecretsDialogContentInternal,
+  ManageSecretsDialogContentSkeleton,
+);
+
+export function ManageSecretsDialog({
+  defaultMode = "list",
+  trigger,
+}: ManageSecretsDialogProps) {
+  const [open, setOpen] = useState(false);
+
+  const handleDialogOpenChange = (open: boolean) => {
+    setOpen(open);
+  };
+
+  const defaultTrigger = (
+    <Button variant="outline" size="xs">
+      Manage Secrets
+    </Button>
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={handleDialogOpenChange}>
+      <DialogTrigger asChild>{trigger ?? defaultTrigger}</DialogTrigger>
+      {open && <ManageSecretsDialogContent defaultMode={defaultMode} />}
+    </Dialog>
+  );
+}

--- a/src/components/shared/SecretsManagement/components/AddSecretButton.tsx
+++ b/src/components/shared/SecretsManagement/components/AddSecretButton.tsx
@@ -1,0 +1,41 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+import useToastNotification from "@/hooks/useToastNotification";
+
+import { addSecret, SecretsQueryKeys } from "../secretsStorage";
+import type { Secret } from "../types";
+
+interface AddSecretButtonProps {
+  secret: Pick<Secret, "name" | "value">;
+  disabled?: boolean;
+  onSuccess: () => void;
+}
+
+export function AddSecretButton({
+  secret,
+  disabled,
+  onSuccess,
+}: AddSecretButtonProps) {
+  const notify = useToastNotification();
+  const queryClient = useQueryClient();
+
+  const { mutate: saveSecret, isPending } = useMutation({
+    mutationFn: () => addSecret(secret.name, secret.value),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: SecretsQueryKeys.All() });
+      onSuccess();
+    },
+    onError: () => {
+      notify("Failed to add secret", "error");
+    },
+  });
+
+  return (
+    <Button onClick={() => saveSecret()} disabled={disabled || isPending}>
+      Add Secret
+      {isPending && <Spinner />}
+    </Button>
+  );
+}

--- a/src/components/shared/SecretsManagement/components/AddSecretForm.tsx
+++ b/src/components/shared/SecretsManagement/components/AddSecretForm.tsx
@@ -1,0 +1,157 @@
+import { type ChangeEvent, useReducer } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
+import { cn } from "@/lib/utils";
+
+import { isValidSecretName, isValidSecretValue, type Secret } from "../types";
+import { AddSecretButton } from "./AddSecretButton";
+import { UpdateSecretButton } from "./UpdateSecretButton";
+
+interface AddSecretFormState {
+  name: string;
+  value: string;
+  nameError: string | null;
+  valueError: string | null;
+}
+
+type AddSecretFormAction =
+  | { type: "SET_NAME"; payload: string }
+  | { type: "SET_VALUE"; payload: string }
+  | { type: "RESET" };
+
+function formReducer(
+  state: AddSecretFormState,
+  action: AddSecretFormAction,
+): AddSecretFormState {
+  switch (action.type) {
+    case "SET_NAME": {
+      const name = action.payload;
+      const nameError =
+        name.length > 0 && !isValidSecretName(name)
+          ? "Secret name cannot be empty"
+          : null;
+      return { ...state, name, nameError };
+    }
+    case "SET_VALUE": {
+      const value = action.payload;
+      const valueError =
+        value.length > 0 && !isValidSecretValue(value)
+          ? "Secret value cannot be empty"
+          : null;
+      return { ...state, value, valueError };
+    }
+    case "RESET":
+      return initialFormState;
+    default:
+      return state;
+  }
+}
+
+const initialFormState: AddSecretFormState = {
+  name: "",
+  value: "",
+  nameError: null,
+  valueError: null,
+};
+
+interface AddSecretFormProps {
+  existingSecret?: Secret;
+  onSuccess: () => void;
+  onCancel: () => void;
+}
+
+export function AddSecretForm({
+  existingSecret,
+  onSuccess,
+  onCancel,
+}: AddSecretFormProps) {
+  const [state, dispatch] = useReducer(formReducer, {
+    ...initialFormState,
+    name: existingSecret?.name ?? "",
+    value: "",
+  });
+
+  const handleNameChange = (e: ChangeEvent<HTMLInputElement>) => {
+    dispatch({ type: "SET_NAME", payload: e.target.value });
+  };
+
+  const handleValueChange = (e: ChangeEvent<HTMLInputElement>) => {
+    dispatch({ type: "SET_VALUE", payload: e.target.value });
+  };
+
+  const isFormValid =
+    isValidSecretName(state.name) &&
+    isValidSecretValue(state.value) &&
+    !state.nameError &&
+    !state.valueError;
+
+  const isReplace = !!existingSecret;
+
+  return (
+    <BlockStack gap="4">
+      <BlockStack gap="2">
+        <Label htmlFor="secret-name">Secret Name</Label>
+        <Input
+          id="secret-name"
+          placeholder="e.g., API_KEY"
+          value={state.name}
+          onChange={handleNameChange}
+          disabled={isReplace}
+          aria-invalid={!!state.nameError}
+          className={cn(state.nameError && "border-destructive")}
+        />
+        {state.nameError && (
+          <Text size="xs" tone="critical">
+            {state.nameError}
+          </Text>
+        )}
+      </BlockStack>
+
+      <BlockStack gap="2">
+        <Label htmlFor="secret-value">
+          {isReplace ? "New Secret Value" : "Secret Value"}
+        </Label>
+        <Input
+          id="secret-value"
+          type="password"
+          placeholder="Enter secret value..."
+          value={state.value}
+          onChange={handleValueChange}
+          aria-invalid={!!state.valueError}
+          className={cn(state.valueError && "border-destructive")}
+        />
+        {state.valueError && (
+          <Text size="xs" tone="critical">
+            {state.valueError}
+          </Text>
+        )}
+        <Text size="xs" tone="subdued">
+          The secret value is stored securely and never displayed.
+        </Text>
+      </BlockStack>
+
+      <InlineStack gap="2" align="end" fill>
+        <Button variant="outline" onClick={onCancel}>
+          Cancel
+        </Button>
+        {existingSecret ? (
+          <UpdateSecretButton
+            secret={{ id: existingSecret.id, value: state.value }}
+            disabled={!isFormValid}
+            onSuccess={onSuccess}
+          />
+        ) : (
+          <AddSecretButton
+            secret={{ name: state.name.trim(), value: state.value }}
+            disabled={!isFormValid}
+            onSuccess={onSuccess}
+          />
+        )}
+      </InlineStack>
+    </BlockStack>
+  );
+}

--- a/src/components/shared/SecretsManagement/components/RemoveSecretButton.tsx
+++ b/src/components/shared/SecretsManagement/components/RemoveSecretButton.tsx
@@ -1,0 +1,44 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icon";
+import useToastNotification from "@/hooks/useToastNotification";
+
+import { removeSecret, SecretsQueryKeys } from "../secretsStorage";
+import type { Secret } from "../types";
+
+interface RemoveSecretButtonProps {
+  secret: Pick<Secret, "id">;
+  onSuccess?: () => void;
+}
+
+export function RemoveSecretButton({
+  secret,
+  onSuccess,
+}: RemoveSecretButtonProps) {
+  const notify = useToastNotification();
+  const queryClient = useQueryClient();
+
+  const { mutate: removeSecretMutation, isPending } = useMutation({
+    mutationFn: () => removeSecret(secret.id),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: SecretsQueryKeys.All() });
+      onSuccess?.();
+    },
+    onError: () => {
+      notify("Failed to remove secret", "error");
+    },
+  });
+
+  return (
+    <Button
+      variant="ghost"
+      size="xs"
+      onClick={() => removeSecretMutation()}
+      disabled={isPending}
+      className="text-destructive hover:text-destructive"
+    >
+      <Icon name="Trash2" size="sm" />
+    </Button>
+  );
+}

--- a/src/components/shared/SecretsManagement/components/SecretsList.tsx
+++ b/src/components/shared/SecretsManagement/components/SecretsList.tsx
@@ -1,0 +1,91 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icon";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Text } from "@/components/ui/typography";
+import { formatRelativeTime } from "@/utils/date";
+
+import { withSuspenseWrapper } from "../../SuspenseWrapper";
+import { getSecrets, SecretsQueryKeys } from "../secretsStorage";
+import type { Secret } from "../types";
+import { RemoveSecretButton } from "./RemoveSecretButton";
+
+interface SecretsListProps {
+  onReplace: (secret: Secret) => void;
+  onRemoveSuccess?: () => void;
+}
+
+function SecretsListInternal({ onReplace, onRemoveSuccess }: SecretsListProps) {
+  const { data: secrets } = useSuspenseQuery({
+    queryKey: SecretsQueryKeys.All(),
+    queryFn: getSecrets,
+  });
+
+  if (secrets.length === 0) {
+    return (
+      <BlockStack align="center" className="py-8">
+        <Icon name="Lock" size="lg" className="text-subdued" />
+        <Text tone="subdued">No secrets configured</Text>
+        <Text size="xs" tone="subdued">
+          Add a secret to get started
+        </Text>
+      </BlockStack>
+    );
+  }
+
+  return (
+    <ScrollArea className="w-full min-h-[100px] max-h-[300px]" type="always">
+      <BlockStack gap="2">
+        {secrets.map((secret) => (
+          <InlineStack
+            key={secret.id}
+            align="space-between"
+            gap="2"
+            className="w-full pr-3 py-1.5 hover:bg-gray-50 rounded-md pl-1"
+          >
+            <InlineStack gap="2" blockAlign="center" wrap="nowrap">
+              <Icon name="Lock" size="lg" className="shrink-0" />
+              <BlockStack gap="0">
+                <Text size="sm" weight="semibold">
+                  {secret.name}
+                </Text>
+                <Text size="xs" tone="subdued">
+                  Added {formatRelativeTime(secret.createdAt)}
+                </Text>
+              </BlockStack>
+            </InlineStack>
+
+            <InlineStack gap="1">
+              <Button
+                variant="ghost"
+                size="xs"
+                onClick={() => onReplace(secret)}
+              >
+                <Icon name="Pencil" size="sm" />
+              </Button>
+              <RemoveSecretButton secret={secret} onSuccess={onRemoveSuccess} />
+            </InlineStack>
+          </InlineStack>
+        ))}
+      </BlockStack>
+    </ScrollArea>
+  );
+}
+
+function SecretsListSkeleton() {
+  return (
+    <BlockStack align="start" gap="3" fill>
+      <Skeleton size="full" />
+      <Skeleton size="full" />
+      <Skeleton size="full" />
+    </BlockStack>
+  );
+}
+
+export const SecretsList = withSuspenseWrapper(
+  SecretsListInternal,
+  SecretsListSkeleton,
+);

--- a/src/components/shared/SecretsManagement/components/UpdateSecretButton.tsx
+++ b/src/components/shared/SecretsManagement/components/UpdateSecretButton.tsx
@@ -1,0 +1,44 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+import useToastNotification from "@/hooks/useToastNotification";
+
+import { SecretsQueryKeys, updateSecret } from "../secretsStorage";
+import type { Secret } from "../types";
+
+interface UpdateSecretButtonProps {
+  secret: Pick<Secret, "id" | "value">;
+  disabled?: boolean;
+  onSuccess: () => void;
+}
+
+export function UpdateSecretButton({
+  secret,
+  disabled,
+  onSuccess,
+}: UpdateSecretButtonProps) {
+  const notify = useToastNotification();
+  const queryClient = useQueryClient();
+
+  const { mutate: updateSecretMutation, isPending } = useMutation({
+    mutationFn: () => updateSecret(secret.id, { value: secret.value }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: SecretsQueryKeys.All() });
+      onSuccess();
+    },
+    onError: () => {
+      notify("Failed to update secret", "error");
+    },
+  });
+
+  return (
+    <Button
+      onClick={() => updateSecretMutation()}
+      disabled={disabled || isPending}
+    >
+      Update Secret
+      {isPending && <Spinner />}
+    </Button>
+  );
+}

--- a/src/components/shared/SecretsManagement/secretsStorage.ts
+++ b/src/components/shared/SecretsManagement/secretsStorage.ts
@@ -1,0 +1,120 @@
+import type { Secret } from "./types";
+
+/**
+ * In-memory mocked storage for secrets.
+ * This will be replaced with an async API storage layer later.
+ */
+
+// In-memory storage
+const secretsStore = new Map<string, Secret>();
+
+// Subscribers for reactive updates
+type Subscriber = () => void;
+const subscribers = new Set<Subscriber>();
+
+function notifySubscribers() {
+  subscribers.forEach((callback) => callback());
+}
+
+/**
+ * Generates a unique ID for a new secret.
+ */
+function generateId(): string {
+  return `secret_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
+}
+
+/**
+ * Gets all secrets from the store.
+ * Returns a promise to simulate async API behavior.
+ */
+export async function getSecrets(): Promise<Secret[]> {
+  // Simulate network delay
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  return Array.from(secretsStore.values()).sort(
+    (a, b) => b.createdAt.getTime() - a.createdAt.getTime(),
+  );
+}
+
+/**
+ * Adds a new secret to the store.
+ */
+export async function addSecret(name: string, value: string): Promise<Secret> {
+  await new Promise((resolve) => setTimeout(resolve, 100));
+
+  // Check for duplicate names
+  const existing = Array.from(secretsStore.values()).find(
+    (s) => s.name === name,
+  );
+  if (existing) {
+    throw new Error(`A secret with name "${name}" already exists`);
+  }
+
+  const secret: Secret = {
+    id: generateId(),
+    name,
+    value,
+    createdAt: new Date(),
+  };
+
+  secretsStore.set(secret.id, secret);
+  notifySubscribers();
+
+  return secret;
+}
+
+/**
+ * Updates an existing secret.
+ */
+export async function updateSecret(
+  id: string,
+  updates: Partial<Pick<Secret, "name" | "value">>,
+): Promise<Secret> {
+  await new Promise((resolve) => setTimeout(resolve, 100));
+
+  const existing = secretsStore.get(id);
+  if (!existing) {
+    throw new Error(`Secret with id "${id}" not found`);
+  }
+
+  // Check for name conflicts if name is being updated
+  if (updates.name && updates.name !== existing.name) {
+    const nameConflict = Array.from(secretsStore.values()).find(
+      (s) => s.name === updates.name && s.id !== id,
+    );
+    if (nameConflict) {
+      throw new Error(`A secret with name "${updates.name}" already exists`);
+    }
+  }
+
+  const updated: Secret = {
+    ...existing,
+    ...updates,
+  };
+
+  secretsStore.set(id, updated);
+  notifySubscribers();
+
+  return updated;
+}
+
+/**
+ * Removes a secret from the store.
+ */
+export async function removeSecret(id: string): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 100));
+
+  if (!secretsStore.has(id)) {
+    throw new Error(`Secret with id "${id}" not found`);
+  }
+
+  secretsStore.delete(id);
+  notifySubscribers();
+}
+
+/**
+ * Query keys for React Query.
+ */
+export const SecretsQueryKeys = {
+  All: () => ["secrets"] as const,
+  Id: (id: string) => ["secrets", id] as const,
+} as const;

--- a/src/components/shared/SecretsManagement/types.ts
+++ b/src/components/shared/SecretsManagement/types.ts
@@ -1,0 +1,23 @@
+/**
+ * Represents a secret stored in the secrets management system.
+ */
+export interface Secret {
+  id: string;
+  name: string;
+  value: string;
+  createdAt: Date;
+}
+
+/**
+ * Checks if a secret name is valid.
+ */
+export function isValidSecretName(name: string): boolean {
+  return name.trim().length > 0;
+}
+
+/**
+ * Checks if a secret value is valid.
+ */
+export function isValidSecretValue(value: string): boolean {
+  return value.length > 0;
+}

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -66,6 +66,14 @@ export const ExistingFlags: ConfigFlags = {
     category: "beta",
   },
 
+  ["secrets"]: {
+    name: "Secrets",
+    description:
+      "Enable the Secrets feature. This will allow you to store secrets, tokens, api keys and other sensitive information in secured way.",
+    default: false,
+    category: "beta",
+  },
+
   ["pipeline-run-filters-bar"]: {
     name: "Pipeline run filters bar (UI only)",
     description:

--- a/src/utils/componentSpec.ts
+++ b/src/utils/componentSpec.ts
@@ -398,7 +398,31 @@ export interface TaskOutputArgument {
     type?: TypeSpecType;
   };
 }
-export type ArgumentType = string | GraphInputArgument | TaskOutputArgument;
+/**
+ * Reference to a secret by name.
+ */
+interface SecretReference {
+  name: string;
+}
+/**
+ * Represents the component argument value that comes from a secret.
+ */
+interface SecretArgument {
+  /**
+   * References a secret by name.
+   */
+  secret: SecretReference;
+}
+
+export interface DynamicDataArgument {
+  dynamicData: SecretArgument;
+}
+
+export type ArgumentType =
+  | string
+  | GraphInputArgument
+  | TaskOutputArgument
+  | DynamicDataArgument;
 
 /**
  * Pair of operands for a binary operation.


### PR DESCRIPTION
## Description

Added a secrets management system that allows users to securely store and use sensitive information like API keys in pipelines. The implementation includes:

- A secrets management dialog accessible from the app menu
- Ability to add, update, and remove secrets
- A secret selection dialog for using secrets in pipeline arguments
- In-memory storage layer (to be replaced with a proper API later)
- Feature flag control to enable/disable the secrets functionality

## Related Issue and Pull requests

## Type of Change

- [x] New feature
- [x] Improvement

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Screenshots (if applicable)

[Secrets management UI demo.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/cb9ee250-15c6-4014-b263-f5f6b0caa4f4.mov" />](https://app.graphite.com/user-attachments/video/cb9ee250-15c6-4014-b263-f5f6b0caa4f4.mov)



## Test Instructions

1. Enable the "secrets" feature flag
2. Click the lock icon in the top navigation bar to open the secrets management dialog
3. Add a new secret with a name and value
4. Verify you can update and delete secrets

## Additional Comments

The current implementation uses an in-memory storage layer with simulated async behavior. This will be replaced with a proper API integration in a future PR.