### PR TITLE
feat: Observe links for logs and events

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/LogsTabExtension.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/LogsTabExtension.tsx
@@ -1,0 +1,4 @@
+export const LogsTabExtension = (_props: {
+  executionId?: string;
+  status?: string;
+}) => null;

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/TaskOverview.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/TaskOverview.tsx
@@ -24,6 +24,7 @@ import ArgumentsSection from "../ArgumentsEditor/ArgumentsSection";
 import ConfigurationSection from "./ConfigurationSection";
 import IOSection from "./IOSection/IOSection";
 import Logs, { OpenLogsInNewWindowLink } from "./logs";
+import { LogsTabExtension } from "./LogsTabExtension";
 import OutputsList from "./OutputsList";
 import RenameTask from "./RenameTask";
 
@@ -147,6 +148,7 @@ const TaskOverview = ({ taskNode }: TaskOverviewProps) => {
           </TabsContent>
           {readOnly && !isSubgraph && (
             <TabsContent value="logs">
+              <LogsTabExtension executionId={executionId} status={status} />
               {!!executionId && (
                 <div className="flex w-full justify-end pr-4">
                   <OpenLogsInNewWindowLink

--- a/src/components/shared/TaskDetails/ExecutionDetails.tsx
+++ b/src/components/shared/TaskDetails/ExecutionDetails.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/utils/componentSpec";
 import { EXIT_CODE_OOM } from "@/utils/constants";
 import { formatDate, formatDuration } from "@/utils/date";
+import { executionPodName, isRecord } from "@/utils/executionDetailsUtil";
 
 import type { AttributeProps } from "../ContextPanel/Blocks/Attribute";
 import { ContentBlock } from "../ContextPanel/Blocks/ContentBlock";
@@ -137,37 +138,6 @@ export const ExecutionDetails = ({
     </ContentBlock>
   );
 };
-
-function executionPodName(
-  containerState?: GetContainerExecutionStateResponse,
-): string | null {
-  if (!containerState || !("debug_info" in containerState)) {
-    return null;
-  }
-
-  const debugInfo = containerState.debug_info;
-
-  if (!isRecord(debugInfo)) {
-    return null;
-  }
-
-  if (typeof debugInfo.pod_name === "string") {
-    return debugInfo.pod_name;
-  }
-
-  if (
-    isRecord(debugInfo.kubernetes) &&
-    typeof debugInfo.kubernetes.pod_name === "string"
-  ) {
-    return debugInfo.kubernetes.pod_name;
-  }
-
-  return null;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
 
 interface ExecutionLinkItem {
   name: string;

--- a/src/utils/executionDetailsUtil.ts
+++ b/src/utils/executionDetailsUtil.ts
@@ -1,0 +1,36 @@
+import type { GetContainerExecutionStateResponse } from "@/api/types.gen";
+
+/**
+ * Extracts the Kubernetes pod name from a container execution state's debug_info.
+ * Checks both `debug_info.pod_name` and `debug_info.kubernetes.pod_name`.
+ */
+export function executionPodName(
+  containerState?: GetContainerExecutionStateResponse,
+): string | null {
+  if (!containerState || !("debug_info" in containerState)) {
+    return null;
+  }
+
+  const debugInfo = containerState.debug_info;
+
+  if (!isRecord(debugInfo)) {
+    return null;
+  }
+
+  if (typeof debugInfo.pod_name === "string") {
+    return debugInfo.pod_name;
+  }
+
+  if (
+    isRecord(debugInfo.kubernetes) &&
+    typeof debugInfo.kubernetes.pod_name === "string"
+  ) {
+    return debugInfo.kubernetes.pod_name;
+  }
+
+  return null;
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}


### PR DESCRIPTION
## Depends On

PR consumes this change [#487](https://app.graphite.com/github/pr/Shopify/oasis-frontend/487/feat-Observe-links-for-logs-and-events).

## Description

- Add a **slot file pattern** (`LogsTabExtension.tsx`) as an extension point in the Logs tab. In OSS it renders nothing (no-op). Another repo using overlays can replace it at build time.

