### PR TITLE
feat_favorites_filter

### DIFF
--- a/src/components/Home/FavoritesSection/FavoritesSection.tsx
+++ b/src/components/Home/FavoritesSection/FavoritesSection.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
+import { Input } from "@/components/ui/input";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Heading, Paragraph, Text } from "@/components/ui/typography";
 import {
@@ -64,10 +65,20 @@ const FavoriteChip = ({
 export const FavoritesSection = () => {
   const { favorites, removeFavorite } = useFavorites();
   const [page, setPage] = useState(0);
+  const [query, setQuery] = useState("");
 
-  const totalPages = Math.ceil(favorites.length / PAGE_SIZE);
+  const normalizedQuery = query.trim().toLowerCase();
+  const filtered = normalizedQuery
+    ? favorites.filter(
+        (favorite) =>
+          favorite.id.toLowerCase().includes(normalizedQuery) ||
+          favorite.name.toLowerCase().includes(normalizedQuery),
+      )
+    : favorites;
+
+  const totalPages = Math.ceil(filtered.length / PAGE_SIZE);
   const safePage = Math.min(page, Math.max(0, totalPages - 1));
-  const paginated = favorites.slice(
+  const paginated = filtered.slice(
     safePage * PAGE_SIZE,
     (safePage + 1) * PAGE_SIZE,
   );
@@ -85,6 +96,36 @@ export const FavoritesSection = () => {
         </Paragraph>
       ) : (
         <BlockStack gap="2">
+          <div className="relative w-48">
+            <Icon
+              name="Search"
+              className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground"
+            />
+            <Input
+              placeholder="Search by name or ID..."
+              value={query}
+              onChange={(e) => {
+                setPage(0);
+                setQuery(e.target.value);
+              }}
+              className="pl-9 pr-8 w-full"
+            />
+            {query && (
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => {
+                  setPage(0);
+                  setQuery("");
+                }}
+                className="absolute right-2 top-1/2 -translate-y-1/2 size-6 text-muted-foreground hover:text-foreground"
+                aria-label="Clear search"
+              >
+                <Icon name="X" size="sm" />
+              </Button>
+            )}
+          </div>
+
           <InlineStack wrap="wrap" gap="2">
             {paginated.map((item) => (
               <FavoriteChip


### PR DESCRIPTION
## Description

Added search functionality to the Favorites section, allowing users to filter favorites by name or ID. The search input includes a search icon and a clear button that appears when there's a query. The pagination logic has been updated to work with filtered results, automatically resetting to the first page when searching.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Navigate to the Home page with existing favorites
2. Verify the search input appears above the favorites list
3. Type in the search field to filter favorites by name or ID
4. Confirm the clear button (X) appears when typing and clears the search when clicked
5. Test pagination with filtered results to ensure it resets appropriately
6. Verify case-insensitive search functionality works correctly

## Additional Comments

The search functionality filters favorites in real-time and automatically resets pagination to the first page when the search query changes. The search is case-insensitive and matches both favorite names and IDs.