### PR TITLE
fix: select secret dialog ux

### DIFF
--- a/src/components/shared/SecretsManagement/SelectSecretDialog.tsx
+++ b/src/components/shared/SecretsManagement/SelectSecretDialog.tsx
@@ -84,7 +84,7 @@ function SelectableSecretsList({
               className="w-full pr-3 py-2 hover:bg-gray-100 rounded-md cursor-pointer transition-colors"
             >
               <InlineStack gap="2" blockAlign="center" wrap="nowrap">
-                <Icon name="Lock" size="lg" />
+                <Icon name="Lock" size="lg" className="shrink-0" />
                 <BlockStack gap="0">
                   <Text size="sm" weight="semibold">
                     {secret.name}
@@ -162,7 +162,7 @@ function SelectSecretDialogContentInternal({
           onSelect={handleSecretSelect}
         />
         <Separator />
-        <InlineStack align="end" fill gap="2">
+        <InlineStack align="end" gap="2" className="w-full">
           <Button
             variant="secondary"
             onClick={() => setMode("add")}


### PR DESCRIPTION
## Description

Fixed layout issues in the SelectSecretDialog component by preventing the Lock icon from shrinking when text is long and ensuring the button container takes full width for proper alignment.

## Related Issue and Pull requests

| Before | After |
| --- | --- |
| ![image.png](https://app.graphite.com/user-attachments/assets/a4f4fe4e-fd74-4c25-9751-15ee6c990ffb.png)<br> | ![image.png](https://app.graphite.com/user-attachments/assets/6d23a6a0-82d3-4cd1-8bdd-ba99670fa717.png)<br> |

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

[Screen Recording 2026-03-03 at 12.33.51 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/3a59e1ae-9293-48da-af69-b77d6f7d017f.mov" />](https://app.graphite.com/user-attachments/video/3a59e1ae-9293-48da-af69-b77d6f7d017f.mov)

## Test Instructions

1. Open the SelectSecretDialog component
2. Verify that Lock icons maintain their size when secret names are long
3. Confirm that buttons are properly aligned at the end of their container
4. Test with various secret name lengths to ensure consistent layout

## Additional Comments

The changes address visual layout inconsistencies where the Lock icon could be compressed by long text and button alignment issues in the dialog footer.