### PR TITLE
chore: Suppress 'ResizeObserver loop completed with undelivered notifications' Warning

### DIFF
--- a/src/services/errorManagement/bugsnag.ts
+++ b/src/services/errorManagement/bugsnag.ts
@@ -30,7 +30,14 @@ const getBugsnagConfig = (): BrowserConfig => {
   };
 };
 
-export const handleBugsnagError = (event: Event): void => {
+export const handleBugsnagError = (event: Event): boolean | void => {
+  if (
+    event.errors[0]?.errorMessage ===
+    "ResizeObserver loop completed with undelivered notifications."
+  ) {
+    return false;
+  }
+
   if (
     event.errors.length > 0 &&
     event.errors[0].errorClass === GENERIC_ERROR_CLASS


### PR DESCRIPTION
## Description

see https://github.com/TangleML/tangle-ui/pull/2017



This PRs aims to suppress the warning, rather than fix it.

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->