### PR TITLE
refactor: Use new flag in API to check pipeline run has ended

### DIFF
--- a/src/api/types.gen.ts
+++ b/src/api/types.gen.ts
@@ -582,6 +582,19 @@ export type GetGraphExecutionStateResponse = {
             [key: string]: number;
         };
     };
+    /**
+     * Summary
+     */
+    summary: ExecutionStatusSummary;
+};
+
+/**
+ * ExecutionStatusSummary
+ */
+export type ExecutionStatusSummary = {
+    total_nodes: number;
+    ended_nodes: number;
+    has_ended: boolean;
 };
 
 /**

--- a/src/components/PipelineRun/RunDetails.test.tsx
+++ b/src/components/PipelineRun/RunDetails.test.tsx
@@ -91,6 +91,7 @@ describe("<RunDetails/>", () => {
       execution1: { SUCCEEDED: 1 },
       execution2: { RUNNING: 1 },
     },
+    summary: { total_nodes: 2, ended_nodes: 1, has_ended: false },
   };
 
   const mockComponentSpec: ComponentSpec = {

--- a/src/components/PipelineRun/RunToolbar.test.tsx
+++ b/src/components/PipelineRun/RunToolbar.test.tsx
@@ -73,6 +73,7 @@ describe("<RunToolbar/>", () => {
       execution1: { SUCCEEDED: 1 },
       execution2: { RUNNING: 1 },
     },
+    summary: { total_nodes: 2, ended_nodes: 1, has_ended: false },
   };
 
   const mockComponentSpec: ComponentSpec = {
@@ -205,6 +206,7 @@ describe("<RunToolbar/>", () => {
               execution1: { SUCCEEDED: 1 },
               execution2: { CANCELLED: 1 },
             },
+            summary: { total_nodes: 2, ended_nodes: 2, has_ended: true },
           },
         },
         rootExecutionId: "456",
@@ -250,6 +252,7 @@ describe("<RunToolbar/>", () => {
               execution1: { SUCCEEDED: 1 },
               execution2: { CANCELLED: 1 },
             },
+            summary: { total_nodes: 2, ended_nodes: 2, has_ended: true },
           },
         },
         rootExecutionId: "456",

--- a/src/components/PipelineRun/RunToolbar.tsx
+++ b/src/components/PipelineRun/RunToolbar.tsx
@@ -5,11 +5,6 @@ import { cn } from "@/lib/utils";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 import { useExecutionData } from "@/providers/ExecutionDataProvider";
 import { extractCanonicalName } from "@/utils/canonicalPipelineName";
-import {
-  countInProgressFromStats,
-  flattenExecutionStatusStats,
-  isExecutionComplete,
-} from "@/utils/executionStatus";
 
 import { ViewYamlButton } from "../shared/Buttons/ViewYamlButton";
 import { buildTakSpecShape } from "../shared/PipelineRunNameTemplate/types";
@@ -44,12 +39,8 @@ export const RunToolbar = () => {
     return null;
   }
 
-  const executionStatusStats =
-    metadata?.execution_status_stats ??
-    flattenExecutionStatusStats(state.child_execution_status_stats);
-
-  const isInProgress = countInProgressFromStats(executionStatusStats) > 0;
-  const isComplete = isExecutionComplete(executionStatusStats);
+  const isComplete = state.summary.has_ended;
+  const isInProgress = !isComplete;
 
   const isViewingSubgraph = currentSubgraphPath.length > 1;
 

--- a/src/hooks/usePipelineRunData.ts
+++ b/src/hooks/usePipelineRunData.ts
@@ -7,10 +7,6 @@ import {
   fetchExecutionState,
   fetchPipelineRun,
 } from "@/services/executionService";
-import {
-  flattenExecutionStatusStats,
-  isExecutionComplete,
-} from "@/utils/executionStatus";
 
 const useRootExecutionId = (id: string) => {
   const { backendUrl } = useBackend();
@@ -79,10 +75,7 @@ export const usePipelineRunData = (id: string) => {
         if (!state) {
           return false;
         }
-        const stats = flattenExecutionStatusStats(
-          state.child_execution_status_stats,
-        );
-        return isExecutionComplete(stats) ? false : 5000;
+        return state.summary?.has_ended ? false : 5000;
       }
       return false;
     },

--- a/src/routes/PipelineRun/PipelineRun.test.tsx
+++ b/src/routes/PipelineRun/PipelineRun.test.tsx
@@ -167,6 +167,7 @@ describe("<PipelineRun/>", () => {
       "execution-1": { SUCCEEDED: 1 },
       "execution-2": { RUNNING: 1 },
     },
+    summary: { total_nodes: 2, ended_nodes: 1, has_ended: false },
   };
 
   beforeEach(() => {

--- a/src/utils/executionStatus.test.ts
+++ b/src/utils/executionStatus.test.ts
@@ -2,11 +2,9 @@ import { describe, expect, test } from "vitest";
 
 import type { GetGraphExecutionStateResponse } from "@/api/types.gen";
 import {
-  countInProgressFromStats,
   flattenExecutionStatusStats,
   getExecutionStatusLabel,
   getOverallExecutionStatusFromStats,
-  isExecutionComplete,
 } from "@/utils/executionStatus";
 
 type ChildExecutionStatusStats =
@@ -140,73 +138,5 @@ describe("getOverallExecutionStatusFromStats()", () => {
         SUCCEEDED: 5,
       }),
     ).toBe("UNINITIALIZED");
-  });
-});
-
-describe("countInProgressFromStats()", () => {
-  test("counts all in-progress statuses", () => {
-    expect(
-      countInProgressFromStats({
-        RUNNING: 2,
-        PENDING: 1,
-        QUEUED: 3,
-        SUCCEEDED: 10,
-      }),
-    ).toBe(6);
-  });
-
-  test("returns 0 when no in-progress statuses", () => {
-    expect(
-      countInProgressFromStats({
-        SUCCEEDED: 5,
-        FAILED: 2,
-      }),
-    ).toBe(0);
-  });
-
-  test("counts all in-progress status types", () => {
-    expect(
-      countInProgressFromStats({
-        RUNNING: 1,
-        PENDING: 1,
-        QUEUED: 1,
-        WAITING_FOR_UPSTREAM: 1,
-        CANCELLING: 1,
-        UNINITIALIZED: 1,
-      }),
-    ).toBe(6);
-  });
-});
-
-describe("isExecutionComplete()", () => {
-  test("returns true when all tasks are in terminal states", () => {
-    expect(
-      isExecutionComplete({
-        SUCCEEDED: 5,
-        FAILED: 2,
-      }),
-    ).toBe(true);
-  });
-
-  test("returns false when any tasks are in progress", () => {
-    expect(
-      isExecutionComplete({
-        SUCCEEDED: 5,
-        RUNNING: 1,
-      }),
-    ).toBe(false);
-  });
-
-  test("returns false for empty stats", () => {
-    expect(isExecutionComplete({})).toBe(false);
-  });
-
-  test("returns true for cancelled/skipped executions", () => {
-    expect(
-      isExecutionComplete({
-        CANCELLED: 3,
-        SKIPPED: 2,
-      }),
-    ).toBe(true);
   });
 });

--- a/src/utils/executionStatus.ts
+++ b/src/utils/executionStatus.ts
@@ -43,18 +43,6 @@ export const EXECUTION_STATUS_BG_COLORS: Record<string, string> = {
 };
 
 /**
- * Statuses considered "in progress" (not terminal).
- */
-const IN_PROGRESS_STATUSES = new Set([
-  "RUNNING",
-  "PENDING",
-  "QUEUED",
-  "WAITING_FOR_UPSTREAM",
-  "CANCELLING",
-  "UNINITIALIZED",
-]);
-
-/**
  * Priority order for determining overall/aggregate execution status.
  * Higher priority statuses appear first — if any task has SYSTEM_ERROR,
  * the overall status should reflect that before checking for FAILED, etc.
@@ -133,23 +121,4 @@ export function getOverallExecutionStatusFromStats(
   // Fallback: return any status with a non-zero count
   const firstNonZero = Object.entries(stats).find(([, c]) => (c ?? 0) > 0);
   return firstNonZero?.[0];
-}
-
-/**
- * Count the number of in-progress tasks from execution stats.
- */
-export function countInProgressFromStats(stats: ExecutionStatusStats): number {
-  let count = 0;
-  for (const status of IN_PROGRESS_STATUSES) {
-    count += stats[status] ?? 0;
-  }
-  return count;
-}
-
-/**
- * Check if execution is complete based on stats (no in-progress tasks and at least one task).
- */
-export function isExecutionComplete(stats: ExecutionStatusStats): boolean {
-  const total = Object.values(stats).reduce((sum, c) => sum + (c ?? 0), 0);
-  return total > 0 && countInProgressFromStats(stats) === 0;
 }


