### PR TITLE
feat: open secrets if no other dynamic data is available

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/DynamicDataDropdown.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/DynamicDataDropdown.tsx
@@ -39,6 +39,9 @@ export const DynamicDataDropdown = ({
 
   const dynamicDataGroups = getDynamicDataGroups(isTaskLevel, taskAnnotations);
 
+  const isSecretsOnly =
+    dynamicDataGroups.length === 1 && dynamicDataGroups[0].requiresDialog;
+
   const handleOpenChange = (open: boolean) => {
     setIsOpen(open);
     onOpenChange?.(open);
@@ -49,6 +52,22 @@ export const DynamicDataDropdown = ({
     onOpenChange?.(false);
     onOpenSecretDialog();
   };
+
+  if (isSecretsOnly) {
+    return (
+      <Button
+        className={triggerClassName}
+        disabled={disabled}
+        variant="ghost"
+        size="xs"
+        title="Use Dynamic Data"
+        data-testid="open-secret-dialog-button"
+        onClick={handleSecretDialogOpen}
+      >
+        <Icon name="Lock" />
+      </Button>
+    );
+  }
 
   return (
     <DropdownMenu open={isOpen} onOpenChange={handleOpenChange}>

--- a/tests/e2e/secrets-in-arguments.spec.ts
+++ b/tests/e2e/secrets-in-arguments.spec.ts
@@ -92,17 +92,14 @@ test.describe("Secrets in Component Arguments", () => {
     ).toBeVisible();
 
     await githubPatField.hover();
-    const dynamicDataDropdown = githubPatField.getByTestId(
-      "dynamic-data-dropdown-trigger",
-    );
-    await expect(dynamicDataDropdown).toBeVisible();
-    await dynamicDataDropdown.click();
 
-    const selectSecretOption = page.getByRole("menuitem", {
-      name: "Select Secret...",
-    });
-    await expect(selectSecretOption).toBeVisible();
-    await selectSecretOption.click();
+    // When only secrets are available (no task annotations), the component renders
+    // a direct button that opens the secret dialog immediately
+    const directSecretButton = githubPatField.getByTestId(
+      "open-secret-dialog-button",
+    );
+    await expect(directSecretButton).toBeVisible();
+    await directSecretButton.click();
 
     const selectSecretDialog = page.getByTestId("select-secret-dialog");
     await expect(


### PR DESCRIPTION
## Description

Added a conditional rendering optimization for the DynamicDataDropdown component. When only secrets are available as dynamic data options, the component now renders a simplified lock button that directly opens the secret dialog instead of showing the full dropdown menu.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## [Screen Recording 2026-02-25 at 9.44.01 AM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/07f6e3f7-6f15-43c0-8eeb-0ba606d8d642.mov" />](https://app.graphite.com/user-attachments/video/07f6e3f7-6f15-43c0-8eeb-0ba606d8d642.mov)

## Test Instructions

1. Navigate to a task node's arguments editor where only secret dynamic data is available
2. Verify that a lock icon button appears instead of the dropdown trigger
3. Click the lock button and confirm it opens the secret dialog directly
4. Test scenarios with mixed dynamic data types to ensure the dropdown still appears normally

## Additional Comments

This change improves the user experience by providing a more direct interface when secrets are the only available dynamic data option, eliminating unnecessary dropdown navigation.