### PR TITLE
Updates revently viewed

### DIFF
--- a/src/hooks/useRecentlyViewed.ts
+++ b/src/hooks/useRecentlyViewed.ts
@@ -1,11 +1,13 @@
+import { useEffect, useState } from "react";
+
 import { getStorage } from "@/utils/typedStorage";
 
 const RECENTLY_VIEWED_KEY = "Home/recently_viewed";
-const MAX_ITEMS = 5;
+const MAX_ITEMS = 10;
 
 type RecentlyViewedType = "pipeline" | "run" | "component";
 
-interface RecentlyViewedItem {
+export interface RecentlyViewedItem {
   type: RecentlyViewedType;
   id: string;
   name: string;
@@ -44,6 +46,23 @@ function parseRecentlyViewed(json: string): RecentlyViewedItem[] {
 function readRecentlyViewed(): RecentlyViewedItem[] {
   const json = localStorage.getItem(RECENTLY_VIEWED_KEY);
   return json ? parseRecentlyViewed(json) : [];
+}
+
+export function useRecentlyViewed() {
+  const [recentlyViewed, setRecentlyViewed] =
+    useState<RecentlyViewedItem[]>(readRecentlyViewed);
+
+  useEffect(() => {
+    const handleStorage = (e: StorageEvent) => {
+      if (e.key === RECENTLY_VIEWED_KEY) {
+        setRecentlyViewed(readRecentlyViewed());
+      }
+    };
+    window.addEventListener("storage", handleStorage);
+    return () => window.removeEventListener("storage", handleStorage);
+  }, []);
+
+  return { recentlyViewed };
 }
 
 export function addRecentlyViewed(item: Omit<RecentlyViewedItem, "viewedAt">) {

--- a/src/routes/Dashboard/DashboardRecentlyViewedView.tsx
+++ b/src/routes/Dashboard/DashboardRecentlyViewedView.tsx
@@ -1,3 +1,87 @@
+import { Link } from "@tanstack/react-router";
+
+import { Icon } from "@/components/ui/icon";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Paragraph, Text } from "@/components/ui/typography";
+import {
+  type RecentlyViewedItem,
+  useRecentlyViewed,
+} from "@/hooks/useRecentlyViewed";
+import { APP_ROUTES, EDITOR_PATH, RUNS_BASE_PATH } from "@/routes/router";
+import { formatRelativeTime } from "@/utils/date";
+
+function getRecentlyViewedUrl(item: RecentlyViewedItem): string {
+  if (item.type === "pipeline") return `${EDITOR_PATH}/${item.id}`;
+  if (item.type === "run") return `${RUNS_BASE_PATH}/${item.id}`;
+  return APP_ROUTES.DASHBOARD_COMPONENTS;
+}
+
+const RecentlyViewedCard = ({ item }: { item: RecentlyViewedItem }) => {
+  const isPipeline = item.type === "pipeline";
+
+  return (
+    <Link
+      to={getRecentlyViewedUrl(item)}
+      className={`flex flex-col gap-2 p-3 border rounded-lg transition-colors no-underline ${
+        isPipeline
+          ? "bg-violet-50/40 hover:bg-violet-50 border-violet-100"
+          : "bg-emerald-50/40 hover:bg-emerald-50 border-emerald-100"
+      }`}
+    >
+      {/* Type badge */}
+      <InlineStack gap="1" blockAlign="center" align="space-between">
+        <InlineStack gap="1" blockAlign="center">
+          <Icon
+            name={isPipeline ? "GitBranch" : "Play"}
+            size="sm"
+            className={`shrink-0 ${isPipeline ? "text-violet-500" : "text-emerald-500"}`}
+          />
+          <Text
+            size="xs"
+            weight="semibold"
+            className={isPipeline ? "text-violet-600" : "text-emerald-600"}
+          >
+            {isPipeline ? "Pipeline" : "Run"}
+          </Text>
+        </InlineStack>
+        <Text size="xs" className="text-muted-foreground">
+          {formatRelativeTime(new Date(item.viewedAt))}
+        </Text>
+      </InlineStack>
+
+      {/* Name */}
+      <Text size="sm" weight="semibold" className="truncate leading-tight">
+        {item.name}
+      </Text>
+
+      {/* ID */}
+      <Text size="xs" className="truncate text-muted-foreground font-mono">
+        {item.id}
+      </Text>
+    </Link>
+  );
+};
+
 export function DashboardRecentlyViewedView() {
-  return <>placeholder</>;
+  const { recentlyViewed } = useRecentlyViewed();
+
+  return (
+    <BlockStack gap="4">
+      <Text as="h2" size="lg" weight="semibold">
+        Recently Viewed
+      </Text>
+
+      {recentlyViewed.length === 0 ? (
+        <Paragraph tone="subdued" size="sm">
+          Nothing viewed yet. Open a pipeline or run to see it here.
+        </Paragraph>
+      ) : (
+        <div className="grid grid-cols-4 gap-3">
+          {recentlyViewed.map((item) => (
+            <RecentlyViewedCard key={`${item.type}-${item.id}`} item={item} />
+          ))}
+        </div>
+      )}
+    </BlockStack>
+  );
 }


### PR DESCRIPTION
## Description

Implemented the recently viewed dashboard component that displays a grid of recently accessed pipelines and runs. The component shows cards with type badges, names, IDs, and relative timestamps. Increased the maximum number of tracked items from 5 to 10 and exported the `RecentlyViewedItem` interface for reuse. Added navigation functionality to allow users to click on cards to return to previously viewed items.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Navigate to the dashboard
2. View some pipelines and runs to populate the recently viewed list
3. Return to the dashboard and verify the recently viewed section displays the items
4. Click on recently viewed cards to ensure navigation works correctly
5. Verify the relative timestamps display correctly (just now, minutes ago, hours ago, days ago)
6. Test with both pipeline and run items to ensure proper styling and icons

## Additional Comments

The component displays up to 10 recently viewed items in a 4-column grid layout. Pipeline items are styled with violet colors and GitBranch icons, while run items use emerald colors and Play icons. The relative time formatting provides user-friendly timestamps for when items were last viewed.