### PR TITLE
fix: ResizeObserver loop completed with undelivered notifications

### DIFF
--- a/src/components/shared/FullscreenElement/FullscreenElement.test.tsx
+++ b/src/components/shared/FullscreenElement/FullscreenElement.test.tsx
@@ -24,18 +24,33 @@ describe("FullscreenElement", () => {
     expect(screen.getByTestId("test-content")).toBeInTheDocument();
   });
 
-  test("appends container to document.body in fullscreen mode", () => {
+  test("applies contents class in normal mode", () => {
     render(
-      <FullscreenElement fullscreen={true}>
-        <div data-testid="fullscreen-content">Fullscreen</div>
+      <FullscreenElement fullscreen={false}>
+        <div data-testid="test-content">Content</div>
       </FullscreenElement>,
     );
 
-    const fullscreenContainer = screen.getByTestId("fullscreen-container");
+    const container = screen.getByTestId("fullscreen-container");
 
-    expect(fullscreenContainer.parentElement).toBe(document.body);
+    expect(container).toHaveClass("contents");
+    expect(container).toHaveClass("pointer-events-auto");
+    expect(container).not.toHaveClass("fixed");
+  });
 
-    expect(screen.getByTestId("fullscreen-content")).toBeInTheDocument();
+  test("applies fixed positioning in fullscreen mode", () => {
+    render(
+      <FullscreenElement fullscreen={true}>
+        <div data-testid="test-content">Fullscreen</div>
+      </FullscreenElement>,
+    );
+
+    const container = screen.getByTestId("fullscreen-container");
+
+    expect(container).toHaveClass("fixed");
+    expect(container).toHaveClass("z-2147483647");
+    expect(container).toHaveClass("pointer-events-auto");
+    expect(container).not.toHaveClass("contents");
   });
 
   test("switches from normal to fullscreen mode", () => {
@@ -45,17 +60,9 @@ describe("FullscreenElement", () => {
       </FullscreenElement>,
     );
 
-    const switchingContentA = screen.getByTestId("switching-content");
+    const container = screen.getByTestId("fullscreen-container");
 
-    const elementMountingPoint = screen.getByTestId(
-      "fullscreen-element-mounting-point",
-    );
-    const fullscreenContainer = screen.getByTestId("fullscreen-container");
-
-    expect(fullscreenContainer).toBeInTheDocument();
-    expect(fullscreenContainer.parentElement).toBe(elementMountingPoint);
-    expect(fullscreenContainer).toHaveClass("contents");
-    expect(fullscreenContainer).toHaveClass("pointer-events-auto");
+    expect(container).toHaveClass("contents");
 
     rerender(
       <FullscreenElement fullscreen={true}>
@@ -63,15 +70,8 @@ describe("FullscreenElement", () => {
       </FullscreenElement>,
     );
 
-    const switchingContentB = screen.getByTestId("switching-content");
-
-    expect(switchingContentA).toStrictEqual(switchingContentB);
-
-    expect(fullscreenContainer).toBeInTheDocument();
-    expect(fullscreenContainer.parentElement).toBe(document.body);
-    expect(fullscreenContainer).toHaveClass("fixed");
-    expect(fullscreenContainer).toHaveClass("z-[2147483647]");
-    expect(fullscreenContainer).toHaveClass("pointer-events-auto");
+    expect(container).toHaveClass("fixed");
+    expect(container).toHaveClass("z-2147483647");
   });
 
   test("switches from fullscreen to normal mode", () => {
@@ -81,17 +81,9 @@ describe("FullscreenElement", () => {
       </FullscreenElement>,
     );
 
-    const switchingContentA = screen.getByTestId("switching-content");
+    const container = screen.getByTestId("fullscreen-container");
 
-    const elementMountingPoint = screen.getByTestId(
-      "fullscreen-element-mounting-point",
-    );
-    const fullscreenContainer = screen.getByTestId("fullscreen-container");
-
-    expect(fullscreenContainer).toBeInTheDocument();
-    expect(fullscreenContainer.parentElement).toBe(document.body);
-    expect(fullscreenContainer).toHaveClass("fixed");
-    expect(fullscreenContainer).toHaveClass("z-[2147483647]");
+    expect(container).toHaveClass("fixed");
 
     rerender(
       <FullscreenElement fullscreen={false}>
@@ -99,27 +91,7 @@ describe("FullscreenElement", () => {
       </FullscreenElement>,
     );
 
-    const switchingContentB = screen.getByTestId("switching-content");
-
-    expect(switchingContentA).toStrictEqual(switchingContentB);
-
-    expect(fullscreenContainer).toBeInTheDocument();
-    expect(fullscreenContainer.parentElement).toBe(elementMountingPoint);
-    expect(fullscreenContainer).toHaveClass("contents");
-    expect(fullscreenContainer).toHaveClass("pointer-events-auto");
-  });
-
-  test("cleans up container when unmounting from fullscreen mode", () => {
-    const { unmount } = render(
-      <FullscreenElement fullscreen={true}>
-        <div data-testid="cleanup-content">Content</div>
-      </FullscreenElement>,
-    );
-
-    const fullscreenContainer = screen.getByTestId("fullscreen-container");
-
-    unmount();
-
-    expect(fullscreenContainer).not.toBeInTheDocument();
+    expect(container).toHaveClass("contents");
+    expect(container).not.toHaveClass("fixed");
   });
 });

--- a/src/components/shared/FullscreenElement/FullscreenElement.tsx
+++ b/src/components/shared/FullscreenElement/FullscreenElement.tsx
@@ -1,80 +1,21 @@
-import {
-  type PropsWithChildren,
-  type RefObject,
-  useEffect,
-  useRef,
-} from "react";
-import { createPortal } from "react-dom";
+import type { PropsWithChildren } from "react";
 
 import { cn } from "@/lib/utils";
-
-interface FullscreenElementProps extends PropsWithChildren {
-  fullscreen: boolean;
-  defaultMountElement: RefObject<HTMLElement | null>;
-}
-
-function FullscreenElementPortal({
-  children,
-  fullscreen,
-  defaultMountElement,
-}: FullscreenElementProps) {
-  const id = useRef(Math.random().toString(15).substring(2, 15));
-  const containerElementRef = useRef<HTMLElement>(
-    document.createElement("div"),
-  );
-
-  useEffect(() => {
-    containerElementRef.current.dataset.testid = "fullscreen-container";
-    if (fullscreen) {
-      containerElementRef.current.className = cn(
-        "fixed",
-        "top-0",
-        "left-0",
-        "z-[2147483647]",
-        "w-full",
-        "h-full",
-        "overflow-hidden",
-        "pointer-events-auto",
-      );
-      document.body.appendChild(containerElementRef.current);
-    } else {
-      containerElementRef.current.className = cn(
-        "contents",
-        "pointer-events-auto",
-      );
-
-      if (defaultMountElement.current) {
-        defaultMountElement.current.appendChild(containerElementRef.current);
-      }
-    }
-
-    return () => {
-      containerElementRef.current.remove();
-    };
-  }, [fullscreen, defaultMountElement]);
-
-  return createPortal(<>{children}</>, containerElementRef.current, id.current);
-}
 
 export function FullscreenElement({
   children,
   fullscreen,
 }: PropsWithChildren<{ fullscreen: boolean }>) {
-  const mountRef = useRef<HTMLDivElement>(null);
-
   return (
-    <>
-      <div
-        ref={mountRef}
-        data-testid="fullscreen-element-mounting-point"
-        style={{ display: "contents" }}
-      />
-      <FullscreenElementPortal
-        fullscreen={fullscreen}
-        defaultMountElement={mountRef}
-      >
-        {children}
-      </FullscreenElementPortal>
-    </>
+    <div
+      data-testid="fullscreen-container"
+      className={cn(
+        fullscreen
+          ? "fixed top-0 left-0 z-2147483647 w-full h-full overflow-hidden pointer-events-auto"
+          : "contents pointer-events-auto",
+      )}
+    >
+      {children}
+    </div>
   );
 }


### PR DESCRIPTION
## Description

Since introducing BugSnag earlier this month we have been flooded by warnings

```
ResizeObserver loop completed with undelivered notifications
```

  
However we do not directly use any ResizeObservers in our codebase.

I explored this with Claude and we determined the warning was caused by the large amounts of layout shifting happening when the CodeVIewer's `fullscreen` mode is activated, overwhelming the internal ResizeObservers of ReactFlow. The layout shift is the result of the current `FullscreenElement` dismounting all children and then remounting them again in fullscreen (or vice-versa).  
The issue doesn't cause any lasting degradation and _could_ be safely ignored (undelivered notifications suggests it wasn't able to process all changes in that one specific render loop).

Unfortunately, due to differences between production and local dev (e.g. bundling) the issue is not reproducible in local environments.  
  
Nevertheless, the issue prompted me to take a closer look at our `FullscreenElement` component. Working with Claude we have simplified the component greatly, and in a manner than hopefully will reduce the amount of resizing/layout changes triggered whenever the CodeViewer is made fullscreen.

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

(hopefully) closes https://github.com/Shopify/oasis-frontend/issues/556

and https://github.com/shop/issues/issues/21771

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

NOTE: the original issue/warning message is not reproducible locally.

- FullscreenElement still correctly toggles fullscreen. Currently used in CodeViewer & Component Editor.

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

Since the original issue is not reproducible locally it may be more prudent to treat this PR as a refactoring of `FullscreenElement` and, if approved, we can ship it and see if the warnings on production cease.

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->