### PR TITLE
fix: Use relative time when viewing logs/events when a node is still running

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/LogsEventsOverlaySection.test.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/LogsEventsOverlaySection.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 
 import type { GetContainerExecutionStateResponse } from "@/api/types.gen";
+import { MINUTES } from "@/utils/constants";
 
 import {
   addDaysAndFormat,
+  elapsedMinutesCeil,
   extractPodName,
   isRecordWithString,
   resolvePodLogsHydrationReplacements,
@@ -80,39 +82,81 @@ describe("resolvePodLogsHydrationReplacements", () => {
     );
   });
 
-  it("uses current time when ended_at is missing (still running)", () => {
-    const before = Date.now();
+  it("uses relative time format when ended_at is missing (still running)", () => {
+    const now = 1_700_000_000_000;
+    vi.spyOn(Date, "now").mockReturnValue(now);
+
+    const thirtyMinAgo = new Date(now - 30 * MINUTES).toISOString();
+
     const result = resolvePodLogsHydrationReplacements(
-      { paddingMinutes: 0 },
-      makeContainerState({ ended_at: null }),
+      { paddingMinutes: 5 },
+      makeContainerState({ started_at: thirtyMinAgo, ended_at: null }),
       "pod-running",
     );
-    const after = Date.now();
 
-    const endMs = new Date(result.endTime).getTime();
-    expect(endMs).toBeGreaterThanOrEqual(before);
-    expect(endMs).toBeLessThanOrEqual(after + 1000);
+    expect(result.startTime).toBe("now-35m");
+    expect(result.endTime).toBe("now");
+
+    vi.restoreAllMocks();
   });
 
-  it("uses current time when started_at is missing", () => {
+  it("caps endTime to 'now' when padded ended_at would be in the future", () => {
+    const now = 1_700_000_000_000;
+    vi.spyOn(Date, "now").mockReturnValue(now);
+
+    const twoMinAgo = new Date(now - 2 * MINUTES).toISOString();
+
+    const result = resolvePodLogsHydrationReplacements(
+      { paddingMinutes: 5 },
+      makeContainerState({ started_at: twoMinAgo, ended_at: twoMinAgo }),
+      "pod-just-finished",
+    );
+
+    expect(result.endTime).toBe("now");
+
+    vi.restoreAllMocks();
+  });
+
+  it("falls back to now-60m / now when started_at is missing", () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
-    const before = Date.now();
     const result = resolvePodLogsHydrationReplacements(
-      { paddingMinutes: 0 },
+      { paddingMinutes: 5 },
       makeContainerState({ started_at: null }),
       "pod-unknown",
     );
-    const after = Date.now();
 
-    const startMs = new Date(result.startTime).getTime();
-    expect(startMs).toBeGreaterThanOrEqual(before);
-    expect(startMs).toBeLessThanOrEqual(after + 1000);
+    expect(result.startTime).toBe("now-60m");
+    expect(result.endTime).toBe("now");
     expect(warnSpy).toHaveBeenCalledWith(
       expect.stringContaining("started_at is missing"),
     );
 
     warnSpy.mockRestore();
+  });
+});
+
+describe("elapsedMinutesCeil", () => {
+  it("rounds up partial minutes", () => {
+    const ninetySecondsAgo = new Date(Date.now() - 90_000).toISOString();
+    expect(elapsedMinutesCeil(ninetySecondsAgo)).toBe(2);
+  });
+
+  it("returns exact minutes for whole-minute offsets", () => {
+    const fiveMinAgo = new Date(Date.now() - 5 * MINUTES).toISOString();
+    const result = elapsedMinutesCeil(fiveMinAgo);
+    expect(result).toBeGreaterThanOrEqual(5);
+    expect(result).toBeLessThanOrEqual(6);
+  });
+
+  it("returns 0 for a future timestamp", () => {
+    const future = new Date(Date.now() + MINUTES).toISOString();
+    expect(elapsedMinutesCeil(future)).toBe(0);
+  });
+
+  it("returns 1 for a timestamp just under 1 minute ago", () => {
+    const thirtySecsAgo = new Date(Date.now() - 30_000).toISOString();
+    expect(elapsedMinutesCeil(thirtySecsAgo)).toBe(1);
   });
 });
 

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/logsEventsResolvers.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/logsEventsResolvers.ts
@@ -2,6 +2,7 @@ import type {
   ContainerExecutionStatus,
   GetContainerExecutionStateResponse,
 } from "@/api/types.gen";
+import { MINUTES } from "@/utils/constants";
 import { formatDate } from "@/utils/date";
 
 // --- Per-block typed replacement types ---
@@ -89,6 +90,14 @@ export function extractPodName(
 
 // --- Resolver functions ---
 
+const DEFAULT_FALLBACK_MINUTES = 60;
+const RELATIVE_NOW = "now";
+
+export function elapsedMinutesCeil(startIso: string): number {
+  const elapsedMs = Date.now() - new Date(startIso).getTime();
+  return Math.ceil(Math.max(elapsedMs, 0) / MINUTES);
+}
+
 export function resolvePodLogsHydrationReplacements(
   metadata: Record<string, unknown>,
   containerState: GetContainerExecutionStateResponse,
@@ -97,22 +106,41 @@ export function resolvePodLogsHydrationReplacements(
   const paddingMinutes =
     typeof metadata.paddingMinutes === "number" ? metadata.paddingMinutes : 0;
 
-  // started_at should always be present — LogsEventsOverlaySection guards
-  // against null before calling this resolver. Fallback is purely defensive.
+  // No start — defensive fallback (LogsEventsOverlaySection guards against
+  // this, so reaching here means something unexpected happened).
   if (!containerState.started_at) {
     console.warn(
       "[resolvePodLogsHydrationReplacements] started_at is missing — this should not happen",
     );
+    return {
+      podName,
+      startTime: `${RELATIVE_NOW}-${DEFAULT_FALLBACK_MINUTES}m`,
+      endTime: RELATIVE_NOW,
+    };
   }
-  const startTime = containerState.started_at
-    ? adjustTimestamp(containerState.started_at, -paddingMinutes)
-    : new Date().toISOString();
 
-  const endTime = containerState.ended_at
-    ? adjustTimestamp(containerState.ended_at, paddingMinutes)
-    : adjustTimestamp(new Date().toISOString(), paddingMinutes);
+  // No end — task still running. Use relative time so Observe auto-refreshes.
+  if (!containerState.ended_at) {
+    const totalMinutes =
+      elapsedMinutesCeil(containerState.started_at) + paddingMinutes;
+    return {
+      podName,
+      startTime: `${RELATIVE_NOW}-${totalMinutes}m`,
+      endTime: RELATIVE_NOW,
+    };
+  }
 
-  return { podName, startTime, endTime };
+  // Both present — use absolute padded timestamps.
+  // Cap endTime to "now" so we never request a future time range from Observe.
+  const paddedEnd = adjustTimestamp(containerState.ended_at, paddingMinutes);
+  const endTime =
+    new Date(paddedEnd).getTime() > Date.now() ? RELATIVE_NOW : paddedEnd;
+
+  return {
+    podName,
+    startTime: adjustTimestamp(containerState.started_at, -paddingMinutes),
+    endTime,
+  };
 }
 
 export function resolveRetentionNoticeHydrationReplacements(


### PR DESCRIPTION
## Description

Closes https://github.com/Shopify/oasis-frontend/issues/526

When a node is still running, the old code would put hard code `start` and `end` time relative to the current time the user views the node.  Issues with this is:
- Goes out of sync with latest logs/events
- Didn't work if it's still running, because the end time had a padding of 5 additional minutes into the future (the padding was meant for when a run is completed).

Now, the code does:
- If start time is missing -- Use relative time for the past hour to retrieve logs/events.
- If end time is missing -- Use relative time for the past minutes (plus 5 minute padding) the node has been running to retrieve logs/events.
- If start/end are available -- Use static start/end times with 5 minute padding.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Test Instructions

- Find a run that a node has not finished
- Click on that node and go to logs panel
- Click on both Observe's logs/events that goes to the site.
  - Confirm the time range is using `now` with some minutes
  - Confirm running the query doesn't fail

## Video

**Use cases:**
- Node running
- Node ended recently (within 5 minutes of current time)
- Node completed for a while

[Screen Recording 2026-03-20 at 3.28.43 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/5421f2d1-53c4-45b7-9c94-4e8d8f699c5f.mov" />](https://app.graphite.com/user-attachments/video/5421f2d1-53c4-45b7-9c94-4e8d8f699c5f.mov)