### PR TITLE
chore: Rework created-by-me setting

### DIFF
--- a/src/components/Home/RunSection/RunSection.tsx
+++ b/src/components/Home/RunSection/RunSection.tsx
@@ -93,12 +93,6 @@ export const RunSection = ({ onEmptyList, hideFilters }: RunSectionProps) => {
       },
     });
 
-  useEffect(() => {
-    if (!search.page_token && search.filter === undefined) {
-      handleFilterChange(isCreatedByMeDefault);
-    }
-  }, [isCreatedByMeDefault]);
-
   const handleFilterChange = (value: boolean) => {
     const nextSearch: RunSectionSearch = { ...search };
     delete nextSearch.page_token;

--- a/src/components/shared/CreatedByFilter/CreatedByFilter.tsx
+++ b/src/components/shared/CreatedByFilter/CreatedByFilter.tsx
@@ -12,6 +12,8 @@ interface CreatedByFilterProps {
   onChange: (value: string | undefined) => void;
   /** Called when user clicks the clear button (for immediate clearing). */
   onClear: () => void;
+  /** Pre-fills the input on mount and triggers onChange if no URL value is set. */
+  defaultValue?: string;
 }
 
 /**
@@ -21,13 +23,21 @@ export function CreatedByFilter({
   value,
   onChange,
   onClear,
+  defaultValue,
 }: CreatedByFilterProps) {
-  const [inputValue, setInputValue] = useState(value ?? "");
+  const [inputValue, setInputValue] = useState(value ?? defaultValue ?? "");
 
   // Sync internal state when value changes externally (e.g., URL navigation, badge removal)
   useEffect(() => {
     setInputValue(value ?? "");
   }, [value]);
+
+  // Apply defaultValue on mount if no URL value is already set
+  useEffect(() => {
+    if (defaultValue && value === undefined) {
+      onChange(defaultValue);
+    }
+  }, []);
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     const newValue = e.target.value;

--- a/src/components/shared/PipelineRunFiltersBar/PipelineRunFiltersBar.tsx
+++ b/src/components/shared/PipelineRunFiltersBar/PipelineRunFiltersBar.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import type { DateRange } from "react-day-picker";
 
 import { CreatedByFilter } from "@/components/shared/CreatedByFilter/CreatedByFilter";
+import { useFlagValue } from "@/components/shared/Settings/useFlags";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { DatePickerWithRange } from "@/components/ui/date-picker";
@@ -35,6 +36,7 @@ export function PipelineRunFiltersBar({
   totalCount,
   filteredCount,
 }: PipelineRunFiltersBarProps) {
+  const isCreatedByMeDefault = useFlagValue("created-by-me-default");
   const {
     filters,
     setFilter,
@@ -205,6 +207,9 @@ export function PipelineRunFiltersBar({
           value={filters.created_by}
           onChange={(value) => setFilterDebounced("created_by", value)}
           onClear={() => setFilter("created_by", undefined)}
+          defaultValue={
+            isCreatedByMeDefault && !filters.created_by ? "me" : undefined
+          }
         />
 
         {/* Date Range */}


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

Reworked how the "created by me" setting works so that it automatically populates the search field with "me", rather than silently appending "created_by:me" to the url

![image.png](https://app.graphite.com/user-attachments/assets/d7e619b3-ae1b-45b7-a2db-5e61c9d464be.png)



This fixes issues/conflicts users are having with searching for other user's pipelines while the setting is active

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix
- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->