### PR TITLE
wip cache

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/StatusIndicator.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/StatusIndicator.tsx
@@ -17,19 +17,22 @@ import {
 type StatusIndicatorProps = {
   status: string;
   disabledCache?: boolean;
+  isCached?: boolean;
 };
 
 export const StatusIndicator = ({
   status,
   disabledCache = false,
+  isCached = false,
 }: StatusIndicatorProps) => {
   const { style, text, icon } = getStatusMetadata(status);
+  const hasAdjacentBadge = disabledCache || isCached;
 
   return (
     <div className="absolute -z-1 -top-5 left-0 flex items-start">
       <div
         className={cn("h-8.75 rounded-t-md px-2.5 py-1 text-[10px]", style, {
-          "rounded-tr-none": disabledCache,
+          "rounded-tr-none": hasAdjacentBadge,
         })}
       >
         <div className="flex items-center gap-1 font-mono text-white">
@@ -38,9 +41,21 @@ export const StatusIndicator = ({
         </div>
       </div>
       {disabledCache && (
-        <div className="h-5.5 bg-orange-400 rounded-tr-md flex items-center px-1.5">
+        <div
+          className={cn(
+            "h-5.5 bg-orange-400 flex items-center px-1.5",
+            !isCached && "rounded-tr-md",
+          )}
+        >
           <QuickTooltip content="Cache Disabled" className="whitespace-nowrap">
             <Icon name="ZapOff" size="xs" className="text-white" />
+          </QuickTooltip>
+        </div>
+      )}
+      {isCached && (
+        <div className="h-5.5 bg-teal-500 rounded-tr-md flex items-center px-1.5">
+          <QuickTooltip content="Cached" className="whitespace-nowrap">
+            <Icon name="Database" size="xs" className="text-white" />
           </QuickTooltip>
         </div>
       )}

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNode.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNode.tsx
@@ -24,10 +24,15 @@ const TaskNodeInternal = ({ data, selected, id }: NodeProps) => {
 
   const typedData = useMemo(() => data as TaskNodeData, [data]);
 
+  const taskId = typedData.taskId ?? "";
+
   const status = useMemo(() => {
-    const taskId = typedData.taskId ?? "";
     return executionData?.taskExecutionStatusMap.get(taskId);
-  }, [executionData?.taskExecutionStatusMap, typedData.taskId]);
+  }, [executionData?.taskExecutionStatusMap, taskId]);
+
+  const isCached = useMemo(() => {
+    return executionData?.cachedTaskIds.has(taskId) ?? false;
+  }, [executionData?.cachedTaskIds, taskId]);
 
   const disabledCache = isCacheDisabled(typedData.taskSpec);
 
@@ -43,7 +48,11 @@ const TaskNodeInternal = ({ data, selected, id }: NodeProps) => {
         )}
       >
         {!!status && (
-          <StatusIndicator status={status} disabledCache={disabledCache} />
+          <StatusIndicator
+            status={status}
+            disabledCache={disabledCache}
+            isCached={isCached}
+          />
         )}
         <TaskNodeCard />
       </div>

--- a/src/hooks/useCacheStatusMap.ts
+++ b/src/hooks/useCacheStatusMap.ts
@@ -1,0 +1,73 @@
+import { useQueries } from "@tanstack/react-query";
+import { useMemo } from "react";
+
+import type {
+  GetContainerExecutionStateResponse,
+  GetExecutionInfoResponse,
+  PipelineRunResponse,
+} from "@/api/types.gen";
+import { useBackend } from "@/providers/BackendProvider";
+import { useComponentSpec } from "@/providers/ComponentSpecProvider";
+import { isGraphImplementation } from "@/utils/componentSpec";
+import { TWENTY_FOUR_HOURS_IN_MS } from "@/utils/constants";
+import { fetchWithErrorHandling } from "@/utils/fetchWithErrorHandling";
+
+/**
+ * Fetches container execution state for all leaf (non-subgraph) tasks in a
+ * completed run and determines which used a cached result by comparing
+ * the container's ended_at time against the run's created_at time.
+ *
+ * Returns a Set of taskIds that used cached results.
+ * Only enabled when the run is complete to avoid unnecessary requests.
+ */
+export function useCacheStatusMap(
+  details: GetExecutionInfoResponse | undefined,
+  metadata: PipelineRunResponse | undefined,
+  isRunComplete: boolean,
+): Set<string> {
+  const { backendUrl } = useBackend();
+  const { currentGraphSpec } = useComponentSpec();
+
+  const leafTaskEntries = useMemo(() => {
+    if (!details?.child_task_execution_ids || !isRunComplete) return [];
+
+    return Object.entries(details.child_task_execution_ids).filter(
+      ([taskId]) => {
+        const task = currentGraphSpec.tasks[taskId];
+        const impl = task?.componentRef?.spec?.implementation;
+        return impl && !isGraphImplementation(impl);
+      },
+    );
+  }, [details?.child_task_execution_ids, currentGraphSpec, isRunComplete]);
+
+  const queries = useQueries({
+    queries: leafTaskEntries.map(([, executionId]) => ({
+      queryKey: ["container-execution-state", executionId],
+      queryFn: (): Promise<GetContainerExecutionStateResponse> =>
+        fetchWithErrorHandling(
+          `${backendUrl}/api/executions/${executionId}/container_state`,
+        ),
+      enabled: isRunComplete,
+      staleTime: TWENTY_FOUR_HOURS_IN_MS,
+      refetchOnWindowFocus: false,
+    })),
+  });
+
+  const allSettled = queries.every((q) => !q.isLoading);
+  const runCreatedAt = metadata?.created_at;
+
+  return useMemo(() => {
+    const set = new Set<string>();
+    if (!allSettled || !runCreatedAt) return set;
+
+    const createdAt = new Date(runCreatedAt);
+    leafTaskEntries.forEach(([taskId], index) => {
+      const endedAt = queries[index]?.data?.ended_at;
+      if (endedAt && new Date(endedAt) < createdAt) {
+        set.add(taskId);
+      }
+    });
+    return set;
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- queries array is unstable; allSettled gates recomputation
+  }, [allSettled, leafTaskEntries, runCreatedAt]);
+}

--- a/src/providers/ExecutionDataProvider.tsx
+++ b/src/providers/ExecutionDataProvider.tsx
@@ -7,6 +7,7 @@ import type {
   GetGraphExecutionStateResponse,
   PipelineRunResponse,
 } from "@/api/types.gen";
+import { useCacheStatusMap } from "@/hooks/useCacheStatusMap";
 import { usePipelineRunData } from "@/hooks/usePipelineRunData";
 import {
   createRequiredContext,
@@ -15,7 +16,11 @@ import {
 import type { BreadcrumbSegment } from "@/hooks/useSubgraphBreadcrumbs";
 import { useSubgraphBreadcrumbs } from "@/hooks/useSubgraphBreadcrumbs";
 import { useFetchPipelineRunMetadata } from "@/services/executionService";
-import { getOverallExecutionStatusFromStats } from "@/utils/executionStatus";
+import {
+  flattenExecutionStatusStats,
+  getOverallExecutionStatusFromStats,
+  isExecutionComplete,
+} from "@/utils/executionStatus";
 
 import { useComponentSpec } from "./ComponentSpecProvider";
 
@@ -37,6 +42,7 @@ interface ExecutionDataContextType {
   isLoading: boolean;
   error: Error | null;
   taskExecutionStatusMap: Map<string, string>;
+  cachedTaskIds: Set<string>;
   segments: BreadcrumbSegment[];
 }
 
@@ -273,6 +279,16 @@ export function ExecutionDataProvider({
     [details, state],
   );
 
+  const isRunComplete = useMemo(() => {
+    if (!state?.child_execution_status_stats) return false;
+    const stats = flattenExecutionStatusStats(
+      state.child_execution_status_stats,
+    );
+    return isExecutionComplete(stats);
+  }, [state]);
+
+  const cachedTaskIds = useCacheStatusMap(details, metadata, isRunComplete);
+
   const value = useMemo(
     () => ({
       currentExecutionId,
@@ -286,6 +302,7 @@ export function ExecutionDataProvider({
       isLoading,
       error,
       taskExecutionStatusMap,
+      cachedTaskIds,
       segments,
     }),
     [
@@ -300,6 +317,7 @@ export function ExecutionDataProvider({
       isLoading,
       error,
       taskExecutionStatusMap,
+      cachedTaskIds,
       segments,
     ],
   );


### PR DESCRIPTION
## Description

Added cache status indicators and information throughout the pipeline execution interface. Tasks that used cached results now display a teal "Cached" badge alongside existing status indicators. The task details panel shows cache status, original completion time, and links to the source run when applicable. This enhancement helps users understand when tasks are reusing previous execution results.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Run a pipeline with caching enabled
2. Re-run the same pipeline to trigger cached execution
3. Verify that cached tasks display a teal "Cached" badge in the flow canvas
4. Click on a cached task and check the execution details panel shows cache status, original completion time, and source run link
5. Ensure the cache badge appears correctly alongside disabled cache indicators when both conditions are present

## Additional Comments

The cache detection logic compares task completion time with run creation time - if a task completed before the run started, it's considered cached. The feature only activates for completed runs to avoid unnecessary API calls during active execution.