### PR TITLE
fix: Horizontal overflow in URI links

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/IOCellDetails.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/IOCellDetails.tsx
@@ -1,6 +1,7 @@
 import type { ArtifactDataResponse } from "@/api/types.gen";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Link } from "@/components/ui/link";
+import { Text } from "@/components/ui/typography";
 import type { InputSpec, OutputSpec } from "@/utils/componentSpec";
 import { convertArtifactUriToHTTPUrl } from "@/utils/URL";
 
@@ -19,7 +20,7 @@ const IOCellDetails = ({ io, artifactData, actions }: IOCellDetailsProps) => {
   return (
     <BlockStack gap="3" className="pb-3 pt-5 border rounded-b-md bg-gray-50">
       {artifactData.value && (
-        <InlineStack className="px-3 py-0 w-full">
+        <InlineStack className="px-3 w-full">
           <span
             className="flex-1 w-full cursor-copy overflow-hidden"
             onClick={handleCopyValue}
@@ -30,14 +31,15 @@ const IOCellDetails = ({ io, artifactData, actions }: IOCellDetailsProps) => {
       )}
 
       {artifactData.uri && (
-        <InlineStack className="px-3 py-0">
-          <span className="font-medium text-xs min-w-24 max-w-24">URI:</span>
+        <InlineStack className="px-3">
+          <Text size="xs">URI:</Text>
           <Link
             external
             href={convertArtifactUriToHTTPUrl(
               artifactData.uri,
               artifactData.is_dir,
             )}
+            className="text-xs whitespace-pre-wrap break-all"
           >
             {artifactData.uri}
           </Link>

--- a/src/components/ui/link.tsx
+++ b/src/components/ui/link.tsx
@@ -53,9 +53,11 @@ function Link({
       {...props}
       className={cn(linkVariants({ variant, size }), className)}
     >
-      <InlineStack gap="1" className="w-full">
+      <InlineStack gap="1" wrap="nowrap" fill>
         {children}
-        {external && <Icon name="ExternalLink" size={size} />}
+        {external && (
+          <Icon name="ExternalLink" size={size} className="min-w-3" />
+        )}
       </InlineStack>
     </a>
   );


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Fix a horizontal overflow in input/output artifact URI links. And makes the fontsize more reasonable.

before

![image.png](https://app.graphite.com/user-attachments/assets/722b821f-34c5-4f52-a84d-07535729988b.png)

after

![image.png](https://app.graphite.com/user-attachments/assets/a5928458-a770-4793-acef-246f1e8aa73e.png)

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
