### PR TITLE
feat: Variable Font Size for Flex Nodes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@radix-ui/react-scroll-area": "^1.2.10",
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-separator": "^1.1.8",
+        "@radix-ui/react-slider": "^1.3.6",
         "@radix-ui/react-slot": "^1.2.4",
         "@radix-ui/react-switch": "^1.2.6",
         "@radix-ui/react-tabs": "^1.1.13",
@@ -3164,6 +3165,39 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-slot": "1.2.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slider": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.3.6.tgz",
+      "integrity": "sha512-JPYb1GuM1bxfjMRlNLE+BcmBC8onfCi60Blk7OBqi2MLTFdS+8401U4uFjnwkOr49BLmXxLC6JHkvAsx5OJvHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@radix-ui/react-scroll-area": "^1.2.10",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-separator": "^1.1.8",
+    "@radix-ui/react-slider": "^1.3.6",
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tabs": "^1.1.13",

--- a/src/components/shared/ReactFlow/FlowCanvas/FlexNode/FlexNode.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlexNode/FlexNode.tsx
@@ -8,7 +8,6 @@ import {
 import { type MouseEvent, useEffect, useState } from "react";
 
 import { BlockStack } from "@/components/ui/layout";
-import { Paragraph } from "@/components/ui/typography";
 import { cn } from "@/lib/utils";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 import { useContextPanel } from "@/providers/ContextPanelProvider";
@@ -26,7 +25,14 @@ const MIN_SIZE = { width: 50, height: 50 };
 
 const FlexNode = ({ data, id, selected }: FlexNodeProps) => {
   const { properties, readOnly, locked = false } = data;
-  const { title, content, color, borderColor } = properties;
+  const {
+    title,
+    content,
+    color,
+    borderColor,
+    titleFontSize = 12,
+    contentFontSize = 10,
+  } = properties;
 
   const [isInlineEditing, setIsInlineEditing] = useState(false);
   const [isContextPanelFocus, setIsContextPanelFocus] = useState(false);
@@ -221,22 +227,29 @@ const FlexNode = ({ data, id, selected }: FlexNodeProps) => {
             />
 
             {title && (
-              <Paragraph size="sm" weight="semibold">
+              <p
+                style={{ fontSize: titleFontSize }}
+                className="font-bold whitespace-pre-wrap"
+              >
                 {title}
-              </Paragraph>
+              </p>
             )}
 
             {isInlineEditing ? (
               <InlineTextEditor
                 value={content}
                 placeholder="Enter text..."
+                textSize={contentFontSize}
                 onSave={handleSaveContent}
                 onCancel={() => setIsInlineEditing(false)}
               />
             ) : (
-              <Paragraph size="xs" className="whitespace-pre-wrap">
+              <p
+                style={{ fontSize: contentFontSize }}
+                className="whitespace-pre-wrap"
+              >
                 {content}
-              </Paragraph>
+              </p>
             )}
           </BlockStack>
         </div>

--- a/src/components/shared/ReactFlow/FlowCanvas/FlexNode/FlexNodeEditor.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlexNode/FlexNodeEditor.tsx
@@ -12,11 +12,13 @@ import { Textarea } from "@/components/ui/textarea";
 import { Paragraph, Text } from "@/components/ui/typography";
 import { cn } from "@/lib/utils";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
+import { FONT_SIZE_MD, FONT_SIZE_SM } from "@/utils/constants";
 import { updateSubgraphSpec } from "@/utils/subgraphUtils";
 
 import { StackingControls } from "../../FlowControls/StackingControls";
 import { updateFlexNodeInComponentSpec } from "./interface";
 import LockToggle from "./LockToggle";
+import { TextSizeSelector } from "./TextSizeSelector";
 import type { FlexNodeData } from "./types";
 import { DEFAULT_BORDER_COLOR } from "./utils";
 
@@ -126,6 +128,48 @@ const ContentEditor = ({
     setContent(e.target.value);
   };
 
+  const handleTitleFontSizeChange = (newSize: number) => {
+    const updatedSubgraphSpec = updateFlexNodeInComponentSpec(
+      currentSubgraphSpec,
+      {
+        ...flexNode,
+        properties: {
+          ...properties,
+          titleFontSize: newSize,
+        },
+      },
+    );
+
+    const newRootSpec = updateSubgraphSpec(
+      componentSpec,
+      currentSubgraphPath,
+      updatedSubgraphSpec,
+    );
+
+    setComponentSpec(newRootSpec);
+  };
+
+  const handleContentFontSizeChange = (newSize: number) => {
+    const updatedSubgraphSpec = updateFlexNodeInComponentSpec(
+      currentSubgraphSpec,
+      {
+        ...flexNode,
+        properties: {
+          ...properties,
+          contentFontSize: newSize,
+        },
+      },
+    );
+
+    const newRootSpec = updateSubgraphSpec(
+      componentSpec,
+      currentSubgraphPath,
+      updatedSubgraphSpec,
+    );
+
+    setComponentSpec(newRootSpec);
+  };
+
   const saveChanges = () => {
     const updatedSubgraphSpec = updateFlexNodeInComponentSpec(
       currentSubgraphSpec,
@@ -177,12 +221,25 @@ const ContentEditor = ({
     <ContentBlock title="Content">
       <BlockStack gap="2">
         <BlockStack>
-          <Label
-            htmlFor="flex-node-title"
-            className="text-muted-foreground text-xs"
+          <InlineStack
+            gap="4"
+            align="space-between"
+            blockAlign="end"
+            wrap="nowrap"
+            fill
           >
-            Title
-          </Label>
+            <Label
+              htmlFor="flex-node-title"
+              className="text-muted-foreground text-xs"
+            >
+              Title
+            </Label>
+            <TextSizeSelector
+              value={properties.titleFontSize ?? FONT_SIZE_MD}
+              onChange={handleTitleFontSizeChange}
+              className="mb-1"
+            />
+          </InlineStack>
           <Input
             id="flex-node-title"
             value={title}
@@ -192,12 +249,25 @@ const ContentEditor = ({
           />
         </BlockStack>
         <BlockStack>
-          <Label
-            htmlFor="flex-node-content"
-            className="text-muted-foreground text-xs"
+          <InlineStack
+            gap="4"
+            align="space-between"
+            blockAlign="end"
+            wrap="nowrap"
+            fill
           >
-            Note
-          </Label>
+            <Label
+              htmlFor="flex-node-content"
+              className="text-muted-foreground text-xs"
+            >
+              Note
+            </Label>
+            <TextSizeSelector
+              value={properties.contentFontSize ?? FONT_SIZE_SM}
+              onChange={handleContentFontSizeChange}
+              className="mb-1"
+            />
+          </InlineStack>
           <Textarea
             id="flex-node-content"
             value={content}
@@ -282,7 +352,7 @@ const ColorEditor = ({
         title="Color"
         items={[
           {
-            label: "Backgroud",
+            label: "Background",
             value: properties.color,
             copyable: true,
           },

--- a/src/components/shared/ReactFlow/FlowCanvas/FlexNode/InlineTextEditor.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlexNode/InlineTextEditor.tsx
@@ -11,6 +11,7 @@ import { Textarea } from "@/components/ui/textarea";
 interface InlineTextEditorProps {
   value: string;
   placeholder?: string;
+  textSize?: number;
   onSave: (value: string) => void;
   onCancel: () => void;
 }
@@ -18,6 +19,7 @@ interface InlineTextEditorProps {
 export const InlineTextEditor = ({
   value,
   placeholder = "Enter text...",
+  textSize,
   onSave,
   onCancel,
 }: InlineTextEditorProps) => {
@@ -65,6 +67,7 @@ export const InlineTextEditor = ({
       onBlur={handleBlur}
       onKeyDown={handleKeyDown}
       className="min-h-10 resize-none nodrag nopan focus-visible:ring-0 focus-visible:border-0 focus-visible:text-xs text-xs shadow-none p-0 rounded-none"
+      style={{ fontSize: textSize }}
       onMouseDown={(e) => e.stopPropagation()}
       onClick={(e) => e.stopPropagation()}
     />

--- a/src/components/shared/ReactFlow/FlowCanvas/FlexNode/TextSizeSelector.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlexNode/TextSizeSelector.tsx
@@ -1,0 +1,60 @@
+import { Icon } from "@/components/ui/icon";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Slider } from "@/components/ui/slider";
+import { Text } from "@/components/ui/typography";
+import { cn } from "@/lib/utils";
+
+interface TextSizeSelectorProps {
+  value: number;
+  onChange: (size: number) => void;
+  className?: string;
+}
+
+const TEXT_SIZE_MAX = 64;
+const TEXT_SIZE_MIN = 6;
+
+export const TextSizeSelector = ({
+  value,
+  onChange,
+  className,
+}: TextSizeSelectorProps) => {
+  return (
+    <Popover>
+      <PopoverTrigger>
+        <div
+          className={cn(
+            "cursor-pointer border border-muted rounded-sm p-1 bg-background h-fit aspect-square hover:bg-secondary flex items-center justify-center",
+            className,
+          )}
+        >
+          <Icon name="Type" />
+        </div>
+      </PopoverTrigger>
+
+      <PopoverContent className="p-3">
+        <BlockStack gap="2">
+          <InlineStack align="space-between" blockAlign="center" fill>
+            <Text size="xs" tone="subdued">
+              Font Size
+            </Text>
+            <Text size="xs" font="mono">
+              {value}px
+            </Text>
+          </InlineStack>
+          <Slider
+            value={[value]}
+            onValueChange={([newValue]) => onChange(newValue)}
+            min={TEXT_SIZE_MIN}
+            max={TEXT_SIZE_MAX}
+            step={1}
+          />
+        </BlockStack>
+      </PopoverContent>
+    </Popover>
+  );
+};

--- a/src/components/shared/ReactFlow/FlowCanvas/FlexNode/types.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlexNode/types.ts
@@ -16,6 +16,8 @@ type FlexNodeProperties = {
   content: string;
   color: string;
   borderColor?: string;
+  titleFontSize?: number;
+  contentFontSize?: number;
 };
 
 type FlexNodeMetadata = {

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -1,0 +1,26 @@
+import * as SliderPrimitive from "@radix-ui/react-slider";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Slider = React.forwardRef<
+  React.ElementRef<typeof SliderPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <SliderPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative flex w-full touch-none select-none items-center",
+      className,
+    )}
+    {...props}
+  >
+    <SliderPrimitive.Track className="relative h-1.5 w-full grow overflow-hidden rounded-full bg-primary/20">
+      <SliderPrimitive.Range className="absolute h-full bg-primary" />
+    </SliderPrimitive.Track>
+    <SliderPrimitive.Thumb className="block h-4 w-4 rounded-full border border-primary/50 bg-background shadow transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50" />
+  </SliderPrimitive.Root>
+));
+Slider.displayName = SliderPrimitive.Root.displayName;
+
+export { Slider };

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -47,6 +47,9 @@ export const BOTTOM_FOOTER_HEIGHT = 30; // px
 
 export const DEFAULT_NODE_DIMENSIONS = { w: 300, h: undefined };
 
+export const FONT_SIZE_MD = 12;
+export const FONT_SIZE_SM = 10;
+
 export enum ComponentSearchFilter {
   NAME = "Name",
   INPUTNAME = "Input Name",


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Allows both the title and body text of a Flex Node to be customizable via a slider in the context panel.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] New feature

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

![image.png](https://app.graphite.com/user-attachments/assets/14b15a64-b24f-4999-9fe7-c71f75b95a88.png)

![image.png](https://app.graphite.com/user-attachments/assets/df8d405a-0e59-4177-baff-5ca88d481d92.png)

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

- Edit a sticky note via the context panel. Confirm you can change the font size via a new popover above the edit box. Sticky Note should update in real time.

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
