### PR TITLE
Enable pipeline run filters bar with JSON filter query support

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -5,7 +5,8 @@
     "src/api/**",
     "src/components/ui/**",
     "openapi-ts.config.ts",
-    "src/config/announcements.ts"
+    "src/config/announcements.ts",
+    "src/components/shared/BetaFeatureWrapper/BetaFeatureWrapper.tsx"
   ],
   "ignoreDependencies": [
     "@radix-ui/react-accordion",

--- a/src/components/Home/RunSection/RunSection.tsx
+++ b/src/components/Home/RunSection/RunSection.tsx
@@ -24,7 +24,7 @@ import { useBackend } from "@/providers/BackendProvider";
 import { getBackendStatusString } from "@/utils/backend";
 import { fetchWithErrorHandling } from "@/utils/fetchWithErrorHandling";
 import {
-  filtersToApiString,
+  filtersToFilterQuery,
   parseFilterParam,
 } from "@/utils/pipelineRunFilterUtils";
 
@@ -32,7 +32,7 @@ import RunRow from "./RunRow";
 
 const PIPELINE_RUNS_QUERY_URL = "/api/pipeline_runs/";
 const PAGE_TOKEN_QUERY_KEY = "page_token";
-const FILTER_QUERY_KEY = "filter";
+const FILTER_QUERY_PARAM_KEY = "filter_query";
 const CREATED_BY_ME_FILTER = "created_by:me";
 const INCLUDE_PIPELINE_NAME_QUERY_KEY = "include_pipeline_names";
 const INCLUDE_EXECUTION_STATS_QUERY_KEY = "include_execution_stats";
@@ -57,7 +57,7 @@ export const RunSection = ({ onEmptyList, hideFilters }: RunSectionProps) => {
   const filters = parseFilterParam(search.filter);
   const createdByValue = filters.created_by;
 
-  const apiFilterString = filtersToApiString(filters);
+  const apiFilterQuery = filtersToFilterQuery(filters);
 
   const [searchUser, setSearchUser] = useState(createdByValue ?? "");
 
@@ -71,17 +71,17 @@ export const RunSection = ({ onEmptyList, hideFilters }: RunSectionProps) => {
 
   const { data, isLoading, isFetching, error, isFetched } =
     useQuery<ListPipelineJobsResponse>({
-      queryKey: ["runs", backendUrl, pageToken, apiFilterString],
+      queryKey: ["runs", backendUrl, pageToken, apiFilterQuery],
       refetchOnWindowFocus: false,
       enabled: configured && available,
       queryFn: async () => {
-        const u = new URL(PIPELINE_RUNS_QUERY_URL, backendUrl);
-        if (pageToken) u.searchParams.set(PAGE_TOKEN_QUERY_KEY, pageToken);
-        if (apiFilterString)
-          u.searchParams.set(FILTER_QUERY_KEY, apiFilterString);
+        const url = new URL(PIPELINE_RUNS_QUERY_URL, backendUrl);
+        if (pageToken) url.searchParams.set(PAGE_TOKEN_QUERY_KEY, pageToken);
+        if (apiFilterQuery)
+          url.searchParams.set(FILTER_QUERY_PARAM_KEY, apiFilterQuery);
 
-        u.searchParams.set(INCLUDE_PIPELINE_NAME_QUERY_KEY, "true");
-        u.searchParams.set(INCLUDE_EXECUTION_STATS_QUERY_KEY, "true");
+        url.searchParams.set(INCLUDE_PIPELINE_NAME_QUERY_KEY, "true");
+        url.searchParams.set(INCLUDE_EXECUTION_STATS_QUERY_KEY, "true");
 
         if (!available) {
           throw new Error("Backend is not available");
@@ -89,7 +89,7 @@ export const RunSection = ({ onEmptyList, hideFilters }: RunSectionProps) => {
 
         dataVersion.current++;
 
-        return fetchWithErrorHandling(u.toString());
+        return fetchWithErrorHandling(url.toString());
       },
     });
 

--- a/src/components/shared/PipelineRunFiltersBar/PipelineRunFiltersBar.tsx
+++ b/src/components/shared/PipelineRunFiltersBar/PipelineRunFiltersBar.tsx
@@ -2,56 +2,25 @@ import { format } from "date-fns";
 import { useState } from "react";
 import type { DateRange } from "react-day-picker";
 
-import type { ContainerExecutionStatus } from "@/api/types.gen";
-import { AnnotationFilterInput } from "@/components/shared/AnnotationFilterInput/AnnotationFilterInput";
 import { CreatedByFilter } from "@/components/shared/CreatedByFilter/CreatedByFilter";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from "@/components/ui/collapsible";
 import { DatePickerWithRange } from "@/components/ui/date-picker";
 import { Icon } from "@/components/ui/icon";
 import { Input } from "@/components/ui/input";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { Text } from "@/components/ui/typography";
 import { useRunSearchParams } from "@/hooks/useRunSearchParams";
-import type { AnnotationFilter, SortField } from "@/types/pipelineRunFilters";
+import type { AnnotationFilter } from "@/types/pipelineRunFilters";
 import {
-  EXECUTION_STATUS_LABELS,
-  getExecutionStatusLabel,
-} from "@/utils/executionStatus";
-
-function isValidStatus(value: string): value is ContainerExecutionStatus {
-  return value in EXECUTION_STATUS_LABELS;
-}
-
-const STATUS_OPTIONS = Object.keys(EXECUTION_STATUS_LABELS).filter(
-  isValidStatus,
-);
-
-const SORT_FIELD_OPTIONS: { value: SortField; label: string }[] = [
-  { value: "created_at", label: "Date" },
-  { value: "pipeline_name", label: "Name" },
-];
-
-function isValidSortField(value: string): value is SortField {
-  return SORT_FIELD_OPTIONS.some((option) => option.value === value);
-}
+  parseUTCAsLocalDate,
+  toEndOfDayUTC,
+  toStartOfDayUTC,
+} from "@/utils/date";
 
 const MAX_VISIBLE_BADGES = 4;
 
 type FilterBadgeKey =
-  | "status"
   | "pipeline_name"
   | "created_by"
   | "date_range"
@@ -77,14 +46,18 @@ export function PipelineRunFiltersBar({
   } = useRunSearchParams();
 
   const [nameInput, setNameInput] = useState(filters.pipeline_name ?? "");
-  const [isAdvancedOpen, setIsAdvancedOpen] = useState(false);
   const [showAllBadges, setShowAllBadges] = useState(false);
 
+  // Annotation inline input state
+  const [isAnnotationExpanded, setIsAnnotationExpanded] = useState(false);
+  const [annotationKeyInput, setAnnotationKeyInput] = useState("");
+  const [annotationValueInput, setAnnotationValueInput] = useState("");
+
   const createdAfter = filters.created_after
-    ? new Date(filters.created_after)
+    ? parseUTCAsLocalDate(filters.created_after)
     : undefined;
   const createdBefore = filters.created_before
-    ? new Date(filters.created_before)
+    ? parseUTCAsLocalDate(filters.created_before)
     : undefined;
 
   const dateRange: DateRange | undefined =
@@ -94,13 +67,31 @@ export function PipelineRunFiltersBar({
 
   const handleDateRangeChange = (range: DateRange | undefined) => {
     setFilters({
-      created_after: range?.from?.toISOString(),
-      created_before: range?.to?.toISOString(),
+      created_after: range?.from ? toStartOfDayUTC(range.from) : undefined,
+      created_before: range?.to ? toEndOfDayUTC(range.to) : undefined,
     });
   };
 
-  const handleAnnotationsChange = (annotations: AnnotationFilter[]) => {
-    setFilter("annotations", annotations.length > 0 ? annotations : undefined);
+  const handleAddAnnotation = () => {
+    const trimmedKey = annotationKeyInput.trim();
+    if (!trimmedKey) return;
+
+    const newFilter: AnnotationFilter = {
+      key: trimmedKey,
+      value: annotationValueInput.trim() || undefined,
+    };
+
+    const current = filters.annotations ?? [];
+    setFilter("annotations", [...current, newFilter]);
+    setAnnotationKeyInput("");
+    setAnnotationValueInput("");
+    setIsAnnotationExpanded(false);
+  };
+
+  const handleCancelAnnotation = () => {
+    setIsAnnotationExpanded(false);
+    setAnnotationKeyInput("");
+    setAnnotationValueInput("");
   };
 
   const handleClearAll = () => {
@@ -109,29 +100,12 @@ export function PipelineRunFiltersBar({
     setShowAllBadges(false);
   };
 
-  const isSortDescending = filters.sort_direction !== "asc";
-
-  const toggleSortDirection = () => {
-    const newSortDirection = isSortDescending ? "asc" : "desc";
-    setFilter("sort_direction", newSortDirection);
-  };
-
-  const hasAnnotations = filters.annotations && filters.annotations.length > 0;
-
   // Build list of all active filter badges
   const allBadges: Array<{
     key: FilterBadgeKey;
     label: string;
     onRemove: () => void;
   }> = [];
-
-  if (filters.status) {
-    allBadges.push({
-      key: "status",
-      label: getExecutionStatusLabel(filters.status),
-      onRemove: () => setFilter("status", undefined),
-    });
-  }
 
   if (filters.pipeline_name) {
     allBadges.push({
@@ -153,12 +127,8 @@ export function PipelineRunFiltersBar({
   }
 
   if (filters.created_after || filters.created_before) {
-    const fromStr = filters.created_after
-      ? format(new Date(filters.created_after), "MMM d")
-      : "";
-    const toStr = filters.created_before
-      ? format(new Date(filters.created_before), "MMM d")
-      : "";
+    const fromStr = createdAfter ? format(createdAfter, "MMM d") : "";
+    const toStr = createdBefore ? format(createdBefore, "MMM d") : "";
     const separator = fromStr && toStr ? " – " : "";
 
     allBadges.push({
@@ -196,198 +166,163 @@ export function PipelineRunFiltersBar({
   const hasHiddenBadges = hiddenBadgeCount > 0 && !showAllBadges;
 
   return (
-    <Collapsible open={isAdvancedOpen} onOpenChange={setIsAdvancedOpen}>
-      <BlockStack gap="3">
-        {/* Row 1: Basic Filters */}
-        <InlineStack gap="3" align="center">
-          {/* Search Input - flexible width */}
-          <div className="relative flex-1 min-w-0">
-            <Icon
-              name="Search"
-              className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground"
+    <BlockStack gap="3">
+      {/* Row 1: All Filters */}
+      <InlineStack gap="3" align="center">
+        {/* Search Input - flexible width */}
+        <div className="relative flex-1 min-w-0">
+          <Icon
+            name="Search"
+            className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground"
+          />
+          <Input
+            placeholder="Search by pipeline name..."
+            value={nameInput}
+            onChange={(e) => {
+              setNameInput(e.target.value);
+              setFilterDebounced("pipeline_name", e.target.value);
+            }}
+            className="pl-9 pr-8 w-full"
+          />
+          {nameInput && (
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => {
+                setNameInput("");
+                setFilter("pipeline_name", undefined);
+              }}
+              className="absolute right-2 top-1/2 -translate-y-1/2 size-6 text-muted-foreground hover:text-foreground"
+              aria-label="Clear search"
+            >
+              <Icon name="X" size="sm" />
+            </Button>
+          )}
+        </div>
+
+        {/* Created By Filter */}
+        <CreatedByFilter
+          value={filters.created_by}
+          onChange={(value) => setFilterDebounced("created_by", value)}
+          onClear={() => setFilter("created_by", undefined)}
+        />
+
+        {/* Date Range */}
+        <div className="shrink-0">
+          <DatePickerWithRange
+            value={dateRange}
+            onChange={handleDateRangeChange}
+            placeholder="Date range (UTC)"
+          />
+        </div>
+
+        {/* Annotation Filter - inline */}
+        {!isAnnotationExpanded ? (
+          <Button
+            variant="outline"
+            size="sm"
+            className="shrink-0"
+            onClick={() => setIsAnnotationExpanded(true)}
+          >
+            <Icon name="Plus" size="xs" className="mr-1" />
+            Annotation
+          </Button>
+        ) : (
+          <InlineStack gap="1" align="center" className="shrink-0">
+            <Input
+              placeholder="Key"
+              value={annotationKeyInput}
+              onChange={(e) => setAnnotationKeyInput(e.target.value)}
+              onEnter={handleAddAnnotation}
+              onEscape={handleCancelAnnotation}
+              className="w-28 h-8 text-sm"
+              autoFocus
             />
             <Input
-              placeholder="Search by pipeline name..."
-              value={nameInput}
-              onChange={(e) => {
-                setNameInput(e.target.value);
-                setFilterDebounced("pipeline_name", e.target.value);
-              }}
-              className="pl-9 pr-8 w-full"
+              placeholder="Value (optional)"
+              value={annotationValueInput}
+              onChange={(e) => setAnnotationValueInput(e.target.value)}
+              onEnter={handleAddAnnotation}
+              onEscape={handleCancelAnnotation}
+              className="w-36 h-8 text-sm"
             />
-            {nameInput && (
-              <Button
-                variant="ghost"
-                size="icon"
-                onClick={() => {
-                  setNameInput("");
-                  setFilter("pipeline_name", undefined);
-                }}
-                className="absolute right-2 top-1/2 -translate-y-1/2 size-6 text-muted-foreground hover:text-foreground"
-                aria-label="Clear search"
-              >
-                <Icon name="X" size="sm" />
-              </Button>
-            )}
-          </div>
-
-          {/* Created By Filter */}
-          <CreatedByFilter
-            value={filters.created_by}
-            onChange={(value) => setFilterDebounced("created_by", value)}
-            onClear={() => setFilter("created_by", undefined)}
-          />
-
-          {/* Status Filter */}
-          <Select
-            value={filters.status ?? "all"}
-            onValueChange={(value) =>
-              setFilter("status", isValidStatus(value) ? value : undefined)
-            }
-          >
-            <SelectTrigger className="w-44 shrink-0">
-              <SelectValue placeholder="Status" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">All statuses</SelectItem>
-              {STATUS_OPTIONS.map((status) => (
-                <SelectItem key={status} value={status}>
-                  {getExecutionStatusLabel(status)}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-
-          {/* Date Range */}
-          <div className="shrink-0">
-            <DatePickerWithRange
-              value={dateRange}
-              onChange={handleDateRangeChange}
-              placeholder="Date range"
-            />
-          </div>
-
-          {/* Sort Controls */}
-          <InlineStack gap="1" align="center" className="shrink-0">
-            <Select
-              value={filters.sort_field ?? "created_at"}
-              onValueChange={(value) =>
-                setFilter(
-                  "sort_field",
-                  isValidSortField(value) ? value : undefined,
-                )
-              }
-            >
-              <SelectTrigger className="w-24">
-                <SelectValue placeholder="Sort" />
-              </SelectTrigger>
-              <SelectContent>
-                {SORT_FIELD_OPTIONS.map((field) => (
-                  <SelectItem key={field.value} value={field.value}>
-                    {field.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            <Button variant="ghost" size="icon" onClick={toggleSortDirection}>
-              {isSortDescending ? (
-                <Icon name="ArrowDownAZ" />
-              ) : (
-                <Icon name="ArrowUpAZ" />
-              )}
-            </Button>
-          </InlineStack>
-
-          {/* Advanced Toggle */}
-          <CollapsibleTrigger asChild>
             <Button
-              variant={hasAnnotations ? "secondary" : "outline"}
+              variant="outline"
               size="sm"
-              className="shrink-0"
+              onClick={handleAddAnnotation}
+              disabled={!annotationKeyInput.trim()}
             >
-              Advanced
-              {hasAnnotations && (
-                <Badge variant="secondary" className="ml-1.5 h-5 min-w-5 px-1">
-                  {filters.annotations?.length}
-                </Badge>
-              )}
-              {isAdvancedOpen ? (
-                <Icon name="ChevronUp" className="ml-1" />
-              ) : (
-                <Icon name="ChevronDown" className="ml-1" />
-              )}
+              Add
             </Button>
-          </CollapsibleTrigger>
-        </InlineStack>
-
-        {/* Row 2: Advanced Filters (Collapsible) */}
-        <CollapsibleContent>
-          <div className="rounded-md border bg-muted/30 px-4 py-3">
-            <AnnotationFilterInput
-              filters={filters.annotations ?? []}
-              onChange={handleAnnotationsChange}
-            />
-          </div>
-        </CollapsibleContent>
-
-        {/* Row 3: Active Filters & Count */}
-        {(hasActiveFilters || totalCount !== undefined) && (
-          <InlineStack gap="2" align="center" blockAlign="center">
-            {totalCount !== undefined && (
-              <Text size="sm" tone="subdued">
-                Showing {filteredCount ?? totalCount} of {totalCount} runs
-              </Text>
-            )}
-
-            <div className="flex-1" />
-
-            {hasActiveFilters && (
-              <InlineStack gap="2" align="center">
-                {visibleBadges.map((badge) => (
-                  <Badge key={badge.key} variant="outline">
-                    {badge.label}
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      onClick={badge.onRemove}
-                      className="ml-1 size-4 hover:text-destructive hover:bg-transparent"
-                      aria-label={`Remove ${badge.label} filter`}
-                    >
-                      <Icon name="X" size="xs" />
-                    </Button>
-                  </Badge>
-                ))}
-
-                {hasHiddenBadges && (
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => setShowAllBadges(true)}
-                    className="h-6 px-2 text-xs"
-                  >
-                    +{hiddenBadgeCount} more
-                  </Button>
-                )}
-
-                {showAllBadges && allBadges.length > MAX_VISIBLE_BADGES && (
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => setShowAllBadges(false)}
-                    className="h-6 px-2 text-xs"
-                  >
-                    Show less
-                  </Button>
-                )}
-
-                <Button variant="ghost" size="sm" onClick={handleClearAll}>
-                  Clear all ({activeFilterCount})
-                </Button>
-              </InlineStack>
-            )}
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleCancelAnnotation}
+              aria-label="Cancel"
+            >
+              <Icon name="X" size="xs" />
+            </Button>
           </InlineStack>
         )}
-      </BlockStack>
-    </Collapsible>
+      </InlineStack>
+
+      {/* Row 2: Active Filters & Count */}
+      {(hasActiveFilters || totalCount !== undefined) && (
+        <InlineStack gap="2" align="center" blockAlign="center">
+          {totalCount !== undefined && (
+            <Text size="sm" tone="subdued">
+              Showing {filteredCount ?? totalCount} of {totalCount} runs
+            </Text>
+          )}
+
+          <div className="flex-1" />
+
+          {hasActiveFilters && (
+            <InlineStack gap="2" align="center">
+              {visibleBadges.map((badge) => (
+                <Badge key={badge.key} variant="outline">
+                  {badge.label}
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={badge.onRemove}
+                    className="ml-1 size-4 hover:text-destructive hover:bg-transparent"
+                    aria-label={`Remove ${badge.label} filter`}
+                  >
+                    <Icon name="X" size="xs" />
+                  </Button>
+                </Badge>
+              ))}
+
+              {hasHiddenBadges && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setShowAllBadges(true)}
+                  className="h-6 px-2 text-xs"
+                >
+                  +{hiddenBadgeCount} more
+                </Button>
+              )}
+
+              {showAllBadges && allBadges.length > MAX_VISIBLE_BADGES && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setShowAllBadges(false)}
+                  className="h-6 px-2 text-xs"
+                >
+                  Show less
+                </Button>
+              )}
+
+              <Button variant="ghost" size="sm" onClick={handleClearAll}>
+                Clear all ({activeFilterCount})
+              </Button>
+            </InlineStack>
+          )}
+        </InlineStack>
+      )}
+    </BlockStack>
   );
 }

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -38,12 +38,4 @@ export const ExistingFlags: ConfigFlags = {
     default: false,
     category: "beta",
   },
-
-  ["pipeline-run-filters-bar"]: {
-    name: "Pipeline run filters bar (Experimental)",
-    description:
-      "Enable the advanced pipeline run filters bar. Note: Only 'Created by' filter is currently functional. Other filters are UI previews.",
-    default: false,
-    category: "beta",
-  },
 };

--- a/src/routes/Home/Home.tsx
+++ b/src/routes/Home/Home.tsx
@@ -2,14 +2,11 @@ import { useRef, useState } from "react";
 
 import { PipelineSection, RunSection } from "@/components/Home";
 import { AnnouncementBanners } from "@/components/shared/AnnouncementBanners";
-import { BetaFeatureWrapper } from "@/components/shared/BetaFeatureWrapper/BetaFeatureWrapper";
 import { PipelineRunFiltersBar } from "@/components/shared/PipelineRunFiltersBar/PipelineRunFiltersBar";
-import { useFlagValue } from "@/components/shared/Settings/useFlags";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 const Home = () => {
   const [activeTab, setActiveTab] = useState("runs");
-  const isFiltersBarEnabled = useFlagValue("pipeline-run-filters-bar");
 
   const handleTabSelect = (value: string) => {
     setActiveTab(value);
@@ -43,15 +40,8 @@ const Home = () => {
           <PipelineSection />
         </TabsContent>
         <TabsContent value="runs" className="flex flex-col gap-4">
-          {isFiltersBarEnabled && (
-            <BetaFeatureWrapper flagKey="pipeline-run-filters-bar">
-              <PipelineRunFiltersBar />
-            </BetaFeatureWrapper>
-          )}
-          <RunSection
-            onEmptyList={handlePipelineRunsEmpty}
-            hideFilters={isFiltersBarEnabled}
-          />
+          <PipelineRunFiltersBar />
+          <RunSection onEmptyList={handlePipelineRunsEmpty} hideFilters />
         </TabsContent>
       </Tabs>
     </div>

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,4 +1,41 @@
 /**
+ * Convert a local Date to the start of that calendar day in UTC (00:00:00.000Z).
+ */
+export const toStartOfDayUTC = (date: Date): string => {
+  const d = new Date(
+    Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()),
+  );
+  return d.toISOString();
+};
+
+/**
+ * Convert a local Date to the end of that calendar day in UTC (23:59:59.999Z).
+ */
+export const toEndOfDayUTC = (date: Date): string => {
+  const d = new Date(
+    Date.UTC(
+      date.getFullYear(),
+      date.getMonth(),
+      date.getDate(),
+      23,
+      59,
+      59,
+      999,
+    ),
+  );
+  return d.toISOString();
+};
+
+/**
+ * Parse a UTC ISO string back to a local Date preserving the UTC calendar day.
+ * Ensures the displayed date matches the UTC date regardless of timezone.
+ */
+export const parseUTCAsLocalDate = (iso: string): Date => {
+  const d = new Date(iso);
+  return new Date(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
+};
+
+/**
  * Format date string to localized string
  */
 const defaultFormat: Intl.DateTimeFormatOptions = {

--- a/src/utils/pipelineRunFilterUtils.ts
+++ b/src/utils/pipelineRunFilterUtils.ts
@@ -9,12 +9,6 @@ import { isValidExecutionStatus } from "@/utils/executionStatus";
 const VALID_SORT_FIELDS = new Set<string>(["created_at", "pipeline_name"]);
 const VALID_SORT_DIRECTIONS = new Set<string>(["asc", "desc"]);
 
-/**
- * List of filter keys that the API currently supports.
- * Add keys here as the backend adds support for more filters.
- */
-const SUPPORTED_API_FILTERS: (keyof PipelineRunFilters)[] = ["created_by"];
-
 export function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -84,27 +78,86 @@ export function validateFilters(parsed: unknown): PipelineRunFilters {
   return filters;
 }
 
+/** Predicate types for the filter_query JSON format */
+type FilterQueryPredicate =
+  | { key_exists: { key: string } }
+  | { value_equals: { key: string; value: string } }
+  | { value_contains: { key: string; value_substring: string } }
+  | { value_in: { key: string; values: string[] } }
+  | { not: FilterQueryPredicate }
+  | {
+      time_range: {
+        key: string;
+        start_time?: string;
+        end_time?: string;
+      };
+    };
+
+interface FilterQuery {
+  and: FilterQueryPredicate[];
+}
+
 /**
- * Converts PipelineRunFilters to the API's key:value string format.
- * Only includes filters that the API actually supports.
+ * Converts PipelineRunFilters to the backend's filter_query JSON format.
+ * This sends all supported filters server-side (created_by, pipeline_name,
+ * date range, annotations). Status filtering remains client-side since
+ * execution stats are computed separately.
  *
- * @example
- * // Input: { created_by: "me", status: "FAILED", annotations: [...] }
- * // Output: "created_by:me" (status and annotations are stripped as unsupported)
+ * @returns JSON string for the filter_query param, or undefined if no filters apply.
  */
-export function filtersToApiString(
+export function filtersToFilterQuery(
   filters: PipelineRunFilters,
 ): string | undefined {
-  const parts: string[] = [];
+  const predicates: FilterQueryPredicate[] = [];
 
-  for (const key of SUPPORTED_API_FILTERS) {
-    const value = filters[key];
-    if (value) {
-      parts.push(`${key}:${value}`);
+  if (filters.created_by) {
+    predicates.push({
+      value_equals: {
+        key: "system/pipeline_run.created_by",
+        value: filters.created_by,
+      },
+    });
+  }
+
+  if (filters.pipeline_name) {
+    predicates.push({
+      value_contains: {
+        key: "system/pipeline_run.name",
+        value_substring: filters.pipeline_name,
+      },
+    });
+  }
+
+  if (filters.created_after || filters.created_before) {
+    const timeRange: FilterQueryPredicate = {
+      time_range: {
+        key: "system/pipeline_run.date.created_at",
+        ...(filters.created_after && { start_time: filters.created_after }),
+        ...(filters.created_before && { end_time: filters.created_before }),
+      },
+    };
+    predicates.push(timeRange);
+  }
+
+  if (filters.annotations) {
+    for (const annotation of filters.annotations) {
+      if (annotation.value) {
+        predicates.push({
+          value_contains: {
+            key: annotation.key,
+            value_substring: annotation.value,
+          },
+        });
+      } else {
+        predicates.push({ key_exists: { key: annotation.key } });
+      }
     }
   }
 
-  return parts.length > 0 ? parts.join(",") : undefined;
+  if (predicates.length === 0) return undefined;
+
+  const query: FilterQuery = { and: predicates };
+  return JSON.stringify(query);
 }
 
 /**


### PR DESCRIPTION
## Description

This pull request implements a new JSON-based filter query system for pipeline runs and simplifies the filtering interface. The changes include:

- Replaced the legacy string-based filter format with a new JSON `filter_query` parameter that supports complex predicates including time ranges, value matching, and annotation filtering
- Simplified the PipelineRunFiltersBar component by removing the collapsible advanced section and making annotation filtering inline with dedicated input fields
- Updated the RunSection to use the new `filtersToFilterQuery` function and `filter_query` parameter instead of the legacy format
- Removed status and sort controls from the filters bar, focusing on core filtering functionality
- Added the BetaFeatureWrapper component to the knip.json ignore list
- Removed the `pipeline-run-filters-bar` feature flag and made the new filters bar the default experience

## Type of Change

- [x] New feature
- [x] Improvement
- [x] Breaking change

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

1. Test pipeline run filtering with the new inline annotation filter interface
2. Verify that the new JSON-based `filter_query` parameter correctly filters runs by created_by, pipeline_name, date ranges, and annotations
3. Test the simplified filters bar with inline annotation input (key/value pairs)
4. Ensure the filter badges display correctly and can be removed individually
5. Verify the "Clear all" functionality works with the new filter system

## Additional Comments

The new filter query system uses a structured JSON format with predicates like `value_equals`, `value_contains`, `key_exists`, and `time_range`, providing more flexibility than the previous string-based approach. The UI has been streamlined to focus on the most commonly used filters while maintaining full functionality through an improved inline interface.