### PR TITLE
feat: Lock Flex Nodes

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/FlexNode/FlexNodeEditor.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlexNode/FlexNodeEditor.tsx
@@ -10,34 +10,47 @@ import { Label } from "@/components/ui/label";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Textarea } from "@/components/ui/textarea";
 import { Paragraph, Text } from "@/components/ui/typography";
+import { cn } from "@/lib/utils";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 import { updateSubgraphSpec } from "@/utils/subgraphUtils";
 
 import { StackingControls } from "../../FlowControls/StackingControls";
 import { updateFlexNodeInComponentSpec } from "./interface";
+import LockToggle from "./LockToggle";
 import type { FlexNodeData } from "./types";
 import { DEFAULT_BORDER_COLOR } from "./utils";
 
 interface FlexNodeEditorProps {
   flexNode: FlexNodeData;
   readOnly?: boolean;
+  toggleLock?: () => void;
 }
 
 export const FlexNodeEditor = ({
   flexNode,
   readOnly = false,
+  toggleLock,
 }: FlexNodeEditorProps) => {
-  const { metadata, zIndex, size, position } = flexNode;
+  const { metadata, zIndex, size, position, locked = false } = flexNode;
 
   return (
     <BlockStack gap="4" className="h-full px-2">
-      <Text size="lg" weight="semibold" className="wrap-anywhere">
-        Sticky Note
-      </Text>
+      <InlineStack gap="2" blockAlign="center">
+        <Text size="lg" weight="semibold" className="wrap-anywhere">
+          Sticky Note
+        </Text>
+        {toggleLock && (
+          <LockToggle
+            locked={locked}
+            onToggleLock={toggleLock}
+            className={cn(locked && "text-red-500 hover:text-red-500")}
+          />
+        )}
+      </InlineStack>
 
-      <ContentEditor flexNode={flexNode} readOnly={readOnly} />
+      <ContentEditor flexNode={flexNode} readOnly={readOnly || locked} />
 
-      <ColorEditor flexNode={flexNode} readOnly={readOnly} />
+      <ColorEditor flexNode={flexNode} readOnly={readOnly || locked} />
 
       <KeyValueList
         title="Layout"
@@ -81,7 +94,7 @@ export const FlexNodeEditor = ({
         ]}
       />
 
-      {!readOnly && <ZIndexEditor flexNode={flexNode} />}
+      {!readOnly && !locked && <ZIndexEditor flexNode={flexNode} />}
     </BlockStack>
   );
 };

--- a/src/components/shared/ReactFlow/FlowCanvas/FlexNode/LockToggle.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlexNode/LockToggle.tsx
@@ -1,0 +1,54 @@
+import { type MouseEvent } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icon";
+import { cn } from "@/lib/utils";
+
+interface LockToggleProps {
+  size?: "xs" | "sm" | "md" | "lg" | "xl";
+  locked: boolean;
+  onToggleLock: () => void;
+  showOnlyOnHover?: boolean;
+  className?: string;
+}
+
+const LockToggle = ({
+  size = "md",
+  locked,
+  onToggleLock,
+  showOnlyOnHover = false,
+  className,
+}: LockToggleProps) => {
+  const handleLockToggle = (e: MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    onToggleLock();
+  };
+
+  const sizeClasses = {
+    xs: "w-2! h-2!",
+    sm: "w-3! h-3!",
+    md: "w-4! h-4!",
+    lg: "w-5! h-5!",
+    xl: "w-6! h-6!",
+  };
+
+  return (
+    <Button
+      variant="ghost"
+      size="min"
+      onClick={handleLockToggle}
+      className={cn(
+        "opacity-60 hover:bg-transparent hover:opacity-100",
+        !locked && showOnlyOnHover && "hidden group-hover:block hover:block",
+        className,
+      )}
+    >
+      <Icon
+        name={locked ? "Lock" : "LockOpen"}
+        className={cn(sizeClasses[size])}
+      />
+    </Button>
+  );
+};
+
+export default LockToggle;

--- a/src/components/shared/ReactFlow/FlowCanvas/FlexNode/types.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlexNode/types.ts
@@ -8,6 +8,7 @@ export interface FlexNodeData extends Record<string, unknown> {
   position: XYPosition;
   zIndex: number;
   readOnly?: boolean;
+  locked?: boolean;
 }
 
 type FlexNodeProperties = {

--- a/src/components/shared/ReactFlow/FlowCanvas/FlexNode/utils.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlexNode/utils.ts
@@ -15,7 +15,7 @@ export const createFlexNode = (
   flexNode: FlexNodeData,
   readOnly: boolean = false,
 ) => {
-  const { id, position, size, zIndex } = flexNode;
+  const { id, position, size, zIndex, locked } = flexNode;
 
   return {
     id,
@@ -25,5 +25,8 @@ export const createFlexNode = (
     type: "flex",
     connectable: false,
     zIndex,
+    selectable: !locked,
+    draggable: !locked,
+    className: locked ? "pointer-events-auto!" : undefined,
   } as Node;
 };


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

As suggested by @maxy-shpfy this PR adds the ability to "lock" sticky notes, preventing them from being selected or moved.

This is achieved by hovering over a sticky note and clicking the lock icon in the top right. A locked sticky note will show the lock icon in the top right at all times (an unlocked one will only show when hovered). To unlock a sticky note either click the lock again, or double click the note.



Alternatively, the lock functionality can be accessed via the flex node context panel.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] New feature

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

![image.png](https://app.graphite.com/user-attachments/assets/6a858366-d691-47f0-b309-f66b38fc4661.png)

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

- Add a sticky note to convas
- Hover over it, you should see the lock icon appear in the top-right
- Click the lock to lock the sticky note. You should no longer be able to select the sticky note.
- Unlock it by clicking the lock icon, or by double-clicking the node.

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->