### PR TITLE
fix: support dynamic arguments in usecomponentspectoedges hook

### DIFF
--- a/src/hooks/useComponentSpecToEdges.ts
+++ b/src/hooks/useComponentSpecToEdges.ts
@@ -11,6 +11,7 @@ import {
   type ComponentSpec,
   type GraphInputArgument,
   type GraphSpec,
+  isDynamicDataArgument,
   isSecretArgument,
   type TaskOutputArgument,
   type TaskSpec,
@@ -85,7 +86,7 @@ const createEdgeForArgument = (
     return [createGraphInputEdge(taskId, inputName, argument.graphInput)];
   }
 
-  if (isSecretArgument(argument)) {
+  if (isSecretArgument(argument) || isDynamicDataArgument(argument)) {
     return [];
   }
 


### PR DESCRIPTION
## Description

Added handling for dynamic data arguments in the edge creation logic. Dynamic data arguments are now treated the same as secret arguments and will not generate edges in the component specification to edges conversion process.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## [Screen Recording 2026-02-26 at 5.56.49 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/6f67b618-552b-4bb5-8d45-d301e5db9d98.mov" />](https://app.graphite.com/user-attachments/video/6f67b618-552b-4bb5-8d45-d301e5db9d98.mov)



## Test Instructions

1. Create a component with dynamic data arguments
2. Verify that no edges are created for dynamic data arguments in the graph visualization
3. Ensure existing functionality for other argument types remains unchanged

## Additional Comments

This change ensures that dynamic data arguments follow the same edge creation pattern as secret arguments, preventing unnecessary edge generation in the graph structure.