### PR TITLE
chore: Add onEnter and onEscape to Input Component

### DIFF
--- a/src/components/Editor/Context/Tags/TagEditor.tsx
+++ b/src/components/Editor/Context/Tags/TagEditor.tsx
@@ -32,13 +32,8 @@ export const TagEditor = ({
         value={value}
         onChange={handleChange}
         onBlur={onSave}
-        onKeyDown={(e) => {
-          if (e.key === "Enter") {
-            onSave();
-          } else if (e.key === "Escape") {
-            onCancel();
-          }
-        }}
+        onEnter={onSave}
+        onEscape={onCancel}
         placeholder="Enter tag name..."
         className="h-7 text-xs w-36"
       />

--- a/src/components/shared/AnnotationFilterInput/AnnotationFilterInput.tsx
+++ b/src/components/shared/AnnotationFilterInput/AnnotationFilterInput.tsx
@@ -1,4 +1,3 @@
-import type { KeyboardEvent } from "react";
 import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
@@ -48,16 +47,10 @@ export function AnnotationFilterInput({
     onChange(newFilters);
   };
 
-  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Enter" && keyInput.trim()) {
-      e.preventDefault();
-      handleAdd();
-    }
-    if (e.key === "Escape") {
-      setIsExpanded(false);
-      setKeyInput("");
-      setValueInput("");
-    }
+  const handleCancel = () => {
+    setIsExpanded(false);
+    setKeyInput("");
+    setValueInput("");
   };
 
   return (
@@ -77,7 +70,8 @@ export function AnnotationFilterInput({
             placeholder="Key"
             value={keyInput}
             onChange={(e) => setKeyInput(e.target.value)}
-            onKeyDown={handleKeyDown}
+            onEnter={handleAdd}
+            onEscape={handleCancel}
             className="w-28 h-8 text-sm"
             autoFocus
           />
@@ -85,7 +79,8 @@ export function AnnotationFilterInput({
             placeholder="Value (optional)"
             value={valueInput}
             onChange={(e) => setValueInput(e.target.value)}
-            onKeyDown={handleKeyDown}
+            onEnter={handleAdd}
+            onEscape={handleCancel}
             className="w-36 h-8 text-sm"
           />
           <Button
@@ -99,11 +94,7 @@ export function AnnotationFilterInput({
           <Button
             variant="ghost"
             size="sm"
-            onClick={() => {
-              setIsExpanded(false);
-              setKeyInput("");
-              setValueInput("");
-            }}
+            onClick={handleCancel}
             aria-label="Cancel"
           >
             <Icon name="X" size="xs" />

--- a/src/components/shared/AnnotationFilterInput/EditableAnnotationBadge.tsx
+++ b/src/components/shared/AnnotationFilterInput/EditableAnnotationBadge.tsx
@@ -1,4 +1,4 @@
-import type { KeyboardEvent, MouseEvent } from "react";
+import type { MouseEvent } from "react";
 import { useEffect, useRef, useState } from "react";
 
 import { Badge } from "@/components/ui/badge";
@@ -54,17 +54,6 @@ export function EditableAnnotationBadge({
     setIsEditing(false);
   };
 
-  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Enter") {
-      e.preventDefault();
-      handleSave();
-    }
-    if (e.key === "Escape") {
-      e.preventDefault();
-      handleCancel();
-    }
-  };
-
   const handleDoubleClick = (e: MouseEvent<HTMLElement>) => {
     e.preventDefault();
     setIsEditing(true);
@@ -81,14 +70,16 @@ export function EditableAnnotationBadge({
           ref={keyInputRef}
           value={editKey}
           onChange={(e) => setEditKey(e.target.value)}
-          onKeyDown={handleKeyDown}
+          onEnter={handleSave}
+          onEscape={handleCancel}
           className="h-6 w-20 px-1.5 text-xs"
           placeholder="Key"
         />
         <Input
           value={editValue}
           onChange={(e) => setEditValue(e.target.value)}
-          onKeyDown={handleKeyDown}
+          onEnter={handleSave}
+          onEscape={handleCancel}
           className="h-6 w-24 px-1.5 text-xs"
           placeholder="Value"
         />

--- a/src/components/shared/Dialogs/InputDialog.tsx
+++ b/src/components/shared/Dialogs/InputDialog.tsx
@@ -1,4 +1,4 @@
-import { type KeyboardEvent, type ReactNode, useEffect, useState } from "react";
+import { type ReactNode, useEffect, useState } from "react";
 
 import {
   AlertDialog,
@@ -56,19 +56,13 @@ export function InputDialog({
   };
 
   const handleConfirm = () => {
-    onConfirm?.(value.trim());
-  };
+    const trimmedValue = value.trim();
 
-  const handleKeyDown = (e: KeyboardEvent) => {
-    if (e.key === "Escape") {
-      onCancel?.();
+    if (trimmedValue.length === 0 || disabled) {
+      return;
     }
 
-    if (disabled) return;
-
-    if (e.key === "Enter" && value.trim()) {
-      handleConfirm();
-    }
+    onConfirm?.(trimmedValue);
   };
 
   useEffect(() => {
@@ -96,7 +90,8 @@ export function InputDialog({
           value={value}
           onChange={(e) => handleValueChange(e.target.value)}
           placeholder={placeholder}
-          onKeyDown={handleKeyDown}
+          onEnter={handleConfirm}
+          onEscape={onCancel}
           autoFocus
           className={cn(!!error && "border-destructive")}
         />

--- a/src/components/shared/Submitters/Oasis/components/SubmitTaskArgumentsDialog.tsx
+++ b/src/components/shared/Submitters/Oasis/components/SubmitTaskArgumentsDialog.tsx
@@ -1,10 +1,5 @@
 import { useMutation } from "@tanstack/react-query";
-import {
-  type ChangeEvent,
-  type KeyboardEvent,
-  useEffect,
-  useState,
-} from "react";
+import { type ChangeEvent, useEffect, useState } from "react";
 
 import type { TaskSpecOutput } from "@/api/types.gen";
 import TooltipButton from "@/components/shared/Buttons/TooltipButton";
@@ -258,12 +253,6 @@ const CopyFromRunPopover = ({
     }
   };
 
-  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Enter") {
-      handleCustomRunIdSubmit();
-    }
-  };
-
   return (
     <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
       <PopoverTrigger asChild>
@@ -283,7 +272,7 @@ const CopyFromRunPopover = ({
                 placeholder="Run ID"
                 value={customRunId}
                 onChange={(e) => setCustomRunId(e.target.value)}
-                onKeyDown={handleKeyDown}
+                onEnter={handleCustomRunIdSubmit}
                 disabled={isCopyingFromRun}
                 className={cn(isError && "border-red-300", "flex-1")}
               />

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -24,8 +24,15 @@ function Input({
   type,
   readOnly,
   variant = readOnly ? "readOnly" : "default",
+  onEnter,
+  onEscape,
+  onKeyDown,
   ...props
-}: React.ComponentProps<"input"> & VariantProps<typeof inputVariants>) {
+}: React.ComponentProps<"input"> &
+  VariantProps<typeof inputVariants> & {
+    onEnter?: () => void;
+    onEscape?: () => void;
+  }) {
   return (
     <input
       type={type}
@@ -36,6 +43,19 @@ function Input({
         className,
       )}
       readOnly={readOnly}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" && onEnter) {
+          e.preventDefault();
+          e.stopPropagation();
+          onEnter();
+        } else if (e.key === "Escape" && onEscape) {
+          e.preventDefault();
+          e.stopPropagation();
+          onEscape();
+        }
+
+        onKeyDown?.(e);
+      }}
       {...props}
     />
   );


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Add native `onEnter` and `onEscape` handlers to `Input` component to streamline use of these common actions.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Cleanup/Refactor

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->
- All affected input fields should behave as expected

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
