### PR TITLE
feat: Link to Node on Canvas

### DIFF
--- a/src/components/Editor/IOEditor/InputValueEditor/InputValueEditor.tsx
+++ b/src/components/Editor/IOEditor/InputValueEditor/InputValueEditor.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 
 import { updateInputNameOnComponentSpec } from "@/components/Editor/utils/updateInputNameOnComponentSpec";
+import { LinkNodeButton } from "@/components/shared/Buttons/LinkNodeButton";
 import { ConfirmationDialog } from "@/components/shared/Dialogs";
 import { InfoBox } from "@/components/shared/InfoBox";
 import { removeGraphInput } from "@/components/shared/ReactFlow/FlowCanvas/utils/removeNode";
@@ -327,6 +328,8 @@ export const InputValueEditor = ({
         )}
 
         <IOZIndexEditor ioSpec={input} ioType="input" />
+
+        {disabled && <LinkNodeButton nodeId={inputNameToNodeId(input.name)} />}
       </InlineStack>
 
       <ConfirmationDialog

--- a/src/components/Editor/IOEditor/OutputNameEditor/OutputNameEditor.tsx
+++ b/src/components/Editor/IOEditor/OutputNameEditor/OutputNameEditor.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 
+import { LinkNodeButton } from "@/components/shared/Buttons/LinkNodeButton";
 import ConfirmationDialog from "@/components/shared/Dialogs/ConfirmationDialog";
 import { removeGraphOutput } from "@/components/shared/ReactFlow/FlowCanvas/utils/removeNode";
 import { Button } from "@/components/ui/button";
@@ -215,6 +216,10 @@ export const OutputNameEditor = ({
         )}
 
         <IOZIndexEditor ioSpec={output} ioType="output" />
+
+        {disabled && (
+          <LinkNodeButton nodeId={outputNameToNodeId(output.name)} />
+        )}
       </InlineStack>
 
       <ConfirmationDialog

--- a/src/components/PipelineRun/PipelineRunPage.tsx
+++ b/src/components/PipelineRun/PipelineRunPage.tsx
@@ -11,11 +11,13 @@ import type { FlowCanvasRef } from "../shared/ReactFlow/FlowCanvas/FlowCanvas";
 import type { LayoutAlgorithm } from "../shared/ReactFlow/FlowCanvas/utils/autolayout";
 import { RunDetails } from "./RunDetails";
 import { RunToolbar } from "./RunToolbar";
