### PR TITLE
feat: Option to auto-delete empty pipelines

### DIFF
--- a/src/components/Editor/Context/RenamePipeline.tsx
+++ b/src/components/Editor/Context/RenamePipeline.tsx
@@ -9,6 +9,7 @@ import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 import { APP_ROUTES } from "@/routes/router";
 import { renameComponentFileInList } from "@/utils/componentStore";
 import { USER_PIPELINES_LIST_NAME } from "@/utils/constants";
+import { skipNextNavigationBlock } from "@/utils/skipNavigationBlock";
 import { tracking } from "@/utils/tracking";
 
 const RenamePipeline = () => {
@@ -44,6 +45,7 @@ const RenamePipeline = () => {
     const urlName = encodeURIComponent(name);
     const url = APP_ROUTES.PIPELINE_EDITOR.replace("$name", urlName);
 
+    skipNextNavigationBlock();
     navigate({ to: url });
   };
 

--- a/src/components/layout/AppMenu.tsx
+++ b/src/components/layout/AppMenu.tsx
@@ -57,11 +57,10 @@ const DefaultAppMenu = () => {
     >
       <InlineStack align="space-between" wrap="nowrap">
         <InlineStack gap="8" wrap="nowrap" className="min-w-0 flex-1">
-          <Link
-            href="/"
+          <RouterLink
+            to="/"
             aria-label="Home"
-            variant="block"
-            className="shrink-0"
+            className="shrink-0 inline-flex"
             {...tracking("header.logo")}
           >
             <img
@@ -69,7 +68,7 @@ const DefaultAppMenu = () => {
               alt="logo"
               className="h-8 filter cursor-pointer shrink-0"
             />
-          </Link>
+          </RouterLink>
 
           {title && (
             <CopyText className="text-white text-md font-bold truncate max-w-32 sm:max-w-48 md:max-w-64 lg:max-w-md">

--- a/src/components/layout/RootLayout.tsx
+++ b/src/components/layout/RootLayout.tsx
@@ -1,5 +1,6 @@
 import { Outlet } from "@tanstack/react-router";
 import { TanStackRouterDevtools } from "@tanstack/router-devtools";
+import { useEffect } from "react";
 import { ToastContainer } from "react-toastify";
 
 import { useClickTracking } from "@/hooks/useClickTracking";
@@ -9,6 +10,7 @@ import { AnalyticsProvider } from "@/providers/AnalyticsProvider";
 import { BackendProvider } from "@/providers/BackendProvider";
 import { ComponentSpecProvider } from "@/providers/ComponentSpecProvider";
 import { PipelineStorageProvider } from "@/services/pipelineStorage/PipelineStorageProvider";
+import { processPendingDeletions } from "@/utils/deletePipelineCleanup";
 
 import AppMenu from "./AppMenu";
 
@@ -41,6 +43,11 @@ function RootLayoutContent() {
 
 const RootLayout = () => {
   useDocumentTitle();
+
+  useEffect(() => {
+    void processPendingDeletions();
+  }, []);
+
   return (
     <AnalyticsProvider>
       <RootLayoutContent />

--- a/src/components/shared/Dialogs/ConfirmationDialog.tsx
+++ b/src/components/shared/Dialogs/ConfirmationDialog.tsx
@@ -1,3 +1,4 @@
+import type { VariantProps } from "class-variance-authority";
 import { type MouseEvent, type ReactNode, useCallback } from "react";
 
 import {
@@ -11,11 +12,20 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
+import { Button, buttonVariants } from "@/components/ui/button";
+
+type SecondaryAction = {
+  label: string;
+  onClick: () => void;
+  variant: VariantProps<typeof buttonVariants>["variant"];
+};
 
 type ConfirmationDialogProps = {
   title?: string;
   description?: string;
   content?: ReactNode;
+  destructive?: boolean;
+  secondaryAction?: SecondaryAction;
   onConfirm: () => void;
   onCancel?: () => void;
 } & (
@@ -31,6 +41,8 @@ const ConfirmationDialog = ({
   title = defaultTitle,
   description = defaultDescription,
   content,
+  destructive = false,
+  secondaryAction,
   isOpen,
   onConfirm,
   onCancel = () => {},
@@ -55,6 +67,14 @@ const ConfirmationDialog = ({
     [onCancel],
   );
 
+  const handleSecondaryAction = useCallback(
+    (e: MouseEvent) => {
+      e.stopPropagation();
+      secondaryAction?.onClick();
+    },
+    [secondaryAction],
+  );
+
   return (
     <AlertDialog open={isOpen}>
       {trigger && (
@@ -74,8 +94,24 @@ const ConfirmationDialog = ({
         {content}
         <AlertDialogFooter>
           <AlertDialogCancel onClick={handleCancel}>Cancel</AlertDialogCancel>
-          <AlertDialogAction onClick={handleConfirm} autoFocus>
-            Continue
+          {secondaryAction && (
+            <Button
+              variant={secondaryAction.variant ?? "outline"}
+              onClick={handleSecondaryAction}
+            >
+              {secondaryAction.label}
+            </Button>
+          )}
+          <AlertDialogAction
+            onClick={handleConfirm}
+            autoFocus
+            className={
+              destructive
+                ? buttonVariants({ variant: "destructive" })
+                : undefined
+            }
+          >
+            {destructive ? "Delete" : "Continue"}
           </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>

--- a/src/components/shared/NewPipelineButton.tsx
+++ b/src/components/shared/NewPipelineButton.tsx
@@ -7,7 +7,6 @@ import { EDITOR_PATH } from "@/routes/router";
 import { writeComponentToFileListFromText } from "@/utils/componentStore";
 import {
   defaultPipelineYamlWithName,
-  IS_GITHUB_PAGES,
   USER_PIPELINES_LIST_NAME,
 } from "@/utils/constants";
 
@@ -39,10 +38,7 @@ const NewPipelineButton = ({
       return;
     }
 
-    navigate({
-      to: clickThroughUrl,
-      reloadDocument: !IS_GITHUB_PAGES,
-    });
+    navigate({ to: clickThroughUrl });
   };
 
   return (

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -31,6 +31,14 @@ export const ExistingFlags: ConfigFlags = {
     category: "setting",
   },
 
+  ["auto-delete-empty-pipelines"]: {
+    name: "Auto-delete empty pipelines",
+    description:
+      "Delete empty pipelines automatically when you navigate away from the editor.",
+    default: true,
+    category: "setting",
+  },
+
   ["templatized-pipeline-run-name"]: {
     name: "Templatized pipeline run name",
     description:

--- a/src/routes/Editor/Editor.tsx
+++ b/src/routes/Editor/Editor.tsx
@@ -1,19 +1,29 @@
 import "@/styles/editor.css";
 
 import { DndContext } from "@dnd-kit/core";
+import { useBlocker } from "@tanstack/react-router";
 import { ReactFlowProvider } from "@xyflow/react";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 import PipelineEditor from "@/components/Editor/PipelineEditor";
+import ConfirmationDialog from "@/components/shared/Dialogs/ConfirmationDialog";
 import { InfoBox } from "@/components/shared/InfoBox";
 import { LoadingScreen } from "@/components/shared/LoadingScreen";
+import { getFlexNodeAnnotations } from "@/components/shared/ReactFlow/FlowCanvas/FlexNode/interface";
+import { isFlagEnabled } from "@/components/shared/Settings/useFlags";
 import { BlockStack } from "@/components/ui/layout";
 import { Paragraph } from "@/components/ui/typography";
 import { useLoadComponentSpecFromPath } from "@/hooks/useLoadComponentSpecFromPath";
 import { addRecentlyViewed } from "@/hooks/useRecentlyViewed";
+import { useComponentSpec } from "@/providers/ComponentSpecProvider";
+import { deletePipeline } from "@/services/pipelineService";
+import { markPipelineForDeletion } from "@/utils/deletePipelineCleanup";
+import { consumeSkipNavigationBlock } from "@/utils/skipNavigationBlock";
 
 const Editor = () => {
   const { componentSpec, error } = useLoadComponentSpecFromPath();
+  const { graphSpec } = useComponentSpec();
+
   useEffect(() => {
     if (!componentSpec?.name) return;
     addRecentlyViewed({
@@ -22,6 +32,60 @@ const Editor = () => {
       name: componentSpec.name,
     });
   }, [componentSpec?.name]);
+
+  const shouldBlockRef = useRef(false);
+  const nameRef = useRef(componentSpec?.name);
+  nameRef.current = componentSpec?.name;
+
+  const isModifiedRef = useRef(false);
+  if (componentSpec) {
+    isModifiedRef.current =
+      Boolean(componentSpec.description) ||
+      Object.keys(componentSpec.metadata?.annotations ?? {}).some(
+        (k) => k !== "sdk" && k !== "editor.flow-direction",
+      );
+  }
+
+  const isPipelineEmpty =
+    !Object.keys(graphSpec.tasks ?? {}).length &&
+    !Object.keys(graphSpec.outputValues ?? {}).length &&
+    !componentSpec?.inputs?.length &&
+    !componentSpec?.outputs?.length &&
+    !(componentSpec && getFlexNodeAnnotations(componentSpec).length);
+
+  shouldBlockRef.current =
+    Boolean(componentSpec?.name) &&
+    isFlagEnabled("auto-delete-empty-pipelines") &&
+    isPipelineEmpty;
+
+  const blocker = useBlocker({
+    shouldBlockFn: ({ next }) => {
+      if (!shouldBlockRef.current) return false;
+      if (next.pathname.startsWith("/settings")) return false;
+      if (consumeSkipNavigationBlock()) return false;
+      return true;
+    },
+    enableBeforeUnload: false,
+    withResolver: true,
+  });
+
+  useEffect(() => {
+    if (blocker.status !== "blocked") return;
+    if (isModifiedRef.current) return;
+    const name = nameRef.current;
+    if (name) void deletePipeline(name);
+    blocker.proceed();
+  }, [blocker.status]);
+
+  useEffect(() => {
+    const handleBeforeUnload = () => {
+      if (!shouldBlockRef.current) return;
+      const name = nameRef.current;
+      if (name) markPipelineForDeletion(name);
+    };
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => window.removeEventListener("beforeunload", handleBeforeUnload);
+  }, []);
 
   if (error) {
     return (
@@ -42,11 +106,31 @@ const Editor = () => {
   }
 
   return (
-    <DndContext>
-      <ReactFlowProvider>
-        <PipelineEditor />
-      </ReactFlowProvider>
-    </DndContext>
+    <>
+      <DndContext>
+        <ReactFlowProvider>
+          <PipelineEditor />
+        </ReactFlowProvider>
+      </DndContext>
+
+      <ConfirmationDialog
+        isOpen={blocker.status === "blocked" && isModifiedRef.current}
+        title="Delete empty pipeline?"
+        description="This pipeline has been modified but is still empty."
+        destructive
+        secondaryAction={{
+          label: "Keep Pipeline",
+          onClick: () => blocker.proceed?.(),
+          variant: "default",
+        }}
+        onConfirm={() => {
+          const name = nameRef.current;
+          if (name) void deletePipeline(name);
+          blocker.proceed?.();
+        }}
+        onCancel={() => blocker.reset?.()}
+      />
+    </>
   );
 };
 

--- a/src/utils/deletePipelineCleanup.ts
+++ b/src/utils/deletePipelineCleanup.ts
@@ -1,0 +1,32 @@
+import { isFlagEnabled } from "@/components/shared/Settings/useFlags";
+import { deletePipeline } from "@/services/pipelineService";
+
+const KEY_PREFIX = "tangle:deletePipeline:";
+
+export const markPipelineForDeletion = (name: string) => {
+  localStorage.setItem(KEY_PREFIX + name, "1");
+};
+
+// Deletes pipelines marked during a previous page load (from Editor's beforeunload handler).
+// Skips any pipeline whose editor URL matches the current URL — that means the user refreshed.
+export const processPendingDeletions = async () => {
+  if (!isFlagEnabled("auto-delete-empty-pipelines")) return;
+
+  const currentPath = window.location.pathname + window.location.hash;
+  const keys: string[] = [];
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    if (key?.startsWith(KEY_PREFIX)) keys.push(key);
+  }
+  for (const key of keys) {
+    const name = key.slice(KEY_PREFIX.length);
+    const editorPath = `/editor/${encodeURIComponent(name)}`;
+    if (currentPath === editorPath || currentPath.endsWith(`#${editorPath}`)) {
+      // User refreshed or navigated back — clear the mark but keep the pipeline.
+      localStorage.removeItem(key);
+      continue;
+    }
+    localStorage.removeItem(key);
+    await deletePipeline(name);
+  }
+};

--- a/src/utils/skipNavigationBlock.ts
+++ b/src/utils/skipNavigationBlock.ts
@@ -1,0 +1,11 @@
+let pending = false;
+
+export const skipNextNavigationBlock = () => {
+  pending = true;
+};
+
+export const consumeSkipNavigationBlock = () => {
+  const was = pending;
+  pending = false;
+  return was;
+};

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -323,6 +323,31 @@ export async function setBetaFlag(
 }
 
 /**
+ * Sets a beta flag directly in localStorage without navigating to the settings page.
+ * Use this instead of setBetaFlag when calling from inside the editor, to avoid
+ * triggering beforeunload (which would mark an empty pipeline for auto-deletion).
+ * @param page - Playwright page object
+ * @param flagKey - The flag key as defined in flags.ts
+ * @param enabled - Whether the flag should be enabled or disabled
+ */
+export async function setFlagDirectly(
+  page: Page,
+  flagKey: string,
+  enabled: boolean,
+): Promise<void> {
+  await page.evaluate(
+    ({ key, value }) => {
+      const betaFlags = JSON.parse(
+        localStorage.getItem("betaFlags") ?? "{}",
+      ) as Record<string, boolean>;
+      betaFlags[key] = value;
+      localStorage.setItem("betaFlags", JSON.stringify(betaFlags));
+    },
+    { key: flagKey, value: enabled },
+  );
+}
+
+/**
  * Secrets Management Helpers
  */
 

--- a/tests/e2e/published-componentlib.spec.ts
+++ b/tests/e2e/published-componentlib.spec.ts
@@ -10,7 +10,7 @@ import {
   locateFolderByName,
   openComponentLibFolder,
   removeComponentFromCanvas,
-  setBetaFlag,
+  setFlagDirectly,
 } from "./helpers";
 
 /**
@@ -26,10 +26,9 @@ test.describe("Published Component Library", () => {
 
   test.beforeAll(async ({ browser }) => {
     page = await browser.newPage();
-
+    await page.goto("/");
+    await setFlagDirectly(page, "remote-component-library-search", true);
     await createNewPipeline(page);
-    await setBetaFlag(page, "remote-component-library-search", true);
-    await page.goBack();
 
     await expect(page.locator("[data-testid='search-input']")).toBeVisible();
   });

--- a/tests/e2e/secrets-in-arguments.spec.ts
+++ b/tests/e2e/secrets-in-arguments.spec.ts
@@ -7,6 +7,7 @@ import {
   locateFlowCanvas,
   navigateToSecretsList,
   removeSecret,
+  setFlagDirectly,
   waitForContextPanel,
 } from "./helpers";
 
@@ -27,6 +28,8 @@ test.describe("Secrets in Component Arguments", () => {
 
   test.beforeAll(async ({ browser }) => {
     page = await browser.newPage();
+    await page.goto("/");
+    await setFlagDirectly(page, "auto-delete-empty-pipelines", false);
     await createNewPipeline(page);
     editorUrl = page.url();
   });


### PR DESCRIPTION
## Description

Adds a preference setting to automatically delete empty pipelines when the user navigates away from them.

This is a quality of life improvement for when someone clicks "new pipeline" and then decides they didn't actually want a new pipeline. Or if they choose to delete everything in a pipeline it will just go away. Essentially, this PR is trying to avoid the user's pipeline list of getting filled up with empty pipelines.

Arguably this should be default behaviour, but I decided to make it a setting for now so people can opt-out. We can make it default behaviour in future if we think it's appropriate.

The conditions for a pipeline to be autodeleted are:

- Must have autodelete setting active
- Pipeline must have no tasks, inputs or outputs, or sticky notes
- Must be navigating away from the pipeline editor (i.e. refreshing the page will not process the deletion) - exception: settings page

The user will be prompted for confirmation prior to autodeletion if the above conditions are true AND:

- The pipeline has been edited in some (e.g. updated metadata)
- Or, the pipeline has undo/redo history

Otherwise, the pipeline will be silently removed.

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

![image.png](https://app.graphite.com/user-attachments/assets/94fb3923-e8d8-4d36-b611-ce86869957d1.png)

![image.png](https://app.graphite.com/user-attachments/assets/f3673a91-3954-49a5-9524-35ef401773d1.png)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

1. turn on the setting in settings>preferences
2. create a new pipeline via the top nav's "New Pipeline" button
3. navigate away from it
4. confirm that it has been auto deleted

create new empty pipelines and confirm:

1. adding a node to the pipeline does not auto delete
2. editing metadata to the pipeline (canvas still empty) prompts for confirmation prior to deletion
3. refreshing the page does not auto delete
4. navigating to `/settings` does not auto delete, and the pipeline can be returned to with the "back" button
5. creating a new a pipeline while an empty one is open will delete (or ask for confirmation, if appropriate)

take an existing pipeline with nodes and data and confirm that removing all the nodes and then navigating away triggers a delete confirmation

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

This is not my preferred long-term solution. In the long term we should look to have "draft state" pipelines and/or temporary storage for new pipelines.

A comment on the code:

The auto-delete feature requires two complementary mechanisms because navigations come in two fundamentally different forms:

**SPA navigation** (clicking the logo, back button, New Pipeline, etc.) goes through TanStack Router. `useBlocker` intercepts it synchronously before the route changes, allowing us to either silently delete or show a confirmation dialog before proceeding.

**Full-page unloads** (browser refresh, or any navigation that triggers `beforeunload`) bypass the router entirely. The browser gives no opportunity to show a custom dialog or perform async work at this point. Instead, `Editor` marks the pipeline for deletion in `localStorage` during `beforeunload`, and `processPendingDeletions` runs on the next app load to carry out the deletion — skipping it if the current URL is the same pipeline (i.e. the user just refreshed).

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->