### PR TITLE
Add components section

### DIFF
--- a/src/components/shared/FavoriteToggle.tsx
+++ b/src/components/shared/FavoriteToggle.tsx
@@ -1,7 +1,7 @@
-import { Star } from "lucide-react";
 import { type MouseEvent } from "react";
 
 import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icon";
 import { type FavoriteType, useFavorites } from "@/hooks/useFavorites";
 import { cn } from "@/lib/utils";
 
@@ -31,7 +31,7 @@ export const FavoriteToggle = ({ type, id, name }: FavoriteToggleProps) => {
       variant="ghost"
       size="icon"
     >
-      <Star className="h-4 w-4" fill={active ? "currentColor" : "none"} />
+      <Icon name="Star" className={cn(active ? "fill-warning" : "fill-none")} />
     </Button>
   );
 };

--- a/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
@@ -35,6 +35,7 @@ import { useCopyPaste } from "@/hooks/useCopyPaste";
 import { useGhostNode } from "@/hooks/useGhostNode";
 import { useIOSelectionPersistence } from "@/hooks/useIOSelectionPersistence";
 import { useNodeCallbacks } from "@/hooks/useNodeCallbacks";
+import { addRecentlyViewed } from "@/hooks/useRecentlyViewed";
 import { useSubgraphKeyboardNavigation } from "@/hooks/useSubgraphKeyboardNavigation";
 import useToastNotification from "@/hooks/useToastNotification";
 import { useUserDetails } from "@/hooks/useUserDetails";
@@ -679,6 +680,15 @@ const FlowCanvasContent = ({
           );
 
           setComponentSpec(newComponentSpec);
+
+          const ref = hydratedComponentRef;
+          if (ref.digest && ref.spec?.name) {
+            addRecentlyViewed({
+              type: "component",
+              id: ref.digest,
+              name: ref.spec.name,
+            });
+          }
         }
       } catch (error) {
         console.error("Failed to add imported component to canvas:", error);
@@ -790,6 +800,15 @@ const FlowCanvasContent = ({
       );
 
       setComponentSpec(newRootSpec);
+
+      const ref = droppedTask?.componentRef;
+      if (ref?.digest && ref.spec?.name) {
+        addRecentlyViewed({
+          type: "component",
+          id: ref.digest,
+          name: ref.spec.name,
+        });
+      }
     }
   };
 