+import { useFitNodeFromUrl } from "./useFitNodeFromUrl";
 
 const GRID_SIZE = 10;
 
 const PipelineRunPage = () => {
   const flowCanvasRef = useRef<FlowCanvasRef>(null);
+  const { linkedNodeId } = useFitNodeFromUrl();
 
   const [flowConfig, setFlowConfig] = useState<ReactFlowProps>({
     snapGrid: [GRID_SIZE, GRID_SIZE],
@@ -44,7 +46,12 @@ const PipelineRunPage = () => {
       <ComponentLibraryProvider>
         <InlineStack fill>
           <BlockStack fill className="flex-1">
-            <FlowCanvas ref={flowCanvasRef} {...flowConfig} readOnly>
+            <FlowCanvas
+              ref={flowCanvasRef}
+              {...flowConfig}
+              readOnly
+              fitViewOnInit={!linkedNodeId}
+            >
               <MiniMap position="bottom-left" pannable />
               <RunToolbar />
               <FlowControls

--- a/src/components/PipelineRun/useFitNodeFromUrl.ts
+++ b/src/components/PipelineRun/useFitNodeFromUrl.ts
@@ -1,0 +1,65 @@
+import { useEffect } from "react";
+
+import { useNodesOverlay } from "@/components/shared/ReactFlow/NodesOverlay/NodesOverlayProvider";
+
+/**
+ * Reads `?nodeId=` from the URL on mount, fits that node into view, selects it,
+ * and highlights it with an orange border. The highlight clears (and the param
+ * is removed from the URL) on the next user pointer or keyboard interaction.
+ */
+export const useFitNodeFromUrl = () => {
+  const { fitNodeIntoView, selectNode, notifyNode } = useNodesOverlay();
+
+  const linkedNodeId = new URLSearchParams(window.location.search).get(
+    "nodeId",
+  );
+
+  useEffect(() => {
+    if (!linkedNodeId) return;
+
+    const nodeId = linkedNodeId;
+    let timeoutId: ReturnType<typeof setTimeout>;
+    let isHighlighted = false;
+
+    const clearHighlight = () => {
+      if (!isHighlighted) return;
+
+      isHighlighted = false;
+
+      notifyNode(nodeId, { type: "clear" });
+
+      const url = new URL(window.location.href);
+      url.searchParams.delete("nodeId");
+
+      history.replaceState(null, "", url.toString());
+      document.removeEventListener("pointerdown", clearHighlight);
+      document.removeEventListener("keydown", clearHighlight);
+    };
+
+    const focus = async () => {
+      const success = await fitNodeIntoView(nodeId);
+      if (!success) return;
+
+      isHighlighted = true;
+
+      selectNode(nodeId);
+      notifyNode(nodeId, { type: "highlight" });
+
+      timeoutId = setTimeout(() => {
+        document.addEventListener("pointerdown", clearHighlight);
+        document.addEventListener("keydown", clearHighlight);
+      }, 500);
+    };
+
+    // Double-RAF to allow the canvas to render nodes before querying them
+    const frameId = requestAnimationFrame(() => requestAnimationFrame(focus));
+
+    return () => {
+      cancelAnimationFrame(frameId);
+      clearTimeout(timeoutId);
+      clearHighlight();
+    };
+  }, []);
+
+  return { linkedNodeId };
+};

--- a/src/components/shared/Buttons/LinkNodeButton.tsx
+++ b/src/components/shared/Buttons/LinkNodeButton.tsx
@@ -1,0 +1,23 @@
+import useToastNotification from "@/hooks/useToastNotification";
+
+import { ActionButton } from "./ActionButton";
+
+interface LinkNodeButtonProps {
+  nodeId: string;
+}
+
+export const LinkNodeButton = ({ nodeId }: LinkNodeButtonProps) => {
+  const notify = useToastNotification();
+
+  const handleLink = () => {
+    const link = new URL(window.location.href);
+    link.searchParams.set("nodeId", nodeId);
+    navigator.clipboard.writeText(link.toString());
+
+    notify(`Link copied to clipboard`, "success");
+  };
+
+  return (
+    <ActionButton tooltip="Shareable Link" icon="Link" onClick={handleLink} />
+  );
+};

--- a/src/components/shared/ReactFlow/FlowCanvas/FlexNode/FlexNodeEditor.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlexNode/FlexNodeEditor.tsx
@@ -1,5 +1,6 @@
 import { type ChangeEvent, useEffect, useState } from "react";
 
+import { LinkNodeButton } from "@/components/shared/Buttons/LinkNodeButton";
 import { ContentBlock } from "@/components/shared/ContextPanel/Blocks/ContentBlock";
 import { KeyValueList } from "@/components/shared/ContextPanel/Blocks/KeyValueList";
 import { CopyText } from "@/components/shared/CopyText/CopyText";
@@ -95,6 +96,8 @@ export const FlexNodeEditor = ({
       />
 
       {!readOnly && !locked && <ZIndexEditor flexNode={flexNode} />}
+
+      {readOnly && <LinkNodeButton nodeId={flexNode.id} />}
     </BlockStack>
   );
 };

--- a/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
@@ -111,6 +111,7 @@ export interface FlowCanvasRef {
 
 interface FlowCanvasProps extends ReactFlowProps {
   readOnly?: boolean;
+  fitViewOnInit?: boolean;
   ref?: Ref<FlowCanvasRef>;
 }
 
@@ -125,11 +126,13 @@ const FlowCanvas = ({ ref, ...props }: FlowCanvasProps) => {
 const FlowCanvasContent = ({
   readOnly,
   nodesConnectable,
+  fitViewOnInit = true,
   ref,
   children,
   ...rest
 }: FlowCanvasProps) => {
   const initialCanvasLoaded = useRef(false);
+  const initialFitDone = useRef(false);
 
   const { clearContent, setContent, setOpen } = useContextPanel();
   const { data: currentUserDetails } = useUserDetails();
@@ -886,11 +889,16 @@ const FlowCanvasContent = ({
   ]);
 
   useEffect(() => {
-    reactFlowInstance?.fitView({
-      maxZoom: 1,
-      duration: 300,
-    });
-  }, [currentSubgraphPath, reactFlowInstance]);
+    if (!reactFlowInstance) return;
+
+    if (!initialFitDone.current) {
+      initialFitDone.current = true;
+
+      if (!fitViewOnInit) return;
+    }
+
+    reactFlowInstance.fitView({ maxZoom: 1, duration: 300 });
+  }, [currentSubgraphPath, reactFlowInstance, fitViewOnInit]);
 
   // Reset when loading a new component file
   useEffect(() => {
@@ -898,13 +906,11 @@ const FlowCanvasContent = ({
   }, [componentSpec?.name, resetPrevSpec]);
 
   const fitView = () => {
-    reactFlowInstance?.fitView({
-      maxZoom: 1,
-    });
+    reactFlowInstance?.fitView({ maxZoom: 1 });
   };
 
   useScheduleExecutionOnceWhenConditionMet(
-    initialCanvasLoaded.current && !!reactFlowInstance,
+    fitViewOnInit && initialCanvasLoaded.current && !!reactFlowInstance,
     fitView,
   );
 

--- a/src/components/shared/ReactFlow/NodesOverlay/NodesOverlayProvider.tsx
+++ b/src/components/shared/ReactFlow/NodesOverlay/NodesOverlayProvider.tsx
@@ -44,6 +44,7 @@ interface NodesOverlayContextType {
   setReactFlowInstance: (instance: ReactFlowInstance) => void;
   registerNode: (options: RegisterNodeOptions) => () => void;
   fitNodeIntoView: (nodeId: string) => Promise<boolean>;
+  selectNode: (nodeId: string) => void;
   getNodeIdsByDigest: (digest: string) => string[];
   // todo: consider EventTarget
   notifyNode: (nodeId: string, message: NotifyMessage) => void;
@@ -58,6 +59,7 @@ const NodesOverlayContext = createContext<NodesOverlayContextType>({
   setReactFlowInstance: () => {},
   registerNode: () => () => {},
   fitNodeIntoView: () => Promise.resolve(false),
+  selectNode: () => {},
   getNodeIdsByDigest: () => [],
   notifyNode: () => {},
 });
@@ -120,11 +122,18 @@ export const NodesOverlayProvider = ({ children }: PropsWithChildren<{}>) => {
     node.onNotify?.(message);
   }, []);
 
+  const selectNode = useCallback((nodeId: string) => {
+    instanceRef.current?.setNodes((nodes) =>
+      nodes.map((node) => ({ ...node, selected: node.id === nodeId })),
+    );
+  }, []);
+
   const value = useMemo(
     () => ({
       setReactFlowInstance,
       registerNode,
       fitNodeIntoView,
+      selectNode,
       getNodeIdsByDigest,
       notifyNode,
     }),
@@ -132,6 +141,7 @@ export const NodesOverlayProvider = ({ children }: PropsWithChildren<{}>) => {
       setReactFlowInstance,
       registerNode,
       fitNodeIntoView,
+      selectNode,
       getNodeIdsByDigest,
       notifyNode,
     ],

--- a/src/components/shared/TaskDetails/Actions.tsx
+++ b/src/components/shared/TaskDetails/Actions.tsx
@@ -2,6 +2,7 @@ import { type TaskNodeContextType } from "@/providers/TaskNodeProvider";
 import type { HydratedComponentReference } from "@/utils/componentSpec";
 import { isSubgraph } from "@/utils/subgraphUtils";
 
+import { LinkNodeButton } from "../Buttons/LinkNodeButton";
 import { ViewYamlButton } from "../Buttons/ViewYamlButton";
 import { ActionBlock } from "../ContextPanel/Blocks/ActionBlock";
 import { CopyYamlButton } from "./Actions/CopyYamlButton";
@@ -27,7 +28,7 @@ const TaskActions = ({
   readOnly = false,
   className,
 }: TaskActionsProps) => {
-  const { taskId, taskSpec, state, callbacks } = taskNode || {};
+  const { taskId, nodeId, taskSpec, state, callbacks } = taskNode || {};
   const { onDuplicate, onUpgrade, onDelete } = callbacks || {};
   const isCustomComponent = state?.isCustomComponent;
 
@@ -48,6 +49,7 @@ const TaskActions = ({
   );
 
   // Canvas Actions
+  const linkTask = readOnly && nodeId && <LinkNodeButton nodeId={nodeId} />;
   const duplicateTask = onDuplicate && !readOnly && (
     <DuplicateTaskButton onDuplicate={onDuplicate} />
   );
@@ -74,6 +76,7 @@ const TaskActions = ({
     upgradeTask,
     navigateToSubgraph,
     unpackSubgraphButton,
+    linkTask,
     deleteComponent,
   ].filter(Boolean);
 

--- a/src/routes/PipelineRun/PipelineRun.tsx
+++ b/src/routes/PipelineRun/PipelineRun.tsx
@@ -6,6 +6,7 @@ import { useEffect } from "react";
 import PipelineRunPage from "@/components/PipelineRun";
 import { InfoBox } from "@/components/shared/InfoBox";
 import { LoadingScreen } from "@/components/shared/LoadingScreen";
+import { NodesOverlayProvider } from "@/components/shared/ReactFlow/NodesOverlay/NodesOverlayProvider";
 import { BlockStack } from "@/components/ui/layout";
 import { Paragraph } from "@/components/ui/typography";
 import { faviconManager } from "@/favicon";
@@ -141,12 +142,14 @@ const PipelineRun = () => {
   return (
     <DndContext>
       <ReactFlowProvider>
-        <ExecutionDataProvider
-          pipelineRunId={id}
-          subgraphExecutionId={subgraphExecutionId}
-        >
-          <PipelineRunContent />
-        </ExecutionDataProvider>
+        <NodesOverlayProvider>
+          <ExecutionDataProvider
+            pipelineRunId={id}
+            subgraphExecutionId={subgraphExecutionId}
+          >
+            <PipelineRunContent />
+          </ExecutionDataProvider>
+        </NodesOverlayProvider>
       </ReactFlowProvider>
     </DndContext>
   );


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

Adds a button to Task, IO & Flex Nodes in Run View to copy a shareable link to clipboard. This link, when loaded, will load the pipeline and zoom the view into the chosen node. The node will be automatically selected & highlighted. The highlight will clear when the user clicks anywhere. The url will also clean itself up. I have done this because it felt annoying to have the task permanently highlighted, and it made the url logic complex if I then wanted to highlight a different node.

## Related Issue and Pull requests

Closes https://github.com/Shopify/oasis-frontend/issues/498



<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

- [x] New feature

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## [zoom-to-node.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/5685caf2-d722-4778-8f2f-fa9cae6396b6.mov" />](https://app.graphite.com/user-attachments/video/5685caf2-d722-4778-8f2f-fa9cae6396b6.mov)

## Test Instructions

1. Navigate to a run
2. Select a Task
3. Confirm the "Shareable Link" button is available
4. Click the button and paste the link into a new tab
5. Confirm the run loads and the view is zoomed into the node, which is selected and highlighted
6. Click anywhere to remove the highlight and clean up the url
7. Repeat & confirm for Inputs, Outputs and Flex Nodes
8. Confirm the share button does not appear in the editor

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->