### PR TITLE
feat: use secrets in canvas tasks and arguments editor

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/utils.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/utils.ts
@@ -2,6 +2,7 @@ import type { ArgumentInput } from "@/types/arguments";
 import {
   type ArgumentType,
   type GraphSpec,
+  isSecretArgument,
   type TaskSpec,
   type TypeSpecType,
 } from "@/utils/componentSpec";
@@ -70,6 +71,10 @@ export const getInputValue = (argumentInput: ArgumentInput) => {
 
   if (argument === undefined) {
     return argumentInput.inputSpec.default;
+  }
+
+  if (isSecretArgument(argument)) {
+    return "";
   }
 
   if (isScalar(argument)) {

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/Handles.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/Handles.tsx
@@ -2,10 +2,12 @@ import { Handle, Position, useConnection } from "@xyflow/react";
 import {
   type MouseEvent as ReactMouseEvent,
   useCallback,
+  useMemo,
   useState,
 } from "react";
 import { useEffect, useRef } from "react";
 
+import { Icon } from "@/components/ui/icon";
 import {
   Tooltip,
   TooltipContent,
@@ -14,12 +16,18 @@ import {
 import { useHandleEdgeSelection } from "@/hooks/useHandleEdgeSelection";
 import { cn } from "@/lib/utils";
 import { useTaskNode } from "@/providers/TaskNodeProvider";
-import type { InputSpec, OutputSpec } from "@/utils/componentSpec";
+import {
+  type ArgumentType,
+  type InputSpec,
+  isSecretArgument,
+  type OutputSpec,
+} from "@/utils/componentSpec";
 
 type InputHandleProps = {
   input: InputSpec;
   invalid: boolean;
   value?: string;
+  rawValue?: ArgumentType;
   highlight?: boolean;
   onLabelClick?: (e: ReactMouseEvent<HTMLDivElement>) => void;
   onHandleSelectionChange?: (key: string, selected: boolean) => void;
@@ -29,6 +37,7 @@ export const InputHandle = ({
   input,
   invalid,
   value,
+  rawValue,
   highlight,
   onLabelClick,
   onHandleSelectionChange,
@@ -52,6 +61,8 @@ export const InputHandle = ({
   const missing = invalid ? "bg-red-700!" : "bg-gray-500!";
   const hasValue = value !== undefined && value !== null;
   const hasDefault = input.default !== undefined && input.default !== "";
+
+  const isSecret = useMemo(() => isSecretArgument(rawValue), [rawValue]);
 
   const handleHandleClick = useCallback(
     (e: ReactMouseEvent<HTMLDivElement>) => {
@@ -184,15 +195,23 @@ export const InputHandle = ({
           </div>
           {(hasValue || hasDefault) && (
             <div
-              className="flex w-fit max-w-1/2 min-w-0"
+              className="flex w-fit max-w-1/2 min-w-0 items-center gap-1"
               data-testid={`input-handle-value-${input.name}`}
             >
+              {isSecret && (
+                <Icon
+                  name="Lock"
+                  size="xs"
+                  className="text-amber-600 shrink-0"
+                />
+              )}
               <Tooltip>
                 <TooltipTrigger asChild>
                   <div
                     className={cn(
                       "text-xs text-gray-800! truncate inline-block text-right pr-2",
                       !hasValue && "text-gray-400! italic",
+                      isSecret && "text-amber-700!",
                     )}
                   >
                     {hasValue ? value : input.default}
@@ -200,6 +219,7 @@ export const InputHandle = ({
                 </TooltipTrigger>
                 <TooltipContent side="top">
                   <div className="text-xs">
+                    {isSecret && "Secret: "}
                     {hasValue ? value : input.default}
                   </div>
                 </TooltipContent>

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeInputs.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeInputs.tsx
@@ -204,6 +204,7 @@ export function TaskNodeInputs({
                   ? `+${hiddenInputs} more input${hiddenInputs > 1 ? "s" : ""}`
                   : " "
               }
+              rawValue={values?.[input.name]}
               onHandleSelectionChange={handleSelectionChange}
               highlight={checkHighlight(input)}
               onLabelClick={handleLabelClick}
@@ -224,6 +225,7 @@ export function TaskNodeInputs({
               input={input}
               invalid={invalidArguments.includes(input.name)}
               value={getDisplayValue(values?.[input.name], graphSpec)}
+              rawValue={values?.[input.name]}
               onHandleSelectionChange={handleSelectionChange}
               highlight={checkHighlight(input)}
               onLabelClick={handleLabelClick}

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/handleUtils.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/handleUtils.ts
@@ -1,7 +1,9 @@
+import { extractSecretName } from "@/components/shared/SecretsManagement/types";
 import {
   type ArgumentType,
   type GraphSpec,
   isGraphInputArgument,
+  isSecretArgument,
   isTaskOutputArgument,
 } from "@/utils/componentSpec";
 import { getTaskDisplayName } from "@/utils/getComponentName";
@@ -10,6 +12,7 @@ import { getValue } from "@/utils/string";
 /**
  * Formats display values for TaskNode input handles.
  * Shows connected nodes as "→ ComponentName.outputName" and regular values as formatted strings.
+ * For secret arguments, returns the secret name.
  */
 export const getDisplayValue = (
   value: string | ArgumentType | undefined,
@@ -33,6 +36,10 @@ export const getDisplayValue = (
     const inputName = value.graphInput?.inputName;
 
     return `→ ${inputName}`;
+  }
+
+  if (isSecretArgument(value)) {
+    return extractSecretName(value);
   }
 
   // For non-connected values, use the original logic

--- a/src/components/shared/SecretsManagement/SelectSecretDialog.tsx
+++ b/src/components/shared/SecretsManagement/SelectSecretDialog.tsx
@@ -1,0 +1,192 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { useState } from "react";
+
+import { withSuspenseWrapper } from "@/components/shared/SuspenseWrapper";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Icon } from "@/components/ui/icon";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Separator } from "@/components/ui/separator";
+import { Spinner } from "@/components/ui/spinner";
+import { Text } from "@/components/ui/typography";
+
+import { AddSecretForm } from "./components/AddSecretForm";
+import { getSecrets, SecretsQueryKeys } from "./secretsStorage";
+import type { Secret } from "./types";
+
+type DialogMode = "select" | "add";
+
+interface SelectSecretDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSelect: (secretName: string) => void;
+}
+
+function SelectSecretDialogContentSkeleton() {
+  return (
+    <BlockStack align="center" className="py-8">
+      <Spinner />
+    </BlockStack>
+  );
+}
+
+interface SelectableSecretsListProps {
+  secrets: Secret[];
+  onSelect: (secret: Secret) => void;
+}
+
+function SelectableSecretsList({
+  secrets,
+  onSelect,
+}: SelectableSecretsListProps) {
+  if (secrets.length === 0) {
+    return (
+      <BlockStack align="center" className="py-8">
+        <Icon name="Lock" size="lg" className="text-gray-300" />
+        <Text tone="subdued">No secrets configured</Text>
+        <Text size="xs" tone="subdued">
+          Add a secret to use it in your arguments
+        </Text>
+      </BlockStack>
+    );
+  }
+
+  return (
+    <ScrollArea className="w-full min-h-[100px] max-h-[300px]" type="always">
+      <BlockStack gap="2">
+        {secrets.map((secret) => (
+          <button
+            key={secret.id}
+            type="button"
+            className="w-full text-left"
+            onClick={() => onSelect(secret)}
+          >
+            <InlineStack
+              align="space-between"
+              gap="2"
+              className="w-full pr-3 py-2 hover:bg-gray-100 rounded-md cursor-pointer transition-colors"
+            >
+              <InlineStack gap="2" blockAlign="center" wrap="nowrap">
+                <Icon name="Lock" size="lg" />
+                <BlockStack gap="0">
+                  <Text size="sm" weight="semibold">
+                    {secret.name}
+                  </Text>
+                </BlockStack>
+              </InlineStack>
+              <Icon name="ChevronRight" size="sm" className="text-gray-400" />
+            </InlineStack>
+          </button>
+        ))}
+      </BlockStack>
+    </ScrollArea>
+  );
+}
+
+interface SelectSecretDialogContentProps {
+  onSelect: (secretName: string) => void;
+}
+
+function SelectSecretDialogContentInternal({
+  onSelect,
+}: SelectSecretDialogContentProps) {
+  const { data: secrets } = useSuspenseQuery({
+    queryKey: SecretsQueryKeys.All(),
+    queryFn: getSecrets,
+  });
+
+  const [mode, setMode] = useState<DialogMode>("select");
+
+  const handleSecretSelect = (secret: Secret) => {
+    onSelect(secret.name);
+  };
+
+  const handleAddSuccess = () => {
+    setMode("select");
+  };
+
+  const handleBackToSelect = () => {
+    setMode("select");
+  };
+
+  if (mode === "add") {
+    return (
+      <>
+        <DialogHeader>
+          <DialogTitle>
+            <InlineStack align="start" gap="1" blockAlign="center">
+              <Button variant="ghost" size="sm" onClick={handleBackToSelect}>
+                <Icon name="ArrowLeft" />
+              </Button>
+              Add Secret
+            </InlineStack>
+          </DialogTitle>
+        </DialogHeader>
+        <AddSecretForm
+          onSuccess={handleAddSuccess}
+          onCancel={handleBackToSelect}
+        />
+      </>
+    );
+  }
+
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>Select a Secret</DialogTitle>
+      </DialogHeader>
+      <DialogDescription>
+        Choose a secret to use as the value for this argument. The secret will
+        be injected at runtime.
+      </DialogDescription>
+      <BlockStack gap="4">
+        <SelectableSecretsList
+          secrets={secrets}
+          onSelect={handleSecretSelect}
+        />
+        <Separator />
+        <InlineStack align="end" fill gap="2">
+          <Button variant="secondary" onClick={() => setMode("add")}>
+            <InlineStack align="center" gap="1">
+              <Icon name="Plus" />
+              Add Secret
+            </InlineStack>
+          </Button>
+        </InlineStack>
+      </BlockStack>
+    </>
+  );
+}
+
+const SelectSecretDialogContent = withSuspenseWrapper(
+  SelectSecretDialogContentInternal,
+  SelectSecretDialogContentSkeleton,
+);
+
+export function SelectSecretDialog({
+  open,
+  onOpenChange,
+  onSelect,
+}: SelectSecretDialogProps) {
+  const handleSelect = (secretName: string) => {
+    onSelect(secretName);
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      {open && (
+        <DialogContent data-testid="select-secret-dialog">
+          <SelectSecretDialogContent onSelect={handleSelect} />
+        </DialogContent>
+      )}
+    </Dialog>
+  );
+}

--- a/src/components/shared/SecretsManagement/types.ts
+++ b/src/components/shared/SecretsManagement/types.ts
@@ -1,3 +1,5 @@
+import type { DynamicDataArgument } from "@/utils/componentSpec";
+
 /**
  * Represents a secret stored in the secrets management system.
  */
@@ -20,4 +22,22 @@ export function isValidSecretName(name: string): boolean {
  */
 export function isValidSecretValue(value: string): boolean {
   return value.length > 0;
+}
+
+/**
+ * Creates a SecretArgument from a secret name.
+ * @param secretName - The name of the secret
+ * @returns A SecretArgument object
+ */
+export function createSecretArgument(secretName: string): DynamicDataArgument {
+  return { dynamicData: { secret: { name: secretName } } };
+}
+
+/**
+ * Extracts the secret name from a SecretArgument.
+ * @param arg - The SecretArgument
+ * @returns The secret name
+ */
+export function extractSecretName(arg: DynamicDataArgument): string {
+  return arg.dynamicData.secret.name;
 }

--- a/src/hooks/useComponentSpecToEdges.ts
+++ b/src/hooks/useComponentSpecToEdges.ts
@@ -6,13 +6,14 @@ import {
 } from "@xyflow/react";
 import { useEffect } from "react";
 
-import type {
-  ArgumentType,
-  ComponentSpec,
-  GraphInputArgument,
-  GraphSpec,
-  TaskOutputArgument,
-  TaskSpec,
+import {
+  type ArgumentType,
+  type ComponentSpec,
+  type GraphInputArgument,
+  type GraphSpec,
+  isSecretArgument,
+  type TaskOutputArgument,
+  type TaskSpec,
 } from "@/utils/componentSpec";
 import {
   inputNameToNodeId,
@@ -82,6 +83,10 @@ const createEdgeForArgument = (
 
   if ("graphInput" in argument) {
     return [createGraphInputEdge(taskId, inputName, argument.graphInput)];
+  }
+
+  if (isSecretArgument(argument)) {
+    return [];
   }
 
   console.error("Impossible task input argument kind: ", argument);

--- a/src/utils/componentSpec.ts
+++ b/src/utils/componentSpec.ts
@@ -553,3 +553,11 @@ export const isGraphInputArgument = (
   arg?: ArgumentType,
 ): arg is GraphInputArgument =>
   typeof arg === "object" && arg !== null && "graphInput" in arg;
+
+export const isSecretArgument = (
+  arg?: ArgumentType,
+): arg is DynamicDataArgument =>
+  typeof arg === "object" &&
+  arg !== null &&
+  "dynamicData" in arg &&
+  "secret" in arg.dynamicData;


### PR DESCRIPTION
## Description

Added support for secret arguments in the task node UI. Users can now select secrets from a dialog and use them as argument values. Secret arguments are displayed with a lock icon and special formatting to distinguish them from regular values.

## Type of Change

- [x] New feature
- [x] Improvement

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Screenshots (if applicable)

[Secret in Arguments and Canvas.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/5ed85616-de62-4705-855b-618d969ed133.mov" />](https://app.graphite.com/user-attachments/video/5ed85616-de62-4705-855b-618d969ed133.mov)



## Test Instructions

1. Enable the "secrets" feature flag
2. Open a task node's arguments editor
3. Click the lock icon to select a secret
4. Verify the secret is displayed correctly in both the editor and node UI
5. Test clearing a secret and reverting to a regular value

## Additional Comments

This implementation includes:

- A new SecretArgumentInput component for displaying selected secrets
- Integration with the SelectSecretDialog for choosing secrets
- Visual indicators (lock icon, amber text) for secret values
- Proper handling of secret values in the node UI