--- a/src/routes/Dashboard/DashboardComponentsView.tsx
+++ b/src/routes/Dashboard/DashboardComponentsView.tsx
@@ -1,0 +1,617 @@
+import { useQuery } from "@tanstack/react-query";
+import { useNavigate, useSearch } from "@tanstack/react-router";
+import { useState } from "react";
+
+import type { ListPublishedComponentsResponse } from "@/api/types.gen";
+import { CodeViewer } from "@/components/shared/CodeViewer";
+import { CopyText } from "@/components/shared/CopyText/CopyText";
+import { SuspenseWrapper } from "@/components/shared/SuspenseWrapper";
+import { GithubDetails } from "@/components/shared/TaskDetails/GithubDetails";
+import { Badge } from "@/components/ui/badge";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { Icon } from "@/components/ui/icon";
+import { Input } from "@/components/ui/input";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Heading, Paragraph, Text } from "@/components/ui/typography";
+import { useHydrateComponentReference } from "@/hooks/useHydrateComponentReference";
+import { cn } from "@/lib/utils";
+import { useBackend } from "@/providers/BackendProvider";
+import {
+  fetchUserComponents,
+  flattenFolders,
+} from "@/providers/ComponentLibraryProvider/componentLibrary";
+import { APP_ROUTES } from "@/routes/router";
+import { fetchAndStoreComponentLibrary } from "@/services/componentService";
+import type { ComponentFolder } from "@/types/componentLibrary";
+import type {
+  ComponentReference,
+  InputSpec,
+  OutputSpec,
+} from "@/utils/componentSpec";
+import { TOP_NAV_HEIGHT } from "@/utils/constants";
+import { fetchWithErrorHandling } from "@/utils/fetchWithErrorHandling";
+
+const PUBLISHED_COMPONENTS_URL = "/api/published_components/";
+
+// ─── Collapsible section header ──────────────────────────────────────────────
+
+const CollapsibleSection = ({
+  label,
+  count,
+  defaultOpen = true,
+  children,
+}: {
+  label: string;
+  count: number;
+  defaultOpen?: boolean;
+  children: React.ReactNode;
+}) => (
+  <Collapsible defaultOpen={defaultOpen}>
+    <CollapsibleTrigger className="group w-full flex items-center gap-1.5 px-3 py-1.5 bg-muted/40 border-b border-border/50 sticky top-0 z-10 hover:bg-muted/60 cursor-pointer">
+      <Icon
+        name="ChevronRight"
+        className="text-muted-foreground transition-transform shrink-0 group-data-[state=open]:rotate-90"
+        size="sm"
+      />
+      <Text
+        size="xs"
+        className="text-muted-foreground font-medium uppercase tracking-wide flex-1 text-left"
+      >
+        {label}
+      </Text>
+      <Text size="xs" className="text-muted-foreground tabular-nums">
+        {count}
+      </Text>
+    </CollapsibleTrigger>
+    <CollapsibleContent>{children}</CollapsibleContent>
+  </Collapsible>
+);
+
+// ─── Shared row ──────────────────────────────────────────────────────────────
+
+const ComponentRow = ({
+  component,
+  selectedDigest,
+  onSelect,
+  depth = 0,
+}: {
+  component: ComponentReference;
+  selectedDigest?: string;
+  onSelect: (c: ComponentReference) => void;
+  depth?: number;
+}) => (
+  <button
+    onClick={() => onSelect(component)}
+    style={{ paddingLeft: `${depth * 12 + 12}px` }}
+    className={cn(
+      "w-full text-left pr-3 py-1.5 border-b border-border/50 hover:bg-muted/50 flex flex-col gap-0 cursor-pointer",
+      selectedDigest === component.digest && "bg-muted",
+    )}
+  >
+    <Text size="xs" className="truncate">
+      {component.name ?? component.digest ?? "Unnamed"}
+    </Text>
+    {component.published_by && (
+      <Text
+        size="xs"
+        className="text-muted-foreground/70 truncate leading-tight"
+      >
+        {component.published_by}
+      </Text>
+    )}
+  </button>
+);
+
+// ─── Folder node (recursive, for library tree) ───────────────────────────────
+
+const FolderNode = ({
+  folder,
+  depth,
+  selectedDigest,
+  onSelect,
+}: {
+  folder: ComponentFolder;
+  depth: number;
+  selectedDigest?: string;
+  onSelect: (c: ComponentReference) => void;
+}) => (
+  <Collapsible defaultOpen>
+    <CollapsibleTrigger
+      aria-label={`${folder.name} folder`}
+      style={{ paddingLeft: `${depth * 12 + 12}px` }}
+      className="group w-full flex items-center gap-1.5 pr-3 py-0.5 border-b border-border/50 bg-muted/10 hover:bg-muted/30 cursor-pointer text-left"
+    >
+      <Icon
+        name="ChevronRight"
+        className="text-muted-foreground transition-transform shrink-0 group-data-[state=open]:rotate-90"
+        size="sm"
+      />
+      <Text size="xs" className="text-muted-foreground font-medium truncate">
+        {folder.name}
+      </Text>
+    </CollapsibleTrigger>
+    <CollapsibleContent>
+      {folder.components?.map((c) => (
+        <ComponentRow
+          key={c.digest ?? c.url ?? c.name}
+          component={c}
+          selectedDigest={selectedDigest}
+          onSelect={onSelect}
+          depth={depth + 1}
+        />
+      ))}
+      {folder.folders?.map((sub) => (
+        <FolderNode
+          key={sub.name}
+          folder={sub}
+          depth={depth + 1}
+          selectedDigest={selectedDigest}
+          onSelect={onSelect}
+        />
+      ))}
+    </CollapsibleContent>
+  </Collapsible>
+);
+
+// ─── Component List ─────────────────────────────────────────────────────────
+
+const ComponentList = ({
+  query,
+  selectedDigest,
+  onSelect,
+}: {
+  query: string;
+  selectedDigest?: string;
+  onSelect: (component: ComponentReference) => void;
+}) => {
+  const { backendUrl, configured, available, ready } = useBackend();
+
+  // User components — IndexedDB, no backend needed
+  const { data: userFolder } = useQuery({
+    queryKey: ["userComponents"],
+    queryFn: fetchUserComponents,
+    staleTime: 0,
+    refetchOnMount: "always",
+  });
+
+  // Static library — fetched from a remote YAML, same as editor sidebar
+  const { data: componentLibrary } = useQuery({
+    queryKey: ["componentLibrary"],
+    queryFn: fetchAndStoreComponentLibrary,
+    staleTime: 1000 * 60 * 60,
+  });
+
+  // Published components — from the backend API
+  const { data: publishedData, isLoading: publishedLoading } =
+    useQuery<ListPublishedComponentsResponse>({
+      queryKey: ["published-components", backendUrl],
+      refetchOnWindowFocus: false,
+      enabled: configured && available,
+      queryFn: async () => {
+        const url = new URL(PUBLISHED_COMPONENTS_URL, backendUrl);
+        return fetchWithErrorHandling(url.toString());
+      },
+    });
+
+  if (!ready || publishedLoading) {
+    return (
+      <BlockStack gap="2" className="p-3">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <Skeleton key={i} className="h-9 w-full" />
+        ))}
+      </BlockStack>
+    );
+  }
+
+  const q = query.trim().toLowerCase();
+
+  const matches = (name?: string | null, author?: string | null) =>
+    !q || name?.toLowerCase().includes(q) || author?.toLowerCase().includes(q);
+
+  const userComponents = (userFolder?.components ?? []).filter((c) =>
+    matches(c.name, c.published_by),
+  );
+
+  const allLibraryComponents = componentLibrary
+    ? flattenFolders(componentLibrary)
+    : [];
+  const filteredLibraryComponents = allLibraryComponents.filter((c) =>
+    matches(c.name, c.published_by),
+  );
+
+  const publishedComponents = (publishedData?.published_components ?? [])
+    .filter((c) => matches(c.name, c.published_by))
+    .map(
+      (c): ComponentReference => ({
+        digest: c.digest,
+        url: c.url ?? `${backendUrl}/api/components/${c.digest}`,
+        name: c.name ?? undefined,
+        published_by: c.published_by,
+      }),
+    );
+
+  const total =
+    userComponents.length +
+    filteredLibraryComponents.length +
+    publishedComponents.length;
+
+  if (total === 0) {
+    return (
+      <div className="px-4 py-3">
+        <Paragraph tone="subdued" size="sm">
+          {q ? "No components match your search." : "No components found."}
+        </Paragraph>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {userComponents.length > 0 && (
+        <CollapsibleSection
+          label="User Components"
+          count={userComponents.length}
+        >
+          {userComponents.map((c) => (
+            <ComponentRow
+              key={c.digest ?? c.url ?? c.name}
+              component={c}
+              selectedDigest={selectedDigest}
+              onSelect={onSelect}
+            />
+          ))}
+        </CollapsibleSection>
+      )}
+
+      {filteredLibraryComponents.length > 0 && componentLibrary && (
+        <CollapsibleSection
+          label="Library Components"
+          count={filteredLibraryComponents.length}
+        >
+          {q
+            ? // When searching, show a flat filtered list
+              filteredLibraryComponents.map((c) => (
+                <ComponentRow
+                  key={c.digest ?? c.url ?? c.name}
+                  component={c}
+                  selectedDigest={selectedDigest}
+                  onSelect={onSelect}
+                />
+              ))
+            : // When not searching, show the folder tree
+              componentLibrary.folders.map((folder) => (
+                <FolderNode
+                  key={folder.name}
+                  folder={folder}
+                  depth={0}
+                  selectedDigest={selectedDigest}
+                  onSelect={onSelect}
+                />
+              ))}
+        </CollapsibleSection>
+      )}
+
+      {publishedComponents.length > 0 && (
+        <CollapsibleSection
+          label="Published Components"
+          count={publishedComponents.length}
+        >
+          {publishedComponents.map((c) => (
+            <ComponentRow
+              key={c.digest}
+              component={c}
+              selectedDigest={selectedDigest}
+              onSelect={onSelect}
+            />
+          ))}
+        </CollapsibleSection>
+      )}
+    </>
+  );
+};
+
+// ─── Compact I/O table ───────────────────────────────────────────────────────
+
+const IORow = ({
+  name,
+  type,
+  required,
+  defaultValue,
+  description,
+}: {
+  name: string;
+  type?: unknown;
+  required?: boolean;
+  defaultValue?: unknown;
+  description?: string;
+}) => (
+  <div className="grid grid-cols-[1fr_auto_auto] items-start gap-x-3 gap-y-0.5 px-3 py-2 border-b border-border/50 last:border-0">
+    <div className="flex flex-col gap-0.5 min-w-0">
+      <Text size="xs" weight="semibold" className="truncate font-mono">
+        {name}
+      </Text>
+      {description && (
+        <Text size="xs" className="text-muted-foreground leading-snug">
+          {description}
+        </Text>
+      )}
+      {defaultValue !== undefined && (
+        <Text size="xs" className="text-muted-foreground">
+          Default: <span className="font-mono">{String(defaultValue)}</span>
+        </Text>
+      )}
+    </div>
+    <Text size="xs" className="text-muted-foreground shrink-0 pt-0.5">
+      {type ? String(type) : "—"}
+    </Text>
+    <Badge
+      className={cn(
+        "shrink-0 mt-0.5 text-[10px] font-semibold leading-none",
+        required
+          ? "bg-rose-100 text-rose-700 hover:bg-rose-100"
+          : "bg-muted text-muted-foreground hover:bg-muted",
+      )}
+    >
+      {required ? "req" : "opt"}
+    </Badge>
+  </div>
+);
+
+const CompactIO = ({
+  inputs,
+  outputs,
+}: {
+  inputs?: InputSpec[];
+  outputs?: OutputSpec[];
+}) => (
+  <BlockStack gap="3">
+    {inputs && inputs.length > 0 && (
+      <div>
+        <Text
+          size="xs"
+          className="text-muted-foreground font-medium uppercase tracking-wide px-1 mb-1"
+        >
+          Inputs
+        </Text>
+        <div className="border border-border rounded-md overflow-hidden">
+          {inputs.map((input) => (
+            <IORow
+              key={input.name}
+              name={input.name}
+              type={input.type}
+              required={!input.optional}
+              defaultValue={input.default}
+              description={input.description}
+            />
+          ))}
+        </div>
+      </div>
+    )}
+    {outputs && outputs.length > 0 && (
+      <div>
+        <Text
+          size="xs"
+          className="text-muted-foreground font-medium uppercase tracking-wide px-1 mb-1"
+        >
+          Outputs
+        </Text>
+        <div className="border border-border rounded-md overflow-hidden">
+          {outputs.map((output) => (
+            <IORow
+              key={output.name}
+              name={output.name}
+              type={output.type}
+              description={output.description}
+            />
+          ))}
+        </div>
+      </div>
+    )}
+  </BlockStack>
+);
+
+// ─── Detail Panel (Suspense) ────────────────────────────────────────────────
+
+const ComponentDetailInner = ({ digest }: { digest: string }) => {
+  const { backendUrl } = useBackend();
+  const componentRef: ComponentReference = {
+    digest,
+    url: `${backendUrl}/api/components/${digest}`,
+  };
+  const hydrated = useHydrateComponentReference(componentRef);
+
+  if (!hydrated?.spec) {
+    return (
+      <Paragraph tone="subdued" size="sm">
+        Could not load component details.
+      </Paragraph>
+    );
+  }
+
+  const { spec } = hydrated;
+  const annotations = spec.metadata?.annotations ?? {};
+  const author =
+    typeof annotations.author === "string" ? annotations.author : undefined;
+  const canonicalUrl =
+    typeof annotations.canonical_location === "string"
+      ? annotations.canonical_location
+      : undefined;
+  const gitRemoteUrl =
+    typeof annotations.git_remote_url === "string"
+      ? annotations.git_remote_url
+      : undefined;
+  const gitRemoteBranch =
+    typeof annotations.git_remote_branch === "string"
+      ? annotations.git_remote_branch
+      : undefined;
+  const gitRelativeDir =
+    typeof annotations.git_relative_dir === "string"
+      ? annotations.git_relative_dir
+      : undefined;
+  const componentYamlPath =
+    typeof annotations.component_yaml_path === "string"
+      ? annotations.component_yaml_path
+      : undefined;
+  const documentationPath =
+    typeof annotations.documentation_path === "string"
+      ? annotations.documentation_path
+      : undefined;
+
+  let reconstructedUrl: string | undefined;
+  let documentationUrl: string | undefined;
+
+  if (gitRemoteUrl && gitRemoteBranch && gitRelativeDir) {
+    const repoPath = gitRemoteUrl
+      .replace(/^https:\/\/github\.com\//, "")
+      .replace(/\.git$/, "");
+    const buildGitHubUrl = (filePath: string) =>
+      `https://github.com/${repoPath}/blob/${gitRemoteBranch}/${gitRelativeDir}/${filePath}`;
+    if (!hydrated.url && componentYamlPath)
+      reconstructedUrl = buildGitHubUrl(componentYamlPath);
+    if (documentationPath) documentationUrl = buildGitHubUrl(documentationPath);
+  }
+
+  const hasIO =
+    (spec.inputs && spec.inputs.length > 0) ||
+    (spec.outputs && spec.outputs.length > 0);
+
+  return (
+    // Side-by-side layout: info+IO on left, source code sticky on right
+    <InlineStack gap="6" blockAlign="start">
+      {/* Left: metadata + I/O — flows naturally with the page scroll */}
+      <div className="flex-2 min-w-0 flex flex-col gap-4">
+        {/* Header */}
+        <BlockStack gap="1">
+          <Heading level={2}>{spec.name ?? digest}</Heading>
+          {author && (
+            <Text size="sm" className="text-muted-foreground">
+              {author}
+            </Text>
+          )}
+          {hydrated.digest && (
+            <Badge
+              variant="outline"
+              className="font-mono text-xs min-w-0 max-w-full overflow-hidden"
+            >
+              <CopyText size="xs" className="font-mono truncate">
+                {hydrated.digest}
+              </CopyText>
+            </Badge>
+          )}
+        </BlockStack>
+
+        {spec.description && (
+          <Paragraph size="sm" tone="subdued">
+            {spec.description}
+          </Paragraph>
+        )}
+
+        <GithubDetails
+          url={hydrated.url ?? reconstructedUrl}
+          canonicalUrl={canonicalUrl}
+          documentationUrl={documentationUrl}
+        />
+
+        {hasIO && <CompactIO inputs={spec.inputs} outputs={spec.outputs} />}
+      </div>
+
+      {/* Right: source code — sticky so it stays in view while left side scrolls */}
+      {hydrated.text && (
+        <div className="flex-3 min-w-0">
+          <div
+            className="sticky top-0 flex flex-col gap-1.5"
+            style={{ height: `calc(100vh - ${TOP_NAV_HEIGHT + 48}px)` }}
+          >
+            <Text
+              size="xs"
+              className="text-muted-foreground font-medium uppercase tracking-wide shrink-0"
+            >
+              Source
+            </Text>
+            <div className="flex-1 min-h-0">
+              <CodeViewer
+                code={hydrated.text}
+                language="yaml"
+                filename={spec.name ?? "component.yaml"}
+              />
+            </div>
+          </div>
+        </div>
+      )}
+    </InlineStack>
+  );
+};
+
+// ─── Main View ──────────────────────────────────────────────────────────────
+
+export function DashboardComponentsView() {
+  const [query, setQuery] = useState("");
+  const navigate = useNavigate();
+  // useSearch strict:false is required here — this route has no validateSearch defined
+  const { component: selectedDigest } = useSearch({ strict: false }) as {
+    component?: string;
+  };
+  const handleSelect = (component: ComponentReference) => {
+    navigate({
+      to: APP_ROUTES.DASHBOARD_COMPONENTS,
+      search: { component: component.digest },
+    });
+  };
+
+  return (
+    <div
+      className="flex -mt-4 -mb-6 -mx-8 overflow-hidden border-t border-border"
+      style={{ height: `calc(100vh - ${TOP_NAV_HEIGHT}px)` }}
+    >
+      {/* Left: component list */}
+      <div className="w-64 shrink-0 border-r border-border flex flex-col overflow-hidden">
+        <div className="p-3 border-b border-border shrink-0">
+          <Input
+            placeholder="Search components..."
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+          />
+        </div>
+        <div className="flex-1 overflow-y-auto">
+          <ComponentList
+            query={query}
+            selectedDigest={selectedDigest}
+            onSelect={handleSelect}
+          />
+        </div>
+      </div>
+
+      {/* Right: detail panel — single scroll, source sticky on right */}
+      <div className="flex-1 min-w-0 overflow-y-auto p-6">
+        {selectedDigest ? (
+          <SuspenseWrapper
+            fallback={
+              <InlineStack gap="6">
+                <div className="flex-1 flex flex-col gap-3">
+                  <Skeleton className="h-6 w-48" />
+                  <Skeleton className="h-4 w-32" />
+                  <Skeleton className="h-4 w-full" />
+                  <Skeleton className="h-4 w-3/4" />
+                </div>
+                <Skeleton className="flex-3 min-w-0 h-64" />
+              </InlineStack>
+            }
+          >
+            <ComponentDetailInner digest={selectedDigest} />
+          </SuspenseWrapper>
+        ) : (
+          <InlineStack fill>
+            <Paragraph tone="subdued" size="sm">
+              Select a component to view its details.
+            </Paragraph>
+          </InlineStack>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/routes/Dashboard/DashboardFavoritesView.tsx
+++ b/src/routes/Dashboard/DashboardFavoritesView.tsx
@@ -5,70 +5,49 @@ import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
 import { Input } from "@/components/ui/input";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
-import { Paragraph, Text } from "@/components/ui/typography";
+import { Heading, Paragraph, Text } from "@/components/ui/typography";
 import { type FavoriteItem, useFavorites } from "@/hooks/useFavorites";
-import { cn } from "@/lib/utils";
-import { EDITOR_PATH, RUNS_BASE_PATH } from "@/routes/router";
+
+import { getFavoriteUrl, TypePill } from "./TypePill";
 
 const PAGE_SIZE = 20;
 
-function getFavoriteUrl(item: FavoriteItem): string {
-  if (item.type === "pipeline") return `${EDITOR_PATH}/${item.id}`;
-  return `${RUNS_BASE_PATH}/${item.id}`;
-}
-
-const FavoriteCard = ({ item }: { item: FavoriteItem }) => {
-  const { removeFavorite } = useFavorites();
-
-  const isPipeline = item.type === "pipeline";
-
-  return (
-    <Link
-      to={getFavoriteUrl(item)}
-      className="group relative flex flex-col gap-2.5 p-3 rounded-lg transition-all shadow-sm hover:shadow-md bg-card border border-border hover:border-foreground/20 no-underline overflow-hidden"
+const FavoriteCard = ({
+  item,
+  onRemove,
+}: {
+  item: FavoriteItem;
+  onRemove: () => void;
+}) => (
+  <Link
+    to={getFavoriteUrl(item)}
+    className="group relative flex flex-col gap-2.5 p-3 rounded-lg transition-all shadow-sm hover:shadow-md bg-card border border-border hover:border-foreground/20 no-underline overflow-hidden"
+  >
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        onRemove();
+      }}
+      className="absolute top-2 right-2 size-5 opacity-0 group-hover:opacity-100 text-muted-foreground hover:text-foreground"
+      aria-label="Remove from favorites"
     >
-      {/* Remove button */}
-      <Button
-        variant="ghost"
-        size="icon"
-        onClick={(e) => {
-          e.preventDefault();
-          e.stopPropagation();
-          removeFavorite(item.type, item.id);
-        }}
-        className="absolute top-2 right-2 size-5 opacity-0 group-hover:opacity-100 text-muted-foreground hover:text-foreground"
-        aria-label="Remove from favorites"
-      >
-        <Icon name="X" size="sm" />
-      </Button>
+      <Icon name="X" size="sm" />
+    </Button>
 
-      {/* Type pill */}
-      <InlineStack>
-        <span
-          className={cn(
-            "inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-xs font-semibold",
-            isPipeline
-              ? "bg-violet-100 text-violet-700"
-              : "bg-emerald-100 text-emerald-700",
-          )}
-        >
-          <Icon name={isPipeline ? "GitBranch" : "Play"} size="sm" />
-          {isPipeline ? "Pipeline" : "Run"}
-        </span>
-      </InlineStack>
+    <TypePill type={item.type} className="self-start" />
 
-      {/* Name */}
-      <Text size="sm" weight="semibold" className="truncate pr-4 leading-tight">
-        {item.name}
-      </Text>
+    <Text size="sm" weight="semibold" className="truncate pr-4 leading-tight">
+      {item.name}
+    </Text>
 
-      {/* ID */}
-      <Text size="xs" tone="subdued" font="mono" className="truncate">
-        {item.id}
-      </Text>
-    </Link>
-  );
-};
+    <Text size="xs" tone="subdued" font="mono" className="truncate">
+      {item.id}
+    </Text>
+  </Link>
+);
 
 interface FavoritesSearchBarProps {
   query: string;
@@ -105,7 +84,7 @@ const FavoritesSearchBar = ({
 );
 
 export function DashboardFavoritesView() {
-  const { favorites } = useFavorites();
+  const { favorites, removeFavorite } = useFavorites();
   const [page, setPage] = useState(0);
   const [query, setQuery] = useState("");
 
@@ -132,9 +111,7 @@ export function DashboardFavoritesView() {
 
   return (
     <BlockStack gap="4">
-      <Text as="h2" size="lg" weight="semibold">
-        Favorites
-      </Text>
+      <Heading level={2}>Favorites</Heading>
 
       {favorites.length === 0 ? (
         <Paragraph tone="subdued" size="sm">
@@ -151,7 +128,11 @@ export function DashboardFavoritesView() {
           ) : (
             <div className="grid grid-cols-4 gap-3">
               {paginated.map((item) => (
-                <FavoriteCard key={`${item.type}-${item.id}`} item={item} />
+                <FavoriteCard
+                  key={`${item.type}-${item.id}`}
+                  item={item}
+                  onRemove={() => removeFavorite(item.type, item.id)}
+                />
               ))}
             </div>
           )}

--- a/src/routes/Dashboard/DashboardHomeView.tsx
+++ b/src/routes/Dashboard/DashboardHomeView.tsx
@@ -3,73 +3,25 @@ import { Link } from "@tanstack/react-router";
 import { RunSection } from "@/components/Home/RunSection/RunSection";
 import { AnnouncementBanners } from "@/components/shared/AnnouncementBanners";
 import { Button } from "@/components/ui/button";
-import { Icon, type IconName } from "@/components/ui/icon";
+import { Icon } from "@/components/ui/icon";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { Paragraph, Text } from "@/components/ui/typography";
+import { Heading, Paragraph, Text } from "@/components/ui/typography";
 import { type FavoriteItem, useFavorites } from "@/hooks/useFavorites";
 import {
   type RecentlyViewedItem,
   useRecentlyViewed,
 } from "@/hooks/useRecentlyViewed";
-import { cn } from "@/lib/utils";
-import { APP_ROUTES, EDITOR_PATH, RUNS_BASE_PATH } from "@/routes/router";
+import { APP_ROUTES } from "@/routes/router";
 import { formatRelativeTime } from "@/utils/date";
 
+import { getFavoriteUrl, getRecentlyViewedUrl, TypePill } from "./TypePill";
+
 const PREVIEW_COUNT = 5;
-
-function getRecentlyViewedUrl(item: RecentlyViewedItem): string {
-  if (item.type === "pipeline") return `${EDITOR_PATH}/${item.id}`;
-  if (item.type === "run") return `${RUNS_BASE_PATH}/${item.id}`;
-  return APP_ROUTES.DASHBOARD_COMPONENTS;
-}
-
-function getFavoriteUrl(item: FavoriteItem): string {
-  if (item.type === "pipeline") return `${EDITOR_PATH}/${item.id}`;
-  return `${RUNS_BASE_PATH}/${item.id}`;
-}
-
-type ItemType = "pipeline" | "run" | "component";
-
-const TYPE_CONFIG: Record<
-  ItemType,
-  { className: string; icon: IconName; label: string }
-> = {
-  pipeline: {
-    className: "bg-violet-100 text-violet-700",
-    icon: "GitBranch",
-    label: "Pipeline",
-  },
-  run: {
-    className: "bg-emerald-100 text-emerald-700",
-    icon: "Play",
-    label: "Run",
-  },
-  component: {
-    className: "bg-blue-100 text-blue-700",
-    icon: "Package",
-    label: "Component",
-  },
-};
-
-const TypePill = ({ type }: { type: ItemType }) => {
-  const config = TYPE_CONFIG[type];
-  return (
-    <span
-      className={cn(
-        "inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-xs font-semibold shrink-0",
-        config.className,
-      )}
-    >
-      <Icon name={config.icon} size="sm" />
-      {config.label}
-    </span>
-  );
-};
 
 interface SectionHeaderProps {
   title: string;
@@ -82,10 +34,8 @@ const SectionHeader = ({
   viewAllTo,
   viewAllLabel = "View all",
 }: SectionHeaderProps) => (
-  <InlineStack gap="3" blockAlign="center">
-    <Text as="h2" size="lg" weight="semibold">
-      {title}
-    </Text>
+  <InlineStack gap="3" blockAlign="center" className="min-w-0">
+    <Heading level={2}>{title}</Heading>
     <Link
       to={viewAllTo}
       className="text-xs text-muted-foreground hover:text-foreground"
@@ -102,53 +52,57 @@ const FavoritePreviewRow = ({
   item: FavoriteItem;
   onRemove: () => void;
 }) => (
-  <Link
-    to={getFavoriteUrl(item)}
-    className="group flex items-center gap-3 px-4 py-2.5 hover:bg-muted/50 no-underline"
-  >
-    <TypePill type={item.type} />
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <Text size="sm" className="flex-1 min-w-0 truncate">
-          {item.name}
-        </Text>
-      </TooltipTrigger>
-      <TooltipContent>{item.name}</TooltipContent>
-    </Tooltip>
-    <Button
-      variant="ghost"
-      size="icon"
-      onClick={(e) => {
-        e.preventDefault();
-        e.stopPropagation();
-        onRemove();
-      }}
-      className="shrink-0 size-5 opacity-0 group-hover:opacity-100 text-muted-foreground hover:text-foreground"
-      aria-label="Remove from favorites"
+  <InlineStack gap="2" className="min-w-0 overflow-hidden">
+    <Link
+      to={getFavoriteUrl(item)}
+      className="group flex w-full items-center gap-3 px-4 py-3 hover:bg-muted/50 no-underline"
     >
-      <Icon name="X" size="sm" />
-    </Button>
-  </Link>
+      <TypePill type={item.type} />
+      <Tooltip>
+        <TooltipTrigger className="flex-1 min-w-0 overflow-hidden text-left">
+          <Text size="sm" className="truncate block">
+            {item.name}
+          </Text>
+        </TooltipTrigger>
+        <TooltipContent>{item.name}</TooltipContent>
+      </Tooltip>
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          onRemove();
+        }}
+        className="shrink-0 size-5 opacity-0 group-hover:opacity-100 text-muted-foreground hover:text-foreground"
+        aria-label="Remove from favorites"
+      >
+        <Icon name="X" size="sm" />
+      </Button>
+    </Link>
+  </InlineStack>
 );
 
 const RecentlyViewedPreviewRow = ({ item }: { item: RecentlyViewedItem }) => (
-  <Link
-    to={getRecentlyViewedUrl(item)}
-    className="flex items-center gap-3 px-4 py-2.5 hover:bg-muted/50 no-underline"
-  >
-    <TypePill type={item.type} />
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <Text size="sm" className="flex-1 min-w-0 truncate">
-          {item.name}
-        </Text>
-      </TooltipTrigger>
-      <TooltipContent>{item.name}</TooltipContent>
-    </Tooltip>
-    <Text size="xs" className="text-muted-foreground shrink-0">
-      {formatRelativeTime(new Date(item.viewedAt))}
-    </Text>
-  </Link>
+  <InlineStack gap="2" className="min-w-0 overflow-hidden">
+    <Link
+      to={getRecentlyViewedUrl(item)}
+      className="flex w-full items-center gap-3 px-4 py-3 hover:bg-muted/50 no-underline"
+    >
+      <TypePill type={item.type} />
+      <Tooltip>
+        <TooltipTrigger className="flex-1 min-w-0 overflow-hidden text-left">
+          <Text size="sm" className="truncate block">
+            {item.name}
+          </Text>
+        </TooltipTrigger>
+        <TooltipContent>{item.name}</TooltipContent>
+      </Tooltip>
+      <Text size="xs" className="text-muted-foreground shrink-0">
+        {formatRelativeTime(new Date(item.viewedAt))}
+      </Text>
+    </Link>
+  </InlineStack>
 );
 
 const FavoritesPreview = () => {
@@ -156,12 +110,12 @@ const FavoritesPreview = () => {
   const preview = favorites.slice(0, PREVIEW_COUNT);
 
   return (
-    <BlockStack gap="3" className="min-w-0">
+    <BlockStack gap="4" className="min-w-0">
       <SectionHeader
         title="Favorites"
         viewAllTo={APP_ROUTES.DASHBOARD_FAVORITES}
       />
-      <div className="border border-border rounded-lg overflow-hidden divide-y divide-border">
+      <div className="w-full border border-border rounded-lg overflow-hidden divide-y divide-border">
         {preview.length === 0 ? (
           <div className="px-4 py-3">
             <Paragraph tone="subdued" size="sm">
@@ -184,15 +138,17 @@ const FavoritesPreview = () => {
 
 const RecentlyViewedPreview = () => {
   const { recentlyViewed } = useRecentlyViewed();
-  const preview = recentlyViewed.slice(0, PREVIEW_COUNT);
+  const preview = recentlyViewed
+    .filter((item) => item.type !== "component")
+    .slice(0, PREVIEW_COUNT);
 
   return (
-    <BlockStack gap="3" className="min-w-0">
+    <BlockStack gap="4" className="min-w-0">
       <SectionHeader
         title="Recently Viewed"
         viewAllTo={APP_ROUTES.DASHBOARD_RECENTLY_VIEWED}
       />
-      <div className="border border-border rounded-lg overflow-hidden divide-y divide-border">
+      <div className="w-full border border-border rounded-lg overflow-hidden divide-y divide-border">
         {preview.length === 0 ? (
           <div className="px-4 py-3">
             <Paragraph tone="subdued" size="sm">
@@ -212,15 +168,68 @@ const RecentlyViewedPreview = () => {
   );
 };
 
+const RecentComponentPreviewRow = ({ item }: { item: RecentlyViewedItem }) => (
+  <InlineStack gap="2" className="min-w-0 overflow-hidden">
+    <Link
+      to={APP_ROUTES.DASHBOARD_COMPONENTS}
+      search={{ component: item.id }}
+      className="flex w-full items-center gap-3 px-4 py-3 hover:bg-muted/50 no-underline"
+    >
+      <TypePill type="component" />
+      <Tooltip>
+        <TooltipTrigger className="flex-1 min-w-0 overflow-hidden text-left">
+          <Text size="sm" className="truncate block">
+            {item.name}
+          </Text>
+        </TooltipTrigger>
+        <TooltipContent>{item.name}</TooltipContent>
+      </Tooltip>
+      <Text size="xs" className="text-muted-foreground shrink-0">
+        {formatRelativeTime(new Date(item.viewedAt))}
+      </Text>
+    </Link>
+  </InlineStack>
+);
+
+const RecentComponentsPreview = () => {
+  const { recentlyViewed } = useRecentlyViewed();
+  const preview = recentlyViewed
+    .filter((item) => item.type === "component")
+    .slice(0, PREVIEW_COUNT);
+
+  return (
+    <BlockStack gap="4" className="min-w-0">
+      <SectionHeader
+        title="Recently Used Components"
+        viewAllTo={APP_ROUTES.DASHBOARD_COMPONENTS}
+        viewAllLabel="View all"
+      />
+      <div className="w-full border border-border rounded-lg overflow-hidden divide-y divide-border">
+        {preview.length === 0 ? (
+          <div className="px-4 py-3">
+            <Paragraph tone="subdued" size="sm">
+              No components viewed yet. Open a component to see it here.
+            </Paragraph>
+          </div>
+        ) : (
+          preview.map((item) => (
+            <RecentComponentPreviewRow key={item.id} item={item} />
+          ))
+        )}
+      </div>
+    </BlockStack>
+  );
+};
+
 export function DashboardHomeView() {
   return (
     <BlockStack gap="6">
       <AnnouncementBanners />
 
-      <div className="grid grid-cols-3 gap-6">
+      <div className="grid grid-cols-3 gap-6 overflow-hidden">
         <FavoritesPreview />
         <RecentlyViewedPreview />
-        <div />
+        <RecentComponentsPreview />
       </div>
 
       <BlockStack gap="3">

--- a/src/routes/Dashboard/DashboardLayout.tsx
+++ b/src/routes/Dashboard/DashboardLayout.tsx
@@ -89,7 +89,7 @@ export function DashboardLayout() {
         <div className="flex-1 min-h-4" />
 
         {/* Bottom utilities */}
-        <div className="flex flex-col gap-1 px-3 border-t border-border pt-3 pb-3">
+        <BlockStack gap="1" className="px-3 border-t border-border pt-3 pb-3">
           <UILink
             href={DOCUMENTATION_URL}
             external
@@ -120,32 +120,36 @@ export function DashboardLayout() {
           )}
 
           {/* Footer links */}
-          <div className="flex flex-col gap-0.5 pt-2 mt-1 border-t border-border">
+          <BlockStack className="gap-0.5 pt-2 mt-1 border-t border-border">
             {[
               { label: "About", href: ABOUT_URL },
               { label: "Give feedback", href: GIVE_FEEDBACK_URL },
               { label: "Privacy policy", href: PRIVACY_POLICY_URL },
             ].map(({ label, href }) => (
-              <a
+              <UILink
                 key={label}
                 href={href}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="px-3 py-1 text-xs text-muted-foreground hover:text-foreground rounded-md hover:bg-accent"
+                variant="block"
+                size="xs"
+                className="px-3 py-1 text-muted-foreground hover:text-foreground rounded-md hover:bg-accent"
               >
                 {label}
-              </a>
+              </UILink>
             ))}
-            <a
+            <UILink
               href={`${GIT_REPO_URL}/commit/${GIT_COMMIT}`}
               target="_blank"
               rel="noopener noreferrer"
-              className="px-3 py-1 text-xs text-muted-foreground hover:text-foreground rounded-md hover:bg-accent font-mono"
+              variant="block"
+              size="xs"
+              className="px-3 py-1 text-muted-foreground hover:text-foreground rounded-md hover:bg-accent font-mono"
             >
               ver: {GIT_COMMIT.substring(0, 6)}
-            </a>
-          </div>
-        </div>
+            </UILink>
+          </BlockStack>
+        </BlockStack>
       </div>
 
       {/* Main content — independent scroll */}

--- a/src/routes/Dashboard/DashboardPipelinesView.tsx
+++ b/src/routes/Dashboard/DashboardPipelinesView.tsx
@@ -1,13 +1,11 @@
 import { PipelineSection } from "@/components/Home/PipelineSection/PipelineSection";
 import { BlockStack } from "@/components/ui/layout";
-import { Text } from "@/components/ui/typography";
+import { Heading } from "@/components/ui/typography";
 
 export function DashboardPipelinesView() {
   return (
     <BlockStack gap="4">
-      <Text as="h2" size="lg" weight="semibold">
-        Pipelines
-      </Text>
+      <Heading level={2}>Pipelines</Heading>
       <PipelineSection />
     </BlockStack>
   );

--- a/src/routes/Dashboard/DashboardRecentlyViewedView.tsx
+++ b/src/routes/Dashboard/DashboardRecentlyViewedView.tsx
@@ -4,66 +4,46 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
-import { Paragraph, Text } from "@/components/ui/typography";
+import { Heading, Paragraph, Text } from "@/components/ui/typography";
 import {
   type RecentlyViewedItem,
   useRecentlyViewed,
 } from "@/hooks/useRecentlyViewed";
-import { APP_ROUTES, EDITOR_PATH, RUNS_BASE_PATH } from "@/routes/router";
 import { formatRelativeTime } from "@/utils/date";
+
+import { getRecentlyViewedUrl, TypePill } from "./TypePill";
 
 const PAGE_SIZE = 20;
 
-function getRecentlyViewedUrl(item: RecentlyViewedItem): string {
-  if (item.type === "pipeline") return `${EDITOR_PATH}/${item.id}`;
-  if (item.type === "run") return `${RUNS_BASE_PATH}/${item.id}`;
-  return APP_ROUTES.DASHBOARD_COMPONENTS;
-}
-
-const RecentlyViewedCard = ({ item }: { item: RecentlyViewedItem }) => {
-  const isPipeline = item.type === "pipeline";
-
-  return (
-    <Link to={getRecentlyViewedUrl(item)} className="no-underline block">
-      <BlockStack
-        gap="2"
-        className="p-3 rounded-lg transition-all shadow-sm hover:shadow-md bg-card border border-border hover:border-foreground/20 overflow-hidden"
-      >
-        {/* Type pill + timestamp */}
-        <InlineStack blockAlign="center" align="space-between">
-          <InlineStack>
-            <span
-              className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-xs font-semibold ${
-                isPipeline
-                  ? "bg-violet-100 text-violet-700"
-                  : "bg-emerald-100 text-emerald-700"
-              }`}
-            >
-              <Icon name={isPipeline ? "GitBranch" : "Play"} size="sm" />
-              {isPipeline ? "Pipeline" : "Run"}
-            </span>
-          </InlineStack>
-          <Text size="xs" className="text-muted-foreground">
-            {formatRelativeTime(new Date(item.viewedAt))}
-          </Text>
-        </InlineStack>
-
-        {/* Name */}
-        <Text size="sm" weight="semibold" className="truncate leading-tight">
-          {item.name}
+const RecentlyViewedCard = ({ item }: { item: RecentlyViewedItem }) => (
+  <Link to={getRecentlyViewedUrl(item)} className="no-underline block">
+    <BlockStack
+      gap="2"
+      className="p-3 rounded-lg transition-all shadow-sm hover:shadow-md bg-card border border-border hover:border-foreground/20 overflow-hidden"
+    >
+      <InlineStack blockAlign="center" align="space-between">
+        <TypePill type={item.type} />
+        <Text size="xs" className="text-muted-foreground">
+          {formatRelativeTime(new Date(item.viewedAt))}
         </Text>
+      </InlineStack>
 
-        {/* ID */}
-        <Text size="xs" className="truncate text-muted-foreground font-mono">
-          {item.id}
-        </Text>
-      </BlockStack>
-    </Link>
-  );
-};
+      <Text size="sm" weight="semibold" className="truncate leading-tight">
+        {item.name}
+      </Text>
+
+      <Text size="xs" className="truncate text-muted-foreground font-mono">
+        {item.id}
+      </Text>
+    </BlockStack>
+  </Link>
+);
 
 export function DashboardRecentlyViewedView() {
-  const { recentlyViewed } = useRecentlyViewed();
+  const { recentlyViewed: allRecentlyViewed } = useRecentlyViewed();
+  const recentlyViewed = allRecentlyViewed.filter(
+    (item) => item.type !== "component",
+  );
   const [page, setPage] = useState(0);
 
   const totalPages = Math.ceil(recentlyViewed.length / PAGE_SIZE);
@@ -75,9 +55,7 @@ export function DashboardRecentlyViewedView() {
 
   return (
     <BlockStack gap="4">
-      <Text as="h2" size="lg" weight="semibold">
-        Recently Viewed
-      </Text>
+      <Heading level={2}>Recently Viewed</Heading>
 
       {recentlyViewed.length === 0 ? (
         <Paragraph tone="subdued" size="sm">

--- a/src/routes/Dashboard/DashboardRunsView.tsx
+++ b/src/routes/Dashboard/DashboardRunsView.tsx
@@ -1,14 +1,12 @@
 import { RunSection } from "@/components/Home/RunSection/RunSection";
 import { PipelineRunFiltersBar } from "@/components/shared/PipelineRunFiltersBar/PipelineRunFiltersBar";
 import { BlockStack } from "@/components/ui/layout";
-import { Text } from "@/components/ui/typography";
+import { Heading } from "@/components/ui/typography";
 
 export function DashboardRunsView() {
   return (
     <BlockStack gap="4">
-      <Text as="h2" size="lg" weight="semibold">
-        Runs
-      </Text>
+      <Heading level={2}>Runs</Heading>
       <PipelineRunFiltersBar />
       <RunSection hideFilters />
     </BlockStack>

--- a/src/routes/Dashboard/TypePill.tsx
+++ b/src/routes/Dashboard/TypePill.tsx
@@ -1,0 +1,61 @@
+import { Icon, type IconName } from "@/components/ui/icon";
+import type { FavoriteItem } from "@/hooks/useFavorites";
+import type { RecentlyViewedItem } from "@/hooks/useRecentlyViewed";
+import { cn } from "@/lib/utils";
+import { APP_ROUTES, EDITOR_PATH, RUNS_BASE_PATH } from "@/routes/router";
+
+type ItemType = "pipeline" | "run" | "component";
+
+const TYPE_CONFIG: Record<
+  ItemType,
+  { className: string; icon: IconName; label: string }
+> = {
+  pipeline: {
+    className: "bg-violet-100 text-violet-700",
+    icon: "GitBranch",
+    label: "Pipeline",
+  },
+  run: {
+    className: "bg-emerald-100 text-emerald-700",
+    icon: "Play",
+    label: "Run",
+  },
+  component: {
+    className: "bg-sky-100 text-sky-700",
+    icon: "Package",
+    label: "Component",
+  },
+};
+
+export const TypePill = ({
+  type,
+  className,
+}: {
+  type: ItemType;
+  className?: string;
+}) => {
+  const config = TYPE_CONFIG[type];
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-xs font-semibold shrink-0",
+        config.className,
+        className,
+      )}
+    >
+      <Icon name={config.icon} size="sm" />
+      {config.label}
+    </span>
+  );
+};
+
+export function getFavoriteUrl(item: FavoriteItem): string {
+  if (item.type === "pipeline") return `${EDITOR_PATH}/${item.id}`;
+  return `${RUNS_BASE_PATH}/${item.id}`;
+}
+
+export function getRecentlyViewedUrl(item: RecentlyViewedItem): string {
+  if (item.type === "pipeline") return `${EDITOR_PATH}/${item.id}`;
+  if (item.type === "run") return `${RUNS_BASE_PATH}/${item.id}`;
+  return APP_ROUTES.DASHBOARD_COMPONENTS;
+}

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -17,6 +17,7 @@ import { isFlagEnabled } from "@/components/shared/Settings/useFlags";
 import { BASE_URL, IS_GITHUB_PAGES } from "@/utils/constants";
 
 import RootLayout from "../components/layout/RootLayout";
+import { DashboardComponentsView } from "./Dashboard/DashboardComponentsView";
 import { DashboardFavoritesView } from "./Dashboard/DashboardFavoritesView";
 import { DashboardHomeView } from "./Dashboard/DashboardHomeView";
 import { DashboardLayout } from "./Dashboard/DashboardLayout";
@@ -107,9 +108,6 @@ const dashboardIndexRoute = createRoute({
   component: DashboardHomeView,
 });
 
-// Placeholder component — replaced in subsequent PRs
-const ComingSoon = () => null;
-
 const dashboardRunsRoute = createRoute({
   getParentRoute: () => dashboardRoute,
   path: "/runs",
@@ -125,7 +123,7 @@ const dashboardPipelinesRoute = createRoute({
 const dashboardComponentsRoute = createRoute({
   getParentRoute: () => dashboardRoute,
   path: "/components",
-  component: ComingSoon,
+  component: DashboardComponentsView,
 });
 
 const dashboardFavoritesRoute = createRoute({


### PR DESCRIPTION
## Description

This PR implements a comprehensive components dashboard that allows users to browse, search, and view details for components from multiple sources. The dashboard includes a searchable component list with collapsible sections for user components, library components, and published components. When a component is selected, detailed information is displayed including metadata, inputs/outputs, and source code. Additionally, recently used components are now tracked and displayed on the dashboard home page.

Note: This is a foundational PR to build the component dashboard upon. Its not the final state, but its a shippable state.

## Type of Change

- [x] New feature

## Key Features

- **Component Browser**: Three-panel layout with search functionality and hierarchical component organization
- **Component Details**: Side-by-side view showing metadata, I/O specifications, and syntax-highlighted source code
- **Recently Used Tracking**: Components are automatically added to recently viewed when dropped onto the canvas
- **Multi-source Support**: Displays components from user library, static component library, and published components from the backend
- **Responsive Design**: Sticky positioning for source code panel and proper overflow handling

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

1. Navigate to the dashboard and verify the new "Recently Used Components" section appears
2. Go to the Components tab in the dashboard
3. Test searching for components across different sources
4. Select a component and verify the detail panel shows metadata, I/O specs, and source code
5. In the flow editor, drag and drop a component onto the canvas
6. Return to the dashboard and verify the component appears in the recently used section
7. Test the collapsible sections and folder navigation in the component list

## Additional Comments

The component tracking functionality integrates with the existing `useRecentlyViewed` hook and filters component entries separately from other dashboard items to maintain clean separation between different content types.  
  
  
![image.png](https://app.graphite.com/user-attachments/assets/d50eb9c6-6b1d-4fa8-9277-4529ce40a34e.png)![image.png](https://app.graphite.com/user-attachments/assets/943225ea-f3e0-4ce0-b09a-cbd937aacd8d.png)![image.png](https://app.graphite.com/user-attachments/assets/87d805f0-7d6c-4493-8639-03a712e2fe90.png)![image.png](https://app.graphite.com/user-attachments/assets/36b95ed4-93d5-41d8-8122-9526abe18a45.png)![image.png](https://app.graphite.com/user-attachments/assets/458e31ae-5615-4785-bd2d-63480176c485.png)





![image.png](https://app.graphite.com/user-attachments/assets/9521c908-43ba-4383-9381-69d70a3ed2af.png)





