### PR TITLE
feat: display secrets in pipeline run view

### DIFF
--- a/src/utils/nodes/taskArguments.ts
+++ b/src/utils/nodes/taskArguments.ts
@@ -1,6 +1,10 @@
 import type { TaskSpecOutput } from "@/api/types.gen";
 
-import type { ComponentSpec } from "../componentSpec";
+import {
+  type ArgumentType,
+  type ComponentSpec,
+  isSecretArgument,
+} from "../componentSpec";
 
 /**
  * Gets the string value of a task argument.
@@ -17,9 +21,14 @@ export function getArgumentValue(
     return undefined;
   }
 
-  const argument = taskArguments?.[inputName];
+  const argument = taskArguments?.[inputName] as ArgumentType;
+
   if (typeof argument === "string") {
     return argument;
+  }
+
+  if (isSecretArgument(argument)) {
+    return `🔒 ${argument.dynamicData.secret.name}`;
   }
 
   return undefined;


### PR DESCRIPTION
## Description

Added support for displaying secret arguments in task argument values. When a task argument is a secret, it will now be displayed as "🔒 [secret name]" instead of being undefined.

## Type of Change

- [x] New feature
- [x] Improvement

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

[Screen Recording 2026-02-17 at 5.29.30 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/cfea7ce3-9bb0-4878-9d31-7ce943452107.mov" />](https://app.graphite.com/user-attachments/video/cfea7ce3-9bb0-4878-9d31-7ce943452107.mov)



1. Create a task with a secret argument
2. Verify that the secret is displayed with a lock icon and the secret name