### PR TITLE
chore: update vertexAiCompiler

### DIFF
--- a/src/components/shared/Submitters/GoogleCloud/compiler/vertexAiCompiler.ts
+++ b/src/components/shared/Submitters/GoogleCloud/compiler/vertexAiCompiler.ts
@@ -4,6 +4,7 @@ import {
   type InputSpec,
   isContainerImplementation,
   isGraphImplementation,
+  isSecretArgument,
   type StringOrPlaceholder,
   type TypeSpecType,
 } from "@/utils/componentSpec";
@@ -313,6 +314,10 @@ function buildVertexParameterArgumentSpec(
       },
     };
     return result;
+  } else if (isSecretArgument(taskArgument)) {
+    throw Error(
+      `Secret arguments are not supported in Vertex AI compilation. Input "${inputSpec.name}" uses secret "${taskArgument.secret.name}"`,
+    );
   } else {
     throw Error(`Unknown kind of task argument: "${taskArgument}"`);
   }
@@ -392,6 +397,10 @@ function buildVertexArtifactArgumentSpec(
       },
     };
     return result;
+  } else if (isSecretArgument(taskArgument)) {
+    throw Error(
+      `Secret arguments are not supported in Vertex AI compilation. Input "${inputSpec.name}" uses secret "${taskArgument.secret.name}"`,
+    );
   } else {
     throw Error(`Unknown kind of task argument: "${taskArgument}"`);
   }


### PR DESCRIPTION
## Description

Added error handling for secret arguments in Vertex AI compilation. The changes throw specific error messages when secret arguments are encountered in both parameter and artifact argument specifications, as they are not supported in Vertex AI.

## Related Issue and Pull requests

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

Test by attempting to compile a component with secret arguments for Vertex AI and verify that the appropriate error message is displayed.

## Additional Comments

This change improves error handling by providing clear error messages when users attempt to use secret arguments with Vertex AI, which doesn't support this feature.