### PR TITLE
chore: enable ci checks for every pr

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
   pull_request:
-    branches: [ master ]
 
 jobs:
   test:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -2,9 +2,7 @@ name: Playwright Tests
 
 on:
   push:
-    branches: [master]
   pull_request:
-    branches: [master]
   # Allow manual triggering for testing in any branch
   workflow_dispatch:
 


### PR DESCRIPTION
## Description

Removed branch restrictions from CI and Playwright workflow triggers to allow workflows to run on all branches instead of only the master branch.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Create a new branch from any branch other than master
2. Push changes to the new branch
3. Verify that both CI and Playwright workflows are triggered
4. Create a pull request from the new branch
5. Confirm workflows run as expected

## Additional Comments

This change enables continuous integration testing on all branches, providing better development workflow flexibility and ensuring code quality across all feature branches.