### PR TITLE
fix: Multi-Node Job events viewed in GCP (not Observe)

### DIFF
--- a/docs/generic-overlay-guide.md
+++ b/docs/generic-overlay-guide.md
@@ -12,6 +12,7 @@ A developer guide for building custom overlays using the Composer system.
 4. [File Structure](#file-structure)
 5. [Quick Start: Creating Your First Overlay](#quick-start-creating-your-first-overlay)
 6. [Reference Tables](#reference-tables)
+7. [Conditional Block Rendering with `displayFor`](#conditional-block-rendering-with-displayfor)
 
 ---
 
@@ -44,17 +45,19 @@ flowchart TB
             Resolvers["3. Per-block resolvers"]
         end
 
-        subgraph hydrate ["hydrateSchema"]
-            Validate["4. validateBlock - check required, apply defaults"]
-            Substitute["5. substitutePlaceholders - replace tokens"]
+        subgraph hydrate ["filterAndHydrateSchema"]
+            Filter["4. filterByDisplayFor - remove non-matching blocks"]
+            Validate["5. validateBlock - check required, apply defaults"]
+            Substitute["6. substitutePlaceholders - replace tokens"]
         end
 
-        ComposerComp["6. Composer"]
+        ComposerComp["7. Composer"]
         RegistryNode["BlockRegistry - TextBlock, LinkBlock"]
 
         FetchData --> Resolvers
         ReadMeta --> Resolvers
-        Resolvers -->|"Record of BlockHydrationReplacements"| Validate
+        Resolvers -->|"Record of BlockHydrationReplacements"| Filter
+        Filter --> Validate
         Validate --> Substitute
         Substitute -->|"hydrated ComposerSchema"| ComposerComp
         ComposerComp --> RegistryNode
@@ -70,6 +73,7 @@ flowchart TB
 | ---------- | ---------------------------- | -------------------------------------------------------------------------------- |
 | Load       | `ComposerSchema`             | Raw JSON parsed into `{ metadata, sections[] }`                                  |
 | Resolve    | `BlockHydrationReplacements` | Per-block `Record<string, string / number / boolean>` of resolved values         |
+| Filter     | `ComposerSchema` (filtered)  | Blocks removed if their `displayFor` doesn't match the current execution type    |
 | Validate   | `BlockValidationResult`      | Merges defaults, reports missing required replacements                           |
 | Substitute | `ComposerSchema` (hydrated)  | Placeholders like `{podName}` replaced with actual values in properties          |
 | Render     | `BlockDescriptor`            | Discriminated union dispatched to `TextBlock` or `LinkBlock` via `BlockRegistry` |
@@ -83,7 +87,7 @@ sequenceDiagram
     participant Section as FeatureOverlaySection
     participant Schema as featureOverlaySchema.json
     participant Resolvers as featureResolvers
-    participant Hydrate as hydrateSchema
+    participant Hydrate as filterAndHydrateSchema
     participant Composer as Composer
     participant Block as TextBlock / LinkBlock
 
@@ -96,9 +100,12 @@ sequenceDiagram
     Section->>Resolvers: resolve per block ID
     Resolvers-->>Section: Record of BlockHydrationReplacements
 
-    Section->>Hydrate: hydrateSchema(schema, allReplacements)
+    Section->>Hydrate: filterAndHydrateSchema(schema, allReplacements, displayFor)
 
-    loop Each BlockDescriptor with replacements
+    Hydrate->>Hydrate: filterByDisplayFor(schema, displayFor)
+    Note over Hydrate: Remove blocks whose displayFor<br/>doesn't include the execution type
+
+    loop Each surviving BlockDescriptor with replacements
         Hydrate->>Hydrate: validateBlock() -> BlockValidationResult
         alt BlockValidationResult.ok
             Hydrate->>Hydrate: substitutePlaceholders(properties, values)
@@ -147,7 +154,7 @@ src/
 | --------------------------- | ----------- | ---------------------------------------------------------------------------------------------------------------- |
 | `featureOverlaySchema.json` | Per feature | Schema JSON defining sections, blocks, replacements, and metadata constants                                      |
 | `composerSchema.ts`         | Core        | Shared TypeScript types: `ComposerSchema`, `BlockDescriptor`, `TextBlockProperties`, `LinkBlockProperties`, etc. |
-| `hydrateSchema.ts`          | Core        | `loadSchema`, `validateSchema`, `hydrateSchema`, `substitutePlaceholders` utilities                              |
+| `hydrateSchema.ts`          | Core        | `loadSchema`, `validateSchema`, `filterAndHydrateSchema`, `substitutePlaceholders` utilities                     |
 | `Composer.tsx`              | Core        | Pure renderer: maps `ComposerSchema` to React components via `BlockRegistry`                                     |
 | `TextBlock.tsx`             | Core        | Renders text blocks with tone, wrap, and visibility support                                                      |
 | `LinkBlock.tsx`             | Core        | Renders link blocks with `buildUrl` and title fallback                                                           |
@@ -261,7 +268,10 @@ Create `StatusOverlaySection.tsx`:
 ```typescript
 import { Composer } from "@/components/shared/Composer/Composer";
 import overlaySchema from "@/config/statusOverlaySchema.json";
-import { hydrateSchema, loadSchema } from "@/services/composer/hydrateSchema";
+import {
+  filterAndHydrateSchema,
+  loadSchema,
+} from "@/services/composer/hydrateSchema";
 import type { BlockHydrationReplacements } from "@/types/composerSchema";
 
 import {
@@ -278,7 +288,6 @@ interface StatusOverlayProps {
 export const StatusOverlaySection = ({
   userId,
 }: StatusOverlayProps) => {
-  // Fetch runtime data via API hook — same pattern as LogsEventsOverlaySection
   const { data: userProfile } = useFetchUserProfile(userId);
 
   if (schema.sections.length === 0) return null;
@@ -291,12 +300,13 @@ export const StatusOverlaySection = ({
     profileLink: resolveProfileLinkReplacements(userId),
   };
 
-  const hydrated = hydrateSchema(schema, allReplacements);
+  // Pass null for displayFor when no conditional rendering is needed
+  const hydrated = filterAndHydrateSchema(schema, allReplacements);
   return <Composer schema={hydrated} />;
 };
 ```
 
-The keys in `allReplacements` (`"greeting"`, `"profileLink"`) must match the block `id` values in the schema. `loadSchema` is called once at module level — it validates the schema on import and returns a typed `ComposerSchema`.
+The keys in `allReplacements` (`"greeting"`, `"profileLink"`) must match the block `id` values in the schema. `loadSchema` is called once at module level — it validates the schema on import and returns a typed `ComposerSchema`. When no `displayFor` filtering is needed, omit the third argument (all blocks render).
 
 ### Overwriting the Default Schema
 
@@ -342,11 +352,79 @@ Declared per block under the `replacements` key. Each entry describes a `{placeh
 
 ### Schema-Level Properties
 
-| Property                | Type                                    | Description                                                                                                                                 |
-| ----------------------- | --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `metadata`              | `Record<string, unknown>`               | Constants accessible by resolvers (e.g., `paddingMinutes`, `retentionDays`). Not used as placeholders directly.                             |
-| `sections[].id`         | `string`                                | Unique section identifier. Duplicates produce a validation warning.                                                                         |
-| `sections[].title`      | `string`                                | Section heading rendered in the UI                                                                                                          |
-| `blocks[].id`           | `string`                                | Unique block identifier. Used as the key in the `allReplacements` map passed to `hydrateSchema()`. Duplicates produce a validation warning. |
-| `blocks[].blockType`    | `"TextBlock"` or `"LinkBlock"`          | Determines which component renders the block via `BlockRegistry`                                                                            |
-| `blocks[].replacements` | `Record<string, ReplacementDescriptor>` | Declares which `{placeholder}` tokens exist in this block's properties. Keys are placeholder names, not block IDs.                          |
+| Property                | Type                                    | Description                                                                                                                                          |
+| ----------------------- | --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `metadata`              | `Record<string, unknown>`               | Constants accessible by resolvers (e.g., `paddingMinutes`, `retentionDays`). Not used as placeholders directly.                                      |
+| `sections[].id`         | `string`                                | Unique section identifier. Duplicates produce a validation warning.                                                                                  |
+| `sections[].title`      | `string`                                | Section heading rendered in the UI                                                                                                                   |
+| `blocks[].id`           | `string`                                | Unique block identifier. Used as the key in the `allReplacements` map passed to `filterAndHydrateSchema()`. Duplicates produce a validation warning. |
+| `blocks[].blockType`    | `"TextBlock"` or `"LinkBlock"`          | Determines which component renders the block via `BlockRegistry`                                                                                     |
+| `blocks[].replacements` | `Record<string, ReplacementDescriptor>` | Declares which `{placeholder}` tokens exist in this block's properties. Keys are placeholder names, not block IDs.                                   |
+| `blocks[].displayFor`   | `string[]` (optional)                   | Whitelist of execution types this block should render for. See [Conditional Block Rendering](#conditional-block-rendering-with-displayfor).          |
+
+---
+
+## Conditional Block Rendering with `displayFor`
+
+Some overlays need to show different blocks depending on runtime context — for example, `kubernetes_pod` executions vs. `kubernetes_job` executions. Instead of hardcoding block IDs in the section component, declare a `displayFor` whitelist on each block in the schema JSON.
+
+### How It Works
+
+| `displayFor` value                     | Behavior                                               |
+| -------------------------------------- | ------------------------------------------------------ |
+| Absent / undefined                     | Block is shown for **all** execution types             |
+| `["kubernetes_pod"]`                   | Block is shown only when `displayFor="kubernetes_pod"` |
+| `["kubernetes_job"]`                   | Block is shown only when `displayFor="kubernetes_job"` |
+| `["kubernetes_pod", "kubernetes_job"]` | Block is shown for both types                          |
+
+### Schema Example
+
+```json
+{
+  "id": "podEvents",
+  "blockType": "LinkBlock",
+  "displayFor": ["kubernetes_pod"],
+  "properties": { "urlTemplate": "https://example.com/pod-events" },
+  "replacements": { "podName": { "type": "string", "required": true } }
+}
+```
+
+### Usage
+
+```typescript
+import {
+  filterAndHydrateSchema,
+  loadSchema,
+} from "@/services/composer/hydrateSchema";
+
+const schema = loadSchema(overlayJSON);
+
+// Provide replacements for ALL blocks unconditionally.
+// filterAndHydrateSchema removes non-matching blocks before hydration.
+const allReplacements = {
+  podLogs: { podName: "worker-abc", startTime: "...", endTime: "..." },
+  podEvents: { podName: "worker-abc", startTime: "...", endTime: "..." },
+  jobEvents: { jobName: "job-xyz", startTime: "...", endTime: "..." },
+};
+
+const executionType = jobName ? "kubernetes_job" : "kubernetes_pod";
+const hydrated = filterAndHydrateSchema(schema, allReplacements, executionType);
+```
+
+**Function signature:**
+
+```typescript
+filterAndHydrateSchema(
+  schema: ComposerSchema,
+  allReplacements: Record<string, BlockHydrationReplacements>,
+  displayFor?: string | null,
+): ComposerSchema
+```
+
+| Parameter         | Description                                                                                     |
+| ----------------- | ----------------------------------------------------------------------------------------------- |
+| `schema`          | The loaded `ComposerSchema`                                                                     |
+| `allReplacements` | Replacements for all blocks (filtered blocks are simply ignored)                                |
+| `displayFor`      | The execution type string. If `null` or `undefined`, no filtering occurs and all blocks render. |
+
+**Error guard:** If filtering removes _all_ blocks, `filterAndHydrateSchema` logs a `console.error` with the provided `displayFor` value and the set of all `displayFor` values found in the schema, helping diagnose misconfigured schemas.

--- a/src/components/shared/ContextPanel/Blocks/LinkBlock.test.tsx
+++ b/src/components/shared/ContextPanel/Blocks/LinkBlock.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
+import { substitutePlaceholders } from "@/services/composer/hydrateSchema";
 import { QueryParamType } from "@/types/composerSchema";
 
 import { buildUrl, LinkBlock } from "./LinkBlock";
@@ -72,6 +73,34 @@ describe("buildUrl", () => {
     const parsed = new URL(url);
     expect(parsed.searchParams.get("filter")).toBe("name=test&type=all");
     expect(url).toBe("https://example.com/?filter=name%3Dtest%26type%3Dall");
+  });
+
+  it("substitutes placeholders in urlTemplate and appends queryParams", () => {
+    const block = {
+      urlTemplate:
+        "https://example.com/logs;query=name%3D{jobName};startTime={startTime};endTime={endTime}",
+      queryParams: {
+        project: {
+          type: QueryParamType.String as const,
+          value: "my-project",
+        },
+      },
+    };
+
+    const hydrated = substitutePlaceholders(block, {
+      jobName: "my-job-123",
+      startTime: "2026-03-24T01:00:00.000Z",
+      endTime: "2026-03-24T02:00:00.000Z",
+    }) as typeof block;
+    const url = buildUrl(hydrated.urlTemplate, hydrated.queryParams);
+
+    expect(url).toContain("name%3Dmy-job-123");
+    expect(url).toContain(";startTime=2026-03-24T01:00:00.000Z");
+    expect(url).toContain(";endTime=2026-03-24T02:00:00.000Z");
+    expect(url).toContain("?project=my-project");
+    expect(url).not.toContain("{jobName}");
+    expect(url).not.toContain("{startTime}");
+    expect(url).not.toContain("{endTime}");
   });
 });
 

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/LogsEventsOverlaySection.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/LogsEventsOverlaySection.tsx
@@ -2,12 +2,17 @@ import type { ContainerExecutionStatus } from "@/api/types.gen";
 import { Composer } from "@/components/shared/Composer/Composer";
 import overlaySchema from "@/config/logsEventsOverlaySchema.json";
 import { useBackend } from "@/providers/BackendProvider";
-import { hydrateSchema, loadSchema } from "@/services/composer/hydrateSchema";
+import {
+  filterAndHydrateSchema,
+  loadSchema,
+} from "@/services/composer/hydrateSchema";
 import { useFetchContainerExecutionState } from "@/services/executionService";
 import type { BlockHydrationReplacements } from "@/types/composerSchema";
 
 import {
+  extractJobName,
   extractPodName,
+  resolveJobEventsHydrationReplacements,
   resolvePodLogsHydrationReplacements,
   resolveRetentionNoticeHydrationReplacements,
   resolveRunningHintHydrationReplacements,
@@ -33,30 +38,40 @@ export const LogsEventsOverlaySection = ({
   if (schema.sections.length === 0) return null;
 
   const podName = extractPodName(containerState);
-  if (!podName || !containerState?.started_at) return null;
+  const jobName = extractJobName(containerState);
+  const identifier = podName ?? jobName;
+  if (!identifier || !containerState?.started_at) return null;
 
+  const executionType = jobName ? "kubernetes_job" : "kubernetes_pod";
   const { metadata } = schema;
 
-  // Key = block ID from the schema. hydrateSchema() matches each block
-  // to its replacements by this ID.
   const allReplacements: Record<string, BlockHydrationReplacements> = {
-    podLogs: resolvePodLogsHydrationReplacements(
-      metadata,
-      containerState,
-      podName,
-    ),
-    podEvents: resolvePodLogsHydrationReplacements(
-      metadata,
-      containerState,
-      podName,
-    ),
     retentionNotice: resolveRetentionNoticeHydrationReplacements(
       metadata,
       containerState,
     ),
     runningHint: resolveRunningHintHydrationReplacements(status),
+    podLogs: resolvePodLogsHydrationReplacements(
+      metadata,
+      containerState,
+      identifier,
+    ),
+    podEvents: resolvePodLogsHydrationReplacements(
+      metadata,
+      containerState,
+      identifier,
+    ),
+    jobEvents: resolveJobEventsHydrationReplacements(
+      metadata,
+      containerState,
+      identifier,
+    ),
   };
 
-  const hydratedComposerSchema = hydrateSchema(schema, allReplacements);
-  return <Composer schema={hydratedComposerSchema} />;
+  const hydrated = filterAndHydrateSchema(
+    schema,
+    allReplacements,
+    executionType,
+  );
+  return <Composer schema={hydrated} />;
 };

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/logsEventsResolvers.test.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/logsEventsResolvers.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+
+import type { GetContainerExecutionStateResponse } from "@/api/types.gen";
+
+import {
+  extractJobName,
+  extractPodName,
+  resolveJobEventsHydrationReplacements,
+} from "./logsEventsResolvers";
+
+describe("extractPodName", () => {
+  it("returns null for undefined container state", () => {
+    expect(extractPodName(undefined)).toBeNull();
+  });
+
+  it("returns null when debug_info is missing", () => {
+    const state: GetContainerExecutionStateResponse = { status: "SUCCEEDED" };
+    expect(extractPodName(state)).toBeNull();
+  });
+
+  it("extracts pod_name from debug_info top level", () => {
+    const state: GetContainerExecutionStateResponse = {
+      status: "SUCCEEDED",
+      debug_info: { pod_name: "worker-abc-123" },
+    };
+    expect(extractPodName(state)).toBe("worker-abc-123");
+  });
+
+  it("extracts pod_name from debug_info.kubernetes", () => {
+    const state: GetContainerExecutionStateResponse = {
+      status: "SUCCEEDED",
+      debug_info: { kubernetes: { pod_name: "worker-xyz-456" } },
+    };
+    expect(extractPodName(state)).toBe("worker-xyz-456");
+  });
+
+  it("returns null for job-only responses (no pod_name anywhere)", () => {
+    const state: GetContainerExecutionStateResponse = {
+      status: "SUCCEEDED",
+      debug_info: {
+        kubernetes_job: { job_name: "tangle-ce-019d1c5fa8836e423671" },
+      },
+    };
+    expect(extractPodName(state)).toBeNull();
+  });
+});
+
+describe("extractJobName", () => {
+  it("returns null for undefined container state", () => {
+    expect(extractJobName(undefined)).toBeNull();
+  });
+
+  it("returns null when debug_info is missing", () => {
+    const state: GetContainerExecutionStateResponse = { status: "SUCCEEDED" };
+    expect(extractJobName(state)).toBeNull();
+  });
+
+  it("returns null for pod-only responses", () => {
+    const state: GetContainerExecutionStateResponse = {
+      status: "SUCCEEDED",
+      debug_info: { pod_name: "worker-abc-123" },
+    };
+    expect(extractJobName(state)).toBeNull();
+  });
+
+  it("extracts job_name from debug_info.kubernetes_job", () => {
+    const state: GetContainerExecutionStateResponse = {
+      status: "SUCCEEDED",
+      debug_info: {
+        kubernetes_job: { job_name: "tangle-ce-019d1c5fa8836e423671" },
+      },
+    };
+    expect(extractJobName(state)).toBe("tangle-ce-019d1c5fa8836e423671");
+  });
+
+  it("returns null when kubernetes_job exists but job_name is missing", () => {
+    const state: GetContainerExecutionStateResponse = {
+      status: "SUCCEEDED",
+      debug_info: { kubernetes_job: { some_other_key: "value" } },
+    };
+    expect(extractJobName(state)).toBeNull();
+  });
+});
+
+describe("resolveJobEventsHydrationReplacements", () => {
+  const metadata = { paddingMinutes: 5 };
+  const jobName = "tangle-ce-019d1c5fa8836e423671";
+
+  it("returns absolute padded timestamps for a completed job", () => {
+    const state: GetContainerExecutionStateResponse = {
+      status: "SUCCEEDED",
+      started_at: "2026-03-24T01:17:00.000Z",
+      ended_at: "2026-03-24T03:18:13.000Z",
+    };
+
+    const result = resolveJobEventsHydrationReplacements(
+      metadata,
+      state,
+      jobName,
+    );
+
+    expect(result.jobName).toBe(jobName);
+    expect(result.startTime).toBe("2026-03-24T01:12:00.000Z");
+    expect(result.endTime).toBe("2026-03-24T03:23:13.000Z");
+  });
+
+  it("returns relative time when job is still running", () => {
+    const fiveMinutesAgo = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+    const state: GetContainerExecutionStateResponse = {
+      status: "RUNNING",
+      started_at: fiveMinutesAgo,
+    };
+
+    const result = resolveJobEventsHydrationReplacements(
+      metadata,
+      state,
+      jobName,
+    );
+
+    expect(result.jobName).toBe(jobName);
+    expect(result.startTime).toMatch(/^now-\d+m$/);
+    expect(result.endTime).toBe("now");
+  });
+
+  it("returns fallback relative time when started_at is missing", () => {
+    const state: GetContainerExecutionStateResponse = {
+      status: "SUCCEEDED",
+    };
+
+    const result = resolveJobEventsHydrationReplacements(
+      metadata,
+      state,
+      jobName,
+    );
+
+    expect(result.jobName).toBe(jobName);
+    expect(result.startTime).toBe("now-60m");
+    expect(result.endTime).toBe("now");
+  });
+});

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/logsEventsResolvers.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/logsEventsResolvers.ts
@@ -15,6 +15,12 @@ type PodLogsHydrationReplacements = {
   endTime: string;
 };
 
+type JobEventsHydrationReplacements = {
+  jobName: string;
+  startTime: string;
+  endTime: string;
+};
+
 type RetentionNoticeHydrationReplacements = {
   retentionDays: number;
   expiryDate: string;
@@ -88,6 +94,16 @@ export function extractPodName(
   return null;
 }
 
+export function extractJobName(
+  containerState: GetContainerExecutionStateResponse | undefined,
+): string | null {
+  const k8sJob = containerState?.debug_info?.kubernetes_job;
+  if (isRecordWithString(k8sJob, "job_name")) {
+    return k8sJob.job_name;
+  }
+  return null;
+}
+
 // --- Resolver functions ---
 
 const DEFAULT_FALLBACK_MINUTES = 60;
@@ -98,11 +114,13 @@ export function elapsedMinutesCeil(startIso: string): number {
   return Math.ceil(Math.max(elapsedMs, 0) / MINUTES);
 }
 
-export function resolvePodLogsHydrationReplacements(
+type TimeRange = { startTime: string; endTime: string };
+
+function resolveTimeRange(
   metadata: Record<string, unknown>,
   containerState: GetContainerExecutionStateResponse,
-  podName: string,
-): PodLogsHydrationReplacements {
+  callerName: string,
+): TimeRange {
   const paddingMinutes =
     typeof metadata.paddingMinutes === "number" ? metadata.paddingMinutes : 0;
 
@@ -110,10 +128,9 @@ export function resolvePodLogsHydrationReplacements(
   // this, so reaching here means something unexpected happened).
   if (!containerState.started_at) {
     console.warn(
-      "[resolvePodLogsHydrationReplacements] started_at is missing — this should not happen",
+      `[${callerName}] started_at is missing — this should not happen`,
     );
     return {
-      podName,
       startTime: `${RELATIVE_NOW}-${DEFAULT_FALLBACK_MINUTES}m`,
       endTime: RELATIVE_NOW,
     };
@@ -124,22 +141,50 @@ export function resolvePodLogsHydrationReplacements(
     const totalMinutes =
       elapsedMinutesCeil(containerState.started_at) + paddingMinutes;
     return {
-      podName,
       startTime: `${RELATIVE_NOW}-${totalMinutes}m`,
       endTime: RELATIVE_NOW,
     };
   }
 
   // Both present — use absolute padded timestamps.
-  // Cap endTime to "now" so we never request a future time range from Observe.
+  // Cap endTime to "now" so we never request a future time range.
   const paddedEnd = adjustTimestamp(containerState.ended_at, paddingMinutes);
   const endTime =
     new Date(paddedEnd).getTime() > Date.now() ? RELATIVE_NOW : paddedEnd;
 
   return {
-    podName,
     startTime: adjustTimestamp(containerState.started_at, -paddingMinutes),
     endTime,
+  };
+}
+
+export function resolvePodLogsHydrationReplacements(
+  metadata: Record<string, unknown>,
+  containerState: GetContainerExecutionStateResponse,
+  podName: string,
+): PodLogsHydrationReplacements {
+  return {
+    podName,
+    ...resolveTimeRange(
+      metadata,
+      containerState,
+      "resolvePodLogsHydrationReplacements",
+    ),
+  };
+}
+
+export function resolveJobEventsHydrationReplacements(
+  metadata: Record<string, unknown>,
+  containerState: GetContainerExecutionStateResponse,
+  jobName: string,
+): JobEventsHydrationReplacements {
+  return {
+    jobName,
+    ...resolveTimeRange(
+      metadata,
+      containerState,
+      "resolveJobEventsHydrationReplacements",
+    ),
   };
 }
 

--- a/src/services/composer/hydrateSchema.test.ts
+++ b/src/services/composer/hydrateSchema.test.ts
@@ -8,6 +8,7 @@ import {
 } from "@/types/composerSchema";
 
 import {
+  filterAndHydrateSchema,
   hydrateSchema,
   isComposerSchema,
   loadSchema,
@@ -740,5 +741,193 @@ describe("isComposerSchema", () => {
     expect(isComposerSchema({ metadata: {}, sections: "not-array" })).toBe(
       false,
     );
+  });
+});
+
+describe("filterAndHydrateSchema", () => {
+  const schemaWithDisplayFor: ComposerSchema = {
+    metadata: { retentionDays: 30 },
+    sections: [
+      {
+        id: "logsAndEvents",
+        title: "Logs & Events",
+        blocks: [
+          {
+            id: "retentionNotice",
+            blockType: BlockType.TextBlock,
+            properties: { text: "{retentionDays}-day retention." },
+            replacements: {
+              retentionDays: { type: ReplacementType.Number, required: true },
+            },
+          },
+          {
+            id: "podLogs",
+            blockType: BlockType.LinkBlock,
+            displayFor: ["kubernetes_pod", "kubernetes_job"],
+            properties: {
+              urlTemplate: "https://example.com/logs?pod={podName}",
+            },
+            replacements: {
+              podName: { type: ReplacementType.String, required: true },
+            },
+          },
+          {
+            id: "podEvents",
+            blockType: BlockType.LinkBlock,
+            displayFor: ["kubernetes_pod"],
+            properties: {
+              urlTemplate: "https://example.com/events?pod={podName}",
+            },
+            replacements: {
+              podName: { type: ReplacementType.String, required: true },
+            },
+          },
+          {
+            id: "jobEvents",
+            blockType: BlockType.LinkBlock,
+            displayFor: ["kubernetes_job"],
+            properties: {
+              urlTemplate: "https://example.com/events?job={jobName}",
+            },
+            replacements: {
+              jobName: { type: ReplacementType.String, required: true },
+            },
+          },
+          {
+            id: "runningHint",
+            blockType: BlockType.TextBlock,
+            properties: { text: "Still running." },
+          },
+        ],
+      },
+    ],
+  };
+
+  const allReplacements = {
+    retentionNotice: { retentionDays: 30 },
+    podLogs: { podName: "pod-abc" },
+    podEvents: { podName: "pod-abc" },
+    jobEvents: { jobName: "job-xyz" },
+  };
+
+  it("keeps pod-only and shared blocks when displayFor is 'kubernetes_pod'", () => {
+    const result = filterAndHydrateSchema(
+      schemaWithDisplayFor,
+      allReplacements,
+      "kubernetes_pod",
+    );
+    const blockIds = result.sections[0].blocks.map((b) => b.id);
+    expect(blockIds).toContain("retentionNotice");
+    expect(blockIds).toContain("podLogs");
+    expect(blockIds).toContain("podEvents");
+    expect(blockIds).toContain("runningHint");
+    expect(blockIds).not.toContain("jobEvents");
+  });
+
+  it("keeps job-only and shared blocks when displayFor is 'kubernetes_job'", () => {
+    const result = filterAndHydrateSchema(
+      schemaWithDisplayFor,
+      allReplacements,
+      "kubernetes_job",
+    );
+    const blockIds = result.sections[0].blocks.map((b) => b.id);
+    expect(blockIds).toContain("retentionNotice");
+    expect(blockIds).toContain("podLogs");
+    expect(blockIds).toContain("jobEvents");
+    expect(blockIds).toContain("runningHint");
+    expect(blockIds).not.toContain("podEvents");
+  });
+
+  it("keeps all blocks when displayFor is undefined", () => {
+    const result = filterAndHydrateSchema(
+      schemaWithDisplayFor,
+      allReplacements,
+      undefined,
+    );
+    const blockIds = result.sections[0].blocks.map((b) => b.id);
+    expect(blockIds).toEqual([
+      "retentionNotice",
+      "podLogs",
+      "podEvents",
+      "jobEvents",
+      "runningHint",
+    ]);
+  });
+
+  it("keeps all blocks when displayFor is null", () => {
+    const result = filterAndHydrateSchema(
+      schemaWithDisplayFor,
+      allReplacements,
+      null,
+    );
+    const blockIds = result.sections[0].blocks.map((b) => b.id);
+    expect(blockIds).toEqual([
+      "retentionNotice",
+      "podLogs",
+      "podEvents",
+      "jobEvents",
+      "runningHint",
+    ]);
+  });
+
+  it("filters out tagged blocks that don't match, keeps untagged blocks", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const result = filterAndHydrateSchema(
+      schemaWithDisplayFor,
+      allReplacements,
+      "nonexistent",
+    );
+
+    const survivingBlockIds = result.sections[0].blocks.map((b) => b.id);
+    expect(survivingBlockIds).toEqual(["retentionNotice", "runningHint"]);
+
+    expect(errorSpy).not.toHaveBeenCalled();
+
+    errorSpy.mockRestore();
+  });
+
+  it("hydrates surviving blocks with placeholder substitution", () => {
+    const result = filterAndHydrateSchema(
+      schemaWithDisplayFor,
+      allReplacements,
+      "kubernetes_pod",
+    );
+
+    const retentionBlock = result.sections[0].blocks.find(
+      (b) => b.id === "retentionNotice",
+    );
+    expect(
+      (retentionBlock as { properties: { text: string } }).properties.text,
+    ).toBe("30-day retention.");
+
+    const podEventsBlock = result.sections[0].blocks.find(
+      (b) => b.id === "podEvents",
+    );
+    expect(
+      (podEventsBlock as { properties: { urlTemplate: string } }).properties
+        .urlTemplate,
+    ).toBe("https://example.com/events?pod=pod-abc");
+  });
+
+  it("does not mutate the original schema", () => {
+    const originalBlockCount = schemaWithDisplayFor.sections[0].blocks.length;
+
+    filterAndHydrateSchema(
+      schemaWithDisplayFor,
+      allReplacements,
+      "kubernetes_pod",
+    );
+
+    expect(schemaWithDisplayFor.sections[0].blocks).toHaveLength(
+      originalBlockCount,
+    );
+    expect(schemaWithDisplayFor.sections[0].blocks.map((b) => b.id)).toEqual([
+      "retentionNotice",
+      "podLogs",
+      "podEvents",
+      "jobEvents",
+      "runningHint",
+    ]);
   });
 });

--- a/src/services/composer/hydrateSchema.ts
+++ b/src/services/composer/hydrateSchema.ts
@@ -247,3 +247,38 @@ export function hydrateSchema(
     })),
   };
 }
+
+function filterByDisplayFor(
+  schema: ComposerSchema,
+  displayFor: string,
+): ComposerSchema {
+  return {
+    ...schema,
+    sections: schema.sections.map((section) => ({
+      ...section,
+      blocks: section.blocks.filter(
+        (b) => !b.displayFor || b.displayFor.includes(displayFor),
+      ),
+    })),
+  };
+}
+
+/**
+ * Filters blocks by `displayFor` whitelist, then hydrates surviving blocks.
+ *
+ * @param schema - The static ComposerSchema (from JSON config)
+ * @param allReplacements - Map of block ID -> resolved replacement values
+ * @param displayFor - Execution type to filter by (e.g., "pod", "job").
+ *   If null/undefined, no filtering is applied and all blocks are rendered.
+ * @returns A new ComposerSchema with non-matching blocks removed and placeholders substituted
+ */
+export function filterAndHydrateSchema(
+  schema: ComposerSchema,
+  allReplacements: Record<string, BlockHydrationReplacements>,
+  displayFor?: string | null,
+): ComposerSchema {
+  const filtered =
+    displayFor == null ? schema : filterByDisplayFor(schema, displayFor);
+
+  return hydrateSchema(filtered, allReplacements);
+}

--- a/src/types/composerSchema.ts
+++ b/src/types/composerSchema.ts
@@ -47,6 +47,12 @@ interface BlockDescriptorBase {
    * Declares which {placeholder} tokens appear in this block's properties.
    */
   replacements?: Record<string, ReplacementDescriptor>;
+  /**
+   * Whitelist of execution types this block should be displayed for
+   * (e.g., ["pod"], ["job"], ["pod", "job"]).
+   * If absent or undefined, the block is displayed for all execution types.
+   */
+  displayFor?: string[];
 }
 
 export interface TextBlockDescriptor extends BlockDescriptorBase {


### PR DESCRIPTION
## Description

Closes https://github.com/Shopify/oasis-frontend/issues/545

Added support for Kubernetes Job events in the logs/events overlay by introducing job name extraction and filtering logic. The overlay now dynamically shows either pod events or job events based on the execution type, preventing both from appearing simultaneously. Added comprehensive test coverage for the new functionality including job name extraction, time range resolution, and schema filtering.

## Related Issue and Pull requests

## Type of Change

- [x] New feature
- [x] Improvement

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Test with a Kubernetes Job execution to verify job events appear instead of pod events
2. Test with a regular pod execution to verify pod events still work as before
3. Verify that placeholder substitution works correctly in URL templates with job names and time ranges
4. Confirm that the schema filtering correctly excludes the appropriate block type based on execution type

## Additional Comments

The changes maintain backward compatibility while extending functionality to support Kubernetes Jobs. The filtering mechanism ensures clean separation between pod and job event displays based on the execution context.