### PR TITLE
fix: update artifacts in real-time

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/IONode/IONode.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/IONode/IONode.tsx
@@ -20,6 +20,10 @@ import { useContextPanel } from "@/providers/ContextPanelProvider";
 import { useExecutionDataOptional } from "@/providers/ExecutionDataProvider";
 import { getExecutionArtifacts } from "@/services/executionService";
 import type { OutputSpec } from "@/utils/componentSpec";
+import {
+  flattenExecutionStatusStats,
+  isExecutionComplete,
+} from "@/utils/executionStatus";
 import { getArgumentValue } from "@/utils/nodes/taskArguments";
 import { isViewingSubgraph } from "@/utils/subgraphUtils";
 
@@ -282,10 +286,18 @@ const OutputNodeContent = ({
   rootExecutionId,
   backendUrl,
 }: OutputNodeContentProps) => {
+  const executionData = useExecutionDataOptional();
+  const rootState = executionData?.rootState;
+
+  const rootStats = flattenExecutionStatusStats(
+    rootState?.child_execution_status_stats,
+  );
+  const executionDone = !rootState || isExecutionComplete(rootStats);
+
   const { data: artifacts } = useQuery({
     queryKey: ["artifacts", rootExecutionId],
     queryFn: () => getExecutionArtifacts(String(rootExecutionId), backendUrl),
-    enabled: !!rootExecutionId,
+    enabled: !!rootExecutionId && executionDone,
   });
 
   const artifact = artifacts?.output_artifacts?.[output.name];

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOSection.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOSection.tsx
@@ -10,6 +10,10 @@ import { getExecutionArtifacts } from "@/services/executionService";
 import { getBackendStatusString } from "@/utils/backend";
 import type { TaskSpec } from "@/utils/componentSpec";
 import { isOlderThanDays } from "@/utils/date";
+import {
+  flattenExecutionStatusStats,
+  isExecutionComplete,
+} from "@/utils/executionStatus";
 
 import IOExtras from "./IOExtras";
 import IOInputs from "./IOInputs";
@@ -23,7 +27,12 @@ interface IOSectionProps {
 
 const IOSection = ({ taskSpec, executionId, readOnly }: IOSectionProps) => {
   const { backendUrl, configured, available } = useBackend();
-  const { metadata } = useExecutionData();
+  const { metadata, rootState } = useExecutionData();
+
+  const rootStats = flattenExecutionStatusStats(
+    rootState?.child_execution_status_stats,
+  );
+  const executionDone = !rootState || isExecutionComplete(rootStats);
 
   const {
     data: artifacts,
@@ -33,7 +42,7 @@ const IOSection = ({ taskSpec, executionId, readOnly }: IOSectionProps) => {
   } = useQuery({
     queryKey: ["artifacts", executionId],
     queryFn: () => getExecutionArtifacts(String(executionId), backendUrl),
-    enabled: !!executionId,
+    enabled: !!executionId && executionDone,
   });
 
   if (!configured) {


### PR DESCRIPTION
## Description

At the moment if you have a taask or node selected and you're watching for artifacts as the execution finishes nothing will happened. You have to deselect and reselect the node for artifact details to appear.



This PR changes that by fetching the artifacts only when the execution has completed.

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->