### PR TITLE
fix: Page Refresh every time a componentRef is Hydrated

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNode.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNode.tsx
@@ -1,6 +1,8 @@
 import { type NodeProps } from "@xyflow/react";
 import { memo, useMemo } from "react";
 
+import { withSuspenseWrapper } from "@/components/shared/SuspenseWrapper";
+import { Skeleton } from "@/components/ui/skeleton";
 import { useEdgeSelectionHighlight } from "@/hooks/useEdgeSelectionHighlight";
 import { cn } from "@/lib/utils";
 import { useExecutionDataOptional } from "@/providers/ExecutionDataProvider";
@@ -11,7 +13,13 @@ import { isCacheDisabled } from "@/utils/cache";
 import { StatusIndicator } from "./StatusIndicator";
 import { TaskNodeCard } from "./TaskNodeCard";
 
-const TaskNode = ({ data, selected, id }: NodeProps) => {
+const TaskNodeSkeleton = () => (
+  <div className="w-60 h-30 rounded-lg border border-border bg-background">
+    <Skeleton className="w-full h-full" />
+  </div>
+);
+
+const TaskNodeInternal = ({ data, selected, id }: NodeProps) => {
   const executionData = useExecutionDataOptional();
 
   const typedData = useMemo(() => data as TaskNodeData, [data]);
@@ -42,5 +50,7 @@ const TaskNode = ({ data, selected, id }: NodeProps) => {
     </TaskNodeProvider>
   );
 };
+
+const TaskNode = withSuspenseWrapper(TaskNodeInternal, TaskNodeSkeleton);
 
 export default memo(TaskNode);


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

Fixes an issue where any time a Task Node needed to hydrate a componentRef for the first time, the entire canvas would reload.

This was occurring due to a missing suspense boundary around the task node.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

Confirm you can add new tasks to canvas (including creating subgraphs) without the page reloading.

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
