### PR TITLE
chore: retire secrets beta flag

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/ArgumentInputField.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/ArgumentInputField.tsx
@@ -11,7 +11,6 @@ import {
 import TooltipButton from "@/components/shared/Buttons/TooltipButton";
 import { SelectSecretDialog } from "@/components/shared/SecretsManagement/SelectSecretDialog";
 import { createSecretArgument } from "@/components/shared/SecretsManagement/types";
-import { useFlagValue } from "@/components/shared/Settings/useFlags";
 import { Icon } from "@/components/ui/icon";
 import { Input } from "@/components/ui/input";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
@@ -227,14 +226,13 @@ export const ArgumentInputField = ({
 
   const undoValue = useMemo(() => argument, []);
 
-  const isSecretUIEnabled = useFlagValue("secrets");
   // Multi-node data is available when editing task arguments (always true in TaskNode context)
   // The "pipeline level" restriction only applies to pipeline input values, not task arguments
   const isTaskLevel = true;
 
   const isDynamicData = useMemo(
-    () => isSecretUIEnabled && isDynamicDataArgument(argument.value),
-    [argument.value, isSecretUIEnabled],
+    () => isDynamicDataArgument(argument.value),
+    [argument.value],
   );
 
   const dynamicDataDisplayInfo = useMemo(() => {
@@ -510,7 +508,7 @@ export const ArgumentInputField = ({
               disabled={disabled}
               disabledCopy={disabledCopy}
               disabledReset={disabledReset}
-              isDynamicDataEnabled={isSecretUIEnabled}
+              isDynamicDataEnabled
               isTaskLevel={isTaskLevel}
               taskAnnotations={taskAnnotations}
               onInputChange={handleInputChange}

--- a/src/components/shared/SecretsManagement/ManageSecretsButton.tsx
+++ b/src/components/shared/SecretsManagement/ManageSecretsButton.tsx
@@ -1,16 +1,9 @@
 import { Icon } from "@/components/ui/icon";
 
 import TooltipButton from "../Buttons/TooltipButton";
-import { useFlagValue } from "../Settings/useFlags";
 import { ManageSecretsDialog } from "./ManageSecretsDialog";
 
 export function ManageSecretsButton() {
-  const isSecretsEnabled = useFlagValue("secrets");
-
-  if (!isSecretsEnabled) {
-    return null;
-  }
-
   return (
     <ManageSecretsDialog
       trigger={

--- a/src/components/shared/Submitters/Oasis/components/SubmitTaskArgumentsDialog.tsx
+++ b/src/components/shared/Submitters/Oasis/components/SubmitTaskArgumentsDialog.tsx
@@ -17,7 +17,6 @@ import {
   createSecretArgument,
   extractSecretName,
 } from "@/components/shared/SecretsManagement/types";
-import { useFlagValue } from "@/components/shared/Settings/useFlags";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -339,7 +338,6 @@ const ArgumentField = ({
   onChange,
   isHighlighted,
 }: ArgumentFieldProps) => {
-  const isSecretUIEnabled = useFlagValue("secrets");
   const [isSelectSecretDialogOpen, setIsSelectSecretDialogOpen] =
     useState(false);
 
@@ -408,23 +406,21 @@ const ArgumentField = ({
                 placeholder={placeholder}
                 className={cn(
                   isRequired && !hasValidValue && "border-red-300",
-                  isSecretUIEnabled && "group-hover:pr-8",
+                  "group-hover:pr-8",
                   "bg-white!",
                 )}
               />
-              {isSecretUIEnabled && (
-                <InlineStack className="absolute right-0 top-1/2 -translate-y-1/2 mr-1 px-1 bg-white">
-                  <TooltipButton
-                    onClick={() => setIsSelectSecretDialogOpen(true)}
-                    className="hover:bg-transparent hover:text-blue-500 hidden group-hover:flex"
-                    variant="ghost"
-                    size="xs"
-                    tooltip="Use Secret"
-                  >
-                    <Icon name="Lock" />
-                  </TooltipButton>
-                </InlineStack>
-              )}
+              <InlineStack className="absolute right-0 top-1/2 -translate-y-1/2 mr-1 px-1 bg-white">
+                <TooltipButton
+                  onClick={() => setIsSelectSecretDialogOpen(true)}
+                  className="hover:bg-transparent hover:text-blue-500 hidden group-hover:flex"
+                  variant="ghost"
+                  size="xs"
+                  tooltip="Use Secret"
+                >
+                  <Icon name="Lock" />
+                </TooltipButton>
+              </InlineStack>
             </>
           )}
         </div>

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -39,14 +39,6 @@ export const ExistingFlags: ConfigFlags = {
     category: "beta",
   },
 
-  ["secrets"]: {
-    name: "Secrets and Dynamic Data",
-    description:
-      "Enable the Dynamic Data and Secrets feature. This will allow you to store secrets, tokens, api keys and other sensitive information in secured way.",
-    default: false,
-    category: "beta",
-  },
-
   ["pipeline-run-filters-bar"]: {
     name: "Pipeline run filters bar (Experimental)",
     description:

--- a/tests/e2e/secrets-in-arguments.spec.ts
+++ b/tests/e2e/secrets-in-arguments.spec.ts
@@ -24,7 +24,6 @@ test.describe("Secrets in Component Arguments", () => {
   test.beforeAll(async ({ browser }) => {
     page = await browser.newPage();
     await createNewPipeline(page);
-    await enableSecretsFlag(page);
   });
 
   test.afterAll(async () => {
@@ -173,29 +172,6 @@ test.describe("Secrets in Component Arguments", () => {
     ).toBeVisible();
   });
 });
-
-/**
- * Enables the secrets beta flag via the personal preferences dialog
- */
-async function enableSecretsFlag(page: Page): Promise<void> {
-  await page.getByTestId("personal-preferences-button").click();
-
-  const dialog = page.getByTestId("personal-preferences-dialog");
-  await expect(dialog).toBeVisible();
-
-  await dialog.getByRole("tab", { name: "Beta Features" }).click();
-
-  const secretsSwitch = dialog.getByTestId("secrets-switch");
-  await expect(secretsSwitch).toBeVisible({ timeout: 10000 });
-
-  if ((await secretsSwitch.getAttribute("aria-checked")) !== "true") {
-    await secretsSwitch.click();
-    await expect(secretsSwitch).toHaveAttribute("aria-checked", "true");
-  }
-
-  await dialog.press("Escape");
-  await expect(dialog).toBeHidden();
-}
 
 /**
  * Opens the Manage Secrets dialog via the top bar button

--- a/tests/e2e/secrets-management.spec.ts
+++ b/tests/e2e/secrets-management.spec.ts
@@ -17,27 +17,6 @@ test.describe("Secrets Management", () => {
     page = await browser.newPage();
 
     await createNewPipeline(page);
-
-    // Enable the secrets beta flag
-    await page.getByTestId("personal-preferences-button").click();
-
-    const dialog = page.getByTestId("personal-preferences-dialog");
-    await expect(dialog).toBeVisible();
-
-    await dialog.getByRole("tab", { name: "Beta Features" }).click();
-
-    const secretsSwitch = dialog.getByTestId("secrets-switch");
-    await expect(secretsSwitch).toBeVisible({ timeout: 10000 });
-
-    // Enable secrets if not already enabled
-    if ((await secretsSwitch.getAttribute("aria-checked")) !== "true") {
-      await secretsSwitch.click();
-      await expect(secretsSwitch).toHaveAttribute("aria-checked", "true");
-    }
-
-    // Close dialog
-    await dialog.press("Escape");
-    await expect(dialog).toBeHidden();
   });
 
   test.afterAll(async () => {


### PR DESCRIPTION
## Description

Enables the secrets and dynamic data feature by default by removing the feature flag. The secrets functionality is now permanently enabled, removing all conditional checks based on the `secrets` flag. This includes removing the flag definition, flag imports, and conditional rendering logic throughout the codebase.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Verify that the ManageSecretsButton is now always visible
2. Test that secret selection functionality works in ArgumentInputField
3. Confirm that the lock icon for secret selection appears on hover in SubmitTaskArgumentsDialog
4. Ensure that dynamic data arguments are properly detected and handled
5. Verify that the secrets feature flag no longer appears in the settings

## Additional Comments

This change makes the secrets and dynamic data feature a core part of the application rather than an optional beta feature. All users will now have access to secure storage and management of sensitive information like API keys and tokens.