### PR TITLE
feat: Multiselection Context Panel

### DIFF
--- a/react-compiler.config.js
+++ b/react-compiler.config.js
@@ -53,6 +53,7 @@ export const REACT_COMPILER_ENABLED_DIRS = [
   "src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/ZIndexEditor.tsx",
   "src/components/Editor/IOEditor/IOZIndexEditor.tsx",
   "src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/DynamicDataDropdown.tsx",
+  "src/components/shared/ReactFlow/FlowCanvas/Multiselect",
   "src/components/shared/HighlightText.tsx",
   "src/components/shared/AnnouncementBanners.tsx",
 

--- a/src/components/shared/ReactFlow/FlowCanvas/ConfirmationDialogs/DeleteConfirmation.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/ConfirmationDialogs/DeleteConfirmation.tsx
@@ -4,6 +4,7 @@ import { BlockStack } from "@/components/ui/layout";
 import { Text } from "@/components/ui/typography";
 import { createStringList, truncate } from "@/utils/string";
 
+import { getFlexNodeDisplayName } from "../FlexNode/utils";
 import { isFlexNode, type NodesAndEdges } from "../types";
 import { thisCannotBeUndone } from "./shared";
 
@@ -131,11 +132,8 @@ export function getDeleteConfirmationDetails(deletedElements: NodesAndEdges) {
 function getNodeIdsForDisplay(nodes: Node[]) {
   return nodes.map((node) => {
     if (isFlexNode(node)) {
-      const textContent =
-        node.data.properties.title ||
-        truncate(node.data.properties.content, 12, { breakWords: false });
-
-      return `'${textContent.length ? textContent : "untitled"}' (Sticky Note)`;
+      const textContent = getFlexNodeDisplayName(node.data);
+      return `'${textContent}' (Sticky Note)`;
     }
 
     return node.id;

--- a/src/components/shared/ReactFlow/FlowCanvas/FlexNode/FlexNode.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlexNode/FlexNode.tsx
@@ -8,6 +8,7 @@ import {
 import { type MouseEvent, useEffect, useState } from "react";
 
 import { BlockStack } from "@/components/ui/layout";
+import { useIsMultiSelect } from "@/hooks/useIsMultiSelect";
 import { cn } from "@/lib/utils";
 import { useContextPanel } from "@/providers/ContextPanelProvider";
 
@@ -43,6 +44,8 @@ const FlexNode = ({ data, id, selected }: FlexNodeProps) => {
   } = useContextPanel();
 
   const { updateFlexNode, updateProperties } = useFlexNodeUpdate(data);
+
+  const { isMultiSelect, isMultiSelectRef } = useIsMultiSelect();
 
   const toggleLock = () => {
     updateFlexNode({ locked: !locked });
@@ -120,7 +123,7 @@ const FlexNode = ({ data, id, selected }: FlexNodeProps) => {
   };
 
   useEffect(() => {
-    if (selected) {
+    if (selected && !isMultiSelect) {
       setIsContextPanelFocus(true);
       setContent(
         <FlexNodeEditor
@@ -136,11 +139,11 @@ const FlexNode = ({ data, id, selected }: FlexNodeProps) => {
     }
 
     return () => {
-      if (selected) {
+      if (selected && !isMultiSelectRef.current) {
         clearContent();
       }
     };
-  }, [selected]);
+  }, [selected, isMultiSelect]);
 
   useEffect(() => {
     if (isContextPanelFocus) {

--- a/src/components/shared/ReactFlow/FlowCanvas/FlexNode/utils.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlexNode/utils.ts
@@ -1,5 +1,7 @@
 import { type Node } from "@xyflow/react";
 
+import { truncate } from "@/utils/string";
+
 import type { FlexNodeData } from "./types";
 
 export const DEFAULT_STICKY_NOTE = {
@@ -30,3 +32,13 @@ export const createFlexNode = (
     className: locked ? "pointer-events-auto!" : undefined,
   } as Node;
 };
+
+export function getFlexNodeDisplayName(data: FlexNodeData): string {
+  if (data.properties.title) {
+    return data.properties.title;
+  }
+  if (data.properties.content) {
+    return truncate(data.properties.content, 12, { breakWords: false });
+  }
+  return "untitled";
+}

--- a/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
@@ -61,7 +61,8 @@ import {
   computeDropPositionFromRefs,
   createGhostEdge,
 } from "./GhostNode/utils";
-import SelectionToolbar from "./SelectionToolbar";
+import { MultiSelectPanel } from "./Multiselect/MultiSelectPanel";
+import SelectionToolbar from "./Multiselect/SelectionToolbar";
 import { handleGroupNodes } from "./Subgraphs/create/handleGroupNodes";
 import { NewSubgraphDialog } from "./Subgraphs/create/NewSubgraphDialog";
 import { canGroupNodes } from "./Subgraphs/create/utils";
@@ -130,7 +131,7 @@ const FlowCanvasContent = ({
 }: FlowCanvasProps) => {
   const initialCanvasLoaded = useRef(false);
 
-  const { clearContent } = useContextPanel();
+  const { clearContent, setContent, setOpen } = useContextPanel();
   const { data: currentUserDetails } = useUserDetails();
 
   useSubgraphKeyboardNavigation();
@@ -148,6 +149,13 @@ const FlowCanvasContent = ({
     useIOSelectionPersistence();
 
   const store = useStoreApi();
+  const getSelectedNodes = () =>
+    store
+      .getState()
+      .nodes.filter(
+        (node) => node.selected && node.type && SELECTABLE_NODES.has(node.type),
+      );
+
   const { edges: specEdges, onEdgesChange } =
     useComponentSpecToEdges(currentSubgraphSpec);
   const [nodes, setNodes, onNodesChange] = useNodesState<Node>([]);
@@ -320,13 +328,6 @@ const FlowCanvasContent = ({
   const selectedNodes = nodes.filter(
     (node) => node.selected && node.type && SELECTABLE_NODES.has(node.type),
   );
-
-  const selectedEdges = edges.filter((edge) => edge.selected);
-
-  const selectedElements = {
-    nodes: selectedNodes,
-    edges: selectedEdges,
-  };
 
   const canUpgrade = selectedNodes.some(
     (node) => node.type && UPGRADEABLE_NODES.has(node.type),
@@ -680,11 +681,12 @@ const FlowCanvasContent = ({
   };
 
   const onRemoveNodes = async () => {
+    const nodes = getSelectedNodes();
     const confirmed = await triggerConfirmation(
-      getDeleteConfirmationDetails({ nodes: selectedNodes, edges: [] }),
+      getDeleteConfirmationDetails({ nodes, edges: [] }),
     );
     if (confirmed) {
-      onElementsRemove(selectedElements);
+      onElementsRemove({ nodes, edges: [] });
     }
   };
 
@@ -754,7 +756,7 @@ const FlowCanvasContent = ({
       updatedComponentSpec: updatedSubgraphSpec,
       newNodes,
       updatedNodes,
-    } = duplicateNodes(currentSubgraphSpec, selectedNodes, {
+    } = duplicateNodes(currentSubgraphSpec, getSelectedNodes(), {
       selected: true,
       author: currentUserDetails?.id,
     });
@@ -779,7 +781,7 @@ const FlowCanvasContent = ({
     const includedNodes: Node[] = [];
     const excludedNodes: Node[] = [];
 
-    selectedNodes.forEach((node) => {
+    getSelectedNodes().forEach((node) => {
       if (node.type && !UPGRADEABLE_NODES.has(node.type)) {
         excludedNodes.push(node);
         return;
@@ -907,12 +909,13 @@ const FlowCanvasContent = ({
 
   const onCopy = () => {
     // Copy selected nodes to clipboard
-    if (selectedNodes.length > 0) {
-      const selectedNodesJson = JSON.stringify(selectedNodes);
+    const nodes = getSelectedNodes();
+    if (nodes.length > 0) {
+      const selectedNodesJson = JSON.stringify(nodes);
       navigator.clipboard.writeText(selectedNodesJson).catch((err) => {
         console.error("Failed to copy nodes to clipboard:", err);
       });
-      const message = `Copied ${selectedNodes.length} nodes to clipboard`;
+      const message = `Copied ${nodes.length} nodes to clipboard`;
       notify(message, "success");
     }
   };
@@ -1036,13 +1039,14 @@ const FlowCanvasContent = ({
   };
 
   const onAutoLayout = () => {
+    const nodes = getSelectedNodes();
     const connectedEdges = edges.filter(
       (edge) =>
-        selectedNodes.some((node) => node.id === edge.source) ||
-        selectedNodes.some((node) => node.id === edge.target),
+        nodes.some((node) => node.id === edge.source) ||
+        nodes.some((node) => node.id === edge.target),
     );
 
-    applyAutoLayout(selectedNodes, connectedEdges);
+    applyAutoLayout(nodes, connectedEdges);
   };
 
   useImperativeHandle(
@@ -1052,6 +1056,29 @@ const FlowCanvasContent = ({
     }),
     [handleAutoLayout],
   );
+
+  const multiSelectCallbacks = {
+    onDelete: !readOnly ? onRemoveNodes : undefined,
+    onDuplicate: !readOnly ? onDuplicateNodes : undefined,
+    onUpgrade: !readOnly && canUpgrade ? onUpgradeNodes : undefined,
+    onGroup: !readOnly && canGroup ? onGroupNodes : undefined,
+    onCopy: onCopy,
+    onAutoLayout: onAutoLayout,
+  };
+
+  useEffect(() => {
+    const nodes = getSelectedNodes();
+    if (nodes.length > 1) {
+      setContent(
+        <MultiSelectPanel
+          selectedNodes={nodes}
+          readOnly={!!readOnly}
+          {...multiSelectCallbacks}
+        />,
+      );
+      setOpen(true);
+    }
+  }, [currentSubgraphSpec, readOnly, canUpgrade, canGroup]);
 
   return (
     <BlockStack fill>
@@ -1096,14 +1123,7 @@ const FlowCanvasContent = ({
           align="end"
           className="z-9999!"
         >
-          <SelectionToolbar
-            onDelete={!readOnly ? onRemoveNodes : undefined}
-            onDuplicate={!readOnly ? onDuplicateNodes : undefined}
-            onCopy={!readOnly ? undefined : onCopy}
-            onUpgrade={!readOnly && canUpgrade ? onUpgradeNodes : undefined}
-            onGroup={!readOnly && canGroup ? onGroupNodes : undefined}
-            onAutoLayout={onAutoLayout}
-          />
+          <SelectionToolbar {...multiSelectCallbacks} />
         </NodeToolbar>
         {children}
       </ReactFlow>

--- a/src/components/shared/ReactFlow/FlowCanvas/IONode/IONode.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/IONode/IONode.tsx
@@ -10,6 +10,7 @@ import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { QuickTooltip } from "@/components/ui/tooltip";
 import { Paragraph } from "@/components/ui/typography";
 import { useEdgeSelectionHighlight } from "@/hooks/useEdgeSelectionHighlight";
+import { useIsMultiSelect } from "@/hooks/useIsMultiSelect";
 import { cn } from "@/lib/utils";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 import { useContextPanel } from "@/providers/ContextPanelProvider";
@@ -83,6 +84,8 @@ const IONode = ({ id, type, data, selected = false }: IONodeProps) => {
 
   const readOnly = !!data.readOnly;
 
+  const { isMultiSelect, isMultiSelectRef } = useIsMultiSelect();
+
   const isInSubgraph = isViewingSubgraph(currentSubgraphPath);
 
   const handleType = isInput ? "source" : "target";
@@ -117,7 +120,7 @@ const IONode = ({ id, type, data, selected = false }: IONodeProps) => {
   );
 
   useEffect(() => {
-    if (selected) {
+    if (selected && !isMultiSelect) {
       if (input && isInput) {
         setContent(
           <InputValueEditor
@@ -148,11 +151,11 @@ const IONode = ({ id, type, data, selected = false }: IONodeProps) => {
     }
 
     return () => {
-      if (selected) {
+      if (selected && !isMultiSelectRef.current) {
         clearContent();
       }
     };
-  }, [input, output, selected, readOnly]);
+  }, [input, output, selected, isMultiSelect, readOnly]);
 
   const connectedOutput = getOutputConnectedDetails(
     currentGraphSpec,

--- a/src/components/shared/ReactFlow/FlowCanvas/Multiselect/FlexDetailPanel.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/Multiselect/FlexDetailPanel.tsx
@@ -1,0 +1,28 @@
+import type { Node } from "@xyflow/react";
+
+import { InfoBox } from "@/components/shared/InfoBox";
+import { Paragraph } from "@/components/ui/typography";
+
+import { FlexNodeEditor } from "../FlexNode/FlexNodeEditor";
+import { isFlexNodeData } from "../FlexNode/types";
+
+export const FlexDetailPanel = ({
+  node,
+  readOnly,
+}: {
+  node: Node;
+  readOnly: boolean;
+}) => {
+  const data = node.data;
+  if (!isFlexNodeData(data)) {
+    return (
+      <InfoBox title="Unable to Load Sticky Note Details" variant="error">
+        <Paragraph size="sm" tone="subdued">
+          Invalid data for Sticky Note.
+        </Paragraph>
+      </InfoBox>
+    );
+  }
+
+  return <FlexNodeEditor flexNode={data} readOnly={readOnly} />;
+};

--- a/src/components/shared/ReactFlow/FlowCanvas/Multiselect/InputDetailPanel.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/Multiselect/InputDetailPanel.tsx
@@ -1,0 +1,31 @@
+import type { Node } from "@xyflow/react";
+
+import { InputValueEditor } from "@/components/Editor/IOEditor/InputValueEditor";
+import { InfoBox } from "@/components/shared/InfoBox";
+import { Paragraph } from "@/components/ui/typography";
+import { useComponentSpec } from "@/providers/ComponentSpecProvider";
+import { nodeIdToInputName } from "@/utils/nodes/nodeIdUtils";
+
+export const InputDetailPanel = ({
+  node,
+  readOnly,
+}: {
+  node: Node;
+  readOnly: boolean;
+}) => {
+  const { currentSubgraphSpec } = useComponentSpec();
+  const name = nodeIdToInputName(node.id);
+  const input = currentSubgraphSpec.inputs?.find((i) => i.name === name);
+
+  if (!input) {
+    return (
+      <InfoBox title="Unable to Load Input Details" variant="error">
+        <Paragraph size="sm" tone="subdued">
+          {`Input "${name}" not found in pipeline spec.`}
+        </Paragraph>
+      </InfoBox>
+    );
+  }
+
+  return <InputValueEditor input={input} disabled={readOnly} />;
+};

--- a/src/components/shared/ReactFlow/FlowCanvas/Multiselect/MultiSelectPanel.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/Multiselect/MultiSelectPanel.tsx
@@ -1,0 +1,180 @@
+import type { Node } from "@xyflow/react";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icon";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Heading, Text } from "@/components/ui/typography";
+
+import { ActionButton } from "../../../Buttons/ActionButton";
+import { ContentBlock } from "../../../ContextPanel/Blocks/ContentBlock";
+import { FlexDetailPanel } from "./FlexDetailPanel";
+import { InputDetailPanel } from "./InputDetailPanel";
+import { OutputDetailPanel } from "./OutputDetailPanel";
+import { TaskDetailPanel } from "./TaskDetailPanel";
+import { getNodeDisplayName, getNodeTypeIcon, getNodeTypeLabel } from "./utils";
+
+interface MultiSelectPanelProps {
+  selectedNodes: Node[];
+  readOnly: boolean;
+  onCopy?: () => void;
+  onDuplicate?: () => void;
+  onDelete?: () => void;
+  onUpgrade?: () => void;
+  onGroup?: () => void;
+  onAutoLayout?: () => void;
+}
+
+export const MultiSelectPanel = ({
+  selectedNodes,
+  readOnly,
+  onCopy,
+  onDuplicate,
+  onDelete,
+  onUpgrade,
+  onGroup,
+  onAutoLayout,
+}: MultiSelectPanelProps) => {
+  const [detailNodeId, setDetailNodeId] = useState<string | null>(null);
+
+  const detailNode = selectedNodes.find((n) => n.id === detailNodeId);
+
+  if (detailNode) {
+    return (
+      <NodeDetail
+        node={detailNode}
+        readOnly={readOnly}
+        onBack={() => setDetailNodeId(null)}
+      />
+    );
+  }
+
+  return (
+    <BlockStack align="start" gap="4" className="p-2">
+      <Heading level={2}>{selectedNodes.length} nodes selected</Heading>
+
+      <ContentBlock title="Selected nodes">
+        <BlockStack gap="1">
+          {selectedNodes.map((node) => {
+            const iconName = getNodeTypeIcon(node.type);
+            const typeLabel = getNodeTypeLabel(node.type);
+            const displayName = getNodeDisplayName(node);
+
+            return (
+              <Button
+                key={node.id}
+                variant="ghost"
+                className="w-full h-fit"
+                onClick={() => setDetailNodeId(node.id)}
+              >
+                <InlineStack align="space-between" blockAlign="center" fill>
+                  <InlineStack blockAlign="center" gap="2">
+                    <Icon
+                      name={iconName}
+                      className="text-muted-foreground"
+                      size="sm"
+                    />
+                    <Text
+                      size="sm"
+                      className="truncate whitespace-normal text-left"
+                    >
+                      {displayName}
+                    </Text>
+                  </InlineStack>
+
+                  <InlineStack blockAlign="center" gap="1">
+                    <Text size="xs" tone="subdued">
+                      {typeLabel}
+                    </Text>
+                    <Icon
+                      name="ChevronRight"
+                      className="text-muted-foreground"
+                      size="sm"
+                    />
+                  </InlineStack>
+                </InlineStack>
+              </Button>
+            );
+          })}
+        </BlockStack>
+      </ContentBlock>
+
+      <ContentBlock title="Actions">
+        <InlineStack gap="1">
+          {onUpgrade && (
+            <ActionButton
+              icon="CircleFadingArrowUp"
+              tooltip="Update tasks"
+              onClick={onUpgrade}
+            />
+          )}
+          {onGroup && (
+            <ActionButton
+              icon="Workflow"
+              tooltip="Create subgraph"
+              onClick={onGroup}
+            />
+          )}
+          {onDuplicate && (
+            <ActionButton
+              icon="Copy"
+              tooltip="Duplicate nodes"
+              onClick={onDuplicate}
+            />
+          )}
+          {onCopy && (
+            <ActionButton
+              icon="ClipboardPlus"
+              tooltip="Copy YAML"
+              onClick={onCopy}
+            />
+          )}
+          {onAutoLayout && (
+            <ActionButton
+              icon="LayoutGrid"
+              tooltip="Auto layout"
+              onClick={onAutoLayout}
+            />
+          )}
+          {onDelete && (
+            <ActionButton
+              icon="Trash"
+              tooltip="Delete all"
+              onClick={onDelete}
+              destructive
+            />
+          )}
+        </InlineStack>
+      </ContentBlock>
+    </BlockStack>
+  );
+};
+
+const NodeDetail = ({
+  node,
+  readOnly,
+  onBack,
+}: {
+  node: Node;
+  readOnly: boolean;
+  onBack: () => void;
+}) => {
+  return (
+    <BlockStack inlineAlign="start" align="start" gap="2" fill>
+      <Button variant="ghost" size="sm" onClick={onBack}>
+        <Icon name="ChevronLeft" />
+        Back to selection
+      </Button>
+      {node.type === "task" && <TaskDetailPanel node={node} />}
+      {node.type === "input" && (
+        <InputDetailPanel node={node} readOnly={readOnly} />
+      )}
+      {node.type === "output" && (
+        <OutputDetailPanel node={node} readOnly={readOnly} />
+      )}
+      {node.type === "flex" && (
+        <FlexDetailPanel node={node} readOnly={readOnly} />
+      )}
+    </BlockStack>
+  );
+};

--- a/src/components/shared/ReactFlow/FlowCanvas/Multiselect/OutputDetailPanel.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/Multiselect/OutputDetailPanel.tsx
@@ -1,0 +1,40 @@
+import type { Node } from "@xyflow/react";
+
+import { OutputNameEditor } from "@/components/Editor/IOEditor/OutputNameEditor";
+import { getOutputConnectedDetails } from "@/components/Editor/utils/getOutputConnectedDetails";
+import { InfoBox } from "@/components/shared/InfoBox";
+import { Paragraph } from "@/components/ui/typography";
+import { useComponentSpec } from "@/providers/ComponentSpecProvider";
+import { nodeIdToOutputName } from "@/utils/nodes/nodeIdUtils";
+
+export const OutputDetailPanel = ({
+  node,
+  readOnly,
+}: {
+  node: Node;
+  readOnly: boolean;
+}) => {
+  const { currentSubgraphSpec, currentGraphSpec } = useComponentSpec();
+  const name = nodeIdToOutputName(node.id);
+  const output = currentSubgraphSpec.outputs?.find((o) => o.name === name);
+
+  if (!output) {
+    return (
+      <InfoBox title="Unable to Load Output Details" variant="error">
+        <Paragraph size="sm" tone="subdued">
+          {`Output "${name}" not found in pipeline spec.`}
+        </Paragraph>
+      </InfoBox>
+    );
+  }
+
+  const connectedDetails = getOutputConnectedDetails(currentGraphSpec, name);
+
+  return (
+    <OutputNameEditor
+      output={output}
+      disabled={readOnly}
+      connectedDetails={connectedDetails}
+    />
+  );
+};

--- a/src/components/shared/ReactFlow/FlowCanvas/Multiselect/SelectionToolbar.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/Multiselect/SelectionToolbar.tsx
@@ -1,10 +1,9 @@
 import { icons } from "lucide-react";
 
+import TooltipButton from "@/components/shared/Buttons/TooltipButton";
 import { Icon } from "@/components/ui/icon";
 import { InlineStack } from "@/components/ui/layout";
 import { cn } from "@/lib/utils";
-
-import TooltipButton from "../../Buttons/TooltipButton";
 
 interface SelectionToolbarProps {
   onCopy?: () => void;

--- a/src/components/shared/ReactFlow/FlowCanvas/Multiselect/TaskDetailPanel.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/Multiselect/TaskDetailPanel.tsx
@@ -1,0 +1,38 @@
+import type { Node } from "@xyflow/react";
+
+import { InfoBox } from "@/components/shared/InfoBox";
+import { Paragraph } from "@/components/ui/typography";
+import { useExecutionDataOptional } from "@/providers/ExecutionDataProvider";
+import { TaskNodeProvider, useTaskNode } from "@/providers/TaskNodeProvider";
+import type { TaskNodeData } from "@/types/taskNode";
+
+import TaskOverview from "../TaskNode/TaskOverview";
+
+export const TaskDetailPanel = ({ node }: { node: Node }) => {
+  const data = node.data as TaskNodeData;
+
+  const executionData = useExecutionDataOptional();
+
+  if (!data.taskId || !data.taskSpec) {
+    return (
+      <InfoBox title="Unable to Load Task Details" variant="error">
+        <Paragraph size="sm" tone="subdued">
+          Unable to load task details. Missing task ID or task specification.
+        </Paragraph>
+      </InfoBox>
+    );
+  }
+
+  const status = executionData?.taskExecutionStatusMap.get(data.taskId);
+
+  return (
+    <TaskNodeProvider data={data} status={status} selected>
+      <TaskDetailContent />
+    </TaskNodeProvider>
+  );
+};
+
+const TaskDetailContent = () => {
+  const taskNode = useTaskNode();
+  return <TaskOverview taskNode={taskNode} />;
+};

--- a/src/components/shared/ReactFlow/FlowCanvas/Multiselect/utils.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/Multiselect/utils.ts
@@ -1,0 +1,55 @@
+import type { Node } from "@xyflow/react";
+import type { icons } from "lucide-react";
+
+import { getTaskDisplayName } from "@/utils/getComponentName";
+import {
+  nodeIdToInputName,
+  nodeIdToOutputName,
+  nodeIdToTaskId,
+} from "@/utils/nodes/nodeIdUtils";
+
+import { isFlexNodeData } from "../FlexNode/types";
+import { getFlexNodeDisplayName } from "../FlexNode/utils";
+
+export function getNodeTypeIcon(
+  nodeType: string | undefined,
+): keyof typeof icons {
+  switch (nodeType) {
+    case "task":
+      return "Boxes";
+    case "input":
+      return "SquareArrowRightEnter";
+    case "output":
+      return "SquareArrowRightExit";
+    case "flex":
+      return "StickyNote";
+    default:
+      return "Circle";
+  }
+}
+
+export function getNodeTypeLabel(nodeType: string | undefined): string {
+  switch (nodeType) {
+    case "task":
+      return "Task";
+    case "input":
+      return "Input";
+    case "output":
+      return "Output";
+    case "flex":
+      return "Note";
+    default:
+      return nodeType ?? "";
+  }
+}
+
+export function getNodeDisplayName(node: Node): string {
+  if (node.type === "task") return getTaskDisplayName(nodeIdToTaskId(node.id));
+  if (node.type === "input") return nodeIdToInputName(node.id);
+  if (node.type === "output") return nodeIdToOutputName(node.id);
+  if (node.type === "flex")
+    return isFlexNodeData(node.data)
+      ? getFlexNodeDisplayName(node.data)
+      : node.id;
+  return node.id;
+}

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeCard.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeCard.tsx
@@ -11,6 +11,7 @@ import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { QuickTooltip } from "@/components/ui/tooltip";
 import { Text } from "@/components/ui/typography";
 import { useEdgeSelectionHighlight } from "@/hooks/useEdgeSelectionHighlight";
+import { useIsMultiSelect } from "@/hooks/useIsMultiSelect";
 import { buildExecutionUrl } from "@/hooks/useSubgraphBreadcrumbs";
 import { cn } from "@/lib/utils";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
@@ -62,6 +63,8 @@ const TaskNodeCard = () => {
 
   const { name, displayName, state, nodeId, taskSpec, taskId } = taskNode;
   const { dimensions, selected, highlighted, readOnly, isCollapsed } = state;
+
+  const { isMultiSelect, isMultiSelectRef } = useIsMultiSelect();
 
   const { isConnectedToSelectedEdge } = useEdgeSelectionHighlight(nodeId);
 
@@ -158,18 +161,19 @@ const TaskNodeCard = () => {
   ]);
 
   useEffect(() => {
-    if (selected) {
+    if (selected && !isMultiSelect) {
       setContent(taskConfigMarkup);
       setContextPanelOpen(true);
     }
 
     return () => {
-      if (selected) {
+      if (selected && !isMultiSelectRef.current) {
         clearContent();
       }
     };
   }, [
     selected,
+    isMultiSelect,
     taskConfigMarkup,
     setContent,
     clearContent,

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeInputs.test.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeInputs.test.tsx
@@ -37,8 +37,8 @@ describe("<TaskNodeInputs />", () => {
       inputs,
       taskSpec,
       state: { readOnly: false },
-      select: vi.fn(),
       nodeId: "test-node",
+      callbacks: { onSelect: vi.fn() },
     } as any);
   };
 

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeInputs.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeInputs.tsx
@@ -31,7 +31,8 @@ export function TaskNodeInputs({
   expanded,
   onBackgroundClick,
 }: TaskNodeInputsProps) {
-  const { inputs, taskSpec, state, select } = useTaskNode();
+  const { inputs, taskSpec, state, callbacks } = useTaskNode();
+  const { onSelect } = callbacks;
   const { graphSpec } = useComponentSpec();
   const {
     highlightSearchFilter,
@@ -119,9 +120,9 @@ export function TaskNodeInputs({
   const handleLabelClick = useCallback(
     (e: MouseEvent) => {
       e.stopPropagation();
-      select();
+      onSelect?.();
     },
-    [select],
+    [onSelect],
   );
 
   useEffect(() => {

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeOutputs.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeOutputs.tsx
@@ -23,7 +23,8 @@ export function TaskNodeOutputs({
   expanded,
   onBackgroundClick,
 }: TaskNodeOutputsProps) {
-  const { nodeId, outputs, state, select } = useTaskNode();
+  const { nodeId, outputs, state, callbacks } = useTaskNode();
+  const { onSelect } = callbacks;
   const {
     highlightSearchFilter,
     resetSearchFilter,
@@ -108,9 +109,9 @@ export function TaskNodeOutputs({
   const handleLabelClick = useCallback(
     (e: MouseEvent) => {
       e.stopPropagation();
-      select();
+      onSelect?.();
     },
-    [select],
+    [onSelect],
   );
 
   useEffect(() => {

--- a/src/components/shared/ReactFlow/FlowCanvas/utils/duplicateNodes.test.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/utils/duplicateNodes.test.ts
@@ -84,6 +84,7 @@ const createMockTaskNodeCallbacks = () => ({
   onDelete: vi.fn(),
   onDuplicate: vi.fn(),
   onUpgrade: vi.fn(),
+  onSelect: vi.fn(),
 });
 
 const createMockNodeCallbacks = (): NodeCallbacks => ({
@@ -93,6 +94,7 @@ const createMockNodeCallbacks = (): NodeCallbacks => ({
   onDelete: vi.fn(),
   onDuplicate: vi.fn(),
   onUpgrade: vi.fn(),
+  onSelect: vi.fn(),
 });
 
 const createMockTaskNode = (

--- a/src/hooks/useIsMultiSelect.ts
+++ b/src/hooks/useIsMultiSelect.ts
@@ -1,0 +1,11 @@
+import { useStore } from "@xyflow/react";
+import { useRef } from "react";
+
+export function useIsMultiSelect() {
+  const isMultiSelect = useStore(
+    (s) => s.nodes.filter((n) => n.selected).length > 1,
+  );
+  const ref = useRef(isMultiSelect);
+  ref.current = isMultiSelect;
+  return { isMultiSelect, isMultiSelectRef: ref };
+}

--- a/src/hooks/useNodeCallbacks.ts
+++ b/src/hooks/useNodeCallbacks.ts
@@ -251,6 +251,17 @@ export const useNodeCallbacks = ({
     ],
   );
 
+  const onSelect = useCallback(
+    (ids: NodeAndTaskId) => {
+      reactFlowInstance.setNodes((nodes) =>
+        nodes.map((node) =>
+          node.id === ids.nodeId ? { ...node, selected: true } : node,
+        ),
+      );
+    },
+    [reactFlowInstance],
+  );
+
   return {
     onDelete,
     setArguments,
@@ -258,5 +269,6 @@ export const useNodeCallbacks = ({
     setCacheStaleness,
     onDuplicate,
     onUpgrade,
+    onSelect,
   };
 };

--- a/src/providers/TaskNodeProvider.tsx
+++ b/src/providers/TaskNodeProvider.tsx
@@ -1,4 +1,3 @@
-import { useReactFlow } from "@xyflow/react";
 import { type ReactNode, useCallback, useMemo } from "react";
 
 import useComponentFromUrl from "@/hooks/useComponentFromUrl";
@@ -57,6 +56,7 @@ type TaskNodeCallbacks = {
   onDelete?: () => void;
   onDuplicate?: () => void;
   onUpgrade?: () => void;
+  onSelect?: () => void;
 };
 
 type TaskNodeProviderProps = {
@@ -77,7 +77,6 @@ export type TaskNodeContextType = {
   displayName: string;
   state: TaskNodeState;
   callbacks: TaskNodeCallbacks;
-  select: () => void;
 };
 
 const TaskNodeContext =
@@ -90,7 +89,6 @@ export const TaskNodeProvider = ({
   status,
 }: TaskNodeProviderProps) => {
   const notify = useToastNotification();
-  const reactFlowInstance = useReactFlow();
 
   const taskSpec = data.taskSpec;
   const taskId = data.taskId;
@@ -103,6 +101,7 @@ export const TaskNodeProvider = ({
     setArguments,
     setAnnotations,
     setCacheStaleness,
+    onSelect,
   } = data.callbacks ?? DEFAULT_TASK_NODE_CALLBACKS;
 
   const componentRef =
@@ -183,14 +182,6 @@ export const TaskNodeProvider = ({
     onUpgrade(mostRecentComponentRef);
   }, [onUpgrade, isOutdated, mostRecentComponentRef, notify]);
 
-  const select = useCallback(() => {
-    reactFlowInstance.setNodes((nodes) =>
-      nodes.map((node) =>
-        node.id === nodeId ? { ...node, selected: true } : node,
-      ),
-    );
-  }, [nodeId, reactFlowInstance]);
-
   const state = useMemo(
     (): TaskNodeState => ({
       selected: selected && !data.isGhost,
@@ -224,6 +215,7 @@ export const TaskNodeProvider = ({
       onDelete: handleDeleteTaskNode,
       onDuplicate: handleDuplicateTaskNode,
       onUpgrade: handleUpgradeTaskNode,
+      onSelect,
     }),
     [
       handleSetArguments,
@@ -232,6 +224,7 @@ export const TaskNodeProvider = ({
       handleDeleteTaskNode,
       handleDuplicateTaskNode,
       handleUpgradeTaskNode,
+      onSelect,
     ],
   );
 
@@ -247,7 +240,6 @@ export const TaskNodeProvider = ({
       displayName,
       state,
       callbacks,
-      select,
     }),
     [
       componentRef,
@@ -260,7 +252,6 @@ export const TaskNodeProvider = ({
       displayName,
       state,
       callbacks,
-      select,
     ],
   );
 

--- a/src/types/taskNode.ts
+++ b/src/types/taskNode.ts
@@ -32,6 +32,7 @@ interface TaskNodeCallbacks {
   onDelete: () => void;
   onDuplicate: (selected?: boolean) => void;
   onUpgrade: (newComponentRef: ComponentReference) => void;
+  onSelect: () => void;
 }
 
 function noop() {}
@@ -43,6 +44,7 @@ export const DEFAULT_TASK_NODE_CALLBACKS: TaskNodeCallbacks = {
   onDuplicate: noop,
   onUpgrade: noop,
   setCacheStaleness: noop,
+  onSelect: noop,
 };
 
 // Dynamic Node Callback types - every callback has a version with the node & task id added to it as an input parameter

--- a/src/utils/nodes/createNodesFromComponentSpec.test.ts
+++ b/src/utils/nodes/createNodesFromComponentSpec.test.ts
@@ -19,6 +19,7 @@ describe("createNodesFromComponentSpec", () => {
     setCacheStaleness: vi.fn(),
     onDuplicate: vi.fn(),
     onUpgrade: vi.fn(),
+    onSelect: vi.fn(),
   };
 
   const readOnly = false;


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

Adds a specific context panel view for when multiple nodes are selected.

The new view shows a list of selected nodes followed by the standard array of multi-select toolbar actions. The nodes in the list can be selected to open their specific context panels, with a "back" button to go back to the multiselection panel.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

Closes https://github.com/Shopify/oasis-frontend/issues/497

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

![image.png](https://app.graphite.com/user-attachments/assets/4fd885c1-8570-4440-af9d-bd98c4246fb9.png)

![image.png](https://app.graphite.com/user-attachments/assets/80e049ee-36ac-41e5-a618-efa9698abb66.png)

## Test Instructions

- Confirm you can select multiple nodes and view the panel on both Edit and Run pages
- Confirm you can select an individual node with the group via the context panel to view its specific details, and can then go back
- Confirm that updating a task, input, output, flex node from within the multiselect flow does not break the flow

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

This PR also refines the naming process for Sticky Notes.

There is a multiselect check added inside each of task, io and flex nodes to avoid a race condition on displaying content in the context panel.

I absolutely loathe the process for adding a new callback to a task and the extremely loose typing associated with tasks. I would love to address this as done in https://github.com/TangleML/tangle-ui/pull/928 though I also understand it may be addressed as part of the Object-Model work.

Deleting a node from with the multiselect interface and then undoing via ctrl+z will not restore the node to the select because the selection is managed by reactflow whilst undo/redo is via the component spec.

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->