### PR TITLE
chore: Prevent unnecessary API calls to get container execution details

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/logs.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/logs.tsx
@@ -7,6 +7,7 @@ import { Link } from "@/components/ui/link";
 import { Spinner } from "@/components/ui/spinner";
 import { useBackend } from "@/providers/BackendProvider";
 import { getBackendStatusString } from "@/utils/backend";
+import { CONTAINER_STATUSES_PRE_LAUNCH } from "@/utils/executionStatus";
 
 const LogDisplay = ({
   logs,
@@ -52,15 +53,14 @@ const LogDisplay = ({
   );
 };
 
+/**
+ * Statuses where the container is running and actively producing logs.
+ * Used to decide whether to poll for new log content.
+ */
 const isStatusActivelyLogging = (status?: string): boolean => {
-  if (!status) {
-    return false;
-  }
   switch (status) {
     case "RUNNING":
     case "PENDING":
-    case "QUEUED":
-    case "WAITING_FOR_UPSTREAM":
     case "CANCELLING":
       return true;
     default:
@@ -68,24 +68,14 @@ const isStatusActivelyLogging = (status?: string): boolean => {
   }
 };
 
+/**
+ * Returns true if the container may have logs worth fetching.
+ */
 const shouldStatusHaveLogs = (status?: string): boolean => {
   if (!status) {
     return false;
   }
-
-  if (isStatusActivelyLogging(status)) {
-    return true;
-  }
-
-  switch (status) {
-    case "FAILED":
-    case "SYSTEM_ERROR":
-    case "SUCCEEDED":
-    case "CANCELLED":
-      return true;
-    default:
-      return false;
-  }
+  return !CONTAINER_STATUSES_PRE_LAUNCH.has(status);
 };
 
 const getLogs = async (executionId: string, backendUrl: string) => {
@@ -104,8 +94,9 @@ const Logs = ({
 }) => {
   const { backendUrl, configured, available } = useBackend();
 
-  const [isLogging, setIsLogging] = useState(!!executionId);
-  const [shouldHaveLogs, setShouldHaveLogs] = useState(!!executionId);
+  const shouldFetch = !!executionId && shouldStatusHaveLogs(status);
+  const shouldPoll = shouldFetch && isStatusActivelyLogging(status);
+
   const [logs, setLogs] = useState<{
     log_text?: string;
     system_error_exception_full?: string;
@@ -113,17 +104,10 @@ const Logs = ({
   const { data, isLoading, error, refetch } = useQuery({
     queryKey: ["logs", executionId],
     queryFn: () => getLogs(String(executionId), backendUrl),
-    enabled: isLogging,
-    refetchInterval: 5000,
+    enabled: shouldFetch,
+    refetchInterval: shouldPoll ? 5000 : false,
     refetchIntervalInBackground: false,
   });
-
-  useEffect(() => {
-    if (status) {
-      setIsLogging(isStatusActivelyLogging(status));
-      setShouldHaveLogs(shouldStatusHaveLogs(status));
-    }
-  }, [status]);
 
   useEffect(() => {
     if (data && !error) {
@@ -139,8 +123,10 @@ const Logs = ({
   }, [data, error]);
 
   useEffect(() => {
-    refetch();
-  }, [backendUrl, refetch]);
+    if (shouldFetch) {
+      refetch();
+    }
+  }, [backendUrl, refetch, shouldFetch]);
 
   if (!configured) {
     return (
@@ -150,7 +136,7 @@ const Logs = ({
     );
   }
 
-  if (!shouldHaveLogs) {
+  if (!shouldFetch && !logs) {
     return (
       <InfoBox title="No logs available" variant="info">
         Logs are available only for active, queued and completed executions.

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/tests/logs.test.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/tests/logs.test.tsx
@@ -87,18 +87,20 @@ describe("OpenLogsInNewWindowLink", () => {
     const statusesThatShouldHaveLogs: ContainerExecutionStatus[] = [
       "RUNNING",
       "PENDING",
-      "QUEUED",
-      "WAITING_FOR_UPSTREAM",
       "CANCELLING",
       "FAILED",
       "SYSTEM_ERROR",
       "SUCCEEDED",
+      // CANCELLED may have logs when the task was cancelled mid-run; the
+      // backend uploads logs before termination in that path.
       "CANCELLED",
     ];
 
     const statusesThatShouldNotHaveLogs: ContainerExecutionStatus[] = [
       "INVALID",
       "UNINITIALIZED",
+      "QUEUED",
+      "WAITING_FOR_UPSTREAM",
       "SKIPPED",
     ];
 

--- a/src/components/shared/TaskDetails/Details.tsx
+++ b/src/components/shared/TaskDetails/Details.tsx
@@ -125,6 +125,7 @@ const TaskDetailsInternal = ({
         <ExecutionDetails
           executionId={executionId}
           componentSpec={hydratedComponentRef.spec}
+          status={status}
           className={BASE_BLOCK_CLASS}
         />
       )}

--- a/src/components/shared/TaskDetails/ExecutionDetails.tsx
+++ b/src/components/shared/TaskDetails/ExecutionDetails.tsx
@@ -18,12 +18,14 @@ import { InfoBox } from "../InfoBox";
 interface ExecutionDetailsProps {
   executionId: string;
   componentSpec?: ComponentSpec;
+  status?: string;
   className?: string;
 }
 
 export const ExecutionDetails = ({
   executionId,
   componentSpec,
+  status,
   className,
 }: ExecutionDetailsProps) => {
   const { backendUrl } = useBackend();
@@ -35,7 +37,11 @@ export const ExecutionDetails = ({
     data: containerState,
     isLoading: isLoadingContainerState,
     error: containerStateError,
-  } = useFetchContainerExecutionState(executionId, backendUrl);
+  } = useFetchContainerExecutionState(
+    isSubgraph ? undefined : executionId,
+    backendUrl,
+    status,
+  );
 
   const getExecutionItems = () => {
     const items: AttributeProps[] = [

--- a/src/services/executionService.ts
+++ b/src/services/executionService.ts
@@ -13,6 +13,7 @@ import {
   TWENTY_FOUR_HOURS_IN_MS,
 } from "@/utils/constants";
 import {
+  CONTAINER_STATUSES_PRE_LAUNCH,
   flattenExecutionStatusStats,
   getOverallExecutionStatusFromStats,
 } from "@/utils/executionStatus";
@@ -69,11 +70,15 @@ const fetchContainerExecutionState = async (
 export const useFetchContainerExecutionState = (
   executionId: string | undefined,
   backendUrl: string,
+  status?: string,
 ) => {
+  const shouldFetch =
+    !!executionId && (!status || !CONTAINER_STATUSES_PRE_LAUNCH.has(status));
+
   return useQuery<GetContainerExecutionStateResponse>({
     queryKey: ["container-execution-state", executionId],
     queryFn: () => fetchContainerExecutionState(executionId!, backendUrl),
-    enabled: !!executionId,
+    enabled: shouldFetch,
     refetchOnWindowFocus: false,
   });
 };

--- a/src/utils/executionStatus.ts
+++ b/src/utils/executionStatus.ts
@@ -43,6 +43,23 @@ export const EXECUTION_STATUS_BG_COLORS: Record<string, string> = {
 };
 
 /**
+ * Statuses where the container was never launched.
+ * Used to skip fetches to /container_state and /container_log — both of which
+ * require a container execution record that won't exist for these statuses.
+ *
+ * CANCELLED is excluded: a task cancelled mid-run (while PENDING or RUNNING)
+ * will have a container execution record and uploaded logs, and the frontend
+ * cannot distinguish that from a pre-launch cancellation by status alone.
+ */
+export const CONTAINER_STATUSES_PRE_LAUNCH = new Set([
+  "INVALID",
+  "UNINITIALIZED",
+  "QUEUED",
+  "WAITING_FOR_UPSTREAM",
+  "SKIPPED",
+]);
+
+/**
  * Statuses considered "in progress" (not terminal).
  */
 const IN_PROGRESS_STATUSES = new Set([


### PR DESCRIPTION
## Description

## Before

![image.png](https://app.graphite.com/user-attachments/assets/b01e3301-d7f3-47f7-b329-048e7bce65df.png)

## After

![image.png](https://app.graphite.com/user-attachments/assets/676aa0e2-0b2a-432f-a1c1-b57824c2ebf7.png)

Optimized container execution state and log fetching by preventing unnecessary API calls for containers in expected non-execution states. Added status-based conditional fetching that skips requests when containers are in states like INVALID, UNINITIALIZED, QUEUED, WAITING_FOR_UPSTREAM, or SKIPPED, where execution records and logs are not expected to exist. Refined log polling logic to only poll for actively running containers (RUNNING, PENDING, CANCELLING) while still allowing log fetches for completed states that may have logs.

## Related Issue and Pull requests

## Type of Change

- [x] Improvement

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality

## Screenshots (if applicable)

## Test Instructions

1. Navigate to task details for containers with statuses: INVALID, UNINITIALIZED, QUEUED, WAITING_FOR_UPSTREAM, or SKIPPED
2. Verify that no container execution state or log API calls are made for these statuses
3. Confirm that containers with RUNNING, PENDING, or CANCELLING statuses actively poll for logs every 5 seconds
4. Test that completed containers (SUCCEEDED, FAILED, SYSTEM_ERROR, CANCELLED) fetch logs once without polling
5. Verify that the ExecutionDetails and Logs components still render correctly for all status types

## Additional Comments

This change reduces unnecessary network requests and prevents potential errors when trying to fetch execution state or logs for containers that haven't been launched or were terminated before execution began. The CANCELLED status is intentionally handled carefully since tasks cancelled mid-run may have logs uploaded by the backend before termination.