### PR TITLE
chore: Retire Component Highlight Beta

### DIFF
--- a/src/components/shared/ReactFlow/FlowSidebar/components/ComponentItem.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/components/ComponentItem.tsx
@@ -77,9 +77,6 @@ const ComponentMarkup = ({
   isLoading,
   error,
 }: ComponentMarkupProps) => {
-  const isHighlightTasksOnComponentHoverEnabled = useFlagValue(
-    "highlight-node-on-component-hover",
-  );
   const isRemoteComponentLibrarySearchEnabled = useFlagValue(
     "remote-component-library-search",
   );
@@ -124,8 +121,6 @@ const ComponentMarkup = ({
   );
 
   const onMouseEnter = useCallback(() => {
-    if (!isHighlightTasksOnComponentHoverEnabled) return;
-
     if (!digest) return;
 
     const nodeIds = getNodeIdsByDigest(digest);
@@ -134,11 +129,9 @@ const ComponentMarkup = ({
         type: "highlight",
       });
     });
-  }, [digest, isHighlightTasksOnComponentHoverEnabled]);
+  }, [digest]);
 
   const onMouseLeave = useCallback(() => {
-    if (!isHighlightTasksOnComponentHoverEnabled) return;
-
     if (!digest) return;
 
     const nodeIds = getNodeIdsByDigest(digest);
@@ -147,11 +140,9 @@ const ComponentMarkup = ({
         type: "clear",
       });
     });
-  }, [digest, isHighlightTasksOnComponentHoverEnabled]);
+  }, [digest]);
 
   const onMouseClick = useCallback(() => {
-    if (!isHighlightTasksOnComponentHoverEnabled) return;
-
     if (!digest) return;
 
     const nodeIds = getNodeIdsByDigest(digest);
@@ -160,12 +151,7 @@ const ComponentMarkup = ({
     carousel.current = carousel.current + 1;
 
     fitNodeIntoView(nodeIds[idx]);
-  }, [
-    digest,
-    getNodeIdsByDigest,
-    fitNodeIntoView,
-    isHighlightTasksOnComponentHoverEnabled,
-  ]);
+  }, [digest, getNodeIdsByDigest, fitNodeIntoView]);
 
   const onComponentDetailsDialogOpenChange = useCallback((open: boolean) => {
     if (open) {

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -4,14 +4,6 @@ const isRemoteComponentLibraryEnabled =
   import.meta.env.VITE_DEFAULT_REMOTE_COMPONENT_LIBRARY_BETA === "true";
 
 export const ExistingFlags: ConfigFlags = {
-  ["highlight-node-on-component-hover"]: {
-    name: "Highlight tasks on component hover",
-    description:
-      "Highlight the tasks on the Pipeline canvas when the component is hovered over in the component library.",
-    default: false,
-    category: "beta",
-  },
-
   ["remote-component-library-search"]: {
     name: "Published Components Library",
     description: "Enable the Published Components Library feature.",


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Remove the Component Highlight Beta and make the behaviour default for everyone.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Improvement
- [x] Cleanup/Refactor

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->
- Confirm that hovering over a component in the component library will highlight the equivalent tasks on the canvas

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
