### PR TITLE
Add test announcement to window for testing only

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,6 +34,19 @@
   </head>
   <body>
     <div id="app"></div>
+    <script>
+      // Test announcements — remove before merging
+      window.__TANGLE_ANNOUNCEMENTS__ = [
+        {
+          id: "gpu-quota-enforcement-march-2026",
+          title: "Upcoming: GPU Quota Enforcement for Tangle Workloads",
+          body: "GPU workloads will soon require registered project quotas. Please ensure your quota groups are configured before enforcement begins. For any questions, reach out in the #tangle Slack channel.",
+          variant: "warning",
+          dismissible: true,
+          expiresAt: "2026-04-01",
+        },
+      ];
+    </script>
     <script type="module" src="/src/index.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
## Description
THIS IS FOR TESTING ONLY

Added a test announcement for GPU quota enforcement to the global window object. The announcement warns users about upcoming GPU quota requirements for Tangle workloads, scheduled to take effect before April 1, 2026. The announcement is configured as a dismissible warning that expires on April 1, 2026.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Load the application in a browser
2. Verify that the GPU quota enforcement announcement appears
3. Test that the announcement can be dismissed
4. Confirm the announcement displays as a warning variant

## Additional Comments

This is marked as a test announcement and should be removed before merging to production. The announcement references the #tangle Slack channel for user questions about quota configuration.