### PR TITLE
chore: Support Required Annotations

### DIFF
--- a/src/components/shared/Dialogs/MultilineTextInputDialog.tsx
+++ b/src/components/shared/Dialogs/MultilineTextInputDialog.tsx
@@ -19,6 +19,7 @@ interface MultilineTextInputDialogProps {
   placeholder?: string;
   initialValue?: string;
   open: boolean;
+  required?: boolean;
   maxLength?: number;
   onCancel: () => void;
   onConfirm: (value: string) => void;
@@ -30,6 +31,7 @@ export const MultilineTextInputDialog = ({
   placeholder,
   initialValue = "",
   open,
+  required = false,
   maxLength,
   onCancel,
   onConfirm,
@@ -72,6 +74,7 @@ export const MultilineTextInputDialog = ({
           onChange={(e) => setValue(e.target.value)}
           placeholder={placeholder}
           className="min-h-32 max-h-[80vh]"
+          required={required}
           maxLength={maxLength}
         />
         <DialogFooter>

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/AnnotationsEditor.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/AnnotationsEditor.tsx
@@ -55,9 +55,16 @@ export const AnnotationsEditor = ({
 
       {pinnedAnnotations.map((config) => (
         <BlockStack key={config.annotation}>
-          <Paragraph size="xs" tone="subdued">
-            {config.label} {config.unit && `(${config.unit})`}
-          </Paragraph>
+          <InlineStack>
+            <Paragraph size="xs" tone="subdued">
+              {config.label} {config.unit && `(${config.unit})`}
+            </Paragraph>
+            {config.required && (
+              <Paragraph size="xs" tone="critical">
+                *
+              </Paragraph>
+            )}
+          </InlineStack>
 
           <AnnotationsInput
             key={config.annotation}

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/AnnotationsInput.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/AnnotationsInput.tsx
@@ -228,6 +228,7 @@ export const AnnotationsInput = ({
             ? handleQuantitySelectChange
             : handleNonQuantitySelectChange
         }
+        required={config?.required}
       >
         <div className="relative group grow min-w-24">
           <SelectTrigger className={cn("w-full", className)}>
@@ -273,6 +274,7 @@ export const AnnotationsInput = ({
           onBlur={handleBlur}
           autoFocus={autoFocus}
           className={className}
+          required={config?.required}
         />
 
         {config?.max !== undefined && (
@@ -305,6 +307,7 @@ export const AnnotationsInput = ({
             autoFocus={autoFocus}
             className={cn("min-w-16", className)}
             maxLength={config?.max}
+            required={config?.required}
           />
           <Button
             className="absolute right-0 top-1/2 -translate-y-1/2 hover:bg-transparent hover:text-blue-500 hidden group-hover:flex h-8 w-8 p-0"
@@ -344,6 +347,7 @@ export const AnnotationsInput = ({
             }
             onBlur={handleBlur}
             onChange={handleQuantityValueInputChange}
+            required={config?.required}
           />
         )}
         {deletable && onDelete && (
@@ -365,6 +369,7 @@ export const AnnotationsInput = ({
             onCancel={handleDialogCancel}
             onConfirm={handleDialogConfirm}
             maxLength={config?.max}
+            required={config?.required}
           />
         )}
     </>
@@ -375,6 +380,7 @@ const QuantityInput = ({
   value,
   min,
   max,
+  required,
   disabled,
   onBlur,
   onChange,
@@ -382,6 +388,7 @@ const QuantityInput = ({
   value: string;
   min?: number;
   max?: number;
+  required?: boolean;
   disabled: boolean;
   onBlur: () => void;
   onChange: (value: string) => void;
@@ -410,6 +417,7 @@ const QuantityInput = ({
           !currentQuantity && !disabled && "border-destructive/50",
         )}
         disabled={disabled}
+        required={required}
       />
       {max !== undefined && (
         <Paragraph size="xs" tone="subdued" className="whitespace-nowrap">

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/ComputeResourcesEditor.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/ComputeResourcesEditor.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from "react";
 
-import { BlockStack } from "@/components/ui/layout";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Heading, Paragraph } from "@/components/ui/typography";
 import type { AnnotationConfig, Annotations } from "@/types/annotations";
 
@@ -79,9 +79,16 @@ const ComputeResourceField = ({
 
   return (
     <BlockStack key={resource.annotation}>
-      <Paragraph size="xs" tone="subdued">
-        {label}
-      </Paragraph>
+      <InlineStack>
+        <Paragraph size="xs" tone="subdued">
+          {label}
+        </Paragraph>
+        {resource.required && (
+          <Paragraph size="xs" tone="critical">
+            *
+          </Paragraph>
+        )}
+      </InlineStack>
 
       <AnnotationsInput
         value={value}

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/utils.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/utils.ts
@@ -11,6 +11,7 @@ interface JSONSchemaProperty {
   exclusiveMaximum?: number;
   pattern?: string;
   enum?: string[];
+  required?: boolean;
   "x-unit"?: string;
   "x-append"?: string;
   "x-enable-quantity"?: boolean;
@@ -52,6 +53,10 @@ export function parseSchemaToAnnotationConfig(
       annotation,
       label: property.title || annotation,
     };
+
+    if (property.required) {
+      config.required = true;
+    }
 
     // Handle unit
     if (property["x-unit"]) {

--- a/src/types/annotations.ts
+++ b/src/types/annotations.ts
@@ -16,4 +16,5 @@ export type AnnotationConfig = {
   min?: number;
   max?: number;
   hidden?: boolean;
+  required?: boolean;
 };

--- a/src/utils/validations.test.ts
+++ b/src/utils/validations.test.ts
@@ -11,6 +11,62 @@ vi.mock("./componentSpec", () => ({
   isGraphImplementation: vi.fn(),
 }));
 
+// Mock the annotation schema with generic test data, avoiding references to real providers
+vi.mock(
+  "@/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/utils",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("@/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/utils")
+      >();
+
+    const mockSchema = {
+      cloud_provider: {
+        annotation: "test.io/cloud-provider",
+        type: "string",
+        title: "Cloud Provider",
+      },
+      launcher_annotation_schemas: {
+        "provider-with-required": {
+          type: "object",
+          title: "Provider With Required Fields",
+          properties: {
+            "test.io/required-field": {
+              type: "string",
+              title: "Required Field",
+              required: true,
+            },
+            "test.io/optional-field": {
+              type: "string",
+              title: "Optional Field",
+            },
+          },
+        },
+        "provider-without-required": {
+          type: "object",
+          title: "Provider Without Required Fields",
+          properties: {
+            "test.io/some-field": {
+              type: "string",
+              title: "Some Field",
+            },
+          },
+        },
+      },
+      common_annotations: {
+        type: "object",
+        title: "Common Annotations",
+        properties: {},
+      },
+    };
+
+    return {
+      ...actual,
+      launcherTaskAnnotationSchema: mockSchema,
+    };
+  },
+);
+
 const { isGraphImplementation } = await import("./componentSpec");
 
 // Helper to check if errors contain a specific message
@@ -441,6 +497,127 @@ describe("checkComponentSpecValidity", () => {
           e.message === "Not connected to any tasks",
       );
       expect(outputError).toBeDefined();
+    });
+
+    describe("Task Annotation Validation", () => {
+      const CLOUD_PROVIDER_ANNOTATION = "test.io/cloud-provider";
+      const REQUIRED_FIELD_ANNOTATION = "test.io/required-field";
+      const REQUIRED_ANNOTATION_ERROR =
+        'Required annotation "Required Field" is missing';
+
+      const makeTaskWithAnnotations = (
+        annotations: Record<string, string>,
+      ) => ({
+        componentRef: {
+          name: "child-component",
+          spec: {
+            name: "child-component",
+            implementation: { container: { image: "child-image" } },
+          },
+        },
+        annotations,
+      });
+
+      it("should return error when a required annotation is missing for the selected provider", () => {
+        const componentSpec: ComponentSpec = {
+          name: "test-component",
+          implementation: {
+            graph: {
+              tasks: {
+                task1: makeTaskWithAnnotations({
+                  [CLOUD_PROVIDER_ANNOTATION]: "provider-with-required",
+                }),
+              },
+            },
+          },
+        };
+
+        const result = checkComponentSpecValidity(componentSpec);
+
+        expect(result.isValid).toBe(false);
+        expectErrorWithMessage(result.errors, REQUIRED_ANNOTATION_ERROR);
+        expect(
+          result.errors.find((e) => e.message === REQUIRED_ANNOTATION_ERROR)
+            ?.taskId,
+        ).toBe("task1");
+      });
+
+      it("should return error when required annotation is whitespace only", () => {
+        const componentSpec: ComponentSpec = {
+          name: "test-component",
+          implementation: {
+            graph: {
+              tasks: {
+                task1: makeTaskWithAnnotations({
+                  [CLOUD_PROVIDER_ANNOTATION]: "provider-with-required",
+                  [REQUIRED_FIELD_ANNOTATION]: "   ",
+                }),
+              },
+            },
+          },
+        };
+
+        const result = checkComponentSpecValidity(componentSpec);
+
+        expect(result.isValid).toBe(false);
+        expectErrorWithMessage(result.errors, REQUIRED_ANNOTATION_ERROR);
+      });
+
+      it("should not return error when the required annotation has a value", () => {
+        const componentSpec: ComponentSpec = {
+          name: "test-component",
+          implementation: {
+            graph: {
+              tasks: {
+                task1: makeTaskWithAnnotations({
+                  [CLOUD_PROVIDER_ANNOTATION]: "provider-with-required",
+                  [REQUIRED_FIELD_ANNOTATION]: "some-value",
+                }),
+              },
+            },
+          },
+        };
+
+        const result = checkComponentSpecValidity(componentSpec);
+
+        expectNoErrorWithMessage(result.errors, REQUIRED_ANNOTATION_ERROR);
+      });
+
+      it("should not validate provider-specific annotations when no provider is selected", () => {
+        const componentSpec: ComponentSpec = {
+          name: "test-component",
+          implementation: {
+            graph: {
+              tasks: {
+                task1: makeTaskWithAnnotations({}),
+              },
+            },
+          },
+        };
+
+        const result = checkComponentSpecValidity(componentSpec);
+
+        expectNoErrorWithMessage(result.errors, REQUIRED_ANNOTATION_ERROR);
+      });
+
+      it("should not return required annotation errors for a provider with no required fields", () => {
+        const componentSpec: ComponentSpec = {
+          name: "test-component",
+          implementation: {
+            graph: {
+              tasks: {
+                task1: makeTaskWithAnnotations({
+                  [CLOUD_PROVIDER_ANNOTATION]: "provider-without-required",
+                }),
+              },
+            },
+          },
+        };
+
+        const result = checkComponentSpecValidity(componentSpec);
+
+        expectNoErrorWithMessage(result.errors, REQUIRED_ANNOTATION_ERROR);
+      });
     });
 
     it("should detect circular dependencies", () => {

--- a/src/utils/validations.ts
+++ b/src/utils/validations.ts
@@ -1,4 +1,12 @@
 import {
+  getCloudProviderConfig,
+  getCommonAnnotations,
+  getProviderSchema,
+  launcherTaskAnnotationSchema,
+  parseSchemaToAnnotationConfig,
+} from "@/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/utils";
+
+import {
   type ArgumentType,
   type ComponentSpec,
   type GraphInputArgument,
@@ -251,6 +259,9 @@ const validateSingleTask = (
   // Validate required inputs
   errors.push(...validateTaskRequiredInputs(taskId, task));
 
+  // Validate required annotations
+  errors.push(...validateTaskAnnotations(taskId, task));
+
   return errors;
 };
 
@@ -397,6 +408,54 @@ const validateTaskRequiredInputs = (
         }
       }
     });
+  }
+
+  return errors;
+};
+
+const validateTaskAnnotations = (
+  taskId: string,
+  task: TaskSpec,
+): ValidationError[] => {
+  const errors: ValidationError[] = [];
+  const taskAnnotations = (task.annotations ?? {}) as Record<string, string>;
+
+  // Check provider-specific required annotations (only when that provider is selected)
+  const cloudProviderAnnotation = getCloudProviderConfig(
+    launcherTaskAnnotationSchema,
+  )?.annotation;
+  const selectedProvider = cloudProviderAnnotation
+    ? taskAnnotations[cloudProviderAnnotation]
+    : undefined;
+
+  if (selectedProvider) {
+    const providerSchema = getProviderSchema(
+      launcherTaskAnnotationSchema,
+      selectedProvider,
+    );
+
+    if (providerSchema) {
+      for (const config of parseSchemaToAnnotationConfig(providerSchema)) {
+        if (config.required && !taskAnnotations[config.annotation]?.trim()) {
+          errors.push({
+            type: "task",
+            message: `Required annotation "${config.label}" is missing`,
+            taskId,
+          });
+        }
+      }
+    }
+  }
+
+  // Check common required annotations (always visible)
+  for (const config of getCommonAnnotations(launcherTaskAnnotationSchema)) {
+    if (config.required && !taskAnnotations[config.annotation]?.trim()) {
+      errors.push({
+        type: "task",
+        message: `Required annotation "${config.label}" is missing`,
+        taskId,
+      });
+    }
   }
 
   return errors;


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

Adds support for required annotations.

A required annotation will trigger a pipeline validation error if it is not provided, preventing the user from submitting the pipeline.

For annotations embedded within a selection (e.g. cloud provider) the required field will only apply when the respective option is selected. i.e. you will not get an error for missing fields in the Nebius config if you chose GCP.

## Related Issue and Pull requests

Closes https://github.com/Shopify/oasis-frontend/issues/502

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

![image.png](https://app.graphite.com/user-attachments/assets/11ceb35b-d79c-41ed-9a56-94314f74aed8.png)

![image.png](https://app.graphite.com/user-attachments/assets/ed13218f-992c-4fdc-a7ea-b5923f0fab21.png)

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

- Select nebius cloud config on a task
- Confirm a red asterisks appears, indicating it's a required field
- Keep the field empty. Confirm the pipeline validator throws an error for the missing annotation
- Fill in the field. Confirm the validation error is now gone.

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->