### PR TITLE
Fix multi component edge selection

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
@@ -1,6 +1,7 @@
 import {
   type Connection,
   type Edge,
+  type EdgeChange,
   type FinalConnectionState,
   type Node,
   type NodeChange,
@@ -142,6 +143,20 @@ const FlowCanvas = ({
     useComponentSpecToEdges(currentSubgraphSpec);
   const [nodes, setNodes, onNodesChange] = useNodesState<Node>([]);
   const [edges, setEdges] = useEdgesState<Edge>(specEdges);
+
+  const isBoxSelecting = useRef(false);
+
+  const handleEdgesChange = (changes: EdgeChange[]) => {
+    if (!isBoxSelecting.current) {
+      onEdgesChange(changes);
+      return;
+    }
+
+    const filtered = changes.filter((change) => change.type !== "select");
+    if (filtered.length > 0) {
+      onEdgesChange(filtered);
+    }
+  };
 
   const isConnecting = useConnection((connection) => connection.inProgress);
   const connectionSourceHandle = useConnection(
@@ -807,7 +822,12 @@ const FlowCanvas = ({
     }
   };
 
+  const handleSelectionStart = () => {
+    isBoxSelecting.current = true;
+  };
+
   const handleSelectionEnd = () => {
+    isBoxSelecting.current = false;
     setShowToolbar(true);
   };
 
@@ -953,7 +973,7 @@ const FlowCanvas = ({
         maxZoom={3}
         selectionMode={selectionMode}
         onNodesChange={handleOnNodesChange}
-        onEdgesChange={onEdgesChange}
+        onEdgesChange={handleEdgesChange}
         nodeTypes={nodeTypes}
         edgeTypes={edgeTypes}
         onConnect={onConnect}
@@ -966,6 +986,7 @@ const FlowCanvas = ({
         onInit={onInit}
         deleteKeyCode={["Delete", "Backspace"]}
         onSelectionChange={handleSelectionChange}
+        onSelectionStart={handleSelectionStart}
         onSelectionEnd={handleSelectionEnd}
         nodesConnectable={readOnly ? false : nodesConnectable}
         connectOnClick={!readOnly}


### PR DESCRIPTION
## Description

Prevents edge selection during box selection to avoid dimming unrelated nodes. This fix maintains the ability to select edges by clicking directly on them, but blocks automatic edge selection that occurs when using the box selection tool.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Test Instructions  
Before:

  
![Screenshot 2026-02-10 at 2.54.41 PM.png](https://app.graphite.com/user-attachments/assets/b455f10f-b28a-4b98-a6a9-130f2d14d080.png)

AFTER:

![Screenshot 2026-02-10 at 2.53.55 PM.png](https://app.graphite.com/user-attachments/assets/14f51025-ba28-40de-a283-f89a580e82bd.png)

1. Create a pipeline with multiple nodes and edges
2. Try to select multiple nodes using box selection (shift + drag)
3. Verify that edges are not automatically selected during box selection
4. Verify that you can still select edges by clicking directly on them
5. Verify that you can still select edges by clicking on task nodes inputs and outputs