### PR TITLE
Hackday/aggregator component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ playwright-report
 #local files
 .local/
 .planning/
+**/__pycache__

--- a/public/component_library.yaml
+++ b/public/component_library.yaml
@@ -1,5 +1,10 @@
 annotations: {}
 folders:
+  - name: Aggregation
+    components:
+      - url: /components/aggregator/component.yaml
+        name: Aggregate Inputs
+        author: Hargun Singh, Morgan Wowk
   - name: Quick start
     components:
       - url: https://raw.githubusercontent.com/Ark-kun/pipeline_components/57f780b15922061e59833541b71f3d099e710177/components/datasets/Chicago_Taxi_Trips/quick_start_version/component.yaml

--- a/public/components/aggregator/component.yaml
+++ b/public/components/aggregator/component.yaml
@@ -1,0 +1,217 @@
+name: Aggregate Inputs
+description: |
+  Aggregates multiple inputs into a single output.
+  Supports dictionary, array, and CSV output formats.
+  Connect upstream components to the input slots and choose an output format.
+metadata:
+  annotations:
+    author: Hargun Singh, Morgan Wowk
+    # --- Aggregator-specific annotations (read by frontend) ---
+    aggregator: "true"
+    aggregator_min_inputs: "2"
+    aggregator_default_output_type: "dict"
+    aggregator_supported_output_types: "dict,array,csv"
+    aggregator_visible_inputs: "2"
+inputs:
+- {name: input_1, type: String, description: "First input to aggregate.", optional: true}
+- {name: input_2, type: String, description: "Second input to aggregate.", optional: true}
+- {name: input_3, type: String, description: "Third input to aggregate.", optional: true}
+- {name: input_4, type: String, description: "Fourth input to aggregate.", optional: true}
+- {name: input_5, type: String, description: "Fifth input to aggregate.", optional: true}
+- {name: input_6, type: String, description: "Sixth input to aggregate.", optional: true}
+- {name: input_7, type: String, description: "Seventh input to aggregate.", optional: true}
+- {name: input_8, type: String, description: "Eighth input to aggregate.", optional: true}
+- {name: input_9, type: String, description: "Ninth input to aggregate.", optional: true}
+- {name: input_10, type: String, description: "Tenth input to aggregate.", optional: true}
+- name: output_type
+  type: String
+  description: "Output format: dict (JSON object keyed by input name), array (JSON array of values), or csv (union of CSV inputs with matching columns)."
+  default: "dict"
+  optional: true
+outputs:
+- name: aggregated_output
+  type: String
+  description: "The aggregated result in the chosen format."
+implementation:
+  container:
+    image: python:3.12-slim
+    command:
+    - sh
+    - -ec
+    - |
+      program_path=$(mktemp)
+      printf "%s" "$0" > "$program_path"
+      python3 -u "$program_path" "$@"
+    - |
+      import argparse
+      import csv
+      import io
+      import json
+      import os
+
+
+      def _make_parent_dirs_and_return_path(file_path: str) -> str:
+          os.makedirs(os.path.dirname(file_path), exist_ok=True)
+          return file_path
+
+
+      def aggregate(
+          aggregated_output_path: str,
+          output_type: str = "dict",
+          **input_paths: str,
+      ) -> None:
+          # Collect all provided inputs
+          inputs = {}
+          for key, path in sorted(input_paths.items()):
+              if path and os.path.exists(path):
+                  with open(path, "r") as f:
+                      inputs[key] = f.read()
+
+          if not inputs:
+              raise ValueError("No inputs provided. At least one input must be connected.")
+
+          if output_type == "dict":
+              result = json.dumps(inputs, indent=2)
+
+          elif output_type == "array":
+              result = json.dumps(list(inputs.values()), indent=2)
+
+          elif output_type == "csv":
+              all_rows = []
+              header = None
+
+              for _name, csv_text in inputs.items():
+                  text = csv_text.strip()
+                  if not text:
+                      continue
+                  reader = csv.reader(io.StringIO(text))
+                  rows = list(reader)
+                  if not rows or rows == [['']]:
+                      continue
+                  if header is None:
+                      header = rows[0]
+                      all_rows.append(header)
+                      all_rows.extend(rows[1:])
+                  elif rows[0] == header:
+                      all_rows.extend(rows[1:])
+                  else:
+                      raise ValueError(
+                          f"CSV column mismatch. Expected {header}, got {rows[0]}. "
+                          "All CSV inputs must have the same columns."
+                      )
+
+              if not all_rows:
+                  raise ValueError("No valid CSV data found in any input.")
+
+              output = io.StringIO()
+              writer = csv.writer(output)
+              writer.writerows(all_rows)
+              result = output.getvalue()
+
+          else:
+              raise ValueError(
+                  f"Unknown output_type: '{output_type}'. Must be 'dict', 'array', or 'csv'."
+              )
+
+          os.makedirs(os.path.dirname(aggregated_output_path), exist_ok=True)
+          with open(aggregated_output_path, "w") as f:
+              f.write(result)
+
+
+      _parser = argparse.ArgumentParser(
+          prog="Aggregate Inputs",
+          description="Aggregates multiple inputs into a single output.",
+      )
+      for i in range(1, 11):
+          _parser.add_argument(
+              f"--input-{i}",
+              dest=f"input_{i}_path",
+              type=str,
+              required=False,
+              default=None,
+          )
+      _parser.add_argument(
+          "--output-type",
+          dest="output_type",
+          type=str,
+          required=False,
+          default="dict",
+      )
+      _parser.add_argument(
+          "--aggregated-output",
+          dest="aggregated_output_path",
+          type=_make_parent_dirs_and_return_path,
+          required=True,
+      )
+      _parsed_args = vars(_parser.parse_args())
+
+      # Separate output args from input paths
+      _output_path = _parsed_args.pop("aggregated_output_path")
+      _output_type = _parsed_args.pop("output_type")
+
+      # Filter to only provided input paths
+      _input_paths = {k.replace("_path", ""): v for k, v in _parsed_args.items() if v is not None}
+
+      aggregate(
+          aggregated_output_path=_output_path,
+          output_type=_output_type,
+          **_input_paths,
+      )
+    args:
+    - if:
+        cond: {isPresent: input_1}
+        then:
+        - --input-1
+        - {inputPath: input_1}
+    - if:
+        cond: {isPresent: input_2}
+        then:
+        - --input-2
+        - {inputPath: input_2}
+    - if:
+        cond: {isPresent: input_3}
+        then:
+        - --input-3
+        - {inputPath: input_3}
+    - if:
+        cond: {isPresent: input_4}
+        then:
+        - --input-4
+        - {inputPath: input_4}
+    - if:
+        cond: {isPresent: input_5}
+        then:
+        - --input-5
+        - {inputPath: input_5}
+    - if:
+        cond: {isPresent: input_6}
+        then:
+        - --input-6
+        - {inputPath: input_6}
+    - if:
+        cond: {isPresent: input_7}
+        then:
+        - --input-7
+        - {inputPath: input_7}
+    - if:
+        cond: {isPresent: input_8}
+        then:
+        - --input-8
+        - {inputPath: input_8}
+    - if:
+        cond: {isPresent: input_9}
+        then:
+        - --input-9
+        - {inputPath: input_9}
+    - if:
+        cond: {isPresent: input_10}
+        then:
+        - --input-10
+        - {inputPath: input_10}
+    - if:
+        cond: {isPresent: output_type}
+        then:
+        - --output-type
+        - {inputValue: output_type}
+    - --aggregated-output
+    - {outputPath: aggregated_output}

