### PR TITLE
feat: display dynamic data groups only for curtain tasks with annotations

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/ArgumentInputField.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/ArgumentInputField.tsx
@@ -42,6 +42,7 @@ import { DynamicDataDropdown } from "./DynamicDataDropdown";
 import {
   createSystemDataArgument,
   getDynamicDataDisplayInfo,
+  type TaskAnnotations,
 } from "./dynamicDataUtils";
 import {
   getDefaultValue,
@@ -50,6 +51,7 @@ import {
   getPlaceholder,
   typeSpecToString,
 } from "./utils";
+
 interface PlainArgumentInputProps {
   argument: ArgumentInput;
   inputValue: string;
@@ -59,6 +61,7 @@ interface PlainArgumentInputProps {
   disabledReset: boolean;
   isDynamicDataEnabled: boolean;
   isTaskLevel: boolean;
+  taskAnnotations?: TaskAnnotations;
   onInputChange: (e: ChangeEvent) => void;
   onBlur: () => void;
   onExpand: () => void;
@@ -81,6 +84,7 @@ const PlainArgumentInput = ({
   disabledReset,
   isDynamicDataEnabled,
   isTaskLevel,
+  taskAnnotations,
   onInputChange,
   onBlur,
   onExpand,
@@ -133,6 +137,7 @@ const PlainArgumentInput = ({
           <DynamicDataDropdown
             disabled={disabled}
             isTaskLevel={isTaskLevel}
+            taskAnnotations={taskAnnotations}
             triggerClassName={ACTIONS_BASE_CLASS}
             onOpenSecretDialog={onOpenSecretDialog}
             onSelectSystemData={onSelectSystemData}
@@ -200,10 +205,12 @@ const PlainArgumentInput = ({
 export const ArgumentInputField = ({
   argument,
   disabled = false,
+  taskAnnotations,
   onSave,
 }: {
   argument: ArgumentInput;
   disabled?: boolean;
+  taskAnnotations?: TaskAnnotations;
   onSave: (argument: ArgumentInput) => void;
 }) => {
   const notify = useToastNotification();
@@ -505,6 +512,7 @@ export const ArgumentInputField = ({
               disabledReset={disabledReset}
               isDynamicDataEnabled={isSecretUIEnabled}
               isTaskLevel={isTaskLevel}
+              taskAnnotations={taskAnnotations}
               onInputChange={handleInputChange}
               onBlur={handleBlur}
               onExpand={handleExpand}

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/ArgumentsEditor.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/ArgumentsEditor.tsx
@@ -1,9 +1,12 @@
+import { useMemo } from "react";
+
 import { BlockStack } from "@/components/ui/layout";
 import { Heading } from "@/components/ui/typography";
 import type { ArgumentInput } from "@/types/arguments";
 import type { ArgumentType, TaskSpec } from "@/utils/componentSpec";
 
 import { ArgumentInputField } from "./ArgumentInputField";
+import type { TaskAnnotations } from "./dynamicDataUtils";
 import { getArgumentInputs } from "./utils";
 
 interface ArgumentsEditorProps {
@@ -18,6 +21,10 @@ export const ArgumentsEditor = ({
   disabled = false,
 }: ArgumentsEditorProps) => {
   const argumentInputs = getArgumentInputs(taskSpec);
+  const taskAnnotations = useMemo(
+    () => taskSpec.annotations as TaskAnnotations | undefined,
+    [taskSpec.annotations],
+  );
 
   const handleArgumentSave = (argument: ArgumentInput) => {
     const argumentValues = {
@@ -47,6 +54,7 @@ export const ArgumentsEditor = ({
             argument={argument}
             onSave={handleArgumentSave}
             disabled={disabled}
+            taskAnnotations={taskAnnotations}
           />
         ))}
       </BlockStack>

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/DynamicDataDropdown.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/DynamicDataDropdown.tsx
@@ -14,11 +14,12 @@ import { Icon } from "@/components/ui/icon";
 import { InlineStack } from "@/components/ui/layout";
 import { cn } from "@/lib/utils";
 
-import { getDynamicDataGroups } from "./dynamicDataUtils";
+import { getDynamicDataGroups, type TaskAnnotations } from "./dynamicDataUtils";
 
 interface DynamicDataDropdownProps {
   disabled: boolean;
   isTaskLevel: boolean;
+  taskAnnotations?: TaskAnnotations;
   triggerClassName?: string;
   onOpenSecretDialog: () => void;
   onSelectSystemData: (key: string) => void;
@@ -28,6 +29,7 @@ interface DynamicDataDropdownProps {
 export const DynamicDataDropdown = ({
   disabled,
   isTaskLevel,
+  taskAnnotations,
   triggerClassName,
   onOpenSecretDialog,
   onSelectSystemData,
@@ -35,7 +37,7 @@ export const DynamicDataDropdown = ({
 }: DynamicDataDropdownProps) => {
   const [isOpen, setIsOpen] = useState(false);
 
-  const dynamicDataGroups = getDynamicDataGroups(isTaskLevel);
+  const dynamicDataGroups = getDynamicDataGroups(isTaskLevel, taskAnnotations);
 
   const handleOpenChange = (open: boolean) => {
     setIsOpen(open);

--- a/src/config/dynamicDataSchema.json
+++ b/src/config/dynamicDataSchema.json
@@ -15,6 +15,9 @@
       "icon": "Network",
       "x-text-color": "text-cyan-600!",
       "x-task-level-only": true,
+      "x-requires-task-annotation": {
+        "key": "tangleml.com/launchers/kubernetes/multi_node/number_of_nodes"
+      },
       "description": "Data available in multi-node execution context",
       "properties": {
         "system/multi_node/node_index": {


### PR DESCRIPTION
## Description

Added support for task annotation-based filtering of dynamic data groups in the ArgumentsEditor. The system now checks for required task annotations before displaying certain dynamic data options to users. Specifically, the multi-node execution context data is now only available for tasks with the `cloud-pipelines.net/orchestration/cloud_provider` annotation set to `nebius_jobs`.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

[Screen Recording 2026-02-24 at 5.17.15 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/8fd88fa0-6b04-4be9-bb45-b8d45d00f126.mov" />](https://app.graphite.com/user-attachments/video/8fd88fa0-6b04-4be9-bb45-b8d45d00f126.mov)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

I used local override for `src/config/launcherTaskAnnotationSchema.json` to be 

```
{
  "$schema": "http://json-schema.org/draft-07/schema#",
  "type": "object",
  "title": "Launcher Annotation Configuration",
  "cloud_provider": {
    "annotation": "cloud-pipelines.net/orchestration/cloud_provider",
    "type": "string",
    "title": "Cloud provider"
  },
  "launcher_annotation_schemas": {
    "nebius_jobs": {
      "type": "object",
      "title": "Nebius Jobs Compute Resources",
      "x-label": "Nebius Jobs",
      "properties": {
        "cloud-pipelines.net/launchers/nebius_jobs/nodes_count": {
          "type": "number",
          "title": "Nodes Count",
          "description": "Number of nodes for distributed execution",
          "minimum": 1
        }
      },
      "required": ["cloud-pipelines.net/launchers/nebius_jobs/nodes_count"]
    }
  },
  "common_annotations": {
    "type": "object",
    "title": "Common Annotations",
    "properties": {
      "editor.position": {
        "type": "string",
        "title": "Node position",
        "x-type": "json"
      },
      "display_name": {
        "type": "string",
        "title": "Display Name",
        "x-type": "string",
        "exclusiveMaximum": 100
      }
    }
  }
}

```

1. Create a task with the annotation `cloud-pipelines.net/orchestration/cloud_provider: nebius_jobs`
2. Open the ArgumentsEditor for this task
3. Verify that multi-node execution context options are available in the dynamic data dropdown
4. Create a task without this annotation or with a different value
5. Verify that multi-node execution context options are not displayed

## Additional Comments

This change introduces a new filtering mechanism that allows dynamic data groups to specify required task annotations. The filtering is applied at runtime based on the task's annotations, ensuring that context-specific options are only shown when appropriate.