### PR TITLE
feat: Add Toggle for Collapsing Nodes

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/AnnotationsSection.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/AnnotationsSection.tsx
@@ -4,6 +4,7 @@ import { BlockStack } from "@/components/ui/layout";
 import { Separator } from "@/components/ui/separator";
 import useToastNotification from "@/hooks/useToastNotification";
 import type { AnnotationConfig, Annotations } from "@/types/annotations";
+import { HIDDEN_ANNOTATIONS } from "@/utils/annotations";
 import type { TaskSpec } from "@/utils/componentSpec";
 
 import { AnnotationsEditor } from "./AnnotationsEditor";
@@ -61,7 +62,7 @@ export const AnnotationsSection = ({
 
     return Object.entries(annotations).reduce<Annotations>(
       (acc, [key, value]) => {
-        if (!managedAnnotationKeys.has(key)) {
+        if (!managedAnnotationKeys.has(key) && !HIDDEN_ANNOTATIONS.has(key)) {
           acc[key] = value;
         }
         return acc;

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeCard.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeCard.tsx
@@ -51,20 +51,17 @@ const TaskNodeCard = () => {
   const executionState = executionData?.state;
 
   const nodeRef = useRef<HTMLDivElement | null>(null);
-  const contentRef = useRef<HTMLDivElement>(null);
 
   const [updateOverlayDialogOpen, setUpdateOverlayDialogOpen] = useState<
     UpdateOverlayMessage["data"] | undefined
   >();
   const [highlightedState, setHighlighted] = useState(false);
 
-  const [scrollHeight, setScrollHeight] = useState(0);
-  const [condensed, setCondensed] = useState(false);
   const [expandedInputs, setExpandedInputs] = useState(false);
   const [expandedOutputs, setExpandedOutputs] = useState(false);
 
   const { name, displayName, state, nodeId, taskSpec, taskId } = taskNode;
-  const { dimensions, selected, highlighted, readOnly } = state;
+  const { dimensions, selected, highlighted, readOnly, isCollapsed } = state;
 
   const { isConnectedToSelectedEdge } = useEdgeSelectionHighlight(nodeId);
 
@@ -161,23 +158,6 @@ const TaskNodeCard = () => {
   ]);
 
   useEffect(() => {
-    if (nodeRef.current) {
-      setScrollHeight(nodeRef.current.scrollHeight);
-    }
-  }, []);
-
-  useEffect(() => {
-    if (!dimensions.h) {
-      setCondensed(false);
-      return;
-    }
-
-    if (contentRef.current && scrollHeight > 0) {
-      setCondensed(scrollHeight > dimensions.h);
-    }
-  }, [scrollHeight, dimensions.h]);
-
-  useEffect(() => {
     if (selected) {
       setContent(taskConfigMarkup);
       setContextPanelOpen(true);
@@ -211,7 +191,7 @@ const TaskNodeCard = () => {
   return (
     <Card
       className={cn(
-        "rounded-2xl border-gray-200 border-2 wrap-break-word p-0 drop-shadow-none gap-2",
+        "rounded-2xl border-gray-200 border-2 wrap-break-word p-0 drop-shadow-none gap-2 min-h-fit",
         selected ? "border-gray-500" : "hover:border-slate-200",
         (highlighted || highlightedState) && "border-orange-500!",
         isConnectedToSelectedEdge &&
@@ -220,7 +200,7 @@ const TaskNodeCard = () => {
       )}
       style={{
         width: dimensions.w + "px",
-        height: condensed || !dimensions.h ? "auto" : dimensions.h + "px",
+        height: isCollapsed || !dimensions.h ? "auto" : dimensions.h + "px",
         transition: "height 0.2s",
       }}
       ref={nodeRef}
@@ -279,21 +259,22 @@ const TaskNodeCard = () => {
         <div
           style={{
             maxHeight:
-              dimensions.h && !(expandedInputs || expandedOutputs)
+              !isCollapsed &&
+              dimensions.h &&
+              !(expandedInputs || expandedOutputs)
                 ? `${dimensions.h}px`
                 : "100%",
           }}
           className="min-h-fit"
-          ref={contentRef}
         >
           <TaskNodeInputs
-            condensed={condensed}
+            collapsed={isCollapsed}
             expanded={expandedInputs}
             onBackgroundClick={handleInputSectionClick}
           />
 
           <TaskNodeOutputs
-            condensed={condensed}
+            collapsed={isCollapsed}
             expanded={expandedOutputs}
             onBackgroundClick={handleOutputSectionClick}
           />

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeInputs.test.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeInputs.test.tsx
@@ -80,7 +80,7 @@ describe("<TaskNodeInputs />", () => {
 
       useMockedUseTaskNode(inputs, taskSpec);
 
-      render(<TaskNodeInputs condensed={false} expanded={true} />, {
+      render(<TaskNodeInputs collapsed={false} expanded={true} />, {
         wrapper: TestWrapper,
       });
 
@@ -108,7 +108,7 @@ describe("<TaskNodeInputs />", () => {
       );
     });
 
-    it("should show hidden invalid arguments warning in condensed mode", () => {
+    it("should show hidden invalid arguments warning in collapsed mode", () => {
       const inputs = [
         createMockInput("visibleInput", "String", false),
         createMockInput("hiddenInvalidInput1", "String", false),
@@ -123,7 +123,7 @@ describe("<TaskNodeInputs />", () => {
 
       useMockedUseTaskNode(inputs, taskSpec);
 
-      render(<TaskNodeInputs condensed={true} expanded={false} />, {
+      render(<TaskNodeInputs collapsed={true} expanded={false} />, {
         wrapper: TestWrapper,
       });
 
@@ -147,7 +147,7 @@ describe("<TaskNodeInputs />", () => {
 
       useMockedUseTaskNode(inputs, taskSpec);
 
-      render(<TaskNodeInputs condensed={true} expanded={false} />, {
+      render(<TaskNodeInputs collapsed={true} expanded={false} />, {
         wrapper: TestWrapper,
       });
 
@@ -170,7 +170,7 @@ describe("<TaskNodeInputs />", () => {
 
       useMockedUseTaskNode(inputs, taskSpec);
 
-      render(<TaskNodeInputs condensed={true} expanded={false} />, {
+      render(<TaskNodeInputs collapsed={true} expanded={false} />, {
         wrapper: TestWrapper,
       });
 
@@ -183,7 +183,7 @@ describe("<TaskNodeInputs />", () => {
     it("should handle edge case with no inputs", () => {
       useMockedUseTaskNode([], createMockTaskSpec());
 
-      render(<TaskNodeInputs condensed={false} expanded={true} />, {
+      render(<TaskNodeInputs collapsed={false} expanded={true} />, {
         wrapper: TestWrapper,
       });
 
@@ -214,7 +214,7 @@ describe("<TaskNodeInputs />", () => {
 
       useMockedUseTaskNode(inputs, taskSpec);
 
-      render(<TaskNodeInputs condensed={false} expanded={true} />, {
+      render(<TaskNodeInputs collapsed={false} expanded={true} />, {
         wrapper: TestWrapper,
       });
 

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeInputs.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeInputs.tsx
@@ -21,13 +21,13 @@ import { InputHandle } from "./Handles";
 import { getDisplayValue } from "./handleUtils";
 
 interface TaskNodeInputsProps {
-  condensed: boolean;
+  collapsed: boolean;
   expanded: boolean;
   onBackgroundClick?: () => void;
 }
 
 export function TaskNodeInputs({
-  condensed,
+  collapsed,
   expanded,
   onBackgroundClick,
 }: TaskNodeInputsProps) {
@@ -76,12 +76,12 @@ export function TaskNodeInputs({
 
   const handleBackgroundClick = useCallback(
     (e: MouseEvent) => {
-      if (condensed && onBackgroundClick) {
+      if (collapsed && onBackgroundClick) {
         e.stopPropagation();
         onBackgroundClick();
       }
     },
-    [condensed, onBackgroundClick],
+    [collapsed, onBackgroundClick],
   );
 
   const handleSelectionChange = useCallback(
@@ -176,7 +176,7 @@ export function TaskNodeInputs({
 
   const hiddenInputs = inputs.length - connectedInputs.length;
   if (hiddenInputs < 1) {
-    condensed = false;
+    collapsed = false;
   }
 
   const hiddenInvalidArguments = invalidArguments.filter(
@@ -188,11 +188,11 @@ export function TaskNodeInputs({
     <div
       className={cn(
         "flex flex-col items-center gap-3 p-2 bg-gray-100 border border-gray-200 rounded-lg",
-        condensed && onBackgroundClick && "hover:bg-gray-200/70 cursor-pointer",
+        collapsed && onBackgroundClick && "hover:bg-gray-200/70 cursor-pointer",
       )}
       onClick={handleBackgroundClick}
     >
-      {condensed && !expanded ? (
+      {collapsed && !expanded ? (
         <>
           {connectedInputs.map((input, i) => (
             <InputHandle
@@ -231,7 +231,7 @@ export function TaskNodeInputs({
               onLabelClick={handleLabelClick}
             />
           ))}
-          {condensed && (
+          {collapsed && (
             <span className="text-xs text-gray-400 mt-1">
               (Click to collapse)
             </span>

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeOutputs.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeOutputs.tsx
@@ -13,13 +13,13 @@ import { checkArtifactMatchesSearchFilters } from "@/utils/searchUtils";
 import { OutputHandle } from "./Handles";
 
 type TaskNodeOutputsProps = {
-  condensed: boolean;
+  collapsed: boolean;
   expanded: boolean;
   onBackgroundClick?: () => void;
 };
 
 export function TaskNodeOutputs({
-  condensed,
+  collapsed,
   expanded,
   onBackgroundClick,
 }: TaskNodeOutputsProps) {
@@ -65,12 +65,12 @@ export function TaskNodeOutputs({
 
   const handleBackgroundClick = useCallback(
     (e: MouseEvent) => {
-      if (condensed && onBackgroundClick) {
+      if (collapsed && onBackgroundClick) {
         e.stopPropagation();
         onBackgroundClick();
       }
     },
-    [condensed, onBackgroundClick],
+    [collapsed, onBackgroundClick],
   );
 
   const handleSelectionChange = useCallback(
@@ -161,18 +161,18 @@ export function TaskNodeOutputs({
 
   const hiddenOutputs = outputs.length - outputsWithTaskInput.length;
   if (hiddenOutputs < 1) {
-    condensed = false;
+    collapsed = false;
   }
 
   return (
     <div
       className={cn(
         "flex flex-col justify-end items-center gap-3 p-2 bg-gray-100 border border-gray-200 rounded-lg",
-        condensed && onBackgroundClick && "hover:bg-gray-200/70 cursor-pointer",
+        collapsed && onBackgroundClick && "hover:bg-gray-200/70 cursor-pointer",
       )}
       onClick={handleBackgroundClick}
     >
-      {condensed && !expanded ? (
+      {collapsed && !expanded ? (
         outputsWithTaskInput.map((output, i) => (
           <OutputHandle
             key={output.name}
@@ -198,7 +198,7 @@ export function TaskNodeOutputs({
               onLabelClick={handleLabelClick}
             />
           ))}
-          {condensed && (
+          {collapsed && (
             <span className="text-xs text-gray-400 mt-1">
               (Click to collapse)
             </span>

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/TaskConfiguration.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/TaskConfiguration.tsx
@@ -41,6 +41,15 @@ const TaskConfiguration = ({ taskNode }: TaskConfigurationProps) => {
           onCheckedChange={handleDisableCacheChange}
         />
       </InlineStack>
+      <InlineStack align="space-between" gap="2" className="w-full">
+        <Paragraph tone="subdued" size="sm">
+          Collapse node
+        </Paragraph>
+        <Switch
+          checked={taskNode.state.isCollapsed}
+          onCheckedChange={taskNode.callbacks.setCollapsed}
+        />
+      </InlineStack>
     </BlockStack>
   );
 };

--- a/src/providers/TaskNodeProvider.tsx
+++ b/src/providers/TaskNodeProvider.tsx
@@ -12,6 +12,12 @@ import {
   type TaskNodeDimensions,
 } from "@/types/taskNode";
 import {
+  EDITOR_COLLAPSED_ANNOTATION,
+  getAnnotationValue,
+  removeAnnotation,
+  setAnnotation,
+} from "@/utils/annotations";
+import {
   type ArgumentType,
   type ComponentReference,
   type HydratedComponentReference,
@@ -39,6 +45,7 @@ type TaskNodeState = Readonly<{
   connectable: boolean;
   status?: string;
   isCustomComponent: boolean;
+  isCollapsed: boolean;
   dimensions: TaskNodeDimensions;
 }>;
 
@@ -46,6 +53,7 @@ type TaskNodeCallbacks = {
   setArguments: (args: Record<string, ArgumentType>) => void;
   setAnnotations: (annotations: Annotations) => void;
   setCacheStaleness: (cacheStaleness: string | undefined) => void;
+  setCollapsed: (collapsed: boolean) => void;
   onDelete?: () => void;
   onDuplicate?: () => void;
   onUpgrade?: () => void;
@@ -139,6 +147,25 @@ export const TaskNodeProvider = ({
     [setCacheStaleness, notify],
   );
 
+  const isCollapsed =
+    getAnnotationValue(taskSpec?.annotations, EDITOR_COLLAPSED_ANNOTATION) ===
+    "true";
+
+  const handleSetCollapsed = useCallback(
+    (collapsed: boolean) => {
+      const updatedAnnotations = collapsed
+        ? setAnnotation(
+            taskSpec?.annotations,
+            EDITOR_COLLAPSED_ANNOTATION,
+            "true",
+          )
+        : removeAnnotation(taskSpec?.annotations, EDITOR_COLLAPSED_ANNOTATION);
+
+      setAnnotations(updatedAnnotations as Annotations);
+    },
+    [taskSpec?.annotations, setAnnotations],
+  );
+
   const handleDeleteTaskNode = useCallback(() => {
     onDelete();
   }, [onDelete]);
@@ -173,6 +200,7 @@ export const TaskNodeProvider = ({
       status: data.isGhost ? undefined : status,
       disabled: data.isGhost ?? false,
       isCustomComponent,
+      isCollapsed,
       dimensions,
     }),
     [
@@ -182,6 +210,7 @@ export const TaskNodeProvider = ({
       data.isGhost,
       status,
       isCustomComponent,
+      isCollapsed,
       dimensions,
     ],
   );
@@ -191,6 +220,7 @@ export const TaskNodeProvider = ({
       setArguments: handleSetArguments,
       setAnnotations: handleSetAnnotations,
       setCacheStaleness: handleSetCacheStaleness,
+      setCollapsed: handleSetCollapsed,
       onDelete: handleDeleteTaskNode,
       onDuplicate: handleDuplicateTaskNode,
       onUpgrade: handleUpgradeTaskNode,
@@ -198,6 +228,7 @@ export const TaskNodeProvider = ({
     [
       handleSetArguments,
       handleSetAnnotations,
+      handleSetCollapsed,
       handleDeleteTaskNode,
       handleDuplicateTaskNode,
       handleUpgradeTaskNode,

--- a/src/utils/annotations.ts
+++ b/src/utils/annotations.ts
@@ -11,6 +11,7 @@ export const PIPELINE_RUN_NOTES_ANNOTATION = "notes";
 export const PIPELINE_CANONICAL_NAME_ANNOTATION = "canonical-pipeline-name";
 export const RUN_NAME_TEMPLATE_ANNOTATION = "run-name-template";
 export const EDITOR_POSITION_ANNOTATION = "editor.position";
+export const EDITOR_COLLAPSED_ANNOTATION = "editor.collapsed";
 export const FLEX_NODES_ANNOTATION = "flex-nodes";
 
 export const DEFAULT_COMMON_ANNOTATIONS: AnnotationConfig[] = [
@@ -26,6 +27,10 @@ export const DEFAULT_COMMON_ANNOTATIONS: AnnotationConfig[] = [
     max: DISPLAY_NAME_MAX_LENGTH,
   },
 ];
+
+export const HIDDEN_ANNOTATIONS = new Set<string>([
+  EDITOR_COLLAPSED_ANNOTATION,
+]);
 
 type Annotations =
   | {
@@ -69,7 +74,7 @@ export function getAnnotationValue(
  * @param value - The value to set
  * @returns
  */
-function setAnnotation(
+export function setAnnotation(
   annotations: Annotations,
   key: string,
   value: string | undefined,
@@ -206,4 +211,22 @@ export function ensureAnnotations(
       },
     },
   };
+}
+
+/*
+ * Removes an annotation from the annotations object.
+ * @param annotations - The annotations object
+ * @param key - The key of the annotation to remove
+ * @returns Updated annotations object with the specified annotation removed
+ */
+export function removeAnnotation(
+  annotations: Annotations,
+  key: string,
+): Annotations {
+  if (!annotations || !hasAnnotation(annotations, key)) {
+    return annotations;
+  }
+
+  const { [key]: _, ...rest } = annotations;
+  return rest;
 }


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Remove auto-collapsing of nodes based on `editor.position.height` and instead introduce a new annotation `editor.collapsed` for manual toggling of whether the node is collapsed.

Users can now toggle collapsed state via a switch in the task configuration section. Collapsed state is no longer directly related to the values entered in `editor.position`. Instead, `editor.position` height and width values will be used for the uncollapsed node state, if provided.

Collapse logic & rendering is unchanged from before.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

Closes https://github.com/Shopify/oasis-frontend/issues/476

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

![image.png](https://app.graphite.com/user-attachments/assets/99020e0b-75d4-4c50-b6e5-eaac030be9e1.png)

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

- Select a task; preferably one with many inputs & outputs
- navigate to the task configuration section
- toggle "collapse node" on and off. confirm the node on the canvas collapses appropriately
- modify the task's `editor.position` annotation to add a height value. confirm it does not affect collapsed state.

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
