### PR TITLE
fix: close code viewer with esc

### DIFF
--- a/src/components/shared/CodeViewer/CodeViewer.tsx
+++ b/src/components/shared/CodeViewer/CodeViewer.tsx
@@ -39,6 +39,7 @@ const CodeViewer = ({
     const handleEscapeKey = (e: KeyboardEvent) => {
       if (isFullscreen && e.key === "Escape") {
         setIsFullscreen(false);
+        onClose?.();
         e.preventDefault();
         e.stopPropagation();
       }


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Closing the fullscreen codeviewer with `esc` currently does not trigger the `onClose` callback. This PR fixes that.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