--- a/public/components/aggregator/component.yaml
+++ b/public/components/aggregator/component.yaml
@@ -7,18 +7,18 @@ metadata:
   annotations:
     author: Hargun Singh, Morgan Wowk
     # --- Aggregator-specific annotations (read by frontend) ---
-    aggregator: "true"
-    aggregator_default_output_type: "JsonObject"
-    aggregator_supported_output_types: "JsonObject,JsonArray,CSV"
+    tangleml.com/aggregator_components/enabled: "true"
+    tangleml.com/aggregator_components/default_output_type: "JsonObject"
+    tangleml.com/aggregator_components/supported_output_types: "JsonObject,JsonArray,CSV"
     # --- Dynamic input mask ---
     # The frontend reads this pattern and generates input_1, input_2, ... input_N
     # as the user adds inputs. No hardcoded limit.
-    input_mask: "input_{n}"
-    input_mask_type: "String"
-    input_mask_description: "Input {n} to aggregate."
-    input_mask_optional: "true"
-    input_mask_min: "2"
-    input_mask_start: "1"
+    tangleml.com/aggregator_components/input_mask: "input_{n}"
+    tangleml.com/aggregator_components/input_mask_type: "String"
+    tangleml.com/aggregator_components/input_mask_description: "Input {n} to aggregate."
+    tangleml.com/aggregator_components/input_mask_optional: "true"
+    tangleml.com/aggregator_components/input_mask_min: "2"
+    tangleml.com/aggregator_components/input_mask_start: "1"
 inputs:
 - name: output_type
   type: String

