### PR TITLE
update put to patch

### DIFF
--- a/src/routes/Settings/SettingsFlagsContext.tsx
+++ b/src/routes/Settings/SettingsFlagsContext.tsx
@@ -32,7 +32,7 @@ export function SettingsFlagsProvider({ children }: { children: ReactNode }) {
     if (available) {
       const url = new URL(USER_SETTINGS_URL, backendUrl);
       fetchWithErrorHandling(url.toString(), {
-        method: "PUT",
+        method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ settings: { [`flag_${flag}`]: enabled } }),
       }).catch(() => {


### PR DESCRIPTION
## Description

Changed the HTTP method from PUT to PATCH when updating user settings flags. This change aligns with REST API conventions where PATCH is used for partial updates of resources, which is more appropriate for updating individual flag settings.  
  
This was working locally, but I think the API must have gotten changed? Either way, this fixes it.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Navigate to the Settings page
2. Toggle any feature flag on/off
3. Verify that the flag state is properly saved and persists after page refresh
4. Check browser network tab to confirm the request uses PATCH method instead of PUT

## Additional Comments

This change requires the backend API to support PATCH requests for the user settings endpoint. Ensure the backend has been updated accordingly before merging this change.