### PR TITLE
fix: Small OutputNameEditor Input Boxes

### DIFF
--- a/src/components/Editor/IOEditor/OutputNameEditor/OutputNameEditor.tsx
+++ b/src/components/Editor/IOEditor/OutputNameEditor/OutputNameEditor.tsx
@@ -182,15 +182,15 @@ export const OutputNameEditor = ({
   return (
     <BlockStack gap="3" className="p-4 w-full">
       <Heading level={1}>{output.name}</Heading>
-      <div className="flex-1">
-        <NameField
-          inputName={outputName}
-          onNameChange={handleNameChange}
-          onBlur={handleBlur}
-          disabled={disabled}
-          error={validationError}
-        />
-      </div>
+
+      <NameField
+        inputName={outputName}
+        onNameChange={handleNameChange}
+        onBlur={handleBlur}
+        disabled={disabled}
+        error={validationError}
+      />
+
       <DescriptionField
         inputName={output.name}
         inputDescription={outputDescription}
@@ -198,15 +198,14 @@ export const OutputNameEditor = ({
         onBlur={handleBlur}
         disabled={disabled}
       />
-      <div className="w-36">
-        <TypeField
-          inputValue={connectedDetails.outputType ?? "Any"}
-          onInputChange={() => {}}
-          placeholder="Any"
-          disabled
-          inputName={output.name}
-        />
-      </div>
+
+      <TypeField
+        inputValue={connectedDetails.outputType ?? "Any"}
+        onInputChange={() => {}}
+        placeholder="Any"
+        disabled
+        inputName={output.name}
+      />
 
       <InlineStack gap="4">
         {!disabled && (


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

Quick fix to make the output editor input boxes full-width, like the input editor.

## Related Issue and Pull requests


<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

![image.png](https://app.graphite.com/user-attachments/assets/3b0ead0a-5a28-4344-9699-01d4c9dc9350.png)

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->