### PR TITLE
chore: Improve Settings Page Exit UX

### DIFF
--- a/src/components/shared/Settings/Settings.tsx
+++ b/src/components/shared/Settings/Settings.tsx
@@ -12,7 +12,7 @@ interface SettingsProps {
 export function Settings({ settings, onChange }: SettingsProps) {
   return (
     <BlockStack gap="4">
-      <Paragraph weight="semibold">Settings</Paragraph>
+      <Paragraph weight="semibold">Preferences</Paragraph>
       {settings.length === 0 && <Paragraph>No settings available.</Paragraph>}
       {settings.map((setting) => (
         <Setting

--- a/src/routes/Settings/SettingsLayout.tsx
+++ b/src/routes/Settings/SettingsLayout.tsx
@@ -53,7 +53,7 @@ export function SettingsLayout() {
     <SettingsFlagsProvider>
       <div className="container mx-auto p-6 max-w-4xl">
         <BlockStack gap="6">
-          <InlineStack gap="3" blockAlign="center">
+          <InlineStack className="relative w-full">
             <Button
               variant="ghost"
               size="sm"
@@ -61,8 +61,14 @@ export function SettingsLayout() {
               data-testid="settings-back-button"
             >
               <Icon name="ArrowLeft" />
-              <Heading level={1}>Settings</Heading>
+              Back
             </Button>
+            <InlineStack
+              align="center"
+              className="absolute inset-0 pointer-events-none"
+            >
+              <Heading level={1}>Settings</Heading>
+            </InlineStack>
           </InlineStack>
 
           <InlineStack gap="8" blockAlign="start" className="w-full min-h-100">


### PR DESCRIPTION
## Description

As discussed earlier this week, the back button in the settings page is a little confusing given it also encompasses the page title. This PR moves the title to the centre and instead includes the text "back" for the back button. It also changes the section title of the "preferences" page.

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

before

![image.png](https://app.graphite.com/user-attachments/assets/bae97651-92b6-4c26-af1b-4a882dd37674.png)







after

![image.png](https://app.graphite.com/user-attachments/assets/eceef9c2-e80a-4d93-ad90-33d396d83714.png)





<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->