### PR TITLE
fix: Do not show empty artifacts

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/IOCellHeader.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/IOCellHeader.tsx
@@ -1,7 +1,6 @@
-import { ChevronsUpDown } from "lucide-react";
-
 import type { ArtifactDataResponse } from "@/api/types.gen";
 import { CollapsibleTrigger } from "@/components/ui/collapsible";
+import { Icon } from "@/components/ui/icon";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Link } from "@/components/ui/link";
 import {
@@ -42,6 +41,10 @@ const IOCellHeader = ({
     artifactData?.value,
     io.type,
   );
+
+  const hasArtifactDetails =
+    (!!artifactData?.value && artifactData.value.trim() !== "") ||
+    !!artifactData?.uri;
 
   return (
     <BlockStack
@@ -112,14 +115,16 @@ const IOCellHeader = ({
 
               {io.type?.toString()}
 
-              <CollapsibleTrigger
-                disabled={!hasCollapsableContent}
-                className={cn({
-                  hidden: !hasCollapsableContent,
-                })}
-              >
-                <ChevronsUpDown className="w-4 h-4 cursor-pointer" />
-              </CollapsibleTrigger>
+              {hasArtifactDetails && (
+                <CollapsibleTrigger
+                  disabled={!hasCollapsableContent}
+                  className={cn({
+                    hidden: !hasCollapsableContent,
+                  })}
+                >
+                  <Icon name="ChevronsUpDown" className="cursor-pointer" />
+                </CollapsibleTrigger>
+              )}
             </InlineStack>
           </InlineStack>
         )}
@@ -140,7 +145,7 @@ const canShowInlineValue = (
   if (type === "Integer" || type === "Boolean") {
     return true;
   }
-  if (type === "String" && value.length < 31) {
+  if (type === "String" && value.length < 31 && value.trim() !== "") {
     return true;
   }
   return false;


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

An empty input artifact value will no longer render a collapsible that has no content in it.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

![image.png](https://app.graphite.com/user-attachments/assets/a23c7106-dc83-483f-a7da-09229de15b89.png)

Before

![image.png](https://app.graphite.com/user-attachments/assets/8bbc378f-23d3-453a-bd81-f80f285c9fd1.png)

After

![image.png](https://app.graphite.com/user-attachments/assets/519e147e-7019-4fd6-aa62-3b7c5115ef0b.png)

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->



The input/output artifacts code is quite old and the UI is not particularly nice to work with. I am considering a full rework as part of the upcoming Artifact Visualization work.