### PR TITLE
update favourite and recent cards

### DIFF
--- a/src/routes/Dashboard/DashboardFavoritesView.tsx
+++ b/src/routes/Dashboard/DashboardFavoritesView.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from "@tanstack/react-router";
+import { Link } from "@tanstack/react-router";
 import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
@@ -18,26 +18,14 @@ function getFavoriteUrl(item: FavoriteItem): string {
 }
 
 const FavoriteCard = ({ item }: { item: FavoriteItem }) => {
-  const navigate = useNavigate();
   const { removeFavorite } = useFavorites();
 
   const isPipeline = item.type === "pipeline";
 
   return (
-    <a
-      href={getFavoriteUrl(item)}
-      onClick={(e) => {
-        if (!e.metaKey && !e.ctrlKey) {
-          e.preventDefault();
-          navigate({ to: getFavoriteUrl(item) });
-        }
-      }}
-      className={cn(
-        "group relative flex flex-col gap-2 p-3 border rounded-lg cursor-pointer transition-colors text-left w-full",
-        isPipeline
-          ? "bg-violet-50/40 hover:bg-violet-50 border-violet-100"
-          : "bg-emerald-50/40 hover:bg-emerald-50 border-emerald-100",
-      )}
+    <Link
+      to={getFavoriteUrl(item)}
+      className="group relative flex flex-col gap-2.5 p-3 rounded-lg transition-all shadow-sm hover:shadow-md bg-card border border-border hover:border-foreground/20 no-underline"
     >
       {/* Remove button */}
       <Button
@@ -54,23 +42,19 @@ const FavoriteCard = ({ item }: { item: FavoriteItem }) => {
         <Icon name="X" size="sm" />
       </Button>
 
-      {/* Type badge */}
-      <InlineStack gap="1" blockAlign="center">
-        <Icon
-          name={isPipeline ? "GitBranch" : "Play"}
+      {/* Type pill */}
+      <InlineStack>
+        <span
           className={cn(
-            "shrink-0",
-            isPipeline ? "text-violet-500" : "text-emerald-500",
+            "inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-xs font-semibold",
+            isPipeline
+              ? "bg-violet-100 text-violet-700"
+              : "bg-emerald-100 text-emerald-700",
           )}
-          size="sm"
-        />
-        <Text
-          size="xs"
-          weight="semibold"
-          className={cn(isPipeline ? "text-violet-600" : "text-emerald-600")}
         >
+          <Icon name={isPipeline ? "GitBranch" : "Play"} size="sm" />
           {isPipeline ? "Pipeline" : "Run"}
-        </Text>
+        </span>
       </InlineStack>
 
       {/* Name */}
@@ -82,7 +66,7 @@ const FavoriteCard = ({ item }: { item: FavoriteItem }) => {
       <Text size="xs" tone="subdued" font="mono" className="truncate">
         {item.id}
       </Text>
-    </a>
+    </Link>
   );
 };
 

--- a/src/routes/Dashboard/DashboardRecentlyViewedView.tsx
+++ b/src/routes/Dashboard/DashboardRecentlyViewedView.tsx
@@ -22,27 +22,21 @@ const RecentlyViewedCard = ({ item }: { item: RecentlyViewedItem }) => {
   return (
     <Link
       to={getRecentlyViewedUrl(item)}
-      className={`flex flex-col gap-2 p-3 border rounded-lg transition-colors no-underline ${
-        isPipeline
-          ? "bg-violet-50/40 hover:bg-violet-50 border-violet-100"
-          : "bg-emerald-50/40 hover:bg-emerald-50 border-emerald-100"
-      }`}
+      className="flex flex-col gap-2.5 p-3 rounded-lg transition-all shadow-sm hover:shadow-md bg-card border border-border hover:border-foreground/20 no-underline"
     >
-      {/* Type badge */}
-      <InlineStack gap="1" blockAlign="center" align="space-between">
-        <InlineStack gap="1" blockAlign="center">
-          <Icon
-            name={isPipeline ? "GitBranch" : "Play"}
-            size="sm"
-            className={`shrink-0 ${isPipeline ? "text-violet-500" : "text-emerald-500"}`}
-          />
-          <Text
-            size="xs"
-            weight="semibold"
-            className={isPipeline ? "text-violet-600" : "text-emerald-600"}
+      {/* Type pill + timestamp */}
+      <InlineStack blockAlign="center" align="space-between">
+        <InlineStack>
+          <span
+            className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-xs font-semibold ${
+              isPipeline
+                ? "bg-violet-100 text-violet-700"
+                : "bg-emerald-100 text-emerald-700"
+            }`}
           >
+            <Icon name={isPipeline ? "GitBranch" : "Play"} size="sm" />
             {isPipeline ? "Pipeline" : "Run"}
-          </Text>
+          </span>
         </InlineStack>
         <Text size="xs" className="text-muted-foreground">
           {formatRelativeTime(new Date(item.viewedAt))}


### PR DESCRIPTION
## Description

Replaced programmatic navigation with Link components in dashboard favorite and recently viewed cards. Changed the type indicators from simple icon/text combinations to pill-style badges with rounded backgrounds. Updated card styling to use consistent shadow effects and neutral colors instead of type-specific color schemes.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Navigate to the dashboard
2. Verify that favorite cards are clickable and navigate correctly
3. Verify that recently viewed cards are clickable and navigate correctly
4. Test that the remove favorite button works without triggering navigation
5. Confirm that type pills display correctly for both pipelines and runs
6. Check that hover effects work properly on the cards

## Additional Comments

The Link component provides better accessibility and browser behavior (right-click to open in new tab, etc.) compared to programmatic navigation. The pill-style type indicators provide better visual hierarchy and the unified card styling creates a more consistent interface.