### PR TITLE
Add telemetry for settings flags changes

### DIFF
--- a/src/routes/Settings/SettingsFlagsContext.tsx
+++ b/src/routes/Settings/SettingsFlagsContext.tsx
@@ -6,7 +6,11 @@ import {
   createRequiredContext,
   useRequiredContext,
 } from "@/hooks/useRequiredContext";
+import { useBackend } from "@/providers/BackendProvider";
 import type { Flag } from "@/types/configuration";
+import { fetchWithErrorHandling } from "@/utils/fetchWithErrorHandling";
+
+const USER_SETTINGS_URL = "/api/users/me/settings";
 
 interface SettingsFlagsContextValue {
   betaFlags: Flag[];
@@ -20,9 +24,21 @@ const SettingsFlagsContext = createRequiredContext<SettingsFlagsContextValue>(
 
 export function SettingsFlagsProvider({ children }: { children: ReactNode }) {
   const [flags, dispatch] = useFlagsReducer(ExistingFlags);
+  const { backendUrl, available } = useBackend();
 
   const handleSetFlag = (flag: string, enabled: boolean) => {
     dispatch({ type: "setFlag", payload: { key: flag, enabled } });
+
+    if (available) {
+      const url = new URL(USER_SETTINGS_URL, backendUrl);
+      fetchWithErrorHandling(url.toString(), {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ settings: { [`flag_${flag}`]: enabled } }),
+      }).catch(() => {
+        // fire-and-forget — telemetry only, never surface to user
+      });
+    }
   };
 
   const betaFlags = Object.values(flags).filter(


### PR DESCRIPTION
## Description

Added telemetry functionality to track user settings flag changes by sending PUT requests to the backend API when flags are toggled. The implementation uses a fire-and-forget approach where API failures are silently caught to ensure the telemetry doesn't impact user experience.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Navigate to the Settings page
2. Toggle any beta flags on/off
3. Verify that flag changes still work as expected in the UI
4. Check network tab to confirm PUT requests are sent to `/api/users/me/settings` with the correct payload format
5. Test with backend unavailable to ensure graceful degradation

## Additional Comments

The telemetry is implemented as fire-and-forget to avoid surfacing any API errors to users, as this is purely for tracking purposes and shouldn't interfere with the core functionality of toggling flags.