### PR TITLE
hackday: homepage re-design

### DIFF
--- a/src/components/shared/ComponentEditor/components/PreviewTaskNodeCard.tsx
+++ b/src/components/shared/ComponentEditor/components/PreviewTaskNodeCard.tsx
@@ -1,3 +1,5 @@
+import { ReactFlowProvider } from "@xyflow/react";
+
 import { Skeleton } from "@/components/ui/skeleton";
 import { TaskNodeProvider } from "@/providers/TaskNodeProvider";
 
@@ -18,9 +20,11 @@ export const PreviewTaskNodeCard = ({
 
   return (
     <PointersEventBlock>
-      <TaskNodeProvider data={previewNodeData} selected={false}>
-        <TaskNodeCard />
-      </TaskNodeProvider>
+      <ReactFlowProvider>
+        <TaskNodeProvider data={previewNodeData} selected={false}>
+          <TaskNodeCard />
+        </TaskNodeProvider>
+      </ReactFlowProvider>
     </PointersEventBlock>
   );
 };

--- a/src/components/shared/Settings/PersonalPreferencesDialog.tsx
+++ b/src/components/shared/Settings/PersonalPreferencesDialog.tsx
@@ -33,9 +33,20 @@ export function PersonalPreferencesDialog({
   const betaFlags = Object.values(flags).filter(
     (flag) => flag.category === "beta",
   );
-  const settings = Object.values(flags).filter(
-    (flag) => flag.category === "setting",
-  );
+  const isCommandCenterDashboardEnabled =
+    flags.find((flag) => flag.key === "command-center-dashboard")?.enabled ??
+    false;
+  const settings = Object.values(flags).filter((flag) => {
+    if (flag.category !== "setting") return false;
+    if (
+      !isCommandCenterDashboardEnabled &&
+      (flag.key === "dashboard-show-recently-opened" ||
+        flag.key === "dashboard-show-pinned")
+    ) {
+      return false;
+    }
+    return true;
+  });
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -42,6 +42,20 @@ export const ExistingFlags: ConfigFlags = {
     category: "setting",
   },
 
+  ["dashboard-show-recently-opened"]: {
+    name: "Show recently opened section",
+    description: "Show recently opened runs and pipelines on the dashboard.",
+    default: false,
+    category: "setting",
+  },
+
+  ["dashboard-show-pinned"]: {
+    name: "Show pinned section",
+    description: "Show pinned runs and pipelines on the dashboard.",
+    default: false,
+    category: "setting",
+  },
+
   ["in-app-component-editor"]: {
     name: "In-app component editor",
     description:
@@ -70,6 +84,14 @@ export const ExistingFlags: ConfigFlags = {
     name: "Pipeline run filters bar (UI only)",
     description:
       "Non-functional UI preview. This filter bar is not connected to the API and is for testing/development purposes only.",
+    default: false,
+    category: "beta",
+  },
+
+  ["command-center-dashboard"]: {
+    name: "Command Center Dashboard",
+    description:
+      "Replace the default homepage with a unified command center dashboard showing runs, pipelines, components, and quick actions at a glance.",
     default: false,
     category: "beta",
   },

--- a/src/providers/ExecutionDataProvider.tsx
+++ b/src/providers/ExecutionDataProvider.tsx
@@ -14,8 +14,10 @@ import {
 } from "@/hooks/useRequiredContext";
 import type { BreadcrumbSegment } from "@/hooks/useSubgraphBreadcrumbs";
 import { useSubgraphBreadcrumbs } from "@/hooks/useSubgraphBreadcrumbs";
+import { APP_ROUTES } from "@/routes/router";
 import { useFetchPipelineRunMetadata } from "@/services/executionService";
 import { getOverallExecutionStatusFromStats } from "@/utils/executionStatus";
+import { recordRecentRun } from "@/utils/recentRuns";
 
 import { useComponentSpec } from "./ComponentSpecProvider";
 
@@ -266,6 +268,24 @@ export function ExecutionDataProvider({
     currentExecutionId,
     currentSubgraphPath,
     isAtRoot,
+  ]);
+
+  // Track recently viewed runs for the dashboard
+  useEffect(() => {
+    const recentRunTitle =
+      metadata?.pipeline_name ||
+      rootDetails?.task_spec?.componentRef?.name ||
+      "";
+    const recentRunId = runId || pipelineRunId;
+
+    if (recentRunTitle && recentRunId) {
+      recordRecentRun(recentRunTitle, `${APP_ROUTES.RUNS}/${recentRunId}`);
+    }
+  }, [
+    runId,
+    pipelineRunId,
+    metadata?.pipeline_name,
+    rootDetails?.task_spec?.componentRef?.name,
   ]);
 
   const taskExecutionStatusMap = useMemo(

--- a/src/routes/Dashboard/Dashboard.tsx
+++ b/src/routes/Dashboard/Dashboard.tsx
@@ -1,0 +1,689 @@
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+import {
+  type DragEvent,
+  Fragment,
+  type ReactNode,
+  type RefObject,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+
+import type { ListPipelineJobsResponse } from "@/api/types.gen";
+import ImportPipeline from "@/components/shared/ImportPipeline";
+import NewPipelineButton from "@/components/shared/NewPipelineButton";
+import { PipelineRunFiltersBar } from "@/components/shared/PipelineRunFiltersBar/PipelineRunFiltersBar";
+import { useFlagValue } from "@/components/shared/Settings/useFlags";
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icon";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Separator } from "@/components/ui/separator";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Text } from "@/components/ui/typography";
+import { cn } from "@/lib/utils";
+import { useBackend } from "@/providers/BackendProvider";
+import { EDITOR_PATH, QUICK_START_PATH } from "@/routes/router";
+import type { ComponentReference } from "@/utils/componentSpec";
+import {
+  type ComponentFileEntry,
+  getAllComponentFilesFromList,
+} from "@/utils/componentStore";
+import {
+  USER_COMPONENTS_LIST_NAME,
+  USER_PIPELINES_LIST_NAME,
+} from "@/utils/constants";
+import { getOverallExecutionStatusFromStats } from "@/utils/executionStatus";
+import { fetchWithErrorHandling } from "@/utils/fetchWithErrorHandling";
+import { getRecentPipelines } from "@/utils/recentPipelines";
+import { getRecentRuns } from "@/utils/recentRuns";
+
+import { ComponentItem } from "./components/ComponentItem";
+import { DashboardSection } from "./components/DashboardSection";
+import { EmptyState } from "./components/EmptyState";
+import { PaginationControls } from "./components/PaginationControls";
+import { PipelineCard } from "./components/PipelineCard";
+import { RecentItemLink } from "./components/RecentItemLink";
+import { RunsTable } from "./components/RunsTable";
+import { SectionToggleButton, StatCard } from "./components/StatCard";
+import { useCursorPagination } from "./hooks/useCursorPagination";
+import { usePinnedLinks } from "./hooks/usePinnedLinks";
+import { useSectionOrder } from "./hooks/useSectionOrder";
+import { recentItemKey, type RecentLinkItem } from "./types";
+
+const RECENT_RUN_LINKS_LIMIT = 2;
+const RECENT_PIPELINE_LINKS_LIMIT = 2;
+const RECENT_OPENED_VISIBLE_LIMIT = 4;
+const COMPONENTS_PAGE_SIZE = 8;
+const PIPELINES_PAGE_SIZE = 9;
+
+type PipelineGridColumns = 1 | 2 | 3;
+
+function getTopSectionColClass(
+  sectionId: string,
+  topSections: string[],
+): string {
+  if (topSections.length <= 1) return "lg:col-span-10";
+  if (topSections.includes("runs")) {
+    return sectionId === "runs" ? "lg:col-span-7" : "lg:col-span-3";
+  }
+  return "lg:col-span-5";
+}
+
+const Dashboard = () => {
+  const { backendUrl, configured, available } = useBackend();
+  const runsSectionRef = useRef<HTMLDivElement>(null);
+  const pipelinesSectionRef = useRef<HTMLDivElement>(null);
+
+  // -- Runs (with cursor pagination) -------------------------------------------
+  const {
+    pageToken,
+    previousPageTokens,
+    handleNextPage,
+    handlePreviousPage,
+    handleFirstPage,
+  } = useCursorPagination();
+
+  const {
+    data: runsData,
+    isLoading: isRunsLoading,
+    isFetching: isRunsFetching,
+  } = useQuery<ListPipelineJobsResponse>({
+    queryKey: ["dashboard-runs", backendUrl, pageToken],
+    refetchOnWindowFocus: false,
+    enabled: configured && available,
+    queryFn: async () => {
+      const u = new URL("/api/pipeline_runs/", backendUrl);
+      u.searchParams.set("include_pipeline_names", "true");
+      u.searchParams.set("include_execution_stats", "true");
+      if (pageToken) u.searchParams.set("page_token", pageToken);
+      return fetchWithErrorHandling(u.toString());
+    },
+  });
+
+  // -- Pipelines (local IndexedDB) ---------------------------------------------
+  const { data: pipelines = [], isLoading: isPipelinesLoading } = useQuery({
+    queryKey: ["dashboard-pipelines"],
+    refetchOnWindowFocus: false,
+    queryFn: async () => {
+      const map = await getAllComponentFilesFromList(USER_PIPELINES_LIST_NAME);
+      return [...map.entries()]
+        .sort(
+          (a, b) =>
+            new Date(b[1].modificationTime).getTime() -
+            new Date(a[1].modificationTime).getTime(),
+        )
+        .map(([name, entry]) => ({ name, entry }));
+    },
+  });
+
+  // -- User components (local IndexedDB) --------------------------------------
+  const { data: userComponents = [], isLoading: isUserComponentsLoading } =
+    useQuery({
+      queryKey: ["dashboard-user-components"],
+      refetchOnWindowFocus: false,
+      queryFn: async () => {
+        const map = await getAllComponentFilesFromList(
+          USER_COMPONENTS_LIST_NAME,
+        );
+        return [...map.entries()].map<ComponentReference>(([, fileEntry]) => ({
+          ...fileEntry.componentRef,
+          name: fileEntry.name,
+          owned: true,
+        }));
+      },
+    });
+
+  const isFiltersBarEnabled = useFlagValue("pipeline-run-filters-bar");
+  const showRecentlyOpenedSection = useFlagValue(
+    "dashboard-show-recently-opened",
+  );
+  const showPinnedSection = useFlagValue("dashboard-show-pinned");
+
+  // -- Section ordering & visibility ------------------------------------------
+  const {
+    sectionOrder,
+    sectionVisibility,
+    draggingSectionId,
+    dragOverSectionId,
+    visibleSections,
+    toggleSectionVisibility,
+    handleSectionDragStart,
+    handleSectionDragOver,
+    handleSectionDrop,
+    handleSectionDragEnd,
+  } = useSectionOrder();
+
+  // -- Pinned items -----------------------------------------------------------
+  const pipelineNames = new Set(pipelines.map((p) => p.name));
+
+  const {
+    pinnedItems,
+    pinnedUrls,
+    pinnedRunUrls,
+    handleToggleRunPinned,
+    handleTogglePipelinePinned,
+    handleTogglePinnedLink,
+  } = usePinnedLinks(pipelineNames);
+
+  // -- UI state ---------------------------------------------------------------
+  const [expandedComponentId, setExpandedComponentId] = useState<string | null>(
+    null,
+  );
+  const [componentsPage, setComponentsPage] = useState(1);
+  const [pipelinesPage, setPipelinesPage] = useState(1);
+  const [pipelineGridColumns, setPipelineGridColumns] =
+    useState<PipelineGridColumns>(3);
+  const [showAllRecentlyOpened, setShowAllRecentlyOpened] = useState(false);
+
+  // -- Derived data -----------------------------------------------------------
+  const allRuns = runsData?.pipeline_runs ?? [];
+
+  const pipelineItemsForSection: { name: string; entry: ComponentFileEntry }[] =
+    pipelines.map(({ name, entry }) => ({ name, entry }));
+
+  const recentRunLinks: RecentLinkItem[] = getRecentRuns()
+    .slice(0, RECENT_RUN_LINKS_LIMIT)
+    .map((run) => ({ ...run, type: "run" }));
+  const recentPipelineLinks: RecentLinkItem[] = getRecentPipelines()
+    .filter((pipeline) => pipelineNames.has(pipeline.title))
+    .slice(0, RECENT_PIPELINE_LINKS_LIMIT)
+    .map((pipeline) => ({ ...pipeline, type: "pipeline" }));
+  const recentlyOpened = [...recentRunLinks, ...recentPipelineLinks];
+
+  const hasRecentlyOpened = recentlyOpened.length > 0;
+  const visibleRecentlyOpened = showAllRecentlyOpened
+    ? recentlyOpened
+    : recentlyOpened.slice(0, RECENT_OPENED_VISIBLE_LIMIT);
+  const hiddenRecentlyOpenedCount = Math.max(
+    0,
+    recentlyOpened.length - visibleRecentlyOpened.length,
+  );
+
+  const hasPinnedItems = pinnedItems.length > 0;
+  const hasVisiblePinnedFeed = showPinnedSection && hasPinnedItems;
+  const hasVisibleRecentFeed = showRecentlyOpenedSection && hasRecentlyOpened;
+  const hasPagination =
+    !!runsData?.next_page_token || previousPageTokens.length > 0;
+
+  const totalRuns = allRuns.length;
+  const activeRuns = allRuns.filter((r) => {
+    const s = getOverallExecutionStatusFromStats(
+      r.execution_status_stats ?? undefined,
+    );
+    return s === "RUNNING" || s === "PENDING" || s === "QUEUED";
+  }).length;
+  const errorRuns = allRuns.filter((r) => {
+    const s = getOverallExecutionStatusFromStats(
+      r.execution_status_stats ?? undefined,
+    );
+    return s === "FAILED" || s === "SYSTEM_ERROR" || s === "INVALID";
+  }).length;
+
+  const totalPipelines = pipelines.length;
+  const totalPipelinePages = Math.max(
+    1,
+    Math.ceil(totalPipelines / PIPELINES_PAGE_SIZE),
+  );
+  const currentPipelinesPage = Math.min(pipelinesPage, totalPipelinePages);
+  const paginatedPipelineItems = pipelineItemsForSection.slice(
+    (currentPipelinesPage - 1) * PIPELINES_PAGE_SIZE,
+    currentPipelinesPage * PIPELINES_PAGE_SIZE,
+  );
+
+  const totalComponents = userComponents.length;
+  const totalComponentPages = Math.max(
+    1,
+    Math.ceil(totalComponents / COMPONENTS_PAGE_SIZE),
+  );
+  const currentComponentsPage = Math.min(componentsPage, totalComponentPages);
+  const paginatedUserComponents = userComponents.slice(
+    (currentComponentsPage - 1) * COMPONENTS_PAGE_SIZE,
+    currentComponentsPage * COMPONENTS_PAGE_SIZE,
+  );
+
+  const topVisibleSections = visibleSections.slice(0, 2);
+  const lowerVisibleSections = visibleSections.slice(2);
+  const hasVisibleSections = visibleSections.length > 0;
+  const pipelineGridColumnsClass =
+    pipelineGridColumns === 1
+      ? "grid-cols-1"
+      : pipelineGridColumns === 2
+        ? "grid-cols-2"
+        : "grid-cols-3";
+
+  const sectionMeta = {
+    runs: { label: "Runs", count: totalRuns },
+    components: { label: "Components", count: totalComponents },
+    pipelines: { label: "Pipelines", count: totalPipelines },
+  };
+
+  // -- Effects ----------------------------------------------------------------
+  const scrollToSection = (ref: RefObject<HTMLDivElement | null>): void => {
+    ref.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+  };
+
+  useEffect(() => {
+    if (!sectionVisibility.pipelines) return;
+
+    const element = pipelinesSectionRef.current;
+    if (!element) return;
+
+    const updateColumnsFromWidth = (width: number) => {
+      if (width < 520) {
+        setPipelineGridColumns(1);
+        return;
+      }
+
+      if (width < 920) {
+        setPipelineGridColumns(2);
+        return;
+      }
+
+      setPipelineGridColumns(3);
+    };
+
+    updateColumnsFromWidth(element.getBoundingClientRect().width);
+
+    const observer = new ResizeObserver((entries) => {
+      const firstEntry = entries[0];
+      if (!firstEntry) return;
+      updateColumnsFromWidth(firstEntry.contentRect.width);
+    });
+
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [sectionOrder, sectionVisibility.pipelines]);
+
+  // -- Section renderers ------------------------------------------------------
+  const renderSection = (sectionId: string, className?: string): ReactNode => {
+    if (sectionId === "runs") {
+      return (
+        <div ref={runsSectionRef} className={className}>
+          <DashboardSection title="All Runs" count={totalRuns}>
+            {isFiltersBarEnabled && <PipelineRunFiltersBar />}
+            {isRunsLoading || isRunsFetching ? (
+              <BlockStack gap="2">
+                {Array.from({ length: 4 }).map((_, i) => (
+                  <Skeleton key={i} className="h-12 w-full rounded-lg" />
+                ))}
+              </BlockStack>
+            ) : !configured || !available ? (
+              <EmptyState
+                icon="CloudOff"
+                message={
+                  !configured
+                    ? "Configure a backend to see your runs"
+                    : "Backend is currently unavailable"
+                }
+              />
+            ) : allRuns.length === 0 ? (
+              <EmptyState
+                icon="Play"
+                message="No runs yet. Execute a pipeline to see results here."
+              />
+            ) : (
+              <>
+                <RunsTable
+                  runs={allRuns}
+                  showPinControls={showPinnedSection}
+                  pinnedRunUrls={pinnedRunUrls}
+                  onToggleRunPinned={handleToggleRunPinned}
+                />
+                {hasPagination && (
+                  <InlineStack
+                    gap="2"
+                    align="space-between"
+                    blockAlign="center"
+                  >
+                    <InlineStack gap="2">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={handleFirstPage}
+                        disabled={!pageToken}
+                      >
+                        <Icon name="ChevronsLeft" size="sm" />
+                      </Button>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={handlePreviousPage}
+                        disabled={previousPageTokens.length === 0}
+                      >
+                        <Icon name="ChevronLeft" size="sm" />
+                        Previous
+                      </Button>
+                    </InlineStack>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() =>
+                        handleNextPage(runsData?.next_page_token ?? undefined)
+                      }
+                      disabled={!runsData?.next_page_token}
+                    >
+                      Next
+                      <Icon name="ChevronRight" size="sm" />
+                    </Button>
+                  </InlineStack>
+                )}
+              </>
+            )}
+          </DashboardSection>
+        </div>
+      );
+    }
+
+    if (sectionId === "components") {
+      return (
+        <div className={className}>
+          <DashboardSection title="My Components" count={totalComponents}>
+            {isUserComponentsLoading ? (
+              <BlockStack gap="2">
+                {Array.from({ length: 4 }).map((_, i) => (
+                  <Skeleton key={i} className="h-14 w-full rounded-lg" />
+                ))}
+              </BlockStack>
+            ) : userComponents.length === 0 ? (
+              <EmptyState
+                icon="Box"
+                message="No components yet. Create custom components in the pipeline editor."
+              />
+            ) : (
+              <>
+                <BlockStack gap="1">
+                  {paginatedUserComponents.map((c, i) => {
+                    const id =
+                      c.digest ??
+                      `user-${(currentComponentsPage - 1) * COMPONENTS_PAGE_SIZE + i}`;
+                    return (
+                      <ComponentItem
+                        key={id}
+                        component={c}
+                        isExpanded={expandedComponentId === id}
+                        onToggle={() =>
+                          setExpandedComponentId(
+                            expandedComponentId === id ? null : id,
+                          )
+                        }
+                      />
+                    );
+                  })}
+                </BlockStack>
+                {totalComponentPages > 1 && (
+                  <PaginationControls
+                    currentPage={currentComponentsPage}
+                    totalPages={totalComponentPages}
+                    onPreviousPage={() =>
+                      setComponentsPage((page) => Math.max(1, page - 1))
+                    }
+                    onNextPage={() =>
+                      setComponentsPage((page) =>
+                        Math.min(totalComponentPages, page + 1),
+                      )
+                    }
+                  />
+                )}
+              </>
+            )}
+          </DashboardSection>
+        </div>
+      );
+    }
+
+    return (
+      <div ref={pipelinesSectionRef} className={className}>
+        <DashboardSection title="My Pipelines" count={totalPipelines}>
+          {isPipelinesLoading ? (
+            <div className={cn("grid gap-3", pipelineGridColumnsClass)}>
+              {Array.from({ length: 6 }).map((_, i) => (
+                <Skeleton key={i} className="h-20 w-full rounded-xl" />
+              ))}
+            </div>
+          ) : pipelineItemsForSection.length === 0 ? (
+            <EmptyState
+              icon="Workflow"
+              message="No pipelines yet. Create one or start from a template."
+            >
+              <InlineStack gap="2">
+                <NewPipelineButton />
+                {/* Widen to `string` because TanStack Router's `to` expects
+                    registered route literals, but QUICK_START_PATH is a plain
+                    constant. */}
+                <Button variant="secondary" asChild>
+                  <Link to={QUICK_START_PATH as string}>
+                    <Icon name="Sparkles" size="sm" />
+                    Templates
+                  </Link>
+                </Button>
+              </InlineStack>
+            </EmptyState>
+          ) : (
+            <BlockStack gap="2">
+              <div className={cn("grid gap-2", pipelineGridColumnsClass)}>
+                {paginatedPipelineItems.map(({ name, entry }) => (
+                  <PipelineCard
+                    key={name}
+                    name={name}
+                    entry={entry}
+                    showPinControls={showPinnedSection}
+                    pinned={pinnedUrls.has(
+                      `${EDITOR_PATH}/${encodeURIComponent(name)}`,
+                    )}
+                    onTogglePinned={handleTogglePipelinePinned}
+                  />
+                ))}
+              </div>
+              {totalPipelinePages > 1 && (
+                <PaginationControls
+                  currentPage={currentPipelinesPage}
+                  totalPages={totalPipelinePages}
+                  onPreviousPage={() =>
+                    setPipelinesPage((page) => Math.max(1, page - 1))
+                  }
+                  onNextPage={() =>
+                    setPipelinesPage((page) =>
+                      Math.min(totalPipelinePages, page + 1),
+                    )
+                  }
+                />
+              )}
+            </BlockStack>
+          )}
+        </DashboardSection>
+      </div>
+    );
+  };
+
+  // ---------------------------------------------------------------------------
+  return (
+    <div className="mx-auto w-full max-w-7xl px-6 py-8">
+      <BlockStack gap="4" align="stretch">
+        {/* Header */}
+        <BlockStack gap="4">
+          <InlineStack
+            gap="4"
+            align="space-between"
+            blockAlign="end"
+            wrap="nowrap"
+          >
+            <BlockStack gap="0">
+              <Text as="h1" size="2xl" weight="bold">
+                Command Center
+              </Text>
+              <Text as="p" size="sm" tone="subdued">
+                Your ML workspace at a glance
+              </Text>
+            </BlockStack>
+
+            <InlineStack gap="2" wrap="nowrap">
+              {/* Widen to `string` — see comment above about TanStack Router. */}
+              <Button variant="secondary" asChild>
+                <Link to={QUICK_START_PATH as string}>
+                  <Icon name="Sparkles" size="sm" />
+                  Templates
+                </Link>
+              </Button>
+              <ImportPipeline
+                triggerComponent={
+                  <Button variant="secondary">
+                    <Icon name="Upload" size="sm" />
+                    Import
+                  </Button>
+                }
+              />
+            </InlineStack>
+          </InlineStack>
+
+          <Separator />
+
+          {/* Recently opened */}
+          {hasVisibleRecentFeed && (
+            <BlockStack gap="2">
+              <Text as="p" size="xs" tone="subdued" weight="semibold">
+                Recently opened
+              </Text>
+              <InlineStack gap="2" wrap="wrap">
+                {visibleRecentlyOpened.map((item) => (
+                  <RecentItemLink
+                    key={recentItemKey(item)}
+                    item={item}
+                    isPinned={pinnedUrls.has(item.url)}
+                    onTogglePinned={handleTogglePinnedLink}
+                    showPinControls={showPinnedSection}
+                  />
+                ))}
+                {hiddenRecentlyOpenedCount > 0 && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="h-9 rounded-lg border-border/50 bg-transparent px-3 text-xs"
+                    onClick={() => setShowAllRecentlyOpened(true)}
+                  >
+                    +{hiddenRecentlyOpenedCount} more
+                  </Button>
+                )}
+                {showAllRecentlyOpened &&
+                  recentlyOpened.length > RECENT_OPENED_VISIBLE_LIMIT && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-9 rounded-lg px-3 text-xs text-muted-foreground"
+                      onClick={() => setShowAllRecentlyOpened(false)}
+                    >
+                      Show less
+                    </Button>
+                  )}
+              </InlineStack>
+            </BlockStack>
+          )}
+
+          {/* Pinned */}
+          {hasVisiblePinnedFeed && (
+            <BlockStack gap="2">
+              <Text as="p" size="xs" tone="subdued" weight="semibold">
+                Pinned
+              </Text>
+              <InlineStack gap="2" wrap="wrap">
+                {pinnedItems.map((item) => (
+                  <RecentItemLink
+                    key={`pinned-${recentItemKey(item)}`}
+                    item={item}
+                    isPinned={true}
+                    onTogglePinned={handleTogglePinnedLink}
+                    showPinControls={showPinnedSection}
+                  />
+                ))}
+              </InlineStack>
+            </BlockStack>
+          )}
+
+          {/* Summary + section controls */}
+          <div className="grid grid-cols-1 gap-3 xl:grid-cols-[1fr_1fr_auto_1fr_1fr_1fr] xl:items-start">
+            <StatCard
+              label="Active"
+              value={activeRuns}
+              icon="Activity"
+              tone="warning"
+              isLoading={isRunsLoading}
+              onClick={() => scrollToSection(runsSectionRef)}
+            />
+            <StatCard
+              label="Errors"
+              value={errorRuns}
+              icon="TriangleAlert"
+              tone="critical"
+              isLoading={isRunsLoading}
+              onClick={() => scrollToSection(runsSectionRef)}
+            />
+            <InlineStack
+              align="center"
+              blockAlign="center"
+              className="relative hidden min-h-18 px-2 xl:flex"
+            >
+              <div className="pointer-events-none h-2.5 w-2.5 rotate-45 rounded-[2px] border border-border/70 bg-muted/35" />
+            </InlineStack>
+            {sectionOrder.map((sectionId) => (
+              <div key={sectionId} className="relative">
+                <div
+                  draggable
+                  onDragStart={() => handleSectionDragStart(sectionId)}
+                  onDragOver={(event: DragEvent<HTMLDivElement>) =>
+                    handleSectionDragOver(event, sectionId)
+                  }
+                  onDrop={() => handleSectionDrop(sectionId)}
+                  onDragEnd={handleSectionDragEnd}
+                  className={cn(
+                    "w-full cursor-grab rounded-xl transition-all active:cursor-grabbing",
+                    draggingSectionId === sectionId &&
+                      "scale-[1.01] opacity-85 shadow-lg ring-2 ring-violet-500/40",
+                    dragOverSectionId === sectionId &&
+                      "ring-2 ring-violet-500/60 ring-offset-2",
+                  )}
+                >
+                  <SectionToggleButton
+                    label={sectionMeta[sectionId].label}
+                    count={sectionMeta[sectionId].count}
+                    isActive={sectionVisibility[sectionId]}
+                    onToggle={() => toggleSectionVisibility(sectionId)}
+                    showVisibilityIcon={false}
+                  />
+                </div>
+                <div className="pointer-events-none absolute right-3 top-3 text-muted-foreground/75">
+                  <Icon name="GripVertical" size="xs" />
+                </div>
+              </div>
+            ))}
+          </div>
+        </BlockStack>
+
+        {hasVisibleSections && (
+          <BlockStack gap="3">
+            {topVisibleSections.length > 0 && (
+              <div className="grid grid-cols-1 gap-4 lg:grid-cols-10">
+                {topVisibleSections.map((sectionId) => (
+                  <Fragment key={`top-${sectionId}`}>
+                    {renderSection(
+                      sectionId,
+                      cn(
+                        "lg:col-span-10",
+                        getTopSectionColClass(sectionId, topVisibleSections),
+                      ),
+                    )}
+                  </Fragment>
+                ))}
+              </div>
+            )}
+
+            {lowerVisibleSections.map((sectionId) => (
+              <div key={`lower-${sectionId}`}>{renderSection(sectionId)}</div>
+            ))}
+          </BlockStack>
+        )}
+      </BlockStack>
+    </div>
+  );
+};
+
+export default Dashboard;

--- a/src/routes/Dashboard/components/ComponentItem.tsx
+++ b/src/routes/Dashboard/components/ComponentItem.tsx
@@ -1,0 +1,229 @@
+import { useEffect, useState } from "react";
+
+import { ViewYamlButton } from "@/components/shared/Buttons/ViewYamlButton";
+import { CopyYamlButton } from "@/components/shared/TaskDetails/Actions/CopyYamlButton";
+import { DownloadPythonButton } from "@/components/shared/TaskDetails/Actions/DownloadPythonButton";
+import { DownloadYamlButton } from "@/components/shared/TaskDetails/Actions/DownloadYamlButton";
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icon";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
+import { cn } from "@/lib/utils";
+import type { ComponentReference } from "@/utils/componentSpec";
+import { isHydratedComponentReference } from "@/utils/componentSpec";
+
+const SPEC_LIST_PREVIEW_COUNT = 4;
+
+const SpecNameList = ({
+  label,
+  names,
+  showAll,
+  onToggleShowAll,
+}: {
+  label: string;
+  names: string[];
+  showAll: boolean;
+  onToggleShowAll: () => void;
+}) => {
+  const visibleNames = showAll
+    ? names
+    : names.slice(0, SPEC_LIST_PREVIEW_COUNT);
+  const hiddenCount = names.length - visibleNames.length;
+
+  return (
+    <BlockStack gap="2">
+      <InlineStack gap="2" align="space-between" blockAlign="center">
+        <Text as="p" size="xs" weight="semibold" tone="subdued">
+          {label} ({names.length})
+        </Text>
+        {names.length > SPEC_LIST_PREVIEW_COUNT && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-6 px-2 text-[11px] text-muted-foreground"
+            onClick={(event) => {
+              event.stopPropagation();
+              onToggleShowAll();
+            }}
+          >
+            {showAll ? "Show less" : `Show all (${names.length})`}
+          </Button>
+        )}
+      </InlineStack>
+      {names.length === 0 ? (
+        <Text as="p" size="xs" tone="subdued">
+          None
+        </Text>
+      ) : (
+        <BlockStack gap="1">
+          {visibleNames.map((n) => (
+            <InlineStack key={n} gap="2" blockAlign="start">
+              <Text as="span" size="xs" tone="subdued">
+                •
+              </Text>
+              <Text as="p" size="xs" className="wrap-break-word">
+                {n}
+              </Text>
+            </InlineStack>
+          ))}
+          {!showAll && hiddenCount > 0 && (
+            <Text as="p" size="xs" tone="subdued">
+              +{hiddenCount} more
+            </Text>
+          )}
+        </BlockStack>
+      )}
+    </BlockStack>
+  );
+};
+
+export const ComponentItem = ({
+  component,
+  isExpanded,
+  onToggle,
+}: {
+  component: ComponentReference;
+  isExpanded: boolean;
+  onToggle: () => void;
+}) => {
+  const name = component.spec?.name ?? component.name ?? "Unnamed";
+  const spec = component.spec;
+  const description = spec?.description;
+  const inputCount = spec?.inputs?.length ?? 0;
+  const outputCount = spec?.outputs?.length ?? 0;
+  const isDeprecated = "deprecated" in component && !!component.deprecated;
+  const inputNames =
+    spec?.inputs?.map((input) => input.name).filter(Boolean) ?? [];
+  const outputNames =
+    spec?.outputs?.map((output) => output.name).filter(Boolean) ?? [];
+  const [showAllInputs, setShowAllInputs] = useState(false);
+  const [showAllOutputs, setShowAllOutputs] = useState(false);
+
+  const hydrated =
+    "spec" in component && isHydratedComponentReference(component)
+      ? component
+      : undefined;
+
+  useEffect(() => {
+    if (!isExpanded) {
+      setShowAllInputs(false);
+      setShowAllOutputs(false);
+    }
+  }, [isExpanded]);
+
+  const toggleShowAllInputs = () => setShowAllInputs((prev) => !prev);
+  const toggleShowAllOutputs = () => setShowAllOutputs((prev) => !prev);
+
+  return (
+    <div
+      className={cn(
+        "relative z-0 w-full rounded-xl border border-transparent bg-transparent transition-all duration-200 ease-out",
+        isExpanded
+          ? "z-10 scale-[1.01] bg-violet-500/6 border-violet-500/10 shadow-[0_10px_24px_-12px_rgba(124,58,237,0.25)]"
+          : "hover:bg-card/70 hover:border-border/60",
+      )}
+    >
+      <button
+        onClick={onToggle}
+        className="flex w-full cursor-pointer items-center gap-2.5 px-3 py-2.5 text-left"
+      >
+        <div className="shrink-0 rounded-lg bg-violet-500/10 p-1.5 text-violet-600 dark:text-violet-400">
+          <Icon name="Box" size="sm" />
+        </div>
+        <BlockStack gap="0" className="min-w-0 flex-1 overflow-hidden">
+          <InlineStack gap="2" blockAlign="center" className="overflow-hidden">
+            <Text
+              as="p"
+              size="sm"
+              weight="semibold"
+              className="line-clamp-2 wrap-break-word"
+            >
+              {name}
+            </Text>
+            {isDeprecated && (
+              <Text as="span" size="xs" tone="critical" className="shrink-0">
+                deprecated
+              </Text>
+            )}
+          </InlineStack>
+          {description && (
+            <Text
+              as="p"
+              size="xs"
+              tone="subdued"
+              className="mt-0.5 line-clamp-2"
+            >
+              {description}
+            </Text>
+          )}
+        </BlockStack>
+        <InlineStack gap="3" blockAlign="center" className="shrink-0">
+          {inputCount > 0 && (
+            <Text as="span" size="xs" tone="subdued">
+              {inputCount} in
+            </Text>
+          )}
+          {outputCount > 0 && (
+            <Text as="span" size="xs" tone="subdued">
+              {outputCount} out
+            </Text>
+          )}
+        </InlineStack>
+        <div className="shrink-0 text-muted-foreground">
+          <Icon
+            name="ChevronDown"
+            size="sm"
+            className={cn(
+              "transition-transform duration-200 ease-out",
+              isExpanded && "rotate-180",
+            )}
+          />
+        </div>
+      </button>
+
+      <div
+        className={cn(
+          "grid transition-all duration-200 ease-out",
+          isExpanded
+            ? "grid-rows-[1fr] opacity-100"
+            : "grid-rows-[0fr] opacity-0",
+        )}
+      >
+        <div className="overflow-hidden">
+          <div className="border-t border-border/60 px-3 pb-3 pt-2">
+            <BlockStack gap="3" className="w-full">
+              <SpecNameList
+                label="Inputs"
+                names={inputNames}
+                showAll={showAllInputs}
+                onToggleShowAll={toggleShowAllInputs}
+              />
+              <SpecNameList
+                label="Outputs"
+                names={outputNames}
+                showAll={showAllOutputs}
+                onToggleShowAll={toggleShowAllOutputs}
+              />
+
+              {hydrated && (
+                <InlineStack
+                  gap="1"
+                  wrap="wrap"
+                  className="border-t border-border/50 pt-1"
+                >
+                  <DownloadYamlButton componentRef={hydrated} />
+                  {hydrated.spec.metadata?.annotations
+                    ?.python_original_code && (
+                    <DownloadPythonButton componentRef={hydrated} />
+                  )}
+                  <CopyYamlButton componentRef={hydrated} />
+                  <ViewYamlButton componentRef={hydrated} />
+                </InlineStack>
+              )}
+            </BlockStack>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/routes/Dashboard/components/DashboardSection.tsx
+++ b/src/routes/Dashboard/components/DashboardSection.tsx
@@ -1,0 +1,76 @@
+import type { ReactNode } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Icon } from "@/components/ui/icon";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
+
+const SectionHeader = ({
+  title,
+  count,
+  actionLabel,
+  onAction,
+}: {
+  title: string;
+  count?: number;
+  actionLabel?: string;
+  onAction?: () => void;
+}) => (
+  <CardHeader className="px-3 pb-1 pt-2">
+    <InlineStack
+      gap="2"
+      align="space-between"
+      blockAlign="center"
+      wrap="nowrap"
+    >
+      <InlineStack gap="2" blockAlign="baseline">
+        <CardTitle className="text-base leading-tight">{title}</CardTitle>
+        {count !== undefined && (
+          <Text as="span" size="xs" tone="subdued" className="leading-none">
+            ({count})
+          </Text>
+        )}
+      </InlineStack>
+      {actionLabel && onAction && (
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onAction}
+          className="text-xs text-muted-foreground"
+        >
+          {actionLabel}
+          <Icon name="ArrowRight" size="xs" />
+        </Button>
+      )}
+    </InlineStack>
+  </CardHeader>
+);
+
+export const DashboardSection = ({
+  title,
+  count,
+  actionLabel,
+  onAction,
+  children,
+}: {
+  title: string;
+  count?: number;
+  actionLabel?: string;
+  onAction?: () => void;
+  children: ReactNode;
+}) => (
+  <Card className="gap-0 overflow-hidden border-0 bg-transparent shadow-none">
+    <SectionHeader
+      title={title}
+      count={count}
+      actionLabel={actionLabel}
+      onAction={onAction}
+    />
+    <CardContent className="overflow-hidden p-0">
+      <BlockStack gap="3" className="min-w-0 px-3 pb-3 pt-1">
+        {children}
+      </BlockStack>
+    </CardContent>
+  </Card>
+);

--- a/src/routes/Dashboard/components/EmptyState.tsx
+++ b/src/routes/Dashboard/components/EmptyState.tsx
@@ -1,0 +1,25 @@
+import type { ReactNode } from "react";
+
+import { Icon } from "@/components/ui/icon";
+import { BlockStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
+
+export const EmptyState = ({
+  icon,
+  message,
+  children,
+}: {
+  icon: Parameters<typeof Icon>[0]["name"];
+  message: string;
+  children?: ReactNode;
+}) => (
+  <BlockStack gap="3" align="center" className="py-8">
+    <div className="rounded-full bg-muted p-3 text-muted-foreground">
+      <Icon name={icon} size="xl" />
+    </div>
+    <Text as="p" size="sm" tone="subdued" className="max-w-xs text-center">
+      {message}
+    </Text>
+    {children}
+  </BlockStack>
+);

--- a/src/routes/Dashboard/components/PaginationControls.tsx
+++ b/src/routes/Dashboard/components/PaginationControls.tsx
@@ -1,0 +1,44 @@
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icon";
+import { InlineStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
+
+interface PaginationControlsProps {
+  currentPage: number;
+  totalPages: number;
+  onPreviousPage: () => void;
+  onNextPage: () => void;
+}
+
+export const PaginationControls = ({
+  currentPage,
+  totalPages,
+  onPreviousPage,
+  onNextPage,
+}: PaginationControlsProps) => (
+  <InlineStack gap="2" align="space-between" blockAlign="center">
+    <Text as="span" size="xs" tone="subdued">
+      Page {currentPage} of {totalPages}
+    </Text>
+    <InlineStack gap="2">
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={onPreviousPage}
+        disabled={currentPage === 1}
+      >
+        <Icon name="ChevronLeft" size="sm" />
+        Previous
+      </Button>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={onNextPage}
+        disabled={currentPage === totalPages}
+      >
+        Next
+        <Icon name="ChevronRight" size="sm" />
+      </Button>
+    </InlineStack>
+  </InlineStack>
+);

--- a/src/routes/Dashboard/components/PipelineCard.tsx
+++ b/src/routes/Dashboard/components/PipelineCard.tsx
@@ -1,0 +1,144 @@
+import { useNavigate } from "@tanstack/react-router";
+import { type KeyboardEvent } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icon";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
+import { cn } from "@/lib/utils";
+import { EDITOR_PATH } from "@/routes/router";
+import { isGraphImplementation } from "@/utils/componentSpec";
+import type { ComponentFileEntry } from "@/utils/componentStore";
+import { formatRelativeTime } from "@/utils/date";
+
+export const PipelineCard = ({
+  name,
+  entry,
+  showPinControls = false,
+  pinned = false,
+  onTogglePinned,
+}: {
+  name: string;
+  entry: ComponentFileEntry;
+  showPinControls?: boolean;
+  pinned?: boolean;
+  onTogglePinned?: (name: string) => void;
+}) => {
+  const navigate = useNavigate();
+  const relativeTime = entry.modificationTime
+    ? formatRelativeTime(entry.modificationTime)
+    : null;
+
+  const spec = entry.componentRef.spec;
+  const description = spec?.description;
+  const inputCount = spec?.inputs?.length ?? 0;
+  const outputCount = spec?.outputs?.length ?? 0;
+
+  const taskCount =
+    spec?.implementation && isGraphImplementation(spec.implementation)
+      ? Object.keys(spec.implementation.graph.tasks).length
+      : 0;
+
+  const openPipeline = () => {
+    navigate({ to: `${EDITOR_PATH}/${encodeURIComponent(name)}` });
+  };
+
+  const onCardKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      openPipeline();
+    }
+  };
+
+  const handlePinnedToggle = () => {
+    onTogglePinned?.(name);
+  };
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={openPipeline}
+      onKeyDown={onCardKeyDown}
+      className="group flex w-full cursor-pointer items-start gap-3 rounded-xl border border-transparent bg-transparent px-3 py-2 text-left transition-all duration-200 ease-out hover:bg-violet-500/6 hover:shadow-[0_8px_20px_-12px_rgba(124,58,237,0.3)]"
+    >
+      <div className="mt-0.5 shrink-0 rounded-lg bg-primary/8 p-1.5 text-primary transition-colors group-hover:bg-primary/12">
+        <Icon name="Workflow" size="sm" />
+      </div>
+      <BlockStack gap="0" className="min-w-0 flex-1 overflow-hidden">
+        <Text
+          as="p"
+          size="sm"
+          weight="semibold"
+          className="truncate"
+          title={name}
+        >
+          {name}
+        </Text>
+        {description && (
+          <Text
+            as="p"
+            size="xs"
+            tone="subdued"
+            className="mt-0.5 truncate leading-tight"
+            title={description}
+          >
+            {description}
+          </Text>
+        )}
+        <InlineStack gap="3" blockAlign="center" className="mt-1">
+          {taskCount > 0 && (
+            <InlineStack gap="1" blockAlign="center" className="shrink-0">
+              <Icon name="Layers" size="xs" />
+              <Text as="span" size="xs" tone="subdued">
+                {taskCount} tasks
+              </Text>
+            </InlineStack>
+          )}
+          {inputCount > 0 && (
+            <InlineStack gap="1" blockAlign="center" className="shrink-0">
+              <Icon name="ArrowDownToLine" size="xs" />
+              <Text as="span" size="xs" tone="subdued">
+                {inputCount} in
+              </Text>
+            </InlineStack>
+          )}
+          {outputCount > 0 && (
+            <InlineStack gap="1" blockAlign="center" className="shrink-0">
+              <Icon name="ArrowUpFromLine" size="xs" />
+              <Text as="span" size="xs" tone="subdued">
+                {outputCount} out
+              </Text>
+            </InlineStack>
+          )}
+          {relativeTime && (
+            <Text
+              as="span"
+              size="xs"
+              tone="subdued"
+              className="ml-auto shrink-0 leading-none"
+            >
+              {relativeTime}
+            </Text>
+          )}
+        </InlineStack>
+      </BlockStack>
+      {showPinControls && onTogglePinned && (
+        <div className="shrink-0" onClick={(event) => event.stopPropagation()}>
+          <Button
+            variant="ghost"
+            size="icon"
+            className={cn(
+              "h-7 w-7 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100",
+              pinned && "text-violet-500",
+            )}
+            onClick={handlePinnedToggle}
+            aria-label={pinned ? "Unpin pipeline" : "Pin pipeline"}
+          >
+            <Icon name={pinned ? "Pin" : "PinOff"} size="sm" />
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/routes/Dashboard/components/RecentItemLink.tsx
+++ b/src/routes/Dashboard/components/RecentItemLink.tsx
@@ -1,0 +1,79 @@
+import { Link } from "@tanstack/react-router";
+
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icon";
+import { InlineStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
+import { cn } from "@/lib/utils";
+
+import type { RecentLinkItem } from "../types";
+
+export const RecentItemLink = ({
+  item,
+  isPinned,
+  onTogglePinned,
+  showPinControls = true,
+}: {
+  item: RecentLinkItem;
+  isPinned: boolean;
+  onTogglePinned: (item: RecentLinkItem) => void;
+  showPinControls?: boolean;
+}) => {
+  const isRun = item.type === "run";
+  const surfaceClass = isRun
+    ? "border-violet-500/20 bg-violet-500/6 hover:bg-violet-500/12"
+    : "border-border/40 bg-transparent hover:bg-violet-500/6";
+
+  return (
+    <InlineStack
+      gap="1"
+      blockAlign="center"
+      className={cn(
+        "group/chip rounded-lg border px-1.5 py-1 transition-all duration-200 ease-out",
+        surfaceClass,
+        "hover:shadow-[0_8px_20px_-12px_rgba(124,58,237,0.3)]",
+      )}
+    >
+      <Link
+        to={item.url}
+        className="group/link flex min-w-0 items-center gap-2 px-1.5 py-0.5"
+      >
+        <Icon
+          name={isRun ? "Play" : "Workflow"}
+          size="xs"
+          className={cn(
+            "shrink-0",
+            isRun ? "text-violet-600 dark:text-violet-400" : "text-primary",
+          )}
+        />
+        <Text
+          as="span"
+          size="sm"
+          className="max-w-48 truncate"
+          title={item.title}
+        >
+          {item.title}
+        </Text>
+        <Icon
+          name="ArrowRight"
+          size="xs"
+          className="shrink-0 text-muted-foreground opacity-0 transition-all duration-200 group-hover/link:translate-x-0.5 group-hover/link:opacity-100"
+        />
+      </Link>
+      {showPinControls && (
+        <Button
+          variant="ghost"
+          size="icon"
+          className={cn(
+            "h-7 w-7 opacity-0 transition-opacity group-hover/chip:opacity-100 group-focus-within/chip:opacity-100 focus-visible:opacity-100",
+            isPinned && "text-violet-500",
+          )}
+          aria-label={isPinned ? "Unpin item" : "Pin item"}
+          onClick={() => onTogglePinned(item)}
+        >
+          <Icon name={isPinned ? "Pin" : "PinOff"} size="sm" />
+        </Button>
+      )}
+    </InlineStack>
+  );
+};

--- a/src/routes/Dashboard/components/RunsTable.tsx
+++ b/src/routes/Dashboard/components/RunsTable.tsx
@@ -1,0 +1,229 @@
+import { useNavigate } from "@tanstack/react-router";
+import { type MouseEvent } from "react";
+
+import type { ListPipelineJobsResponse } from "@/api/types.gen";
+import { StatusBar, StatusIcon } from "@/components/shared/Status";
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icon";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { Text } from "@/components/ui/typography";
+import useToastNotification from "@/hooks/useToastNotification";
+import { cn } from "@/lib/utils";
+import { APP_ROUTES } from "@/routes/router";
+import { convertUTCToLocalTime, formatDate } from "@/utils/date";
+import { getOverallExecutionStatusFromStats } from "@/utils/executionStatus";
+
+type PipelineRunItem = ListPipelineJobsResponse["pipeline_runs"][number];
+
+const RUN_CELL_BASE =
+  "py-2.5 align-middle bg-transparent transition-all duration-300 ease-out group-hover:bg-violet-500/6";
+const RUN_CELL_SHADOW =
+  "group-hover:shadow-[0_14px_28px_-18px_rgba(124,58,237,0.32)]";
+
+function truncateMiddle(str: string, maxLength = 28) {
+  if (!str || str.length <= maxLength) return str;
+  const keep = Math.floor((maxLength - 3) / 2);
+  return str.slice(0, keep) + "..." + str.slice(-keep);
+}
+
+const CreatedByCell = ({ createdBy }: { createdBy: string }) => {
+  const notify = useToastNotification();
+  const truncated = truncateMiddle(createdBy);
+  const isTruncated = createdBy !== truncated;
+
+  const handleCopy = (e: MouseEvent) => {
+    e.stopPropagation();
+    navigator.clipboard.writeText(createdBy);
+    notify(`"${createdBy}" copied to clipboard`, "success");
+  };
+
+  const button = (
+    <Button
+      variant="ghost"
+      size="sm"
+      className="h-auto px-1 py-0 text-xs text-muted-foreground underline-offset-2 hover:underline"
+      onClick={handleCopy}
+    >
+      {truncated}
+    </Button>
+  );
+
+  if (!isTruncated) return button;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{button}</TooltipTrigger>
+      <TooltipContent>
+        <Text as="span" size="xs">
+          {createdBy}
+        </Text>
+      </TooltipContent>
+    </Tooltip>
+  );
+};
+
+export const RunsTable = ({
+  runs,
+  showPinControls = false,
+  pinnedRunUrls,
+  onToggleRunPinned,
+}: {
+  runs: PipelineRunItem[];
+  showPinControls?: boolean;
+  pinnedRunUrls?: Set<string>;
+  onToggleRunPinned?: (run: PipelineRunItem) => void;
+}) => {
+  const navigate = useNavigate();
+
+  return (
+    <table className="w-full table-fixed border-collapse">
+      {/* Inline styles are necessary here: Tailwind doesn't support width on
+          <col> elements, and colgroup is the most reliable cross-browser way
+          to set fixed column widths on a table-fixed layout. */}
+      <colgroup>
+        <col style={{ width: 28 }} />
+        <col />
+        <col style={{ width: "30%" }} />
+        <col style={{ width: 140 }} />
+        <col style={{ width: 160 }} />
+        {showPinControls && <col style={{ width: 46 }} />}
+      </colgroup>
+      <thead>
+        <tr className="border-b border-border/30 text-left">
+          <th className="py-2 pl-3 pr-1" />
+          <th className="px-2 py-2">
+            <Text as="span" size="xs" tone="subdued">
+              Name
+            </Text>
+          </th>
+          <th className="px-2 py-2">
+            <Text as="span" size="xs" tone="subdued">
+              Status
+            </Text>
+          </th>
+          <th className="px-2 py-2">
+            <Text as="span" size="xs" tone="subdued">
+              Date
+            </Text>
+          </th>
+          <th className="px-2 py-2 pr-3">
+            <Text as="span" size="xs" tone="subdued">
+              Initiated By
+            </Text>
+          </th>
+          {showPinControls && <th className="py-2 pl-1 pr-3" />}
+        </tr>
+      </thead>
+      <tbody>
+        {runs.map((run) => {
+          const overallStatus = getOverallExecutionStatusFromStats(
+            run.execution_status_stats ?? undefined,
+          );
+          const createdAt = run.created_at
+            ? formatDate(convertUTCToLocalTime(run.created_at).toISOString())
+            : null;
+          const createdBy = run.created_by ?? "Unknown";
+          const totalTasks = run.execution_status_stats
+            ? Object.values(run.execution_status_stats).reduce(
+                (sum, c) => sum + (c ?? 0),
+                0,
+              )
+            : 0;
+
+          const clickUrl = `${APP_ROUTES.RUNS}/${run.id}`;
+          const isPinned = pinnedRunUrls?.has(clickUrl) ?? false;
+
+          const handleRowClick = (e: MouseEvent<HTMLElement>) => {
+            if (e.target instanceof HTMLElement && e.target.closest("button")) {
+              return;
+            }
+
+            if (e.ctrlKey || e.metaKey) {
+              window.open(clickUrl, "_blank");
+              return;
+            }
+            navigate({ to: clickUrl });
+          };
+
+          return (
+            <tr
+              key={run.id}
+              onClick={handleRowClick}
+              className="group cursor-pointer border-b border-border/20 last:border-b-0"
+            >
+              <td
+                className={cn(
+                  RUN_CELL_BASE,
+                  RUN_CELL_SHADOW,
+                  "rounded-l-xl pl-3 pr-1",
+                )}
+              >
+                <StatusIcon status={overallStatus} />
+              </td>
+              <td className={cn(RUN_CELL_BASE, "overflow-hidden px-2")}>
+                <Text as="p" size="sm" weight="semibold" className="truncate">
+                  {run.pipeline_name ?? "Unknown pipeline"}
+                </Text>
+                <Text
+                  as="p"
+                  size="xs"
+                  tone="subdued"
+                  font="mono"
+                  className="truncate leading-tight"
+                >
+                  #{String(run.id).slice(0, 14)}
+                  {totalTasks > 0 && (
+                    <Text as="span" size="xs" tone="subdued" font="default">
+                      {" "}
+                      &middot; {totalTasks} tasks
+                    </Text>
+                  )}
+                </Text>
+              </td>
+              <td className={cn(RUN_CELL_BASE, "px-2")}>
+                <StatusBar executionStatusStats={run.execution_status_stats} />
+              </td>
+              <td className={cn(RUN_CELL_BASE, "whitespace-nowrap px-2")}>
+                <Text as="span" size="xs" tone="subdued">
+                  {createdAt ?? "—"}
+                </Text>
+              </td>
+              <td
+                className={cn(
+                  RUN_CELL_BASE,
+                  RUN_CELL_SHADOW,
+                  "overflow-hidden rounded-r-xl px-2 pr-3",
+                )}
+              >
+                <CreatedByCell createdBy={createdBy} />
+              </td>
+              {showPinControls && onToggleRunPinned && (
+                <td className={cn(RUN_CELL_BASE, RUN_CELL_SHADOW, "pl-1 pr-3")}>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className={cn(
+                      "h-7 w-7 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100",
+                      isPinned && "text-violet-500",
+                    )}
+                    aria-label={isPinned ? "Unpin run" : "Pin run"}
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      onToggleRunPinned(run);
+                    }}
+                  >
+                    <Icon name={isPinned ? "Pin" : "PinOff"} size="sm" />
+                  </Button>
+                </td>
+              )}
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  );
+};

--- a/src/routes/Dashboard/components/StatCard.tsx
+++ b/src/routes/Dashboard/components/StatCard.tsx
@@ -1,0 +1,113 @@
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icon";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Text } from "@/components/ui/typography";
+import { cn } from "@/lib/utils";
+
+const TONE_BG: Record<string, string> = {
+  default: "bg-primary/10 text-primary",
+  info: "bg-blue-500/10 text-blue-600 dark:text-blue-400",
+  warning: "bg-amber-500/10 text-amber-600 dark:text-amber-400",
+  critical: "bg-red-500/10 text-red-600 dark:text-red-400",
+};
+
+const PURPLE_SURFACE_BG = "bg-violet-500/6";
+const PURPLE_SURFACE_BG_HOVER = "hover:bg-violet-500/10";
+const PURPLE_BORDER = "border-violet-500/25";
+
+export const StatCard = ({
+  label,
+  value,
+  icon,
+  tone = "default",
+  isLoading,
+  onClick,
+}: {
+  label: string;
+  value: string | number;
+  icon: Parameters<typeof Icon>[0]["name"];
+  tone?: keyof typeof TONE_BG;
+  isLoading?: boolean;
+  onClick?: () => void;
+}) => (
+  <button
+    type="button"
+    onClick={onClick}
+    disabled={!onClick}
+    className={cn(
+      "h-full min-h-18 w-full rounded-xl border bg-transparent px-4 py-3 text-left transition-colors",
+      PURPLE_BORDER,
+      onClick
+        ? cn(
+            "cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+            PURPLE_SURFACE_BG_HOVER,
+          )
+        : "cursor-default",
+    )}
+  >
+    <InlineStack gap="3" blockAlign="center" wrap="nowrap">
+      <div className={cn("shrink-0 rounded-lg p-2", TONE_BG[tone])}>
+        <Icon name={icon} size="md" />
+      </div>
+      <BlockStack gap="0">
+        {isLoading ? (
+          <Skeleton className="h-7 w-8 rounded" />
+        ) : (
+          <Text as="span" size="xl" weight="bold" className="leading-none">
+            {value}
+          </Text>
+        )}
+        <Text as="span" size="xs" tone="subdued" className="leading-none">
+          {label}
+        </Text>
+      </BlockStack>
+    </InlineStack>
+  </button>
+);
+
+export const SectionToggleButton = ({
+  label,
+  count,
+  isActive,
+  onToggle,
+  showVisibilityIcon = true,
+}: {
+  label: string;
+  count: number;
+  isActive: boolean;
+  onToggle: () => void;
+  showVisibilityIcon?: boolean;
+}) => (
+  <Button
+    variant="outline"
+    onClick={onToggle}
+    className={cn(
+      "h-full min-h-18 w-full rounded-xl px-4 py-3 text-left",
+      isActive
+        ? cn(PURPLE_BORDER, PURPLE_SURFACE_BG, "text-foreground")
+        : cn(PURPLE_BORDER, "bg-transparent text-muted-foreground"),
+      "hover:bg-violet-500/10",
+    )}
+  >
+    <InlineStack align="start" blockAlign="center" className="w-full">
+      <BlockStack gap="0" align="start">
+        <InlineStack gap="1" blockAlign="center">
+          <Text as="span" size="xl" weight="bold" className="leading-none">
+            {count}
+          </Text>
+          {showVisibilityIcon && (
+            <Icon
+              name={isActive ? "Eye" : "EyeOff"}
+              size="sm"
+              className="text-muted-foreground"
+            />
+          )}
+        </InlineStack>
+        <Text as="span" size="xs" tone="subdued" className="leading-none">
+          {label}
+        </Text>
+      </BlockStack>
+    </InlineStack>
+  </Button>
+);

--- a/src/routes/Dashboard/hooks/useCursorPagination.ts
+++ b/src/routes/Dashboard/hooks/useCursorPagination.ts
@@ -1,0 +1,32 @@
+import { useState } from "react";
+
+export function useCursorPagination() {
+  const [pageToken, setPageToken] = useState<string | undefined>(undefined);
+  const [previousPageTokens, setPreviousPageTokens] = useState<string[]>([]);
+
+  const handleNextPage = (nextPageToken: string | undefined) => {
+    if (nextPageToken) {
+      setPreviousPageTokens((prev) => [...prev, pageToken ?? ""]);
+      setPageToken(nextPageToken);
+    }
+  };
+
+  const handlePreviousPage = () => {
+    const prev = previousPageTokens[previousPageTokens.length - 1];
+    setPreviousPageTokens((tokens) => tokens.slice(0, -1));
+    setPageToken(prev || undefined);
+  };
+
+  const handleFirstPage = () => {
+    setPreviousPageTokens([]);
+    setPageToken(undefined);
+  };
+
+  return {
+    pageToken,
+    previousPageTokens,
+    handleNextPage,
+    handlePreviousPage,
+    handleFirstPage,
+  };
+}

--- a/src/routes/Dashboard/hooks/usePinnedLinks.ts
+++ b/src/routes/Dashboard/hooks/usePinnedLinks.ts
@@ -1,0 +1,65 @@
+import { useState } from "react";
+
+import type { ListPipelineJobsResponse } from "@/api/types.gen";
+import { APP_ROUTES, EDITOR_PATH } from "@/routes/router";
+import { getPinnedItems, setPinnedItem } from "@/utils/pinnedItems";
+
+import type { RecentLinkItem } from "../types";
+
+function loadPinnedLinks(): RecentLinkItem[] {
+  return getPinnedItems()
+    .filter(
+      (item): item is RecentLinkItem =>
+        item.type === "run" || item.type === "pipeline",
+    )
+    .map((item) => ({ ...item }));
+}
+
+export function usePinnedLinks(pipelineNames: Set<string>) {
+  const [pinnedLinks, setPinnedLinks] =
+    useState<RecentLinkItem[]>(loadPinnedLinks);
+
+  const updateFromStorage = () => setPinnedLinks(loadPinnedLinks());
+
+  const pinnedItems = pinnedLinks.filter((item) =>
+    item.type === "pipeline" ? pipelineNames.has(item.title) : true,
+  );
+  const pinnedUrls = new Set(pinnedItems.map((item) => item.url));
+  const pinnedRunUrls = new Set(
+    pinnedItems.filter((item) => item.type === "run").map((item) => item.url),
+  );
+
+  const handleToggleRunPinned = (
+    run: ListPipelineJobsResponse["pipeline_runs"][number],
+  ) => {
+    const url = `${APP_ROUTES.RUNS}/${run.id}`;
+    setPinnedItem(
+      { title: run.pipeline_name ?? `Run ${run.id}`, type: "run", url },
+      !pinnedRunUrls.has(url),
+    );
+    updateFromStorage();
+  };
+
+  const handleTogglePipelinePinned = (name: string) => {
+    const url = `${EDITOR_PATH}/${encodeURIComponent(name)}`;
+    setPinnedItem({ title: name, type: "pipeline", url }, !pinnedUrls.has(url));
+    updateFromStorage();
+  };
+
+  const handleTogglePinnedLink = (item: RecentLinkItem) => {
+    setPinnedItem(
+      { title: item.title, type: item.type, url: item.url },
+      !pinnedUrls.has(item.url),
+    );
+    updateFromStorage();
+  };
+
+  return {
+    pinnedItems,
+    pinnedUrls,
+    pinnedRunUrls,
+    handleToggleRunPinned,
+    handleTogglePipelinePinned,
+    handleTogglePinnedLink,
+  };
+}

--- a/src/routes/Dashboard/hooks/useSectionOrder.ts
+++ b/src/routes/Dashboard/hooks/useSectionOrder.ts
@@ -1,0 +1,136 @@
+import { type DragEvent, useEffect, useState } from "react";
+
+import type { DashboardSectionId } from "../types";
+
+const SECTION_ORDER_STORAGE_KEY = "dashboard/section-order";
+
+const DEFAULT_SECTION_ORDER: DashboardSectionId[] = [
+  "runs",
+  "components",
+  "pipelines",
+];
+
+function isDashboardSectionId(value: unknown): value is DashboardSectionId {
+  return value === "runs" || value === "components" || value === "pipelines";
+}
+
+function getInitialSectionOrder(): DashboardSectionId[] {
+  try {
+    const raw = localStorage.getItem(SECTION_ORDER_STORAGE_KEY);
+    if (!raw) return DEFAULT_SECTION_ORDER;
+
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      !Array.isArray(parsed) ||
+      parsed.length !== DEFAULT_SECTION_ORDER.length
+    ) {
+      return DEFAULT_SECTION_ORDER;
+    }
+
+    const parsedIds = parsed.filter(isDashboardSectionId);
+    if (parsedIds.length !== DEFAULT_SECTION_ORDER.length) {
+      return DEFAULT_SECTION_ORDER;
+    }
+
+    const uniqueIds = new Set(parsedIds);
+    if (uniqueIds.size !== DEFAULT_SECTION_ORDER.length) {
+      return DEFAULT_SECTION_ORDER;
+    }
+
+    return parsedIds;
+  } catch {
+    return DEFAULT_SECTION_ORDER;
+  }
+}
+
+export function useSectionOrder() {
+  const [sectionOrder, setSectionOrder] = useState<DashboardSectionId[]>(
+    getInitialSectionOrder,
+  );
+  const [sectionVisibility, setSectionVisibility] = useState<
+    Record<DashboardSectionId, boolean>
+  >({
+    runs: true,
+    components: true,
+    pipelines: true,
+  });
+  const [draggingSectionId, setDraggingSectionId] =
+    useState<DashboardSectionId | null>(null);
+  const [dragOverSectionId, setDragOverSectionId] =
+    useState<DashboardSectionId | null>(null);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(
+        SECTION_ORDER_STORAGE_KEY,
+        JSON.stringify(sectionOrder),
+      );
+    } catch {
+      // localStorage full or unavailable — silently ignore
+    }
+  }, [sectionOrder]);
+
+  const toggleSectionVisibility = (sectionId: DashboardSectionId) => {
+    setSectionVisibility((previous) => ({
+      ...previous,
+      [sectionId]: !previous[sectionId],
+    }));
+  };
+
+  const handleSectionDragStart = (sectionId: DashboardSectionId) => {
+    setDraggingSectionId(sectionId);
+    setDragOverSectionId(null);
+  };
+
+  const handleSectionDragOver = (
+    event: DragEvent<HTMLDivElement>,
+    sectionId: DashboardSectionId,
+  ) => {
+    event.preventDefault();
+    if (draggingSectionId && draggingSectionId !== sectionId) {
+      setDragOverSectionId(sectionId);
+    }
+  };
+
+  const handleSectionDrop = (targetSectionId: DashboardSectionId) => {
+    if (!draggingSectionId) return;
+
+    setSectionOrder((previous) => {
+      const sourceIndex = previous.indexOf(draggingSectionId);
+      const targetIndex = previous.indexOf(targetSectionId);
+      if (sourceIndex < 0 || targetIndex < 0 || sourceIndex === targetIndex) {
+        return previous;
+      }
+
+      const reordered = [...previous];
+      const [moved] = reordered.splice(sourceIndex, 1);
+      reordered.splice(targetIndex, 0, moved);
+      return reordered;
+    });
+
+    setDraggingSectionId(null);
+    setDragOverSectionId(null);
+  };
+
+  const handleSectionDragEnd = () => {
+    setDraggingSectionId(null);
+    setDragOverSectionId(null);
+  };
+
+  const visibleSections = sectionOrder.filter(
+    (sectionId) => sectionVisibility[sectionId],
+  );
+
+  return {
+    sectionOrder,
+    sectionVisibility,
+    draggingSectionId,
+    dragOverSectionId,
+    visibleSections,
+    toggleSectionVisibility,
+    handleSectionDragStart,
+    handleSectionDragOver,
+    handleSectionDrop,
+    handleSectionDragEnd,
+  };
+}

--- a/src/routes/Dashboard/types.ts
+++ b/src/routes/Dashboard/types.ts
@@ -1,0 +1,12 @@
+import type { RecentPipelineLink } from "@/utils/recentPipelines";
+import type { RecentRunLink } from "@/utils/recentRuns";
+
+export type RecentLinkItem =
+  | (RecentRunLink & { type: "run" })
+  | (RecentPipelineLink & { type: "pipeline" });
+
+export type DashboardSectionId = "runs" | "components" | "pipelines";
+
+export function recentItemKey(item: RecentLinkItem): string {
+  return `${item.type}-${item.url}`;
+}

--- a/src/routes/Dashboard/utils/pipelineOrganization.test.ts
+++ b/src/routes/Dashboard/utils/pipelineOrganization.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getAvailablePipelineTags,
+  organizePipelines,
+  type PipelineListItem,
+} from "@/routes/Dashboard/utils/pipelineOrganization";
+
+function makeItem(
+  name: string,
+  tags: string[] = [],
+  pinned = false,
+): PipelineListItem<string> {
+  return {
+    name,
+    entry: name,
+    metadata: { tags, pinned },
+  };
+}
+
+describe("pipelineOrganization", () => {
+  it("returns sorted unique tags", () => {
+    const items = [
+      makeItem("a", ["beta", "core"]),
+      makeItem("b", ["core", "team-x"]),
+    ];
+
+    expect(getAvailablePipelineTags(items)).toEqual(["beta", "core", "team-x"]);
+  });
+
+  it("keeps one all-pipelines group for none grouping", () => {
+    const items = [makeItem("a"), makeItem("b")];
+
+    expect(organizePipelines(items, "none")).toEqual([
+      { title: "All pipelines", items },
+    ]);
+  });
+
+  it("groups pinned first when enabled", () => {
+    const items = [
+      makeItem("a", [], true),
+      makeItem("b", [], false),
+      makeItem("c", [], true),
+    ];
+
+    expect(organizePipelines(items, "pinned-first")).toEqual([
+      { title: "Pinned", items: [items[0], items[2]] },
+      { title: "Others", items: [items[1]] },
+    ]);
+  });
+
+  it("groups by first tag and falls back to Untagged", () => {
+    const items = [
+      makeItem("a", ["data", "critical"]),
+      makeItem("b", []),
+      makeItem("c", ["alerts"]),
+    ];
+
+    expect(organizePipelines(items, "tag")).toEqual([
+      { title: "alerts", items: [items[2]] },
+      { title: "data", items: [items[0]] },
+      { title: "Untagged", items: [items[1]] },
+    ]);
+  });
+});

--- a/src/routes/Dashboard/utils/pipelineOrganization.ts
+++ b/src/routes/Dashboard/utils/pipelineOrganization.ts
@@ -1,0 +1,80 @@
+import type { PipelineMetadata } from "@/utils/pipelineMetadataStore";
+
+export interface PipelineListItem<TEntry = unknown> {
+  name: string;
+  entry: TEntry;
+  metadata?: PipelineMetadata;
+}
+
+type PipelineGrouping = "none" | "tag" | "pinned-first";
+
+interface PipelineGroup<TEntry = unknown> {
+  title: string;
+  items: PipelineListItem<TEntry>[];
+}
+
+export function getAvailablePipelineTags<TEntry>(
+  items: PipelineListItem<TEntry>[],
+): string[] {
+  const tags = new Set<string>();
+
+  for (const item of items) {
+    for (const tag of item.metadata?.tags ?? []) {
+      tags.add(tag);
+    }
+  }
+
+  return [...tags].sort((a, b) => a.localeCompare(b));
+}
+
+function getPrimaryGroupTag<TEntry>(item: PipelineListItem<TEntry>): string {
+  const firstTag = item.metadata?.tags[0];
+  return firstTag ?? "Untagged";
+}
+
+function getPinnedItems<TEntry>(
+  items: PipelineListItem<TEntry>[],
+): PipelineListItem<TEntry>[] {
+  return items.filter((item) => item.metadata?.pinned);
+}
+
+function getUnpinnedItems<TEntry>(
+  items: PipelineListItem<TEntry>[],
+): PipelineListItem<TEntry>[] {
+  return items.filter((item) => !item.metadata?.pinned);
+}
+
+export function organizePipelines<TEntry>(
+  items: PipelineListItem<TEntry>[],
+  grouping: PipelineGrouping,
+): PipelineGroup<TEntry>[] {
+  if (grouping === "none") {
+    return [{ title: "All pipelines", items }];
+  }
+
+  if (grouping === "pinned-first") {
+    const pinned = getPinnedItems(items);
+    const others = getUnpinnedItems(items);
+    const groups: PipelineGroup<TEntry>[] = [];
+
+    if (pinned.length > 0) groups.push({ title: "Pinned", items: pinned });
+    if (others.length > 0) groups.push({ title: "Others", items: others });
+
+    return groups.length > 0 ? groups : [{ title: "All pipelines", items: [] }];
+  }
+
+  const groupsMap = new Map<string, PipelineListItem<TEntry>[]>();
+  for (const item of items) {
+    const title = getPrimaryGroupTag(item);
+    const existing = groupsMap.get(title);
+    if (existing) {
+      existing.push(item);
+    } else {
+      groupsMap.set(title, [item]);
+    }
+  }
+
+  return [...groupsMap.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([title, groupedItems]) => ({ title, items: groupedItems }));
+}

--- a/src/routes/Home/Home.tsx
+++ b/src/routes/Home/Home.tsx
@@ -1,13 +1,37 @@
-import { useRef, useState } from "react";
+import { useNavigate, useSearch } from "@tanstack/react-router";
+import { useEffect, useRef, useState } from "react";
 
 import { PipelineSection, RunSection } from "@/components/Home";
 import { PipelineRunFiltersBar } from "@/components/shared/PipelineRunFiltersBar/PipelineRunFiltersBar";
 import { useFlagValue } from "@/components/shared/Settings/useFlags";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { DASHBOARD_PATH } from "@/routes/router";
+
+function getTabFromSearch(search: unknown): string | undefined {
+  if (typeof search !== "object" || search === null || !("tab" in search)) {
+    return undefined;
+  }
+  const { tab } = search;
+  return typeof tab === "string" ? tab : undefined;
+}
 
 const Home = () => {
-  const [activeTab, setActiveTab] = useState("runs");
+  const search: unknown = useSearch({ strict: false });
+  const tabFromUrl = getTabFromSearch(search);
+
+  const [activeTab, setActiveTab] = useState(tabFromUrl ?? "runs");
   const isFiltersBarEnabled = useFlagValue("pipeline-run-filters-bar");
+  const isDashboardEnabled = useFlagValue("command-center-dashboard");
+  const navigate = useNavigate();
+
+  // Only redirect to dashboard if no explicit tab param (i.e. direct navigation)
+  useEffect(() => {
+    if (isDashboardEnabled && !tabFromUrl) {
+      // Widen to `string` because TanStack Router's `to` expects registered
+      // route literals, but DASHBOARD_PATH is a plain constant.
+      navigate({ to: DASHBOARD_PATH as string, replace: true });
+    }
+  }, [isDashboardEnabled, navigate, tabFromUrl]);
 
   const handleTabSelect = (value: string) => {
     setActiveTab(value);

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -12,6 +12,7 @@ import { AuthorizationResultScreen as HuggingFaceAuthorizationResultScreen } fro
 import { BASE_URL, IS_GITHUB_PAGES } from "@/utils/constants";
 
 import RootLayout from "../components/layout/RootLayout";
+import Dashboard from "./Dashboard/Dashboard";
 import Editor from "./Editor";
 import Home from "./Home";
 import NotFoundPage from "./NotFoundPage";
@@ -27,8 +28,10 @@ declare module "@tanstack/react-router" {
 export const EDITOR_PATH = "/editor";
 export const RUNS_BASE_PATH = "/runs";
 export const QUICK_START_PATH = "/quick-start";
+export const DASHBOARD_PATH = "/dashboard";
 export const APP_ROUTES = {
   HOME: "/",
+  DASHBOARD: DASHBOARD_PATH,
   QUICK_START: QUICK_START_PATH,
   PIPELINE_EDITOR: `${EDITOR_PATH}/$name`,
   RUN_DETAIL: `${RUNS_BASE_PATH}/$id`,
@@ -84,6 +87,12 @@ const huggingFaceAuthCallbackRoute = createRoute({
   component: HuggingFaceAuthorizationResultScreen,
 });
 
+const dashboardRoute = createRoute({
+  getParentRoute: () => mainLayout,
+  path: APP_ROUTES.DASHBOARD,
+  component: Dashboard,
+});
+
 const runDetailRoute = createRoute({
   getParentRoute: () => mainLayout,
   path: APP_ROUTES.RUN_DETAIL,
@@ -98,6 +107,7 @@ const runDetailWithSubgraphRoute = createRoute({
 
 const appRouteTree = mainLayout.addChildren([
   indexRoute,
+  dashboardRoute,
   quickStartRoute,
   editorRoute,
   runDetailRoute,

--- a/src/utils/pinnedItems.ts
+++ b/src/utils/pinnedItems.ts
@@ -1,0 +1,61 @@
+import { isRecord } from "@/utils/typeGuards";
+
+const STORAGE_KEY = "dashboard/pinned-items";
+const MAX_PINNED = 20;
+
+type PinnedItemType = "pipeline" | "run";
+
+interface PinnedItem {
+  title: string;
+  type: PinnedItemType;
+  url: string;
+}
+
+function isPinnedItem(value: unknown): value is PinnedItem {
+  return (
+    isRecord(value) &&
+    typeof value.title === "string" &&
+    (value.type === "pipeline" || value.type === "run") &&
+    typeof value.url === "string"
+  );
+}
+
+function getAll(): PinnedItem[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(isPinnedItem);
+  } catch {
+    return [];
+  }
+}
+
+function save(items: PinnedItem[]): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
+  } catch {
+    // localStorage full or unavailable — silently ignore
+  }
+}
+
+export function getPinnedItems(type?: PinnedItemType): PinnedItem[] {
+  const items = getAll();
+  if (!type) return items;
+  return items.filter((item) => item.type === type);
+}
+
+export function setPinnedItem(item: PinnedItem, isPinned: boolean): void {
+  const current = getAll();
+  const filtered = current.filter(
+    (currentItem) => currentItem.url !== item.url,
+  );
+  if (!isPinned) {
+    save(filtered);
+    return;
+  }
+
+  const updated = [item, ...filtered].slice(0, MAX_PINNED);
+  save(updated);
+}

--- a/src/utils/pipelineMetadataStore.test.ts
+++ b/src/utils/pipelineMetadataStore.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  getAllPipelineMetadata,
+  getPipelineMetadata,
+  setPipelineTags,
+  togglePipelinePinned,
+} from "@/utils/pipelineMetadataStore";
+
+const STORAGE_KEY = "dashboard/pipeline-metadata";
+
+describe("pipelineMetadataStore", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("returns empty map when storage is missing", () => {
+    expect(getAllPipelineMetadata()).toEqual({});
+  });
+
+  it("sets and gets pipeline tags", () => {
+    setPipelineTags("pipeline-a", ["team-a", "urgent", "team-a", "  "]);
+
+    expect(getPipelineMetadata("pipeline-a")).toEqual({
+      tags: ["team-a", "urgent"],
+      pinned: false,
+    });
+  });
+
+  it("toggles pinned while preserving existing tags", () => {
+    setPipelineTags("pipeline-a", ["alpha"]);
+    togglePipelinePinned("pipeline-a");
+
+    expect(getPipelineMetadata("pipeline-a")).toEqual({
+      tags: ["alpha"],
+      pinned: true,
+    });
+
+    togglePipelinePinned("pipeline-a");
+
+    expect(getPipelineMetadata("pipeline-a")).toEqual({
+      tags: ["alpha"],
+      pinned: false,
+    });
+  });
+
+  it("ignores invalid persisted values", () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        ok: { tags: ["one"], pinned: true },
+        bad1: { tags: "one", pinned: true },
+        bad2: { tags: ["one"], pinned: "yes" },
+      }),
+    );
+
+    expect(getAllPipelineMetadata()).toEqual({
+      ok: { tags: ["one"], pinned: true },
+    });
+  });
+});

--- a/src/utils/pipelineMetadataStore.ts
+++ b/src/utils/pipelineMetadataStore.ts
@@ -1,0 +1,105 @@
+import { isRecord } from "@/utils/typeGuards";
+
+const STORAGE_KEY = "dashboard/pipeline-metadata";
+
+export interface PipelineMetadata {
+  tags: string[];
+  pinned: boolean;
+}
+
+type PipelineMetadataMap = Record<string, PipelineMetadata>;
+
+function normalizeTags(tags: string[]): string[] {
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+
+  for (const tag of tags) {
+    const trimmed = tag.trim();
+    if (trimmed.length === 0) continue;
+    if (seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    normalized.push(trimmed);
+  }
+
+  return normalized;
+}
+
+function isPipelineMetadata(value: unknown): value is PipelineMetadata {
+  return (
+    isRecord(value) &&
+    Array.isArray(value.tags) &&
+    value.tags.every((tag) => typeof tag === "string") &&
+    typeof value.pinned === "boolean"
+  );
+}
+
+function parsePipelineMetadataMap(raw: unknown): PipelineMetadataMap {
+  if (!isRecord(raw)) return {};
+
+  const map: PipelineMetadataMap = {};
+
+  for (const [name, value] of Object.entries(raw)) {
+    if (typeof name !== "string") continue;
+    if (!isPipelineMetadata(value)) continue;
+
+    map[name] = {
+      tags: normalizeTags(value.tags),
+      pinned: value.pinned,
+    };
+  }
+
+  return map;
+}
+
+function savePipelineMetadataMap(map: PipelineMetadataMap): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(map));
+  } catch {
+    // localStorage full or unavailable — silently ignore
+  }
+}
+
+export function getAllPipelineMetadata(): PipelineMetadataMap {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+
+    const parsed: unknown = JSON.parse(raw);
+    return parsePipelineMetadataMap(parsed);
+  } catch {
+    return {};
+  }
+}
+
+export function getPipelineMetadata(
+  name: string,
+): PipelineMetadata | undefined {
+  return getAllPipelineMetadata()[name];
+}
+
+export function setPipelineTags(
+  name: string,
+  tags: string[],
+): PipelineMetadata {
+  const map = getAllPipelineMetadata();
+  const previous = map[name];
+  const next: PipelineMetadata = {
+    tags: normalizeTags(tags),
+    pinned: previous?.pinned ?? false,
+  };
+  map[name] = next;
+  savePipelineMetadataMap(map);
+  return next;
+}
+
+export function togglePipelinePinned(name: string): PipelineMetadata {
+  const map = getAllPipelineMetadata();
+  const previous = map[name];
+  const next: PipelineMetadata = {
+    tags: previous?.tags ?? [],
+    pinned: !(previous?.pinned ?? false),
+  };
+  map[name] = next;
+  savePipelineMetadataMap(map);
+  return next;
+}

--- a/src/utils/recentItems.ts
+++ b/src/utils/recentItems.ts
@@ -1,0 +1,61 @@
+import { isRecord } from "@/utils/typeGuards";
+
+const STORAGE_KEY = "dashboard/recent-items";
+const MAX_RECENT = 20;
+
+type RecentItemType = "pipeline" | "run";
+
+interface RecentItem {
+  title: string;
+  type: RecentItemType;
+  url: string;
+}
+
+function isRecentItem(value: unknown): value is RecentItem {
+  return (
+    isRecord(value) &&
+    typeof value.title === "string" &&
+    (value.type === "pipeline" || value.type === "run") &&
+    typeof value.url === "string"
+  );
+}
+
+function getAll(): RecentItem[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(isRecentItem);
+  } catch {
+    return [];
+  }
+}
+
+function save(items: RecentItem[]): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
+  } catch {
+    // localStorage full or unavailable — silently ignore
+  }
+}
+
+/**
+ * Returns all recent items sorted by most recently opened first.
+ * Optionally filter by type.
+ */
+export function getRecentItems(type?: RecentItemType): RecentItem[] {
+  const items = getAll();
+  if (!type) return items;
+  return items.filter((item) => item.type === type);
+}
+
+/** Stores a recent item, deduped by URL, newest first. */
+export function recordRecentItem(item: RecentItem): void {
+  const current = getAll();
+  const filtered = current.filter(
+    (currentItem) => currentItem.url !== item.url,
+  );
+  const updated = [item, ...filtered].slice(0, MAX_RECENT);
+  save(updated);
+}

