### PR TITLE
feat: Create YAML import endpoint for Tangle Deploy to preview pipeline

### DIFF
--- a/src/routes/Import/Import.test.tsx
+++ b/src/routes/Import/Import.test.tsx
@@ -1,0 +1,265 @@
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { importPipelineFromYaml } from "@/services/pipelineService";
+
+import { ImportPage, isAllowedImportUrl } from "./index";
+
+const mockNavigate = vi.fn();
+const mockRouterNavigate = vi.fn();
+let mockSearchParams: { url?: string } = {
+  url: "http://127.0.0.1:54321/tangle-deploy/pipeline.yaml",
+};
+
+vi.mock("@tanstack/react-router", async (importOriginal) => {
+  return {
+    ...(await importOriginal()),
+    useNavigate: () => mockNavigate,
+    useSearch: () => mockSearchParams,
+    useRouter: () => ({ navigate: mockRouterNavigate }),
+  };
+});
+
+vi.mock("@/services/pipelineService", () => ({
+  importPipelineFromYaml: vi.fn(),
+}));
+
+describe("isAllowedImportUrl", () => {
+  test("accepts valid localhost URL with high port", () => {
+    expect(
+      isAllowedImportUrl("http://127.0.0.1:54321/tangle-deploy/pipeline.yaml"),
+    ).toBe(true);
+  });
+
+  test("accepts minimum allowed port", () => {
+    expect(
+      isAllowedImportUrl("http://127.0.0.1:10000/tangle-deploy/pipeline.yaml"),
+    ).toBe(true);
+  });
+
+  test("rejects wrong scheme (https)", () => {
+    expect(
+      isAllowedImportUrl("https://127.0.0.1:54321/tangle-deploy/pipeline.yaml"),
+    ).toBe(false);
+  });
+
+  test("rejects wrong host", () => {
+    expect(
+      isAllowedImportUrl("http://evil.com:54321/tangle-deploy/pipeline.yaml"),
+    ).toBe(false);
+  });
+
+  test("rejects localhost hostname (must be 127.0.0.1)", () => {
+    expect(
+      isAllowedImportUrl("http://localhost:54321/tangle-deploy/pipeline.yaml"),
+    ).toBe(false);
+  });
+
+  test("rejects port below minimum", () => {
+    expect(
+      isAllowedImportUrl("http://127.0.0.1:6379/tangle-deploy/pipeline.yaml"),
+    ).toBe(false);
+  });
+
+  test("rejects missing port", () => {
+    expect(
+      isAllowedImportUrl("http://127.0.0.1/tangle-deploy/pipeline.yaml"),
+    ).toBe(false);
+  });
+
+  test("rejects wrong path", () => {
+    expect(isAllowedImportUrl("http://127.0.0.1:54321/pipeline.yaml")).toBe(
+      false,
+    );
+  });
+
+  test("rejects malformed URL", () => {
+    expect(isAllowedImportUrl("not-a-url")).toBe(false);
+  });
+
+  test("rejects empty string", () => {
+    expect(isAllowedImportUrl("")).toBe(false);
+  });
+});
+
+describe("ImportPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSearchParams = {
+      url: "http://127.0.0.1:54321/tangle-deploy/pipeline.yaml",
+    };
+    globalThis.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test("shows confirmation screen with URL before fetching", () => {
+    render(<ImportPage />);
+    expect(screen.getByTestId("import-confirm-button")).toHaveTextContent(
+      "Import Pipeline",
+    );
+    expect(screen.getByText(/127\.0\.0\.1:54321/)).toBeInTheDocument();
+    expect(screen.getByText("Cancel")).toBeInTheDocument();
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  test("fetches and imports after clicking confirm button", async () => {
+    const user = userEvent.setup();
+    const yamlContent = "name: Test Pipeline\nimplementation: {}";
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve(yamlContent),
+    });
+    (importPipelineFromYaml as ReturnType<typeof vi.fn>).mockResolvedValue({
+      successful: true,
+      name: "Test Pipeline",
+    });
+
+    render(<ImportPage />);
+
+    await user.click(screen.getByTestId("import-confirm-button"));
+
+    await waitFor(() => {
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        "http://127.0.0.1:54321/tangle-deploy/pipeline.yaml",
+      );
+    });
+
+    await waitFor(() => {
+      expect(importPipelineFromYaml).toHaveBeenCalledWith(yamlContent, true);
+    });
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith({
+        to: "/editor/Test%20Pipeline",
+      });
+    });
+  });
+
+  test("shows error UI when fetch returns non-OK response", async () => {
+    const user = userEvent.setup();
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: "Not Found",
+    });
+
+    render(<ImportPage />);
+    await user.click(screen.getByTestId("import-confirm-button"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Import Failed")).toBeInTheDocument();
+      expect(
+        screen.getByText(/Failed to fetch pipeline: 404 Not Found/),
+      ).toBeInTheDocument();
+    });
+  });
+
+  test("shows error when import returns failure", async () => {
+    const user = userEvent.setup();
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve("invalid: yaml"),
+    });
+    (importPipelineFromYaml as ReturnType<typeof vi.fn>).mockResolvedValue({
+      successful: false,
+      name: "",
+      errorMessage: "Invalid pipeline format",
+    });
+
+    render(<ImportPage />);
+    await user.click(screen.getByTestId("import-confirm-button"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Import Failed")).toBeInTheDocument();
+      expect(screen.getByText(/Invalid pipeline format/)).toBeInTheDocument();
+    });
+  });
+
+  test("shows error for missing url parameter", () => {
+    mockSearchParams = {};
+
+    render(<ImportPage />);
+
+    expect(screen.getByText("Import Failed")).toBeInTheDocument();
+    expect(screen.getByText(/URL must be/)).toBeInTheDocument();
+  });
+
+  test("shows error for invalid URL (wrong host)", () => {
+    mockSearchParams = {
+      url: "http://evil.com:54321/tangle-deploy/pipeline.yaml",
+    };
+
+    render(<ImportPage />);
+
+    expect(screen.getByText("Import Failed")).toBeInTheDocument();
+    expect(screen.getByText(/URL must be/)).toBeInTheDocument();
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  test("shows error for invalid URL (port too low)", () => {
+    mockSearchParams = {
+      url: "http://127.0.0.1:80/tangle-deploy/pipeline.yaml",
+    };
+
+    render(<ImportPage />);
+
+    expect(screen.getByText("Import Failed")).toBeInTheDocument();
+    expect(screen.getByText(/URL must be/)).toBeInTheDocument();
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  test("shows error for invalid URL (wrong path)", () => {
+    mockSearchParams = { url: "http://127.0.0.1:54321/some-other-path" };
+
+    render(<ImportPage />);
+
+    expect(screen.getByText("Import Failed")).toBeInTheDocument();
+    expect(screen.getByText(/URL must be/)).toBeInTheDocument();
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  test("shows error when fetched content is empty", async () => {
+    const user = userEvent.setup();
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve("   "),
+    });
+
+    render(<ImportPage />);
+    await user.click(screen.getByTestId("import-confirm-button"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Import Failed")).toBeInTheDocument();
+      expect(
+        screen.getByText(/The fetched pipeline content is empty/),
+      ).toBeInTheDocument();
+    });
+  });
+
+  test("shows error when fetch throws a network error", async () => {
+    const user = userEvent.setup();
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("Network failure"),
+    );
+
+    render(<ImportPage />);
+    await user.click(screen.getByTestId("import-confirm-button"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Import Failed")).toBeInTheDocument();
+      expect(screen.getByText(/Network failure/)).toBeInTheDocument();
+    });
+  });
+
+  test("cancel button navigates home", async () => {
+    const user = userEvent.setup();
+    render(<ImportPage />);
+    await user.click(screen.getByText("Cancel"));
+
+    expect(mockRouterNavigate).toHaveBeenCalledWith({ to: "/" });
+  });
+});

--- a/src/routes/Import/index.tsx
+++ b/src/routes/Import/index.tsx
@@ -1,0 +1,294 @@
+import { useNavigate, useRouter, useSearch } from "@tanstack/react-router";
+import { useRef, useState } from "react";
+
+import { InfoBox } from "@/components/shared/InfoBox";
+import { Button } from "@/components/ui/button";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Spinner } from "@/components/ui/spinner";
+import { Paragraph, Text } from "@/components/ui/typography";
+import { EDITOR_PATH } from "@/routes/router";
+import { importPipelineFromYaml } from "@/services/pipelineService";
+
+/**
+ * Import route that fetches a pipeline YAML from a URL and imports it into the editor.
+ *
+ * Used by tangle-deploy CLI's `tangle-view-pipeline` command, which starts a temporary
+ * local HTTP server and opens: /app/editor/import-pipeline?url=http://127.0.0.1:PORT/tangle-deploy/pipeline.yaml
+ *
+ * Flow:
+ * 1. Read `url` from search params, validate with isAllowedImportUrl()
+ * 2. Show confirmation screen with URL
+ * 3. On user click: fetch YAML from the URL
+ * 4. Import into IndexedDB via importPipelineFromYaml (overwrite if same name exists)
+ * 5. Redirect to the editor
+ */
+
+/**
+ * OS-assigned ephemeral ports (port=0) are always well above this threshold:
+ * macOS: 49152-65535, Linux: 32768-60999. This check is a safety net to block
+ * well-known service ports (e.g., Redis 6379, Elasticsearch 9200) in case
+ * someone crafts a malicious import URL.
+ */
+const MIN_ALLOWED_PORT = 10000;
+
+export function isAllowedImportUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== "http:") return false;
+    if (parsed.hostname !== "127.0.0.1") return false;
+    const port = parseInt(parsed.port, 10);
+    if (!parsed.port || isNaN(port) || port < MIN_ALLOWED_PORT) return false;
+    if (parsed.pathname !== "/tangle-deploy/pipeline.yaml") return false;
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+enum Step {
+  Fetching = "fetching",
+  Importing = "importing",
+  Done = "done",
+}
+
+const STEPS: { key: Step; label: string; emoji: string }[] = [
+  { key: Step.Fetching, label: "Fetching pipeline", emoji: "📡" },
+  { key: Step.Importing, label: "Importing into editor", emoji: "📦" },
+  { key: Step.Done, label: "Opening editor", emoji: "🚀" },
+];
+
+const StepIndicator = ({
+  currentStep,
+  pipelineName,
+}: {
+  currentStep: Step;
+  pipelineName: string | null;
+}) => {
+  const currentIndex = STEPS.findIndex((s) => s.key === currentStep);
+
+  return (
+    <BlockStack gap="3">
+      {STEPS.map((step, i) => {
+        const isActive = i === currentIndex;
+        const isComplete = i < currentIndex;
+        const isPending = i > currentIndex;
+
+        return (
+          <InlineStack
+            key={step.key}
+            gap="3"
+            blockAlign="center"
+            className={`rounded-lg px-4 py-3 transition-all duration-300 ${
+              isActive
+                ? "bg-primary/10 border border-primary/20"
+                : isComplete
+                  ? "bg-muted/50"
+                  : "opacity-40"
+            }`}
+          >
+            <Text size="lg" className="w-7 text-center">
+              {isComplete ? "✅" : isActive ? step.emoji : "⏳"}
+            </Text>
+            <div className="flex-1 min-w-0">
+              <Paragraph
+                size="sm"
+                weight={isActive ? "semibold" : "regular"}
+                tone={isPending ? "subdued" : undefined}
+              >
+                {step.label}
+                {step.key === Step.Done && pipelineName && (
+                  <Text as="span" font="mono" className="ml-1">
+                    &ldquo;{pipelineName}&rdquo;
+                  </Text>
+                )}
+              </Paragraph>
+            </div>
+            {isActive && <Spinner size={16} />}
+          </InlineStack>
+        );
+      })}
+    </BlockStack>
+  );
+};
+
+interface ErrorScreenProps {
+  title: string;
+  emoji: string;
+  subtitle: string;
+  errorMessage: string;
+  onBack: () => void;
+}
+
+const ErrorScreen = ({
+  title,
+  emoji,
+  subtitle,
+  errorMessage,
+  onBack,
+}: ErrorScreenProps) => (
+  <div className="min-h-screen flex items-center justify-center bg-background p-4">
+    <div className="max-w-sm w-full">
+      <BlockStack gap="6" align="center">
+        <div className="text-center">
+          <Text size="xl" className="mb-3 block">
+            {emoji}
+          </Text>
+          <Text size="xl" weight="bold">
+            {title}
+          </Text>
+          <Paragraph tone="subdued" size="sm" className="mt-1">
+            {subtitle}
+          </Paragraph>
+        </div>
+
+        <InfoBox title="Error Details" variant="error">
+          <Paragraph font="mono" size="xs">
+            {errorMessage}
+          </Paragraph>
+        </InfoBox>
+
+        <Button onClick={onBack} variant="secondary" className="w-full">
+          ← Back to Home
+        </Button>
+      </BlockStack>
+    </div>
+  </div>
+);
+
+type ImportSearch = { url?: string };
+
+export const ImportPage = () => {
+  const search: ImportSearch = useSearch({ strict: false });
+  const navigate = useNavigate();
+  const router = useRouter();
+  const [error, setError] = useState<string | null>(null);
+  const [step, setStep] = useState<Step | null>(null);
+  const [pipelineName, setPipelineName] = useState<string | null>(null);
+  const importedRef = useRef(false);
+
+  const goHome = () => router.navigate({ to: "/" });
+  const url = search.url;
+  const isValidUrl = url && isAllowedImportUrl(url);
+  const validationError = isValidUrl
+    ? null
+    : `URL must be http://127.0.0.1:PORT/tangle-deploy/pipeline.yaml with port >= ${MIN_ALLOWED_PORT}.`;
+
+  const handleImport = async () => {
+    if (!url || importedRef.current) return;
+
+    try {
+      setStep(Step.Fetching);
+      const response = await fetch(url);
+
+      if (!response.ok) {
+        setError(
+          `Failed to fetch pipeline: ${response.status} ${response.statusText}`,
+        );
+        return;
+      }
+
+      const yamlContent = await response.text();
+
+      if (!yamlContent || yamlContent.trim().length === 0) {
+        setError("The fetched pipeline content is empty.");
+        return;
+      }
+
+      setStep(Step.Importing);
+      const result = await importPipelineFromYaml(yamlContent, true);
+
+      if (result.successful) {
+        importedRef.current = true;
+        setPipelineName(result.name);
+        setStep(Step.Done);
+        navigate({
+          to: `${EDITOR_PATH}/${encodeURIComponent(result.name)}`,
+        });
+      } else {
+        setError(result.errorMessage || "Failed to import pipeline from URL.");
+      }
+    } catch (err) {
+      setError(
+        `Failed to import pipeline: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  };
+
+  const errorMessage = error ?? validationError;
+
+  if (errorMessage) {
+    return (
+      <ErrorScreen
+        title="Import Failed"
+        emoji="❌"
+        subtitle="Something went wrong importing the pipeline."
+        errorMessage={errorMessage}
+        onBack={goHome}
+      />
+    );
+  }
+
+  if (step !== null) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-background p-4">
+        <div className="max-w-sm w-full">
+          <BlockStack gap="6" align="center">
+            <div className="text-center">
+              <Text size="xl" className="mb-3 block">
+                🔧
+              </Text>
+              <Text size="xl" weight="bold">
+                Importing Pipeline
+              </Text>
+              <Paragraph tone="subdued" size="sm" className="mt-1">
+                Setting up your pipeline in the editor...
+              </Paragraph>
+            </div>
+
+            <StepIndicator currentStep={step} pipelineName={pipelineName} />
+          </BlockStack>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-background p-4">
+      <div className="max-w-md w-full">
+        <BlockStack gap="6" align="center">
+          <div className="text-center">
+            <Text size="xl" className="mb-3 block">
+              📥
+            </Text>
+            <Text size="xl" weight="bold">
+              Import Pipeline
+            </Text>
+            <Paragraph tone="subdued" size="sm" className="mt-1">
+              A pipeline is ready to be imported from a local source.
+            </Paragraph>
+          </div>
+
+          <InfoBox title="Source" variant="info">
+            <Paragraph font="mono" size="xs" className="break-all">
+              {url}
+            </Paragraph>
+          </InfoBox>
+
+          <Paragraph tone="subdued" size="xs" className="text-center">
+            If a pipeline with the same name already exists, it will be
+            overwritten.
+          </Paragraph>
+
+          <InlineStack gap="3" align="center">
+            <Button onClick={goHome} variant="secondary">
+              Cancel
+            </Button>
+            <Button onClick={handleImport} data-testid="import-confirm-button">
+              Import Pipeline
+            </Button>
+          </InlineStack>
+        </BlockStack>
+      </div>
+    </div>
+  );
+};

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -18,6 +18,7 @@ import { BASE_URL, IS_GITHUB_PAGES } from "@/utils/constants";
 import RootLayout from "../components/layout/RootLayout";
 import Editor from "./Editor";
 import Home from "./Home";
+import { ImportPage } from "./Import";
 import NotFoundPage from "./NotFoundPage";
 import PipelineRun from "./PipelineRun";
 import { QuickStartPage } from "./QuickStart";
@@ -37,9 +38,11 @@ export const EDITOR_PATH = "/editor";
 export const RUNS_BASE_PATH = "/runs";
 export const QUICK_START_PATH = "/quick-start";
 const SETTINGS_PATH = "/settings";
+const IMPORT_PATH = "/app/editor/import-pipeline";
 export const APP_ROUTES = {
   HOME: "/",
   QUICK_START: QUICK_START_PATH,
+  IMPORT: IMPORT_PATH,
   PIPELINE_EDITOR: `${EDITOR_PATH}/$name`,
   RUN_DETAIL: `${RUNS_BASE_PATH}/$id`,
   RUN_DETAIL_WITH_SUBGRAPH: `${RUNS_BASE_PATH}/$id/$subgraphExecutionId`,
@@ -135,6 +138,12 @@ const secretsReplaceRoute = createRoute({
   component: ReplaceSecretView,
 });
 
+const importRoute = createRoute({
+  getParentRoute: () => mainLayout,
+  path: APP_ROUTES.IMPORT,
+  component: ImportPage,
+});
+
 const editorRoute = createRoute({
   getParentRoute: () => mainLayout,
   path: APP_ROUTES.PIPELINE_EDITOR,
@@ -187,6 +196,7 @@ const appRouteTree = mainLayout.addChildren([
   indexRoute,
   quickStartRoute,
   settingsRouteTree,
+  importRoute,
   editorRoute,
   runDetailRoute,
   runDetailWithSubgraphRoute,


### PR DESCRIPTION
## tangle-ui

### Description

Add `/app/editor/import-pipeline` route to enable opening pipeline YAML files directly in the browser editor from external tools.

Look at [PR-28268](https://app.graphite.com/github/pr/Shopify/discovery/28268/feat-Preview-Pipeline-Run-in-browser-with-Tangle-Deploy) for Video Demos for what this PR supports.

#### Changes
- `ImportPage` component (`src/routes/Import/index.tsx`) — strict URL validation (`isAllowedImportUrl`), confirmation dialog before fetch, step indicator UI, error handling with reusable `ErrorScreen` component
- Route `/app/editor/import-pipeline` in `router.ts`
- Unit tests covering URL validation (10 cases), confirmation flow, success path, fetch failures, empty content, missing/invalid URL, and network errors (21 tests total)

#### Security

- UI
  - **Strict URL allowlist**: only accepts `http://127.0.0.1:{port>=10000}/tangle-deploy/pipeline.yaml` — blocks crafted URLs targeting local services
  - **Confirmation dialog**: user must explicitly click "Import Pipeline" before any fetch occurs
  - **Pipeline validation**: `importPipelineFromYaml` validates YAML syntax and graph structure before saving to IndexedDB
  - **Descriptive route path**: renamed from `/import` to `/app/editor/import-pipeline` to avoid root-level conflicts and clarify intent
- CLI Server
  - **CORS headers**: CLI server for cross-origin fetch

### Test Steps
1. Run `npm run start` (frontend on `localhost:3000`)
2. Run `tangle-view-pipeline <any_pipeline.yaml> --ui-url http://localhost:3000` — browser should open, show the step indicator, and redirect to the editor with the pipeline loaded
3. Visit `http://localhost:3000/#/import` (no `url` param) — should show "Missing 'url' parameter" error with Back to Home button
4. Visit `http://localhost:3000/#/import?url=http://bad-url` — should show fetch error UI
5. Run `npm test -- src/routes/Import/Import.test.tsx` — all 6 tests should pass