--- a/public/components/aggregator/component.yaml
+++ b/public/components/aggregator/component.yaml
@@ -8,25 +8,22 @@ metadata:
     author: Hargun Singh, Morgan Wowk
     # --- Aggregator-specific annotations (read by frontend) ---
     aggregator: "true"
-    aggregator_min_inputs: "2"
-    aggregator_default_output_type: "dict"
-    aggregator_supported_output_types: "dict,array,csv"
-    aggregator_visible_inputs: "2"
+    aggregator_default_output_type: "object"
+    aggregator_supported_output_types: "object,array,csv"
+    # --- Dynamic input mask ---
+    # The frontend reads this pattern and generates input_1, input_2, ... input_N
+    # as the user adds inputs. No hardcoded limit.
+    input_mask: "input_{n}"
+    input_mask_type: "String"
+    input_mask_description: "Input {n} to aggregate."
+    input_mask_optional: "true"
+    input_mask_min: "2"
+    input_mask_start: "1"
 inputs:
-- {name: input_1, type: String, description: "First input to aggregate.", optional: true}
-- {name: input_2, type: String, description: "Second input to aggregate.", optional: true}
-- {name: input_3, type: String, description: "Third input to aggregate.", optional: true}
-- {name: input_4, type: String, description: "Fourth input to aggregate.", optional: true}
-- {name: input_5, type: String, description: "Fifth input to aggregate.", optional: true}
-- {name: input_6, type: String, description: "Sixth input to aggregate.", optional: true}
-- {name: input_7, type: String, description: "Seventh input to aggregate.", optional: true}
-- {name: input_8, type: String, description: "Eighth input to aggregate.", optional: true}
-- {name: input_9, type: String, description: "Ninth input to aggregate.", optional: true}
-- {name: input_10, type: String, description: "Tenth input to aggregate.", optional: true}
 - name: output_type
   type: String
-  description: "Output format: dict (JSON object keyed by input name), array (JSON array of values), or csv (union of CSV inputs with matching columns)."
-  default: "dict"
+  description: "Output format: object (JSON object keyed by input name), array (JSON array of values), or csv (union of CSV inputs with matching columns)."
+  default: "object"
   optional: true
 outputs:
 - name: aggregated_output
@@ -43,11 +40,12 @@ implementation:
       printf "%s" "$0" > "$program_path"
       python3 -u "$program_path" "$@"
     - |
-      import argparse
       import csv
       import io
       import json
       import os
+      import re
+      import sys
 
 
       def _make_parent_dirs_and_return_path(file_path: str) -> str:
@@ -57,7 +55,7 @@ implementation:
 
       def aggregate(
           aggregated_output_path: str,
-          output_type: str = "dict",
+          output_type: str = "object",
           **input_paths: str,
       ) -> None:
           # Collect all provided inputs
@@ -70,7 +68,7 @@ implementation:
           if not inputs:
               raise ValueError("No inputs provided. At least one input must be connected.")
 
-          if output_type == "dict":
+          if output_type == "object":
               result = json.dumps(inputs, indent=2)
 
           elif output_type == "array":
