### PR TITLE
Pipeline title length fix

### DIFF
--- a/src/components/Home/PipelineSection/PipelineRow.tsx
+++ b/src/components/Home/PipelineSection/PipelineRow.tsx
@@ -19,6 +19,12 @@ import {
 } from "@/components/ui/popover";
 import { Skeleton } from "@/components/ui/skeleton";
 import { TableCell, TableRow } from "@/components/ui/table";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { Paragraph } from "@/components/ui/typography";
 import { EDITOR_PATH } from "@/routes/router";
 import { deletePipeline } from "@/services/pipelineService";
@@ -26,6 +32,8 @@ import type { ComponentReferenceWithSpec } from "@/utils/componentStore";
 import { formatDate } from "@/utils/date";
 
 import type { MatchedField } from "./usePipelineFilters";
+
+const MAX_TITLE_LENGTH = 80;
 
 interface PipelineRowProps {
   url?: string;
@@ -104,9 +112,25 @@ const PipelineRow = withSuspenseWrapper(
         </TableCell>
         <TableCell>
           <BlockStack gap="0">
-            <Paragraph>
-              <HighlightText text={name ?? ""} query={searchQuery} />
-            </Paragraph>
+            {name && name.length > MAX_TITLE_LENGTH ? (
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Paragraph>
+                      <HighlightText
+                        text={name.slice(0, MAX_TITLE_LENGTH) + "..."}
+                        query={searchQuery}
+                      />
+                    </Paragraph>
+                  </TooltipTrigger>
+                  <TooltipContent>{name}</TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            ) : (
+              <Paragraph>
+                <HighlightText text={name ?? ""} query={searchQuery} />
+              </Paragraph>
+            )}
             <MatchBadges
               matchedFields={matchedFields}
               matchedComponentNames={matchedComponentNames}

--- a/src/components/Home/PipelineSection/PipelineSection.tsx
+++ b/src/components/Home/PipelineSection/PipelineSection.tsx
@@ -180,20 +180,20 @@ export const PipelineSection = withSuspenseWrapper(() => {
         actions={<QuickStartButton />}
       />
 
-      <Table>
+      <Table className="table-fixed">
         <TableHeader>
           <TableRow className="text-xs">
-            <TableHead>
+            <TableHead className="w-10">
               <Checkbox
                 checked={isAllSelected}
                 onCheckedChange={handleSelectAll}
               />
             </TableHead>
             <TableHead>Title</TableHead>
-            <TableHead>Modified at</TableHead>
-            <TableHead>Last run</TableHead>
-            <TableHead>Runs</TableHead>
-            <TableHead />
+            <TableHead className="w-40">Modified at</TableHead>
+            <TableHead className="w-44">Last run</TableHead>
+            <TableHead className="w-16">Runs</TableHead>
+            <TableHead className="w-12" />
           </TableRow>
         </TableHeader>
         <TableBody>


### PR DESCRIPTION
## Description

Added tooltip functionality to pipeline titles that exceed 80 characters in length. Long pipeline names are now truncated with "..." and display the full title on hover. Additionally, implemented fixed table layout with specific column widths to improve table structure and prevent layout shifts.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Navigate to the pipeline section
2. Create or find a pipeline with a title longer than 80 characters
3. Verify the title is truncated with "..." 
4. Hover over the truncated title to see the full name in a tooltip
5. Verify table columns maintain consistent widths and alignment

## Additional Comments

The tooltip implementation uses the existing UI tooltip components and only activates for titles exceeding the 80-character limit. Shorter titles continue to display normally without tooltip functionality.