### PR TITLE
feat: Autolayout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@bugsnag/js": "^8.8.1",
         "@bugsnag/plugin-react": "^8.8.0",
+        "@dagrejs/dagre": "^2.0.4",
         "@dnd-kit/core": "^6.3.1",
         "@hey-api/client-fetch": "^0.13.1",
         "@hyperjump/browser": "^1.3.1",
@@ -827,6 +828,21 @@
       "engines": {
         "node": ">=20.19.0"
       }
+    },
+    "node_modules/@dagrejs/dagre": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@dagrejs/dagre/-/dagre-2.0.4.tgz",
+      "integrity": "sha512-J6vCWTNpicHF4zFlZG1cS5DkGzMr9941gddYkakjrg3ZNev4bbqEgLHFTWiFrcJm7UCRu7olO3K6IRDd9gSGhA==",
+      "license": "MIT",
+      "dependencies": {
+        "@dagrejs/graphlib": "3.0.4"
+      }
+    },
+    "node_modules/@dagrejs/graphlib": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@dagrejs/graphlib/-/graphlib-3.0.4.tgz",
+      "integrity": "sha512-HxZ7fCvAwTLCWCO0WjDkzAFQze8LdC6iOpKbetDKHIuDfIgMlIzYzqZ4nxwLlclQX+3ZVeZ1K2OuaOE2WWcyOg==",
+      "license": "MIT"
     },
     "node_modules/@date-fns/tz": {
       "version": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   "dependencies": {
     "@bugsnag/js": "^8.8.1",
     "@bugsnag/plugin-react": "^8.8.0",
+    "@dagrejs/dagre": "^2.0.4",
     "@dnd-kit/core": "^6.3.1",
     "@hey-api/client-fetch": "^0.13.1",
     "@hyperjump/browser": "^1.3.1",

--- a/src/components/Editor/PipelineEditor.tsx
+++ b/src/components/Editor/PipelineEditor.tsx
@@ -1,7 +1,7 @@
 import "@/styles/editor.css";
 
 import { Background, MiniMap, type ReactFlowProps } from "@xyflow/react";
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 import { CollapsibleContextPanel } from "@/components/shared/ContextPanel/CollapsibleContextPanel";
 import {
@@ -21,12 +21,16 @@ import {
 import { ContextPanelProvider } from "@/providers/ContextPanelProvider";
 
 import { LoadingScreen } from "../shared/LoadingScreen";
+import type { FlowCanvasRef } from "../shared/ReactFlow/FlowCanvas/FlowCanvas";
+import type { LayoutAlgorithm } from "../shared/ReactFlow/FlowCanvas/utils/autolayout";
 import { NodesOverlayProvider } from "../shared/ReactFlow/NodesOverlay/NodesOverlayProvider";
 import PipelineDetails from "./Context/PipelineDetails";
 
 const GRID_SIZE = 10;
 
 const PipelineEditor = () => {
+  const flowCanvasRef = useRef<FlowCanvasRef>(null);
+
   const { componentSpec, isLoading } = useComponentSpec();
 
   const [flowConfig, setFlowConfig] = useState<ReactFlowProps>({
@@ -44,6 +48,10 @@ const PipelineEditor = () => {
     }));
   };
 
+  const handleAutoLayout = (algorithm: LayoutAlgorithm) => {
+    flowCanvasRef.current?.autoLayout(algorithm);
+  };
+
   // If the pipeline is loading or the component spec is empty, show a loading spinner
   if (isLoading || componentSpec === EMPTY_GRAPH_COMPONENT_SPEC) {
     return <LoadingScreen message="Loading Pipeline" />;
@@ -58,12 +66,13 @@ const PipelineEditor = () => {
               <InlineStack fill>
                 <FlowSidebar />
                 <BlockStack fill className="flex-1 relative">
-                  <FlowCanvas {...flowConfig}>
+                  <FlowCanvas ref={flowCanvasRef} {...flowConfig}>
                     <MiniMap position="bottom-left" pannable />
                     <FlowControls
-                      className="ml-56! mb-6!"
+                      className="ml-56! mb-3!"
                       config={flowConfig}
                       updateConfig={updateFlowConfig}
+                      onAutoLayout={handleAutoLayout}
                       showInteractive={false}
                     />
                     <Background gap={GRID_SIZE} className="bg-slate-50!" />

--- a/src/components/PipelineRun/PipelineRunPage.tsx
+++ b/src/components/PipelineRun/PipelineRunPage.tsx
@@ -1,5 +1,5 @@
 import { Background, MiniMap, type ReactFlowProps } from "@xyflow/react";
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 
 import { FlowCanvas, FlowControls } from "@/components/shared/ReactFlow";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
@@ -7,12 +7,16 @@ import { ComponentLibraryProvider } from "@/providers/ComponentLibraryProvider";
 import { ContextPanelProvider } from "@/providers/ContextPanelProvider";
 
 import { CollapsibleContextPanel } from "../shared/ContextPanel/CollapsibleContextPanel";
+import type { FlowCanvasRef } from "../shared/ReactFlow/FlowCanvas/FlowCanvas";
+import type { LayoutAlgorithm } from "../shared/ReactFlow/FlowCanvas/utils/autolayout";
 import { RunDetails } from "./RunDetails";
 import { RunToolbar } from "./RunToolbar";
 
 const GRID_SIZE = 10;
 
 const PipelineRunPage = () => {
+  const flowCanvasRef = useRef<FlowCanvasRef>(null);
+
   const [flowConfig, setFlowConfig] = useState<ReactFlowProps>({
     snapGrid: [GRID_SIZE, GRID_SIZE],
     snapToGrid: true,
@@ -31,18 +35,23 @@ const PipelineRunPage = () => {
     [],
   );
 
+  const handleAutoLayout = (algorithm: LayoutAlgorithm) => {
+    flowCanvasRef.current?.autoLayout(algorithm);
+  };
+
   return (
     <ContextPanelProvider defaultContent={<RunDetails />}>
       <ComponentLibraryProvider>
         <InlineStack fill>
           <BlockStack fill className="flex-1">
-            <FlowCanvas {...flowConfig} readOnly>
+            <FlowCanvas ref={flowCanvasRef} {...flowConfig} readOnly>
               <MiniMap position="bottom-left" pannable />
               <RunToolbar />
               <FlowControls
-                className="ml-56! mb-6!"
+                className="ml-56! mb-3!"
                 config={flowConfig}
                 updateConfig={updateFlowConfig}
+                onAutoLayout={handleAutoLayout}
                 showInteractive={false}
               />
               <Background gap={GRID_SIZE} className="bg-slate-50!" />

--- a/src/components/shared/ReactFlow/FlowCanvas/utils/autolayout.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/utils/autolayout.ts
@@ -1,0 +1,210 @@
+import dagre from "@dagrejs/dagre";
+import type { Edge, Node, XYPosition } from "@xyflow/react";
+
+import { DEFAULT_NODE_DIMENSIONS } from "@/utils/constants";
+
+export type LayoutAlgorithm =
+  | "sugiyama"
+  | "sugiyama_centered"
+  | "digco"
+  | "dwyer";
+
+export const autoLayoutNodes = (
+  nodes: Node[],
+  edges: Edge[],
+  algorithm: LayoutAlgorithm = "sugiyama",
+): Node[] => {
+  const dagreGraph = new dagre.graphlib.Graph();
+
+  let config;
+  switch (algorithm) {
+    case "sugiyama_centered":
+      config = {
+        rankdir: "LR",
+        ranker: "network-simplex",
+        nodesep: 30,
+        edgesep: 10,
+        ranksep: 20,
+      };
+      break;
+    case "digco":
+      config = {
+        rankdir: "LR",
+        ranker: "tight-tree",
+        nodesep: 30,
+        edgesep: 10,
+        ranksep: 80,
+      };
+      break;
+    case "dwyer":
+      config = {
+        rankdir: "LR",
+        ranker: "longest-path",
+        nodesep: 60,
+        edgesep: 15,
+        ranksep: 100,
+      };
+      break;
+    case "sugiyama":
+    default:
+      config = {
+        rankdir: "LR",
+        ranker: "network-simplex",
+        nodesep: 40,
+        edgesep: 20,
+        ranksep: 80,
+      };
+  }
+
+  dagreGraph.setGraph(config);
+  dagreGraph.setDefaultEdgeLabel(() => ({}));
+
+  nodes.forEach((node) => {
+    dagreGraph.setNode(node.id, {
+      width: node.measured?.width,
+      height: node.measured?.height,
+    });
+  });
+
+  edges.forEach((edge) => {
+    dagreGraph.setEdge(edge.source, edge.target);
+  });
+
+  dagre.layout(dagreGraph);
+
+  // Apply custom centering for sugiyama_centered
+  let centeredPositions: Map<string, XYPosition> | null = null;
+  if (algorithm === "sugiyama_centered") {
+    centeredPositions = centerNodesInBuckets(nodes, dagreGraph, config);
+  }
+
+  return nodes.map((node) => {
+    const nodeWithPosition = dagreGraph.node(node.id);
+
+    let position;
+    if (centeredPositions && centeredPositions.has(node.id)) {
+      const centered = centeredPositions.get(node.id)!;
+      position = {
+        x: centered.x - (node?.measured?.width || 0) / 2,
+        y: centered.y - (node?.measured?.height || 0) / 2,
+      };
+    } else {
+      position = {
+        x: nodeWithPosition.x - (node?.measured?.width || 0) / 2,
+        y: nodeWithPosition.y - (node?.measured?.height || 0) / 2,
+      };
+    }
+
+    return {
+      ...node,
+      position,
+    };
+  });
+};
+
+/**
+ * Center nodes vertically within horizontal buckets.
+ * After Sugiyama layout, nodes may be spread vertically. This function:
+ * 1. Buckets nodes by x position (rank)
+ * 2. Within each bucket, sorts nodes by distance from global average y
+ * 3. Places nodes as close as possible to center without overlapping
+ *
+ * This algorithm was adapted by AI directly from the tangle-deploy source code:
+ * https://github.com/Shopify/discovery/blob/main/oasis/tangle-deploy/src/tangle_deploy/auto_layout.py#L35
+ */
+function centerNodesInBuckets(
+  nodes: Node[],
+  dagreGraph: dagre.graphlib.Graph,
+  config: {
+    nodesep: number;
+    rankdir?: string;
+    ranker?: string;
+    edgesep?: number;
+    ranksep?: number;
+  },
+): Map<string, XYPosition> {
+  const positions = new Map<
+    string,
+    XYPosition & { width: number; height: number }
+  >();
+
+  // Initialize buckets
+  nodes.forEach((node) => {
+    const nodeWithPosition = dagreGraph.node(node.id);
+    positions.set(node.id, {
+      x: nodeWithPosition.x,
+      y: nodeWithPosition.y,
+      width: node.measured?.width || DEFAULT_NODE_DIMENSIONS.w || 300,
+      height: node.measured?.height || DEFAULT_NODE_DIMENSIONS.h || 300,
+    });
+  });
+
+  if (nodes.length === 0) return new Map();
+
+  const allY = Array.from(positions.values()).map((p) => p.y);
+  const avgY = allY.reduce((sum, y) => sum + y, 0) / allY.length;
+
+  const buckets = new Map<number, string[]>();
+
+  for (const [nodeId, pos] of positions.entries()) {
+    const bucketIdx = Math.round(pos.x);
+    if (!buckets.has(bucketIdx)) {
+      buckets.set(bucketIdx, []);
+    }
+    buckets.get(bucketIdx)!.push(nodeId);
+  }
+
+  const centeredPositions = new Map<string, XYPosition>();
+
+  // Process each bucket
+  for (const [_, nodeIds] of buckets.entries()) {
+    if (nodeIds.length === 1) {
+      const pos = positions.get(nodeIds[0])!;
+      centeredPositions.set(nodeIds[0], {
+        x: pos.x,
+        y: avgY,
+      });
+      continue;
+    }
+
+    const bucketAvgY =
+      nodeIds.reduce((sum, id) => sum + positions.get(id)!.y, 0) /
+      nodeIds.length;
+
+    nodeIds.sort((a, b) => {
+      const distA = Math.abs(positions.get(a)!.y - bucketAvgY);
+      const distB = Math.abs(positions.get(b)!.y - bucketAvgY);
+      return distA - distB;
+    });
+
+    let occupiedMin: number | null = null;
+    let occupiedMax: number | null = null;
+
+    for (const nodeId of nodeIds) {
+      const pos = positions.get(nodeId)!;
+      const originalY = pos.y;
+      const height = pos.height;
+
+      let centeredY: number;
+
+      if (occupiedMin === null) {
+        centeredY = avgY;
+        occupiedMin = avgY - height / 2 - config.nodesep;
+        occupiedMax = avgY + height / 2 + config.nodesep;
+      } else if (originalY < bucketAvgY) {
+        centeredY = occupiedMin - height / 2;
+        occupiedMin = centeredY - height / 2 - config.nodesep;
+      } else {
+        centeredY = (occupiedMax || 0) + height / 2;
+        occupiedMax = centeredY + height / 2 + config.nodesep;
+      }
+
+      centeredPositions.set(nodeId, {
+        x: pos.x,
+        y: centeredY,
+      });
+    }
+  }
+
+  return centeredPositions;
+}

--- a/src/components/shared/ReactFlow/FlowControls/FlowControls.tsx
+++ b/src/components/shared/ReactFlow/FlowControls/FlowControls.tsx
@@ -11,20 +11,51 @@ import {
 } from "lucide-react";
 import { useCallback, useState } from "react";
 
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icon";
+import { BlockStack } from "@/components/ui/layout";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Spinner } from "@/components/ui/spinner";
+import { Text } from "@/components/ui/typography";
 import { cn } from "@/lib/utils";
+
+import type { LayoutAlgorithm } from "../FlowCanvas/utils/autolayout";
 
 interface FlowControlsProps extends ControlProps {
   config: ReactFlowProps;
   updateConfig: (config: Partial<ReactFlowProps>) => void;
+  onAutoLayout?: (algorithm: LayoutAlgorithm) => void;
 }
+
+const LAYOUT_ALGORITHMS: {
+  value: LayoutAlgorithm;
+  label: string;
+  description: string;
+}[] = [
+  { value: "sugiyama", label: "Sugiyama", description: "Layered" },
+  {
+    value: "sugiyama_centered",
+    label: "Sugiyama Centered",
+    description: "Centered",
+  },
+  { value: "digco", label: "Digco", description: "Compact" },
+  { value: "dwyer", label: "Dwyer", description: "Organic" },
+];
 
 export default function FlowControls({
   config,
   updateConfig,
+  onAutoLayout,
   ...props
 }: FlowControlsProps) {
   const [multiSelectActive, setMultiSelectActive] = useState(false);
   const [lockActive, setLockActive] = useState(!config.nodesDraggable);
+  const [layoutPopoverOpen, setLayoutPopoverOpen] = useState(false);
+  const [isLayouting, setIsLayouting] = useState(false);
 
   const onClickMultiSelect = useCallback(() => {
     updateConfig({
@@ -40,6 +71,20 @@ export default function FlowControls({
     });
     setLockActive(!lockActive);
   }, [lockActive, updateConfig]);
+
+  const handleLayoutSelect = async (algorithm: LayoutAlgorithm) => {
+    setIsLayouting(true);
+    setLayoutPopoverOpen(false);
+
+    // Delay subsequent execution to the next frame to ensure the popover has closed and the loading spinner has rendered
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+
+    try {
+      await onAutoLayout?.(algorithm);
+    } finally {
+      setIsLayouting(false);
+    }
+  };
 
   return (
     <Controls {...props}>
@@ -61,6 +106,39 @@ export default function FlowControls({
       >
         <SquareDashedMousePointerIcon className="scale-120" />
       </ControlButton>
+      {onAutoLayout && (
+        <Popover open={layoutPopoverOpen} onOpenChange={setLayoutPopoverOpen}>
+          <PopoverTrigger asChild>
+            <ControlButton disabled={isLayouting}>
+              {isLayouting ? (
+                <Spinner className="fill-none! scale-120" />
+              ) : (
+                <Icon name="LayoutGrid" className="stroke-none scale-120" />
+              )}
+            </ControlButton>
+          </PopoverTrigger>
+          <PopoverContent className="w-fit p-2" align="end" side="right">
+            <BlockStack gap="1">
+              <Text size="sm" className="ml-1">
+                Auto Layout
+              </Text>
+              {LAYOUT_ALGORITHMS.map((algo) => (
+                <Button
+                  key={algo.value}
+                  variant="ghost"
+                  size="sm"
+                  className="w-full justify-start"
+                  onClick={() => handleLayoutSelect(algo.value)}
+                  disabled={isLayouting}
+                >
+                  <Text>{algo.label}</Text>
+                  <Text tone="subdued">({algo.description})</Text>
+                </Button>
+              ))}
+            </BlockStack>
+          </PopoverContent>
+        </Popover>
+      )}
     </Controls>
   );
 }


### PR DESCRIPTION
## Description

Adds a button to the flow controls by the minimap to autolayout the graph. The new button opens a popover with a couple different autolayout options to choose from.

The algorithms offered match those available in `tangle-deploy`.

When an option is selected the popover will close and the button will show a loading spinner until the autolayout algorithm completes.

## Related Issue and Pull requests

Closes https://github.com/Shopify/oasis-frontend/issues/377

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] New feature

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

![image.png](https://app.graphite.com/user-attachments/assets/e9127275-f34c-4846-a34f-d52ea492b8ea.png)

[autolayout-demo.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/e58897fc-7675-4fb3-841c-fb223ab6bab5.mov" />](https://app.graphite.com/user-attachments/video/e58897fc-7675-4fb3-841c-fb223ab6bab5.mov)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

- Open a large, complex and messy pipeline. e.g. [clone this pipeline](https://oasis.shopify.io/runs/019c9271083e74b9cd17)
- In the bottom left, confirm the autolayout button is there
- Click the autolayout button and select an option from the popover
- Confirm that the nodes are automatically spread out
- Repeat for each option
- Confirm that the loading spinner shows while the action is processing
- Confirm that this works on both the editor & run pages

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

Exact specs of the layout, e.g. node spacing etc can be tweaked to suit our preferences.

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->