### PR TITLE
fix: Do not visualize large artifacts & fix missing artifact uri

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/IONode/IONode.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/IONode/IONode.tsx
@@ -5,6 +5,7 @@ import { memo, useCallback, useEffect, useMemo } from "react";
 
 import { InputValueEditor } from "@/components/Editor/IOEditor/InputValueEditor";
 import { OutputNameEditor } from "@/components/Editor/IOEditor/OutputNameEditor";
+import type { OutputConnectedDetails } from "@/components/Editor/utils/getOutputConnectedDetails";
 import { getOutputConnectedDetails } from "@/components/Editor/utils/getOutputConnectedDetails";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
@@ -18,6 +19,7 @@ import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 import { useContextPanel } from "@/providers/ContextPanelProvider";
 import { useExecutionDataOptional } from "@/providers/ExecutionDataProvider";
 import { getExecutionArtifacts } from "@/services/executionService";
+import type { OutputSpec } from "@/utils/componentSpec";
 import { getArgumentValue } from "@/utils/nodes/taskArguments";
 import { isViewingSubgraph } from "@/utils/subgraphUtils";
 
@@ -48,12 +50,6 @@ const IONode = ({ id, type, data, selected = false }: IONodeProps) => {
   const executionData = useExecutionDataOptional();
   const taskArguments = executionData?.rootDetails?.task_spec.arguments;
   const rootExecutionId = executionData?.rootExecutionId;
-
-  const { data: artifacts } = useQuery({
-    queryKey: ["artifacts", rootExecutionId],
-    queryFn: () => getExecutionArtifacts(String(rootExecutionId), backendUrl),
-    enabled: !!rootExecutionId,
-  });
 
   const {
     setContent,
@@ -149,15 +145,14 @@ const IONode = ({ id, type, data, selected = false }: IONodeProps) => {
           output.name,
         );
 
-        const artifact = artifacts?.output_artifacts?.[output.name];
-
         setContent(
-          <OutputNameEditor
+          <OutputNodeContent
             output={output}
             connectedDetails={outputConnectedDetails}
             key={output.name}
             disabled={readOnly}
-            artifact={artifact}
+            rootExecutionId={rootExecutionId}
+            backendUrl={backendUrl}
           />,
         );
       }
@@ -271,3 +266,36 @@ const IONode = ({ id, type, data, selected = false }: IONodeProps) => {
 };
 
 export default memo(IONode);
+
+interface OutputNodeContentProps {
+  output: OutputSpec;
+  connectedDetails: OutputConnectedDetails;
+  disabled: boolean;
+  rootExecutionId: string | undefined;
+  backendUrl: string;
+}
+
+const OutputNodeContent = ({
+  output,
+  connectedDetails,
+  disabled,
+  rootExecutionId,
+  backendUrl,
+}: OutputNodeContentProps) => {
+  const { data: artifacts } = useQuery({
+    queryKey: ["artifacts", rootExecutionId],
+    queryFn: () => getExecutionArtifacts(String(rootExecutionId), backendUrl),
+    enabled: !!rootExecutionId,
+  });
+
+  const artifact = artifacts?.output_artifacts?.[output.name];
+
+  return (
+    <OutputNameEditor
+      output={output}
+      connectedDetails={connectedDetails}
+      disabled={disabled}
+      artifact={artifact}
+    />
+  );
+};

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/IOCell.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/IOCell.tsx
@@ -7,6 +7,8 @@ import { formatBytes } from "@/utils/string";
 import ArtifactURI from "./ArtifactURI";
 import ArtifactVisualizer from "./ArtifactVisualizer/ArtifactVisualizer";
 
+const MAX_VISUALIZABLE_SIZE_BYTES = 50 * 1024 * 1024; // 50 MB
+
 interface IOCellProps {
   name: string;
   type?: string;
@@ -18,6 +20,10 @@ const IOCell = ({ name, type, artifact }: IOCellProps) => {
   const inlineValue = artifactData?.value;
   const hasInlineValue = canShowInlineValue(inlineValue);
   const hasDetails = Boolean(artifactData?.uri || hasInlineValue);
+  const isTooLargeToVisualize =
+    !hasInlineValue &&
+    !!artifactData?.total_size &&
+    artifactData.total_size > MAX_VISUALIZABLE_SIZE_BYTES;
 
   const artifactType =
     type ?? artifact?.type_name ?? (artifactData?.is_dir ? "Directory" : "Any");
@@ -64,14 +70,17 @@ const IOCell = ({ name, type, artifact }: IOCellProps) => {
           </CopyText>
         )}
 
-        {!artifactData?.uri && artifact && hasDetails && (
-          <ArtifactVisualizer
-            artifact={artifact}
-            name={name}
-            type={type ?? "text"}
-            value={hasInlineValue ? inlineValue : undefined}
-          />
-        )}
+        {!artifactData?.uri &&
+          artifact &&
+          hasDetails &&
+          !isTooLargeToVisualize && (
+            <ArtifactVisualizer
+              artifact={artifact}
+              name={name}
+              type={type ?? "text"}
+              value={hasInlineValue ? inlineValue : undefined}
+            />
+          )}
       </InlineStack>
 
       {!!artifactData?.uri && (
@@ -83,7 +92,7 @@ const IOCell = ({ name, type, artifact }: IOCellProps) => {
         >
           <ArtifactURI uri={artifactData.uri} isDir={artifactData.is_dir} />
 
-          {artifact && hasDetails && (
+          {artifact && hasDetails && !isTooLargeToVisualize && (
             <ArtifactVisualizer
               artifact={artifact}
               name={name}
@@ -92,6 +101,12 @@ const IOCell = ({ name, type, artifact }: IOCellProps) => {
             />
           )}
         </InlineStack>
+      )}
+
+      {!hasDetails && (
+        <Text size="xs" tone="subdued">
+          No data available
+        </Text>
       )}
     </BlockStack>
   );


### PR DESCRIPTION
## Description

Artifacts over 50mb in size will not have a visualization option in the UI.



Also fixes a bug where you had to refresh the page to display newly created artifact URI & link on an output node.



Note: this does not address an issue where the artifact details will not update in real-time if you have the node or task selected and the execution completes. I couldn't find a quick & easy solution to this so I will address separately. For now you will have to remount the component be reselecting the task or node.

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->