### PR TITLE
Add scrollToBottom prop to CodeViewer for auto-scrolling to logs end

### DIFF
--- a/src/components/shared/CodeViewer/CodeSyntaxHighlighter.tsx
+++ b/src/components/shared/CodeViewer/CodeSyntaxHighlighter.tsx
@@ -1,21 +1,36 @@
 import MonacoEditor from "@monaco-editor/react";
+import type { editor } from "monaco-editor";
 import { memo } from "react";
 
 interface CodeSyntaxHighlighterProps {
   code: string;
   language: string;
+  scrollToBottom?: boolean;
+}
+
+function revealLastLine(editor: editor.IStandaloneCodeEditor) {
+  const lineCount = editor.getModel()?.getLineCount() ?? 1;
+  editor.revealLine(lineCount);
 }
 
 const CodeSyntaxHighlighter = memo(function CodeSyntaxHighlighter({
   code,
   language,
+  scrollToBottom = false,
 }: CodeSyntaxHighlighterProps) {
+  const handleMount = (editor: editor.IStandaloneCodeEditor) => {
+    if (scrollToBottom) {
+      revealLastLine(editor);
+    }
+  };
+
   return (
     <MonacoEditor
       key={code} // force re-render when code changes
       defaultLanguage={language}
       theme="vs-dark"
       defaultValue={code}
+      onMount={handleMount}
       options={{
         readOnly: true,
         minimap: {

--- a/src/components/shared/CodeViewer/CodeViewer.tsx
+++ b/src/components/shared/CodeViewer/CodeViewer.tsx
@@ -11,6 +11,7 @@ interface CodeViewerProps {
   language?: string;
   filename?: string;
   fullscreen?: boolean;
+  scrollToBottom?: boolean;
   onClose?: () => void;
 }
 
@@ -21,6 +22,7 @@ const CodeViewer = ({
   language = "yaml",
   filename = "",
   fullscreen = false,
+  scrollToBottom = false,
   onClose,
 }: CodeViewerProps) => {
   const [isFullscreen, setIsFullscreen] = useState(fullscreen);
@@ -79,7 +81,11 @@ const CodeViewer = ({
               minHeight: DEFAULT_CODE_VIEWER_HEIGHT,
             }}
           >
-            <CodeSyntaxHighlighter code={code} language={language} />
+            <CodeSyntaxHighlighter
+              code={code}
+              language={language}
+              scrollToBottom={scrollToBottom}
+            />
           </div>
         </div>
       </div>

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/logs.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/logs.tsx
@@ -34,6 +34,7 @@ const LogDisplay = ({
             code={logs.log_text || ""}
             language="text"
             filename="Execution Logs"
+            scrollToBottom
           />
         </div>
       )}
@@ -43,6 +44,7 @@ const LogDisplay = ({
             code={logs.system_error_exception_full || ""}
             language="text"
             filename="System Error Logs"
+            scrollToBottom
           />
         </div>
       )}


### PR DESCRIPTION
## Description
Resolves: https://github.com/Shopify/oasis-frontend/issues/303

Added an optional `scrollToBottom` prop to the CodeViewer and CodeSyntaxHighlighter components that automatically scrolls to the bottom of the code when the Monaco editor mounts. This feature is now enabled for task execution logs and system error logs to improve user experience by showing the most recent log entries first.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Navigate to a task node with execution logs or system error logs
2. Open the logs view
3. Verify that the code viewer automatically scrolls to the bottom showing the most recent log entries
4. Test with both execution logs and system error logs to ensure the feature works in both cases

## Additional Comments

The `scrollToBottom` prop defaults to `false` to maintain backward compatibility with existing usage of the CodeViewer component. The feature uses Monaco Editor's `revealLine` method to scroll to the last line of the code content.