### PR TITLE
Dashboard and beta

### DIFF
--- a/src/components/shared/Settings/useFlags.ts
+++ b/src/components/shared/Settings/useFlags.ts
@@ -7,6 +7,17 @@ import type { BetaFlagsStorage } from "./types";
 
 const storage = getStorage<keyof BetaFlagsStorage, BetaFlagsStorage>();
 
+/**
+ * Non-hook flag check for use outside React (e.g., route beforeLoad).
+ */
+export function isFlagEnabled(flagName: keyof typeof ExistingFlags): boolean {
+  return (
+    storage.getItem("betaFlags")?.[flagName] ??
+    ExistingFlags[flagName]?.default ??
+    false
+  );
+}
+
 export function useFlags() {
   return {
     getFlags: () => storage.getItem("betaFlags"),

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -46,4 +46,12 @@ export const ExistingFlags: ConfigFlags = {
     default: false,
     category: "beta",
   },
+
+  ["dashboard"]: {
+    name: "Dashboard",
+    description:
+      "Enable the new Dashboard page, a redesigned homepage experience.",
+    default: false,
+    category: "beta",
+  },
 };

--- a/src/routes/Dashboard/Dashboard.tsx
+++ b/src/routes/Dashboard/Dashboard.tsx
@@ -1,0 +1,22 @@
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
+
+export const Dashboard = () => {
+  return (
+    <BlockStack gap="4" className="container mx-auto w-3/4 p-4">
+      <InlineStack align="space-between" blockAlign="center">
+        <Text as="h1" size="xl" weight="bold">
+          Dashboard
+        </Text>
+        <Text
+          as="span"
+          size="xs"
+          weight="semibold"
+          className="px-2 py-1 rounded-full bg-amber-100 text-amber-800"
+        >
+          Beta
+        </Text>
+      </InlineStack>
+    </BlockStack>
+  );
+};

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -13,9 +13,11 @@ import { AuthorizationResultScreen as HuggingFaceAuthorizationResultScreen } fro
 import { AddSecretView } from "@/components/shared/SecretsManagement/components/AddSecretView";
 import { ReplaceSecretView } from "@/components/shared/SecretsManagement/components/ReplaceSecretView";
 import { SecretsListView } from "@/components/shared/SecretsManagement/components/SecretsListView";
+import { isFlagEnabled } from "@/components/shared/Settings/useFlags";
 import { BASE_URL, IS_GITHUB_PAGES } from "@/utils/constants";
 
 import RootLayout from "../components/layout/RootLayout";
+import { Dashboard } from "./Dashboard/Dashboard";
 import Editor from "./Editor";
 import Home from "./Home";
 import { ImportPage } from "./Import";
@@ -39,8 +41,10 @@ export const RUNS_BASE_PATH = "/runs";
 export const QUICK_START_PATH = "/quick-start";
 const SETTINGS_PATH = "/settings";
 const IMPORT_PATH = "/app/editor/import-pipeline";
+const DASHBOARD_PATH = "/dashboard";
 export const APP_ROUTES = {
   HOME: "/",
+  DASHBOARD: DASHBOARD_PATH,
   QUICK_START: QUICK_START_PATH,
   IMPORT: IMPORT_PATH,
   PIPELINE_EDITOR: `${EDITOR_PATH}/$name`,
@@ -74,6 +78,17 @@ const indexRoute = createRoute({
   getParentRoute: () => mainLayout,
   path: APP_ROUTES.HOME,
   component: Home,
+});
+
+const dashboardRoute = createRoute({
+  getParentRoute: () => mainLayout,
+  path: APP_ROUTES.DASHBOARD,
+  component: Dashboard,
+  beforeLoad: () => {
+    if (!isFlagEnabled("dashboard")) {
+      throw redirect({ to: APP_ROUTES.HOME });
+    }
+  },
 });
 
 const quickStartRoute = createRoute({
@@ -194,6 +209,7 @@ const settingsRouteTree = settingsLayoutRoute.addChildren([
 
 const appRouteTree = mainLayout.addChildren([
   indexRoute,
+  dashboardRoute,
   quickStartRoute,
   settingsRouteTree,
   importRoute,


### PR DESCRIPTION
## Description

This pull request introduces a new Dashboard page as a beta feature. The Dashboard is implemented as a redesigned homepage experience that can be enabled through a feature flag. The page includes a simple layout with a title and beta badge indicator.

## Related Issue and Pull requests

Closes #1965
Part of #1964

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Enable the Dashboard feature flag by setting `dashboard: true` in localStorage under the `betaFlags` key
2. Navigate to `/dashboard` to view the new Dashboard page
3. Verify that accessing `/dashboard` without the feature flag enabled redirects to the home page
4. Confirm the Dashboard page displays the title and beta badge correctly

## Additional Comments

The Dashboard feature is currently behind a beta flag and will redirect users to the home page if the flag is not enabled. The feature flag can be controlled through localStorage or will use the default value (false) defined in the flags configuration.