### PR TITLE
fix: force index.html to be entry point in vite config

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -35,6 +35,7 @@ export default defineConfig({
     manifest: "assets-registry.json",
     rollupOptions: {
       input: {
+        index: path.resolve(__dirname, "index.html"),
         main: path.resolve(__dirname, "src/index.tsx"),
       },
     },


### PR DESCRIPTION
## Description

Added `index.html` as an entry point to the Vite build configuration's rollup input options alongside the existing main TypeScript entry point.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Run the build process to ensure both entry points are properly processed
2. Verify that the generated assets registry includes both the HTML and TypeScript entry points
3. Test that the application loads correctly with the new build configuration

## Additional Comments

This change ensures that the HTML file is explicitly included in the build process, which may be necessary for proper asset handling and deployment.

Previously vite tend to ignore index.html if it was not referring any dynamic assets.