### PR TITLE
fix: Erroneous ComponentDetailsDialog Read-Only State

### DIFF
--- a/src/components/shared/Dialogs/ComponentDetailsDialog.tsx
+++ b/src/components/shared/Dialogs/ComponentDetailsDialog.tsx
@@ -30,6 +30,7 @@ import { DialogContext } from "./dialog.context";
 interface ComponentDetailsProps {
   component: ComponentReference;
   displayName: string;
+  readOnly?: boolean;
   trigger?: ReactNode;
   onClose?: () => void;
 }
@@ -61,7 +62,7 @@ const ComponentDetailsDialogContentSkeleton = () => {
 };
 
 const ComponentDetailsDialogContent = withSuspenseWrapper(
-  ({ component, displayName }: ComponentDetailsProps) => {
+  ({ component, displayName, readOnly }: ComponentDetailsProps) => {
     const remoteComponentLibrarySearchEnabled = useFlagValue(
       "remote-component-library-search",
     );
@@ -111,43 +112,50 @@ const ComponentDetailsDialogContent = withSuspenseWrapper(
                 Implementation
               </TabsTrigger>
 
-              {hasPublishSection ? (
+              {hasPublishSection && (
                 <TabsTrigger value="publish" className="flex-1">
                   <Icon name="LibraryBig" />
                   Publish
                 </TabsTrigger>
-              ) : null}
+              )}
             </TabsList>
 
             <div className="overflow-auto h-[40vh]">
-              <TabsContent value="details" className="h-full">
+              <TabsContent value="details">
                 {remoteComponentLibrarySearchEnabled && (
-                  <PublishedComponentDetails component={componentRef} />
+                  <PublishedComponentDetails
+                    component={componentRef}
+                    readOnly={readOnly}
+                  />
                 )}
 
                 <TaskDetails componentRef={componentRef} />
-                <TaskActions componentRef={componentRef} className="mt-2" />
+                <TaskActions
+                  componentRef={componentRef}
+                  readOnly={readOnly}
+                  className="mt-2"
+                />
               </TabsContent>
 
-              <TabsContent value="io" className="h-full">
+              <TabsContent value="io">
                 <TaskIO componentSpec={componentSpec} />
               </TabsContent>
 
-              <TabsContent value="implementation" className="h-full">
+              <TabsContent value="implementation">
                 <TaskImplementation
                   displayName={displayName}
                   componentRef={componentRef}
                 />
               </TabsContent>
 
-              {hasPublishSection ? (
-                <TabsContent value="publish" className="h-full">
+              {hasPublishSection && (
+                <TabsContent value="publish">
                   <PublishComponent
                     component={componentRef}
                     displayName={displayName}
                   />
                 </TabsContent>
-              ) : null}
+              )}
             </div>
           </Tabs>
         )}
@@ -161,6 +169,7 @@ const ComponentDetails = ({
   component,
   displayName,
   trigger,
+  readOnly,
   onClose,
 }: ComponentDetailsProps) => {
   const [open, setOpen] = useState(false);
@@ -208,6 +217,7 @@ const ComponentDetails = ({
           <ComponentDetailsDialogContent
             component={component}
             displayName={displayName}
+            readOnly={readOnly}
           />
         </DialogContext.Provider>
       </DialogContent>

--- a/src/components/shared/ManageComponent/PublishedComponentBadge.tsx
+++ b/src/components/shared/ManageComponent/PublishedComponentBadge.tsx
@@ -22,7 +22,11 @@ export const PublishedComponentBadge = withSuspenseWrapper(
   ({
     children,
     componentRef,
-  }: PropsWithChildren<{ componentRef: ComponentReference }>) => {
+    readOnly,
+  }: PropsWithChildren<{
+    componentRef: ComponentReference;
+    readOnly?: boolean;
+  }>) => {
     const { data: outdatedComponents } = useOutdatedComponents([componentRef]);
     const { data: isPublished } = useHasPublishedComponent(componentRef);
 
@@ -33,6 +37,7 @@ export const PublishedComponentBadge = withSuspenseWrapper(
         <ComponentDetailsDialog
           displayName={componentRef.name ?? "Details"}
           component={componentRef}
+          readOnly={readOnly}
           trigger={
             <Button
               variant="ghost"

--- a/src/components/shared/ManageComponent/PublishedComponentDetails.tsx
+++ b/src/components/shared/ManageComponent/PublishedComponentDetails.tsx
@@ -14,6 +14,7 @@ import { TrimmedDigest } from "./TrimmedDigest";
 
 interface PublishedComponentDetailsProps {
   component: HydratedComponentReference;
+  readOnly?: boolean;
 }
 
 function PublishedComponentDetailsSkeleton() {
@@ -29,6 +30,7 @@ function PublishedComponentDetailsSkeleton() {
 
 function PublishedComponentDetailsContent({
   component,
+  readOnly,
 }: PublishedComponentDetailsProps) {
   const { data: isPublished } = useHasPublishedComponent(component);
   const { data: outdatedComponents } = useOutdatedComponents([component]);
@@ -79,9 +81,11 @@ function PublishedComponentDetailsContent({
               <Paragraph size="xs" tone="critical">
                 There is a newer version of this component available.
               </Paragraph>
-              <Button variant="secondary" size="xs" onClick={onUpdateTasks}>
-                Review tasks
-              </Button>
+              {!readOnly && (
+                <Button variant="secondary" size="xs" onClick={onUpdateTasks}>
+                  Review tasks
+                </Button>
+              )}
             </InlineStack>
           )}
         </BlockStack>

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeCard.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeCard.tsx
@@ -262,7 +262,10 @@ const TaskNodeCard = () => {
         </BlockStack>
 
         {isRemoteComponentLibrarySearchEnabled ? (
-          <PublishedComponentBadge componentRef={taskSpec.componentRef}>
+          <PublishedComponentBadge
+            componentRef={taskSpec.componentRef}
+            readOnly={readOnly}
+          >
             {digestMarkup}
           </PublishedComponentBadge>
         ) : (

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/TaskOverview.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/TaskOverview.tsx
@@ -74,6 +74,7 @@ const TaskOverview = ({ taskNode }: TaskOverviewProps) => {
         <ComponentDetailsDialog
           displayName={displayName}
           component={taskSpec.componentRef}
+          readOnly={readOnly}
         />
         {readOnly && <StatusIcon status={status} tooltip label="task" />}
       </InlineStack>

--- a/src/components/shared/ReactFlow/FlowSidebar/components/ComponentItem.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/components/ComponentItem.tsx
@@ -216,11 +216,11 @@ const ComponentMarkup = ({
                   {displayName}
                 </span>
                 {author && author.length > 0 && (
-                  <span className="truncate text-[10px] text-gray-500 max-w-[100px] font-mono">
+                  <span className="truncate text-[10px] text-gray-500 max-w-25 font-mono">
                     {author}
                   </span>
                 )}
-                <span className="truncate text-[10px] text-gray-500 max-w-[100px] font-mono">
+                <span className="truncate text-[10px] text-gray-500 max-w-25 font-mono">
                   Ver: {digest}
                 </span>
               </div>


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Fixes:
- Edit Component Definition available in Run View
- Review outdated tasks available in run view
- Tab content has an unnecessary scrollbar

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

Before

![image.png](https://app.graphite.com/user-attachments/assets/2ba47f1f-7382-4920-98db-44ef6074e641.png)

After

![image.png](https://app.graphite.com/user-attachments/assets/bf8f807c-076d-499f-853e-0b06ed2f4c8a.png)

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
