### PR TITLE
add favourites to new dashboard

### DIFF
--- a/src/routes/Dashboard/DashboardFavoritesView.tsx
+++ b/src/routes/Dashboard/DashboardFavoritesView.tsx
@@ -1,0 +1,5 @@
+import { FavoritesSection } from "@/components/Home/FavoritesSection/FavoritesSection";
+
+export function DashboardFavoritesView() {
+  return <FavoritesSection />;
+}

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -17,6 +17,7 @@ import { isFlagEnabled } from "@/components/shared/Settings/useFlags";
 import { BASE_URL, IS_GITHUB_PAGES } from "@/utils/constants";
 
 import RootLayout from "../components/layout/RootLayout";
+import { DashboardFavoritesView } from "./Dashboard/DashboardFavoritesView";
 import { DashboardLayout } from "./Dashboard/DashboardLayout";
 import Editor from "./Editor";
 import Home from "./Home";
@@ -128,7 +129,7 @@ const dashboardComponentsRoute = createRoute({
 const dashboardFavoritesRoute = createRoute({
   getParentRoute: () => dashboardRoute,
   path: "/favorites",
-  component: ComingSoon,
+  component: DashboardFavoritesView,
 });
 
 const dashboardRecentlyViewedRoute = createRoute({


### PR DESCRIPTION
## Description

Added a new FavoritesSection component that displays user favorites with search and pagination functionality. The component shows favorite pipelines and runs as clickable chips with different styling, includes a search input to filter by name or ID, and supports pagination for large lists. Connected this component to the dashboard favorites route, replacing the placeholder "Coming Soon" page.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Navigate to the dashboard favorites page
2. Verify the favorites section displays correctly when no favorites exist
3. Add some favorite pipelines and runs using the star functionality
4. Test the search functionality by filtering favorites by name or ID
5. Verify pagination works correctly when there are more than 10 favorites
6. Test clicking on favorite chips navigates to the correct pipeline or run
7. Test removing favorites using the X button on each chip

## Additional Comments

The component integrates with the existing useFavorites hook and uses consistent UI components from the design system. Pipeline favorites are styled with violet colors while run favorites use emerald colors for visual distinction.