### PR TITLE
Add batch_id support to pipeline runs

### DIFF
--- a/src/components/PipelineRun/RunDetails.tsx
+++ b/src/components/PipelineRun/RunDetails.tsx
@@ -111,6 +111,14 @@ export const RunDetails = () => {
                 ? new Date(metadata.created_at).toLocaleString()
                 : undefined,
             },
+            ...(metadata.annotations?.batch_id
+              ? [
+                  {
+                    label: "Batch Id",
+                    value: String(metadata.annotations.batch_id),
+                  },
+                ]
+              : []),
           ]}
         />
       )}

--- a/src/services/pipelineRunService.ts
+++ b/src/services/pipelineRunService.ts
@@ -71,6 +71,7 @@ export const createBatchPipelineRuns = async (
   }
 
   return response.json() as Promise<{
+    batch_id: string;
     created_runs: Array<{
       id: number;
       root_execution_id: number;
@@ -90,6 +91,7 @@ export const savePipelineRun = async (
   pipelineName: string,
   pipelineDigest?: string,
   pipelineDescription?: string,
+  batchId?: string,
 ): Promise<PipelineRun> => {
   const pipelineRunsDb = localForage.createInstance({
     name: DB_NAME,
@@ -104,6 +106,7 @@ export const savePipelineRun = async (
     pipeline_name: pipelineName || "Untitled Pipeline",
     pipeline_digest: pipelineDigest,
     pipeline_description: pipelineDescription,
+    batch_id: batchId,
   };
 
   await pipelineRunsDb.setItem(String(responseData.id), pipelineRun);

--- a/src/types/pipelineRun.ts
+++ b/src/types/pipelineRun.ts
@@ -6,6 +6,7 @@ export interface PipelineRun {
   pipeline_name: string;
   pipeline_description?: string;
   pipeline_digest?: string;
+  batch_id?: string;
   status?: string;
   statusCounts?: TaskStatusCounts;
 }

--- a/src/utils/submitPipeline.ts
+++ b/src/utils/submitPipeline.ts
@@ -181,7 +181,13 @@ export async function submitBatchPipelineRuns(
     | undefined;
   for (const run of response.created_runs) {
     if (run.id) {
-      await savePipelineRun(run, pipelineName, digest);
+      await savePipelineRun(
+        run,
+        pipelineName,
+        digest,
+        undefined,
+        response.batch_id,
+      );
     }
   }
 


### PR DESCRIPTION
## Description

Added batch ID tracking to pipeline runs by introducing a `batch_id` field to the `PipelineRun` interface and related service functions. The `createBatchPipelineRuns` response now includes a `batch_id`, which is passed through to `savePipelineRun` and stored with each pipeline run in the batch.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Create a batch pipeline run and verify that the batch_id is properly returned from the API
2. Confirm that individual pipeline runs within the batch are saved with the correct batch_id
3. Verify that existing pipeline runs without batch_id continue to work as expected

## Additional Comments

The `batch_id` field is optional to maintain backward compatibility with existing pipeline runs that were created before batch tracking was implemented.