### PR TITLE
feat: Copy RunID from Run Page

### DIFF
--- a/src/components/Home/RunSection/RunRow.tsx
+++ b/src/components/Home/RunSection/RunRow.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "@tanstack/react-router";
 import { type MouseEvent } from "react";
 
 import type { PipelineRunResponse } from "@/api/types.gen";
+import { CopyText } from "@/components/shared/CopyText/CopyText";
 import { StatusBar, StatusIcon } from "@/components/shared/Status";
 import { TagList } from "@/components/shared/Tags/TagList";
 import { Button } from "@/components/ui/button";
@@ -101,9 +102,15 @@ const RunRow = ({ run }: { run: PipelineRunResponse }) => {
           <Paragraph className="truncate max-w-100 text-sm" title={name}>
             {name}
           </Paragraph>
-          <Paragraph tone="subdued" className="text-sm" title={runId}>
-            #{runId}
-          </Paragraph>
+          <div
+            onClick={(e) => e.stopPropagation()}
+            className="flex items-center text-sm"
+          >
+            #
+            <CopyText size="sm" className="text-muted-foreground">
+              {runId}
+            </CopyText>
+          </div>
         </InlineStack>
       </TableCell>
       <TableCell>


### PR DESCRIPTION
## Description

A quick stopgap solution to allow users to easily copy run id from the run page, as per user request.

Proper support for this will be introduced with the new homepage design coming in a few weeks.

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

![image.png](https://app.graphite.com/user-attachments/assets/efa507ad-5d6c-4e74-9c72-18862d40ae5f.png)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->