### PR TITLE
fix: force manifest build

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -33,6 +33,11 @@ export default defineConfig({
   base: "/",
   build: {
     manifest: "assets-registry.json",
+    rollupOptions: {
+      input: {
+        main: path.resolve(__dirname, "src/index.tsx"),
+      },
+    },
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Description

Added rollup configuration to the Vite build settings, specifying `src/index.tsx` as the main entry point for the application bundle.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Run the build process using `npm run build` or `yarn build`
2. Verify that the application builds successfully
3. Check that the generated bundle includes the correct entry point
4. Test that the application loads and functions correctly in production mode

## Additional Comments

This change explicitly defines the main entry point for Rollup bundling, which can help ensure consistent build behavior and may improve build performance by providing clearer module resolution.