### PR TITLE
feat: use API as secrets storage

### DIFF
--- a/src/components/PipelineRun/components/RerunPipelineButton.tsx
+++ b/src/components/PipelineRun/components/RerunPipelineButton.tsx
@@ -73,9 +73,9 @@ export const RerunPipelineButton = ({
               componentSpec,
             ),
           ),
-          // The generated API types don't include SecretArgument but the backend supports it
-          taskArguments: (executionData?.rootDetails?.task_spec.arguments ??
-            undefined) as Record<string, ArgumentType> | undefined,
+          // Generated API definitions slightly differs from the componentSpec
+          taskArguments: executionData?.rootDetails?.task_spec
+            .arguments as Record<string, ArgumentType>,
           authorizationToken,
           runNameOverride,
           onSuccess: resolve,

--- a/src/components/shared/SecretsManagement/SelectSecretDialog.tsx
+++ b/src/components/shared/SecretsManagement/SelectSecretDialog.tsx
@@ -18,8 +18,8 @@ import { Spinner } from "@/components/ui/spinner";
 import { Text } from "@/components/ui/typography";
 
 import { AddSecretForm } from "./components/AddSecretForm";
-import { getSecrets, SecretsQueryKeys } from "./secretsStorage";
-import type { Secret } from "./types";
+import { fetchSecretsList } from "./secretsStorage";
+import { type Secret, SecretsQueryKeys } from "./types";
 
 type DialogMode = "select" | "add";
 
@@ -99,7 +99,7 @@ function SelectSecretDialogContentInternal({
 }: SelectSecretDialogContentProps) {
   const { data: secrets } = useSuspenseQuery({
     queryKey: SecretsQueryKeys.All(),
-    queryFn: getSecrets,
+    queryFn: fetchSecretsList,
   });
 
   const [mode, setMode] = useState<DialogMode>("select");

--- a/src/components/shared/SecretsManagement/components/AddSecretButton.tsx
+++ b/src/components/shared/SecretsManagement/components/AddSecretButton.tsx
@@ -4,8 +4,9 @@ import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import useToastNotification from "@/hooks/useToastNotification";
 
-import { addSecret, SecretsQueryKeys } from "../secretsStorage";
+import { addSecret } from "../secretsStorage";
 import type { Secret } from "../types";
+import { SecretsQueryKeys } from "../types";
 
 interface AddSecretButtonProps {
   secret: Pick<Secret, "name" | "value">;
@@ -22,7 +23,7 @@ export function AddSecretButton({
   const queryClient = useQueryClient();
 
   const { mutate: saveSecret, isPending } = useMutation({
-    mutationFn: () => addSecret(secret.name, secret.value),
+    mutationFn: () => addSecret(secret),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: SecretsQueryKeys.All() });
       onSuccess();

--- a/src/components/shared/SecretsManagement/components/RemoveSecretButton.tsx
+++ b/src/components/shared/SecretsManagement/components/RemoveSecretButton.tsx
@@ -4,8 +4,9 @@ import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
 import useToastNotification from "@/hooks/useToastNotification";
 
-import { removeSecret, SecretsQueryKeys } from "../secretsStorage";
+import { removeSecret } from "../secretsStorage";
 import type { Secret } from "../types";
+import { SecretsQueryKeys } from "../types";
 
 interface RemoveSecretButtonProps {
   secret: Pick<Secret, "id">;

--- a/src/components/shared/SecretsManagement/components/SecretsList.tsx
+++ b/src/components/shared/SecretsManagement/components/SecretsList.tsx
@@ -9,8 +9,8 @@ import { Text } from "@/components/ui/typography";
 import { formatRelativeTime } from "@/utils/date";
 
 import { withSuspenseWrapper } from "../../SuspenseWrapper";
-import { getSecrets, SecretsQueryKeys } from "../secretsStorage";
-import type { Secret } from "../types";
+import { fetchSecretsList } from "../secretsStorage";
+import { type Secret, SecretsQueryKeys } from "../types";
 import { RemoveSecretButton } from "./RemoveSecretButton";
 
 interface SecretsListProps {
@@ -21,7 +21,7 @@ interface SecretsListProps {
 function SecretsListInternal({ onReplace, onRemoveSuccess }: SecretsListProps) {
   const { data: secrets } = useSuspenseQuery({
     queryKey: SecretsQueryKeys.All(),
-    queryFn: getSecrets,
+    queryFn: fetchSecretsList,
   });
 
   if (secrets.length === 0) {

--- a/src/components/shared/SecretsManagement/components/UpdateSecretButton.tsx
+++ b/src/components/shared/SecretsManagement/components/UpdateSecretButton.tsx
@@ -4,8 +4,8 @@ import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import useToastNotification from "@/hooks/useToastNotification";
 
-import { SecretsQueryKeys, updateSecret } from "../secretsStorage";
-import type { Secret } from "../types";
+import { updateSecret } from "../secretsStorage";
+import { type Secret, SecretsQueryKeys } from "../types";
 
 interface UpdateSecretButtonProps {
   secret: Pick<Secret, "id" | "value">;
@@ -22,7 +22,7 @@ export function UpdateSecretButton({
   const queryClient = useQueryClient();
 
   const { mutate: updateSecretMutation, isPending } = useMutation({
-    mutationFn: () => updateSecret(secret.id, { value: secret.value }),
+    mutationFn: () => updateSecret(secret.id, secret),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: SecretsQueryKeys.All() });
       onSuccess();

--- a/src/components/shared/SecretsManagement/types.ts
+++ b/src/components/shared/SecretsManagement/types.ts
@@ -6,8 +6,11 @@ import type { DynamicDataArgument } from "@/utils/componentSpec";
 export interface Secret {
   id: string;
   name: string;
-  value: string;
+  value?: string;
   createdAt: Date;
+  updatedAt: Date;
+  expiresAt?: Date;
+  description?: string;
 }
 
 /**
@@ -41,3 +44,11 @@ export function createSecretArgument(secretName: string): DynamicDataArgument {
 export function extractSecretName(arg: DynamicDataArgument): string {
   return arg.dynamicData.secret.name;
 }
+
+/**
+ * Query keys for React Query.
+ */
+export const SecretsQueryKeys = {
+  All: () => ["secrets"] as const,
+  Id: (id: string) => ["secrets", id] as const,
+} as const;


### PR DESCRIPTION
## Description

Refactored the secrets management system to use the API endpoints instead of the in-memory mock storage. This change connects the frontend secrets management UI to the backend API by:

1. Replacing mock functions with actual API calls:
    - `getSecrets` → `fetchSecretsList`
    - Updated `addSecret`, `updateSecret`, and `removeSecret` to use API endpoints
2. Modified the Secret type to make the `value` property optional, as the API doesn't return secret values when listing secrets
3. Moved the `SecretsQueryKeys` from secretsStorage.ts to types.ts for better organization

## Type of Change

- [x] Improvement
- [x] Refactor

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots

[Secrets real usage.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/fd91b01a-4071-43dc-9d97-d14917ccf4e3.mov" />](https://app.graphite.com/user-attachments/video/fd91b01a-4071-43dc-9d97-d14917ccf4e3.mov)



## Test Instructions

1. Open the Secrets Management dialog
2. Create a new secret
3. Update an existing secret
4. Delete a secret
5. Verify all operations work correctly with the backend API