### PR TITLE
chore: Improved Exiting from Settings Page

### DIFF
--- a/src/components/layout/AppMenu.tsx
+++ b/src/components/layout/AppMenu.tsx
@@ -1,5 +1,8 @@
-import { Link as RouterLink } from "@tanstack/react-router";
-import { Menu, Plus, Upload } from "lucide-react";
+import {
+  Link as RouterLink,
+  useLocation,
+  useRouter,
+} from "@tanstack/react-router";
 import { useState } from "react";
 
 import logo from "/Tangle_white.png";
@@ -31,10 +34,20 @@ import TooltipButton from "../shared/Buttons/TooltipButton";
 import NewPipelineButton from "../shared/NewPipelineButton";
 
 const AppMenu = () => {
+  const router = useRouter();
+  const location = useLocation();
+
   const requiresAuthorization = isAuthorizationRequired();
   const { componentSpec } = useComponentSpec();
-  const title = componentSpec?.name;
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+
+  const title = componentSpec?.name;
+
+  const handleGoBack = () => {
+    router.history.back();
+  };
+
+  const isOnSettingsRoute = location.pathname.startsWith("/settings");
 
   return (
     <div
@@ -64,7 +77,7 @@ const AppMenu = () => {
             <ImportPipeline
               triggerComponent={
                 <TooltipButton tooltip="Import Pipeline">
-                  <Upload className="h-4 w-4" />
+                  <Icon name="Upload" />
                 </TooltipButton>
               }
             />
@@ -72,7 +85,7 @@ const AppMenu = () => {
               <Tooltip>
                 <TooltipTrigger asChild>
                   <NewPipelineButton>
-                    <Plus className="h-4 w-4" />
+                    <Icon name="Plus" />
                   </NewPipelineButton>
                 </TooltipTrigger>
                 <TooltipContent>New Pipeline</TooltipContent>
@@ -82,11 +95,27 @@ const AppMenu = () => {
           </div>
 
           {/* Settings & status */}
-          <RouterLink to="/settings/backend">
-            <TooltipButton tooltip="Settings">
+          {isOnSettingsRoute ? (
+            <TooltipButton
+              tooltip="Close Settings"
+              onClick={handleGoBack}
+              className="relative"
+            >
               <Icon name="Settings" />
+              <Icon
+                name="X"
+                size="xs"
+                className="absolute bottom-1.5 right-1.5 bg-foreground rounded-full"
+              />
             </TooltipButton>
-          </RouterLink>
+          ) : (
+            <RouterLink to="/settings/backend">
+              <TooltipButton tooltip="Settings">
+                <Icon name="Settings" />
+              </TooltipButton>
+            </RouterLink>
+          )}
+
           <Link
             href={DOCUMENTATION_URL}
             target="_blank"
@@ -96,6 +125,7 @@ const AppMenu = () => {
               <Icon name="CircleQuestionMark" />
             </TooltipButton>
           </Link>
+
           {requiresAuthorization && <TopBarAuthentication />}
 
           {/* Mobile hamburger menu */}
@@ -107,7 +137,7 @@ const AppMenu = () => {
                 className="md:hidden text-white hover:bg-stone-800"
                 aria-label="Open menu"
               >
-                <Menu className="h-5 w-5" />
+                <Icon name="Menu" size="lg" />
               </Button>
             </SheetTrigger>
             <SheetContent

--- a/src/routes/Settings/SettingsLayout.tsx
+++ b/src/routes/Settings/SettingsLayout.tsx
@@ -61,15 +61,11 @@ export function SettingsLayout() {
               data-testid="settings-back-button"
             >
               <Icon name="ArrowLeft" />
+              <Heading level={1}>Settings</Heading>
             </Button>
-            <Heading level={1}>Settings</Heading>
           </InlineStack>
 
-          <InlineStack
-            gap="8"
-            blockAlign="start"
-            className="w-full min-h-[400px]"
-          >
+          <InlineStack gap="8" blockAlign="start" className="w-full min-h-100">
             <BlockStack
               gap="1"
               className="w-48 shrink-0 border-r border-border pr-4"


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Makes it easier to get out of the Settings window.

You can now click the settings icon in the nav to close it and go back.
Or, the original "close" button how includes the "Settings" title text as well.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

![image.png](https://app.graphite.com/user-attachments/assets/04c80a23-7708-43fd-abc8-1e327d874cd3.png)

![image.png](https://app.graphite.com/user-attachments/assets/34b992ce-7d1a-487f-9f50-215426201354.png)

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->
- confirm settings and routing work as expected

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
