### PR TITLE
feat_favorites_toggle_ui

### DIFF
--- a/react-compiler.config.js
+++ b/react-compiler.config.js
@@ -30,6 +30,7 @@ export const REACT_COMPILER_ENABLED_DIRS = [
   "src/hooks/useEdgeSelectionHighlight.ts",
   "src/hooks/useRunSearchParams.ts",
   "src/hooks/useFavorites.ts",
+  "src/components/shared/FavoriteToggle.tsx",
 
   "src/components/shared/Tags",
   "src/components/shared/Submitters/Oasis/components",

--- a/src/components/Editor/Context/PipelineDetails.tsx
+++ b/src/components/Editor/Context/PipelineDetails.tsx
@@ -7,6 +7,7 @@ import { ContentBlock } from "@/components/shared/ContextPanel/Blocks/ContentBlo
 import { KeyValueList } from "@/components/shared/ContextPanel/Blocks/KeyValueList";
 import { TextBlock } from "@/components/shared/ContextPanel/Blocks/TextBlock";
 import { CopyText } from "@/components/shared/CopyText/CopyText";
+import { FavoriteToggle } from "@/components/shared/FavoriteToggle";
 import { PipelineDescription } from "@/components/shared/PipelineDescription/PipelineDescription";
 import { PipelineRunNameTemplateEditor } from "@/components/shared/PipelineRunNameTemplate/PipelineRunNameTemplateEditor";
 import { useFlagValue } from "@/components/shared/Settings/useFlags";
@@ -102,6 +103,16 @@ const PipelineDetails = () => {
   const actions = [
     <RenamePipeline key="rename-pipeline-action" />,
     <ViewYamlButton key="view-pipeline-yaml" componentSpec={componentSpec} />,
+    ...(componentSpec.name
+      ? [
+          <FavoriteToggle
+            key="favorite-pipeline"
+            type="pipeline"
+            id={componentSpec.name}
+            name={componentSpec.name}
+          />,
+        ]
+      : []),
   ];
 
   return (

--- a/src/components/Home/PipelineSection/PipelineRow.tsx
+++ b/src/components/Home/PipelineSection/PipelineRow.tsx
@@ -2,6 +2,7 @@ import { useNavigate } from "@tanstack/react-router";
 import { type MouseEvent } from "react";
 
 import { ConfirmationDialog } from "@/components/shared/Dialogs";
+import { FavoriteToggle } from "@/components/shared/FavoriteToggle";
 import { HighlightText } from "@/components/shared/HighlightText";
 import { PipelineRunInfoCondensed } from "@/components/shared/PipelineRunDisplay/PipelineRunInfoCondensed";
 import { PipelineRunsList } from "@/components/shared/PipelineRunDisplay/PipelineRunsList";
@@ -161,20 +162,23 @@ const PipelineRow = withSuspenseWrapper(
           {name && <PipelineRunsButton pipelineName={name} />}
         </TableCell>
         <TableCell className="w-0">
-          <ConfirmationDialog
-            trigger={
-              <Button
-                variant="ghost"
-                size="icon"
-                className="opacity-0 group-hover:opacity-100 cursor-pointer text-destructive-foreground hover:text-destructive-foreground"
-              >
-                <Icon name="Trash" />
-              </Button>
-            }
-            title={`Delete pipeline "${name}"?`}
-            description="Are you sure you want to delete this pipeline? Existing pipeline runs will not be impacted. This action cannot be undone."
-            onConfirm={confirmPipelineDelete}
-          />
+          <InlineStack gap="1" blockAlign="center">
+            {name && <FavoriteToggle type="pipeline" id={name} name={name} />}
+            <ConfirmationDialog
+              trigger={
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="opacity-0 group-hover:opacity-100 cursor-pointer text-destructive-foreground hover:text-destructive-foreground"
+                >
+                  <Icon name="Trash" />
+                </Button>
+              }
+              title={`Delete pipeline "${name}"?`}
+              description="Are you sure you want to delete this pipeline? Existing pipeline runs will not be impacted. This action cannot be undone."
+              onConfirm={confirmPipelineDelete}
+            />
+          </InlineStack>
         </TableCell>
       </TableRow>
     );

--- a/src/components/Home/RunSection/RunRow.tsx
+++ b/src/components/Home/RunSection/RunRow.tsx
@@ -4,6 +4,7 @@ import { type MouseEvent } from "react";
 
 import type { PipelineRunResponse } from "@/api/types.gen";
 import { CopyText } from "@/components/shared/CopyText/CopyText";
+import { FavoriteToggle } from "@/components/shared/FavoriteToggle";
 import { StatusBar, StatusIcon } from "@/components/shared/Status";
 import { TagList } from "@/components/shared/Tags/TagList";
 import { Button } from "@/components/ui/button";
@@ -126,6 +127,9 @@ const RunRow = ({ run }: { run: PipelineRunResponse }) => {
       </TableCell>
       <TableCell className="max-w-64">
         {tags && tags.length > 0 && <TagList tags={tags} />}
+      </TableCell>
+      <TableCell className="w-0">
+        <FavoriteToggle type="run" id={runId} name={name} />
       </TableCell>
     </TableRow>
   );

--- a/src/components/PipelineRun/RunToolbar.tsx
+++ b/src/components/PipelineRun/RunToolbar.tsx
@@ -1,3 +1,4 @@
+import { FavoriteToggle } from "@/components/shared/FavoriteToggle";
 import { InlineStack } from "@/components/ui/layout";
 import { useCheckComponentSpecFromPath } from "@/hooks/useCheckComponentSpecFromPath";
 import { useUserDetails } from "@/hooks/useUserDetails";
@@ -66,6 +67,9 @@ export const RunToolbar = () => {
         isViewingSubgraph ? "top-23" : "top-14",
       )}
     >
+      {runId && pipelineName && (
+        <FavoriteToggle type="run" id={runId} name={pipelineName} />
+      )}
       <ViewYamlButton componentSpec={componentSpec} displayLabel="View" />
 
       {canAccessEditorSpec && pipelineName && (

--- a/src/components/shared/FavoriteToggle.tsx
+++ b/src/components/shared/FavoriteToggle.tsx
@@ -1,0 +1,37 @@
+import { Star } from "lucide-react";
+import { type MouseEvent } from "react";
+
+import { Button } from "@/components/ui/button";
+import { type FavoriteType, useFavorites } from "@/hooks/useFavorites";
+import { cn } from "@/lib/utils";
+
+interface FavoriteToggleProps {
+  type: FavoriteType;
+  id: string;
+  name: string;
+}
+
+export const FavoriteToggle = ({ type, id, name }: FavoriteToggleProps) => {
+  const { isFavorite, toggleFavorite } = useFavorites();
+  const active = isFavorite(type, id);
+
+  const handleClick = (e: MouseEvent) => {
+    e.stopPropagation();
+    toggleFavorite({ type, id, name });
+  };
+
+  return (
+    <Button
+      onClick={handleClick}
+      data-testid="favorite-toggle"
+      className={cn(
+        "w-fit h-fit p-1 hover:text-warning",
+        active ? "text-warning" : "text-gray-500/50",
+      )}
+      variant="ghost"
+      size="icon"
+    >
+      <Star className="h-4 w-4" fill={active ? "currentColor" : "none"} />
+    </Button>
+  );
+};


### PR DESCRIPTION
## Description

Added favorite functionality to pipelines and runs throughout the application. Users can now mark pipelines and runs as favorites using a star icon toggle button. The `FavoriteToggle` component has been integrated into:

- Pipeline details context panel
- Pipeline rows in the home section
- Run rows in the home section  
- Pipeline run toolbar

The toggle button displays as a filled star when favorited and an outline when not favorited, with appropriate hover states and click handling to prevent event propagation.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Navigate to the home page and verify star icons appear next to pipelines and runs
2. Click the star icon to toggle favorite status - it should fill/unfill appropriately
3. Open a pipeline in the editor and verify the favorite toggle appears in the context panel actions
4. Open a pipeline run and verify the favorite toggle appears in the run toolbar
5. Verify clicking the favorite toggle doesn't interfere with other row/button interactions

## Additional Comments

The `FavoriteToggle` component uses the `useFavorites` hook to manage favorite state and integrates with the existing UI patterns. The component prevents click event propagation to avoid conflicts with row selection or navigation.