### PR TITLE
feat: Compute Resource Editor descriptions and editable enums

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/AnnotationsInput.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/AnnotationsInput.tsx
@@ -37,6 +37,11 @@ interface AnnotationsInputProps {
   onDelete?: () => void;
 }
 
+const CUSTOM_OPTION_SENTINEL = "__custom__";
+
+// enableQuantity takes precedence over allowCustomValue in the onValueChange ternary.
+// Combining both flags on the same config is intentionally unsupported — CUSTOM_OPTION_SENTINEL
+// is not handled in the quantity path.
 export const AnnotationsInput = ({
   value = "",
   config,
@@ -51,6 +56,10 @@ export const AnnotationsInput = ({
   const [isInvalid, setIsInvalid] = useState(false);
   const [lastSavedValue, setLastSavedValue] = useState(value);
   const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [isCustomMode, setIsCustomMode] = useState(() => {
+    if (!config?.allowCustomValue || !value) return false;
+    return !config.options?.some((opt) => opt.value === value);
+  });
 
   const inputType = config?.type ?? "string";
   const placeholder = config?.label ?? "";
@@ -201,12 +210,37 @@ export const AnnotationsInput = ({
       }
     } else {
       setInputValue("");
-      if (onBlur && "" !== lastSavedValue) {
+      if (onBlur && lastSavedValue !== "") {
         onBlur("");
         setLastSavedValue("");
       }
     }
   }, [config, onBlur, lastSavedValue]);
+
+  const handleSelectOrCustomChange = useCallback(
+    (selectedKey: string) => {
+      if (selectedKey === CUSTOM_OPTION_SENTINEL) {
+        // Don't propagate onBlur here — the user hasn't typed a custom value yet.
+        // Calling onBlur("") would remove the annotation, causing the value prop to
+        // update to "" and the useEffect to reset isCustomMode back to false.
+        setIsCustomMode(true);
+        setInputValue("");
+      } else {
+        setIsCustomMode(false);
+        handleNonQuantitySelectChange(selectedKey);
+      }
+    },
+    [handleNonQuantitySelectChange],
+  );
+
+  const handleBackToSelect = useCallback(() => {
+    setIsCustomMode(false);
+    setInputValue("");
+    if (onBlur && "" !== lastSavedValue) {
+      onBlur("");
+      setLastSavedValue("");
+    }
+  }, [onBlur, lastSavedValue]);
 
   const handleSwitchChange = useCallback(
     (checked: boolean) => {
@@ -252,49 +286,89 @@ export const AnnotationsInput = ({
   useEffect(() => {
     setInputValue(value);
     setLastSavedValue(value);
-  }, [value]);
+    if (config?.allowCustomValue) {
+      setIsCustomMode(
+        !!value && !config.options?.some((opt) => opt.value === value),
+      );
+    }
+  }, [value, config]);
 
   let inputElement = null;
 
   if (config?.options && config.options.length > 0) {
-    const currentValue = config?.enableQuantity
-      ? getKeyFromInputValue(inputValue)
-      : inputValue;
+    if (config.allowCustomValue && isCustomMode) {
+      inputElement = (
+        <InlineStack gap="2" wrap="nowrap" className="grow">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="shrink-0 h-8 w-8"
+            onClick={handleBackToSelect}
+            title="Back to options"
+            type="button"
+          >
+            <Icon name="List" className="size-3 text-muted-foreground" />
+          </Button>
+          <Input
+            value={inputValue}
+            onChange={validateChange}
+            onBlur={handleBlur}
+            autoFocus
+            placeholder={`Custom ${placeholder}`}
+            className={className}
+            required={config?.required}
+          />
+        </InlineStack>
+      );
+    } else {
+      const currentValue = config?.enableQuantity
+        ? getKeyFromInputValue(inputValue)
+        : inputValue;
 
-    inputElement = (
-      <Select
-        value={currentValue}
-        onValueChange={
-          config?.enableQuantity
-            ? handleQuantitySelectChange
-            : handleNonQuantitySelectChange
-        }
-        required={config?.required}
-      >
-        <div className="relative group grow min-w-24">
-          <SelectTrigger className={cn("w-full", className)}>
-            <SelectValue placeholder={"Select " + placeholder} />
-          </SelectTrigger>
-          {!!currentValue && (
-            <Button
-              variant="ghost"
-              size="min"
-              className="absolute right-8 top-1/2 -translate-y-1/2 hidden group-hover:block"
-              onClick={handleClearSelection}
-            >
-              <Icon name="X" className="size-3 text-muted-foreground" />
-            </Button>
-          )}
-        </div>
-        <SelectContent>
-          {config.options.map((opt) => (
-            <SelectItem key={opt.value} value={opt.value}>
-              {opt.name}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-    );
+      const selectOptions = config.allowCustomValue
+        ? [
+            ...config.options,
+            { value: CUSTOM_OPTION_SENTINEL, name: "Custom..." },
+          ]
+        : config.options;
+
+      inputElement = (
+        <Select
+          value={currentValue}
+          onValueChange={
+            config?.enableQuantity
+              ? handleQuantitySelectChange
+              : config.allowCustomValue
+                ? handleSelectOrCustomChange
+                : handleNonQuantitySelectChange
+          }
+          required={config?.required}
+        >
+          <div className="relative group grow min-w-24">
+            <SelectTrigger className={cn("w-full", className)}>
+              <SelectValue placeholder={"Select " + placeholder} />
+            </SelectTrigger>
+            {!!currentValue && (
+              <Button
+                variant="ghost"
+                size="min"
+                className="absolute right-8 top-1/2 -translate-y-1/2 hidden group-hover:block"
+                onClick={handleClearSelection}
+              >
+                <Icon name="X" className="size-3 text-muted-foreground" />
+              </Button>
+            )}
+          </div>
+          <SelectContent>
+            {selectOptions.map((opt) => (
+              <SelectItem key={opt.value} value={opt.value}>
+                {opt.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      );
+    }
   } else if (inputType === "boolean") {
     inputElement = (
       <Switch

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/ComputeResourcesEditor.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/ComputeResourcesEditor.tsx
@@ -1,11 +1,19 @@
 import { useCallback } from "react";
 
+import TooltipButton from "@/components/shared/Buttons/TooltipButton";
+import { Icon } from "@/components/ui/icon";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import { Heading, Paragraph } from "@/components/ui/typography";
 import type { AnnotationConfig, Annotations } from "@/types/annotations";
 import { getAnnotationValue } from "@/utils/annotations";
 
 import { AnnotationsInput } from "./AnnotationsInput";
+import { DescriptionWithLinks } from "./DescriptionWithLinks";
 
 interface ComputeResourcesEditorProps {
   annotations: Annotations;
@@ -78,7 +86,7 @@ const ComputeResourceField = ({
 
   return (
     <BlockStack key={resource.annotation}>
-      <InlineStack>
+      <InlineStack gap="1" align="center">
         <Paragraph size="xs" tone="subdued">
           {label}
         </Paragraph>
@@ -86,6 +94,25 @@ const ComputeResourceField = ({
           <Paragraph size="xs" tone="critical">
             *
           </Paragraph>
+        )}
+        {resource.description && (
+          <Popover>
+            <PopoverTrigger asChild>
+              <TooltipButton
+                tooltip="Description"
+                variant="ghost"
+                size="min"
+                className="[&_svg]:size-3 text-muted-foreground hover:text-foreground"
+              >
+                <Icon name="Info" />
+              </TooltipButton>
+            </PopoverTrigger>
+            <PopoverContent>
+              <Paragraph size="xs" tone="subdued" className="italic">
+                <DescriptionWithLinks text={resource.description} />
+              </Paragraph>
+            </PopoverContent>
+          </Popover>
         )}
       </InlineStack>
 

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/DescriptionWithLinks.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/DescriptionWithLinks.tsx
@@ -1,0 +1,36 @@
+import { Fragment } from "react";
+
+import { Icon } from "@/components/ui/icon";
+
+// Matches http/https URLs; defined at module level to avoid re-creation on every render.
+const URL_REGEX = /https?:\/\/\S+/g;
+
+interface DescriptionWithLinksProps {
+  text: string;
+}
+
+export function DescriptionWithLinks({ text }: DescriptionWithLinksProps) {
+  const parts = text.split(URL_REGEX);
+  const urls = text.match(URL_REGEX) ?? [];
+
+  return (
+    <>
+      {parts.map((part, i) => (
+        <Fragment key={i}>
+          {part}
+          {urls[i] && (
+            <a
+              href={urls[i]}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-0.5 break-all underline hover:opacity-80"
+            >
+              {urls[i]}
+              <Icon name="ExternalLink" className="size-3 shrink-0" />
+            </a>
+          )}
+        </Fragment>
+      ))}
+    </>
+  );
+}

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/utils.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/utils.ts
@@ -18,6 +18,7 @@ interface JSONSchemaProperty {
   "x-append"?: string;
   "x-enable-quantity"?: boolean;
   "x-enum-labels"?: Record<string, string>;
+  "x-allow-custom-value"?: boolean;
   "x-hidden"?: boolean;
   "x-type"?: string;
 }
@@ -112,6 +113,15 @@ export function parseSchemaToAnnotationConfig(
         name: property["x-enum-labels"]?.[value] || value,
       }));
       config.options = options;
+    }
+
+    // Handle custom value allowance
+    if (property["x-allow-custom-value"]) {
+      config.allowCustomValue = true;
+    }
+
+    if (property.description) {
+      config.description = property.description;
     }
 
     // Handle quantity enablement

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/ArgumentInputField.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/ArgumentInputField.tsx
@@ -9,6 +9,7 @@ import {
 } from "react";
 
 import TooltipButton from "@/components/shared/Buttons/TooltipButton";
+import { DescriptionWithLinks } from "@/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/DescriptionWithLinks";
 import { SelectSecretDialog } from "@/components/shared/SecretsManagement/SelectSecretDialog";
 import { createSecretArgument } from "@/components/shared/SecretsManagement/types";
 import { Icon } from "@/components/ui/icon";
@@ -461,7 +462,7 @@ export const ArgumentInputField = ({
               </PopoverTrigger>
               <PopoverContent>
                 <Paragraph size="xs" tone="subdued" className="italic">
-                  {argument.inputSpec.description}
+                  <DescriptionWithLinks text={argument.inputSpec.description} />
                 </Paragraph>
               </PopoverContent>
             </Popover>

--- a/src/types/annotations.ts
+++ b/src/types/annotations.ts
@@ -11,10 +11,12 @@ export type AnnotationConfig = {
   unit?: string;
   append?: string;
   options?: AnnotationOption[];
+  allowCustomValue?: boolean;
   enableQuantity?: boolean;
   type?: "string" | "number" | "integer" | "boolean" | "json";
   min?: number;
   max?: number;
   hidden?: boolean;
   required?: boolean;
+  description?: string;
 };


### PR DESCRIPTION
## Description

Added support for custom values in annotation select dropdowns and enhanced description display with clickable links. When `allowCustomValue` is enabled, users can select "Custom..." from the dropdown to enter their own value, with a back button to return to predefined options. Descriptions in both annotations and arguments now automatically convert URLs to clickable external links with an icon indicator.

![Screenshot 2026-03-16 at 6.21.07 PM.png](https://app.graphite.com/user-attachments/assets/48c5dcd6-ba0f-4e31-9085-7730e58f2688.png)

![Screenshot 2026-03-16 at 6.21.44 PM.png](https://app.graphite.com/user-attachments/assets/dc83f49e-8529-424d-bc28-af83b8116818.png)

![image.png](https://app.graphite.com/user-attachments/assets/b7eb165c-d512-4e73-81a0-0ac5ebc3ca54.png)



## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

- [x] New feature
- [x] Improvement

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

1. Create an annotation configuration with `x-allow-custom-value: true` and predefined options
2. Verify the "Custom..." option appears in the dropdown
3. Select "Custom..." and confirm it switches to text input mode with a back button
4. Test entering custom values and switching back to predefined options
5. Add descriptions with URLs to annotations/arguments and verify they render as clickable links

## Additional Comments

The custom value feature maintains state properly when switching between modes and integrates seamlessly with existing quantity and validation logic. The link parsing uses a simple regex for HTTP/HTTPS URLs and opens them in new tabs to not disrupt workflows.