### PR TITLE
chore: Consolidate Duplicated Annotation Type Definitions

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/AnnotationsEditor.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/AnnotationsEditor.tsx
@@ -1,10 +1,12 @@
-import { PlusCircleIcon } from "lucide-react";
-
 import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icon";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Heading, Paragraph } from "@/components/ui/typography";
 import type { AnnotationConfig, Annotations } from "@/types/annotations";
-import { DEFAULT_COMMON_ANNOTATIONS } from "@/utils/annotations";
+import {
+  DEFAULT_COMMON_ANNOTATIONS,
+  getAnnotationValue,
+} from "@/utils/annotations";
 
 import { AnnotationsInput } from "./AnnotationsInput";
 import {
@@ -48,7 +50,7 @@ export const AnnotationsEditor = ({
           className="w-fit"
           type="button"
         >
-          <PlusCircleIcon className="h-4 w-4" />
+          <Icon name="CirclePlus" />
           New
         </Button>
       </InlineStack>
@@ -68,7 +70,7 @@ export const AnnotationsEditor = ({
 
           <AnnotationsInput
             key={config.annotation}
-            value={annotations[config.annotation]}
+            value={getAnnotationValue(annotations, config.annotation, "")}
             onBlur={(newValue) => onSave(config.annotation, newValue)}
             annotations={annotations}
             config={config}
@@ -76,7 +78,7 @@ export const AnnotationsEditor = ({
         </BlockStack>
       ))}
 
-      {remainingAnnotations.map(([key, value]) => (
+      {remainingAnnotations.map(([key]) => (
         <BlockStack key={key}>
           <Paragraph size="xs" tone="subdued">
             {key}
@@ -84,7 +86,7 @@ export const AnnotationsEditor = ({
 
           <AnnotationsInput
             key={key}
-            value={value}
+            value={getAnnotationValue(annotations, key, "")}
             onBlur={(newValue) => onSave(key, newValue)}
             onDelete={() => onRemove(key)}
             annotations={annotations}

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/AnnotationsInput.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/AnnotationsInput.tsx
@@ -23,6 +23,7 @@ import { Paragraph } from "@/components/ui/typography";
 import { useCallbackOnUnmount } from "@/hooks/useCallbackOnUnmount";
 import { cn } from "@/lib/utils";
 import type { AnnotationConfig, Annotations } from "@/types/annotations";
+import { getAnnotationValue as getAnnotationString } from "@/utils/annotations";
 import { clamp } from "@/utils/math";
 
 interface AnnotationsInputProps {
@@ -482,11 +483,17 @@ function parseJsonAndGetProperty(
 }
 
 function getAnnotationKey(annotation: string, annotations: Annotations) {
-  return parseJsonAndGetProperty(annotations[annotation] || "{}", true);
+  return parseJsonAndGetProperty(
+    getAnnotationString(annotations, annotation, "{}"),
+    true,
+  );
 }
 
 function getAnnotationValue(annotation: string, annotations: Annotations) {
-  return parseJsonAndGetProperty(annotations[annotation] || "{}", false);
+  return parseJsonAndGetProperty(
+    getAnnotationString(annotations, annotation, "{}"),
+    false,
+  );
 }
 
 function getKeyFromInputValue(inputValue: string): string {

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/AnnotationsSection.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/AnnotationsSection.tsx
@@ -4,7 +4,7 @@ import { BlockStack } from "@/components/ui/layout";
 import { Separator } from "@/components/ui/separator";
 import useToastNotification from "@/hooks/useToastNotification";
 import type { AnnotationConfig, Annotations } from "@/types/annotations";
-import { HIDDEN_ANNOTATIONS } from "@/utils/annotations";
+import { getAnnotationValue, HIDDEN_ANNOTATIONS } from "@/utils/annotations";
 import type { TaskSpec } from "@/utils/componentSpec";
 
 import { AnnotationsEditor } from "./AnnotationsEditor";
@@ -29,7 +29,7 @@ export const AnnotationsSection = ({
 }: AnnotationsSectionProps) => {
   const notify = useToastNotification();
 
-  const rawAnnotations = (taskSpec.annotations || {}) as Annotations;
+  const rawAnnotations = taskSpec.annotations ?? {};
 
   const [annotations, setAnnotations] = useState<Annotations>({
     ...rawAnnotations,
@@ -51,7 +51,7 @@ export const AnnotationsSection = ({
   const [newRows, setNewRows] = useState<Array<NewAnnotationRowData>>([]);
 
   const selectedProvider = cloudProviderConfig
-    ? annotations[cloudProviderConfig.annotation]
+    ? getAnnotationValue(annotations, cloudProviderConfig.annotation)
     : undefined;
 
   const commonAnnotations = useMemo(() => {

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/ComputeResourcesEditor.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/ComputeResourcesEditor.tsx
@@ -3,6 +3,7 @@ import { useCallback } from "react";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Heading, Paragraph } from "@/components/ui/typography";
 import type { AnnotationConfig, Annotations } from "@/types/annotations";
+import { getAnnotationValue } from "@/utils/annotations";
 
 import { AnnotationsInput } from "./AnnotationsInput";
 
@@ -67,13 +68,11 @@ const ComputeResourceField = ({
     [resource, onSave],
   );
 
+  const rawValue = getAnnotationValue(annotations, resource.annotation, "");
   const value =
-    resource.append && annotations[resource.annotation]
-      ? annotations[resource.annotation].replace(
-          new RegExp(`${resource.append}$`),
-          "",
-        )
-      : annotations[resource.annotation];
+    resource.append && rawValue
+      ? rawValue.replace(new RegExp(`${resource.append}$`), "")
+      : rawValue;
 
   const label = resource.label + (resource.unit ? ` (${resource.unit})` : "");
 

--- a/src/providers/TaskNodeProvider.tsx
+++ b/src/providers/TaskNodeProvider.tsx
@@ -160,7 +160,7 @@ export const TaskNodeProvider = ({
           )
         : removeAnnotation(taskSpec?.annotations, EDITOR_COLLAPSED_ANNOTATION);
 
-      setAnnotations(updatedAnnotations as Annotations);
+      setAnnotations(updatedAnnotations ?? {});
     },
     [taskSpec?.annotations, setAnnotations],
   );

--- a/src/types/annotations.ts
+++ b/src/types/annotations.ts
@@ -1,4 +1,4 @@
-export type Annotations = Record<string, string>;
+export type Annotations = Record<string, unknown>;
 
 export type AnnotationOption = {
   value: string;

--- a/src/utils/annotations.ts
+++ b/src/utils/annotations.ts
@@ -1,7 +1,7 @@
 import type { XYPosition } from "@xyflow/react";
 
 import { getNodeTypeZIndexDefault } from "@/components/shared/ReactFlow/FlowCanvas/utils/zIndex";
-import type { AnnotationConfig } from "@/types/annotations";
+import type { AnnotationConfig, Annotations } from "@/types/annotations";
 
 import type { ComponentSpec } from "./componentSpec";
 
@@ -35,12 +35,6 @@ export const HIDDEN_ANNOTATIONS = new Set<string>([
   EDITOR_COLLAPSED_ANNOTATION,
 ]);
 
-type Annotations =
-  | {
-      [k: string]: unknown;
-    }
-  | undefined;
-
 /**
  * Gets the value of an annotation.
  * @param annotations - The annotations object
@@ -49,17 +43,17 @@ type Annotations =
  * @returns
  */
 export function getAnnotationValue(
-  annotations: Annotations | null,
+  annotations: Annotations | null | undefined,
   key: string,
   defaultValue: string,
 ): string;
 export function getAnnotationValue(
-  annotations: Annotations | null,
+  annotations: Annotations | null | undefined,
   key: string,
   defaultValue?: undefined,
 ): string | undefined;
 export function getAnnotationValue(
-  annotations: Annotations | null,
+  annotations: Annotations | null | undefined,
   key: string,
   defaultValue?: string,
 ) {
@@ -67,7 +61,9 @@ export function getAnnotationValue(
     return defaultValue;
   }
 
-  return hasAnnotation(annotations, key) ? annotations?.[key] : defaultValue;
+  return hasAnnotation(annotations, key)
+    ? (annotations[key] as string)
+    : defaultValue;
 }
 
 /**
@@ -78,7 +74,7 @@ export function getAnnotationValue(
  * @returns
  */
 export function setAnnotation(
-  annotations: Annotations,
+  annotations: Annotations | undefined,
   key: string,
   value: string | undefined,
 ) {
@@ -95,7 +91,7 @@ export function setAnnotation(
  * @returns boolean
  */
 function hasAnnotation(
-  annotations: Annotations,
+  annotations: Annotations | undefined,
   key: string,
 ): annotations is Annotations {
   if (!annotations) {
@@ -137,7 +133,7 @@ export const setComponentSpecAnnotation = (
  * @returns updated annotations object
  */
 export const setPositionInAnnotations = (
-  annotations: Annotations,
+  annotations: Annotations | undefined,
   position: XYPosition,
 ): Annotations => {
   const updatedAnnotations = { ...annotations };
@@ -223,9 +219,9 @@ export function ensureAnnotations(
  * @returns Updated annotations object with the specified annotation removed
  */
 export function removeAnnotation(
-  annotations: Annotations,
+  annotations: Annotations | undefined,
   key: string,
-): Annotations {
+): Annotations | undefined {
   if (!annotations || !hasAnnotation(annotations, key)) {
     return annotations;
   }
@@ -240,7 +236,7 @@ export function removeAnnotation(
  * @returns z-index number
  */
 export const extractZIndexFromAnnotations = (
-  annotations: Annotations,
+  annotations: Annotations | undefined,
   nodeType: string,
 ): number => {
   const defaultZIndex = getNodeTypeZIndexDefault(nodeType);


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
There is an `Annotations` type defined in `utils/annotations` and again in `types/annotations` leading to confusion and weird typecasting.

This PR consolidates it down into one `Annotation` type to match that of the Component Spec.

No change to app functionality.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Cleanup/Refactor

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->
- Confirm annotations still work as expected.

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
