### PR TITLE
feat: Double-Click to Edit Flex Nodes in-place

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/FlexNode/FlexNode.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlexNode/FlexNode.tsx
@@ -5,7 +5,7 @@ import {
   type ResizeDragEvent,
   type ResizeParams,
 } from "@xyflow/react";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 import { BlockStack } from "@/components/ui/layout";
 import { Paragraph } from "@/components/ui/typography";
@@ -15,6 +15,7 @@ import { useContextPanel } from "@/providers/ContextPanelProvider";
 import { updateSubgraphSpec } from "@/utils/subgraphUtils";
 
 import { FlexNodeEditor } from "./FlexNodeEditor";
+import { InlineTextEditor } from "./InlineTextEditor";
 import { updateFlexNodeInComponentSpec } from "./interface";
 import type { FlexNodeData } from "./types";
 
@@ -25,6 +26,8 @@ const MIN_SIZE = { width: 50, height: 50 };
 const FlexNode = ({ data, id, selected }: FlexNodeProps) => {
   const { properties, readOnly } = data;
   const { title, content, color } = properties;
+
+  const [isInlineEditing, setIsInlineEditing] = useState(false);
 
   const {
     setContent,
@@ -59,6 +62,28 @@ const FlexNode = ({ data, id, selected }: FlexNodeProps) => {
     );
 
     setComponentSpec(newRootSpec);
+  };
+
+  const handleSaveContent = (newContent: string) => {
+    const updatedSubgraphSpec = updateFlexNodeInComponentSpec(
+      currentSubgraphSpec,
+      {
+        ...data,
+        properties: {
+          ...properties,
+          content: newContent,
+        },
+      },
+    );
+
+    const newRootSpec = updateSubgraphSpec(
+      componentSpec,
+      currentSubgraphPath,
+      updatedSubgraphSpec,
+    );
+
+    setComponentSpec(newRootSpec);
+    setIsInlineEditing(false);
   };
 
   useEffect(() => {
@@ -98,6 +123,7 @@ const FlexNode = ({ data, id, selected }: FlexNodeProps) => {
             "border-2 border-dashed border-warning",
         )}
         style={{ backgroundColor: color }}
+        onDoubleClick={() => setIsInlineEditing(true)}
       >
         <div
           className={cn(
@@ -109,9 +135,18 @@ const FlexNode = ({ data, id, selected }: FlexNodeProps) => {
             <Paragraph size="sm" weight="semibold">
               {title}
             </Paragraph>
-            <Paragraph size="xs" className="whitespace-pre-wrap">
-              {content}
-            </Paragraph>
+            {isInlineEditing ? (
+              <InlineTextEditor
+                value={content}
+                placeholder="Enter text..."
+                onSave={handleSaveContent}
+                onCancel={() => setIsInlineEditing(false)}
+              />
+            ) : (
+              <Paragraph size="xs" className="whitespace-pre-wrap">
+                {content}
+              </Paragraph>
+            )}
           </BlockStack>
         </div>
       </div>

--- a/src/components/shared/ReactFlow/FlowCanvas/FlexNode/InlineTextEditor.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlexNode/InlineTextEditor.tsx
@@ -1,0 +1,72 @@
+import {
+  type ChangeEvent,
+  type KeyboardEvent,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+
+import { Textarea } from "@/components/ui/textarea";
+
+interface InlineTextEditorProps {
+  value: string;
+  placeholder?: string;
+  onSave: (value: string) => void;
+  onCancel: () => void;
+}
+
+export const InlineTextEditor = ({
+  value,
+  placeholder = "Enter text...",
+  onSave,
+  onCancel,
+}: InlineTextEditorProps) => {
+  const [text, setText] = useState(value);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    if (textareaRef.current) {
+      textareaRef.current.focus();
+      textareaRef.current.select();
+    }
+  }, []);
+
+  const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
+    setText(e.target.value);
+  };
+
+  const handleBlur = () => {
+    if (text !== value) {
+      onSave(text);
+    } else {
+      onCancel();
+    }
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      e.stopPropagation();
+      setText(value);
+      onCancel();
+    } else if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      e.stopPropagation();
+      onSave(text);
+    }
+  };
+
+  return (
+    <Textarea
+      ref={textareaRef}
+      value={text}
+      placeholder={placeholder}
+      onChange={handleChange}
+      onBlur={handleBlur}
+      onKeyDown={handleKeyDown}
+      className="min-h-10 resize-none nodrag nopan focus-visible:ring-0 focus-visible:border-0 focus-visible:text-xs text-xs shadow-none p-0 rounded-none"
+      onMouseDown={(e) => e.stopPropagation()}
+      onClick={(e) => e.stopPropagation()}
+    />
+  );
+};


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

Adds an inline text editor to Flex Nodes. This can be activated by double-clicking the node. This is used for the body content only. Title, colour and z-index editing must be done via the context panel.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

Progresses https://github.com/Shopify/oasis-frontend/issues/118

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] New feature

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

![image.png](https://app.graphite.com/user-attachments/assets/37b2b58b-6a38-4a2a-925e-5f27f04ab0f2.png)

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->
- Place a sticky note on the canvas
- Double click it
- Confirm you are able to directly enter text into the body of the sticky note without having to go via the context panel
- Deselect the sticky note and confirm your entered text has saved

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
