### PR TITLE
fix: add syntax highlighting to text visualization

### DIFF
--- a/src/components/shared/CodeViewer/CodeEditor.tsx
+++ b/src/components/shared/CodeViewer/CodeEditor.tsx
@@ -3,22 +3,24 @@ import MonacoEditor from "@monaco-editor/react";
 interface CodeEditorProps {
   value: string;
   language: string;
-  onChange: (value: string) => void;
+  onChange?: (value: string) => void;
+  readOnly?: boolean;
 }
 
-function CodeEditor({ value, language, onChange }: CodeEditorProps) {
+function CodeEditor({ value, language, onChange, readOnly }: CodeEditorProps) {
   return (
     <MonacoEditor
       language={language}
       theme="vs-dark"
       value={value}
-      onChange={(v) => onChange(v ?? "")}
+      onChange={(v) => onChange?.(v ?? "")}
       options={{
         minimap: { enabled: false },
         scrollBeyondLastLine: false,
         lineNumbers: "on",
         wordWrap: "on",
         automaticLayout: true,
+        readOnly,
       }}
     />
   );

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ArtifactVisualizer.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ArtifactVisualizer.tsx
@@ -175,7 +175,7 @@ const InlineContent = ({
       return <JsonVisualizerValue value={value} name={name} />;
     case "text":
     default:
-      return <TextVisualizerValue value={value} />;
+      return <TextVisualizerValue value={value} isFullscreen={isFullscreen} />;
   }
 };
 
@@ -206,7 +206,12 @@ const PreviewContent = ({
 
   switch (type) {
     case "text":
-      return <TextVisualizerRemote signedUrl={signedUrl} />;
+      return (
+        <TextVisualizerRemote
+          signedUrl={signedUrl}
+          isFullscreen={isFullscreen}
+        />
+      );
     case "image":
       return <ImageVisualizer src={signedUrl} name={name} />;
     case "csv":

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/TextVisualizer.test.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/TextVisualizer.test.tsx
@@ -6,6 +6,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { TextVisualizerRemote, TextVisualizerValue } from "./TextVisualizer";
 
+vi.mock("@/components/shared/CodeViewer/CodeEditor", () => ({
+  default: ({ value }: { value: string }) => (
+    <pre data-testid="code-editor">{value}</pre>
+  ),
+}));
+
 const queryClient = new QueryClient({
   defaultOptions: { queries: { retry: false } },
 });
@@ -35,9 +41,19 @@ beforeEach(() => {
 });
 
 describe("TextVisualizerValue", () => {
-  it("renders the value directly", () => {
+  it("renders the value in the code editor", () => {
     renderWithQuery(<TextVisualizerValue value="Hello world" />);
-    expect(screen.getByText("Hello world")).toBeInTheDocument();
+    expect(screen.getByTestId("code-editor")).toHaveTextContent("Hello world");
+  });
+
+  it("renders the language selector", () => {
+    renderWithQuery(<TextVisualizerValue value="Hello world" />);
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+  });
+
+  it("renders 'No data' for empty value", () => {
+    renderWithQuery(<TextVisualizerValue value="" />);
+    expect(screen.getByText("No data")).toBeInTheDocument();
   });
 
   it("does not fetch", () => {
@@ -60,7 +76,9 @@ describe("TextVisualizerRemote", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText("Remote content")).toBeInTheDocument();
+      expect(screen.getByTestId("code-editor")).toHaveTextContent(
+        "Remote content",
+      );
     });
 
     vi.restoreAllMocks();

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/TextVisualizer.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/TextVisualizer.tsx
@@ -1,17 +1,44 @@
-import { BlockStack } from "@/components/ui/layout";
-import { Paragraph, Text } from "@/components/ui/typography";
+import { useState } from "react";
+
+import CodeEditor from "@/components/shared/CodeViewer/CodeEditor";
+import { InlineStack } from "@/components/ui/layout";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Paragraph } from "@/components/ui/typography";
+import {
+  detectLanguage,
+  isLanguageOption,
+  LANGUAGE_OPTIONS,
+} from "@/utils/detectLanguage";
 
 import { useArtifactFetch } from "./useArtifactFetch";
 
 interface TextVisualizerValueProps {
   value: string;
+  isFullscreen?: boolean;
 }
 
 interface TextVisualizerRemoteProps {
   signedUrl: string;
+  isFullscreen?: boolean;
 }
 
-const TextContent = ({ content }: { content: string }) => {
+const TextContent = ({
+  content,
+  isFullscreen,
+}: {
+  content: string;
+  isFullscreen?: boolean;
+}) => {
+  const [selectedLanguage, setSelectedLanguage] = useState(() =>
+    detectLanguage(content),
+  );
+
   if (content.length === 0) {
     return (
       <Paragraph tone="subdued" size="xs">
@@ -21,19 +48,44 @@ const TextContent = ({ content }: { content: string }) => {
   }
 
   return (
-    <BlockStack className="flex-1 min-h-0 min-w-0 overflow-y-auto wrap-anywhere">
-      <Text size="sm">{content}</Text>
-    </BlockStack>
+    <div className="flex flex-col h-full gap-2">
+      <InlineStack>
+        <Select
+          value={selectedLanguage}
+          onValueChange={(v) => {
+            if (isLanguageOption(v)) setSelectedLanguage(v);
+          }}
+        >
+          <SelectTrigger className="w-40">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {LANGUAGE_OPTIONS.map((opt) => (
+              <SelectItem key={opt.value} value={opt.value}>
+                {opt.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </InlineStack>
+      <div className={isFullscreen ? "flex-1 min-h-0" : "h-64"}>
+        <CodeEditor value={content} language={selectedLanguage} readOnly />
+      </div>
+    </div>
   );
 };
 
-export const TextVisualizerValue = ({ value }: TextVisualizerValueProps) => (
-  <TextContent content={value} />
+export const TextVisualizerValue = ({
+  value,
+  isFullscreen,
+}: TextVisualizerValueProps) => (
+  <TextContent content={value} isFullscreen={isFullscreen} />
 );
 
 export const TextVisualizerRemote = ({
   signedUrl,
+  isFullscreen,
 }: TextVisualizerRemoteProps) => {
   const content = useArtifactFetch("text", signedUrl, (r) => r.text());
-  return <TextContent content={content} />;
+  return <TextContent content={content} isFullscreen={isFullscreen} />;
 };


### PR DESCRIPTION
## Description

Adds the multilineeditor's syntax highlighter to TextVisualizer, allowing text artifacts to be properly formatted and have syntax highlighting.

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

before

![image.png](https://app.graphite.com/user-attachments/assets/9039d7db-e76e-4c86-82e3-0ff83f651a3e.png)

after

![image.png](https://app.graphite.com/user-attachments/assets/fc968162-4e09-4a78-bca8-280473d7b10d.png)



<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->