### PR TITLE
chore: e2e for secrets management ui

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           repository: TangleML/tangle
-          ref: stable
+          ref: master
           path: backend
 
       - name: Install uv

--- a/src/components/shared/SecretsManagement/ManageSecretsButton.tsx
+++ b/src/components/shared/SecretsManagement/ManageSecretsButton.tsx
@@ -14,7 +14,10 @@ export function ManageSecretsButton() {
   return (
     <ManageSecretsDialog
       trigger={
-        <TooltipButton tooltip="Manage Secrets">
+        <TooltipButton
+          tooltip="Manage Secrets"
+          data-testid="manage-secrets-button"
+        >
           <Icon name="Lock" />
         </TooltipButton>
       }

--- a/src/components/shared/SecretsManagement/ManageSecretsDialog.tsx
+++ b/src/components/shared/SecretsManagement/ManageSecretsDialog.tsx
@@ -135,7 +135,11 @@ function ManageSecretsDialogContentInternal({
             />
             <Separator />
             <BlockStack gap="1" align="end">
-              <Button variant="secondary" onClick={() => setMode("add")}>
+              <Button
+                variant="secondary"
+                onClick={() => setMode("add")}
+                data-testid="add-secret-button"
+              >
                 <InlineStack align="center" gap="1">
                   <Icon name="Plus" />
                   Add Secret

--- a/src/components/shared/SecretsManagement/SelectSecretDialog.tsx
+++ b/src/components/shared/SecretsManagement/SelectSecretDialog.tsx
@@ -48,7 +48,11 @@ function SelectableSecretsList({
 }: SelectableSecretsListProps) {
   if (secrets.length === 0) {
     return (
-      <BlockStack align="center" className="py-8">
+      <BlockStack
+        align="center"
+        className="py-8"
+        data-testid="select-secret-empty-state"
+      >
         <Icon name="Lock" size="lg" className="text-gray-300" />
         <Text tone="subdued">No secrets configured</Text>
         <Text size="xs" tone="subdued">
@@ -59,7 +63,11 @@ function SelectableSecretsList({
   }
 
   return (
-    <ScrollArea className="w-full min-h-[100px] max-h-[300px]" type="always">
+    <ScrollArea
+      className="w-full min-h-[100px] max-h-[300px]"
+      type="always"
+      data-testid="select-secret-list"
+    >
       <BlockStack gap="2">
         {secrets.map((secret) => (
           <button
@@ -67,6 +75,8 @@ function SelectableSecretsList({
             type="button"
             className="w-full text-left"
             onClick={() => onSelect(secret)}
+            data-testid="selectable-secret-item"
+            data-secret-name={secret.name}
           >
             <InlineStack
               align="space-between"
@@ -153,7 +163,11 @@ function SelectSecretDialogContentInternal({
         />
         <Separator />
         <InlineStack align="end" fill gap="2">
-          <Button variant="secondary" onClick={() => setMode("add")}>
+          <Button
+            variant="secondary"
+            onClick={() => setMode("add")}
+            data-testid="select-secret-add-button"
+          >
             <InlineStack align="center" gap="1">
               <Icon name="Plus" />
               Add Secret

--- a/src/components/shared/SecretsManagement/components/AddSecretButton.tsx
+++ b/src/components/shared/SecretsManagement/components/AddSecretButton.tsx
@@ -34,7 +34,11 @@ export function AddSecretButton({
   });
 
   return (
-    <Button onClick={() => saveSecret()} disabled={disabled || isPending}>
+    <Button
+      onClick={() => saveSecret()}
+      disabled={disabled || isPending}
+      data-testid="add-secret-submit-button"
+    >
       Add Secret
       {isPending && <Spinner />}
     </Button>

--- a/src/components/shared/SecretsManagement/components/AddSecretForm.tsx
+++ b/src/components/shared/SecretsManagement/components/AddSecretForm.tsx
@@ -103,6 +103,7 @@ export function AddSecretForm({
           disabled={isReplace}
           aria-invalid={!!state.nameError}
           className={cn(state.nameError && "border-destructive")}
+          data-testid="secret-name-input"
         />
         {state.nameError && (
           <Text size="xs" tone="critical">
@@ -123,6 +124,7 @@ export function AddSecretForm({
           onChange={handleValueChange}
           aria-invalid={!!state.valueError}
           className={cn(state.valueError && "border-destructive")}
+          data-testid="secret-value-input"
         />
         {state.valueError && (
           <Text size="xs" tone="critical">
@@ -135,7 +137,11 @@ export function AddSecretForm({
       </BlockStack>
 
       <InlineStack gap="2" align="end" fill>
-        <Button variant="outline" onClick={onCancel}>
+        <Button
+          variant="outline"
+          onClick={onCancel}
+          data-testid="secret-form-cancel-button"
+        >
           Cancel
         </Button>
         {existingSecret ? (

--- a/src/components/shared/SecretsManagement/components/RemoveSecretButton.tsx
+++ b/src/components/shared/SecretsManagement/components/RemoveSecretButton.tsx
@@ -38,6 +38,7 @@ export function RemoveSecretButton({
       onClick={() => removeSecretMutation()}
       disabled={isPending}
       className="text-destructive hover:text-destructive"
+      data-testid="secret-remove-button"
     >
       <Icon name="Trash2" size="sm" />
     </Button>

--- a/src/components/shared/SecretsManagement/components/SecretsList.tsx
+++ b/src/components/shared/SecretsManagement/components/SecretsList.tsx
@@ -26,7 +26,11 @@ function SecretsListInternal({ onReplace, onRemoveSuccess }: SecretsListProps) {
 
   if (secrets.length === 0) {
     return (
-      <BlockStack align="center" className="py-8">
+      <BlockStack
+        align="center"
+        className="py-8"
+        data-testid="secrets-empty-state"
+      >
         <Icon name="Lock" size="lg" className="text-subdued" />
         <Text tone="subdued">No secrets configured</Text>
         <Text size="xs" tone="subdued">
@@ -37,7 +41,11 @@ function SecretsListInternal({ onReplace, onRemoveSuccess }: SecretsListProps) {
   }
 
   return (
-    <ScrollArea className="w-full min-h-[100px] max-h-[300px]" type="always">
+    <ScrollArea
+      className="w-full min-h-[100px] max-h-[300px]"
+      type="always"
+      data-testid="secrets-list"
+    >
       <BlockStack gap="2">
         {secrets.map((secret) => (
           <InlineStack
@@ -45,6 +53,8 @@ function SecretsListInternal({ onReplace, onRemoveSuccess }: SecretsListProps) {
             align="space-between"
             gap="2"
             className="w-full pr-3 py-1.5 hover:bg-gray-50 rounded-md pl-1"
+            data-testid="secret-item"
+            data-secret-name={secret.name}
           >
             <InlineStack gap="2" blockAlign="center" wrap="nowrap">
               <Icon name="Lock" size="lg" className="shrink-0" />
@@ -63,6 +73,7 @@ function SecretsListInternal({ onReplace, onRemoveSuccess }: SecretsListProps) {
                 variant="ghost"
                 size="xs"
                 onClick={() => onReplace(secret)}
+                data-testid="secret-edit-button"
               >
                 <Icon name="Pencil" size="sm" />
               </Button>

--- a/src/components/shared/SecretsManagement/components/UpdateSecretButton.tsx
+++ b/src/components/shared/SecretsManagement/components/UpdateSecretButton.tsx
@@ -36,6 +36,7 @@ export function UpdateSecretButton({
     <Button
       onClick={() => updateSecretMutation()}
       disabled={disabled || isPending}
+      data-testid="update-secret-submit-button"
     >
       Update Secret
       {isPending && <Spinner />}

--- a/tests/e2e/secrets-management.spec.ts
+++ b/tests/e2e/secrets-management.spec.ts
@@ -1,0 +1,348 @@
+import { expect, type Page, test } from "@playwright/test";
+
+import { createNewPipeline } from "./helpers";
+
+/**
+ * Due to the serial nature of secrets management (shared state),
+ * tests are run in serial mode with a shared page instance.
+ *
+ * Each test is idempotent - creating and cleaning up its own secrets.
+ */
+test.describe.configure({ mode: "serial" });
+
+test.describe("Secrets Management", () => {
+  let page: Page;
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage();
+
+    await createNewPipeline(page);
+
+    // Enable the secrets beta flag
+    await page.getByTestId("personal-preferences-button").click();
+
+    const dialog = page.getByTestId("personal-preferences-dialog");
+    await expect(dialog).toBeVisible();
+
+    await dialog.getByRole("tab", { name: "Beta Features" }).click();
+
+    const secretsSwitch = dialog.getByTestId("secrets-switch");
+    await expect(secretsSwitch).toBeVisible({ timeout: 10000 });
+
+    // Enable secrets if not already enabled
+    if ((await secretsSwitch.getAttribute("aria-checked")) !== "true") {
+      await secretsSwitch.click();
+      await expect(secretsSwitch).toHaveAttribute("aria-checked", "true");
+    }
+
+    // Close dialog
+    await dialog.press("Escape");
+    await expect(dialog).toBeHidden();
+  });
+
+  test.afterAll(async () => {
+    await page.close();
+  });
+
+  test("Manage Secrets button is visible when flag is enabled", async () => {
+    const manageSecretsButton = page.getByTestId("manage-secrets-button");
+    await expect(
+      manageSecretsButton,
+      "Manage Secrets button should be visible when secrets flag is enabled",
+    ).toBeVisible();
+  });
+
+  test("opens Manage Secrets dialog and verifies empty state", async () => {
+    await openManageSecretsDialog(page);
+
+    const dialog = page.getByTestId("manage-secrets-dialog");
+    await expect(
+      dialog,
+      "Dialog should be visible after opening",
+    ).toBeVisible();
+
+    // Verify empty state is shown
+    const emptyState = dialog.getByTestId("secrets-empty-state");
+    await expect(
+      emptyState,
+      "Empty state should be visible when no secrets exist",
+    ).toBeVisible();
+    await expect(emptyState).toContainText("No secrets configured");
+
+    // Verify Add Secret button is visible
+    const addSecretButton = dialog.getByTestId("add-secret-button");
+    await expect(
+      addSecretButton,
+      "Add Secret button should be visible in list view",
+    ).toBeVisible();
+
+    await closeDialog(page);
+  });
+
+  test("adds a new secret and removes it", async () => {
+    const testSecretName = "TEST_API_KEY";
+    const testSecretValue = "super-secret-value-123";
+
+    await openManageSecretsDialog(page);
+
+    const dialog = page.getByTestId("manage-secrets-dialog");
+
+    // Click Add Secret button
+    await dialog.getByTestId("add-secret-button").click();
+
+    // Verify form is shown with correct title
+    await expect(
+      dialog.getByRole("heading"),
+      "Dialog should show Add Secret form title",
+    ).toContainText("Add Secret");
+
+    // Fill in the secret form
+    await dialog.getByTestId("secret-name-input").fill(testSecretName);
+    await dialog.getByTestId("secret-value-input").fill(testSecretValue);
+
+    // Submit the form
+    await dialog.getByTestId("add-secret-submit-button").click();
+
+    // Verify we're back to list view with the secret visible
+    const secretItem = dialog.locator(
+      `[data-testid="secret-item"][data-secret-name="${testSecretName}"]`,
+    );
+    await expect(
+      secretItem,
+      "Newly added secret should appear in the list",
+    ).toBeVisible();
+    await expect(secretItem).toContainText(testSecretName);
+
+    // Clean up: Remove the secret
+    await secretItem.getByTestId("secret-remove-button").click();
+
+    // Verify secret is removed and empty state is shown
+    await expect(
+      secretItem,
+      "Secret should be removed from list after deletion",
+    ).toBeHidden();
+    await expect(
+      dialog.getByTestId("secrets-empty-state"),
+      "Empty state should reappear after last secret is deleted",
+    ).toBeVisible();
+
+    await closeDialog(page);
+  });
+
+  test("replaces an existing secret value", async () => {
+    const testSecretName = "REPLACE_TEST_SECRET";
+    const initialValue = "initial-value";
+    const replacedValue = "replaced-value";
+
+    await openManageSecretsDialog(page);
+
+    const dialog = page.getByTestId("manage-secrets-dialog");
+
+    // First, create a secret to replace
+    await dialog.getByTestId("add-secret-button").click();
+    await dialog.getByTestId("secret-name-input").fill(testSecretName);
+    await dialog.getByTestId("secret-value-input").fill(initialValue);
+    await dialog.getByTestId("add-secret-submit-button").click();
+
+    // Wait for the secret to appear in the list
+    const secretItem = dialog.locator(
+      `[data-testid="secret-item"][data-secret-name="${testSecretName}"]`,
+    );
+    await expect(
+      secretItem,
+      "Secret should appear in list after creation",
+    ).toBeVisible();
+
+    // Click the edit button to replace the secret
+    await secretItem.getByTestId("secret-edit-button").click();
+
+    // Verify we're in replace mode
+    await expect(
+      dialog.getByRole("heading"),
+      "Dialog should show Replace Secret form title",
+    ).toContainText("Replace Secret");
+
+    // The name input should be disabled in replace mode
+    const nameInput = dialog.getByTestId("secret-name-input");
+    await expect(
+      nameInput,
+      "Name input should be disabled when replacing a secret",
+    ).toBeDisabled();
+    await expect(nameInput).toHaveValue(testSecretName);
+
+    // Fill in the new value
+    await dialog.getByTestId("secret-value-input").fill(replacedValue);
+
+    // Submit the update
+    await dialog.getByTestId("update-secret-submit-button").click();
+
+    // Verify we're back to list view
+    await expect(
+      secretItem,
+      "Secret should remain visible after value update",
+    ).toBeVisible();
+
+    // Clean up: Remove the secret
+    await secretItem.getByTestId("secret-remove-button").click();
+    await expect(
+      secretItem,
+      "Secret should be removed after cleanup",
+    ).toBeHidden();
+
+    await closeDialog(page);
+  });
+
+  test("removes a secret from the list", async () => {
+    const testSecretName = "DELETE_TEST_SECRET";
+    const testSecretValue = "delete-me";
+
+    await openManageSecretsDialog(page);
+
+    const dialog = page.getByTestId("manage-secrets-dialog");
+
+    // Create a secret to delete
+    await dialog.getByTestId("add-secret-button").click();
+    await dialog.getByTestId("secret-name-input").fill(testSecretName);
+    await dialog.getByTestId("secret-value-input").fill(testSecretValue);
+    await dialog.getByTestId("add-secret-submit-button").click();
+
+    // Verify the secret is in the list
+    const secretItem = dialog.locator(
+      `[data-testid="secret-item"][data-secret-name="${testSecretName}"]`,
+    );
+    await expect(
+      secretItem,
+      "Secret should appear in list after creation",
+    ).toBeVisible();
+
+    // Remove the secret
+    await secretItem.getByTestId("secret-remove-button").click();
+
+    // Verify the secret is removed
+    await expect(
+      secretItem,
+      "Secret should be removed from list after deletion",
+    ).toBeHidden();
+
+    // Verify empty state is shown again
+    await expect(
+      dialog.getByTestId("secrets-empty-state"),
+      "Empty state should reappear after last secret is deleted",
+    ).toBeVisible();
+
+    await closeDialog(page);
+  });
+
+  test("cancels adding a secret and returns to list", async () => {
+    await openManageSecretsDialog(page);
+
+    const dialog = page.getByTestId("manage-secrets-dialog");
+
+    // Click Add Secret button
+    await dialog.getByTestId("add-secret-button").click();
+
+    // Verify form is shown
+    await expect(
+      dialog.getByRole("heading"),
+      "Dialog should show Add Secret form",
+    ).toContainText("Add Secret");
+
+    // Click Cancel button
+    await dialog.getByTestId("secret-form-cancel-button").click();
+
+    // Verify we're back to list view
+    await expect(
+      dialog.getByRole("heading"),
+      "Dialog should return to list view after cancel",
+    ).toContainText("Manage Secrets");
+    await expect(dialog.getByTestId("add-secret-button")).toBeVisible();
+
+    await closeDialog(page);
+  });
+
+  test("cancels replacing a secret and returns to list", async () => {
+    const testSecretName = "CANCEL_REPLACE_TEST";
+    const testSecretValue = "cancel-test-value";
+
+    await openManageSecretsDialog(page);
+
+    const dialog = page.getByTestId("manage-secrets-dialog");
+
+    // Create a secret
+    await dialog.getByTestId("add-secret-button").click();
+    await dialog.getByTestId("secret-name-input").fill(testSecretName);
+    await dialog.getByTestId("secret-value-input").fill(testSecretValue);
+    await dialog.getByTestId("add-secret-submit-button").click();
+
+    // Click edit to go to replace mode
+    const secretItem = dialog.locator(
+      `[data-testid="secret-item"][data-secret-name="${testSecretName}"]`,
+    );
+    await expect(
+      secretItem,
+      "Secret should appear in list after creation",
+    ).toBeVisible();
+    await secretItem.getByTestId("secret-edit-button").click();
+
+    // Verify we're in replace mode
+    await expect(
+      dialog.getByRole("heading"),
+      "Dialog should show Replace Secret form",
+    ).toContainText("Replace Secret");
+
+    // Cancel the replace
+    await dialog.getByTestId("secret-form-cancel-button").click();
+
+    // Verify we're back to list view
+    await expect(
+      dialog.getByRole("heading"),
+      "Dialog should return to list view after cancel",
+    ).toContainText("Manage Secrets");
+    await expect(
+      secretItem,
+      "Secret should still be visible after canceling replace",
+    ).toBeVisible();
+
+    // Clean up
+    await secretItem.getByTestId("secret-remove-button").click();
+    await expect(
+      secretItem,
+      "Secret should be removed after cleanup",
+    ).toBeHidden();
+
+    await closeDialog(page);
+  });
+});
+
+/**
+ * Opens the Manage Secrets dialog via the top bar button
+ * @param page - Playwright page object
+ * @throws Error if button is not visible or dialog fails to open
+ */
+async function openManageSecretsDialog(page: Page): Promise<void> {
+  const manageSecretsButton = page.getByTestId("manage-secrets-button");
+  await expect(
+    manageSecretsButton,
+    "Manage Secrets button should be visible to open dialog",
+  ).toBeVisible();
+  await manageSecretsButton.click();
+
+  const dialog = page.getByTestId("manage-secrets-dialog");
+  await expect(
+    dialog,
+    "Manage Secrets dialog should open after clicking button",
+  ).toBeVisible();
+}
+
+/**
+ * Closes the currently open dialog using Escape key
+ * @param page - Playwright page object
+ */
+async function closeDialog(page: Page): Promise<void> {
+  await page.keyboard.press("Escape");
+  const dialog = page.getByTestId("manage-secrets-dialog");
+  await expect(
+    dialog,
+    "Dialog should close after pressing Escape",
+  ).toBeHidden();
+}


### PR DESCRIPTION
## Description

Added comprehensive test identifiers (`data-testid` attributes) to all secrets management components and implemented a complete end-to-end test suite. The test identifiers enable reliable automated testing of the secrets management functionality, covering all user interactions including creating, editing, removing secrets, and handling empty states.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

[Secrets UI e2e.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/c2b69222-0e7a-48a0-afc4-a8e4025989d8.mov" />](https://app.graphite.com/user-attachments/video/c2b69222-0e7a-48a0-afc4-a8e4025989d8.mov)



## Test Instructions

1. Enable the secrets beta flag in personal preferences
2. Click the "Manage Secrets" button to open the dialog
3. Verify all interactive elements have proper test identifiers
4. Run the new e2e test suite: `npm run test:e2e -- secrets-management.spec.ts`
5. Test covers: opening dialog, adding secrets, editing secrets, removing secrets, canceling operations, and empty state handling

## Additional Comments

The e2e tests run in serial mode due to shared secrets state and are designed to be idempotent with proper cleanup. Each test creates and removes its own test data to avoid interference between test runs.

This test spec fully interacts with a backend.