### PR TITLE
fix: Multiline Text Dialog Description overflows when description has a long word or url

### DIFF
--- a/src/components/shared/Dialogs/MultilineTextInputDialog.tsx
+++ b/src/components/shared/Dialogs/MultilineTextInputDialog.tsx
@@ -58,6 +58,7 @@ export const MultilineTextInputDialog = ({
     detectLanguage(initialValue),
   );
   const [isFullscreen, setIsFullscreen] = useState(false);
+  const [isDescriptionExpanded, setIsDescriptionExpanded] = useState(false);
 
   const handleConfirm = () => {
     onConfirm(value);
@@ -90,7 +91,10 @@ export const MultilineTextInputDialog = ({
   }, [initialValue]);
 
   useEffect(() => {
-    if (!open) setIsFullscreen(false);
+    if (!open) {
+      setIsFullscreen(false);
+      setIsDescriptionExpanded(false);
+    }
   }, [open]);
 
   return (
@@ -110,15 +114,16 @@ export const MultilineTextInputDialog = ({
             <Icon name={isFullscreen ? "Minimize2" : "Maximize2"} size="xs" />
           </Button>
         )}
-        <InlineStack
-          gap="2"
-          align="space-between"
-          wrap="nowrap"
-          className="w-full"
+        <DialogDescription
+          className={cn(
+            "break-all",
+            !isDescriptionExpanded && "line-clamp-2",
+            !description ? "hidden" : "",
+          )}
         >
-          <DialogDescription className={cn(!description ? "hidden" : "")}>
-            {description ?? title}
-          </DialogDescription>
+          {description ?? title}
+        </DialogDescription>
+        <InlineStack align="space-between">
           {highlightSyntax && (
             <Select
               value={selectedLanguage}
@@ -135,6 +140,28 @@ export const MultilineTextInputDialog = ({
                 ))}
               </SelectContent>
             </Select>
+          )}
+
+          {!isDescriptionExpanded &&
+            description &&
+            description.length > 100 && (
+              <Button
+                variant="link"
+                size="xs"
+                onClick={() => setIsDescriptionExpanded(true)}
+              >
+                Show more
+              </Button>
+            )}
+
+          {isDescriptionExpanded && (
+            <Button
+              variant="link"
+              size="xs"
+              onClick={() => setIsDescriptionExpanded(false)}
+            >
+              Show less
+            </Button>
           )}
         </InlineStack>
         {highlightSyntax && selectedLanguage !== "plaintext" ? (


### PR DESCRIPTION
## Description

fix a bug where long unbroken strings (e.g. url) in the dialog description would cause horizontal overflows of the dialog container.



Dialog description is now limited to two lines, with a "show more" button give if the user wants to expand it.

The syntax language selector was also moved out of inline and given its own space so it does not overflow.

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

Closes https://github.com/Shopify/oasis-frontend/issues/523

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

![image.png](https://app.graphite.com/user-attachments/assets/3be4e502-1768-45fc-939b-66cd245a0c59.png)



<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->