### PR TITLE
feat: use secrets in submit with arguments dialog

### DIFF
--- a/src/components/PipelineRun/components/RerunPipelineButton.tsx
+++ b/src/components/PipelineRun/components/RerunPipelineButton.tsx
@@ -15,7 +15,7 @@ import { useExecutionDataOptional } from "@/providers/ExecutionDataProvider";
 import { APP_ROUTES } from "@/routes/router";
 import type { PipelineRun } from "@/types/pipelineRun";
 import { extractCanonicalName } from "@/utils/canonicalPipelineName";
-import type { ComponentSpec } from "@/utils/componentSpec";
+import type { ArgumentType, ComponentSpec } from "@/utils/componentSpec";
 import { submitPipelineRun } from "@/utils/submitPipeline";
 
 type RerunPipelineButtonProps = {
@@ -73,7 +73,9 @@ export const RerunPipelineButton = ({
               componentSpec,
             ),
           ),
-          taskArguments: executionData?.rootDetails?.task_spec.arguments,
+          // The generated API types don't include SecretArgument but the backend supports it
+          taskArguments: (executionData?.rootDetails?.task_spec.arguments ??
+            undefined) as Record<string, ArgumentType> | undefined,
           authorizationToken,
           runNameOverride,
           onSuccess: resolve,

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/ArgumentInputField.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/ArgumentInputField.tsx
@@ -37,6 +37,7 @@ import type { ArgumentInput } from "@/types/arguments";
 import { isGraphImplementation, isSecretArgument } from "@/utils/componentSpec";
 
 import { ArgumentInputDialog } from "./ArgumentInputDialog";
+import { SecretArgumentInput } from "./SecretArgumentInput";
 import {
   getDefaultValue,
   getInputValue,
@@ -44,14 +45,6 @@ import {
   getPlaceholder,
   typeSpecToString,
 } from "./utils";
-
-interface SecretArgumentInputProps {
-  secretName: string | null;
-  isRemoved: boolean;
-  disabled: boolean;
-  onClear: () => void;
-}
-
 interface PlainArgumentInputProps {
   argument: ArgumentInput;
   inputValue: string;
@@ -71,40 +64,6 @@ interface PlainArgumentInputProps {
 
 const ACTIONS_BASE_CLASS =
   "hover:bg-transparent hover:text-blue-500 hidden group-hover:flex";
-
-const SecretArgumentInput = ({
-  secretName,
-  isRemoved,
-  disabled,
-  onClear,
-}: SecretArgumentInputProps) => {
-  return (
-    <InlineStack
-      gap="2"
-      blockAlign="center"
-      className={cn(
-        "w-full px-3 py-1 rounded-md border ",
-        isRemoved && "opacity-50",
-      )}
-    >
-      <Icon name="Lock" size="sm" className="text-amber-600 shrink-0" />
-      <Paragraph size="sm" className="truncate flex-1 text-amber-600">
-        {secretName}
-      </Paragraph>
-      {!disabled && (
-        <TooltipButton
-          onClick={onClear}
-          variant="ghost"
-          size="xs"
-          tooltip="Clear Secret"
-          className="shrink-0"
-        >
-          <Icon name="X" size="sm" />
-        </TooltipButton>
-      )}
-    </InlineStack>
-  );
-};
 
 const PlainArgumentInput = ({
   argument,

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/SecretArgumentInput.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/SecretArgumentInput.tsx
@@ -1,0 +1,46 @@
+import TooltipButton from "@/components/shared/Buttons/TooltipButton";
+import { Icon } from "@/components/ui/icon";
+import { InlineStack } from "@/components/ui/layout";
+import { Paragraph } from "@/components/ui/typography";
+import { cn } from "@/lib/utils";
+
+interface SecretArgumentInputProps {
+  secretName: string | null;
+  isRemoved?: boolean;
+  disabled?: boolean;
+  onClear: () => void;
+}
+
+export const SecretArgumentInput = ({
+  secretName,
+  onClear,
+  isRemoved = false,
+  disabled = false,
+}: SecretArgumentInputProps) => {
+  return (
+    <InlineStack
+      gap="2"
+      blockAlign="center"
+      className={cn(
+        "w-full px-3 py-1 rounded-md border ",
+        isRemoved && "opacity-50",
+      )}
+    >
+      <Icon name="Lock" size="sm" className="text-amber-600 shrink-0" />
+      <Paragraph size="sm" className="truncate flex-1 text-amber-600">
+        {secretName}
+      </Paragraph>
+      {!disabled && (
+        <TooltipButton
+          onClick={onClear}
+          variant="ghost"
+          size="xs"
+          tooltip="Clear Secret"
+          className="shrink-0"
+        >
+          <Icon name="X" size="sm" />
+        </TooltipButton>
+      )}
+    </InlineStack>
+  );
+};

--- a/src/components/shared/Submitters/Oasis/OasisSubmitter.tsx
+++ b/src/components/shared/Submitters/Oasis/OasisSubmitter.tsx
@@ -3,7 +3,6 @@ import { useNavigate } from "@tanstack/react-router";
 import { AlertCircle, CheckCircle, Loader2, SendHorizonal } from "lucide-react";
 import { type MouseEvent, useRef, useState } from "react";
 
-import type { TaskSpecOutput } from "@/api/types.gen";
 import { useAwaitAuthorization } from "@/components/shared/Authentication/useAwaitAuthorization";
 import { useFlagValue } from "@/components/shared/Settings/useFlags";
 import { Button } from "@/components/ui/button";
@@ -17,6 +16,7 @@ import { APP_ROUTES } from "@/routes/router";
 import { updateRunNotes } from "@/services/pipelineRunService";
 import type { PipelineRun } from "@/types/pipelineRun";
 import {
+  type ArgumentType,
   type ComponentSpec,
   isGraphImplementation,
 } from "@/utils/componentSpec";
@@ -53,7 +53,7 @@ function useSubmitPipeline() {
       onError,
     }: {
       componentSpec: ComponentSpec;
-      taskArguments?: TaskSpecOutput["arguments"];
+      taskArguments?: Record<string, ArgumentType>;
       onSuccess: (data: PipelineRun) => void;
       onError: (error: Error | string) => void;
     }) => {
@@ -168,7 +168,7 @@ const OasisSubmitter = ({
     setCooldownTime(3);
   };
 
-  const handleSubmit = async (taskArguments?: Record<string, string>) => {
+  const handleSubmit = async (taskArguments?: Record<string, ArgumentType>) => {
     if (!componentSpec) {
       handleError("No pipeline to submit");
       return;
@@ -183,7 +183,7 @@ const OasisSubmitter = ({
 
     if (
       onlyFixableIssues &&
-      !validateArguments(componentSpec?.inputs ?? [], taskArguments ?? {})
+      !validateArguments(componentSpec.inputs ?? [], taskArguments ?? {})
     ) {
       setIsArgumentsDialogOpen(true);
       return;
@@ -199,7 +199,7 @@ const OasisSubmitter = ({
   };
 
   const handleSubmitWithArguments = (
-    args: Record<string, string>,
+    args: Record<string, ArgumentType>,
     notes: string,
   ) => {
     runNotes.current = notes;

--- a/src/utils/submitPipeline.test.ts
+++ b/src/utils/submitPipeline.test.ts
@@ -78,6 +78,7 @@ describe("submitPipelineRun", () => {
               spec: componentSpec,
             },
             arguments: {},
+            annotations: {},
           },
         },
         mockBackendUrl,
@@ -115,6 +116,7 @@ describe("submitPipelineRun", () => {
               spec: componentSpec,
             },
             arguments: { param1: "value1", param2: "value2" },
+            annotations: {},
           },
         },
         mockBackendUrl,
@@ -187,6 +189,7 @@ describe("submitPipelineRun", () => {
               inputA: "valueA",
               inputB: "valueB",
             },
+            annotations: {},
           },
         },
         mockBackendUrl,
@@ -228,6 +231,7 @@ describe("submitPipelineRun", () => {
               taskArg1: "taskValue1",
               taskArg2: "taskValue2",
             },
+            annotations: {},
           },
         },
         mockBackendUrl,
@@ -268,6 +272,7 @@ describe("submitPipelineRun", () => {
               uniqueInputKey: "inputOnlyValue",
               uniqueTaskKey: "taskOnlyValue",
             },
+            annotations: {},
           },
         },
         mockBackendUrl,
@@ -275,10 +280,10 @@ describe("submitPipelineRun", () => {
       );
     });
 
-    it("should filter out non-string taskArguments values", async () => {
+    it("should preserve non-string taskArguments values (e.g., SecretArguments)", async () => {
       // Arrange
       const componentSpec: ComponentSpec = {
-        name: "filter-args-component",
+        name: "preserve-args-component",
         implementation: { container: { image: "test:latest" } },
       };
 
@@ -293,7 +298,7 @@ describe("submitPipelineRun", () => {
         taskArguments: mockTaskArguments as any,
       });
 
-      // Assert - only string values should be included
+      // Assert - all argument values should be preserved (non-strings like SecretArguments are valid)
       expect(pipelineRunService.createPipelineRun).toHaveBeenCalledWith(
         {
           root_task: {
@@ -302,9 +307,10 @@ describe("submitPipelineRun", () => {
             },
             arguments: {
               stringArg: "validString",
-              objectArg: undefined,
-              numberArg: undefined,
+              objectArg: { nested: "value" },
+              numberArg: 123,
             },
+            annotations: {},
           },
         },
         mockBackendUrl,
@@ -335,6 +341,7 @@ describe("submitPipelineRun", () => {
             arguments: {
               inputArg: "inputValue",
             },
+            annotations: {},
           },
         },
         mockBackendUrl,
@@ -426,6 +433,7 @@ describe("submitPipelineRun", () => {
               },
             },
             arguments: {},
+            annotations: {},
           },
         },
         mockBackendUrl,
@@ -589,6 +597,7 @@ describe("submitPipelineRun", () => {
               spec: componentSpec,
             },
             arguments: {},
+            annotations: {},
           },
         }),
         mockBackendUrl,
@@ -835,6 +844,7 @@ describe("submitPipelineRun", () => {
               spec: componentSpec,
             },
             arguments: {},
+            annotations: {},
           },
         }),
         mockBackendUrl,
@@ -869,6 +879,7 @@ describe("submitPipelineRun", () => {
               spec: componentSpec,
             },
             arguments: {},
+            annotations: {},
           },
         }),
         mockBackendUrl,

--- a/src/utils/validations.ts
+++ b/src/utils/validations.ts
@@ -5,6 +5,7 @@ import {
   type GraphSpec,
   type InputSpec,
   isGraphImplementation,
+  isSecretArgument,
   type TaskOutputArgument,
   type TaskSpec,
 } from "./componentSpec";
@@ -30,15 +31,16 @@ export function isFixableIssue(issue: ComponentValidationIssue): boolean {
 
 export function validateArguments(
   inputs: InputSpec[],
-  taskArguments: Record<string, string>,
+  taskArguments: Record<string, ArgumentType>,
 ): boolean {
   const normalizedValues = inputs
     .filter((input) => !input.optional)
-    .map((input) =>
-      String(
-        taskArguments[input.name] || input.value || input.default || "",
-      ).trim(),
-    );
+    .map((input) => {
+      const value = taskArguments[input.name];
+      // SecretArgument is always considered valid
+      if (isSecretArgument(value)) return true;
+      return String(value || input.value || input.default || "").trim();
+    });
   return normalizedValues.every(Boolean);
 }
 


### PR DESCRIPTION
## Description

Added support for SecretArguments in pipeline rerun functionality. This enhancement allows users to securely pass secret values when rerunning pipelines by integrating with the existing secrets management system. The implementation includes UI components for selecting secrets and proper handling of secret arguments throughout the pipeline submission process.

## Type of Change

- [x] New feature
- [x] Improvement

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging



## Screenshots

[Screen Recording 2026-02-17 at 4.51.13 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/4f3bb96b-e689-4d63-89a7-cadb5c2b91e6.mov" />](https://app.graphite.com/user-attachments/video/4f3bb96b-e689-4d63-89a7-cadb5c2b91e6.mov)



## Test Instructions

1. Enable the "secrets" feature flag
2. Create a pipeline with parameters
3. Run the pipeline
4. Attempt to rerun the pipeline
5. Verify that you can select secrets for parameters
6. Confirm that the pipeline runs successfully with the secret values

## Additional Comments

This change properly handles SecretArgument types in the pipeline rerun flow, fixing type issues with the API and ensuring secrets are preserved during resubmission. The UI now shows a lock icon for secret values and provides an option to select secrets for parameters.