### PR TITLE
add new section to the side bar

### DIFF
--- a/src/components/shared/PipelineRunFiltersBar/PipelineRunFiltersBar.tsx
+++ b/src/components/shared/PipelineRunFiltersBar/PipelineRunFiltersBar.tsx
@@ -221,7 +221,6 @@ export function PipelineRunFiltersBar({
           />
         </div>
 
-        {/* Annotation Filter button */}
         {!isAnnotationExpanded && (
           <Button
             variant="outline"

--- a/src/routes/Dashboard/DashboardLayout.tsx
+++ b/src/routes/Dashboard/DashboardLayout.tsx
@@ -1,10 +1,14 @@
 import { Link, Outlet } from "@tanstack/react-router";
 
+import { isAuthorizationRequired } from "@/components/shared/Authentication/helpers";
+import { TopBarAuthentication } from "@/components/shared/Authentication/TopBarAuthentication";
 import { Badge } from "@/components/ui/badge";
 import { Icon, type IconName } from "@/components/ui/icon";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Link as UILink } from "@/components/ui/link";
 import { Heading, Text } from "@/components/ui/typography";
 import { cn } from "@/lib/utils";
+import { DOCUMENTATION_URL } from "@/utils/constants";
 
 interface SidebarItem {
   to: string;
@@ -20,7 +24,15 @@ const SIDEBAR_ITEMS: SidebarItem[] = [
   { to: "/dashboard/recently-viewed", label: "Recently Viewed", icon: "Clock" },
 ];
 
+const navItemClass = (isActive: boolean) =>
+  cn(
+    "w-full px-3 py-2 rounded-md text-sm cursor-pointer hover:bg-accent",
+    isActive && "bg-accent font-medium",
+  );
+
 export function DashboardLayout() {
+  const requiresAuthorization = isAuthorizationRequired();
+
   return (
     <div className="w-full px-8 py-6">
       <BlockStack gap="6">
@@ -33,29 +45,63 @@ export function DashboardLayout() {
 
         <InlineStack gap="8" blockAlign="start" className="w-full min-h-100">
           <BlockStack
-            gap="1"
-            className="w-48 shrink-0 border-r border-border pr-4"
+            inlineAlign="space-between"
+            className="w-48 shrink-0 border-r border-border pr-4 self-stretch"
           >
-            {SIDEBAR_ITEMS.map((item) => (
-              <Link
-                key={item.to}
-                to={item.to}
-                className="w-full"
-                activeProps={{ className: "is-active" }}
+            {/* Top nav */}
+            <BlockStack gap="1">
+              {SIDEBAR_ITEMS.map((item) => (
+                <Link
+                  key={item.to}
+                  to={item.to}
+                  className="w-full"
+                  activeProps={{ className: "is-active" }}
+                >
+                  {({ isActive }) => (
+                    <InlineStack
+                      gap="2"
+                      blockAlign="center"
+                      className={navItemClass(isActive)}
+                    >
+                      <Icon name={item.icon} size="sm" />
+                      <Text size="sm">{item.label}</Text>
+                    </InlineStack>
+                  )}
+                </Link>
+              ))}
+            </BlockStack>
+
+            {/* Bottom utilities */}
+            <BlockStack gap="1" className="border-t border-border pt-3">
+              <UILink
+                href={DOCUMENTATION_URL}
+                external
+                variant="block"
+                className={navItemClass(false)}
               >
+                <InlineStack gap="2" blockAlign="center">
+                  <Icon name="CircleQuestionMark" size="sm" />
+                  <Text size="sm">Docs</Text>
+                </InlineStack>
+              </UILink>
+              <Link to="/settings/backend" className="w-full">
                 {({ isActive }) => (
-                  <div
-                    className={cn(
-                      "flex items-center gap-2 w-full px-3 py-2 rounded-md text-sm cursor-pointer hover:bg-accent",
-                      isActive && "bg-accent font-medium",
-                    )}
+                  <InlineStack
+                    gap="2"
+                    blockAlign="center"
+                    className={navItemClass(isActive)}
                   >
-                    <Icon name={item.icon} size="sm" />
-                    <Text size="sm">{item.label}</Text>
-                  </div>
+                    <Icon name="Settings" size="sm" />
+                    <Text size="sm">Settings</Text>
+                  </InlineStack>
                 )}
               </Link>
-            ))}
+              {requiresAuthorization && (
+                <div className="px-3 py-2">
+                  <TopBarAuthentication />
+                </div>
+              )}
+            </BlockStack>
           </BlockStack>
 
           <BlockStack className="flex-1 min-w-0">


### PR DESCRIPTION
## Description

Enhanced the dashboard sidebar with additional navigation options and authentication integration. The sidebar now includes a documentation link, settings navigation, and conditional authentication controls. Restructured the sidebar layout to separate primary navigation from utility items with a visual divider.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Navigate to the dashboard
2. Verify the sidebar displays all original navigation items (Dashboard, Experiments, Recently Viewed)
3. Check that the bottom section shows the documentation link, settings link, and authentication component (if authorization is required)
4. Test that the documentation link opens in a new tab
5. Verify the settings link navigates to `/settings/backend`
6. Confirm the authentication component appears only when authorization is required

## Additional Comments

The sidebar now uses a flex layout to properly position utility items at the bottom, and includes proper external link handling for the documentation URL.