### PR TITLE
feat: (Un)Pack Flex Nodes into Subgraphs

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/Subgraphs/create/NodeListItem.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/Subgraphs/create/NodeListItem.tsx
@@ -7,6 +7,7 @@ import { InlineStack } from "@/components/ui/layout";
 import { Paragraph } from "@/components/ui/typography";
 import { cn } from "@/lib/utils";
 
+import { isFlexNode } from "../../types";
 import { getNodeTypeColor } from "./utils";
 
 interface NodeListItemProps {
@@ -34,6 +35,12 @@ export function NodeListItem({
     }
   };
 
+  const isFlexType = isFlexNode(node);
+
+  const displayValue = isFlexType
+    ? `Sticky Note: ${node.data.properties.title.length > 0 ? node.data.properties.title : node.id}`
+    : node.id;
+
   return (
     <li key={node.id} className="flex justify-between items-center">
       <InlineStack
@@ -41,9 +48,18 @@ export function NodeListItem({
         className={cn({ "opacity-50": isExcluded })}
         wrap="nowrap"
       >
-        <Badge variant="dot" className={cn(getNodeTypeColor(node.type))} />
+        <Badge
+          variant="dot"
+          className={cn(getNodeTypeColor(node.type))}
+          style={{
+            backgroundColor: isFlexType
+              ? node.data.properties.color
+              : undefined,
+            filter: isFlexType ? "brightness(0.8)" : undefined,
+          }}
+        />
         <Paragraph font="mono" size="xs">
-          {node.id}
+          {displayValue}
         </Paragraph>
         {isOrphaned && (
           <InlineStack gap="1" wrap="nowrap">

--- a/src/components/shared/ReactFlow/FlowCanvas/Subgraphs/create/checkForOrphanedNodes.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/Subgraphs/create/checkForOrphanedNodes.ts
@@ -98,7 +98,7 @@ export const checkForOrphanedNodes = (
     });
 
   const orphanedNodes = selectedNodes.filter(
-    (node) => !connectedNodeIds.has(node.id),
+    (node) => !connectedNodeIds.has(node.id) && node.type !== "flex",
   );
 
   return orphanedNodes;

--- a/src/components/shared/ReactFlow/FlowCanvas/Subgraphs/create/utils.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/Subgraphs/create/utils.ts
@@ -27,6 +27,8 @@ export const canGroupNodes = (nodes: Node[]): GroupingValidation => {
 
 export const getNodeTypeColor = (nodeType: string | undefined): string => {
   switch (nodeType) {
+    case "flex":
+      return "bg-yellow-300";
     case "input":
       return "bg-blue-500";
     case "output":

--- a/src/utils/nodes/unpacking/helpers.ts
+++ b/src/utils/nodes/unpacking/helpers.ts
@@ -1,9 +1,16 @@
 import type { XYPosition } from "@xyflow/react";
 
+import {
+  getFlexNodeAnnotations,
+  serializeFlexNodes,
+} from "@/components/shared/ReactFlow/FlowCanvas/FlexNode/interface";
 import addTask from "@/components/shared/ReactFlow/FlowCanvas/utils/addTask";
 import { setGraphOutputValue } from "@/components/shared/ReactFlow/FlowCanvas/utils/setGraphOutputValue";
 import { setTaskArgument } from "@/components/shared/ReactFlow/FlowCanvas/utils/setTaskArgument";
-import { extractPositionFromAnnotations } from "@/utils/annotations";
+import {
+  extractPositionFromAnnotations,
+  FLEX_NODES_ANNOTATION,
+} from "@/utils/annotations";
 import {
   type ArgumentType,
   type ComponentSpec,
@@ -22,6 +29,51 @@ import {
   getOutputNodesConnectedToTask,
   normalizeNodePositionInGroup,
 } from "@/utils/graphUtils";
+
+export const unpackFlexNodes = (
+  containerSpec: ComponentSpec,
+  containerPosition: XYPosition,
+  componentSpec: ComponentSpec,
+): ComponentSpec => {
+  const updatedSpec = componentSpec;
+
+  const flexNodes = getFlexNodeAnnotations(containerSpec);
+
+  const containerCenter = calculateSpecCenter(containerSpec);
+
+  const newFlexNodes = flexNodes.map((flexNode) => {
+    const position = normalizeNodePositionInGroup(
+      {
+        x: flexNode.position.x,
+        y: flexNode.position.y,
+      },
+      containerPosition,
+      containerCenter,
+    );
+
+    return {
+      ...flexNode,
+      position,
+    };
+  });
+
+  if (!updatedSpec.metadata) {
+    updatedSpec.metadata = {};
+  }
+
+  if (!updatedSpec.metadata.annotations) {
+    updatedSpec.metadata.annotations = {};
+  }
+
+  const existingFlexNodes = getFlexNodeAnnotations(updatedSpec);
+
+  const mergedFlexNodes = [...existingFlexNodes, ...newFlexNodes];
+
+  updatedSpec.metadata.annotations[FLEX_NODES_ANNOTATION] =
+    serializeFlexNodes(mergedFlexNodes);
+
+  return updatedSpec;
+};
 
 export const unpackInputs = (
   containerSpec: ComponentSpec,

--- a/src/utils/nodes/unpacking/unpackSubgraph.test.ts
+++ b/src/utils/nodes/unpacking/unpackSubgraph.test.ts
@@ -16,6 +16,7 @@ import {
   reconnectDownstreamOutputs,
   reconnectDownstreamTasks,
   reconnectUpstreamInputsAndTasks,
+  unpackFlexNodes,
   unpackInputs,
   unpackOutputs,
   unpackTasks,
@@ -77,6 +78,7 @@ describe("unpackSubgraph", () => {
     vi.mocked(extractPositionFromAnnotations).mockReturnValue(mockPosition);
     vi.mocked(getOutputNodesConnectedToTask).mockReturnValue({});
     vi.mocked(getDownstreamTaskNodesConnectedToTask).mockReturnValue({});
+    vi.mocked(unpackFlexNodes).mockImplementation((_, __, spec) => spec);
   });
 
   it("should return unchanged spec if implementation is not a graph", () => {

--- a/src/utils/nodes/unpacking/unpackSubgraph.ts
+++ b/src/utils/nodes/unpacking/unpackSubgraph.ts
@@ -11,6 +11,7 @@ import {
   reconnectDownstreamOutputs,
   reconnectDownstreamTasks,
   reconnectUpstreamInputsAndTasks,
+  unpackFlexNodes,
   unpackInputs,
   unpackOutputs,
   unpackTasks,
@@ -45,6 +46,14 @@ export const unpackSubgraph = (
     getDownstreamTaskNodesConnectedToTask(subgraphTaskId, graphSpec);
 
   let updatedComponentSpec = componentSpec;
+
+  // Unpack flex Nodes
+  const specAfterFlexNodes = unpackFlexNodes(
+    subgraphSpec,
+    subgraphPosition,
+    updatedComponentSpec,
+  );
+  updatedComponentSpec = specAfterFlexNodes;
 
   // Unpack inputs
   const { spec: specAfterInputs, inputNameMap } = unpackInputs(


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

Flex Nodes can now be packed & unpacked from subgraphs.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

Progresses Shopify/oasis-frontend#118

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] New feature

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

![image.png](https://app.graphite.com/user-attachments/assets/6ebee856-d641-48c7-8771-1a00460470c1.png)

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->
- Add a bunch of nodes to the canvas, including at least one sticky note
- Select the nodes and from the toolbar options select "Create Subgraph". Confirm.
- The sticky note should be packed into the new subgraph alongside the other nodes. Look inside to confirm.
- Go back to the parent spec and select the new subgraph node.
- Select the "unpack subgraph" action. The sticky note should reappear on the current canvas alongside the other nodes.

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
