### PR TITLE
Add filter badge key to active filters badge

### DIFF
--- a/src/components/shared/PipelineRunFiltersBar/PipelineRunFiltersBar.tsx
+++ b/src/components/shared/PipelineRunFiltersBar/PipelineRunFiltersBar.tsx
@@ -50,6 +50,13 @@ function isValidSortField(value: string): value is SortField {
 
 const MAX_VISIBLE_BADGES = 4;
 
+type FilterBadgeKey =
+  | "status"
+  | "pipeline_name"
+  | "created_by"
+  | "date_range"
+  | `annotation-${number}`;
+
 interface PipelineRunFiltersBarProps {
   totalCount?: number;
   filteredCount?: number;
@@ -113,7 +120,7 @@ export function PipelineRunFiltersBar({
 
   // Build list of all active filter badges
   const allBadges: Array<{
-    key: string;
+    key: FilterBadgeKey;
     label: string;
     onRemove: () => void;
   }> = [];
@@ -128,7 +135,7 @@ export function PipelineRunFiltersBar({
 
   if (filters.pipeline_name) {
     allBadges.push({
-      key: "name",
+      key: "pipeline_name",
       label: `Name: ${filters.pipeline_name}`,
       onRemove: () => {
         setFilter("pipeline_name", undefined);
@@ -155,7 +162,7 @@ export function PipelineRunFiltersBar({
     const separator = fromStr && toStr ? " – " : "";
 
     allBadges.push({
-      key: "date",
+      key: "date_range",
       label: `${fromStr}${separator}${toStr}`,
       onRemove: () =>
         setFilters({ created_after: undefined, created_before: undefined }),


### PR DESCRIPTION
## Description

Added a new `FilterBadgeKey` type to improve type safety for filter badge keys in the PipelineRunFiltersBar component. This type defines the specific string literals that can be used as keys for filter badges, including "status", "pipeline_name", "created_by", "date_range", and annotation keys.

Also corrected two filter badge keys to be more consistent:
- Changed "name" to "pipeline_name"
- Changed "date" to "date_range"

## Type of Change

- [x] Improvement
- [x] Cleanup/Refactor

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Test Instructions

Verify that the filter badges in the PipelineRunFiltersBar component continue to function correctly, particularly when filtering by pipeline name or date range.