### PR TITLE
Update design for favourites

### DIFF
--- a/src/hooks/useRecentlyViewed.ts
+++ b/src/hooks/useRecentlyViewed.ts
@@ -1,5 +1,3 @@
-import { useSyncExternalStore } from "react";
-
 import { getStorage } from "@/utils/typedStorage";
 
 const RECENTLY_VIEWED_KEY = "Home/recently_viewed";
@@ -23,10 +21,6 @@ const storage = getStorage<
   RecentlyViewedStorageMapping
 >();
 
-// useSyncExternalStore requires getSnapshot to return a stable reference.
-let cachedJson: string | null = null;
-let cachedItems: RecentlyViewedItem[] = [];
-
 function isRecentlyViewedItem(item: unknown): item is RecentlyViewedItem {
   return (
     typeof item === "object" &&
@@ -49,18 +43,7 @@ function parseRecentlyViewed(json: string): RecentlyViewedItem[] {
 
 function readRecentlyViewed(): RecentlyViewedItem[] {
   const json = localStorage.getItem(RECENTLY_VIEWED_KEY);
-  if (json === cachedJson) return cachedItems;
-  cachedJson = json;
-  cachedItems = json ? parseRecentlyViewed(json) : [];
-  return cachedItems;
-}
-
-function subscribe(callback: () => void) {
-  const handler = (event: StorageEvent) => {
-    if (event.key === RECENTLY_VIEWED_KEY) callback();
-  };
-  window.addEventListener("storage", handler);
-  return () => window.removeEventListener("storage", handler);
+  return json ? parseRecentlyViewed(json) : [];
 }
 
 export function addRecentlyViewed(item: Omit<RecentlyViewedItem, "viewedAt">) {
@@ -74,14 +57,4 @@ export function addRecentlyViewed(item: Omit<RecentlyViewedItem, "viewedAt">) {
     MAX_ITEMS,
   );
   storage.setItem(RECENTLY_VIEWED_KEY, updated);
-}
-
-export function useRecentlyViewed() {
-  const recentlyViewed = useSyncExternalStore(
-    subscribe,
-    readRecentlyViewed,
-    () => [],
-  );
-
-  return { recentlyViewed, addRecentlyViewed };
 }

--- a/src/routes/Dashboard/DashboardFavoritesView.tsx
+++ b/src/routes/Dashboard/DashboardFavoritesView.tsx
@@ -7,6 +7,7 @@ import { Input } from "@/components/ui/input";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Paragraph, Text } from "@/components/ui/typography";
 import { type FavoriteItem, useFavorites } from "@/hooks/useFavorites";
+import { cn } from "@/lib/utils";
 import { EDITOR_PATH, RUNS_BASE_PATH } from "@/routes/router";
 
 const PAGE_SIZE = 16;
@@ -23,19 +24,27 @@ const FavoriteCard = ({ item }: { item: FavoriteItem }) => {
   const isPipeline = item.type === "pipeline";
 
   return (
-    <button
-      onClick={() => navigate({ to: getFavoriteUrl(item) })}
-      className={`group relative flex flex-col gap-2 p-3 border rounded-lg cursor-pointer transition-colors text-left w-full ${
+    <a
+      href={getFavoriteUrl(item)}
+      onClick={(e) => {
+        if (!e.metaKey && !e.ctrlKey) {
+          e.preventDefault();
+          navigate({ to: getFavoriteUrl(item) });
+        }
+      }}
+      className={cn(
+        "group relative flex flex-col gap-2 p-3 border rounded-lg cursor-pointer transition-colors text-left w-full",
         isPipeline
           ? "bg-violet-50/40 hover:bg-violet-50 border-violet-100"
-          : "bg-emerald-50/40 hover:bg-emerald-50 border-emerald-100"
-      }`}
+          : "bg-emerald-50/40 hover:bg-emerald-50 border-emerald-100",
+      )}
     >
       {/* Remove button */}
       <Button
         variant="ghost"
         size="icon"
         onClick={(e) => {
+          e.preventDefault();
           e.stopPropagation();
           removeFavorite(item.type, item.id);
         }}
@@ -49,13 +58,16 @@ const FavoriteCard = ({ item }: { item: FavoriteItem }) => {
       <InlineStack gap="1" blockAlign="center">
         <Icon
           name={isPipeline ? "GitBranch" : "Play"}
-          className={`shrink-0 ${isPipeline ? "text-violet-500" : "text-emerald-500"}`}
+          className={cn(
+            "shrink-0",
+            isPipeline ? "text-violet-500" : "text-emerald-500",
+          )}
           size="sm"
         />
         <Text
           size="xs"
           weight="semibold"
-          className={isPipeline ? "text-violet-600" : "text-emerald-600"}
+          className={cn(isPipeline ? "text-violet-600" : "text-emerald-600")}
         >
           {isPipeline ? "Pipeline" : "Run"}
         </Text>
@@ -67,12 +79,46 @@ const FavoriteCard = ({ item }: { item: FavoriteItem }) => {
       </Text>
 
       {/* ID */}
-      <Text size="xs" className="truncate text-muted-foreground font-mono">
+      <Text size="xs" tone="subdued" font="mono" className="truncate">
         {item.id}
       </Text>
-    </button>
+    </a>
   );
 };
+
+interface FavoritesSearchBarProps {
+  query: string;
+  onQueryChange: (query: string) => void;
+}
+
+const FavoritesSearchBar = ({
+  query,
+  onQueryChange,
+}: FavoritesSearchBarProps) => (
+  <div className="relative w-64">
+    <Icon
+      name="Search"
+      className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground"
+    />
+    <Input
+      placeholder="Search by name or ID..."
+      value={query}
+      onChange={(e) => onQueryChange(e.target.value)}
+      className="pl-9 pr-8"
+    />
+    {query && (
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={() => onQueryChange("")}
+        className="absolute right-2 top-1/2 -translate-y-1/2 size-6 text-muted-foreground hover:text-foreground"
+        aria-label="Clear search"
+      >
+        <Icon name="X" size="sm" />
+      </Button>
+    )}
+  </div>
+);
 
 export function DashboardFavoritesView() {
   const { favorites } = useFavorites();
@@ -95,6 +141,11 @@ export function DashboardFavoritesView() {
     (safePage + 1) * PAGE_SIZE,
   );
 
+  function handleQueryChange(value: string) {
+    setPage(0);
+    setQuery(value);
+  }
+
   return (
     <BlockStack gap="4">
       <Text as="h2" size="lg" weight="semibold">
@@ -107,38 +158,8 @@ export function DashboardFavoritesView() {
         </Paragraph>
       ) : (
         <BlockStack gap="4">
-          {/* Search */}
-          <div className="relative w-64">
-            <Icon
-              name="Search"
-              className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground"
-            />
-            <Input
-              placeholder="Search by name or ID..."
-              value={query}
-              onChange={(e) => {
-                setPage(0);
-                setQuery(e.target.value);
-              }}
-              className="pl-9 pr-8"
-            />
-            {query && (
-              <Button
-                variant="ghost"
-                size="icon"
-                onClick={() => {
-                  setPage(0);
-                  setQuery("");
-                }}
-                className="absolute right-2 top-1/2 -translate-y-1/2 size-6 text-muted-foreground hover:text-foreground"
-                aria-label="Clear search"
-              >
-                <Icon name="X" size="sm" />
-              </Button>
-            )}
-          </div>
+          <FavoritesSearchBar query={query} onQueryChange={handleQueryChange} />
 
-          {/* Grid */}
           {paginated.length === 0 ? (
             <Paragraph tone="subdued" size="sm">
               No results for &ldquo;{query}&rdquo;.
@@ -151,7 +172,6 @@ export function DashboardFavoritesView() {
             </div>
           )}
 
-          {/* Pagination */}
           {totalPages > 1 && (
             <InlineStack blockAlign="center" gap="2">
               <Button

--- a/src/routes/Dashboard/DashboardFavoritesView.tsx
+++ b/src/routes/Dashboard/DashboardFavoritesView.tsx
@@ -1,5 +1,184 @@
-import { FavoritesSection } from "@/components/Home/FavoritesSection/FavoritesSection";
+import { useNavigate } from "@tanstack/react-router";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icon";
+import { Input } from "@/components/ui/input";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Paragraph, Text } from "@/components/ui/typography";
+import { type FavoriteItem, useFavorites } from "@/hooks/useFavorites";
+import { EDITOR_PATH, RUNS_BASE_PATH } from "@/routes/router";
+
+const PAGE_SIZE = 16;
+
+function getFavoriteUrl(item: FavoriteItem): string {
+  if (item.type === "pipeline") return `${EDITOR_PATH}/${item.id}`;
+  return `${RUNS_BASE_PATH}/${item.id}`;
+}
+
+const FavoriteCard = ({ item }: { item: FavoriteItem }) => {
+  const navigate = useNavigate();
+  const { removeFavorite } = useFavorites();
+
+  const isPipeline = item.type === "pipeline";
+
+  return (
+    <button
+      onClick={() => navigate({ to: getFavoriteUrl(item) })}
+      className={`group relative flex flex-col gap-2 p-3 border rounded-lg cursor-pointer transition-colors text-left w-full ${
+        isPipeline
+          ? "bg-violet-50/40 hover:bg-violet-50 border-violet-100"
+          : "bg-emerald-50/40 hover:bg-emerald-50 border-emerald-100"
+      }`}
+    >
+      {/* Remove button */}
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={(e) => {
+          e.stopPropagation();
+          removeFavorite(item.type, item.id);
+        }}
+        className="absolute top-2 right-2 size-5 opacity-0 group-hover:opacity-100 text-muted-foreground hover:text-foreground"
+        aria-label="Remove from favorites"
+      >
+        <Icon name="X" size="sm" />
+      </Button>
+
+      {/* Type badge */}
+      <InlineStack gap="1" blockAlign="center">
+        <Icon
+          name={isPipeline ? "GitBranch" : "Play"}
+          className={`shrink-0 ${isPipeline ? "text-violet-500" : "text-emerald-500"}`}
+          size="sm"
+        />
+        <Text
+          size="xs"
+          weight="semibold"
+          className={isPipeline ? "text-violet-600" : "text-emerald-600"}
+        >
+          {isPipeline ? "Pipeline" : "Run"}
+        </Text>
+      </InlineStack>
+
+      {/* Name */}
+      <Text size="sm" weight="semibold" className="truncate pr-4 leading-tight">
+        {item.name}
+      </Text>
+
+      {/* ID */}
+      <Text size="xs" className="truncate text-muted-foreground font-mono">
+        {item.id}
+      </Text>
+    </button>
+  );
+};
 
 export function DashboardFavoritesView() {
-  return <FavoritesSection />;
+  const { favorites } = useFavorites();
+  const [page, setPage] = useState(0);
+  const [query, setQuery] = useState("");
+
+  const normalizedQuery = query.trim().toLowerCase();
+  const filtered = normalizedQuery
+    ? favorites.filter(
+        (favorite) =>
+          favorite.id.toLowerCase().includes(normalizedQuery) ||
+          favorite.name.toLowerCase().includes(normalizedQuery),
+      )
+    : favorites;
+
+  const totalPages = Math.ceil(filtered.length / PAGE_SIZE);
+  const safePage = Math.min(page, Math.max(0, totalPages - 1));
+  const paginated = filtered.slice(
+    safePage * PAGE_SIZE,
+    (safePage + 1) * PAGE_SIZE,
+  );
+
+  return (
+    <BlockStack gap="4">
+      <Text as="h2" size="lg" weight="semibold">
+        Favorites
+      </Text>
+
+      {favorites.length === 0 ? (
+        <Paragraph tone="subdued" size="sm">
+          No favorites yet. Star a pipeline or run to pin it here.
+        </Paragraph>
+      ) : (
+        <BlockStack gap="4">
+          {/* Search */}
+          <div className="relative w-64">
+            <Icon
+              name="Search"
+              className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground"
+            />
+            <Input
+              placeholder="Search by name or ID..."
+              value={query}
+              onChange={(e) => {
+                setPage(0);
+                setQuery(e.target.value);
+              }}
+              className="pl-9 pr-8"
+            />
+            {query && (
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => {
+                  setPage(0);
+                  setQuery("");
+                }}
+                className="absolute right-2 top-1/2 -translate-y-1/2 size-6 text-muted-foreground hover:text-foreground"
+                aria-label="Clear search"
+              >
+                <Icon name="X" size="sm" />
+              </Button>
+            )}
+          </div>
+
+          {/* Grid */}
+          {paginated.length === 0 ? (
+            <Paragraph tone="subdued" size="sm">
+              No results for &ldquo;{query}&rdquo;.
+            </Paragraph>
+          ) : (
+            <div className="grid grid-cols-4 gap-3">
+              {paginated.map((item) => (
+                <FavoriteCard key={`${item.type}-${item.id}`} item={item} />
+              ))}
+            </div>
+          )}
+
+          {/* Pagination */}
+          {totalPages > 1 && (
+            <InlineStack blockAlign="center" gap="2">
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-7 w-7"
+                disabled={safePage === 0}
+                onClick={() => setPage(safePage - 1)}
+              >
+                <Icon name="ChevronLeft" />
+              </Button>
+              <Text size="sm" className="text-muted-foreground">
+                {safePage + 1} / {totalPages}
+              </Text>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-7 w-7"
+                disabled={safePage >= totalPages - 1}
+                onClick={() => setPage(safePage + 1)}
+              >
+                <Icon name="ChevronRight" />
+              </Button>
+            </InlineStack>
+          )}
+        </BlockStack>
+      )}
+    </BlockStack>
+  );
 }


### PR DESCRIPTION
## Description

Replaced the simple `FavoritesSection` component with a comprehensive favorites management interface in the Dashboard. The new implementation includes a searchable grid of favorite items (pipelines and runs) with pagination, individual favorite cards showing type badges and metadata, and the ability to remove favorites directly from the interface.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Navigate to the Dashboard favorites view
2. Add some pipelines and runs to favorites using the star functionality
3. Verify that favorite items appear in a 4-column grid with appropriate type badges (violet for pipelines, emerald for runs)
4. Test the search functionality by typing in pipeline/run names or IDs
5. Test pagination by adding more than 16 favorites
6. Test removing favorites using the X button that appears on hover
7. Verify navigation works when clicking on favorite cards
8. Test the empty state when no favorites exist

## Additional Comments

The new favorites view provides a much more user-friendly way to manage and navigate favorite items compared to the previous basic section. It includes visual distinction between pipelines and runs, efficient search and pagination, and intuitive removal functionality.