### PR DESCRIPTION
## Depends On
This [PR-99](https://app.graphite.com/github/pr/TangleML/tangle/99/feat-GetExecutionNodes-API-returns-number-of-total-and-ended-nodes) must be landed before this can be merged.

## Description

Using new flag `has_ended` in API (`GET /api/executions/{executionId}/state`) to determine if a root execution node is completed.

### NOTE
- Root execution node could be either
  - Root of a Pipeline Run
  - Root of a subgraph
- The `has_ended` flag is context aware of the children nodes' statuses under any root execution node

## Type of Change

- [x] Improvement
- [x] Cleanup/Refactor

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

- Start a pipeline run
- Check Chrome Dev Tools that API (search string `state`) doesn't fetch anymore when run has ended
- Confirm new API response payload
- Confirm component `src/utils/executionStatus.ts` is latest in Chrome

[1.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/5f81c60b-20d1-44b3-82f2-bcae384fc59e.mov" />](https://app.graphite.com/user-attachments/video/5f81c60b-20d1-44b3-82f2-bcae384fc59e.mov)

[2.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/af9ea4de-4501-4608-8dbc-a7768de340ef.mov" />](https://app.graphite.com/user-attachments/video/af9ea4de-4501-4608-8dbc-a7768de340ef.mov)
