### PR TITLE
feat: Transparent Flex Nodes can have a Border

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -7,8 +7,7 @@
     "src/components/ui/**",
     "src/components/shared/StatusFilterSelect/**",
     "openapi-ts.config.ts",
-    "vite.config.ghpages.js",
-    "src/components/shared/ReactFlow/FlowCanvas/FlexNode/interface.ts"
+    "vite.config.ghpages.js"
   ],
   "ignoreDependencies": [
     "@radix-ui/react-accordion",

--- a/src/components/shared/ReactFlow/FlowCanvas/FlexNode/FlexNode.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlexNode/FlexNode.tsx
@@ -25,7 +25,7 @@ const MIN_SIZE = { width: 50, height: 50 };
 
 const FlexNode = ({ data, id, selected }: FlexNodeProps) => {
   const { properties, readOnly } = data;
-  const { title, content, color } = properties;
+  const { title, content, color, borderColor } = properties;
 
   const [isInlineEditing, setIsInlineEditing] = useState(false);
 
@@ -100,6 +100,7 @@ const FlexNode = ({ data, id, selected }: FlexNodeProps) => {
   }, [data, readOnly, selected]);
 
   const isTransparent = color === "transparent";
+  const isBorderTransparent = borderColor === "transparent";
 
   return (
     <>
@@ -117,12 +118,17 @@ const FlexNode = ({ data, id, selected }: FlexNodeProps) => {
         className={cn(
           "p-1 rounded-lg h-full w-full",
           readOnly && selected && "ring-2 ring-ring",
+          isTransparent && "border-2 border-solid",
           isTransparent &&
             !title &&
             !content &&
-            "border-2 border-dashed border-warning",
+            isBorderTransparent &&
+            "border-2 border-dashed border-warning!",
         )}
-        style={{ backgroundColor: color }}
+        style={{
+          backgroundColor: color,
+          borderColor: isTransparent ? borderColor : undefined,
+        }}
         onDoubleClick={() => setIsInlineEditing(true)}
       >
         <div

--- a/src/components/shared/ReactFlow/FlowCanvas/FlexNode/interface.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlexNode/interface.ts
@@ -8,7 +8,7 @@ export function serializeFlexNodes(data: FlexNodeData[]): string {
   return JSON.stringify(data);
 }
 
-export function deserializeFlexNodes(
+function deserializeFlexNodes(
   serializedData: string | undefined,
 ): FlexNodeData[] {
   if (!serializedData) {

--- a/src/components/shared/ReactFlow/FlowCanvas/FlexNode/types.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlexNode/types.ts
@@ -14,6 +14,7 @@ type FlexNodeProperties = {
   title: string;
   content: string;
   color: string;
+  borderColor?: string;
 };
 
 type FlexNodeMetadata = {

--- a/src/components/shared/ReactFlow/FlowCanvas/FlexNode/utils.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlexNode/utils.ts
@@ -9,6 +9,7 @@ export const DEFAULT_STICKY_NOTE = {
 };
 
 export const DEFAULT_FLEX_NODE_SIZE = { width: 150, height: 100 };
+export const DEFAULT_BORDER_COLOR = "#BCBCBC";
 
 export const createFlexNode = (
   flexNode: FlexNodeData,


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

Flex Nodes with a `transparent` background will now allow customization of the border color instead. The border colour, in turn, can also be transparent, essentially allowing blank text to be added to the canvas.

Border colour is not applied to sticky notes with a coloured background and the option to edit the border colour is not available for these nodes.

However, if the flex node does not have any text content and both the background and border is transparent a warning will display and the node will get a dashed orange border. This is because otherwise the node would have no visual content and would be lost on the canvas.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

Closes Shopify/oasis-frontend#118

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] New feature

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

![image.png](https://app.graphite.com/user-attachments/assets/dc8dbb4f-e232-40a8-a141-e09e551b9cda.png)

Invisible Flex Node (no background colour, border colour or text content)

![image.png](https://app.graphite.com/user-attachments/assets/50d94127-7b2d-47b4-a9d4-0851147e4e7c.png)

![image.png](https://app.graphite.com/user-attachments/assets/16f0c9a1-4973-4e8f-9e8d-da024ab10598.png)

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->
Confirm:
- Border colour editing appears when background is transparent
- Border colour is applied to the node
- Border colour can be transparent
- A warning is displayed if the node has no colour or text
- Everything else works as expected

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->

With this PR the first implementation of Sticky Notes is considered complete!

Demo:

[Sticky Notes Part Demo.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/e0ea2dd7-0bd5-4392-9068-8149cd4e5abe.mov" />](https://app.graphite.com/user-attachments/video/e0ea2dd7-0bd5-4392-9068-8149cd4e5abe.mov)

[Sticky Notes Part Demo 2.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/8254a4e7-c24d-4475-af7d-2b2c36cc6273.mov" />](https://app.graphite.com/user-attachments/video/8254a4e7-c24d-4475-af7d-2b2c36cc6273.mov)