--- a/src/utils/recentPipelines.ts
+++ b/src/utils/recentPipelines.ts
@@ -1,0 +1,19 @@
+import { getRecentItems, recordRecentItem } from "@/utils/recentItems";
+
+export interface RecentPipelineLink {
+  title: string;
+  url: string;
+}
+
+export function recordRecentPipeline(title: string, url: string): void {
+  recordRecentItem({
+    title,
+    type: "pipeline",
+    url,
+  });
+}
+
+/** Returns recently opened pipelines, most recent first. */
+export function getRecentPipelines(): RecentPipelineLink[] {
+  return getRecentItems("pipeline").map(({ title, url }) => ({ title, url }));
+}

--- a/src/utils/recentRuns.ts
+++ b/src/utils/recentRuns.ts
@@ -1,0 +1,19 @@
+import { getRecentItems, recordRecentItem } from "@/utils/recentItems";
+
+export interface RecentRunLink {
+  title: string;
+  url: string;
+}
+
+export function recordRecentRun(title: string, url: string): void {
+  recordRecentItem({
+    title,
+    type: "run",
+    url,
+  });
+}
+
+/** Returns recently viewed runs, most recent first. */
+export function getRecentRuns(): RecentRunLink[] {
+  return getRecentItems("run").map(({ title, url }) => ({ title, url }));
+}

--- a/src/utils/typeGuards.ts
+++ b/src/utils/typeGuards.ts
@@ -1,0 +1,4 @@
+/** Runtime check that `value` is a non-null, non-array object. */
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}


### PR DESCRIPTION
## Description

Added a new Command Center Dashboard that provides a unified view of runs, pipelines, and components. This dashboard serves as an alternative homepage, showing all workspace elements at a glance with quick actions.

## Related Issue and Pull requests

## Type of Change

- [x] New feature
- [x] Improvement

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Enable the "Command Center Dashboard" feature flag in settings
2. Navigate to the homepage - you should be redirected to the new dashboard
3. Verify that all sections (Runs, Components, Pipelines) display correctly
4. Test pagination for runs and components
5. Test expanding component details
6. Verify that clicking on pipelines navigates to the editor
7. Verify that clicking on runs navigates to the run details

## Additional Comments

The dashboard is behind a feature flag named "command-center-dashboard" and will only be shown when enabled. The original homepage is still accessible by directly navigating to a specific tab (e.g. /?tab=runs).