### PR TITLE
feat: Show output artifacts in Output Nodes

### DIFF
--- a/src/components/Editor/IOEditor/InputValueEditor/FormFields/FormFields.tsx
+++ b/src/components/Editor/IOEditor/InputValueEditor/FormFields/FormFields.tsx
@@ -1,13 +1,18 @@
 import type { icons } from "lucide-react";
 import { Activity, type ReactNode } from "react";
 
+import type { ArtifactDataResponse } from "@/api/types.gen";
+import { CopyText } from "@/components/shared/CopyText/CopyText";
 import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
 import { Input } from "@/components/ui/input";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Link } from "@/components/ui/link";
 import { Textarea } from "@/components/ui/textarea";
 import { Paragraph } from "@/components/ui/typography";
 import { cn } from "@/lib/utils";
+import type { InputSpec, OutputSpec } from "@/utils/componentSpec";
+import { convertArtifactUriToHTTPUrl } from "@/utils/URL";
 
 type FormFieldAction = {
   icon: keyof typeof icons;
@@ -197,4 +202,41 @@ const TypeField = ({
   </FormField>
 );
 
-export { DescriptionField, NameField, TextField, TypeField };
+const ArtifactField = ({
+  io,
+  artifactData,
+}: {
+  io: InputSpec | OutputSpec;
+  artifactData: ArtifactDataResponse;
+}) => (
+  <FormField label="Artifact" id={`artifact-${io.name}`}>
+    <BlockStack gap="3" className="p-2 border rounded-md bg-background">
+      {artifactData.value && (
+        <InlineStack gap="2">
+          <Paragraph size="xs">Value:</Paragraph>
+          <CopyText size="sm" className="font-light font-mono">
+            {artifactData.value}
+          </CopyText>
+        </InlineStack>
+      )}
+
+      {artifactData.uri && (
+        <InlineStack gap="2" wrap="nowrap" blockAlign="start">
+          <Paragraph size="xs">URI:</Paragraph>
+          <Link
+            external
+            href={convertArtifactUriToHTTPUrl(
+              artifactData.uri,
+              artifactData.is_dir,
+            )}
+            className="text-xs whitespace-pre-wrap break-all"
+          >
+            {artifactData.uri}
+          </Link>
+        </InlineStack>
+      )}
+    </BlockStack>
+  </FormField>
+);
+
+export { ArtifactField, DescriptionField, NameField, TextField, TypeField };

--- a/src/components/Editor/IOEditor/OutputNameEditor/OutputNameEditor.tsx
+++ b/src/components/Editor/IOEditor/OutputNameEditor/OutputNameEditor.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 
+import type { ArtifactDataResponse } from "@/api/types.gen";
 import { LinkNodeButton } from "@/components/shared/Buttons/LinkNodeButton";
 import ConfirmationDialog from "@/components/shared/Dialogs/ConfirmationDialog";
 import { removeGraphOutput } from "@/components/shared/ReactFlow/FlowCanvas/utils/removeNode";
@@ -18,6 +19,7 @@ import { updateSubgraphSpec } from "@/utils/subgraphUtils";
 import { type OutputConnectedDetails } from "../../utils/getOutputConnectedDetails";
 import { updateOutputNameOnComponentSpec } from "../../utils/updateOutputNameOnComponentSpec";
 import {
+  ArtifactField,
   DescriptionField,
   NameField,
   TypeField,
@@ -29,12 +31,14 @@ interface OutputNameEditorProps {
   output: OutputSpec;
   disabled?: boolean;
   connectedDetails: OutputConnectedDetails;
+  artifactData?: ArtifactDataResponse | null;
 }
 
 export const OutputNameEditor = ({
   output,
   disabled,
   connectedDetails,
+  artifactData,
 }: OutputNameEditorProps) => {
   const { transferSelection } = useNodeSelectionTransfer(outputNameToNodeId);
   const {
@@ -206,6 +210,10 @@ export const OutputNameEditor = ({
         disabled
         inputName={output.name}
       />
+
+      {disabled && artifactData && (
+        <ArtifactField artifactData={artifactData} io={output} />
+      )}
 
       <InlineStack gap="4">
         {!disabled && (

--- a/src/components/shared/CopyText/CopyText.tsx
+++ b/src/components/shared/CopyText/CopyText.tsx
@@ -12,6 +12,7 @@ interface CopyTextProps {
   className?: string;
   alwaysShowButton?: boolean;
   compact?: boolean;
+  size?: "xs" | "sm" | "md" | "lg" | "xl";
 }
 
 export const CopyText = ({
@@ -19,6 +20,7 @@ export const CopyText = ({
   className,
   alwaysShowButton = false,
   compact = false,
+  size = "md",
 }: CopyTextProps) => {
   const [isCopied, setIsCopied] = useState(false);
   const [isHovered, setIsHovered] = useState(false);
@@ -52,10 +54,11 @@ export const CopyText = ({
     >
       <InlineStack gap="1" blockAlign="center" wrap="nowrap">
         <Text
+          size={size}
           className={cn(
             "transition-all duration-150",
             className,
-            isCopied && "scale-[1.01] text-emerald-400!",
+            isCopied && "text-emerald-400!",
           )}
         >
           {children}

--- a/src/components/shared/ReactFlow/FlowCanvas/IONode/IONode.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/IONode/IONode.tsx
@@ -1,3 +1,4 @@
+import { useQuery } from "@tanstack/react-query";
 import { Handle, Position, useEdges, useReactFlow } from "@xyflow/react";
 import type { MouseEvent } from "react";
 import { memo, useCallback, useEffect, useMemo } from "react";
@@ -12,9 +13,11 @@ import { Paragraph } from "@/components/ui/typography";
 import { useEdgeSelectionHighlight } from "@/hooks/useEdgeSelectionHighlight";
 import { useIsMultiSelect } from "@/hooks/useIsMultiSelect";
 import { cn } from "@/lib/utils";
+import { useBackend } from "@/providers/BackendProvider";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 import { useContextPanel } from "@/providers/ContextPanelProvider";
 import { useExecutionDataOptional } from "@/providers/ExecutionDataProvider";
+import { getExecutionArtifacts } from "@/services/executionService";
 import { getArgumentValue } from "@/utils/nodes/taskArguments";
 import { isViewingSubgraph } from "@/utils/subgraphUtils";
 
@@ -41,8 +44,16 @@ const IONode = ({ id, type, data, selected = false }: IONodeProps) => {
   const { currentGraphSpec, currentSubgraphSpec, currentSubgraphPath } =
     useComponentSpec();
 
+  const { backendUrl } = useBackend();
   const executionData = useExecutionDataOptional();
   const taskArguments = executionData?.rootDetails?.task_spec.arguments;
+  const rootExecutionId = executionData?.rootExecutionId;
+
+  const { data: artifacts } = useQuery({
+    queryKey: ["artifacts", rootExecutionId],
+    queryFn: () => getExecutionArtifacts(String(rootExecutionId), backendUrl),
+    enabled: !!rootExecutionId,
+  });
 
   const {
     setContent,
@@ -137,12 +148,17 @@ const IONode = ({ id, type, data, selected = false }: IONodeProps) => {
           currentGraphSpec,
           output.name,
         );
+
+        const artifactData =
+          artifacts?.output_artifacts?.[output.name]?.artifact_data;
+
         setContent(
           <OutputNameEditor
             output={output}
             connectedDetails={outputConnectedDetails}
             key={output.name}
             disabled={readOnly}
+            artifactData={artifactData}
           />,
         );
       }


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

Output artifacts, where a value is provided (i.e. string type), are now displayed on an output node's detail panel when selected in run view.

For non-string artifact values only the URI is shown.

## Related Issue and Pull requests

Closes https://github.com/Shopify/oasis-frontend/issues/247

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## ![image.png](https://app.graphite.com/user-attachments/assets/bd7a0078-ddd7-49a7-8378-85bd3e441902.png)



## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

Confirm output artifacts show when clicking an output node - but only for string type value. For non-string it should show only URI.

Confirm no artifacts shown in edit mode or when the exeuction failed to produce an output.

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->