### PR TITLE
fix: avoid failuire in detectlanguage for non-string values

### DIFF
--- a/src/utils/detectLanguage.ts
+++ b/src/utils/detectLanguage.ts
@@ -20,7 +20,8 @@ export function isLanguageOption(value: string): value is LanguageOption {
  * Detection is ordered from most-certain to least-certain.
  */
 export function detectLanguage(value: string): LanguageOption {
-  const trimmed = value.trim();
+  // todo: figure out why we may receive a non-string value
+  const trimmed = String(value).trim();
 
   if (!trimmed) return "plaintext";
 


### PR DESCRIPTION
## Description

Added defensive type conversion in `detectLanguage` function to handle cases where non-string values may be passed as input. The function now converts the input to a string using `String()` before calling `.trim()` to prevent runtime errors.

## Related Issue and Pull requests

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Test the `detectLanguage` function with various input types including strings, numbers, null, and undefined
2. Verify that the function no longer throws errors when receiving non-string inputs
3. Confirm that string inputs continue to work as expected

## Additional Comments

This change addresses a potential runtime error where the function might receive non-string values. A TODO comment has been added to investigate the root cause of why non-string values are being passed to this function.