### PR TITLE
fix: Stale Hydration Cache when Replacing Components

### DIFF
--- a/src/components/shared/ComponentEditor/ComponentEditorDialog.tsx
+++ b/src/components/shared/ComponentEditor/ComponentEditorDialog.tsx
@@ -165,9 +165,9 @@ export const ComponentEditorDialog = withSuspenseWrapper(
           updatedAt: Date.now(),
         });
 
-        addToComponentLibrary(hydratedComponent);
-
         onClose();
+
+        await addToComponentLibrary(hydratedComponent);
 
         notify(
           `Component ${hydratedComponent.name} imported successfully`,

--- a/src/hooks/useHydrateComponentReference.ts
+++ b/src/hooks/useHydrateComponentReference.ts
@@ -9,7 +9,7 @@ import { componentSpecToText } from "@/utils/yaml";
  * For components with digest or URL, use those directly.
  * For inline specs, use a JSON stringification as a stable key.
  */
-function getComponentQueryKey(component: ComponentReference): string {
+export function getComponentQueryKey(component: ComponentReference): string {
   if (component.digest) {
     return `digest:${component.digest}`;
   }

--- a/src/providers/ComponentLibraryProvider/ComponentLibraryProvider.tsx
+++ b/src/providers/ComponentLibraryProvider/ComponentLibraryProvider.tsx
@@ -11,6 +11,7 @@ import {
 import ComponentDuplicateDialog from "@/components/shared/Dialogs/ComponentDuplicateDialog";
 import { GitHubFlatComponentLibrary } from "@/components/shared/GitHubLibrary/githubFlatComponentLibrary";
 import { isGitHubLibraryConfiguration } from "@/components/shared/GitHubLibrary/types";
+import { getComponentQueryKey } from "@/hooks/useHydrateComponentReference";
 import {
   fetchAndStoreComponentLibrary,
   hydrateComponentReference,
@@ -171,6 +172,7 @@ export const ComponentLibraryProvider = ({
 }) => {
   const { graphSpec } = useComponentSpec();
   const { currentSearchFilter } = useForcedSearchContext();
+  const queryClient = useQueryClient();
 
   const { getComponentLibraryObject, existingComponentLibraries } =
     useComponentLibraryRegistry();
@@ -429,6 +431,15 @@ export const ComponentLibraryProvider = ({
   const internalAddComponentToLibrary = useCallback(
     async (hydratedComponent: HydratedComponentReference) => {
       await importComponent(hydratedComponent);
+
+      queryClient.invalidateQueries({
+        queryKey: [
+          "component",
+          "hydrate",
+          getComponentQueryKey(hydratedComponent),
+        ],
+      });
+
       await refreshComponentLibrary();
       await refreshUserComponents();
       setNewComponent(null);


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

Fixes a bug in the import/replace flow where new components may try to access the old component's hydration query cache, or a previously outdated version.

The issue has been fixed by explicitly resetting the query cache when adding a component to the library.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

Closes https://github.com/TangleML/tangle-ui/issues/1921

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

1. Add a component to canvas.
2. Edit component definition
3. Update the component without changing its name
4. Save & replace the existing component definition
5. Add the new component to canvas
6. Edit/view the new component yaml and confirm it is the updated version  


## Additional Comments

Also added a missing `await` statement.

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->