### PR TITLE
feat: Autolayout for Selected Nodes

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
@@ -999,8 +999,16 @@ const FlowCanvasContent = ({
 
   const selectionMode = getSelectionMode();
 
-  const handleAutoLayout = async (algorithm: LayoutAlgorithm) => {
-    const layoutedNodes = autoLayoutNodes(nodes, edges, algorithm);
+  const applyAutoLayout = (
+    nodesToLayout: Node[],
+    edgesToConsider: Edge[],
+    algorithm: LayoutAlgorithm = "sugiyama",
+  ) => {
+    const layoutedNodes = autoLayoutNodes(
+      nodesToLayout,
+      edgesToConsider,
+      algorithm,
+    );
 
     const updatedSubgraphSpec = updateNodePositions(
       layoutedNodes,
@@ -1014,6 +1022,10 @@ const FlowCanvasContent = ({
     );
 
     setComponentSpec(updatedRootSpec);
+  };
+
+  const handleAutoLayout = async (algorithm: LayoutAlgorithm) => {
+    applyAutoLayout(nodes, edges, algorithm);
 
     requestAnimationFrame(() => {
       reactFlowInstance?.fitView({
@@ -1021,6 +1033,16 @@ const FlowCanvasContent = ({
         duration: 300,
       });
     });
+  };
+
+  const onAutoLayout = () => {
+    const connectedEdges = edges.filter(
+      (edge) =>
+        selectedNodes.some((node) => node.id === edge.source) ||
+        selectedNodes.some((node) => node.id === edge.target),
+    );
+
+    applyAutoLayout(selectedNodes, connectedEdges);
   };
 
   useImperativeHandle(
@@ -1080,6 +1102,7 @@ const FlowCanvasContent = ({
             onCopy={!readOnly ? undefined : onCopy}
             onUpgrade={!readOnly && canUpgrade ? onUpgradeNodes : undefined}
             onGroup={!readOnly && canGroup ? onGroupNodes : undefined}
+            onAutoLayout={onAutoLayout}
           />
         </NodeToolbar>
         {children}

--- a/src/components/shared/ReactFlow/FlowCanvas/SelectionToolbar.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/SelectionToolbar.tsx
@@ -12,6 +12,7 @@ interface SelectionToolbarProps {
   onDelete?: () => void;
   onUpgrade?: () => void;
   onGroup?: () => void;
+  onAutoLayout?: () => void;
 }
 
 const SelectionToolbar = ({
@@ -20,6 +21,7 @@ const SelectionToolbar = ({
   onDelete,
   onUpgrade,
   onGroup,
+  onAutoLayout,
 }: SelectionToolbarProps) => {
   return (
     <InlineStack
@@ -50,6 +52,11 @@ const SelectionToolbar = ({
         callback={onCopy}
         icon="ClipboardPlus"
         testId="selection-copy-yaml"
+      />
+      <ToolbarButton
+        name="Auto Layout"
+        callback={onAutoLayout}
+        icon="LayoutGrid"
       />
       <ToolbarButton
         name="Delete All"


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

Adds autolayout button to selection toolbar so it can be applied only to a subset of selected nodes

Currently uses `sugiyama` algorithm by default, but we can look into adding an app-wide user setting for "default algorithm"

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

Related: https://github.com/Shopify/oasis-frontend/issues/377

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] New feature

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

![image.png](https://app.graphite.com/user-attachments/assets/d0d246e9-6d36-42f9-83ea-12bcd69b1d18.png)

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

- Select a group of nodes & in the toolbar choose the new autolayout option. Confirm those nodes at nicely arranged.

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->

I made this a separate PR because I wasn't 100% certain the usefulness of it. Thus we have the option to ship autolayout without this feature if we deem it unnecessary.