### PR TITLE
fix: Replace standalone API_URL calls with BackendUrl

### DIFF
--- a/src/components/shared/GitHubAuth/tests/useGitHubAuthPopup.test.ts
+++ b/src/components/shared/GitHubAuth/tests/useGitHubAuthPopup.test.ts
@@ -13,9 +13,12 @@ import type { BackendAuthResponse } from "@/components/shared/Authentication/typ
 
 import { useGitHubAuthPopup } from "../useGitHubAuthPopup";
 
+vi.mock("@/providers/BackendProvider", () => ({
+  useBackend: () => ({ backendUrl: "https://api.example.com" }),
+}));
+
 vi.mock("@/utils/constants", async (importOriginal) => ({
   ...(await importOriginal()),
-  API_URL: "https://api.example.com",
   APP_ROUTES: {
     GITHUB_AUTH_CALLBACK: "/authorize/github",
   },
@@ -33,7 +36,6 @@ describe("useGitHubAuthPopup()", () => {
     vi.useFakeTimers();
 
     vi.stubEnv("VITE_GITHUB_CLIENT_ID", "test-client-id");
-    vi.stubEnv("VITE_BACKEND_API_URL", "https://api.example.com");
 
     // Mock popup window
     mockPopup = {
@@ -284,7 +286,7 @@ describe("useGitHubAuthPopup()", () => {
 
       expect(mockFetch).toHaveBeenCalledWith(
         expect.stringContaining(
-          "/api/auth/github/callback?code=test-code&state=",
+          "https://api.example.com/api/auth/github/callback?code=test-code&state=",
         ),
       );
       expect(mockOnSuccess).toHaveBeenCalledWith(mockResponse);

--- a/src/components/shared/GitHubAuth/useGitHubAuthPopup.ts
+++ b/src/components/shared/GitHubAuth/useGitHubAuthPopup.ts
@@ -1,8 +1,8 @@
 import { useEffect, useRef, useState } from "react";
 
 import type { BackendAuthResponse } from "@/components/shared/Authentication/types";
+import { useBackend } from "@/providers/BackendProvider";
 import { APP_ROUTES } from "@/routes/router";
-import { API_URL } from "@/utils/constants";
 
 const POPUP_WIDTH = 600;
 const POPUP_HEIGHT = 700;
@@ -32,13 +32,13 @@ function centerPopupOnDocument() {
   };
 }
 
-async function exchangeCodeForToken(code: string) {
+async function exchangeCodeForToken(code: string, backendUrl: string) {
   const state = crypto.randomUUID();
   const oauthExchangeRoute = "/api/auth/github/callback";
 
   const authRequestUrl = new URL(
-    `${API_URL}${oauthExchangeRoute}`,
-    window.location.origin,
+    oauthExchangeRoute,
+    backendUrl ?? window.location.origin,
   );
 
   authRequestUrl.searchParams.set("code", code);
@@ -64,6 +64,7 @@ export function useGitHubAuthPopup({
   onError,
   onClose,
 }: GithubAuthFlowPopupOptions) {
+  const { backendUrl } = useBackend();
   const [isPopupOpen, setIsPopupOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
 
@@ -134,7 +135,7 @@ export function useGitHubAuthPopup({
           }
 
           if (code) {
-            exchangeCodeForToken(code)
+            exchangeCodeForToken(code, backendUrl)
               .then((response) => {
                 onSuccess(response);
                 closePopup();

--- a/src/components/shared/HuggingFaceAuth/useHuggingFaceAuthPopup.ts
+++ b/src/components/shared/HuggingFaceAuth/useHuggingFaceAuthPopup.ts
@@ -7,7 +7,7 @@ import type {
   JWTPayload,
 } from "@/components/shared/Authentication/types";
 import { HOURS } from "@/components/shared/ComponentEditor/constants";
-import { API_URL } from "@/utils/constants";
+import { useBackend } from "@/providers/BackendProvider";
 import { getUserDetails } from "@/utils/user";
 
 import { HUGGING_FACE_DEFAULT_JWT } from "./constants";
@@ -15,10 +15,10 @@ import { HUGGING_FACE_DEFAULT_JWT } from "./constants";
 const POPUP_WIDTH = 600;
 const POPUP_HEIGHT = 700;
 
-function buildAuthUrl() {
+function buildAuthUrl(backendUrl: string) {
   const authUrl = new URL(
     "/api/oauth/huggingface/login",
-    !!API_URL && API_URL !== "" ? API_URL : window.location.origin,
+    backendUrl ?? window.location.origin,
   );
 
   // todo: build target url respecting router settings
@@ -43,6 +43,7 @@ export function useHuggingFaceAuthPopup({
   onClose,
 }: HuggingFaceAuthFlowPopupOptions) {
   const queryClient = useQueryClient();
+  const { backendUrl } = useBackend();
 
   const [isPopupOpen, setIsPopupOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
@@ -113,7 +114,7 @@ export function useHuggingFaceAuthPopup({
     const { left, top } = centerPopupOnDocument();
 
     window.open(
-      buildAuthUrl(),
+      buildAuthUrl(backendUrl),
       "huggingface-auth",
       `width=${POPUP_WIDTH},height=${POPUP_HEIGHT},left=${left},top=${top},scrollbars=yes,resizable=yes`,
     );

--- a/src/providers/BackendProvider.tsx
+++ b/src/providers/BackendProvider.tsx
@@ -6,6 +6,7 @@ import {
   useState,
 } from "react";
 
+import { client } from "@/api/client.gen";
 import useToastNotification from "@/hooks/useToastNotification";
 import { API_URL } from "@/utils/constants";
 import {
@@ -113,6 +114,10 @@ export const BackendProvider = ({ children }: { children: ReactNode }) => {
             else notify(`Backend unavailable: ${res.statusText}`, "error");
           }
           if (saveAvailability) setAvailable(res.ok);
+
+          if (res.ok) {
+            client.setConfig({ baseUrl: normalizedUrl });
+          }
 
           setReady(true);
 

--- a/src/providers/ComponentLibraryProvider/ComponentLibraryProvider.test.tsx
+++ b/src/providers/ComponentLibraryProvider/ComponentLibraryProvider.test.tsx
@@ -32,6 +32,10 @@ vi.mock("@/components/shared/Dialogs/ComponentDuplicateDialog", () => ({
 import { ComponentSpecProvider } from "../ComponentSpecProvider";
 import { ComponentLibraryProvider, useComponentLibrary } from ".";
 
+vi.mock("@/providers/BackendProvider", () => ({
+  useBackend: () => ({ backendUrl: "" }),
+}));
+
 // Mock all dependencies
 vi.mock("@/services/componentService");
 vi.mock("@/utils/componentStore");

--- a/src/providers/ComponentLibraryProvider/ComponentLibraryProvider.tsx
+++ b/src/providers/ComponentLibraryProvider/ComponentLibraryProvider.tsx
@@ -12,6 +12,7 @@ import ComponentDuplicateDialog from "@/components/shared/Dialogs/ComponentDupli
 import { GitHubFlatComponentLibrary } from "@/components/shared/GitHubLibrary/githubFlatComponentLibrary";
 import { isGitHubLibraryConfiguration } from "@/components/shared/GitHubLibrary/types";
 import { getComponentQueryKey } from "@/hooks/useHydrateComponentReference";
+import { useBackend } from "@/providers/BackendProvider";
 import {
   fetchAndStoreComponentLibrary,
   hydrateComponentReference,
@@ -121,6 +122,7 @@ registerLibraryFactory("github", (library) => {
 
 function useComponentLibraryRegistry() {
   const queryClient = useQueryClient();
+  const { backendUrl } = useBackend();
   const [existingComponentLibraries, setExistingComponentLibraries] = useState<
     StoredLibrary[]
   >([]);
@@ -128,12 +130,15 @@ function useComponentLibraryRegistry() {
   const componentLibraries = useMemo(
     () =>
       new Map<AvailableComponentLibraries, Library>([
-        ["published_components", new PublishedComponentsLibrary(queryClient)],
+        [
+          "published_components",
+          new PublishedComponentsLibrary(queryClient, backendUrl),
+        ],
         /**
          * In future we will have other library types,  including "standard_library", "favorite_components", "used_components", etc.
          */
       ]),
-    [queryClient],
+    [queryClient, backendUrl],
   );
 
   /**

--- a/src/providers/ComponentLibraryProvider/libraries/publishedComponentsLibrary.test.ts
+++ b/src/providers/ComponentLibraryProvider/libraries/publishedComponentsLibrary.test.ts
@@ -137,7 +137,10 @@ describe("PublishedComponentsLibrary", () => {
       },
     );
 
-    library = new PublishedComponentsLibrary(mockQueryClient);
+    library = new PublishedComponentsLibrary(
+      mockQueryClient,
+      "http://localhost:8000",
+    );
     vi.clearAllMocks();
 
     // Default fetch mock
@@ -726,7 +729,7 @@ describe("PublishedComponentsLibrary", () => {
       );
     });
 
-    it("should use API_URL for components without URL", async () => {
+    it("should use backendUrl for components without URL", async () => {
       // Arrange
       const publishedComponents = [
         createMockPublishedComponent({ url: undefined }),
@@ -743,8 +746,8 @@ describe("PublishedComponentsLibrary", () => {
 
       // Assert
       expect(result.components!).toHaveLength(1);
-      expect(result.components![0].url).toMatch(
-        /\/api\/components\/test-digest-123$/,
+      expect(result.components![0].url).toBe(
+        "http://localhost:8000/api/components/test-digest-123",
       );
     });
 

--- a/src/providers/ComponentLibraryProvider/libraries/publishedComponentsLibrary.ts
+++ b/src/providers/ComponentLibraryProvider/libraries/publishedComponentsLibrary.ts
@@ -18,7 +18,7 @@ import {
   isDiscoverableComponentReference,
 } from "@/utils/componentSpec";
 import type { ComponentReferenceWithSpec } from "@/utils/componentStore";
-import { API_URL, TWENTY_FOUR_HOURS_IN_MS } from "@/utils/constants";
+import { TWENTY_FOUR_HOURS_IN_MS } from "@/utils/constants";
 
 import { isValidFilterRequest, type LibraryFilterRequest } from "../types";
 import {
@@ -60,9 +60,11 @@ class BackendLibraryError extends Error {
 export class PublishedComponentsLibrary implements Library {
   #knownDigests: Set<string> = new Set();
   #queryClient: QueryClient;
+  #backendUrl: string;
 
-  constructor(queryClient: QueryClient) {
+  constructor(queryClient: QueryClient, backendUrl = "") {
     this.#queryClient = queryClient;
+    this.#backendUrl = backendUrl;
     // load known digests from storage
     // todo: prefetch components?
   }
@@ -242,7 +244,9 @@ export class PublishedComponentsLibrary implements Library {
         ({
           digest: component.digest,
           name: component.name,
-          url: component.url ?? `${API_URL}/api/components/${component.digest}`,
+          url:
+            component.url ??
+            `${this.#backendUrl}/api/components/${component.digest}`,
 
           published_by: component.published_by,
           superseded_by: component.superseded_by,


### PR DESCRIPTION
## Description

There were a few instances where we were still directly referencing `API_URL` rather than `BackendUrl` resulting in some confusion or disconnect when using a custom backend route.



This PR also changes the client api generation to dynamic use the backend url as well, which is configured when the BackendProvider loads.

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

Closes https://github.com/Shopify/oasis-frontend/issues/482

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

Confirm that the following still work:

- Published Component Library (load components)
- Github Auth
- Huggingface Auth

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->