### PR TITLE
Add batch pipeline run submission with 100 run limit

### DIFF
--- a/src/components/shared/Submitters/Oasis/OasisSubmitter.tsx
+++ b/src/components/shared/Submitters/Oasis/OasisSubmitter.tsx
@@ -27,7 +27,11 @@ import {
   isGraphImplementation,
 } from "@/utils/componentSpec";
 import { getFileExtension } from "@/utils/fileImportCommon";
-import { submitPipelineRun } from "@/utils/submitPipeline";
+import {
+  MAX_BATCH_SIZE,
+  submitBatchPipelineRuns,
+  submitPipelineRun,
+} from "@/utils/submitPipeline";
 import { validateArguments } from "@/utils/validations";
 
 import { isAuthorizationRequired } from "../../Authentication/helpers";
@@ -103,9 +107,12 @@ const OasisSubmitter = ({
   isComponentTreeValid = true,
   onlyFixableIssues = false,
 }: OasisSubmitterProps) => {
-  const { isAuthorized } = useAwaitAuthorization();
+  const { awaitAuthorization, isAuthorized } = useAwaitAuthorization();
+  const { getToken } = useAuthLocalStorage();
   const { backendUrl, configured, available } = useBackend();
   const { mutate: submit, isPending: isSubmitting } = useSubmitPipeline();
+  const runNameOverride = useFlagValue("templatized-pipeline-run-name");
+  const queryClient = useQueryClient();
   const isAutoRedirect = useFlagValue("redirect-on-new-pipeline-run");
   const isBulkUploadEnabled = useFlagValue("bulk-argument-upload");
   const isParameterSweepEnabled = useFlagValue("parameter-sweep");
@@ -243,52 +250,58 @@ const OasisSubmitter = ({
       return;
     }
 
+    if (argSets.length > MAX_BATCH_SIZE) {
+      handleError(
+        `Cannot submit more than ${MAX_BATCH_SIZE} runs at once. You are trying to submit ${argSets.length} runs.`,
+      );
+      return;
+    }
+
     const total = argSets.length;
     setBulkProgress({ total, completed: 0, failed: 0 });
     setSubmitSuccess(null);
 
-    let completed = 0;
-    let failed = 0;
-
-    for (const args of argSets) {
-      try {
-        const response = await new Promise<PipelineRun>((resolve, reject) => {
-          submit({
-            componentSpec,
-            taskArguments: args,
-            onSuccess: resolve,
-            onError: reject,
-          });
-        });
-
-        if (runNotes.current.trim() !== "") {
-          saveNotes(response.id.toString());
-        }
-
-        const tags = getPipelineTagsFromSpec(componentSpec);
-        if (tags.length > 0) {
-          saveTags(response.id.toString());
-        }
-
-        completed++;
-      } catch {
-        failed++;
+    try {
+      const authorizationRequired = isAuthorizationRequired();
+      let token = getToken();
+      if (authorizationRequired && !isAuthorized) {
+        token = (await awaitAuthorization()) ?? token;
       }
 
-      setBulkProgress({ total, completed, failed });
-    }
+      const createdRuns = await submitBatchPipelineRuns(
+        componentSpec,
+        argSets,
+        backendUrl,
+        {
+          authorizationToken: token,
+          runNameOverride,
+        },
+      );
 
-    setBulkProgress(null);
-    setSubmitSuccess(failed === 0);
-    setCooldownTime(3);
+      for (const run of createdRuns) {
+        if (runNotes.current.trim() !== "") {
+          saveNotes(run.id.toString());
+        }
+        const tags = getPipelineTagsFromSpec(componentSpec);
+        if (tags.length > 0) {
+          saveTags(run.id.toString());
+        }
+      }
 
-    if (failed === 0) {
+      await queryClient.invalidateQueries({ queryKey: ["pipelineRuns"] });
+
+      setBulkProgress(null);
+      setSubmitSuccess(true);
+      setCooldownTime(3);
       onSubmitComplete?.();
-      notify(`${total} runs submitted successfully`, "success");
-    } else {
+      notify(`All ${total} runs submitted successfully`, "success");
+    } catch (error) {
+      setBulkProgress(null);
+      setSubmitSuccess(false);
+      setCooldownTime(3);
       notify(
-        `${completed} of ${total} runs submitted. ${failed} failed.`,
-        failed === total ? "error" : "warning",
+        `Bulk submission failed: ${error instanceof Error ? error.message : String(error)}`,
+        "error",
       );
     }
   };

--- a/src/components/shared/Submitters/Oasis/components/ParameterSweepDialog.tsx
+++ b/src/components/shared/Submitters/Oasis/components/ParameterSweepDialog.tsx
@@ -124,7 +124,12 @@ export const ParameterSweepDialog = ({
               <Icon name="Table" size="sm" />
               Preview
               {hasActiveParams && runCount > 0 && (
-                <Badge variant="secondary" size="xs" shape="rounded">
+                <Badge
+                  variant="secondary"
+                  size="xs"
+                  shape="rounded"
+                  className="w-auto min-w-4 px-1"
+                >
                   {runCount}
                 </Badge>
               )}

--- a/src/components/shared/Submitters/Oasis/components/SweepPreviewTable.tsx
+++ b/src/components/shared/Submitters/Oasis/components/SweepPreviewTable.tsx
@@ -1,5 +1,4 @@
 import { BlockStack } from "@/components/ui/layout";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import {
   Table,
   TableBody,
@@ -36,7 +35,7 @@ export const SweepPreviewTable = ({
 
   return (
     <BlockStack gap="2">
-      <ScrollArea className="max-h-[50vh]">
+      <div className="max-h-[40vh] overflow-y-auto">
         <Table>
           <TableHeader>
             <TableRow>
@@ -77,7 +76,7 @@ export const SweepPreviewTable = ({
             ))}
           </TableBody>
         </Table>
-      </ScrollArea>
+      </div>
       {totalCount > MAX_PREVIEW_ROWS && (
         <Paragraph size="xs" tone="subdued">
           Showing {MAX_PREVIEW_ROWS} of {totalCount} runs.

--- a/src/services/pipelineRunService.ts
+++ b/src/services/pipelineRunService.ts
@@ -48,6 +48,38 @@ export const createPipelineRun = async (
   return response.json();
 };
 
+export const createBatchPipelineRuns = async (
+  runs: BodyCreateApiPipelineRunsPost[],
+  backendUrl: string,
+  authorizationToken?: string,
+) => {
+  const authorizationHeader = authorizationToken
+    ? { Authorization: `Bearer ${authorizationToken}` }
+    : undefined;
+
+  const response = await fetch(`${backendUrl}/api/pipeline_runs/batch`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...authorizationHeader,
+    },
+    body: JSON.stringify(runs),
+  });
+
+  if (!response.ok) {
+    throw new Error("Failed to create batch pipeline runs");
+  }
+
+  return response.json() as Promise<{
+    created_runs: Array<{
+      id: number;
+      root_execution_id: number;
+      created_at: string;
+      created_by: string;
+    }>;
+  }>;
+};
+
 export const savePipelineRun = async (
   responseData: {
     id: number;

--- a/src/utils/parameterSweep.ts
+++ b/src/utils/parameterSweep.ts
@@ -1,4 +1,5 @@
 import type { ArgumentType } from "./componentSpec";
+import { MAX_BATCH_SIZE } from "./submitPipeline";
 
 /** A sweep defines multiple values for one or more parameters. */
 export interface SweepParameter {
@@ -47,8 +48,6 @@ export function getSweepRunCount(sweepParams: SweepParameter[]): number {
   return activeParams.reduce((total, p) => total * p.values.length, 1);
 }
 
-const MAX_SWEEP_RUNS = 500;
-
 /** Validates sweep configuration and returns an error message if invalid. */
 export function validateSweep(sweepParams: SweepParameter[]): string | null {
   const activeParams = sweepParams.filter((p) => p.values.length > 0);
@@ -64,8 +63,8 @@ export function validateSweep(sweepParams: SweepParameter[]): string | null {
   }
 
   const runCount = getSweepRunCount(sweepParams);
-  if (runCount > MAX_SWEEP_RUNS) {
-    return `This sweep would create ${runCount} runs, which exceeds the maximum of ${MAX_SWEEP_RUNS}. Reduce the number of values or parameters.`;
+  if (runCount > MAX_BATCH_SIZE) {
+    return `Sweep produces ${runCount} runs, which exceeds the maximum of ${MAX_BATCH_SIZE}.`;
   }
 
   return null;

--- a/src/utils/submitPipeline.ts
+++ b/src/utils/submitPipeline.ts
@@ -6,6 +6,7 @@ import { processTemplate } from "@/components/shared/PipelineRunNameTemplate/pro
 import { getRunNameTemplate } from "@/components/shared/PipelineRunNameTemplate/utils";
 import { getArgumentsFromInputs } from "@/components/shared/ReactFlow/FlowCanvas/utils/getArgumentsFromInputs";
 import {
+  createBatchPipelineRuns,
   createPipelineRun,
   savePipelineRun,
 } from "@/services/pipelineRunService";
@@ -18,6 +19,8 @@ import type {
   ComponentSpec,
 } from "./componentSpec";
 import { componentSpecFromYaml } from "./yaml";
+
+export const MAX_BATCH_SIZE = 100;
 
 export async function submitPipelineRun(
   componentSpec: ComponentSpec,
@@ -108,6 +111,81 @@ export async function submitPipelineRun(
   } catch (e) {
     options?.onError?.(e as Error);
   }
+}
+
+export async function submitBatchPipelineRuns(
+  componentSpec: ComponentSpec,
+  argSets: Record<string, ArgumentType>[],
+  backendUrl: string,
+  options?: {
+    authorizationToken?: string;
+    runNameOverride?: boolean;
+    canonicalName?: string;
+  },
+): Promise<PipelineRun[]> {
+  const pipelineName =
+    options?.canonicalName ?? componentSpec.name ?? "Pipeline";
+
+  const specCopy = structuredClone(componentSpec);
+  const componentCache = new Map<string, ComponentSpec>();
+  const fullyLoadedSpec = await processComponentSpec(specCopy, componentCache);
+  const argumentsFromInputs = getArgumentsFromInputs(fullyLoadedSpec);
+
+  const taskAnnotations = options?.runNameOverride
+    ? buildAnnotationsWithCanonicalName(pipelineName)
+    : undefined;
+
+  const runs = argSets.map((taskArguments) => {
+    const payloadArguments: Record<string, ArgumentType> = {
+      ...argumentsFromInputs,
+      ...taskArguments,
+    };
+
+    const stringArguments: Record<string, string> = Object.fromEntries(
+      Object.entries(payloadArguments)
+        .filter(([, v]) => typeof v === "string")
+        .map(([k, v]) => [k, v as string]),
+    );
+
+    const runNameOverride = options?.runNameOverride
+      ? processTemplate(getRunNameTemplate(fullyLoadedSpec) ?? "", {
+          componentRef: { spec: fullyLoadedSpec },
+          arguments: stringArguments,
+        }) || undefined
+      : undefined;
+
+    const payload = {
+      root_task: {
+        componentRef: {
+          spec: {
+            ...fullyLoadedSpec,
+            name: runNameOverride ?? pipelineName,
+          } as ComponentSpecInput,
+        },
+        ...(payloadArguments ? { arguments: payloadArguments } : {}),
+        annotations: taskAnnotations ?? {},
+      },
+    };
+
+    return payload as BodyCreateApiPipelineRunsPost;
+  });
+
+  const response = await createBatchPipelineRuns(
+    runs,
+    backendUrl,
+    options?.authorizationToken,
+  );
+
+  const digest = componentSpec.metadata?.annotations?.digest as
+    | string
+    | undefined;
+  for (const run of response.created_runs) {
+    if (run.id) {
+      await savePipelineRun(run, pipelineName, digest);
+    }
+  }
+
+  return response.created_runs as unknown as PipelineRun[];
 }
 
 const processComponentSpec = async (


### PR DESCRIPTION
## Description

Added batch pipeline run submission functionality to improve performance when submitting multiple pipeline runs simultaneously. The implementation includes a new batch API endpoint, enforces a maximum batch size limit of 100 runs, and replaces the sequential submission approach with a single batch request that handles authorization, run creation, and metadata saving more efficiently.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Navigate to the Oasis submitter with bulk upload or parameter sweep enabled
2. Configure a pipeline with multiple argument sets (test with various sizes up to 100)
3. Submit the batch and verify all runs are created successfully
4. Test error handling by attempting to submit more than 100 runs
5. Verify that run notes and tags are properly saved for each created run
6. Confirm that the pipeline runs list refreshes after batch submission

## Additional Comments

The batch submission approach significantly reduces the time required for bulk operations by eliminating the overhead of individual API calls and sequential processing. The 100-run limit helps prevent potential timeout issues and excessive server load.