### PR TITLE
chore: fix e2e in master

### DIFF
--- a/tests/e2e/componentlib.spec.ts
+++ b/tests/e2e/componentlib.spec.ts
@@ -24,7 +24,33 @@ test.describe("Component Library", () => {
 
   test.beforeAll(async ({ browser }) => {
     page = await browser.newPage();
+
     await createNewPipeline(page);
+
+    await expect(page.locator("[data-testid='search-input']")).toBeVisible();
+
+    await page.getByTestId("personal-preferences-button").click();
+
+    const dialog = page.getByTestId("personal-preferences-dialog");
+    await expect(dialog).toBeVisible();
+
+    await dialog.getByRole("tab", { name: "Beta Features" }).click();
+
+    const switchElement = dialog.getByTestId(
+      "remote-component-library-search-switch",
+    );
+    await expect(switchElement).toBeVisible({ timeout: 10000 });
+
+    // Enable secrets if not already enabled
+    if ((await switchElement.getAttribute("aria-checked")) !== "false") {
+      await switchElement.click();
+      await expect(switchElement).toHaveAttribute("aria-checked", "false");
+    }
+
+    await dialog.press("Escape");
+    await expect(dialog).toBeHidden();
+
+    await locateFolderByName(page, "Standard library");
   });
 
   test.afterAll(async () => {

--- a/tests/e2e/published-componentlib.spec.ts
+++ b/tests/e2e/published-componentlib.spec.ts
@@ -42,8 +42,11 @@ test.describe("Published Component Library", () => {
     );
     await expect(switchElement).toBeVisible({ timeout: 10000 });
 
-    await switchElement.click();
-    await expect(switchElement).toHaveAttribute("aria-checked", "true");
+    // Enable secrets if not already enabled
+    if ((await switchElement.getAttribute("aria-checked")) !== "true") {
+      await switchElement.click();
+      await expect(switchElement).toHaveAttribute("aria-checked", "true");
+    }
 
     // bypass the dialog close button in case it is out of view
     await dialog.press("Escape");

--- a/tests/e2e/published-componentlifecycle.spec.ts
+++ b/tests/e2e/published-componentlifecycle.spec.ts
@@ -40,8 +40,11 @@ test.describe("Published Component Library - Lifecycle", () => {
     );
     await expect(switchElement).toBeVisible({ timeout: 10000 });
 
-    await switchElement.click();
-    await expect(switchElement).toHaveAttribute("aria-checked", "true");
+    // Enable secrets if not already enabled
+    if ((await switchElement.getAttribute("aria-checked")) !== "true") {
+      await switchElement.click();
+      await expect(switchElement).toHaveAttribute("aria-checked", "true");
+    }
 
     await dialog.press("Escape");
     await expect(dialog).toBeHidden();


### PR DESCRIPTION
## Description

Added conditional logic to check if the secrets switch is already enabled before attempting to click it in the published component library tests. This prevents unnecessary clicks and potential test flakiness when the switch is already in the desired state.

## Related Issue and Pull requests

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Run the published component library e2e tests
2. Verify that the secrets switch interaction works correctly regardless of its initial state
3. Confirm that tests pass consistently without flakiness related to the switch state

## Additional Comments

This change improves test reliability by checking the current state of the secrets switch before interacting with it, preventing potential race conditions or unexpected behavior when the switch is already enabled.