### PR TITLE
feat: display job name for multi-node executions

### DIFF
--- a/src/components/shared/TaskDetails/ExecutionDetails.tsx
+++ b/src/components/shared/TaskDetails/ExecutionDetails.tsx
@@ -76,6 +76,11 @@ export const ExecutionDetails = ({
       });
     }
 
+    const jobName = executionJobName(containerState);
+    if (jobName) {
+      items.push({ label: "Job name", value: jobName });
+    }
+
     const podName = executionPodName(containerState);
     if (podName) {
       items.push({ label: "Pod Name", value: podName });
@@ -137,6 +142,29 @@ export const ExecutionDetails = ({
     </ContentBlock>
   );
 };
+
+function executionJobName(
+  containerState?: GetContainerExecutionStateResponse,
+): string | null {
+  if (!containerState || !("debug_info" in containerState)) {
+    return null;
+  }
+
+  const debugInfo = containerState.debug_info;
+
+  if (!isRecord(debugInfo)) {
+    return null;
+  }
+
+  if (
+    isRecord(debugInfo.kubernetes_job) &&
+    typeof debugInfo.kubernetes_job.job_name === "string"
+  ) {
+    return debugInfo.kubernetes_job.job_name;
+  }
+
+  return null;
+}
 
 function executionPodName(
   containerState?: GetContainerExecutionStateResponse,


### PR DESCRIPTION
## Description

Added job name display to the ExecutionDetails component. The component now extracts and shows the Kubernetes job name from the container state's debug information when available, displaying it alongside existing execution details like pod name.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

Use tophat header to test on staging. Run ID = 019c9ca16184fc0bc5de

![image.png](https://app.graphite.com/user-attachments/assets/e0e68bae-b622-4fbe-96e5-724a540cdbb3.png)



## Test Instructions

1. Navigate to a task execution details page
2. Verify that the job name appears in the execution details section when Kubernetes job information is available
3. Confirm that the job name is displayed with the label "Job name"
4. Test with executions that may not have job information to ensure graceful handling

## Additional Comments

The implementation includes proper null checking and type validation to safely extract the job name from the debug_info.kubernetes_job.job_name path in the container state response.