### PR TITLE
fix: rm Manual Timezone Adjustments

### DIFF
--- a/src/components/Home/PipelineSection/PipelineRow.tsx
+++ b/src/components/Home/PipelineSection/PipelineRow.tsx
@@ -178,7 +178,7 @@ const PipelineRunsButton = withSuspenseWrapper(
         >
           <Icon name="List" />
         </PopoverTrigger>
-        <PopoverContent className="w-[500px]">
+        <PopoverContent className="w-125">
           <PipelineRunsList
             pipelineName={pipelineName}
             showMoreButton={false}
@@ -194,7 +194,7 @@ const PipelineRunsButton = withSuspenseWrapper(
 );
 
 function formatModificationTime(modificationTime: Date | undefined) {
-  return modificationTime ? formatDate(modificationTime.toISOString()) : "N/A";
+  return modificationTime ? formatDate(modificationTime) : "N/A";
 }
 
 export default PipelineRow;

--- a/src/components/Home/RunSection/RunRow.tsx
+++ b/src/components/Home/RunSection/RunRow.tsx
@@ -14,7 +14,7 @@ import {
 import { Paragraph } from "@/components/ui/typography";
 import useToastNotification from "@/hooks/useToastNotification";
 import { APP_ROUTES } from "@/routes/router";
-import { convertUTCToLocalTime, formatDate } from "@/utils/date";
+import { formatDate } from "@/utils/date";
 import { getOverallExecutionStatusFromStats } from "@/utils/executionStatus";
 
 const RunRow = ({ run }: { run: PipelineRunResponse }) => {
@@ -82,7 +82,7 @@ const RunRow = ({ run }: { run: PipelineRunResponse }) => {
       <TableCell>
         <InlineStack gap="2" blockAlign="center" wrap="nowrap">
           <StatusIcon status={overallStatus} />
-          <Paragraph className="truncate max-w-[400px] text-sm" title={name}>
+          <Paragraph className="truncate max-w-100 text-sm" title={name}>
             {name}
           </Paragraph>
           <Paragraph tone="subdued" className="text-sm" title={runId}>
@@ -96,9 +96,7 @@ const RunRow = ({ run }: { run: PipelineRunResponse }) => {
         </div>
       </TableCell>
       <TableCell>
-        {run.created_at
-          ? `${formatDate(convertUTCToLocalTime(run.created_at).toISOString())}`
-          : "Data not found..."}
+        {run.created_at ? formatDate(run.created_at) : "Data not found..."}
       </TableCell>
       <TableCell>
         {isTruncated ? createdByButtonWithTooltip : createdByButton}

--- a/src/components/shared/PipelineRunDisplay/PipelineRunInfoCondensed.tsx
+++ b/src/components/shared/PipelineRunDisplay/PipelineRunInfoCondensed.tsx
@@ -3,7 +3,7 @@ import { InlineStack } from "@/components/ui/layout";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Paragraph } from "@/components/ui/typography";
 import type { PipelineRun } from "@/types/pipelineRun";
-import { convertUTCToLocalTime, formatDate } from "@/utils/date";
+import { formatDate } from "@/utils/date";
 
 import { PipelineRunStatus } from "./components/PipelineRunStatus";
 
@@ -13,7 +13,7 @@ export const PipelineRunInfoCondensed = withSuspenseWrapper(
       <InlineStack gap="2">
         <PipelineRunStatus run={run} />
         <Paragraph tone="subdued" size="xs">
-          {formatDate(convertUTCToLocalTime(run.created_at).toISOString())}
+          {formatDate(run.created_at)}
         </Paragraph>
       </InlineStack>
     );

--- a/src/components/shared/PipelineRunDisplay/RunOverview.tsx
+++ b/src/components/shared/PipelineRunDisplay/RunOverview.tsx
@@ -120,7 +120,9 @@ const RunOverview = ({
           {combinedConfig?.showCreatedAt && run.created_at && (
             <div className="flex items-center gap-2">
               <span>•</span>
-              <span className="text-gray-500 text-xs">{`${formatDate(run.created_at || "")}`}</span>
+              <span className="text-gray-500 text-xs">
+                {formatDate(run.created_at)}
+              </span>
             </div>
           )}
           {combinedConfig?.showAuthor && run.created_by && (

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -7,19 +7,10 @@ const defaultFormat: Intl.DateTimeFormatOptions = {
   hour: "2-digit",
   minute: "2-digit",
 };
-export const formatDate = (dateString: string, format = defaultFormat) => {
-  const date = new Date(dateString);
-  return date.toLocaleString("en-US", format);
-};
 
-/**
- * Converts a UTC date string to local time
- * @param utcDateString - The UTC date string to convert
- * @returns Date object in local timezone
- */
-export const convertUTCToLocalTime = (utcDateString: string): Date => {
-  const date = new Date(utcDateString);
-  return new Date(date.getTime() - date.getTimezoneOffset() * 60000);
+export const formatDate = (date: string | Date, format = defaultFormat) => {
+  const dateObj = typeof date === "string" ? new Date(date) : date;
+  return dateObj.toLocaleString("en-US", format);
 };
 
 /**


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
The backend was recently updated to return timezone alongside date strings, so the manual timezone adjustment is no longer needed.

Since the backend was updated this manual adjustment has been causing erroneous times to be reported on runs and pipelines. The issue is currently on Production.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->
Create a run & confirm that in the run list it shows the expected time. Same for pipelines.

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
