### PR TITLE
Add feature flags for bulk argument upload and parameter sweep

### DIFF
--- a/src/components/shared/Submitters/Oasis/OasisSubmitter.tsx
+++ b/src/components/shared/Submitters/Oasis/OasisSubmitter.tsx
@@ -26,7 +26,7 @@ import {
   type ComponentSpec,
   isGraphImplementation,
 } from "@/utils/componentSpec";
-import { getFileExtension } from "@/utils/csvBulkArgumentImport";
+import { getFileExtension } from "@/utils/fileImportCommon";
 import { submitPipelineRun } from "@/utils/submitPipeline";
 import { validateArguments } from "@/utils/validations";
 
@@ -107,6 +107,8 @@ const OasisSubmitter = ({
   const { backendUrl, configured, available } = useBackend();
   const { mutate: submit, isPending: isSubmitting } = useSubmitPipeline();
   const isAutoRedirect = useFlagValue("redirect-on-new-pipeline-run");
+  const isBulkUploadEnabled = useFlagValue("bulk-argument-upload");
+  const isParameterSweepEnabled = useFlagValue("parameter-sweep");
 
   const [submitSuccess, setSubmitSuccess] = useState<boolean | null>(null);
   const [isArgumentsDialogOpen, setIsArgumentsDialogOpen] = useState(false);
@@ -344,12 +346,14 @@ const OasisSubmitter = ({
     hasConfigurableInputs && !isButtonDisabled && isComponentTreeValid;
 
   const handleDragEnter = (e: DragEvent) => {
+    if (!isBulkUploadEnabled) return;
     e.preventDefault();
     dragCounter.current++;
     setIsDraggingOver(true);
   };
 
   const handleDragLeave = (e: DragEvent) => {
+    if (!isBulkUploadEnabled) return;
     e.preventDefault();
     dragCounter.current--;
     if (dragCounter.current === 0) {
@@ -358,10 +362,12 @@ const OasisSubmitter = ({
   };
 
   const handleDragOver = (e: DragEvent) => {
+    if (!isBulkUploadEnabled) return;
     e.preventDefault();
   };
 
   const handleDrop = (e: DragEvent) => {
+    if (!isBulkUploadEnabled) return;
     e.preventDefault();
     dragCounter.current = 0;
     setIsDraggingOver(false);
@@ -405,7 +411,9 @@ const OasisSubmitter = ({
         onDrop={handleDrop}
         className={cn(
           "rounded-md transition-all",
-          isDraggingOver && "ring-2 ring-primary bg-primary/5",
+          isDraggingOver &&
+            isBulkUploadEnabled &&
+            "ring-2 ring-primary bg-primary/5",
         )}
       >
         <InlineStack align="space-between" className="pr-2.5">
@@ -450,16 +458,18 @@ const OasisSubmitter = ({
               >
                 <Icon name="Split" className="rotate-90" />
               </TooltipButton>
-              <TooltipButton
-                tooltip="Parameter sweep"
-                variant="ghost"
-                size="icon"
-                data-testid="parameter-sweep-button"
-                onClick={() => setIsSweepDialogOpen(true)}
-                disabled={!available}
-              >
-                <Icon name="Grid3x3" />
-              </TooltipButton>
+              {isParameterSweepEnabled && (
+                <TooltipButton
+                  tooltip="Parameter sweep"
+                  variant="ghost"
+                  size="icon"
+                  data-testid="parameter-sweep-button"
+                  onClick={() => setIsSweepDialogOpen(true)}
+                  disabled={!available}
+                >
+                  <Icon name="Grid3x3" />
+                </TooltipButton>
+              )}
             </InlineStack>
           )}
         </InlineStack>
@@ -476,7 +486,7 @@ const OasisSubmitter = ({
         />
       )}
 
-      {componentSpec && (
+      {componentSpec && isParameterSweepEnabled && (
         <ParameterSweepDialog
           open={isSweepDialogOpen}
           onCancel={() => setIsSweepDialogOpen(false)}

--- a/src/components/shared/Submitters/Oasis/components/SubmitTaskArgumentsDialog.tsx
+++ b/src/components/shared/Submitters/Oasis/components/SubmitTaskArgumentsDialog.tsx
@@ -13,6 +13,7 @@ import {
   createSecretArgument,
   extractSecretName,
 } from "@/components/shared/SecretsManagement/types";
+import { useFlagValue } from "@/components/shared/Settings/useFlags";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -58,10 +59,8 @@ import {
   type InputSpec,
   isSecretArgument,
 } from "@/utils/componentSpec";
-import {
-  getFileExtension,
-  mapCsvToArguments,
-} from "@/utils/csvBulkArgumentImport";
+import { mapCsvToArguments } from "@/utils/csvBulkArgumentImport";
+import { getFileExtension } from "@/utils/fileImportCommon";
 import { mapJsonToArguments } from "@/utils/jsonBulkArgumentImport";
 import { extractTaskArguments } from "@/utils/nodes/taskArguments";
 import { pluralize } from "@/utils/string";
@@ -96,6 +95,7 @@ export const SubmitTaskArgumentsDialog = ({
   onImportComplete,
 }: SubmitTaskArgumentsDialogProps) => {
   const notify = useToastNotification();
+  const isBulkUploadEnabled = useFlagValue("bulk-argument-upload");
   const initialArgs = getArgumentsFromInputs(componentSpec);
 
   const [runNotes, setRunNotes] = useState<string>("");
@@ -259,13 +259,17 @@ export const SubmitTaskArgumentsDialog = ({
                 Customize the pipeline input values before submitting.
               </Paragraph>
               <InlineStack align="end" gap="1" className="w-full">
-                <DownloadTemplateButton
-                  inputs={inputs}
-                  taskArguments={taskArguments}
-                  bulkInputNames={bulkInputNames}
-                  pipelineName={componentSpec.name}
-                />
-                <ImportFileButton onImport={handleFileImport} />
+                {isBulkUploadEnabled && (
+                  <DownloadTemplateButton
+                    inputs={inputs}
+                    taskArguments={taskArguments}
+                    bulkInputNames={bulkInputNames}
+                    pipelineName={componentSpec.name}
+                  />
+                )}
+                {isBulkUploadEnabled && (
+                  <ImportFileButton onImport={handleFileImport} />
+                )}
                 <CopyFromRunPopover
                   componentSpec={componentSpec}
                   onCopy={handleCopyFromRun}
@@ -322,6 +326,7 @@ export const SubmitTaskArgumentsDialog = ({
                     isBulkEnabled={isBulkEnabled}
                     onBulkToggle={handleBulkToggle}
                     bulkValueCount={bulkValueCount}
+                    showBulkToggle={isBulkUploadEnabled}
                   />
                 );
               })}
@@ -494,6 +499,7 @@ interface ArgumentFieldProps {
   isBulkEnabled?: boolean;
   onBulkToggle?: (name: string, enabled: boolean) => void;
   bulkValueCount?: number;
+  showBulkToggle?: boolean;
 }
 
 const ArgumentField = ({
@@ -504,6 +510,7 @@ const ArgumentField = ({
   isBulkEnabled = false,
   onBulkToggle,
   bulkValueCount = 0,
+  showBulkToggle = false,
 }: ArgumentFieldProps) => {
   const [isSelectSecretDialogOpen, setIsSelectSecretDialogOpen] =
     useState(false);
@@ -553,7 +560,7 @@ const ArgumentField = ({
             {isRequired ? "*" : ""})
           </Paragraph>
           <div className="flex-1" />
-          {canBeBulk && (
+          {canBeBulk && showBulkToggle && (
             <InlineStack gap="1" align="center">
               <Label
                 htmlFor={bulkId}

--- a/src/components/shared/Submitters/Oasis/components/SweepPreviewTable.tsx
+++ b/src/components/shared/Submitters/Oasis/components/SweepPreviewTable.tsx
@@ -1,3 +1,4 @@
+import { BlockStack } from "@/components/ui/layout";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import {
   Table,
@@ -7,7 +8,6 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { BlockStack } from "@/components/ui/layout";
 import { Paragraph, Text } from "@/components/ui/typography";
 import type { ArgumentType } from "@/utils/componentSpec";
 

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -38,4 +38,19 @@ export const ExistingFlags: ConfigFlags = {
     default: false,
     category: "beta",
   },
+  ["bulk-argument-upload"]: {
+    name: "Bulk Argument Upload",
+    description:
+      "Enable bulk argument features: file import (CSV/JSON/YAML), template download, per-input bulk mode toggles, and multi-run submission.",
+    default: false,
+    category: "beta",
+  },
+
+  ["parameter-sweep"]: {
+    name: "Parameter Sweep",
+    description:
+      "Enable parameter sweep: define multiple values per input and submit all combinations as separate runs.",
+    default: false,
+    category: "beta",
+  },
 };

--- a/src/utils/csvBulkArgumentImport.ts
+++ b/src/utils/csvBulkArgumentImport.ts
@@ -1,8 +1,9 @@
+import type { ArgumentType, InputSpec } from "./componentSpec";
 import {
-  type ArgumentType,
-  type InputSpec,
-  isSecretArgument,
-} from "./componentSpec";
+  buildFileImportResult,
+  emptyFileImportResult,
+  type FileImportResult,
+} from "./fileImportCommon";
 
 /**
  * RFC 4180 CSV parser. Handles quoted fields with commas and escaped quotes.
@@ -70,24 +71,6 @@ export function parseCsv(text: string): string[][] {
 }
 
 /**
- * Extracts the file extension (e.g. ".csv", ".json") from a filename.
- * Returns empty string if no extension is found.
- */
-export function getFileExtension(filename: string): string {
-  const dotIdx = filename.lastIndexOf(".");
-  return dotIdx >= 0 ? `.${filename.slice(dotIdx + 1).toLowerCase()}` : "";
-}
-
-export interface FileImportResult {
-  values: Record<string, string>;
-  changedInputNames: string[];
-  enableBulk: boolean;
-  unmatchedColumns: string[];
-  skippedSecretInputs: string[];
-  rowCount: number;
-}
-
-/**
  * Maps CSV data onto pipeline input arguments.
  *
  * Single data row: values go directly into matched inputs.
@@ -100,69 +83,21 @@ export function mapCsvToArguments(
 ): FileImportResult {
   const rows = parseCsv(csvText);
 
-  const empty: FileImportResult = {
-    values: {},
-    changedInputNames: [],
-    enableBulk: false,
-    unmatchedColumns: [],
-    skippedSecretInputs: [],
-    rowCount: 0,
-  };
-
-  if (rows.length === 0) return empty;
+  if (rows.length === 0) return emptyFileImportResult();
 
   const headers = rows[0];
   const dataRows = rows.slice(1);
-  const rowCount = dataRows.length;
 
-  if (rowCount === 0) return { ...empty, rowCount: 0 };
+  if (dataRows.length === 0) return emptyFileImportResult();
 
-  const inputNameSet = new Set(inputs.map((i) => i.name));
-  const secretInputNames = new Set(
-    inputs
-      .filter((i) => isSecretArgument(currentArgs[i.name]))
-      .map((i) => i.name),
-  );
-
-  const unmatchedColumns: string[] = [];
-  const skippedSecretInputs: string[] = [];
-  const values: Record<string, string> = {};
-  const changedInputNames: string[] = [];
-
+  const columns = new Map<string, string[]>();
   for (let colIdx = 0; colIdx < headers.length; colIdx++) {
     const colName = headers[colIdx].trim();
-    if (!colName) continue;
-
-    if (!inputNameSet.has(colName)) {
-      unmatchedColumns.push(colName);
-      continue;
-    }
-
-    if (secretInputNames.has(colName)) {
-      skippedSecretInputs.push(colName);
-      continue;
-    }
-
-    const columnValues = dataRows.map((row) =>
-      colIdx < row.length ? row[colIdx] : "",
+    columns.set(
+      colName,
+      dataRows.map((row) => (colIdx < row.length ? row[colIdx] : "")),
     );
-
-    const newValue =
-      rowCount === 1 ? (columnValues[0] ?? "") : columnValues.join(", ");
-
-    values[colName] = newValue;
-
-    if (currentArgs[colName] !== newValue) {
-      changedInputNames.push(colName);
-    }
   }
 
-  return {
-    values,
-    changedInputNames,
-    enableBulk: rowCount > 1,
-    unmatchedColumns,
-    skippedSecretInputs,
-    rowCount,
-  };
+  return buildFileImportResult(columns, dataRows.length, inputs, currentArgs);
 }

--- a/src/utils/fileImportCommon.ts
+++ b/src/utils/fileImportCommon.ts
@@ -1,0 +1,103 @@
+import {
+  type ArgumentType,
+  type InputSpec,
+  isSecretArgument,
+} from "./componentSpec";
+
+export interface FileImportResult {
+  values: Record<string, string>;
+  changedInputNames: string[];
+  enableBulk: boolean;
+  unmatchedColumns: string[];
+  skippedSecretInputs: string[];
+  rowCount: number;
+}
+
+/**
+ * Extracts the file extension (e.g. ".csv", ".json") from a filename.
+ * Returns empty string if no extension is found.
+ */
+export function getFileExtension(filename: string): string {
+  const dotIdx = filename.lastIndexOf(".");
+  return dotIdx >= 0 ? `.${filename.slice(dotIdx + 1).toLowerCase()}` : "";
+}
+
+const EMPTY_RESULT: FileImportResult = {
+  values: {},
+  changedInputNames: [],
+  enableBulk: false,
+  unmatchedColumns: [],
+  skippedSecretInputs: [],
+  rowCount: 0,
+};
+
+export function emptyFileImportResult(): FileImportResult {
+  return { ...EMPTY_RESULT };
+}
+
+/**
+ * Shared logic for mapping parsed file data (CSV rows, JSON objects, etc.)
+ * onto pipeline input arguments.
+ *
+ * @param columns Map of column/key name → array of string values (one per row)
+ * @param rowCount Number of data rows
+ * @param inputs Pipeline input specs
+ * @param currentArgs Current argument values (to detect changes and secrets)
+ * @param valueJoiner Optional custom joiner for multi-row values. Defaults to
+ *   `(values) => values.join(", ")`. JSON uses this to quote values with commas.
+ */
+export function buildFileImportResult(
+  columns: Map<string, string[]>,
+  rowCount: number,
+  inputs: InputSpec[],
+  currentArgs: Record<string, ArgumentType>,
+  valueJoiner?: (values: string[]) => string,
+): FileImportResult {
+  if (rowCount === 0) return emptyFileImportResult();
+
+  const join = valueJoiner ?? ((values: string[]) => values.join(", "));
+
+  const inputNameSet = new Set(inputs.map((i) => i.name));
+  const secretInputNames = new Set(
+    inputs
+      .filter((i) => isSecretArgument(currentArgs[i.name]))
+      .map((i) => i.name),
+  );
+
+  const unmatchedColumns: string[] = [];
+  const skippedSecretInputs: string[] = [];
+  const values: Record<string, string> = {};
+  const changedInputNames: string[] = [];
+
+  for (const [key, columnValues] of columns) {
+    if (!key) continue;
+
+    if (!inputNameSet.has(key)) {
+      unmatchedColumns.push(key);
+      continue;
+    }
+
+    if (secretInputNames.has(key)) {
+      skippedSecretInputs.push(key);
+      continue;
+    }
+
+    const newValue =
+      rowCount === 1 ? (columnValues[0] ?? "") : join(columnValues);
+
+    values[key] = newValue;
+
+    if (currentArgs[key] !== newValue) {
+      changedInputNames.push(key);
+    }
+  }
+
+  return {
+    values,
+    changedInputNames,
+    enableBulk: rowCount > 1,
+    unmatchedColumns,
+    skippedSecretInputs,
+    rowCount,
+  };
+}

--- a/src/utils/jsonBulkArgumentImport.ts
+++ b/src/utils/jsonBulkArgumentImport.ts
@@ -1,9 +1,9 @@
+import type { ArgumentType, InputSpec } from "./componentSpec";
 import {
-  type ArgumentType,
-  type InputSpec,
-  isSecretArgument,
-} from "./componentSpec";
-import type { FileImportResult } from "./csvBulkArgumentImport";
+  buildFileImportResult,
+  emptyFileImportResult,
+  type FileImportResult,
+} from "./fileImportCommon";
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -23,6 +23,18 @@ function valueToString(value: unknown): string {
 }
 
 /**
+ * Joins multi-row JSON values, quoting plain strings that contain commas
+ * so parseBulkValues doesn't split them. Values starting with { or [ are
+ * already protected by brace/bracket depth tracking in the parser.
+ */
+function jsonValueJoiner(values: string[]): string {
+  const quotedValues = values.map((v) =>
+    v.includes(",") && v[0] !== "{" && v[0] !== "[" ? JSON.stringify(v) : v,
+  );
+  return quotedValues.join(", ");
+}
+
+/**
  * Maps JSON data onto pipeline input arguments.
  *
  * Single object: values go directly into matched inputs.
@@ -39,42 +51,24 @@ export function mapJsonToArguments(
   inputs: InputSpec[],
   currentArgs: Record<string, ArgumentType>,
 ): FileImportResult {
-  const empty: FileImportResult = {
-    values: {},
-    changedInputNames: [],
-    enableBulk: false,
-    unmatchedColumns: [],
-    skippedSecretInputs: [],
-    rowCount: 0,
-  };
-
   let parsed: unknown;
   try {
     parsed = JSON.parse(jsonText);
   } catch {
-    return empty;
+    return emptyFileImportResult();
   }
 
   let rows: Record<string, unknown>[];
   if (Array.isArray(parsed)) {
-    if (!parsed.every(isPlainObject)) return empty;
+    if (!parsed.every(isPlainObject)) return emptyFileImportResult();
     rows = parsed;
   } else if (isPlainObject(parsed)) {
     rows = [parsed];
   } else {
-    return empty;
+    return emptyFileImportResult();
   }
 
-  if (rows.length === 0) return empty;
-
-  const rowCount = rows.length;
-
-  const inputNameSet = new Set(inputs.map((i) => i.name));
-  const secretInputNames = new Set(
-    inputs
-      .filter((i) => isSecretArgument(currentArgs[i.name]))
-      .map((i) => i.name),
-  );
+  if (rows.length === 0) return emptyFileImportResult();
 
   // Collect all unique keys across all rows
   const allKeys = new Set<string>();
@@ -84,50 +78,19 @@ export function mapJsonToArguments(
     }
   }
 
-  const unmatchedColumns: string[] = [];
-  const skippedSecretInputs: string[] = [];
-  const values: Record<string, string> = {};
-  const changedInputNames: string[] = [];
-
+  const columns = new Map<string, string[]>();
   for (const key of allKeys) {
-    if (!inputNameSet.has(key)) {
-      unmatchedColumns.push(key);
-      continue;
-    }
-
-    if (secretInputNames.has(key)) {
-      skippedSecretInputs.push(key);
-      continue;
-    }
-
-    const columnValues = rows.map((row) => valueToString(row[key]));
-
-    let newValue: string;
-    if (rowCount === 1) {
-      newValue = columnValues[0] ?? "";
-    } else {
-      // Quote plain string values that contain commas so parseBulkValues
-      // doesn't split them. Values starting with { or [ are already protected
-      // by brace/bracket depth tracking in the parser.
-      const quotedValues = columnValues.map((v) =>
-        v.includes(",") && v[0] !== "{" && v[0] !== "[" ? JSON.stringify(v) : v,
-      );
-      newValue = quotedValues.join(", ");
-    }
-
-    values[key] = newValue;
-
-    if (currentArgs[key] !== newValue) {
-      changedInputNames.push(key);
-    }
+    columns.set(
+      key,
+      rows.map((row) => valueToString(row[key])),
+    );
   }
 
-  return {
-    values,
-    changedInputNames,
-    enableBulk: rowCount > 1,
-    unmatchedColumns,
-    skippedSecretInputs,
-    rowCount,
-  };
+  return buildFileImportResult(
+    columns,
+    rows.length,
+    inputs,
+    currentArgs,
+    jsonValueJoiner,
+  );
 }


### PR DESCRIPTION
## Description

Added feature flags to control bulk argument upload and parameter sweep functionality. The `bulk-argument-upload` flag controls file import capabilities, template downloads, bulk mode toggles, and multi-run submission. The `parameter-sweep` flag controls the parameter sweep dialog and related UI elements. Both features are now disabled by default and can be enabled independently through the feature flag system.

Refactored file import utilities by extracting common logic into `fileImportCommon.ts`, consolidating shared functionality between CSV and JSON import handlers while maintaining existing behavior.

## Type of Change

- [x] New feature
- [x] Cleanup/Refactor

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

1. Verify that bulk upload features (drag/drop, import buttons, bulk toggles) are hidden when `bulk-argument-upload` flag is disabled
2. Verify that parameter sweep button and dialog are hidden when `parameter-sweep` flag is disabled  
3. Enable both flags and confirm all bulk upload and parameter sweep functionality works as expected
4. Test CSV and JSON file imports to ensure refactored import logic maintains existing behavior

## Additional Comments

This change provides better control over experimental features and allows for gradual rollout of bulk argument and parameter sweep capabilities. The refactoring improves code maintainability by reducing duplication between import handlers.