### PR TITLE
chore: tophat builds for PR scope

### DIFF
--- a/.github/workflows/tophat-build-request.yml
+++ b/.github/workflows/tophat-build-request.yml
@@ -1,0 +1,71 @@
+---
+  name: Tophat Build Request
+  
+  # Triggers tophat build in oasis-frontend for each PR
+  # This allows PRs to be tested on the staging environment
+  
+  on:
+    pull_request:
+      types: [opened, synchronize]
+      paths:
+       - '**'
+  
+  concurrency:
+    group: tophat-build-request-${{ github.event.pull_request.number }}
+    cancel-in-progress: true
+
+  jobs:
+    notify:
+      name: 'Trigger Tophat Build'
+      runs-on: ubuntu-latest
+      permissions:
+          pull-requests: write
+      steps:
+        - name: Get PR Info
+          id: pr_info
+          run: |
+            echo "branch=${{ github.head_ref }}" >> $GITHUB_OUTPUT
+            echo "pr_number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+            echo "sha=$(echo '${{ github.event.pull_request.head.sha }}' | cut -c1-7)" >> $GITHUB_OUTPUT
+  
+        - name: Trigger oasis-frontend Tophat Build
+          env:
+            BUILDKITE_BEARER: ${{ secrets.BUILDKITE_BEARER }}
+            BUILDKITE_PIPELINE: ${{ secrets.BUILDKITE_PIPELINE }}
+          run: |
+            echo "🚀 Triggering tophat build for branch: ${{ steps.pr_info.outputs.branch }}"
+            echo "PR: #${{ steps.pr_info.outputs.pr_number }}"
+            
+            curl -s -o /dev/null -w "%{http_code}" \
+            -H "Authorization: Bearer $BUILDKITE_BEARER" \
+            -X POST "https://api.buildkite.com/v2/organizations/$BUILDKITE_PIPELINE/builds" \
+            -H "Content-Type: application/json" \
+            -d '{
+              "commit": "HEAD",
+              "code": "curl",
+              "branch": "main",
+              "message": "Tophat build for PR #${{ steps.pr_info.outputs.pr_number }}",
+              "author": {
+                "name": "Tangle-UI Workflow",
+                "email": "ci@tangleml.com"
+              },
+              "env": {
+                "TOPHAT_BRANCH": "${{ steps.pr_info.outputs.branch }}"
+              }
+            }' || echo "Note: Buildkite trigger may need configuration"
+            
+            echo "✅ Tophat build triggered"
+  
+        - name: Comment on PR
+          uses: mshick/add-pr-comment@v2
+          env:
+              GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          with:
+              message: |
+                  ### :tophat: To tophat this PR:
+      
+                  You can add the following URL parameter to your browser to tophat this PR:
+      
+                      `?tophat_location=${{ steps.pr_info.outputs.branch }}/${{ steps.pr_info.outputs.sha }}`
+
+                  ---


### PR DESCRIPTION
## Description

Contributes to https://github.com/Shopify/oasis-frontend/issues/180

Added a GitHub workflow that automatically triggers Tophat builds in the oasis-frontend repository when pull requests are opened or updated. The workflow extracts PR information (branch, number, SHA), makes a Buildkite API call to trigger the build, and posts a comment on the PR with instructions on how to tophat the changes using a URL parameter.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

[Tophat Links Demo - v1.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/d594a1a8-445c-4562-91e0-f70752d3ea48.mp4" />](https://app.graphite.com/user-attachments/video/d594a1a8-445c-4562-91e0-f70752d3ea48.mp4)



## Test Instructions

1. Create a test pull request to verify the workflow triggers
2. Check that the workflow runs and successfully makes the Buildkite API call
3. Verify that a comment is posted on the PR with tophat instructions
4. Confirm the comment includes the correct branch name and SHA for the tophat URL parameter

## Additional Comments

This workflow requires the  `BUILDKITE_BEARER`, and `BUILDKITE_PIPELINE` secrets to be configured with appropriate permissions to trigger builds in Buildkite. The workflow runs on all file changes in pull requests and provides developers with an automated way to test their changes on the staging environment.