@@ -110,7 +108,7 @@ implementation:
 
           else:
               raise ValueError(
-                  f"Unknown output_type: '{output_type}'. Must be 'dict', 'array', or 'csv'."
+                  f"Unknown output_type: '{output_type}'. Must be 'object', 'array', or 'csv'."
               )
 
           os.makedirs(os.path.dirname(aggregated_output_path), exist_ok=True)
@@ -118,100 +116,40 @@ implementation:
               f.write(result)
 
 
-      _parser = argparse.ArgumentParser(
-          prog="Aggregate Inputs",
-          description="Aggregates multiple inputs into a single output.",
-      )
-      for i in range(1, 11):
-          _parser.add_argument(
-              f"--input-{i}",
-              dest=f"input_{i}_path",
-              type=str,
-              required=False,
-              default=None,
-          )
-      _parser.add_argument(
-          "--output-type",
-          dest="output_type",
-          type=str,
-          required=False,
-          default="dict",
-      )
-      _parser.add_argument(
-          "--aggregated-output",
-          dest="aggregated_output_path",
-          type=_make_parent_dirs_and_return_path,
-          required=True,
-      )
-      _parsed_args = vars(_parser.parse_args())
+      # --- Dynamic arg parsing ---
+      # Accepts any number of --input-N flags (no hardcoded limit).
+      # The frontend generates these based on the input_mask annotation.
 
-      # Separate output args from input paths
-      _output_path = _parsed_args.pop("aggregated_output_path")
-      _output_type = _parsed_args.pop("output_type")
+      _args = sys.argv[1:]
+      _output_path = None
+      _output_type = "object"
+      _input_paths = {}
 
-      # Filter to only provided input paths
-      _input_paths = {k.replace("_path", ""): v for k, v in _parsed_args.items() if v is not None}
+      _i = 0
+      while _i < len(_args):
+          _arg = _args[_i]
+
+          if _arg == "--aggregated-output" and _i + 1 < len(_args):
+              _output_path = _make_parent_dirs_and_return_path(_args[_i + 1])
+              _i += 2
+          elif _arg == "--output-type" and _i + 1 < len(_args):
+              _output_type = _args[_i + 1]
+              _i += 2
+          else:
+              # Match any --input-N pattern dynamically
+              _match = re.match(r"^--input-(\d+)$", _arg)
+              if _match and _i + 1 < len(_args):
+                  _n = _match.group(1)
+                  _input_paths[f"input_{_n}"] = _args[_i + 1]
+                  _i += 2
+              else:
+                  _i += 1
+
+      if not _output_path:
+          raise ValueError("--aggregated-output is required.")
 
       aggregate(
           aggregated_output_path=_output_path,
           output_type=_output_type,
           **_input_paths,
       )
-    args:
-    - if:
-        cond: {isPresent: input_1}
-        then:
-        - --input-1
-        - {inputPath: input_1}
-    - if:
-        cond: {isPresent: input_2}
-        then:
-        - --input-2
-        - {inputPath: input_2}
-    - if:
-        cond: {isPresent: input_3}
-        then:
-        - --input-3
-        - {inputPath: input_3}
-    - if:
-        cond: {isPresent: input_4}
-        then:
-        - --input-4
-        - {inputPath: input_4}
-    - if:
-        cond: {isPresent: input_5}
-        then:
-        - --input-5
-        - {inputPath: input_5}
-    - if:
-        cond: {isPresent: input_6}
-        then:
-        - --input-6
-        - {inputPath: input_6}
-    - if:
-        cond: {isPresent: input_7}
-        then:
-        - --input-7
-        - {inputPath: input_7}
-    - if:
-        cond: {isPresent: input_8}
-        then:
-        - --input-8
-        - {inputPath: input_8}
-    - if:
-        cond: {isPresent: input_9}
-        then:
-        - --input-9
-        - {inputPath: input_9}
-    - if:
-        cond: {isPresent: input_10}
-        then:
-        - --input-10
-        - {inputPath: input_10}
-    - if:
-        cond: {isPresent: output_type}
-        then:
-        - --output-type
-        - {inputValue: output_type}
-    - --aggregated-output
-    - {outputPath: aggregated_output}

