### PR TITLE
fix: Multiselect Panel not showing more than two nodes

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
@@ -328,6 +328,7 @@ const FlowCanvasContent = ({
   const selectedNodes = nodes.filter(
     (node) => node.selected && node.type && SELECTABLE_NODES.has(node.type),
   );
+  const selectedNodeIds = selectedNodes.map((node) => node.id).join(",");
 
   const canUpgrade = selectedNodes.some(
     (node) => node.type && UPGRADEABLE_NODES.has(node.type),
@@ -1078,7 +1079,7 @@ const FlowCanvasContent = ({
       );
       setOpen(true);
     }
-  }, [currentSubgraphSpec, readOnly, canUpgrade, canGroup]);
+  }, [currentSubgraphSpec, selectedNodeIds, readOnly, canUpgrade, canGroup]);
 
   return (
     <BlockStack fill>


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

Fixes an unintended issue where multiselect dialog only recognizes the first two items selected

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
