### PR TITLE
fix: Incorrect Artifact Visualization Fallback

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/IOCell.test.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/IOCell.test.tsx
@@ -195,7 +195,7 @@ describe("IOCell", () => {
     expect(screen.queryByTestId("artifact-visualizer")).not.toBeInTheDocument();
   });
 
-  it("defaults type to 'text' for inline values without explicit type", () => {
+  it("defaults type to 'Any' for inline values without explicit type or type_name", () => {
     renderWithQuery(
       <IOCell
         name="output"
@@ -210,6 +210,25 @@ describe("IOCell", () => {
     );
 
     const viz = screen.getByTestId("artifact-visualizer");
-    expect(viz).toHaveAttribute("data-type", "text");
+    expect(viz).toHaveAttribute("data-type", "Any");
+  });
+
+  it("uses artifact type_name for visualizer when no explicit type is provided", () => {
+    renderWithQuery(
+      <IOCell
+        name="output"
+        artifact={makeArtifact({
+          type_name: "Image",
+          artifact_data: {
+            total_size: 100,
+            is_dir: false,
+            uri: "gs://bucket/image.png",
+          },
+        })}
+      />,
+    );
+
+    const viz = screen.getByTestId("artifact-visualizer");
+    expect(viz).toHaveAttribute("data-type", "Image");
   });
 });

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/IOCell.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/IOCell.tsx
@@ -77,7 +77,7 @@ const IOCell = ({ name, type, artifact }: IOCellProps) => {
             <ArtifactVisualizer
               artifact={artifact}
               name={name}
-              type={type ?? "text"}
+              type={artifactType}
               value={hasInlineValue ? inlineValue : undefined}
             />
           )}
@@ -96,7 +96,7 @@ const IOCell = ({ name, type, artifact }: IOCellProps) => {
             <ArtifactVisualizer
               artifact={artifact}
               name={name}
-              type={type ?? "text"}
+              type={artifactType}
               value={hasInlineValue ? inlineValue : undefined}
             />
           )}


### PR DESCRIPTION
## Description

Fixes an issue where artifact type would incorrectly fallback to "text" when another source of data (e.g. the input or output node itself) is available.



Specifically, fixes scenarios of images rendering as text.

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

Fixes scenarios where an image is detected and rendered as text  
![image.png](https://app.graphite.com/user-attachments/assets/9cf1ffdf-3805-424b-a5e3-6d5425dd5ca7.png)



<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->