### PR TITLE
Add YAML file import support to task arguments dialog

### DIFF
--- a/src/components/shared/Submitters/Oasis/components/SubmitTaskArgumentsDialog.tsx
+++ b/src/components/shared/Submitters/Oasis/components/SubmitTaskArgumentsDialog.tsx
@@ -1,4 +1,5 @@
 import { useMutation } from "@tanstack/react-query";
+import yaml from "js-yaml";
 import { type ChangeEvent, useRef, useState } from "react";
 
 import type { TaskSpecOutput } from "@/api/types.gen";
@@ -139,16 +140,27 @@ export const SubmitTaskArgumentsDialog = ({
   };
 
   const handleFileImport = (fileText: string, fileExtension: string) => {
-    const isJson = fileExtension === ".json";
+    const isYaml = fileExtension === ".yaml" || fileExtension === ".yml";
+    const isJson = fileExtension === ".json" || isYaml;
+
+    let jsonText = fileText;
+    if (isYaml) {
+      try {
+        jsonText = JSON.stringify(yaml.load(fileText));
+      } catch {
+        notify("YAML file contains invalid syntax", "warning");
+        return;
+      }
+    }
 
     const result = isJson
-      ? mapJsonToArguments(fileText, inputs, taskArguments)
+      ? mapJsonToArguments(jsonText, inputs, taskArguments)
       : mapCsvToArguments(fileText, inputs, taskArguments);
 
     if (result.rowCount === 0 && result.changedInputNames.length === 0) {
       notify(
         isJson
-          ? "JSON file is empty or contains invalid data"
+          ? "File is empty or contains invalid data"
           : "CSV file is empty or contains only headers",
         "warning",
       );
@@ -179,7 +191,7 @@ export const SubmitTaskArgumentsDialog = ({
 
     let message = result.enableBulk
       ? `Imported ${result.rowCount} rows across ${inputCount} ${pluralize(inputCount, "input")}`
-      : `Imported ${inputCount} ${pluralize(inputCount, "input")} from ${isJson ? "JSON" : "CSV"}`;
+      : `Imported ${inputCount} ${pluralize(inputCount, "input")} from ${isJson ? (isYaml ? "YAML" : "JSON") : "CSV"}`;
 
     if (result.unmatchedColumns.length > 0) {
       const keyLabel = isJson ? "keys" : "columns";
@@ -664,7 +676,7 @@ const ImportFileButton = ({
       <input
         ref={fileInputRef}
         type="file"
-        accept=".csv,.json"
+        accept=".csv,.json,.yaml,.yml"
         onChange={handleFileChange}
         className="hidden"
       />


### PR DESCRIPTION
## Description

Added YAML file import support to the SubmitTaskArgumentsDialog component. The dialog now accepts `.yaml` and `.yml` files in addition to existing CSV and JSON formats. YAML files are parsed using the `js-yaml` library and converted to JSON format before processing through the existing argument mapping logic. Added error handling for invalid YAML syntax with appropriate user notifications.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions



```yaml
- experiment_key: "12345"
  predictions: "1234"
  config:
    dslName: experiment_a
    lr: 0.01
    epochs: 100
  tags:
    - production
    - v2
  metadata:
    owner: alice
    team: ml-platform
    priority: 1
  script: "import torch\nmodel = torch.load('checkpoint.pt')\nresults = model.evaluate(dataset='train')"

- experiment_key: "1"
  predictions: "4"
  config:
    dslName: experiment_b
    lr: 0.001
    epochs: 200
  tags:
    - staging
    - v2
  metadata:
    owner: bob
    team: ml-platform
    priority: 2
  script: "from sklearn.ensemble import RandomForestClassifier\nclf = RandomForestClassifier(n_estimators=100, max_depth=5)\nclf.fit(X_train, y_train)"

- experiment_key: "2"
  predictions: "6"
  config:
    dslName: experiment_c
    lr: 0.01
    epochs: 100
    scheduler:
      type: cosine
      warmup_steps: 500
  tags:
    - production
    - v3
  metadata:
    owner: alice
    team: recommendations
    priority: 1
  script: "params = {\"batch_size\": 32, \"dropout\": 0.1}\nrun_training(**params)"

- experiment_key: "9"
  predictions: "5"
  config:
    dslName: experiment_d
    lr: 0.02
    epochs: 50
    scheduler:
      type: linear
      warmup_steps: 100
  tags:
    - canary
  metadata:
    owner: carol
    team: recommendations
    priority: 3
  script: "data = [x for x in range(100) if x % 2 == 0]\nprint(f'filtered {len(data)} items')"

```

1. Navigate to the SubmitTaskArgumentsDialog component
2. Click the import file button
3. Verify that the file picker now accepts `.yaml` and `.yml` files
4. Test importing a valid YAML file with task arguments
5. Test importing an invalid YAML file to verify error handling displays the warning message
6. Confirm that existing CSV and JSON import functionality remains unchanged

## Additional Comments

The implementation reuses the existing JSON argument mapping logic by converting YAML to JSON first, ensuring consistency with the current data processing pipeline.