### PR TITLE
fix: Multiselect Panel using Stale Data for Tasks and Flex Nodes

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/Multiselect/FlexDetailPanel.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/Multiselect/FlexDetailPanel.tsx
@@ -2,9 +2,10 @@ import type { Node } from "@xyflow/react";
 
 import { InfoBox } from "@/components/shared/InfoBox";
 import { Paragraph } from "@/components/ui/typography";
+import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 
 import { FlexNodeEditor } from "../FlexNode/FlexNodeEditor";
-import { isFlexNodeData } from "../FlexNode/types";
+import { getFlexNode } from "../FlexNode/interface";
 
 export const FlexDetailPanel = ({
   node,
@@ -13,8 +14,10 @@ export const FlexDetailPanel = ({
   node: Node;
   readOnly: boolean;
 }) => {
-  const data = node.data;
-  if (!isFlexNodeData(data)) {
+  const { currentSubgraphSpec } = useComponentSpec();
+  const flexNode = getFlexNode(node.id, currentSubgraphSpec);
+
+  if (!flexNode) {
     return (
       <InfoBox title="Unable to Load Sticky Note Details" variant="error">
         <Paragraph size="sm" tone="subdued">
@@ -24,5 +27,5 @@ export const FlexDetailPanel = ({
     );
   }
 
-  return <FlexNodeEditor flexNode={data} readOnly={readOnly} />;
+  return <FlexNodeEditor flexNode={flexNode} readOnly={readOnly} />;
 };

--- a/src/components/shared/ReactFlow/FlowCanvas/Multiselect/TaskDetailPanel.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/Multiselect/TaskDetailPanel.tsx
@@ -2,18 +2,33 @@ import type { Node } from "@xyflow/react";
 
 import { InfoBox } from "@/components/shared/InfoBox";
 import { Paragraph } from "@/components/ui/typography";
+import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 import { useExecutionDataOptional } from "@/providers/ExecutionDataProvider";
 import { TaskNodeProvider, useTaskNode } from "@/providers/TaskNodeProvider";
 import type { TaskNodeData } from "@/types/taskNode";
+import { isGraphImplementation } from "@/utils/componentSpec";
+import { nodeIdToTaskId } from "@/utils/nodes/nodeIdUtils";
 
 import TaskOverview from "../TaskNode/TaskOverview";
 
 export const TaskDetailPanel = ({ node }: { node: Node }) => {
-  const data = node.data as TaskNodeData;
-
+  const { currentSubgraphSpec } = useComponentSpec();
   const executionData = useExecutionDataOptional();
 
-  if (!data.taskId || !data.taskSpec) {
+  if (!isGraphImplementation(currentSubgraphSpec.implementation)) {
+    return (
+      <InfoBox title="Unable to Load Task Details" variant="error">
+        <Paragraph size="sm" tone="subdued">
+          Unable to load task details. Graph specification is invalid.
+        </Paragraph>
+      </InfoBox>
+    );
+  }
+
+  const taskId = nodeIdToTaskId(node.id);
+  const taskSpec = currentSubgraphSpec.implementation.graph.tasks?.[taskId];
+
+  if (!taskId || !taskSpec) {
     return (
       <InfoBox title="Unable to Load Task Details" variant="error">
         <Paragraph size="sm" tone="subdued">
@@ -23,10 +38,11 @@ export const TaskDetailPanel = ({ node }: { node: Node }) => {
     );
   }
 
-  const status = executionData?.taskExecutionStatusMap.get(data.taskId);
+  const status = executionData?.taskExecutionStatusMap.get(taskId);
+  const freshData: TaskNodeData = { ...node.data, taskSpec };
 
   return (
-    <TaskNodeProvider data={data} status={status} selected>
+    <TaskNodeProvider data={freshData} status={status} selected>
       <TaskDetailContent />
     </TaskNodeProvider>
   );


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Fix an issue within the multiselect context panel where task nodes and flex nodes were using stale spec data after an edit has been made via their respective editors.

The nodes now pull data directly from `useComponentSpec` so it is always fresh!

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