--- a/public/components/aggregator/component.yaml
+++ b/public/components/aggregator/component.yaml
@@ -1,15 +1,15 @@
 name: Aggregate Inputs
 description: |
   Aggregates multiple inputs into a single output.
-  Supports dictionary, array, and CSV output formats.
+  Supports JsonObject, JsonArray, and CSV output formats.
   Connect upstream components to the input slots and choose an output format.
 metadata:
   annotations:
     author: Hargun Singh, Morgan Wowk
     # --- Aggregator-specific annotations (read by frontend) ---
     aggregator: "true"
-    aggregator_default_output_type: "object"
-    aggregator_supported_output_types: "object,array,csv"
+    aggregator_default_output_type: "JsonObject"
+    aggregator_supported_output_types: "JsonObject,JsonArray,CSV"
     # --- Dynamic input mask ---
     # The frontend reads this pattern and generates input_1, input_2, ... input_N
     # as the user adds inputs. No hardcoded limit.
@@ -22,8 +22,8 @@ metadata:
 inputs:
 - name: output_type
   type: String
-  description: "Output format: object (JSON object keyed by input name), array (JSON array of values), or csv (union of CSV inputs with matching columns)."
-  default: "object"
+  description: "Output format: JsonObject (JSON object keyed by input name), JsonArray (JSON array of values), or CSV (union of CSV inputs with matching columns)."
+  default: "JsonObject"
   optional: true
 outputs:
 - name: aggregated_output
@@ -55,7 +55,7 @@ implementation:
 
       def aggregate(
           aggregated_output_path: str,
-          output_type: str = "object",
+          output_type: str = "JsonObject",
           **input_paths: str,
       ) -> None:
           # Collect all provided inputs
@@ -68,13 +68,13 @@ implementation:
           if not inputs:
               raise ValueError("No inputs provided. At least one input must be connected.")
 
-          if output_type == "object":
+          if output_type == "JsonObject":
               result = json.dumps(inputs, indent=2)
 
-          elif output_type == "array":
+          elif output_type == "JsonArray":
               result = json.dumps(list(inputs.values()), indent=2)
 
-          elif output_type == "csv":
+          elif output_type == "CSV":
               all_rows = []
               header = None
 
@@ -108,7 +108,7 @@ implementation:
 
           else:
               raise ValueError(
-                  f"Unknown output_type: '{output_type}'. Must be 'object', 'array', or 'csv'."
+                  f"Unknown output_type: '{output_type}'. Must be 'JsonObject', 'JsonArray', or 'CSV'."
               )
 
           os.makedirs(os.path.dirname(aggregated_output_path), exist_ok=True)
@@ -122,7 +122,7 @@ implementation:
 
       _args = sys.argv[1:]
       _output_path = None
-      _output_type = "object"
+      _output_type = "JsonObject"
       _input_paths = {}
 
       _i = 0


### PR DESCRIPTION
# Add Aggregate Inputs component with dynamic input mask

## Summary
Adds the **Aggregate Inputs** component that merges multiple upstream outputs into a single output (object, array, or CSV). Replaces hardcoded input slots with a mask pattern so the frontend can dynamically add unlimited inputs.

## Changes
- **New component** — `public/components/aggregator/component.yaml`
- **Dynamic inputs** — No hardcoded `input_1`–`input_10`; uses `input_mask` annotations the frontend reads to generate inputs on demand
- **Python parsing** — Replaces argparse with regex-based parsing so any `--input-N` is accepted (no upper limit)
- **Output type** — Renamed `dict` → `object` (JSON object) throughout

## How it works
1. Frontend reads `input_mask`, `input_mask_type`, etc. and dynamically creates input handles when the user clicks "Add Input"
2. When serializing the pipeline, the frontend injects the `inputs` array and corresponding `args` blocks for whatever inputs are connected
3. At runtime, the Python script parses whatever `--input-N` flags the runner passes in

## Notes
- Frontend support for the input mask is still required to complete the feature
- Backward compatible — pipelines with static inputs continue to work
