### PR TITLE
Enable remote component library by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,9 +29,6 @@ VITE_GITHUB_PAGES=<boolean>
 # Hugging Face
 VITE_HUGGING_FACE_AUTHORIZATION=<boolean>
 
-# Betas
-VITE_DEFAULT_REMOTE_COMPONENT_LIBRARY_BETA=<boolean>
-
 # Dev Tools
 VITE_ENABLE_DEBUG_MODE=<boolean>
 

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -1,13 +1,10 @@
 import type { ConfigFlags } from "@/types/configuration";
 
-const isRemoteComponentLibraryEnabled =
-  import.meta.env.VITE_DEFAULT_REMOTE_COMPONENT_LIBRARY_BETA === "true";
-
 export const ExistingFlags: ConfigFlags = {
   ["remote-component-library-search"]: {
     name: "Published Components Library",
     description: "Enable the Published Components Library feature.",
-    default: isRemoteComponentLibraryEnabled,
+    default: true,
     category: "beta",
   },
 


### PR DESCRIPTION
## Description

Enabled the Published Components Library feature by default by removing the environment variable dependency and setting the default flag value to `true`. The feature is no longer gated behind the `VITE_DEFAULT_REMOTE_COMPONENT_LIBRARY_BETA` environment variable.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Verify that the Published Components Library feature is enabled by default
2. Confirm that the feature works without requiring the `VITE_DEFAULT_REMOTE_COMPONENT_LIBRARY_BETA` environment variable
3. Test that existing functionality remains unaffected

## Additional Comments

This change promotes the Published Components Library from a beta feature controlled by environment variables to a default-enabled feature.