### PR TITLE
Adds recently viewed

### DIFF
--- a/src/routes/Dashboard/DashboardRecentlyViewedView.tsx
+++ b/src/routes/Dashboard/DashboardRecentlyViewedView.tsx
@@ -1,0 +1,3 @@
+export function DashboardRecentlyViewedView() {
+  return <>placeholder</>;
+}

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -19,6 +19,7 @@ import { BASE_URL, IS_GITHUB_PAGES } from "@/utils/constants";
 import RootLayout from "../components/layout/RootLayout";
 import { DashboardFavoritesView } from "./Dashboard/DashboardFavoritesView";
 import { DashboardLayout } from "./Dashboard/DashboardLayout";
+import { DashboardRecentlyViewedView } from "./Dashboard/DashboardRecentlyViewedView";
 import Editor from "./Editor";
 import Home from "./Home";
 import { ImportPage } from "./Import";
@@ -135,7 +136,7 @@ const dashboardFavoritesRoute = createRoute({
 const dashboardRecentlyViewedRoute = createRoute({
   getParentRoute: () => dashboardRoute,
   path: "/recently-viewed",
-  component: ComingSoon,
+  component: DashboardRecentlyViewedView,
 });
 
 const quickStartRoute = createRoute({


### PR DESCRIPTION
## Description

Added a new `DashboardRecentlyViewedView` component with placeholder content and updated the dashboard recently viewed route to use this new component instead of the `ComingSoon` component.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Navigate to the dashboard recently viewed route (`/dashboard/recently-viewed`)
2. Verify that the placeholder content is displayed instead of the coming soon message
3. Confirm that the route loads without errors

## Additional Comments

This is a foundational change that sets up the structure for the recently viewed dashboard feature. The component currently displays placeholder content and will need to be implemented with actual functionality in future iterations.