### PR TITLE
Add bulk submission support to OasisSubmitter with comma-separated input values

### DIFF
--- a/src/components/shared/Submitters/Oasis/OasisSubmitter.tsx
+++ b/src/components/shared/Submitters/Oasis/OasisSubmitter.tsx
@@ -20,6 +20,7 @@ import {
   PIPELINE_RUN_NOTES_ANNOTATION,
   PIPELINE_TAGS_ANNOTATION,
 } from "@/utils/annotations";
+import { expandBulkArguments } from "@/utils/bulkSubmission";
 import {
   type ArgumentType,
   type ComponentSpec,
@@ -112,6 +113,11 @@ const OasisSubmitter = ({
   const navigate = useNavigate();
 
   const runNotes = useRef<string>("");
+  const [bulkProgress, setBulkProgress] = useState<{
+    total: number;
+    completed: number;
+    failed: number;
+  } | null>(null);
 
   const { mutate: saveNotes } = useMutation({
     mutationFn: (runId: string) =>
@@ -220,18 +226,90 @@ const OasisSubmitter = ({
     });
   };
 
-  const handleSubmitWithArguments = (
+  const handleBulkSubmit = async (argSets: Record<string, ArgumentType>[]) => {
+    if (!componentSpec) {
+      handleError("No pipeline to submit");
+      return;
+    }
+
+    const total = argSets.length;
+    setBulkProgress({ total, completed: 0, failed: 0 });
+    setSubmitSuccess(null);
+
+    let completed = 0;
+    let failed = 0;
+
+    for (const args of argSets) {
+      try {
+        const response = await new Promise<PipelineRun>((resolve, reject) => {
+          submit({
+            componentSpec,
+            taskArguments: args,
+            onSuccess: resolve,
+            onError: reject,
+          });
+        });
+
+        if (runNotes.current.trim() !== "") {
+          saveNotes(response.id.toString());
+        }
+
+        const tags = getPipelineTagsFromSpec(componentSpec);
+        if (tags.length > 0) {
+          saveTags(response.id.toString());
+        }
+
+        completed++;
+      } catch {
+        failed++;
+      }
+
+      setBulkProgress({ total, completed, failed });
+    }
+
+    setBulkProgress(null);
+    setSubmitSuccess(failed === 0);
+    setCooldownTime(3);
+
+    if (failed === 0) {
+      onSubmitComplete?.();
+      notify(`${total} runs submitted successfully`, "success");
+    } else {
+      notify(
+        `${completed} of ${total} runs submitted. ${failed} failed.`,
+        failed === total ? "error" : "warning",
+      );
+    }
+  };
+
+  const handleSubmitWithArguments = async (
     args: Record<string, ArgumentType>,
     notes: string,
+    bulkInputNames: Set<string>,
   ) => {
     runNotes.current = notes;
     setIsArgumentsDialogOpen(false);
-    handleSubmit(args);
+
+    if (bulkInputNames.size === 0) {
+      handleSubmit(args);
+      return;
+    }
+
+    try {
+      const argSets = expandBulkArguments(args, bulkInputNames);
+      await handleBulkSubmit(argSets);
+    } catch (error) {
+      notify(`Bulk submission failed: ${String(error)}`, "error");
+    }
   };
 
   const hasConfigurableInputs = (componentSpec?.inputs?.length ?? 0) > 0;
 
   const getButtonText = () => {
+    if (bulkProgress) {
+      const current = bulkProgress.completed + bulkProgress.failed;
+      return `Submitting ${current + 1} of ${bulkProgress.total}...`;
+    }
     if (cooldownTime > 0) {
       return `Run submitted (${cooldownTime}s)`;
     }
@@ -250,13 +328,14 @@ const OasisSubmitter = ({
     isGraphImplementation(componentSpec.implementation) &&
     Object.keys(componentSpec.implementation.graph.tasks).length > 0;
 
-  const isButtonDisabled = isSubmitting || !isSubmittable;
+  const isBulkSubmitting = bulkProgress !== null;
+  const isButtonDisabled = isSubmitting || isBulkSubmitting || !isSubmittable;
 
   const isArgumentsButtonVisible =
     hasConfigurableInputs && !isButtonDisabled && isComponentTreeValid;
 
   const getButtonIcon = () => {
-    if (isSubmitting) {
+    if (isSubmitting || isBulkSubmitting) {
       return <Loader2 className="animate-spin" />;
     }
     if (submitSuccess === false && cooldownTime > 0) {

--- a/src/components/shared/Submitters/Oasis/components/SubmitTaskArgumentsDialog.tsx
+++ b/src/components/shared/Submitters/Oasis/components/SubmitTaskArgumentsDialog.tsx
@@ -12,6 +12,7 @@ import {
   createSecretArgument,
   extractSecretName,
 } from "@/components/shared/SecretsManagement/types";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -23,6 +24,7 @@ import {
 } from "@/components/ui/dialog";
 import { Icon } from "@/components/ui/icon";
 import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import {
   Popover,
@@ -31,6 +33,7 @@ import {
 } from "@/components/ui/popover";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Spinner } from "@/components/ui/spinner";
+import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { Paragraph } from "@/components/ui/typography";
 import useToastNotification from "@/hooks/useToastNotification";
@@ -41,6 +44,7 @@ import {
   fetchPipelineRun,
 } from "@/services/executionService";
 import type { PipelineRun } from "@/types/pipelineRun";
+import { getBulkRunCount, parseBulkValues } from "@/utils/bulkSubmission";
 import {
   type ArgumentType,
   type ComponentSpec,
@@ -55,7 +59,11 @@ type TaskArguments = TaskSpecOutput["arguments"];
 interface SubmitTaskArgumentsDialogProps {
   open: boolean;
   onCancel: () => void;
-  onConfirm: (args: Record<string, ArgumentType>, notes: string) => void;
+  onConfirm: (
+    args: Record<string, ArgumentType>,
+    notes: string,
+    bulkInputNames: Set<string>,
+  ) => void;
   componentSpec: ComponentSpec;
 }
 
@@ -77,7 +85,14 @@ export const SubmitTaskArgumentsDialog = ({
     new Map(),
   );
 
+  const [bulkInputNames, setBulkInputNames] = useState<Set<string>>(new Set());
+
   const inputs = componentSpec.inputs ?? [];
+
+  const bulkRunCount = getBulkRunCount(taskArguments, bulkInputNames);
+  const hasBulkMismatch = bulkRunCount === -1;
+  const isBulkMode = bulkInputNames.size > 0;
+  const effectiveRunCount = isBulkMode ? Math.max(bulkRunCount, 0) : 1;
 
   const [isValidToSubmit, setIsValidToSubmit] = useState(
     validateArguments(inputs, taskArguments),
@@ -107,19 +122,31 @@ export const SubmitTaskArgumentsDialog = ({
   };
 
   useEffect(() => {
-    setIsValidToSubmit(validateArguments(inputs, taskArguments));
-  }, [inputs, taskArguments]);
+    const baseValid = validateArguments(inputs, taskArguments);
+    const bulkValid = !hasBulkMismatch && bulkRunCount > 0;
+    setIsValidToSubmit(baseValid && bulkValid);
+  }, [inputs, taskArguments, hasBulkMismatch, bulkRunCount]);
 
-  const handleRunNotesChange = (value: string) => {
-    setRunNotes(value);
+  const handleBulkToggle = (name: string, enabled: boolean) => {
+    setBulkInputNames((prev) => {
+      const next = new Set(prev);
+      if (enabled) {
+        next.add(name);
+      } else {
+        next.delete(name);
+      }
+      return next;
+    });
   };
 
-  const handleConfirm = () => onConfirm(taskArguments, runNotes);
+  const handleConfirm = () =>
+    onConfirm(taskArguments, runNotes, bulkInputNames);
 
   const handleCancel = () => {
     setTaskArguments(initialArgs);
     setRunNotes("");
     setHighlightedArgs(new Map());
+    setBulkInputNames(new Set());
     onCancel();
   };
 
@@ -155,18 +182,48 @@ export const SubmitTaskArgumentsDialog = ({
           )}
         </DialogHeader>
 
+        {isBulkMode && (
+          <BlockStack
+            gap="1"
+            className="rounded-md bg-muted px-3 py-2 text-xs text-muted-foreground"
+          >
+            <Paragraph size="xs" weight="semibold">
+              Bulk mode
+            </Paragraph>
+            <Paragraph size="xs">
+              Enter comma-separated values for bulk inputs (e.g.{" "}
+              <Paragraph as="span" size="xs" className="font-mono">
+                A, B, C
+              </Paragraph>
+              ). Each value creates a separate run. Non-bulk inputs reuse their
+              single value across all runs. If multiple inputs are set to bulk,
+              they must have the same number of values.
+            </Paragraph>
+          </BlockStack>
+        )}
+
         {hasInputs && (
           <ScrollArea className="max-h-[60vh] pr-4 w-full">
             <BlockStack gap="4" className="p-1">
               {inputs.map((input) => {
                 const highlightVersion = highlightedArgs.get(input.name);
+                const isBulkEnabled = bulkInputNames.has(input.name);
+                const currentValue = taskArguments[input.name];
+                const bulkValueCount =
+                  isBulkEnabled && typeof currentValue === "string"
+                    ? parseBulkValues(currentValue).length
+                    : 0;
+
                 return (
                   <ArgumentField
                     key={`${input.name}-${highlightVersion ?? "static"}`}
                     input={input}
-                    value={taskArguments[input.name]}
+                    value={currentValue}
                     onChange={handleValueChange}
                     isHighlighted={highlightVersion !== undefined}
+                    isBulkEnabled={isBulkEnabled}
+                    onBulkToggle={handleBulkToggle}
+                    bulkValueCount={bulkValueCount}
                   />
                 );
               })}
@@ -180,18 +237,39 @@ export const SubmitTaskArgumentsDialog = ({
           </Paragraph>
           <Textarea
             value={runNotes}
-            onChange={(e) => handleRunNotesChange(e.target.value)}
+            onChange={(e) => setRunNotes(e.target.value)}
             placeholder="Share context about this pipeline run..."
             className="text-xs!"
           />
         </BlockStack>
+
+        {isBulkMode && (
+          <InlineStack gap="2" align="start" className="px-1">
+            {hasBulkMismatch ? (
+              <Paragraph size="xs" tone="critical">
+                Bulk inputs have different numbers of values. All bulk inputs
+                must have the same count.
+              </Paragraph>
+            ) : (
+              <Paragraph size="xs" tone="subdued">
+                This will submit{" "}
+                <Paragraph as="span" size="xs" weight="semibold">
+                  {effectiveRunCount}
+                </Paragraph>{" "}
+                {effectiveRunCount === 1 ? "run" : "runs"}.
+              </Paragraph>
+            )}
+          </InlineStack>
+        )}
 
         <DialogFooter>
           <Button variant="outline" onClick={handleCancel}>
             Cancel
           </Button>
           <Button onClick={handleConfirm} disabled={!isValidToSubmit}>
-            Submit Run
+            {isBulkMode && effectiveRunCount > 1
+              ? `Submit ${effectiveRunCount} Runs`
+              : "Submit Run"}
           </Button>
         </DialogFooter>
       </DialogContent>
@@ -319,6 +397,9 @@ interface ArgumentFieldProps {
   value: ArgumentType | undefined;
   onChange: (name: string, value: ArgumentType) => void;
   isHighlighted?: boolean;
+  isBulkEnabled?: boolean;
+  onBulkToggle?: (name: string, enabled: boolean) => void;
+  bulkValueCount?: number;
 }
 
 const ArgumentField = ({
@@ -326,14 +407,17 @@ const ArgumentField = ({
   value,
   onChange,
   isHighlighted,
+  isBulkEnabled = false,
+  onBulkToggle,
+  bulkValueCount = 0,
 }: ArgumentFieldProps) => {
   const [isSelectSecretDialogOpen, setIsSelectSecretDialogOpen] =
     useState(false);
 
   const isValueSecret = isSecretArgument(value);
   const secretName = isValueSecret ? extractSecretName(value) : null;
-  // For the submit dialog, we only expect string values or SecretArguments
   const stringValue = typeof value === "string" ? value : "";
+  const canBeBulk = !isValueSecret;
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     onChange(input.name, e.target.value);
@@ -350,9 +434,12 @@ const ArgumentField = ({
 
   const typeLabel = typeSpecToString(input.type);
   const isRequired = !input.optional;
-  const placeholder = input.default ?? "";
+  const placeholder = isBulkEnabled
+    ? "value1, value2, value3"
+    : (input.default ?? "");
   const hasValidValue =
     isValueSecret || Boolean(stringValue) || Boolean(placeholder);
+  const bulkId = `bulk-${input.name}`;
 
   return (
     <>
@@ -363,7 +450,7 @@ const ArgumentField = ({
           isHighlighted && "animate-highlight-fade",
         )}
       >
-        <InlineStack gap="2" align="start">
+        <InlineStack gap="2" align="start" className="w-full">
           <Paragraph size="sm" className="wrap-break-word">
             {input.name}
           </Paragraph>
@@ -371,6 +458,30 @@ const ArgumentField = ({
             ({typeLabel}
             {isRequired ? "*" : ""})
           </Paragraph>
+          <div className="flex-1" />
+          {canBeBulk && (
+            <InlineStack gap="1" align="center">
+              <Label
+                htmlFor={bulkId}
+                className="text-xs text-muted-foreground cursor-pointer"
+              >
+                Bulk
+              </Label>
+              <Switch
+                id={bulkId}
+                checked={isBulkEnabled}
+                onCheckedChange={(checked) =>
+                  onBulkToggle?.(input.name, checked)
+                }
+                className="scale-75"
+              />
+              {isBulkEnabled && bulkValueCount > 0 && (
+                <Badge variant="secondary" size="xs" shape="rounded">
+                  {bulkValueCount}
+                </Badge>
+              )}
+            </InlineStack>
+          )}
         </InlineStack>
 
         {input.description && (

--- a/src/utils/bulkSubmission.test.ts
+++ b/src/utils/bulkSubmission.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  expandBulkArguments,
+  getBulkRunCount,
+  parseBulkValues,
+} from "./bulkSubmission";
+import type { DynamicDataArgument } from "./componentSpec";
+
+function makeSecretArg(name: string): DynamicDataArgument {
+  return { dynamicData: { secret: { name } } };
+}
+
+describe("parseBulkValues", () => {
+  it("splits comma-separated values and trims whitespace", () => {
+    expect(parseBulkValues("A, B, C, D")).toEqual(["A", "B", "C", "D"]);
+  });
+
+  it("returns a single value when no commas", () => {
+    expect(parseBulkValues("hello")).toEqual(["hello"]);
+  });
+
+  it("filters out empty values from trailing commas", () => {
+    expect(parseBulkValues("A, B, ")).toEqual(["A", "B"]);
+  });
+
+  it("filters out empty values from consecutive commas", () => {
+    expect(parseBulkValues("A, , B")).toEqual(["A", "B"]);
+  });
+
+  it("returns empty array for empty string", () => {
+    expect(parseBulkValues("")).toEqual([]);
+  });
+
+  it("returns empty array for only whitespace and commas", () => {
+    expect(parseBulkValues(" , , ")).toEqual([]);
+  });
+
+  it("handles values with internal spaces", () => {
+    expect(parseBulkValues("hello world, foo bar")).toEqual([
+      "hello world",
+      "foo bar",
+    ]);
+  });
+});
+
+describe("expandBulkArguments", () => {
+  it("returns single-element array when no bulk inputs", () => {
+    const args = { input1: "value1", input2: "value2" };
+    const result = expandBulkArguments(args, new Set());
+    expect(result).toEqual([args]);
+  });
+
+  it("expands a single bulk input into multiple argument sets", () => {
+    const args = { dataset: "train, test, val", model: "rf" };
+    const result = expandBulkArguments(args, new Set(["dataset"]));
+    expect(result).toEqual([
+      { dataset: "train", model: "rf" },
+      { dataset: "test", model: "rf" },
+      { dataset: "val", model: "rf" },
+    ]);
+  });
+
+  it("expands two bulk inputs with matching counts", () => {
+    const args = { dataset: "train, test", lr: "0.01, 0.001" };
+    const result = expandBulkArguments(args, new Set(["dataset", "lr"]));
+    expect(result).toEqual([
+      { dataset: "train", lr: "0.01" },
+      { dataset: "test", lr: "0.001" },
+    ]);
+  });
+
+  it("throws when bulk input counts differ", () => {
+    const args = { dataset: "A, B, C", lr: "0.01, 0.001" };
+    expect(() => expandBulkArguments(args, new Set(["dataset", "lr"]))).toThrow(
+      "Bulk inputs have different value counts",
+    );
+  });
+
+  it("preserves non-string arguments (secrets) as-is", () => {
+    const secretArg = makeSecretArg("my-secret");
+    const args = { dataset: "train, test", api_key: secretArg };
+    const result = expandBulkArguments(args, new Set(["dataset"]));
+    expect(result).toEqual([
+      { dataset: "train", api_key: secretArg },
+      { dataset: "test", api_key: secretArg },
+    ]);
+  });
+
+  it("ignores non-string values in bulk input names", () => {
+    const secretArg = makeSecretArg("my-secret");
+    const args = { api_key: secretArg, dataset: "single" };
+    const result = expandBulkArguments(args, new Set(["api_key"]));
+    expect(result).toEqual([args]);
+  });
+});
+
+describe("getBulkRunCount", () => {
+  it("returns 1 when no bulk inputs", () => {
+    expect(getBulkRunCount({ a: "val" }, new Set())).toBe(1);
+  });
+
+  it("returns correct count for single bulk input", () => {
+    expect(getBulkRunCount({ a: "x, y, z" }, new Set(["a"]))).toBe(3);
+  });
+
+  it("returns correct count for multiple matching bulk inputs", () => {
+    expect(getBulkRunCount({ a: "x, y", b: "1, 2" }, new Set(["a", "b"]))).toBe(
+      2,
+    );
+  });
+
+  it("returns -1 for mismatched bulk input counts", () => {
+    expect(
+      getBulkRunCount({ a: "x, y, z", b: "1, 2" }, new Set(["a", "b"])),
+    ).toBe(-1);
+  });
+
+  it("returns 1 when bulk input is non-string", () => {
+    expect(getBulkRunCount({ a: makeSecretArg("s") }, new Set(["a"]))).toBe(1);
+  });
+
+  it("returns 0 for empty bulk input value", () => {
+    expect(getBulkRunCount({ a: "" }, new Set(["a"]))).toBe(0);
+  });
+});

--- a/src/utils/bulkSubmission.ts
+++ b/src/utils/bulkSubmission.ts
@@ -1,0 +1,95 @@
+import type { ArgumentType } from "./componentSpec";
+
+export function parseBulkValues(raw: string): string[] {
+  return raw
+    .split(",")
+    .map((v) => v.trim())
+    .filter((v) => v.length > 0);
+}
+
+function buildBulkCountMismatchMessage(counts: Record<string, number>): string {
+  const details = Object.entries(counts)
+    .map(([name, count]) => `"${name}": ${count}`)
+    .join(", ");
+  return `Bulk inputs have different value counts: ${details}`;
+}
+
+function parseBulkInputs(
+  taskArguments: Record<string, ArgumentType>,
+  bulkInputNames: Set<string>,
+): Record<string, string[]> {
+  const parsed: Record<string, string[]> = {};
+  for (const name of bulkInputNames) {
+    const raw = taskArguments[name];
+    if (typeof raw === "string") {
+      parsed[name] = parseBulkValues(raw);
+    }
+  }
+  return parsed;
+}
+
+/**
+ * Expands bulk inputs into N argument sets.
+ *
+ * { dataset: "train, test", model: "rf" } with dataset as bulk
+ * → [{ dataset: "train", model: "rf" }, { dataset: "test", model: "rf" }]
+ *
+ * All bulk inputs must have equal value counts.
+ * Throws if counts differ.
+ */
+export function expandBulkArguments(
+  taskArguments: Record<string, ArgumentType>,
+  bulkInputNames: Set<string>,
+): Record<string, ArgumentType>[] {
+  if (bulkInputNames.size === 0) return [taskArguments];
+
+  const parsedValues = parseBulkInputs(taskArguments, bulkInputNames);
+  const bulkEntries = Object.entries(parsedValues);
+  if (bulkEntries.length === 0) return [taskArguments];
+
+  const valueCounts = bulkEntries.map(([, values]) => values.length);
+  if (new Set(valueCounts).size > 1) {
+    throw new Error(
+      buildBulkCountMismatchMessage(
+        Object.fromEntries(
+          bulkEntries.map(([name, values]) => [name, values.length]),
+        ),
+      ),
+    );
+  }
+
+  const runCount = valueCounts[0] ?? 1;
+
+  const result: Record<string, ArgumentType>[] = [];
+  for (let i = 0; i < runCount; i++) {
+    const args: Record<string, ArgumentType> = {};
+    for (const [name, value] of Object.entries(taskArguments)) {
+      args[name] = name in parsedValues ? parsedValues[name][i] : value;
+    }
+    result.push(args);
+  }
+
+  return result;
+}
+
+/**
+ * Returns expected number of runs from bulk inputs.
+ *
+ * { a: "x, y, z" } with a as bulk → 3
+ * { a: "x, y", b: "1, 2" } with both as bulk → 2
+ * { a: "x, y", b: "1, 2, 3" } with both as bulk → -1 (mismatch)
+ */
+export function getBulkRunCount(
+  taskArguments: Record<string, ArgumentType>,
+  bulkInputNames: Set<string>,
+): number {
+  if (bulkInputNames.size === 0) return 1;
+
+  const counts = Object.values(
+    parseBulkInputs(taskArguments, bulkInputNames),
+  ).map((values) => values.length);
+
+  if (counts.length === 0) return 1;
+  if (new Set(counts).size > 1) return -1;
+  return counts[0];
+}


### PR DESCRIPTION
## Description

Added bulk submission functionality to the Oasis submitter, allowing users to submit multiple pipeline runs with different parameter values in a single operation. Users can enable bulk mode for individual string inputs using a toggle switch, enter comma-separated values, and submit multiple runs simultaneously. The feature includes progress tracking, validation for mismatched value counts, and comprehensive error handling.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

The video demonstrates both single field bulk and import bulk arguments (handled by the next PR in the stack)  
[bulk_sub.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/3e4c68d3-f188-48e4-b44e-f13eb248929a.mov" />](https://app.graphite.com/user-attachments/video/3e4c68d3-f188-48e4-b44e-f13eb248929a.mov)



## Test Instructions

1. Navigate to a pipeline with configurable string inputs
2. Click "Configure & Submit" to open the arguments dialog
3. Toggle "Bulk" mode for one or more string inputs
4. Enter comma-separated values (e.g., "train, test, validation")
5. Verify the run count displays correctly at the bottom
6. Submit and observe progress tracking during bulk submission
7. Test error handling by providing mismatched value counts across bulk inputs
8. Verify that secret arguments cannot be set to bulk mode

## Additional Comments

The implementation includes comprehensive unit tests for the bulk submission utilities and maintains backward compatibility with existing single-run submissions. Progress tracking shows current submission status and handles partial failures gracefully.