### PR TITLE
chore: Add Artifact Visualization Aliases

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ArtifactVisualizer.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ArtifactVisualizer.tsx
@@ -36,7 +36,25 @@ const VISUALIZABLE_TYPES = new Set([
   "csv",
   "tsv",
   "apacheparquet",
-]);
+] as const);
+
+type VisualizableType =
+  typeof VISUALIZABLE_TYPES extends Set<infer T> ? T : never;
+
+const TYPE_ALIASES: Partial<Record<VisualizableType, string[]>> = {
+  text: ["txt", "log", "yaml", "xml"],
+  image: ["png", "jpg", "jpeg", "gif", "bmp", "svg"],
+  jsonobject: ["json"],
+  apacheparquet: ["parquet", "table"],
+};
+
+const resolveType = (raw: string): VisualizableType | string =>
+  (Object.entries(TYPE_ALIASES) as [VisualizableType, string[]][]).find(
+    ([, aliases]) => aliases.includes(raw),
+  )?.[0] ?? raw;
+
+const isVisualizableType = (type: string): type is VisualizableType =>
+  VISUALIZABLE_TYPES.has(type as VisualizableType);
 
 type ArtifactVisualizerProps = {
   artifact: ArtifactNodeResponse;
@@ -53,13 +71,14 @@ const ArtifactVisualizer = ({
 }: ArtifactVisualizerProps) => {
   const [isFullscreen, setIsFullscreen] = useState(false);
 
-  const normalizedType = type?.toLowerCase().replace(/\s/g, "") ?? "text";
+  const rawType = type?.toLowerCase().replace(/\s/g, "") ?? "text";
+  const normalizedType = resolveType(rawType);
 
   const handleOpenChange = (open: boolean) => {
     if (!open) setIsFullscreen(false);
   };
 
-  if (!VISUALIZABLE_TYPES.has(normalizedType) && !value) return null;
+  if (!isVisualizableType(normalizedType) && !value) return null;
 
   const artifactData = artifact.artifact_data;
   const isJson =


### PR DESCRIPTION
## Description

Adds the following aliases for artifact visualization:

```
  text: ["txt", "log", "text", "yaml", "xml"],
  image: ["png", "jpg", "jpeg", "gif", "bmp", "svg"],
  jsonobject: ["json"],
  apacheparquet: ["parquet", "table"],
```

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

This allows support for a wider range of user-defined data types via mapping and reuse of existing components.



The list of aliases is generated partially from common types and also from what I saw people using on production



## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

Parquet

![image.png](https://app.graphite.com/user-attachments/assets/eb861ca8-ec2f-47bc-9ac6-91c4df135202.png)





Png

![image.png](https://app.graphite.com/user-attachments/assets/b747a056-4666-4719-85d8-24e04f4922e9.png)



<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

generate artifacts of the alias types and confirm their artifacts are visualizable.

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->