### PR TITLE
Refactor Bugsnag error suppression to use configurable list

### DIFF
--- a/src/services/errorManagement/bugsnag.ts
+++ b/src/services/errorManagement/bugsnag.ts
@@ -15,6 +15,19 @@ const TANGLE_ENV = import.meta.env.VITE_TANGLE_ENV;
 
 const GENERIC_ERROR_CLASS = "Error";
 
+// Errors that are intentionally suppressed from Bugsnag reporting.
+//
+// This is NOT an escape hatch for silencing noisy or inconvenient errors.
+// Only add an error here if it meets ALL of the following criteria:
+//   1. It is well understood and confirmed to be non-problematic
+//   2. It cannot be resolved at the source (e.g. a browser/third-party quirk)
+//   3. It provides no actionable signal for debugging
+//
+// Use with discretion — suppressing real errors makes incidents harder to catch.
+const IGNORED_ERROR_MESSAGES = [
+  "ResizeObserver loop completed with undelivered notifications.",
+];
+
 export const IS_BUGSNAG_ENABLED = Boolean(BUGSNAG_API_KEY && TANGLE_ENV);
 
 const getBugsnagConfig = (): BrowserConfig => {
@@ -31,10 +44,7 @@ const getBugsnagConfig = (): BrowserConfig => {
 };
 
 export const handleBugsnagError = (event: Event): boolean | void => {
-  if (
-    event.errors[0]?.errorMessage ===
-    "ResizeObserver loop completed with undelivered notifications."
-  ) {
+  if (IGNORED_ERROR_MESSAGES.includes(event.errors[0]?.errorMessage ?? "")) {
     return false;
   }
 


### PR DESCRIPTION
## Description

Refactored the Bugsnag error filtering logic to use a centralized array of ignored error messages instead of hardcoding specific error strings. Added comprehensive documentation explaining the strict criteria for suppressing errors from Bugsnag reporting, emphasizing that this should only be used for well-understood, non-problematic errors that cannot be resolved at the source.

## Related Issue and Pull requests

## Type of Change

- [x] Cleanup/Refactor

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Verify that ResizeObserver errors are still properly filtered from Bugsnag reporting
2. Test that other errors continue to be reported to Bugsnag as expected
3. Confirm that the error filtering logic works correctly with the new array-based approach

## Additional Comments

This change makes it easier to manage ignored error messages in the future while providing clear guidelines for when errors should be suppressed from reporting. The existing functionality remains unchanged - only the implementation has been improved for better maintainability.