### PR TITLE
feat: Duplicate Flex Nodes

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
@@ -86,7 +86,7 @@ import { removeNode } from "./utils/removeNode";
 import { replaceTaskNode } from "./utils/replaceTaskNode";
 import { updateNodePositions } from "./utils/updateNodePosition";
 
-const SELECTABLE_NODES = new Set(["task", "input", "output"]);
+const SELECTABLE_NODES = new Set(["task", "input", "output", "flex"]);
 const UPGRADEABLE_NODES = new Set(["task"]);
 const REPLACEABLE_NODES = new Set(["task"]);
 const FAST_PLACE_NODE_TYPES = new Set<Node["type"]>(["task"]);
@@ -746,7 +746,10 @@ const FlowCanvasContent = ({
       updatedComponentSpec: updatedSubgraphSpec,
       newNodes,
       updatedNodes,
-    } = duplicateNodes(currentSubgraphSpec, selectedNodes, { selected: true });
+    } = duplicateNodes(currentSubgraphSpec, selectedNodes, {
+      selected: true,
+      author: currentUserDetails?.id,
+    });
 
     const updatedRootSpec = updateSubgraphSpec(
       componentSpec,
@@ -941,6 +944,7 @@ const FlowCanvasContent = ({
             duplicateNodes(currentSubgraphSpec, nodesToPaste, {
               position: reactFlowCenter,
               connection: "internal",
+              author: currentUserDetails?.id,
             });
 
           // Deselect all existing nodes
@@ -1032,6 +1036,7 @@ const FlowCanvasContent = ({
           isVisible={showToolbar}
           offset={0}
           align="end"
+          className="z-9999!"
         >
           <SelectionToolbar
             onDelete={!readOnly ? onRemoveNodes : undefined}

--- a/src/components/shared/ReactFlow/FlowCanvas/utils/addFlexNode.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/utils/addFlexNode.ts
@@ -32,6 +32,7 @@ const addFlexNode = (
   position: XYPosition,
   author: string,
   componentSpec: ComponentSpec,
+  data?: Partial<FlexNodeData>,
 ): AddFlexNodeResult => {
   const nodeId = nanoid();
 
@@ -40,13 +41,15 @@ const addFlexNode = (
     createdBy: author,
   };
 
+  const { properties, size, zIndex } = data || {};
+
   const flexNode: FlexNodeData = {
     id: nodeId,
-    properties: DEFAULT_STICKY_NOTE,
+    properties: properties ?? DEFAULT_STICKY_NOTE,
     metadata,
-    size: DEFAULT_FLEX_NODE_SIZE,
+    size: size ?? DEFAULT_FLEX_NODE_SIZE,
     position: position,
-    zIndex: Z_INDEX_RANGES.flex.default,
+    zIndex: zIndex ?? Z_INDEX_RANGES.flex.default,
   };
 
   const newComponentSpec = updateFlexNodeInComponentSpec(


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Enable copy + paste & duplication via multiselect toolbar for Flex Nodes (Sticky Notes).

Note this PR enables the multiselect toolbar for Flex Nodes meaning there may be, at times, options available that are currently not actionable for Flex Nodes (e.g. "Create subgraph"). This will be remedied upstack.

WARNING: `duplicateNodes` is a monster of a function. It is in dire need of a cleanup but this is not the PR to do it. 

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

Progresses https://github.com/Shopify/oasis-frontend/issues/118

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] New feature

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

![image.png](https://app.graphite.com/user-attachments/assets/db6cd6e0-cd05-417e-a90f-e9bc0d569abc.png)

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

- Select a bunch of Flex Nodes. Copy + Paste using Ctrl C + Ctrl V. It should work.
- As above but duplicate them using the multiselect toolbar.
- As above but also include other node types in the selection.
- Verify everything else works as expected.

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
