### PR TITLE
fix: ReactFlow Warnings due to Edge Rendering & Hydration Conflicts

### DIFF
--- a/src/components/Editor/IOEditor/InputValueEditor/InputValueEditor.test.tsx
+++ b/src/components/Editor/IOEditor/InputValueEditor/InputValueEditor.test.tsx
@@ -1,3 +1,4 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -13,6 +14,18 @@ const mockClearContent = vi.fn();
 
 vi.mock("@/components/Editor/IOEditor/IOZIndexEditor", () => ({
   IOZIndexEditor: () => null,
+}));
+
+vi.mock("@/services/componentService", () => ({
+  hydrateComponentReference: vi.fn((ref) =>
+    Promise.resolve({
+      ...ref,
+      spec: ref.spec || { inputs: [], outputs: [] },
+      text: ref.text || "",
+      digest: ref.digest || "mock-digest",
+      name: ref.name || "mock-component",
+    }),
+  ),
 }));
 
 vi.mock("@/providers/ComponentSpecProvider", () => ({
@@ -42,6 +55,9 @@ vi.mock("@/providers/ComponentSpecProvider", () => ({
     currentSubgraphPath: ["root"],
     setComponentSpec: mockSetComponentSpec,
   }),
+  ComponentSpecProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
 }));
 
 vi.mock("@/providers/ContextPanelProvider", () => ({
@@ -95,12 +111,28 @@ describe("InputValueEditor", () => {
     default: "default value",
   };
 
+  let queryClient: QueryClient;
+
   beforeEach(() => {
     vi.clearAllMocks();
+
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    });
   });
 
+  const renderWithQueryClient = (ui: React.ReactElement) => {
+    return render(
+      <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+    );
+  };
+
   it("displays input description in field", () => {
-    render(<InputValueEditor input={mockInput} />);
+    renderWithQueryClient(<InputValueEditor input={mockInput} />);
 
     const descriptionInput = screen.getByLabelText(
       "Description",
@@ -109,7 +141,7 @@ describe("InputValueEditor", () => {
   });
 
   it("calls onChange when input value changes", () => {
-    render(<InputValueEditor input={mockInput} />);
+    renderWithQueryClient(<InputValueEditor input={mockInput} />);
 
     const valueInput = screen.getByLabelText("Value") as HTMLTextAreaElement;
     fireEvent.change(valueInput, { target: { value: "new value" } });
@@ -120,7 +152,7 @@ describe("InputValueEditor", () => {
   });
 
   it("calls onNameChange when input name changes", () => {
-    render(<InputValueEditor input={mockInput} />);
+    renderWithQueryClient(<InputValueEditor input={mockInput} />);
     const nameInput = screen.getByLabelText("Name") as HTMLInputElement;
     fireEvent.change(nameInput, { target: { value: "NewName" } });
     fireEvent.blur(nameInput);
@@ -131,7 +163,7 @@ describe("InputValueEditor", () => {
   });
 
   it("shows validation error when renaming to existing input name", () => {
-    render(<InputValueEditor input={mockInput} />);
+    renderWithQueryClient(<InputValueEditor input={mockInput} />);
 
     const nameInput = screen.getByLabelText("Name") as HTMLInputElement;
     fireEvent.change(nameInput, { target: { value: "ExistingInput" } });
@@ -146,7 +178,7 @@ describe("InputValueEditor", () => {
   });
 
   it("clears validation error when renaming to unique name", () => {
-    render(<InputValueEditor input={mockInput} />);
+    renderWithQueryClient(<InputValueEditor input={mockInput} />);
 
     const nameInput = screen.getByLabelText("Name") as HTMLInputElement;
 
@@ -170,7 +202,7 @@ describe("InputValueEditor", () => {
       type: "String",
     };
 
-    render(<InputValueEditor input={inputWithoutDefault} />);
+    renderWithQueryClient(<InputValueEditor input={inputWithoutDefault} />);
 
     const valueInput = screen.getByLabelText("Value") as HTMLInputElement;
     expect(valueInput.getAttribute("placeholder")).toBe(
@@ -179,7 +211,7 @@ describe("InputValueEditor", () => {
   });
 
   it("shows default value as placeholder when available", () => {
-    render(<InputValueEditor input={mockInput} />);
+    renderWithQueryClient(<InputValueEditor input={mockInput} />);
 
     const valueInput = screen.getByLabelText("Value") as HTMLInputElement;
     expect(valueInput.getAttribute("placeholder")).toBe("default value");

--- a/src/providers/ComponentSpecProvider.tsx
+++ b/src/providers/ComponentSpecProvider.tsx
@@ -8,6 +8,8 @@ import {
   useState,
 } from "react";
 
+import { SuspenseWrapper } from "@/components/shared/SuspenseWrapper";
+import { usePreHydrateComponentRefs } from "@/hooks/useHydrateComponentReference";
 import { type UndoRedo, useUndoRedo } from "@/hooks/useUndoRedo";
 import { loadPipelineByName } from "@/services/pipelineService";
 import { USER_PIPELINES_LIST_NAME } from "@/utils/constants";
@@ -77,7 +79,7 @@ const ComponentSpecContext = createRequiredContext<ComponentSpecContextType>(
   "ComponentSpecProvider",
 );
 
-export const ComponentSpecProvider = ({
+const ComponentSpecProviderInternal = ({
   spec,
   readOnly = false,
   children,
@@ -89,6 +91,9 @@ export const ComponentSpecProvider = ({
   const [componentSpec, setComponentSpec] = useState<ComponentSpec>(
     spec ?? EMPTY_GRAPH_COMPONENT_SPEC,
   );
+
+  usePreHydrateComponentRefs(componentSpec);
+
   const [digest, setDigest] = useState<string>("");
 
   const [isLoading, setIsLoading] = useState(!!spec);
@@ -316,6 +321,18 @@ export const ComponentSpecProvider = ({
     <ComponentSpecContext.Provider value={value}>
       {children}
     </ComponentSpecContext.Provider>
+  );
+};
+
+export const ComponentSpecProvider = (props: {
+  spec?: ComponentSpec;
+  readOnly?: boolean;
+  children: ReactNode;
+}) => {
+  return (
+    <SuspenseWrapper>
+      <ComponentSpecProviderInternal {...props} />
+    </SuspenseWrapper>
   );
 };
 

--- a/tests/e2e/secrets-in-arguments.spec.ts
+++ b/tests/e2e/secrets-in-arguments.spec.ts
@@ -227,7 +227,9 @@ async function cleanupTestSecret(
 
 /**
  * Drops the Github - Fake Commit Push component onto the canvas
- * by reading the fixture file and using drag-and-drop
+ * by reading the fixture file and using drag-and-drop.
+ *
+ * Waits for component hydration to complete before returning.
  */
 async function dropGithubFakeCommitPushComponent(page: Page) {
   const buffer = readFileSync(
@@ -260,8 +262,9 @@ async function dropGithubFakeCommitPushComponent(page: Page) {
 
   const componentName = "Github - Fake Commit Push";
   const node = page.locator(`[data-testid="rf__node-task_${componentName}"]`);
+
   await expect(node, "Component node should appear on canvas").toBeVisible({
-    timeout: 10000,
+    timeout: 30000,
   });
 
   return node;


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Due to recent changes to component hydration - namely, moving hydration into the task provider - components are now suspended before being rendered on canvas. This results in ReactFlow giving warnings in console about missing handles and nodes. Once the hydration process completes the warnings go away and the graph renders as expected.

This PR aims to solve this issue by pre-hydrating components and saving them to cache when the component spec is first loaded, i.e. before FlowCanvas even begins rendering.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix
- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->
- Load a pipeline
- Confirm the ReactFlow warnings are gone
- Confirm the rest of the app continues to work as expected.

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
