### PR TITLE
chore: Have component editor update preview instantly (no loading spinner)

### DIFF
--- a/src/components/shared/ComponentEditor/components/PreviewTaskNodeCard.tsx
+++ b/src/components/shared/ComponentEditor/components/PreviewTaskNodeCard.tsx
@@ -1,25 +1,46 @@
+import { QueryErrorResetBoundary } from "@tanstack/react-query";
+import { Suspense, useRef } from "react";
+import { ErrorBoundary } from "react-error-boundary";
+
 import { Skeleton } from "@/components/ui/skeleton";
 import { TaskNodeProvider } from "@/providers/TaskNodeProvider";
+import type { TaskNodeData } from "@/types/taskNode";
 
 import { TaskNodeCard } from "../../ReactFlow/FlowCanvas/TaskNode/TaskNodeCard";
-import { withSuspenseWrapper } from "../../SuspenseWrapper";
 import { usePreviewTaskNodeData } from "../usePreviewTaskNodeData";
 import { PointersEventBlock } from "./PointersEventBlock";
 
-export const PreviewTaskNodeCard = withSuspenseWrapper(
-  ({ componentText }: { componentText: string }) => {
-    const previewNodeData = usePreviewTaskNodeData(componentText);
+export const PreviewTaskNodeCard = ({
+  componentText,
+}: {
+  componentText: string;
+}) => {
+  const previewNodeData = usePreviewTaskNodeData(componentText);
+  const lastValidDataRef = useRef<TaskNodeData | null>(null);
 
-    if (!previewNodeData) {
-      return <Skeleton size="lg" shape="square" />;
-    }
+  if (previewNodeData) {
+    lastValidDataRef.current = previewNodeData;
+  }
 
-    return (
-      <PointersEventBlock>
-        <TaskNodeProvider data={previewNodeData} selected={false}>
-          <TaskNodeCard />
-        </TaskNodeProvider>
-      </PointersEventBlock>
-    );
-  },
-);
+  const displayData = previewNodeData || lastValidDataRef.current;
+
+  if (!displayData) {
+    return <Skeleton size="lg" shape="square" />;
+  }
+
+  return (
+    <QueryErrorResetBoundary>
+      {({ reset }) => (
+        <ErrorBoundary onReset={reset} fallbackRender={() => null}>
+          <Suspense fallback={null}>
+            <PointersEventBlock>
+              <TaskNodeProvider data={displayData} selected={false}>
+                <TaskNodeCard />
+              </TaskNodeProvider>
+            </PointersEventBlock>
+          </Suspense>
+        </ErrorBoundary>
+      )}
+    </QueryErrorResetBoundary>
+  );
+};

--- a/src/components/shared/ComponentEditor/usePreviewTaskNodeData.tsx
+++ b/src/components/shared/ComponentEditor/usePreviewTaskNodeData.tsx
@@ -1,34 +1,41 @@
-import { useQuery } from "@tanstack/react-query";
+import { useQueryClient } from "@tanstack/react-query";
 
-import { hydrateComponentReference } from "@/services/componentService";
 import type { TaskNodeData } from "@/types/taskNode";
 import type { HydratedComponentReference } from "@/utils/componentSpec";
 import { generateTaskSpec } from "@/utils/nodes/generateTaskSpec";
+import { componentSpecFromYaml } from "@/utils/yaml";
 
