### PR TITLE
Default dashboard flag

### DIFF
--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -6,6 +6,7 @@ import {
   Outlet,
   redirect,
 } from "@tanstack/react-router";
+import { createElement } from "react";
 
 import { ErrorPage } from "@/components/shared/ErrorPage";
 import { AuthorizationResultScreen as GitHubAuthorizationResultScreen } from "@/components/shared/GitHubAuth/AuthorizationResultScreen";
@@ -47,15 +48,14 @@ export const RUNS_BASE_PATH = "/runs";
 export const QUICK_START_PATH = "/quick-start";
 const SETTINGS_PATH = "/settings";
 const IMPORT_PATH = "/app/editor/import-pipeline";
-const DASHBOARD_PATH = "/dashboard";
 export const APP_ROUTES = {
   HOME: "/",
-  DASHBOARD: DASHBOARD_PATH,
-  DASHBOARD_RUNS: `${DASHBOARD_PATH}/runs`,
-  DASHBOARD_PIPELINES: `${DASHBOARD_PATH}/pipelines`,
-  DASHBOARD_COMPONENTS: `${DASHBOARD_PATH}/components`,
-  DASHBOARD_FAVORITES: `${DASHBOARD_PATH}/favorites`,
-  DASHBOARD_RECENTLY_VIEWED: `${DASHBOARD_PATH}/recently-viewed`,
+  DASHBOARD: "/",
+  DASHBOARD_RUNS: "/runs",
+  DASHBOARD_PIPELINES: "/pipelines",
+  DASHBOARD_COMPONENTS: "/components",
+  DASHBOARD_FAVORITES: "/favorites",
+  DASHBOARD_RECENTLY_VIEWED: "/recently-viewed",
   QUICK_START: QUICK_START_PATH,
   IMPORT: IMPORT_PATH,
   PIPELINE_EDITOR: `${EDITOR_PATH}/$name`,
@@ -85,27 +85,25 @@ const mainLayout = createRoute({
   component: RootLayout,
 });
 
-const indexRoute = createRoute({
-  getParentRoute: () => mainLayout,
-  path: APP_ROUTES.HOME,
-  component: Home,
-});
-
+// Dashboard is a pathless layout — its children resolve to top-level paths
+// (/, /runs, /pipelines, etc.) without a /dashboard prefix.
+// When the dashboard flag is off, the layout is a passthrough and / renders Home.
 const dashboardRoute = createRoute({
+  id: "dashboard-layout",
   getParentRoute: () => mainLayout,
-  path: APP_ROUTES.DASHBOARD,
-  component: DashboardLayout,
-  beforeLoad: () => {
-    if (!isFlagEnabled("dashboard")) {
-      throw redirect({ to: APP_ROUTES.HOME });
-    }
-  },
+  component: () =>
+    isFlagEnabled("dashboard")
+      ? createElement(DashboardLayout)
+      : createElement(Outlet),
 });
 
 const dashboardIndexRoute = createRoute({
   getParentRoute: () => dashboardRoute,
   path: "/",
-  component: DashboardHomeView,
+  component: () =>
+    isFlagEnabled("dashboard")
+      ? createElement(DashboardHomeView)
+      : createElement(Home),
 });
 
 const dashboardRunsRoute = createRoute({
@@ -264,7 +262,6 @@ const dashboardRouteTree = dashboardRoute.addChildren([
 ]);
 
 const appRouteTree = mainLayout.addChildren([
-  indexRoute,
   dashboardRouteTree,
   quickStartRoute,
   settingsRouteTree,


### PR DESCRIPTION
## Description

This pull request enables the Dashboard feature by default and restructures the routing to make Dashboard the primary navigation experience. The Dashboard flag is now enabled by default, and all Dashboard routes have been moved to top-level paths (removing the `/dashboard` prefix). The routing logic has been updated to use a pathless layout pattern where the Dashboard layout wraps all routes when the flag is enabled, and falls back to the original Home component when disabled.

## Related Issue and Pull requests

## Type of Change

- [x] New feature
- [x] Breaking change

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Verify that the Dashboard is now the default homepage experience at `/`
2. Test navigation to all Dashboard sections using the new top-level paths:
   - `/` - Dashboard home
   - `/pipelines` - My Pipelines
   - `/runs` - All Runs
   - `/components` - Components
   - `/favorites` - Favorites
   - `/recently-viewed` - Recently Viewed
3. Verify that disabling the Dashboard flag falls back to the original Home component
4. Ensure all existing functionality within each section continues to work as expected

## Additional Comments

This is a breaking change as it modifies the URL structure for Dashboard routes. Users with bookmarks to `/dashboard/*` paths will need to update them to the new top-level paths.