### PR TITLE
feat: Add Fullscreen Toggle to Multiline Editor

### DIFF
--- a/src/components/shared/Dialogs/MultilineTextInputDialog.tsx
+++ b/src/components/shared/Dialogs/MultilineTextInputDialog.tsx
@@ -8,6 +8,7 @@ import {
   DialogFooter,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { Icon } from "@/components/ui/icon";
 import { InlineStack } from "@/components/ui/layout";
 import {
   Select,
@@ -56,6 +57,7 @@ export const MultilineTextInputDialog = ({
   const [selectedLanguage, setSelectedLanguage] = useState(() =>
     detectLanguage(initialValue),
   );
+  const [isFullscreen, setIsFullscreen] = useState(false);
 
   const handleConfirm = () => {
     onConfirm(value);
@@ -87,11 +89,33 @@ export const MultilineTextInputDialog = ({
     setSelectedLanguage(detectLanguage(initialValue));
   }, [initialValue]);
 
+  useEffect(() => {
+    if (!open) setIsFullscreen(false);
+  }, [open]);
+
   return (
     <Dialog open={open} onOpenChange={onCancel}>
-      <DialogContent>
+      <DialogContent
+        className={cn(isFullscreen && "max-w-none! h-screen! rounded-none!")}
+      >
         <DialogTitle>{title}</DialogTitle>
-        <InlineStack gap="2" align="space-between" wrap="nowrap" fill>
+        {highlightSyntax && (
+          <Button
+            variant="ghost"
+            onClick={() => setIsFullscreen((prev) => !prev)}
+            className="absolute top-3 right-10 rounded-md"
+            aria-label={isFullscreen ? "Exit fullscreen" : "Enter fullscreen"}
+            size="xs"
+          >
+            <Icon name={isFullscreen ? "Minimize2" : "Maximize2"} size="xs" />
+          </Button>
+        )}
+        <InlineStack
+          gap="2"
+          align="space-between"
+          wrap="nowrap"
+          className="w-full"
+        >
           <DialogDescription className={cn(!description ? "hidden" : "")}>
             {description ?? title}
           </DialogDescription>
@@ -114,8 +138,9 @@ export const MultilineTextInputDialog = ({
           )}
         </InlineStack>
         {highlightSyntax && selectedLanguage !== "plaintext" ? (
-          <div className="h-64">
+          <div className={cn(isFullscreen ? "flex-1 min-h-0" : "h-64")}>
             <CodeEditor
+              key={String(isFullscreen)}
               value={value}
               language={selectedLanguage}
               onChange={setValue}


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

User request: add a fullscreen toggle to multiline editor. Enables editing of large data strings with syntax highlighting in fullscreen view.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

![image.png](https://app.graphite.com/user-attachments/assets/a34d174f-4b59-43a0-80c3-21f0e111af3c.png)

## Test Instructions

Click the new fullscreen button in the top right of the multiline editor dialog.

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->