### PR TITLE
chore: emit vite manifest to support tophatting

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -31,6 +31,9 @@ export default defineConfig({
     tailwindcss(),
   ],
   base: "/",
+  build: {
+    manifest: "assets-registry.json",
+  },
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
## Description

Contributes to https://github.com/Shopify/oasis-frontend/issues/180

Enabled manifest generation in the Vite build configuration by setting `manifest: "assets-registry.json"` in the build options. This will generate a manifest.json file during the build process that maps original asset names to their hashed output filenames.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Run `npm run build` or equivalent build command
2. Verify that a `assets-registry.json` file is generated in the build output directory
3. Confirm that the manifest contains mappings of original asset names to their hashed filenames
4. Test that the application still loads and functions correctly with the generated manifest

## Additional Comments

This change enables better asset management and cache busting strategies by providing a manifest file that can be used by server-side applications to reference the correct hashed asset filenames.

This change is required to enable Tophating via CDN.