### PR TITLE
Add parameter sweep dialog to OasisSubmitter

### DIFF
--- a/src/components/shared/Submitters/Oasis/OasisSubmitter.tsx
+++ b/src/components/shared/Submitters/Oasis/OasisSubmitter.tsx
@@ -33,6 +33,7 @@ import { validateArguments } from "@/utils/validations";
 import { isAuthorizationRequired } from "../../Authentication/helpers";
 import { useAuthLocalStorage } from "../../Authentication/useAuthLocalStorage";
 import TooltipButton from "../../Buttons/TooltipButton";
+import { ParameterSweepDialog } from "./components/ParameterSweepDialog";
 import { SubmitTaskArgumentsDialog } from "./components/SubmitTaskArgumentsDialog";
 
 interface OasisSubmitterProps {
@@ -109,6 +110,7 @@ const OasisSubmitter = ({
 
   const [submitSuccess, setSubmitSuccess] = useState<boolean | null>(null);
   const [isArgumentsDialogOpen, setIsArgumentsDialogOpen] = useState(false);
+  const [isSweepDialogOpen, setIsSweepDialogOpen] = useState(false);
   const [pendingImportFile, setPendingImportFile] = useState<{
     text: string;
     extension: string;
@@ -437,16 +439,28 @@ const OasisSubmitter = ({
             )}
           </Button>
           {isArgumentsButtonVisible && (
-            <TooltipButton
-              tooltip="Submit run with arguments"
-              variant="ghost"
-              size="icon"
-              data-testid="run-with-arguments-button"
-              onClick={() => setIsArgumentsDialogOpen(true)}
-              disabled={!available}
-            >
-              <Icon name="Split" className="rotate-90" />
-            </TooltipButton>
+            <InlineStack gap="0">
+              <TooltipButton
+                tooltip="Submit run with arguments"
+                variant="ghost"
+                size="icon"
+                data-testid="run-with-arguments-button"
+                onClick={() => setIsArgumentsDialogOpen(true)}
+                disabled={!available}
+              >
+                <Icon name="Split" className="rotate-90" />
+              </TooltipButton>
+              <TooltipButton
+                tooltip="Parameter sweep"
+                variant="ghost"
+                size="icon"
+                data-testid="parameter-sweep-button"
+                onClick={() => setIsSweepDialogOpen(true)}
+                disabled={!available}
+              >
+                <Icon name="Grid3x3" />
+              </TooltipButton>
+            </InlineStack>
           )}
         </InlineStack>
       </div>
@@ -459,6 +473,18 @@ const OasisSubmitter = ({
           componentSpec={componentSpec}
           initialImportFile={pendingImportFile}
           onImportComplete={() => setPendingImportFile(null)}
+        />
+      )}
+
+      {componentSpec && (
+        <ParameterSweepDialog
+          open={isSweepDialogOpen}
+          onCancel={() => setIsSweepDialogOpen(false)}
+          onConfirm={(argSets) => {
+            setIsSweepDialogOpen(false);
+            handleBulkSubmit(argSets);
+          }}
+          componentSpec={componentSpec}
         />
       )}
     </>

--- a/src/components/shared/Submitters/Oasis/components/ParameterSweepDialog.tsx
+++ b/src/components/shared/Submitters/Oasis/components/ParameterSweepDialog.tsx
@@ -1,0 +1,210 @@
+import { useState } from "react";
+
+import { getArgumentsFromInputs } from "@/components/shared/ReactFlow/FlowCanvas/utils/getArgumentsFromInputs";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Icon } from "@/components/ui/icon";
+import { BlockStack } from "@/components/ui/layout";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Paragraph, Text } from "@/components/ui/typography";
+import type { ArgumentType, ComponentSpec } from "@/utils/componentSpec";
+import {
+  expandSweep,
+  getSweepRunCount,
+  parseRange,
+  type SweepParameter,
+  validateSweep,
+} from "@/utils/parameterSweep";
+
+import { SweepParameterField } from "./SweepParameterField";
+import { MAX_PREVIEW_ROWS, SweepPreviewTable } from "./SweepPreviewTable";
+
+interface ParameterSweepDialogProps {
+  open: boolean;
+  onCancel: () => void;
+  onConfirm: (argSets: Record<string, ArgumentType>[]) => void;
+  componentSpec: ComponentSpec;
+}
+
+export const ParameterSweepDialog = ({
+  open,
+  onCancel,
+  onConfirm,
+  componentSpec,
+}: ParameterSweepDialogProps) => {
+  const inputs = componentSpec.inputs ?? [];
+  const baseArgs = getArgumentsFromInputs(componentSpec);
+
+  const [sweepParams, setSweepParams] = useState<SweepParameter[]>(() =>
+    inputs.map((input) => ({ name: input.name, values: [] })),
+  );
+
+  const activeParams = sweepParams.filter((p) => p.values.length > 0);
+  const runCount = getSweepRunCount(sweepParams);
+  const validationError = validateSweep(sweepParams);
+  const hasActiveParams = activeParams.length > 0;
+
+  const updateParam = (
+    paramName: string,
+    updater: (p: SweepParameter) => SweepParameter,
+  ) => {
+    setSweepParams((prev) =>
+      prev.map((p) => (p.name === paramName ? updater(p) : p)),
+    );
+  };
+
+  const handleAddValues = (paramName: string, raw: string) => {
+    const newValues = raw
+      .split(",")
+      .map((v) => v.trim())
+      .filter((v) => v.length > 0);
+    if (newValues.length === 0) return;
+    updateParam(paramName, (p) => ({
+      ...p,
+      values: [...p.values, ...newValues],
+    }));
+  };
+
+  const handleRemoveValue = (paramName: string, index: number) => {
+    updateParam(paramName, (p) => ({
+      ...p,
+      values: p.values.filter((_, i) => i !== index),
+    }));
+  };
+
+  const handleApplyRange = (paramName: string, rangeStr: string) => {
+    const values = parseRange(rangeStr);
+    if (values) {
+      updateParam(paramName, (p) => ({ ...p, values }));
+    }
+  };
+
+  const handleConfirm = () => {
+    onConfirm(expandSweep(baseArgs, sweepParams));
+  };
+
+  const handleCancel = () => {
+    setSweepParams(inputs.map((input) => ({ name: input.name, values: [] })));
+    onCancel();
+  };
+
+  const previewCombinations = hasActiveParams
+    ? expandSweep(baseArgs, sweepParams).slice(0, MAX_PREVIEW_ROWS)
+    : [];
+
+  return (
+    <Dialog open={open} onOpenChange={handleCancel}>
+      <DialogContent className="sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Parameter Sweep</DialogTitle>
+          <DialogDescription className="hidden">
+            Define multiple values per parameter to explore combinations.
+          </DialogDescription>
+          <Paragraph tone="subdued" size="sm">
+            Add multiple values to parameters and run all combinations
+            automatically.
+          </Paragraph>
+        </DialogHeader>
+
+        <Tabs defaultValue="parameters">
+          <TabsList>
+            <TabsTrigger value="parameters">
+              <Icon name="SlidersHorizontal" size="sm" />
+              Parameters
+            </TabsTrigger>
+            <TabsTrigger value="preview" disabled={!hasActiveParams}>
+              <Icon name="Table" size="sm" />
+              Preview
+              {hasActiveParams && runCount > 0 && (
+                <Badge variant="secondary" size="xs" shape="rounded">
+                  {runCount}
+                </Badge>
+              )}
+            </TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="parameters">
+            <div className="max-h-[40vh] overflow-y-auto pr-2">
+              <BlockStack gap="3" className="p-1">
+                {inputs.map((input) => {
+                  const sweepParam = sweepParams.find(
+                    (p) => p.name === input.name,
+                  );
+                  return (
+                    <SweepParameterField
+                      key={input.name}
+                      input={input}
+                      values={sweepParam?.values ?? []}
+                      onAddValue={(value) => handleAddValues(input.name, value)}
+                      onRemoveValue={(index) =>
+                        handleRemoveValue(input.name, index)
+                      }
+                      onApplyRange={(rangeStr) =>
+                        handleApplyRange(input.name, rangeStr)
+                      }
+                      onClear={() =>
+                        updateParam(input.name, (p) => ({ ...p, values: [] }))
+                      }
+                    />
+                  );
+                })}
+                {inputs.length === 0 && (
+                  <Paragraph tone="subdued" size="sm">
+                    This pipeline has no configurable inputs.
+                  </Paragraph>
+                )}
+              </BlockStack>
+            </div>
+          </TabsContent>
+
+          <TabsContent value="preview">
+            <SweepPreviewTable
+              combinations={previewCombinations}
+              sweepParamNames={activeParams.map((p) => p.name)}
+              totalCount={runCount}
+            />
+          </TabsContent>
+        </Tabs>
+
+        <BlockStack gap="1">
+          {hasActiveParams && (
+            <Paragraph size="xs" tone="subdued">
+              {activeParams.map((p) => p.values.length).join(" x ")} ={" "}
+              <Text as="span" size="xs" weight="semibold">
+                {runCount} {runCount === 1 ? "run" : "runs"}
+              </Text>
+            </Paragraph>
+          )}
+          {validationError && (
+            <Paragraph size="xs" tone="critical">
+              {validationError}
+            </Paragraph>
+          )}
+        </BlockStack>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={handleCancel}>
+            Cancel
+          </Button>
+          <Button
+            onClick={handleConfirm}
+            disabled={validationError !== null || !hasActiveParams}
+            data-testid="sweep-submit-button"
+          >
+            {hasActiveParams && runCount > 0
+              ? `Submit ${runCount} Runs`
+              : "Submit Sweep"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/components/shared/Submitters/Oasis/components/SweepParameterField.tsx
+++ b/src/components/shared/Submitters/Oasis/components/SweepParameterField.tsx
@@ -1,0 +1,205 @@
+import { type ClipboardEvent, type KeyboardEvent, useState } from "react";
+
+import TooltipButton from "@/components/shared/Buttons/TooltipButton";
+import { typeSpecToString } from "@/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/utils";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icon";
+import { Input } from "@/components/ui/input";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Paragraph, Text } from "@/components/ui/typography";
+import type { InputSpec } from "@/utils/componentSpec";
+
+interface SweepParameterFieldProps {
+  input: InputSpec;
+  values: string[];
+  onAddValue: (value: string) => void;
+  onRemoveValue: (index: number) => void;
+  onApplyRange: (rangeStr: string) => void;
+  onClear: () => void;
+}
+
+export const SweepParameterField = ({
+  input,
+  values,
+  onAddValue,
+  onRemoveValue,
+  onApplyRange,
+  onClear,
+}: SweepParameterFieldProps) => {
+  const [inputValue, setInputValue] = useState("");
+  const [showRange, setShowRange] = useState(false);
+  const [rangeInput, setRangeInput] = useState("");
+
+  const typeLabel = typeSpecToString(input.type);
+  const isRequired = !input.optional;
+
+  const submitValue = () => {
+    if (inputValue.trim() === "") return;
+    onAddValue(inputValue);
+    setInputValue("");
+  };
+
+  const submitRange = () => {
+    if (rangeInput.trim() === "") return;
+    onApplyRange(rangeInput);
+    setRangeInput("");
+    setShowRange(false);
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      submitValue();
+    }
+  };
+
+  const handlePaste = (e: ClipboardEvent<HTMLInputElement>) => {
+    const pasted = e.clipboardData.getData("text");
+    if (pasted.includes(",")) {
+      e.preventDefault();
+      onAddValue(pasted);
+      setInputValue("");
+    }
+  };
+
+  return (
+    <BlockStack
+      gap="2"
+      className="rounded-md border border-border p-3"
+      data-testid={`sweep-param-${input.name}`}
+    >
+      <InlineStack gap="2" blockAlign="center" wrap="nowrap" className="w-full">
+        <Text size="sm" weight="semibold" className="shrink-0">
+          {input.name}
+        </Text>
+        <Text size="xs" tone="subdued" className="shrink-0">
+          ({typeLabel}
+          {isRequired ? "*" : ""})
+        </Text>
+        <div className="flex-1" />
+        {values.length > 0 && (
+          <>
+            <Badge
+              variant="secondary"
+              size="xs"
+              shape="rounded"
+              className="shrink-0"
+            >
+              {values.length}
+            </Badge>
+            <Button
+              variant="ghost"
+              size="xs"
+              onClick={onClear}
+              className="shrink-0"
+              data-testid={`sweep-clear-${input.name}`}
+            >
+              <Icon name="X" size="xs" />
+            </Button>
+          </>
+        )}
+      </InlineStack>
+
+      {input.description && (
+        <Paragraph size="xs" tone="subdued" className="italic">
+          {input.description}
+        </Paragraph>
+      )}
+
+      {values.length > 0 && (
+        <InlineStack gap="1" wrap="wrap">
+          {values.map((value, index) => (
+            <Badge
+              key={`${value}-${index}`}
+              variant="secondary"
+              className="gap-1 cursor-default"
+            >
+              <Text size="xs" font="mono" className="max-w-40 truncate">
+                {value}
+              </Text>
+              <button
+                type="button"
+                onClick={() => onRemoveValue(index)}
+                className="ml-0.5 hover:text-destructive"
+                data-testid={`sweep-remove-${input.name}-${index}`}
+              >
+                <Icon name="X" size="xs" />
+              </button>
+            </Badge>
+          ))}
+        </InlineStack>
+      )}
+
+      <InlineStack gap="1" blockAlign="center" className="w-full">
+        <Input
+          value={inputValue}
+          onChange={(e) => setInputValue(e.target.value)}
+          onKeyDown={handleKeyDown}
+          onPaste={handlePaste}
+          placeholder={
+            input.default
+              ? `Add value (default: ${input.default})`
+              : "Type or paste comma-separated values"
+          }
+          className="flex-1 bg-white!"
+          data-testid={`sweep-input-${input.name}`}
+        />
+        <TooltipButton
+          tooltip="Add value(s)"
+          variant="ghost"
+          size="sm"
+          onClick={submitValue}
+          disabled={inputValue.trim() === ""}
+        >
+          <Icon name="Plus" size="sm" />
+        </TooltipButton>
+        <TooltipButton
+          tooltip="Generate values from a numeric range"
+          variant="ghost"
+          size="sm"
+          onClick={() => setShowRange(!showRange)}
+        >
+          <Icon name="Hash" size="sm" />
+        </TooltipButton>
+      </InlineStack>
+
+      {showRange && (
+        <BlockStack gap="1" className="rounded-md bg-muted px-3 py-2">
+          <Paragraph size="xs" weight="semibold">
+            Range generator
+          </Paragraph>
+          <Paragraph size="xs" tone="subdued">
+            Format: start..end [linear|log] [steps]
+          </Paragraph>
+          <Paragraph size="xs" tone="subdued" font="mono">
+            e.g. 0.001..0.1 log 5
+          </Paragraph>
+          <InlineStack gap="1" blockAlign="center">
+            <Input
+              value={rangeInput}
+              onChange={(e) => setRangeInput(e.target.value)}
+              onKeyDown={(e: KeyboardEvent<HTMLInputElement>) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  submitRange();
+                }
+              }}
+              placeholder="0.001..0.1 log 5"
+              className="flex-1 bg-white!"
+              data-testid={`sweep-range-${input.name}`}
+            />
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={submitRange}
+              disabled={rangeInput.trim() === ""}
+            >
+              Apply
+            </Button>
+          </InlineStack>
+        </BlockStack>
+      )}
+    </BlockStack>
+  );
+};

--- a/src/components/shared/Submitters/Oasis/components/SweepPreviewTable.tsx
+++ b/src/components/shared/Submitters/Oasis/components/SweepPreviewTable.tsx
@@ -1,0 +1,90 @@
+import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { BlockStack } from "@/components/ui/layout";
+import { Paragraph, Text } from "@/components/ui/typography";
+import type { ArgumentType } from "@/utils/componentSpec";
+
+const MAX_PREVIEW_ROWS = 50;
+
+interface SweepPreviewTableProps {
+  combinations: Record<string, ArgumentType>[];
+  sweepParamNames: string[];
+  totalCount: number;
+}
+
+export const SweepPreviewTable = ({
+  combinations,
+  sweepParamNames,
+  totalCount,
+}: SweepPreviewTableProps) => {
+  if (combinations.length === 0) {
+    return (
+      <BlockStack fill className="py-8">
+        <Paragraph tone="subdued" size="sm">
+          Add values to parameters to preview the run matrix.
+        </Paragraph>
+      </BlockStack>
+    );
+  }
+
+  return (
+    <BlockStack gap="2">
+      <ScrollArea className="max-h-[50vh]">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-12">
+                <Text size="xs" weight="semibold">
+                  #
+                </Text>
+              </TableHead>
+              {sweepParamNames.map((name) => (
+                <TableHead key={name}>
+                  <Text size="xs" weight="semibold">
+                    {name}
+                  </Text>
+                </TableHead>
+              ))}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {combinations.map((combo, index) => (
+              <TableRow key={index}>
+                <TableCell>
+                  <Text size="xs" tone="subdued">
+                    {index + 1}
+                  </Text>
+                </TableCell>
+                {sweepParamNames.map((name) => (
+                  <TableCell key={name}>
+                    <Text
+                      size="xs"
+                      font="mono"
+                      className="max-w-48 truncate inline-block"
+                    >
+                      {String(combo[name] ?? "")}
+                    </Text>
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </ScrollArea>
+      {totalCount > MAX_PREVIEW_ROWS && (
+        <Paragraph size="xs" tone="subdued">
+          Showing {MAX_PREVIEW_ROWS} of {totalCount} runs.
+        </Paragraph>
+      )}
+    </BlockStack>
+  );
+};
+
+export { MAX_PREVIEW_ROWS };

--- a/src/utils/parameterSweep.test.ts
+++ b/src/utils/parameterSweep.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  expandSweep,
+  getSweepRunCount,
+  parseRange,
+  type SweepParameter,
+  validateSweep,
+} from "./parameterSweep";
+
+describe("expandSweep", () => {
+  const baseArgs = { lr: "0.01", batch_size: "32", model: "resnet" };
+
+  it("returns base arguments when no sweep params have values", () => {
+    const params: SweepParameter[] = [{ name: "lr", values: [] }];
+    expect(expandSweep(baseArgs, params)).toEqual([baseArgs]);
+  });
+
+  it("generates cartesian product for single parameter", () => {
+    const params: SweepParameter[] = [
+      { name: "lr", values: ["0.001", "0.01", "0.1"] },
+    ];
+    const result = expandSweep(baseArgs, params);
+    expect(result).toEqual([
+      { ...baseArgs, lr: "0.001" },
+      { ...baseArgs, lr: "0.01" },
+      { ...baseArgs, lr: "0.1" },
+    ]);
+  });
+
+  it("generates cartesian product for multiple parameters", () => {
+    const params: SweepParameter[] = [
+      { name: "lr", values: ["0.001", "0.01"] },
+      { name: "batch_size", values: ["32", "64"] },
+    ];
+    const result = expandSweep(baseArgs, params);
+    expect(result).toHaveLength(4);
+    expect(result).toEqual([
+      { ...baseArgs, lr: "0.001", batch_size: "32" },
+      { ...baseArgs, lr: "0.001", batch_size: "64" },
+      { ...baseArgs, lr: "0.01", batch_size: "32" },
+      { ...baseArgs, lr: "0.01", batch_size: "64" },
+    ]);
+  });
+
+  it("generates cartesian product for three parameters", () => {
+    const params: SweepParameter[] = [
+      { name: "lr", values: ["0.001", "0.01"] },
+      { name: "batch_size", values: ["32", "64"] },
+      { name: "model", values: ["resnet", "vgg"] },
+    ];
+    const result = expandSweep(baseArgs, params);
+    expect(result).toHaveLength(8);
+  });
+
+  it("skips params with no values", () => {
+    const params: SweepParameter[] = [
+      { name: "lr", values: ["0.001", "0.01"] },
+      { name: "batch_size", values: [] },
+    ];
+    const result = expandSweep(baseArgs, params);
+    expect(result).toHaveLength(2);
+    expect(result[0].batch_size).toBe("32");
+  });
+});
+
+describe("getSweepRunCount", () => {
+  it("returns 0 when no params have values", () => {
+    expect(getSweepRunCount([])).toBe(0);
+  });
+
+  it("returns product of value counts", () => {
+    const params: SweepParameter[] = [
+      { name: "a", values: ["1", "2", "3"] },
+      { name: "b", values: ["x", "y"] },
+    ];
+    expect(getSweepRunCount(params)).toBe(6);
+  });
+
+  it("ignores params with no values", () => {
+    const params: SweepParameter[] = [
+      { name: "a", values: ["1", "2"] },
+      { name: "b", values: [] },
+    ];
+    expect(getSweepRunCount(params)).toBe(2);
+  });
+});
+
+describe("validateSweep", () => {
+  it("returns error when no params have values", () => {
+    const result = validateSweep([{ name: "a", values: [] }]);
+    expect(result).toContain("Add at least one value");
+  });
+
+  it("returns error for empty string values", () => {
+    const result = validateSweep([{ name: "a", values: ["good", " "] }]);
+    expect(result).toContain("Empty values");
+  });
+
+  it("returns error when exceeding max runs", () => {
+    const params: SweepParameter[] = [
+      { name: "a", values: Array.from({ length: 50 }, (_, i) => String(i)) },
+      { name: "b", values: Array.from({ length: 50 }, (_, i) => String(i)) },
+    ];
+    const result = validateSweep(params);
+    expect(result).toContain("exceeds the maximum");
+  });
+
+  it("returns null for valid configuration", () => {
+    const result = validateSweep([
+      { name: "a", values: ["1", "2"] },
+      { name: "b", values: ["x", "y"] },
+    ]);
+    expect(result).toBeNull();
+  });
+});
+
+describe("parseRange", () => {
+  it("returns null for non-range strings", () => {
+    expect(parseRange("hello")).toBeNull();
+    expect(parseRange("1,2,3")).toBeNull();
+  });
+
+  it("generates linear range with default steps", () => {
+    const result = parseRange("0..1");
+    expect(result).toHaveLength(5);
+    expect(result?.[0]).toBe("0");
+    expect(result?.[4]).toBe("1");
+  });
+
+  it("generates linear range with custom steps", () => {
+    const result = parseRange("0..10 linear 3");
+    expect(result).toEqual(["0", "5", "10"]);
+  });
+
+  it("generates log range", () => {
+    const result = parseRange("0.001..1 log 4");
+    expect(result).toHaveLength(4);
+    expect(result?.[0]).toBe("0.001");
+    expect(result?.[3]).toBe("1");
+  });
+
+  it("returns null for log range with non-positive values", () => {
+    expect(parseRange("0..1 log 5")).toBeNull();
+    expect(parseRange("-1..1 log 5")).toBeNull();
+  });
+
+  it("returns null when steps < 2", () => {
+    expect(parseRange("0..1 linear 1")).toBeNull();
+  });
+
+  it("handles negative values in linear range", () => {
+    const result = parseRange("-1..1 linear 3");
+    expect(result).toEqual(["-1", "0", "1"]);
+  });
+});

--- a/src/utils/parameterSweep.ts
+++ b/src/utils/parameterSweep.ts
@@ -1,0 +1,118 @@
+import type { ArgumentType } from "./componentSpec";
+
+/** A sweep defines multiple values for one or more parameters. */
+export interface SweepParameter {
+  name: string;
+  values: string[];
+}
+
+/**
+ * Generates run argument sets from sweep parameters using cartesian product.
+ *
+ * Every combination of all parameter values (N x M x ...).
+ * Non-swept parameters are carried through unchanged.
+ */
+export function expandSweep(
+  baseArguments: Record<string, ArgumentType>,
+  sweepParams: SweepParameter[],
+): Record<string, ArgumentType>[] {
+  const activeParams = sweepParams.filter((p) => p.values.length > 0);
+  if (activeParams.length === 0) return [baseArguments];
+
+  return cartesianProduct(activeParams).map((combo) => ({
+    ...baseArguments,
+    ...combo,
+  }));
+}
+
+function cartesianProduct(params: SweepParameter[]): Record<string, string>[] {
+  if (params.length === 0) return [{}];
+
+  const [first, ...rest] = params;
+  const restCombinations = cartesianProduct(rest);
+
+  const result: Record<string, string>[] = [];
+  for (const value of first.values) {
+    for (const combo of restCombinations) {
+      result.push({ [first.name]: value, ...combo });
+    }
+  }
+  return result;
+}
+
+/** Returns the total number of runs a sweep would produce. */
+export function getSweepRunCount(sweepParams: SweepParameter[]): number {
+  const activeParams = sweepParams.filter((p) => p.values.length > 0);
+  if (activeParams.length === 0) return 0;
+  return activeParams.reduce((total, p) => total * p.values.length, 1);
+}
+
+const MAX_SWEEP_RUNS = 500;
+
+/** Validates sweep configuration and returns an error message if invalid. */
+export function validateSweep(sweepParams: SweepParameter[]): string | null {
+  const activeParams = sweepParams.filter((p) => p.values.length > 0);
+  if (activeParams.length === 0) {
+    return "Add at least one value to a parameter to create a sweep.";
+  }
+
+  const emptyValueParams = activeParams.filter((p) =>
+    p.values.some((v) => v.trim() === ""),
+  );
+  if (emptyValueParams.length > 0) {
+    return `Empty values found in: ${emptyValueParams.map((p) => `"${p.name}"`).join(", ")}`;
+  }
+
+  const runCount = getSweepRunCount(sweepParams);
+  if (runCount > MAX_SWEEP_RUNS) {
+    return `This sweep would create ${runCount} runs, which exceeds the maximum of ${MAX_SWEEP_RUNS}. Reduce the number of values or parameters.`;
+  }
+
+  return null;
+}
+
+/**
+ * Parses a range string like "0.001..0.1 log 5" into discrete values.
+ *
+ * Format: "start..end [scale] [steps]"
+ * - scale: "linear" (default) or "log"
+ * - steps: number of values to generate (default: 5)
+ */
+export function parseRange(rangeStr: string): string[] | null {
+  const rangePattern =
+    /^(-?[\d.]+)\.\.(-?[\d.]+)(?:\s+(linear|log))?(?:\s+(\d+))?$/;
+  const match = rangeStr.trim().match(rangePattern);
+  if (!match) return null;
+
+  const start = Number(match[1]);
+  const end = Number(match[2]);
+  const scaleRaw = match[3] ?? "linear";
+  if (scaleRaw !== "linear" && scaleRaw !== "log") return null;
+  const scale = scaleRaw;
+  const steps = Number(match[4] ?? 5);
+
+  if (Number.isNaN(start) || Number.isNaN(end) || steps < 2) return null;
+
+  if (scale === "log") {
+    if (start <= 0 || end <= 0) return null;
+    const logStart = Math.log10(start);
+    const logEnd = Math.log10(end);
+    return Array.from({ length: steps }, (_, i) => {
+      const t = i / (steps - 1);
+      const value = 10 ** (logStart + t * (logEnd - logStart));
+      return formatNumber(value);
+    });
+  }
+
+  return Array.from({ length: steps }, (_, i) => {
+    const t = i / (steps - 1);
+    const value = start + t * (end - start);
+    return formatNumber(value);
+  });
+}
+
+function formatNumber(n: number): string {
+  // Avoid floating point artifacts like 0.30000000000000004
+  const rounded = Number(n.toPrecision(10));
+  return String(rounded);
+}


### PR DESCRIPTION
## Description

Added a parameter sweep feature to the Oasis submitter that allows users to define multiple values for pipeline parameters and automatically generate all combinations. The feature supports two modes: cartesian product (every combination) and zip (paired values). Users can input values manually, paste comma-separated lists, or generate numeric ranges using a built-in range generator with linear and logarithmic scaling.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

1. Navigate to a pipeline with configurable input parameters
2. Click the new parameter sweep button (grid icon) next to the run with arguments button
3. Add multiple values to one or more parameters using:
   - Manual input (comma-separated values)
   - Range generator (e.g., "0.001..0.1 log 5")
4. Switch between cartesian and zip modes to see different combination strategies
5. Preview the generated run matrix in the Preview tab
6. Submit the sweep to create multiple runs with different parameter combinations
7. Verify that the bulk submission works correctly and creates the expected number of runs

## Additional Comments

The implementation includes comprehensive validation to prevent invalid configurations (mismatched value counts in zip mode, empty values, excessive run counts). The range generator supports both linear and logarithmic scaling with customizable step counts. A maximum limit of 500 runs prevents accidental creation of too many runs.