### PR TITLE
fix: unhandled non-string values in annotation input

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/AnnotationsInput.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/AnnotationsInput.tsx
@@ -476,7 +476,7 @@ function parseJsonAndGetProperty(
   try {
     const obj = JSON.parse(jsonString || "{}");
     const firstKey = Object.keys(obj)[0];
-    return getKey ? firstKey || "" : obj[firstKey] || "";
+    return getKey ? firstKey || "" : String(obj[firstKey] ?? "");
   } catch {
     return "";
   }


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Fix an issue where the annotation editor can crash due to unhandled non-string input.

Generally we expect annotations to be `string` type values but recently it seems to have started to have an influx of pipelines with non-string annotations.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