-export const usePreviewTaskNodeData = (componentText: string) => {
-  const { data: componentRef, isLoading } = useQuery({
-    queryKey: ["componentRef", componentText],
-    queryFn: async () => {
-      const ref = await hydrateComponentReference({ text: componentText });
-      if (!ref) return false;
+export const usePreviewTaskNodeData = (
+  componentText: string,
+): TaskNodeData | false => {
+  const queryClient = useQueryClient();
 
-      return generatePreviewTaskNodeData(ref);
-    },
-  });
+  try {
+    const spec = componentSpecFromYaml(componentText);
+    const name = spec.name ?? "component-preview";
 
-  return isLoading ? false : componentRef;
-};
+    const digest = `preview:${name}`;
 
-const generatePreviewTaskNodeData = (
-  componentRef: HydratedComponentReference,
-): TaskNodeData => {
-  const previewTaskId = `preview-${componentRef.name}`;
-  const taskSpec = generateTaskSpec(componentRef);
+    const componentRef: HydratedComponentReference = {
+      text: componentText,
+      spec,
+      name,
+      digest,
+    };
 
-  return {
-    taskSpec,
-    taskId: previewTaskId,
-    isGhost: false,
-    readOnly: true,
-  };
+    queryClient.setQueryData(
+      ["component", "hydrate", `digest:${digest}`],
+      componentRef,
+    );
+
+    const taskSpec = generateTaskSpec(componentRef);
+    return {
+      taskSpec,
+      taskId: `preview-${name}`,
+      isGhost: false,
+      readOnly: true,
+    };
+  } catch {
+    return false;
+  }
 };


### PR DESCRIPTION
## What changed and why

### Problem

Every keystroke in the component editor caused the preview card on the right to briefly
disappear and show a loading spinner. The root cause was a chain of async operations
triggered on each render:

1. `usePreviewTaskNodeData` used `useQuery` with `componentText` in the query key →
new key on every keystroke → async hydration → `isLoading: true` → skeleton shown.
2. Even after fixing that, `TaskNodeProvider` (which `PreviewTaskNodeCard` renders) calls
`useHydrateComponentReference` internally — a `useSuspenseQuery` — so it would suspend
again whenever its query key changed.
3. `PreviewTaskNodeCard` previously used `withSuspenseWrapper`, whose default fallback is
`<Spinner />`, so any suspension showed a spinner.

---

### `usePreviewTaskNodeData.tsx`

**Before:** wrapped everything in `useQuery` (async). New query key per keystroke → async
re-fetch → loading state on every valid character typed.

**After:** runs synchronously during render. Two key ideas:

- **Synchronous YAML parse** — `componentSpecFromYaml` is called directly (no async).
The result is returned immediately, so there's no loading state.
- **Stable synthetic digest** — instead of using `componentText` as the React Query cache
key, we use `"preview:<component-name>"`. The name rarely changes while you're editing
the body, so the cache key stays constant across keystrokes. This prevents
`useHydrateComponentReference` (inside `TaskNodeProvider`) from ever seeing a new query
key and suspending.
- **Cache pre-population** — `queryClient.setQueryData(["component", "hydrate", "digest:preview:<name>"], componentRef)` is called synchronously during the parent
render, before `TaskNodeProvider` mounts. When `TaskNodeProvider`'s `useSuspenseQuery`
executes, the data is already in cache, so it returns immediately without suspending.

**Safety:** `setQueryData` called during render is unconventional but intentional —
`useMemo` (now removed in favour of React Compiler auto-memoization) ran top-down before
children, which is the same guarantee we have here. The cache key is namespaced
`"preview:<name>"` and will never collide with real component digests (real digests are
SHA-256 hex strings). The entry is overwritten on every valid edit, which is correct.
This only affects `PreviewTaskNodeCard`'s render path; no other component reads this key.

---

### `PreviewTaskNodeCard.tsx`

**Before:** used `withSuspenseWrapper`, which wraps in `QueryErrorResetBoundary → ErrorBoundary → Suspense` with a `<Spinner />` fallback. Any suspension anywhere in the
subtree showed a spinner.

**After:** three changes:

- **`lastValidDataRef`** — stores the last successfully parsed `TaskNodeData`. If the
user types something that produces invalid YAML (e.g. mid-edit), `usePreviewTaskNodeData`
returns `false`, and we fall back to the last valid data instead of unmounting the card.
Only on the very first render with no valid data yet does it show `<Skeleton>`.
- **`Suspense fallback={null}`** **\+** **`ErrorBoundary fallbackRender={() => null}`** — replaced
the spinner-showing `withSuspenseWrapper` with boundaries that silently swallow any
unexpected suspension or error in the preview subtree. The card stays visible; it just
won't update if something inside errors.
- **`QueryErrorResetBoundary`** — allows TanStack Query to reset error state when the
boundary resets (e.g. when the user fixes their YAML after a parse error).

**Safety:** The null fallbacks mean errors inside `TaskNodeCard` in preview mode are
swallowed silently. This is intentional and isolated — `TaskNodeCard` in the real canvas
still has its own boundaries. The preview is explicitly read-only (`readOnly: true`,
`isGhost: false`) so no mutations can originate from it. `lastValidDataRef` is local to
this component and has no effect on the canvas or pipeline state.

---

### Impact on the rest of the codebase

| Concern | Assessment |
| --- | --- |
| Real canvas `TaskNodeCard` | Unaffected. `PreviewTaskNodeCard` is only rendered inside `ComponentEditorDialog`. |
| React Query cache | The `"preview:*"` keys are isolated. No other query reads them. They live only as long as the session. |
| `useHydrateComponentReference` behaviour | Unchanged for all callers except the preview path, which now always finds pre-populated data. |
| `withSuspenseWrapper` / `SuspenseWrapper` | Still used everywhere else. Only `PreviewTaskNodeCard` was changed. |
| Performance | Strictly better. YAML parsing is O(len) and synchronous. The async SHA-256 digest computation that `hydrateComponentReference` previously ran on every keystroke no longer runs in the preview path. |

## Additional Comments

This change improves the user experience by eliminating jarring loading states and flickers while editing component definitions. The stable cache key approach ensures that React Query doesn't invalidate cached data on every keystroke, while the ref-based fallback provides visual continuity during editing.