### PR TITLE
Add announcement banner system to home page

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -4,7 +4,8 @@
     ".git/**",
     "src/api/**",
     "src/components/ui/**",
-    "openapi-ts.config.ts"
+    "openapi-ts.config.ts",
+    "src/config/announcements.ts"
   ],
   "ignoreDependencies": [
     "@radix-ui/react-accordion",

--- a/react-compiler.config.js
+++ b/react-compiler.config.js
@@ -54,6 +54,7 @@ export const REACT_COMPILER_ENABLED_DIRS = [
   "src/components/Editor/IOEditor/IOZIndexEditor.tsx",
   "src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/DynamicDataDropdown.tsx",
   "src/components/shared/HighlightText.tsx",
+  "src/components/shared/AnnouncementBanners.tsx",
 
   // 11-20 useCallback/useMemo
   // "src/components/ui",                         // 12

--- a/src/components/shared/AnnouncementBanners.tsx
+++ b/src/components/shared/AnnouncementBanners.tsx
@@ -1,0 +1,63 @@
+import { useState } from "react";
+
+import { InfoBox } from "@/components/shared/InfoBox";
+import { BlockStack } from "@/components/ui/layout";
+import "@/config/announcements";
+import { getStorage } from "@/utils/typedStorage";
+
+interface DismissedAnnouncementsStorage {
+  "dismissed-announcements": string[];
+}
+
+const storage = getStorage<
+  keyof DismissedAnnouncementsStorage,
+  DismissedAnnouncementsStorage
+>();
+
+function getDismissedIds(): string[] {
+  return storage.getItem("dismissed-announcements") ?? [];
+}
+
+export const AnnouncementBanners = () => {
+  const [dismissedIds, setDismissedIds] = useState(getDismissedIds);
+
+  const announcements = window.__TANGLE_ANNOUNCEMENTS__ ?? [];
+  const now = new Date();
+  const visible = announcements.filter(
+    (a) =>
+      !dismissedIds.includes(a.id) &&
+      (!a.expiresAt || new Date(a.expiresAt) > now),
+  );
+
+  if (visible.length === 0) {
+    return null;
+  }
+
+  const handleDismiss = (id: string) => {
+    const updated = [...dismissedIds, id];
+    storage.setItem("dismissed-announcements", updated);
+    setDismissedIds(updated);
+  };
+
+  return (
+    <BlockStack gap="2">
+      {visible.map((announcement) => {
+        const onDismiss = announcement.dismissible
+          ? () => handleDismiss(announcement.id)
+          : undefined;
+
+        return (
+          <InfoBox
+            key={announcement.id}
+            title={announcement.title}
+            variant={announcement.variant ?? "info"}
+            width="full"
+            onDismiss={onDismiss}
+          >
+            {announcement.body}
+          </InfoBox>
+        );
+      })}
+    </BlockStack>
+  );
+};

--- a/src/components/shared/InfoBox.tsx
+++ b/src/components/shared/InfoBox.tsx
@@ -1,5 +1,9 @@
 import type { ReactNode } from "react";
 
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icon";
+import { InlineStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
 import { cn } from "@/lib/utils";
 
 interface InfoBoxProps {
@@ -8,6 +12,7 @@ interface InfoBoxProps {
   className?: string;
   children: ReactNode;
   variant?: "info" | "error" | "warning" | "success" | "ghost";
+  onDismiss?: () => void;
 }
 
 const variantStyles: Record<
@@ -48,6 +53,7 @@ export const InfoBox = ({
   className,
   children,
   variant = "info",
+  onDismiss,
 }: InfoBoxProps) => {
   const styles = variantStyles[variant];
   const widthClass = widthStyles[width];
@@ -57,12 +63,27 @@ export const InfoBox = ({
       data-testid={`info-box-${variant}`}
       className={cn("border rounded-md p-2", styles.container, widthClass)}
     >
-      <div
-        data-testid="info-box-title"
-        className={cn("text-sm font-semibold mb-1", styles.title)}
-      >
-        {title}
-      </div>
+      <InlineStack align="space-between" blockAlign="start">
+        <Text
+          as="span"
+          size="sm"
+          weight="semibold"
+          className={cn("mb-1", styles.title)}
+          data-testid="info-box-title"
+        >
+          {title}
+        </Text>
+        {onDismiss && (
+          <Button
+            onClick={onDismiss}
+            variant="ghost"
+            size="min"
+            aria-label="Dismiss"
+          >
+            <Icon name="X" size="sm" />
+          </Button>
+        )}
+      </InlineStack>
       <div className={cn("text-sm", className)}>{children}</div>
     </div>
   );

--- a/src/config/announcements.ts
+++ b/src/config/announcements.ts
@@ -1,0 +1,14 @@
+export interface Announcement {
+  id: string;
+  title: string;
+  body: string;
+  variant?: "warning" | "info" | "success" | "error";
+  dismissible?: boolean;
+  expiresAt?: string; // ISO date string, e.g. "2026-04-01"
+}
+
+declare global {
+  interface Window {
+    __TANGLE_ANNOUNCEMENTS__?: Announcement[];
+  }
+}

--- a/src/routes/Home/Home.tsx
+++ b/src/routes/Home/Home.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState } from "react";
 
 import { PipelineSection, RunSection } from "@/components/Home";
+import { AnnouncementBanners } from "@/components/shared/AnnouncementBanners";
 import { BetaFeatureWrapper } from "@/components/shared/BetaFeatureWrapper/BetaFeatureWrapper";
 import { PipelineRunFiltersBar } from "@/components/shared/PipelineRunFiltersBar/PipelineRunFiltersBar";
 import { useFlagValue } from "@/components/shared/Settings/useFlags";
@@ -24,6 +25,7 @@ const Home = () => {
 
   return (
     <div className="container mx-auto w-3/4 p-4 flex flex-col gap-4">
+      <AnnouncementBanners />
       <div className="flex justify-between items-center">
         <h1 className="text-2xl font-bold">Pipelines</h1>
       </div>


### PR DESCRIPTION
## Description

Added an announcement banner system to display important notifications to users on the home page. The system includes a configurable announcements configuration file and a reusable `AnnouncementBanners` component that renders announcements using the existing `InfoBox` component. Currently displays a warning about upcoming GPU quota enforcement for Tangle workloads.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)



![image.png](https://app.graphite.com/user-attachments/assets/1387bb1d-f590-4c4a-8118-fba0c4593369.png)



## Test Instructions

1. Navigate to the home page
2. Verify that the GPU quota enforcement announcement banner appears at the top of the page
3. Confirm the banner displays with a warning variant styling
4. Test that the page functions normally with the banner present
5. Verify that removing all announcements from the config file hides the banner component

## Additional Comments

The announcement system is designed to be easily configurable through the `src/config/announcements.ts` file. New announcements can be added by updating the array with the required `id`, `title`, `body`, and optional `variant` properties. The configuration file has been added to the knip ignore list to prevent unused export warnings when no announcements are active.