### PR TITLE
Add JSON file import support to task arguments dialog

### DIFF
--- a/src/components/shared/Submitters/Oasis/components/SubmitTaskArgumentsDialog.tsx
+++ b/src/components/shared/Submitters/Oasis/components/SubmitTaskArgumentsDialog.tsx
@@ -53,6 +53,7 @@ import {
 } from "@/utils/componentSpec";
 import { generateCsvTemplate } from "@/utils/csvBulkArgumentExport";
 import { mapCsvToArguments } from "@/utils/csvBulkArgumentImport";
+import { mapJsonToArguments } from "@/utils/jsonBulkArgumentImport";
 import { extractTaskArguments } from "@/utils/nodes/taskArguments";
 import { pluralize } from "@/utils/string";
 import { validateArguments } from "@/utils/validations";
@@ -137,11 +138,20 @@ export const SubmitTaskArgumentsDialog = ({
     });
   };
 
-  const handleCsvImport = (csvText: string) => {
-    const result = mapCsvToArguments(csvText, inputs, taskArguments);
+  const handleFileImport = (fileText: string, fileExtension: string) => {
+    const isJson = fileExtension === ".json";
+
+    const result = isJson
+      ? mapJsonToArguments(fileText, inputs, taskArguments)
+      : mapCsvToArguments(fileText, inputs, taskArguments);
 
     if (result.rowCount === 0 && result.changedInputNames.length === 0) {
-      notify("CSV file is empty or contains only headers", "warning");
+      notify(
+        isJson
+          ? "JSON file is empty or contains invalid data"
+          : "CSV file is empty or contains only headers",
+        "warning",
+      );
       return;
     }
 
@@ -169,10 +179,11 @@ export const SubmitTaskArgumentsDialog = ({
 
     let message = result.enableBulk
       ? `Imported ${result.rowCount} rows across ${inputCount} ${pluralize(inputCount, "input")}`
-      : `Imported ${inputCount} ${pluralize(inputCount, "input")} from CSV`;
+      : `Imported ${inputCount} ${pluralize(inputCount, "input")} from ${isJson ? "JSON" : "CSV"}`;
 
     if (result.unmatchedColumns.length > 0) {
-      message += `. Ignored columns: ${result.unmatchedColumns.join(", ")}`;
+      const keyLabel = isJson ? "keys" : "columns";
+      message += `. Ignored ${keyLabel}: ${result.unmatchedColumns.join(", ")}`;
     }
 
     if (result.skippedSecretInputs.length > 0) {
@@ -218,7 +229,7 @@ export const SubmitTaskArgumentsDialog = ({
                   bulkInputNames={bulkInputNames}
                   pipelineName={componentSpec.name}
                 />
-                <ImportCsvButton onImport={handleCsvImport} />
+                <ImportFileButton onImport={handleFileImport} />
                 <CopyFromRunPopover
                   componentSpec={componentSpec}
                   onCopy={handleCopyFromRun}
@@ -247,7 +258,8 @@ export const SubmitTaskArgumentsDialog = ({
               </Paragraph>
               ). Each value creates a separate run. Non-bulk inputs reuse their
               single value across all runs. If multiple inputs are set to bulk,
-              they must have the same number of values.
+              they must have the same number of values. You can also import a
+              CSV or JSON file to populate values automatically.
             </Paragraph>
           </BlockStack>
         )}
@@ -617,10 +629,10 @@ const DownloadCsvTemplateButton = ({
   );
 };
 
-const ImportCsvButton = ({
+const ImportFileButton = ({
   onImport,
 }: {
-  onImport: (csvText: string) => void;
+  onImport: (fileText: string, fileExtension: string) => void;
 }) => {
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -628,11 +640,15 @@ const ImportCsvButton = ({
     const file = e.target.files?.[0];
     if (!file) return;
 
+    const extension = file.name.includes(".")
+      ? `.${file.name.split(".").pop()?.toLowerCase()}`
+      : "";
+
     const reader = new FileReader();
     reader.onload = (event) => {
       const text = event.target?.result;
       if (typeof text === "string") {
-        onImport(text);
+        onImport(text, extension);
       }
     };
     reader.readAsText(file);
@@ -648,7 +664,7 @@ const ImportCsvButton = ({
       <input
         ref={fileInputRef}
         type="file"
-        accept=".csv"
+        accept=".csv,.json"
         onChange={handleFileChange}
         className="hidden"
       />
@@ -657,8 +673,8 @@ const ImportCsvButton = ({
         size="sm"
         onClick={() => fileInputRef.current?.click()}
       >
-        <Icon name="FileSpreadsheet" />
-        Import CSV
+        <Icon name="Upload" />
+        Import
       </Button>
     </>
   );

--- a/src/utils/bulkSubmission.test.ts
+++ b/src/utils/bulkSubmission.test.ts
@@ -42,6 +42,65 @@ describe("parseBulkValues", () => {
       "foo bar",
     ]);
   });
+
+  it("does not split on commas inside JSON objects", () => {
+    expect(parseBulkValues('{"a":1,"b":2}, {"a":3,"b":4}')).toEqual([
+      '{"a":1,"b":2}',
+      '{"a":3,"b":4}',
+    ]);
+  });
+
+  it("does not split on commas inside JSON arrays", () => {
+    expect(parseBulkValues("[1,2,3], [4,5,6]")).toEqual(["[1,2,3]", "[4,5,6]"]);
+  });
+
+  it("does not split on commas inside nested structures", () => {
+    expect(
+      parseBulkValues(
+        '{"config":{"lr":0.01,"epochs":100}}, {"config":{"lr":0.02,"epochs":200}}',
+      ),
+    ).toEqual([
+      '{"config":{"lr":0.01,"epochs":100}}',
+      '{"config":{"lr":0.02,"epochs":200}}',
+    ]);
+  });
+
+  it("handles mix of plain values and JSON objects", () => {
+    expect(parseBulkValues('simple, {"key":"value"}, plain')).toEqual([
+      "simple",
+      '{"key":"value"}',
+      "plain",
+    ]);
+  });
+
+  it("unquotes JSON-quoted values that contain commas", () => {
+    expect(parseBulkValues('"hello, world", "foo, bar"')).toEqual([
+      "hello, world",
+      "foo, bar",
+    ]);
+  });
+
+  it("unquotes mixed quoted and unquoted values", () => {
+    expect(parseBulkValues('simple, "has, comma", plain')).toEqual([
+      "simple",
+      "has, comma",
+      "plain",
+    ]);
+  });
+
+  it("treats an opening quote as starting a quoted value", () => {
+    // An unclosed quote consumes the rest of the string as one value
+    expect(parseBulkValues('"incomplete, normal')).toEqual([
+      '"incomplete, normal',
+    ]);
+  });
+
+  it("handles quoted values with escaped quotes inside", () => {
+    expect(parseBulkValues('"say \\"hello, world\\"", other')).toEqual([
+      'say "hello, world"',
+      "other",
+    ]);
+  });
 });
 
 describe("expandBulkArguments", () => {

--- a/src/utils/bulkSubmission.ts
+++ b/src/utils/bulkSubmission.ts
@@ -1,10 +1,99 @@
 import type { ArgumentType } from "./componentSpec";
 
+/**
+ * Splits a comma-separated bulk value string into individual values.
+ *
+ * Structure-aware: commas inside `{…}`, `[…]`, or `"…"` are not treated
+ * as separators, so JSON-stringified objects survive the round-trip.
+ */
 export function parseBulkValues(raw: string): string[] {
-  return raw
-    .split(",")
-    .map((v) => v.trim())
-    .filter((v) => v.length > 0);
+  const values: string[] = [];
+  let current = "";
+  let braceDepth = 0;
+  let bracketDepth = 0;
+  let inQuote = false;
+
+  for (let i = 0; i < raw.length; i++) {
+    const char = raw[i];
+
+    if (inQuote) {
+      current += char;
+      if (char === "\\" && i + 1 < raw.length) {
+        current += raw[++i];
+      } else if (char === '"') {
+        inQuote = false;
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      inQuote = true;
+      current += char;
+      continue;
+    }
+
+    if (char === "{") {
+      braceDepth++;
+      current += char;
+      continue;
+    }
+
+    if (char === "}") {
+      braceDepth = Math.max(0, braceDepth - 1);
+      current += char;
+      continue;
+    }
+
+    if (char === "[") {
+      bracketDepth++;
+      current += char;
+      continue;
+    }
+
+    if (char === "]") {
+      bracketDepth = Math.max(0, bracketDepth - 1);
+      current += char;
+      continue;
+    }
+
+    if (char === "," && braceDepth === 0 && bracketDepth === 0) {
+      const trimmed = current.trim();
+      if (trimmed.length > 0) {
+        values.push(unquote(trimmed));
+      }
+      current = "";
+      continue;
+    }
+
+    current += char;
+  }
+
+  const trimmed = current.trim();
+  if (trimmed.length > 0) {
+    values.push(unquote(trimmed));
+  }
+
+  return values;
+}
+
+/**
+ * If a value is wrapped in double quotes (e.g. from JSON import quoting
+ * values that contain commas), strip the quotes and unescape.
+ */
+function unquote(value: string): string {
+  if (
+    value.length >= 2 &&
+    value[0] === '"' &&
+    value[value.length - 1] === '"'
+  ) {
+    try {
+      const parsed = JSON.parse(value);
+      if (typeof parsed === "string") return parsed;
+    } catch {
+      // Not valid JSON-quoted string, return as-is
+    }
+  }
+  return value;
 }
 
 function buildBulkCountMismatchMessage(counts: Record<string, number>): string {

--- a/src/utils/jsonBulkArgumentImport.test.ts
+++ b/src/utils/jsonBulkArgumentImport.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from "vitest";
+
+import type { DynamicDataArgument, InputSpec } from "./componentSpec";
+import { mapJsonToArguments } from "./jsonBulkArgumentImport";
+
+function makeSecretArg(name: string): DynamicDataArgument {
+  return { dynamicData: { secret: { name } } };
+}
+
+function makeInput(name: string, optional = false): InputSpec {
+  return { name, optional };
+}
+
+describe("mapJsonToArguments", () => {
+  const inputs = [
+    makeInput("dataset"),
+    makeInput("model"),
+    makeInput("lr", true),
+  ];
+
+  it("populates values from single object", () => {
+    const json = JSON.stringify({ dataset: "train.csv", model: "rf" });
+    const result = mapJsonToArguments(json, inputs, { dataset: "", model: "" });
+
+    expect(result.values).toEqual({ dataset: "train.csv", model: "rf" });
+    expect(result.enableBulk).toBe(false);
+    expect(result.rowCount).toBe(1);
+  });
+
+  it("joins array elements for bulk mode", () => {
+    const json = JSON.stringify([
+      { dataset: "train.csv", model: "rf" },
+      { dataset: "test.csv", model: "gb" },
+      { dataset: "val.csv", model: "nn" },
+    ]);
+    const result = mapJsonToArguments(json, inputs, { dataset: "", model: "" });
+
+    expect(result.values).toEqual({
+      dataset: "train.csv, test.csv, val.csv",
+      model: "rf, gb, nn",
+    });
+    expect(result.enableBulk).toBe(true);
+    expect(result.rowCount).toBe(3);
+  });
+
+  it("JSON.stringifies object values", () => {
+    const json = JSON.stringify({
+      dataset: "train.csv",
+      model: { type: "rf", depth: 5 },
+    });
+    const result = mapJsonToArguments(json, inputs, { dataset: "", model: "" });
+
+    expect(result.values.model).toBe('{"type":"rf","depth":5}');
+  });
+
+  it("JSON.stringifies number values", () => {
+    const json = JSON.stringify({ lr: 0.01 });
+    const result = mapJsonToArguments(json, inputs, {});
+
+    expect(result.values.lr).toBe("0.01");
+  });
+
+  it("JSON.stringifies array values", () => {
+    const json = JSON.stringify({ dataset: [1, 2, 3] });
+    const result = mapJsonToArguments(json, inputs, {});
+
+    expect(result.values.dataset).toBe("[1,2,3]");
+  });
+
+  it("handles mixed string and object values across bulk rows", () => {
+    const json = JSON.stringify([
+      { model: "simple" },
+      { model: { type: "complex", layers: 3 } },
+    ]);
+    const result = mapJsonToArguments(json, inputs, { model: "" });
+
+    expect(result.values.model).toBe('simple, {"type":"complex","layers":3}');
+    expect(result.enableBulk).toBe(true);
+  });
+
+  it("reports unmatched keys", () => {
+    const json = JSON.stringify({ dataset: "train.csv", unknown_key: "foo" });
+    const result = mapJsonToArguments(json, inputs, { dataset: "" });
+
+    expect(result.values).toEqual({ dataset: "train.csv" });
+    expect(result.unmatchedColumns).toEqual(["unknown_key"]);
+  });
+
+  it("skips secret inputs", () => {
+    const json = JSON.stringify({ dataset: "train.csv", api_key: "sk-123" });
+    const inputsWithSecret = [...inputs, makeInput("api_key")];
+    const currentArgs = { dataset: "", api_key: makeSecretArg("my-secret") };
+    const result = mapJsonToArguments(json, inputsWithSecret, currentArgs);
+
+    expect(result.values).toEqual({ dataset: "train.csv" });
+    expect(result.skippedSecretInputs).toEqual(["api_key"]);
+  });
+
+  it("tracks only changed input names", () => {
+    const json = JSON.stringify({ dataset: "train.csv", model: "rf" });
+    const result = mapJsonToArguments(json, inputs, {
+      dataset: "train.csv",
+      model: "",
+    });
+
+    expect(result.changedInputNames).toEqual(["model"]);
+  });
+
+  it("does not include inputs not present in JSON", () => {
+    const json = JSON.stringify({ dataset: "train.csv" });
+    const result = mapJsonToArguments(json, inputs, {
+      dataset: "",
+      model: "existing",
+    });
+
+    expect(result.values).toEqual({ dataset: "train.csv" });
+    expect("model" in result.values).toBe(false);
+  });
+
+  it("treats null values as empty strings", () => {
+    const json = JSON.stringify({ dataset: null });
+    const result = mapJsonToArguments(json, inputs, { dataset: "old" });
+
+    expect(result.values.dataset).toBe("");
+  });
+
+  it("uses empty string for keys missing in some rows", () => {
+    const json = JSON.stringify([
+      { dataset: "a", model: "x" },
+      { dataset: "b" },
+    ]);
+    const result = mapJsonToArguments(json, inputs, { dataset: "", model: "" });
+
+    expect(result.values.dataset).toBe("a, b");
+    expect(result.values.model).toBe("x, ");
+  });
+
+  it("returns empty result for invalid JSON", () => {
+    const result = mapJsonToArguments("not valid json{", inputs, {});
+
+    expect(result.values).toEqual({});
+    expect(result.rowCount).toBe(0);
+  });
+
+  it("returns empty result for non-object JSON", () => {
+    expect(mapJsonToArguments('"just a string"', inputs, {}).rowCount).toBe(0);
+    expect(mapJsonToArguments("42", inputs, {}).rowCount).toBe(0);
+    expect(mapJsonToArguments("true", inputs, {}).rowCount).toBe(0);
+  });
+
+  it("returns empty result for array of non-objects", () => {
+    const result = mapJsonToArguments("[1, 2, 3]", inputs, {});
+
+    expect(result.values).toEqual({});
+    expect(result.rowCount).toBe(0);
+  });
+
+  it("returns empty result for empty array", () => {
+    const result = mapJsonToArguments("[]", inputs, {});
+
+    expect(result.values).toEqual({});
+    expect(result.rowCount).toBe(0);
+  });
+
+  it("handles empty object with rowCount 1", () => {
+    const result = mapJsonToArguments("{}", inputs, {});
+
+    expect(result.values).toEqual({});
+    expect(result.rowCount).toBe(1);
+  });
+
+  it("quotes string values containing commas for bulk round-trip", () => {
+    const inputsWithScript = [...inputs, makeInput("script")];
+    const json = JSON.stringify([
+      { script: "train(lr=0.01, epochs=100)" },
+      { script: "train(lr=0.02, epochs=200)" },
+    ]);
+    const result = mapJsonToArguments(json, inputsWithScript, { script: "" });
+
+    // Values are quoted so parseBulkValues won't split on internal commas
+    expect(result.values.script).toBe(
+      '"train(lr=0.01, epochs=100)", "train(lr=0.02, epochs=200)"',
+    );
+    expect(result.rowCount).toBe(2);
+  });
+
+  it("does not quote string values without commas in bulk", () => {
+    const json = JSON.stringify([
+      { dataset: "train.csv" },
+      { dataset: "test.csv" },
+    ]);
+    const result = mapJsonToArguments(json, inputs, { dataset: "" });
+
+    expect(result.values.dataset).toBe("train.csv, test.csv");
+  });
+});

--- a/src/utils/jsonBulkArgumentImport.ts
+++ b/src/utils/jsonBulkArgumentImport.ts
@@ -1,0 +1,141 @@
+import {
+  type ArgumentType,
+  type InputSpec,
+  isSecretArgument,
+} from "./componentSpec";
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Converts a JSON value to a string for use as an input argument.
+ *
+ * Strings pass through as-is. Objects, arrays, numbers, and booleans
+ * are JSON.stringified so users can write raw JSON in their import files
+ * instead of pre-escaping everything.
+ */
+function valueToString(value: unknown): string {
+  if (value === undefined || value === null) return "";
+  if (typeof value === "string") return value;
+  return JSON.stringify(value);
+}
+
+interface JsonImportResult {
+  values: Record<string, string>;
+  changedInputNames: string[];
+  enableBulk: boolean;
+  unmatchedColumns: string[];
+  skippedSecretInputs: string[];
+  rowCount: number;
+}
+
+/**
+ * Maps JSON data onto pipeline input arguments.
+ *
+ * Single object: values go directly into matched inputs.
+ *   { "dataset": "train.csv", "model": "rf" } → dataset=train.csv, model=rf
+ *
+ * Array of objects: values are joined with ", " (bulk input format).
+ *   [{ "dataset": "a" }, { "dataset": "b" }] → dataset="a, b", bulk enabled
+ *
+ * Non-string values are JSON.stringified:
+ *   { "config": { "lr": 0.01 } } → config='{"lr":0.01}'
+ */
+export function mapJsonToArguments(
+  jsonText: string,
+  inputs: InputSpec[],
+  currentArgs: Record<string, ArgumentType>,
+): JsonImportResult {
+  const empty: JsonImportResult = {
+    values: {},
+    changedInputNames: [],
+    enableBulk: false,
+    unmatchedColumns: [],
+    skippedSecretInputs: [],
+    rowCount: 0,
+  };
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(jsonText);
+  } catch {
+    return empty;
+  }
+
+  let rows: Record<string, unknown>[];
+  if (Array.isArray(parsed)) {
+    if (!parsed.every(isPlainObject)) return empty;
+    rows = parsed;
+  } else if (isPlainObject(parsed)) {
+    rows = [parsed];
+  } else {
+    return empty;
+  }
+
+  if (rows.length === 0) return empty;
+
+  const rowCount = rows.length;
+
+  const inputNameSet = new Set(inputs.map((i) => i.name));
+  const secretInputNames = new Set(
+    inputs
+      .filter((i) => isSecretArgument(currentArgs[i.name]))
+      .map((i) => i.name),
+  );
+
+  // Collect all unique keys across all rows
+  const allKeys = new Set<string>();
+  for (const row of rows) {
+    for (const key of Object.keys(row)) {
+      allKeys.add(key);
+    }
+  }
+
+  const unmatchedColumns: string[] = [];
+  const skippedSecretInputs: string[] = [];
+  const values: Record<string, string> = {};
+  const changedInputNames: string[] = [];
+
+  for (const key of allKeys) {
+    if (!inputNameSet.has(key)) {
+      unmatchedColumns.push(key);
+      continue;
+    }
+
+    if (secretInputNames.has(key)) {
+      skippedSecretInputs.push(key);
+      continue;
+    }
+
+    const columnValues = rows.map((row) => valueToString(row[key]));
+
+    let newValue: string;
+    if (rowCount === 1) {
+      newValue = columnValues[0] ?? "";
+    } else {
+      // Quote plain string values that contain commas so parseBulkValues
+      // doesn't split them. Values starting with { or [ are already protected
+      // by brace/bracket depth tracking in the parser.
+      const quotedValues = columnValues.map((v) =>
+        v.includes(",") && v[0] !== "{" && v[0] !== "[" ? JSON.stringify(v) : v,
+      );
+      newValue = quotedValues.join(", ");
+    }
+
+    values[key] = newValue;
+
+    if (currentArgs[key] !== newValue) {
+      changedInputNames.push(key);
+    }
+  }
+
+  return {
+    values,
+    changedInputNames,
+    enableBulk: rowCount > 1,
+    unmatchedColumns,
+    skippedSecretInputs,
+    rowCount,
+  };
+}


### PR DESCRIPTION
## Description

Added JSON file import support to the task arguments dialog alongside existing CSV import functionality. Users can now import both CSV and JSON files to populate pipeline input values. The JSON import supports single objects for direct value mapping and arrays of objects for bulk input mode. Non-string values (objects, arrays, numbers) are automatically JSON.stringified for proper handling.

Enhanced the bulk value parser to be structure-aware, preventing incorrect splitting on commas inside JSON objects, arrays, or quoted strings during bulk input processing.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions  
JSON used for testing

```json
[
  {
    "experiment_key": "12345",
    "predictions": "1234",
    "config": { "dslName": "experiment_a", "lr": 0.01, "epochs": 100 },
    "tags": ["production", "v2"],
    "metadata": { "owner": "alice", "team": "ml-platform", "priority": 1 },
    "script": "import torch\nmodel = torch.load('checkpoint.pt')\nresults = model.evaluate(dataset='train')"
  },
  {
    "experiment_key": "1",
    "predictions": "4",
    "config": { "dslName": "experiment_b", "lr": 0.001, "epochs": 200 },
    "tags": ["staging", "v2"],
    "metadata": { "owner": "bob", "team": "ml-platform", "priority": 2 },
    "script": "from sklearn.ensemble import RandomForestClassifier\nclf = RandomForestClassifier(n_estimators=100, max_depth=5)\nclf.fit(X_train, y_train)"
  },
  {
    "experiment_key": "2",
    "predictions": "6",
    "config": { "dslName": "experiment_c", "lr": 0.01, "epochs": 100, "scheduler": { "type": "cosine", "warmup_steps": 500 } },
    "tags": ["production", "v3"],
    "metadata": { "owner": "alice", "team": "recommendations", "priority": 1 },
    "script": "params = {\"batch_size\": 32, \"dropout\": 0.1}\nrun_training(**params)"
  },
  {
    "experiment_key": "9",
    "predictions": "5",
    "config": { "dslName": "experiment_d", "lr": 0.02, "epochs": 50, "scheduler": { "type": "linear", "warmup_steps": 100 } },
    "tags": ["canary"],
    "metadata": { "owner": "carol", "team": "recommendations", "priority": 3 },
    "script": "data = [x for x in range(100) if x % 2 == 0]\nprint(f'filtered {len(data)} items')"
  }
]

```

1. Navigate to a pipeline task submission dialog
2. Test CSV import functionality to ensure existing behavior is preserved
3. Test JSON import with a single object: `{"input1": "value1", "input2": "value2"}`
4. Test JSON import with an array for bulk mode: `[{"input1": "a"}, {"input1": "b"}]`
5. Test JSON import with complex values: `{"config": {"lr": 0.01, "epochs": 100}}`
6. Verify bulk input parsing handles JSON objects correctly without splitting on internal commas
7. Test error handling with invalid JSON files

## Additional Comments

The import button now accepts both `.csv` and `.json` files and dynamically handles the appropriate parsing logic based on file extension. The UI messaging adapts to show whether CSV or JSON data was imported, including appropriate terminology for ignored columns/keys.