### PR TITLE
fix: Subgraph Navigation uses root_execution_id Instead of run_id

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/Subgraphs/view/SubgraphBreadcrumbs.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/Subgraphs/view/SubgraphBreadcrumbs.tsx
@@ -20,15 +20,15 @@ export const SubgraphBreadcrumbs = () => {
   const navigate = useNavigate();
   const { currentSubgraphPath, navigateToPath } = useComponentSpec();
   const executionData = useExecutionDataOptional();
-  const rootExecutionId = executionData?.rootExecutionId;
+  const runId = executionData?.runId;
   const segments = executionData?.segments || [];
 
   const getExecutionIdForIndex = useCallback(
     (targetIndex: number): string | undefined => {
-      if (!rootExecutionId) return undefined;
+      if (!runId) return undefined;
 
       if (targetIndex === 0) {
-        return rootExecutionId;
+        return runId;
       }
 
       const segmentIndex = targetIndex - 1;
@@ -38,7 +38,7 @@ export const SubgraphBreadcrumbs = () => {
 
       return undefined;
     },
-    [rootExecutionId, segments],
+    [runId, segments],
   );
 
   const handleBreadcrumbClick = useCallback(
@@ -47,16 +47,16 @@ export const SubgraphBreadcrumbs = () => {
 
       navigateToPath(targetPath);
 
-      if (rootExecutionId && executionData) {
+      if (runId && executionData) {
         const targetExecutionId = getExecutionIdForIndex(targetIndex);
-        const url = buildExecutionUrl(rootExecutionId, targetExecutionId);
+        const url = buildExecutionUrl(runId, targetExecutionId);
         navigate({ to: url });
       }
     },
     [
       currentSubgraphPath,
       navigateToPath,
-      rootExecutionId,
+      runId,
       executionData,
       getExecutionIdForIndex,
       navigate,

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeCard.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeCard.tsx
@@ -47,7 +47,7 @@ const TaskNodeCard = () => {
   } = useContextPanel();
   const { navigateToSubgraph } = useComponentSpec();
   const executionData = useExecutionDataOptional();
-  const rootExecutionId = executionData?.rootExecutionId;
+  const runId = executionData?.runId;
   const details = executionData?.details;
   const executionState = executionData?.state;
 
@@ -143,22 +143,15 @@ const TaskNodeCard = () => {
     if (isSubgraphNode && taskId) {
       navigateToSubgraph(taskId);
 
-      if (rootExecutionId && details?.child_task_execution_ids) {
+      if (runId && details?.child_task_execution_ids) {
         const subgraphExecutionId = details.child_task_execution_ids[taskId];
         if (subgraphExecutionId) {
-          const url = buildExecutionUrl(rootExecutionId, subgraphExecutionId);
+          const url = buildExecutionUrl(runId, subgraphExecutionId);
           navigate({ to: url });
         }
       }
     }
-  }, [
-    isSubgraphNode,
-    taskId,
-    navigateToSubgraph,
-    rootExecutionId,
-    details,
-    navigate,
-  ]);
+  }, [isSubgraphNode, taskId, navigateToSubgraph, runId, details, navigate]);
 
   useEffect(() => {
     if (selected && !isMultiSelect) {

--- a/src/hooks/useSubgraphBreadcrumbs.test.tsx
+++ b/src/hooks/useSubgraphBreadcrumbs.test.tsx
@@ -199,15 +199,15 @@ describe("buildExecutionUrl", () => {
   });
 
   it("should return root URL when subgraphExecutionId equals rootExecutionId", () => {
-    const rootExecutionId = "root-exec-123";
-    const url = buildExecutionUrl(rootExecutionId, rootExecutionId);
+    const runId = "root-exec-123";
+    const url = buildExecutionUrl(runId, runId);
     expect(url).toBe("/runs/root-exec-123");
   });
 
   it("should return nested URL when subgraphExecutionId is different", () => {
-    const rootExecutionId = "root-exec-123";
+    const runId = "root-exec-123";
     const subgraphExecutionId = "subgraph-exec-456";
-    const url = buildExecutionUrl(rootExecutionId, subgraphExecutionId);
+    const url = buildExecutionUrl(runId, subgraphExecutionId);
     expect(url).toBe("/runs/root-exec-123/subgraph-exec-456");
   });
 });

--- a/src/hooks/useSubgraphBreadcrumbs.ts
+++ b/src/hooks/useSubgraphBreadcrumbs.ts
@@ -24,20 +24,20 @@ interface SubgraphBreadcrumbsResult {
  * by fetching parent execution details recursively until reaching the root.
  */
 export const useSubgraphBreadcrumbs = (
-  rootExecutionId: string | undefined,
+  runId: string | null | undefined,
   subgraphExecutionId: string | undefined,
 ): SubgraphBreadcrumbsResult => {
   const { backendUrl } = useBackend();
   const queryClient = useQueryClient();
 
   const { data, isLoading, error } = useQuery({
-    queryKey: ["subgraph-breadcrumbs", rootExecutionId, subgraphExecutionId],
+    queryKey: ["subgraph-breadcrumbs", runId, subgraphExecutionId],
     queryFn: async () => {
-      if (!rootExecutionId || !subgraphExecutionId) {
+      if (!runId || !subgraphExecutionId) {
         return { segments: [] };
       }
 
-      if (subgraphExecutionId === rootExecutionId) {
+      if (subgraphExecutionId === runId) {
         return { segments: [] };
       }
 
@@ -49,7 +49,7 @@ export const useSubgraphBreadcrumbs = (
         staleTime: ONE_MINUTE_IN_MS,
       });
 
-      while (currentExecutionId && currentExecutionId !== rootExecutionId) {
+      while (currentExecutionId && currentExecutionId !== runId) {
         const parentExecutionId = currentDetails.parent_execution_id;
 
         if (!parentExecutionId) {
@@ -92,10 +92,7 @@ export const useSubgraphBreadcrumbs = (
 
       return { segments };
     },
-    enabled:
-      !!rootExecutionId &&
-      !!subgraphExecutionId &&
-      rootExecutionId !== subgraphExecutionId,
+    enabled: !!runId && !!subgraphExecutionId && runId !== subgraphExecutionId,
     staleTime: ONE_MINUTE_IN_MS,
     retry: 1,
   });
@@ -114,10 +111,10 @@ export const useSubgraphBreadcrumbs = (
 };
 
 export const buildExecutionUrl = (
-  rootExecutionId: string,
+  runId: string,
   subgraphExecutionId?: string,
 ): string => {
-  return !subgraphExecutionId || subgraphExecutionId === rootExecutionId
-    ? `/runs/${rootExecutionId}`
-    : `/runs/${rootExecutionId}/${subgraphExecutionId}`;
+  return !subgraphExecutionId || subgraphExecutionId === runId
+    ? `/runs/${runId}`
+    : `/runs/${runId}/${subgraphExecutionId}`;
 };

--- a/src/providers/ExecutionDataProvider.tsx
+++ b/src/providers/ExecutionDataProvider.tsx
@@ -26,7 +26,7 @@ interface CachedExecutionData {
 }
 
 interface ExecutionDataContextType {
-  currentExecutionId: string | undefined;
+  currentExecutionId: string | null | undefined;
   details: GetExecutionInfoResponse | undefined;
   state: GetGraphExecutionStateResponse | undefined;
   rootExecutionId: string | undefined;
@@ -77,16 +77,16 @@ const buildTaskExecutionStatusMap = (
 
 const findExecutionIdAtPath = (
   path: string[],
-  rootExecutionId: string | undefined,
+  runId: string | null | undefined,
   rootDetails: GetExecutionInfoResponse | undefined,
   cache: Map<string, CachedExecutionData>,
   queryClient: ReturnType<typeof useQueryClient>,
 ): string => {
-  if (!rootExecutionId) {
+  if (!runId) {
     return "";
   }
 
-  let currentId = rootExecutionId;
+  let currentId = runId;
   let currentDetails = rootDetails;
 
   for (let i = ROOT_PATH_START_INDEX; i < path.length; i++) {
@@ -168,7 +168,7 @@ export function ExecutionDataProvider({
     path: urlDerivedPath,
     segments,
     isLoading: isLoadingBreadcrumbs,
-  } = useSubgraphBreadcrumbs(rootExecutionId, subgraphExecutionId);
+  } = useSubgraphBreadcrumbs(runId, subgraphExecutionId);
 
   // Wait until rootDetails is loaded so the component spec is available
   useEffect(() => {
@@ -207,12 +207,12 @@ export function ExecutionDataProvider({
     }
 
     if (isAtRoot) {
-      return rootExecutionId;
+      return runId;
     }
 
     return findExecutionIdAtPath(
       currentSubgraphPath,
-      rootExecutionId,
+      runId,
       rootDetails,
       executionDataCache.current,
       queryClient,
@@ -220,7 +220,7 @@ export function ExecutionDataProvider({
   }, [
     subgraphExecutionId,
     currentSubgraphPath,
-    rootExecutionId,
+    runId,
     rootDetails,
     isAtRoot,
     queryClient,


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

Fixes a bug where runs are on the url `/run/{run_id}` but navigating to into a subgraph run switches the url to `/run/{root_execution_id}/{subgraph_execution_id}`

Subgraphs will now use `run_id` as intended. Urls are of the format:
`/run/{run_id}/{subgraph_execution_id}`

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

1. Create a run with a subgraph in it
2. View the run. Note the url.
3. Navigate into the subgraph on your run. Confirm the base url doesn't change and only the subgraph portion id added on.
4. Confirm all other Pipeline Run navigations works as expected.

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->