### PR TITLE
Add CSV import/export functionality to task arguments dialog

### DIFF
--- a/src/components/shared/Submitters/Oasis/components/SubmitTaskArgumentsDialog.tsx
+++ b/src/components/shared/Submitters/Oasis/components/SubmitTaskArgumentsDialog.tsx
@@ -1,5 +1,5 @@
 import { useMutation } from "@tanstack/react-query";
-import { type ChangeEvent, useEffect, useState } from "react";
+import { type ChangeEvent, useRef, useState } from "react";
 
 import type { TaskSpecOutput } from "@/api/types.gen";
 import TooltipButton from "@/components/shared/Buttons/TooltipButton";
@@ -51,7 +51,10 @@ import {
   type InputSpec,
   isSecretArgument,
 } from "@/utils/componentSpec";
+import { generateCsvTemplate } from "@/utils/csvBulkArgumentExport";
+import { mapCsvToArguments } from "@/utils/csvBulkArgumentImport";
 import { extractTaskArguments } from "@/utils/nodes/taskArguments";
+import { pluralize } from "@/utils/string";
 import { validateArguments } from "@/utils/validations";
 
 type TaskArguments = TaskSpecOutput["arguments"];
@@ -94,9 +97,10 @@ export const SubmitTaskArgumentsDialog = ({
   const isBulkMode = bulkInputNames.size > 0;
   const effectiveRunCount = isBulkMode ? Math.max(bulkRunCount, 0) : 1;
 
-  const [isValidToSubmit, setIsValidToSubmit] = useState(
-    validateArguments(inputs, taskArguments),
-  );
+  const isValidToSubmit =
+    validateArguments(inputs, taskArguments) &&
+    !hasBulkMismatch &&
+    bulkRunCount > 0;
 
   const handleCopyFromRun = (args: Record<string, string>) => {
     const diff = Object.entries(args).filter(
@@ -121,12 +125,6 @@ export const SubmitTaskArgumentsDialog = ({
     }));
   };
 
-  useEffect(() => {
-    const baseValid = validateArguments(inputs, taskArguments);
-    const bulkValid = !hasBulkMismatch && bulkRunCount > 0;
-    setIsValidToSubmit(baseValid && bulkValid);
-  }, [inputs, taskArguments, hasBulkMismatch, bulkRunCount]);
-
   const handleBulkToggle = (name: string, enabled: boolean) => {
     setBulkInputNames((prev) => {
       const next = new Set(prev);
@@ -137,6 +135,51 @@ export const SubmitTaskArgumentsDialog = ({
       }
       return next;
     });
+  };
+
+  const handleCsvImport = (csvText: string) => {
+    const result = mapCsvToArguments(csvText, inputs, taskArguments);
+
+    if (result.rowCount === 0 && result.changedInputNames.length === 0) {
+      notify("CSV file is empty or contains only headers", "warning");
+      return;
+    }
+
+    setTaskArguments((prev) => ({ ...prev, ...result.values }));
+
+    if (result.enableBulk) {
+      setBulkInputNames((prev) => {
+        const next = new Set(prev);
+        for (const name of Object.keys(result.values)) {
+          next.add(name);
+        }
+        return next;
+      });
+    }
+
+    const version = Date.now();
+    setHighlightedArgs(
+      new Map(result.changedInputNames.map((name) => [name, version])),
+    );
+
+    const inputCount = result.changedInputNames.length;
+    const hasWarnings =
+      result.unmatchedColumns.length > 0 ||
+      result.skippedSecretInputs.length > 0;
+
+    let message = result.enableBulk
+      ? `Imported ${result.rowCount} rows across ${inputCount} ${pluralize(inputCount, "input")}`
+      : `Imported ${inputCount} ${pluralize(inputCount, "input")} from CSV`;
+
+    if (result.unmatchedColumns.length > 0) {
+      message += `. Ignored columns: ${result.unmatchedColumns.join(", ")}`;
+    }
+
+    if (result.skippedSecretInputs.length > 0) {
+      message += `. Skipped secrets: ${result.skippedSecretInputs.join(", ")}`;
+    }
+
+    notify(message, hasWarnings ? "warning" : "success");
   };
 
   const handleConfirm = () =>
@@ -168,7 +211,14 @@ export const SubmitTaskArgumentsDialog = ({
               <Paragraph tone="subdued" size="sm">
                 Customize the pipeline input values before submitting.
               </Paragraph>
-              <InlineStack align="end" className="w-full">
+              <InlineStack align="end" gap="1" className="w-full">
+                <DownloadCsvTemplateButton
+                  inputs={inputs}
+                  taskArguments={taskArguments}
+                  bulkInputNames={bulkInputNames}
+                  pipelineName={componentSpec.name}
+                />
+                <ImportCsvButton onImport={handleCsvImport} />
                 <CopyFromRunPopover
                   componentSpec={componentSpec}
                   onCopy={handleCopyFromRun}
@@ -531,6 +581,85 @@ const ArgumentField = ({
         onOpenChange={setIsSelectSecretDialogOpen}
         onSelect={handleSecretSelect}
       />
+    </>
+  );
+};
+
+const DownloadCsvTemplateButton = ({
+  inputs,
+  taskArguments,
+  bulkInputNames,
+  pipelineName,
+}: {
+  inputs: InputSpec[];
+  taskArguments: Record<string, ArgumentType>;
+  bulkInputNames: Set<string>;
+  pipelineName?: string;
+}) => {
+  const handleDownload = () => {
+    const csv = generateCsvTemplate(inputs, taskArguments, bulkInputNames);
+    if (!csv) return;
+
+    const blob = new Blob([csv], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `${pipelineName ?? "pipeline"}-arguments.csv`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <Button variant="ghost" size="sm" onClick={handleDownload}>
+      <Icon name="Download" />
+      Template
+    </Button>
+  );
+};
+
+const ImportCsvButton = ({
+  onImport,
+}: {
+  onImport: (csvText: string) => void;
+}) => {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    const reader = new FileReader();
+    reader.onload = (event) => {
+      const text = event.target?.result;
+      if (typeof text === "string") {
+        onImport(text);
+      }
+    };
+    reader.readAsText(file);
+
+    // Reset so the same file can be re-selected
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
+  };
+
+  return (
+    <>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept=".csv"
+        onChange={handleFileChange}
+        className="hidden"
+      />
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={() => fileInputRef.current?.click()}
+      >
+        <Icon name="FileSpreadsheet" />
+        Import CSV
+      </Button>
     </>
   );
 };

--- a/src/utils/csvBulkArgumentExport.test.ts
+++ b/src/utils/csvBulkArgumentExport.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import type { DynamicDataArgument, InputSpec } from "./componentSpec";
+import { generateCsvTemplate } from "./csvBulkArgumentExport";
+
+function makeSecretArg(name: string): DynamicDataArgument {
+  return { dynamicData: { secret: { name } } };
+}
+
+function makeInput(name: string, optional = false): InputSpec {
+  return { name, optional };
+}
+
+describe("generateCsvTemplate", () => {
+  const inputs = [
+    makeInput("dataset"),
+    makeInput("model"),
+    makeInput("lr", true),
+  ];
+
+  it("generates headers with empty defaults", () => {
+    expect(generateCsvTemplate(inputs, {})).toBe("dataset,model,lr\n,,");
+  });
+
+  it("uses current argument values as defaults", () => {
+    const args = { dataset: "train.csv", model: "", lr: "" };
+    expect(generateCsvTemplate(inputs, args)).toBe(
+      "dataset,model,lr\ntrain.csv,,",
+    );
+  });
+
+  it("uses input default when no current value", () => {
+    const inputsWithDefaults: InputSpec[] = [
+      { name: "dataset", default: "data.csv" },
+      { name: "model" },
+    ];
+    expect(generateCsvTemplate(inputsWithDefaults, {})).toBe(
+      "dataset,model\ndata.csv,",
+    );
+  });
+
+  it("skips secret inputs", () => {
+    const args = { dataset: "", model: "", api_key: makeSecretArg("s") };
+    const inputsWithSecret = [...inputs, makeInput("api_key")];
+    expect(generateCsvTemplate(inputsWithSecret, args)).toBe(
+      "dataset,model,lr\n,,",
+    );
+  });
+
+  it("returns empty string when all inputs are secrets", () => {
+    const secretInputs = [makeInput("api_key")];
+    const args = { api_key: makeSecretArg("s") };
+    expect(generateCsvTemplate(secretInputs, args)).toBe("");
+  });
+
+  it("expands bulk inputs into separate rows", () => {
+    const args = { dataset: "train, test, val", model: "rf", lr: "0.01" };
+    const bulk = new Set(["dataset"]);
+    expect(generateCsvTemplate(inputs, args, bulk)).toBe(
+      "dataset,model,lr\ntrain,rf,0.01\ntest,rf,0.01\nval,rf,0.01",
+    );
+  });
+
+  it("expands multiple bulk inputs in parallel", () => {
+    const args = { dataset: "train, test", model: "rf, gb", lr: "0.01" };
+    const bulk = new Set(["dataset", "model"]);
+    expect(generateCsvTemplate(inputs, args, bulk)).toBe(
+      "dataset,model,lr\ntrain,rf,0.01\ntest,gb,0.01",
+    );
+  });
+
+  it("quotes values that contain commas", () => {
+    const args = { dataset: "a,b", model: "rf" };
+    expect(generateCsvTemplate(inputs, args)).toBe(
+      'dataset,model,lr\n"a,b",rf,',
+    );
+  });
+});

--- a/src/utils/csvBulkArgumentExport.ts
+++ b/src/utils/csvBulkArgumentExport.ts
@@ -1,0 +1,71 @@
+import { parseBulkValues } from "./bulkSubmission";
+import {
+  type ArgumentType,
+  type InputSpec,
+  isSecretArgument,
+} from "./componentSpec";
+
+/**
+ * Quotes a CSV field if it contains commas, quotes, or newlines (RFC 4180).
+ */
+function quoteCsvField(value: string): string {
+  if (value.includes(",") || value.includes('"') || value.includes("\n")) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+/**
+ * Generates a CSV with input names as column headers.
+ *
+ * Bulk inputs are expanded into separate rows (one value per row).
+ * Non-bulk inputs repeat their value across all rows.
+ * Skips inputs that currently hold secret values.
+ *
+ * { experiment_key: "12345, 1, 2, 9", predictions: "1234, 4, 6, 5" }
+ * with both as bulk →
+ *   experiment_key,predictions
+ *   12345,1234
+ *   1,4
+ *   2,6
+ *   9,5
+ */
+export function generateCsvTemplate(
+  inputs: InputSpec[],
+  currentArgs: Record<string, ArgumentType>,
+  bulkInputNames: Set<string> = new Set(),
+): string {
+  const nonSecretInputs = inputs.filter(
+    (input) => !isSecretArgument(currentArgs[input.name]),
+  );
+
+  if (nonSecretInputs.length === 0) return "";
+
+  const headers = nonSecretInputs.map((input) => input.name);
+
+  const columns = nonSecretInputs.map((input) => {
+    const current = currentArgs[input.name];
+    const raw =
+      typeof current === "string" && current.length > 0
+        ? current
+        : (input.default ?? "");
+
+    if (bulkInputNames.has(input.name) && raw.length > 0) {
+      return parseBulkValues(raw);
+    }
+    return [raw];
+  });
+
+  const rowCount = Math.max(...columns.map((col) => col.length), 1);
+
+  const rows: string[] = [headers.join(",")];
+  for (let i = 0; i < rowCount; i++) {
+    const row = columns.map((col) => {
+      const value = i < col.length ? col[i] : (col[0] ?? "");
+      return quoteCsvField(value);
+    });
+    rows.push(row.join(","));
+  }
+
+  return rows.join("\n");
+}

--- a/src/utils/csvBulkArgumentImport.test.ts
+++ b/src/utils/csvBulkArgumentImport.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from "vitest";
+
+import type { DynamicDataArgument, InputSpec } from "./componentSpec";
+import { mapCsvToArguments, parseCsv } from "./csvBulkArgumentImport";
+
+function makeSecretArg(name: string): DynamicDataArgument {
+  return { dynamicData: { secret: { name } } };
+}
+
+function makeInput(name: string, optional = false): InputSpec {
+  return { name, optional };
+}
+
+describe("parseCsv", () => {
+  it("parses simple CSV", () => {
+    expect(parseCsv("a,b,c\n1,2,3")).toEqual([
+      ["a", "b", "c"],
+      ["1", "2", "3"],
+    ]);
+  });
+
+  it("handles quoted fields with commas", () => {
+    expect(parseCsv('name,value\n"Smith, John",42')).toEqual([
+      ["name", "value"],
+      ["Smith, John", "42"],
+    ]);
+  });
+
+  it("handles escaped quotes inside quoted fields", () => {
+    expect(parseCsv('a\n"he said ""hi"""')).toEqual([["a"], ['he said "hi"']]);
+  });
+
+  it("returns empty array for empty string", () => {
+    expect(parseCsv("")).toEqual([]);
+  });
+
+  it("parses header-only CSV", () => {
+    expect(parseCsv("a,b,c")).toEqual([["a", "b", "c"]]);
+  });
+
+  it("handles Windows line endings", () => {
+    expect(parseCsv("a,b\r\n1,2")).toEqual([
+      ["a", "b"],
+      ["1", "2"],
+    ]);
+  });
+
+  it("trims whitespace on unquoted fields", () => {
+    expect(parseCsv("  a , b \n 1 , 2 ")).toEqual([
+      ["a", "b"],
+      ["1", "2"],
+    ]);
+  });
+
+  it("handles trailing newline", () => {
+    expect(parseCsv("a,b\n1,2\n")).toEqual([
+      ["a", "b"],
+      ["1", "2"],
+    ]);
+  });
+
+  it("handles multiple data rows", () => {
+    expect(parseCsv("x,y\n1,2\n3,4\n5,6")).toEqual([
+      ["x", "y"],
+      ["1", "2"],
+      ["3", "4"],
+      ["5", "6"],
+    ]);
+  });
+
+  it("handles mixed quoted and unquoted fields", () => {
+    expect(parseCsv('a,b,c\nplain,"has, comma",plain2')).toEqual([
+      ["a", "b", "c"],
+      ["plain", "has, comma", "plain2"],
+    ]);
+  });
+});
+
+describe("mapCsvToArguments", () => {
+  const inputs = [
+    makeInput("dataset"),
+    makeInput("model"),
+    makeInput("lr", true),
+  ];
+
+  it("populates values from single-row CSV", () => {
+    const csv = "dataset,model\ntrain.csv,random_forest";
+    const result = mapCsvToArguments(csv, inputs, { dataset: "", model: "" });
+
+    expect(result.values).toEqual({
+      dataset: "train.csv",
+      model: "random_forest",
+    });
+    expect(result.enableBulk).toBe(false);
+    expect(result.rowCount).toBe(1);
+  });
+
+  it("joins multi-row CSV values with comma-space for bulk mode", () => {
+    const csv = "dataset,model\ntrain.csv,rf\ntest.csv,gb\nval.csv,nn";
+    const result = mapCsvToArguments(csv, inputs, { dataset: "", model: "" });
+
+    expect(result.values).toEqual({
+      dataset: "train.csv, test.csv, val.csv",
+      model: "rf, gb, nn",
+    });
+    expect(result.enableBulk).toBe(true);
+    expect(result.rowCount).toBe(3);
+  });
+
+  it("reports unmatched columns", () => {
+    const csv = "dataset,unknown_col\ntrain.csv,foo";
+    const result = mapCsvToArguments(csv, inputs, { dataset: "" });
+
+    expect(result.values).toEqual({ dataset: "train.csv" });
+    expect(result.unmatchedColumns).toEqual(["unknown_col"]);
+  });
+
+  it("skips secret inputs", () => {
+    const csv = "dataset,api_key\ntrain.csv,sk-123";
+    const inputsWithSecret = [...inputs, makeInput("api_key")];
+    const currentArgs = { dataset: "", api_key: makeSecretArg("my-secret") };
+    const result = mapCsvToArguments(csv, inputsWithSecret, currentArgs);
+
+    expect(result.values).toEqual({ dataset: "train.csv" });
+    expect(result.skippedSecretInputs).toEqual(["api_key"]);
+  });
+
+  it("leaves inputs not in CSV unchanged", () => {
+    const csv = "dataset\ntrain.csv";
+    const result = mapCsvToArguments(csv, inputs, {
+      dataset: "",
+      model: "existing",
+    });
+
+    expect(result.values).toEqual({ dataset: "train.csv" });
+    expect("model" in result.values).toBe(false);
+  });
+
+  it("tracks only changed input names", () => {
+    const csv = "dataset,model\ntrain.csv,rf";
+    const result = mapCsvToArguments(csv, inputs, {
+      dataset: "train.csv",
+      model: "",
+    });
+
+    expect(result.changedInputNames).toEqual(["model"]);
+  });
+
+  it("returns empty result for empty CSV", () => {
+    const result = mapCsvToArguments("", inputs, {});
+
+    expect(result.values).toEqual({});
+    expect(result.rowCount).toBe(0);
+  });
+
+  it("returns empty result for header-only CSV", () => {
+    const result = mapCsvToArguments("dataset,model", inputs, {});
+
+    expect(result.values).toEqual({});
+    expect(result.rowCount).toBe(0);
+  });
+
+  it("reports all columns as unmatched when none match", () => {
+    const csv = "foo,bar\n1,2";
+    const result = mapCsvToArguments(csv, inputs, {});
+
+    expect(result.values).toEqual({});
+    expect(result.unmatchedColumns).toEqual(["foo", "bar"]);
+  });
+});

--- a/src/utils/csvBulkArgumentImport.ts
+++ b/src/utils/csvBulkArgumentImport.ts
@@ -1,0 +1,159 @@
+import {
+  type ArgumentType,
+  type InputSpec,
+  isSecretArgument,
+} from "./componentSpec";
+
+/**
+ * RFC 4180 CSV parser. Handles quoted fields with commas and escaped quotes.
+ *
+ * "name,value\nJohn,42" → [["name","value"],["John","42"]]
+ * 'a,b\n"has, comma",plain' → [["a","b"],["has, comma","plain"]]
+ */
+export function parseCsv(text: string): string[][] {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let field = "";
+  let inQuotes = false;
+  let i = 0;
+
+  while (i < text.length) {
+    const char = text[i];
+
+    if (inQuotes) {
+      if (char === '"') {
+        if (i + 1 < text.length && text[i + 1] === '"') {
+          field += '"';
+          i += 2;
+        } else {
+          inQuotes = false;
+          i++;
+        }
+      } else {
+        field += char;
+        i++;
+      }
+    } else {
+      if (char === '"' && field.length === 0) {
+        inQuotes = true;
+        i++;
+      } else if (char === ",") {
+        row.push(field.trim());
+        field = "";
+        i++;
+      } else if (char === "\r" && i + 1 < text.length && text[i + 1] === "\n") {
+        row.push(field.trim());
+        rows.push(row);
+        row = [];
+        field = "";
+        i += 2;
+      } else if (char === "\n") {
+        row.push(field.trim());
+        rows.push(row);
+        row = [];
+        field = "";
+        i++;
+      } else {
+        field += char;
+        i++;
+      }
+    }
+  }
+
+  // Flush last field/row
+  if (field.length > 0 || row.length > 0) {
+    row.push(field.trim());
+    rows.push(row);
+  }
+
+  return rows;
+}
+
+interface CsvImportResult {
+  values: Record<string, string>;
+  changedInputNames: string[];
+  enableBulk: boolean;
+  unmatchedColumns: string[];
+  skippedSecretInputs: string[];
+  rowCount: number;
+}
+
+/**
+ * Maps CSV data onto pipeline input arguments.
+ *
+ * Single data row: values go directly into matched inputs.
+ * Multiple data rows: values are joined with ", " (bulk input format).
+ */
+export function mapCsvToArguments(
+  csvText: string,
+  inputs: InputSpec[],
+  currentArgs: Record<string, ArgumentType>,
+): CsvImportResult {
+  const rows = parseCsv(csvText);
+
+  const empty: CsvImportResult = {
+    values: {},
+    changedInputNames: [],
+    enableBulk: false,
+    unmatchedColumns: [],
+    skippedSecretInputs: [],
+    rowCount: 0,
+  };
+
+  if (rows.length === 0) return empty;
+
+  const headers = rows[0];
+  const dataRows = rows.slice(1);
+  const rowCount = dataRows.length;
+
+  if (rowCount === 0) return { ...empty, rowCount: 0 };
+
+  const inputNameSet = new Set(inputs.map((i) => i.name));
+  const secretInputNames = new Set(
+    inputs
+      .filter((i) => isSecretArgument(currentArgs[i.name]))
+      .map((i) => i.name),
+  );
+
+  const unmatchedColumns: string[] = [];
+  const skippedSecretInputs: string[] = [];
+  const values: Record<string, string> = {};
+  const changedInputNames: string[] = [];
+
+  for (let colIdx = 0; colIdx < headers.length; colIdx++) {
+    const colName = headers[colIdx].trim();
+    if (!colName) continue;
+
+    if (!inputNameSet.has(colName)) {
+      unmatchedColumns.push(colName);
+      continue;
+    }
+
+    if (secretInputNames.has(colName)) {
+      skippedSecretInputs.push(colName);
+      continue;
+    }
+
+    const columnValues = dataRows.map((row) =>
+      colIdx < row.length ? row[colIdx] : "",
+    );
+
+    const newValue =
+      rowCount === 1 ? (columnValues[0] ?? "") : columnValues.join(", ");
+
+    values[colName] = newValue;
+
+    if (currentArgs[colName] !== newValue) {
+      changedInputNames.push(colName);
+    }
+  }
+
+  return {
+    values,
+    changedInputNames,
+    enableBulk: rowCount > 1,
+    unmatchedColumns,
+    skippedSecretInputs,
+    rowCount,
+  };
+}


### PR DESCRIPTION
## Description

Added CSV import and export functionality to the task arguments dialog. Users can now download a CSV template with current argument values and import CSV files to populate pipeline inputs. The import supports both single-row (direct value assignment) and multi-row (bulk submission) formats. Secret inputs are automatically excluded from CSV operations for security. The system provides feedback on successful imports, unmatched columns, and skipped secret fields.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)



[bulk_sub.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/05c7bf4c-786f-46fe-856b-04d451de5442.mov" />](https://app.graphite.com/user-attachments/video/05c7bf4c-786f-46fe-856b-04d451de5442.mov)



## Test Instructions

1. Open a pipeline submission dialog
2. Click "Template" button to download a CSV template with current argument values
3. Modify the CSV file with test data (single row for direct import, multiple rows for bulk)
4. Click "Import CSV" button and select the modified file
5. Verify that arguments are populated correctly and bulk mode is enabled for multi-row imports
6. Test with CSV containing unmatched columns and verify warning messages
7. Test with pipelines containing secret inputs to ensure they are properly excluded

## Additional Comments

The CSV parser implements RFC 4180 standards, handling quoted fields with commas and escaped quotes. Comprehensive test coverage is included for all parsing and mapping functionality.