### PR TITLE
Introduce analytics event bridge with anonymous tab session tracking

### DIFF
--- a/src/components/layout/RootLayout.tsx
+++ b/src/components/layout/RootLayout.tsx
@@ -4,6 +4,7 @@ import { ToastContainer } from "react-toastify";
 
 import { isFlagEnabled } from "@/components/shared/Settings/useFlags";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+import { AnalyticsProvider } from "@/providers/AnalyticsProvider";
 import { BackendProvider } from "@/providers/BackendProvider";
 import { ComponentSpecProvider } from "@/providers/ComponentSpecProvider";
 import { PipelineStorageProvider } from "@/services/pipelineStorage/PipelineStorageProvider";
@@ -27,27 +28,29 @@ const RootLayout = () => {
     isFlagEnabled("dashboard") && DASHBOARD_PATHS.has(pathname);
 
   return (
-    <BackendProvider>
-      <ComponentSpecProvider>
-        <PipelineStorageProvider>
-          <ToastContainer />
+    <AnalyticsProvider>
+      <BackendProvider>
+        <ComponentSpecProvider>
+          <PipelineStorageProvider>
+            <ToastContainer />
 
-          <div className="App flex flex-col min-h-screen w-full">
-            <AppMenu />
+            <div className="App flex flex-col min-h-screen w-full">
+              <AppMenu />
 
-            <main className="flex-1 grid">
-              <Outlet />
-            </main>
+              <main className="flex-1 grid">
+                <Outlet />
+              </main>
 
-            {!isDashboard && <AppFooter />}
+              {!isDashboard && <AppFooter />}
 
-            {import.meta.env.VITE_ENABLE_ROUTER_DEVTOOLS === "true" && (
-              <TanStackRouterDevtools />
-            )}
-          </div>
-        </PipelineStorageProvider>
-      </ComponentSpecProvider>
-    </BackendProvider>
+              {import.meta.env.VITE_ENABLE_ROUTER_DEVTOOLS === "true" && (
+                <TanStackRouterDevtools />
+              )}
+            </div>
+          </PipelineStorageProvider>
+        </ComponentSpecProvider>
+      </BackendProvider>
+    </AnalyticsProvider>
   );
 };
 

--- a/src/hooks/useUserDetails.ts
+++ b/src/hooks/useUserDetails.ts
@@ -1,11 +1,13 @@
-import { useSuspenseQuery } from "@tanstack/react-query";
+import { queryOptions, useSuspenseQuery } from "@tanstack/react-query";
 
 import { getUserDetails } from "../utils/user";
 
+export const userQueryOptions = queryOptions({
+  queryKey: ["user"],
+  staleTime: 1000 * 60 * 60 * 0.5, // 30 minutes
+  queryFn: getUserDetails,
+});
+
 export function useUserDetails() {
-  return useSuspenseQuery({
-    queryKey: ["user"],
-    staleTime: 1000 * 60 * 60 * 0.5, // 30 minutes
-    queryFn: () => getUserDetails(),
-  });
+  return useSuspenseQuery(userQueryOptions);
 }

--- a/src/providers/AnalyticsProvider.test.tsx
+++ b/src/providers/AnalyticsProvider.test.tsx
@@ -1,0 +1,268 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AnalyticsProvider, useAnalytics } from "./AnalyticsProvider";
+
+// ─── Mock user query ──────────────────────────────────────────────────────────
+
+const mockGetUser = vi.hoisted(() => vi.fn());
+
+vi.mock("@/hooks/useUserDetails", () => ({
+  userQueryOptions: {
+    queryKey: ["user"],
+    queryFn: () => mockGetUser(),
+    staleTime: Infinity,
+  },
+}));
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function captureEvents() {
+  const events: CustomEvent<Record<string, unknown>>[] = [];
+  const handler = (e: Event) =>
+    events.push(e as CustomEvent<Record<string, unknown>>);
+  window.addEventListener("tangle.analytics.track", handler);
+  return {
+    events,
+    cleanup: () =>
+      window.removeEventListener("tangle.analytics.track", handler),
+  };
+}
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <AnalyticsProvider>{children}</AnalyticsProvider>
+      </QueryClientProvider>
+    );
+  }
+  return Wrapper;
+}
+
+beforeEach(() => {
+  sessionStorage.clear();
+  vi.clearAllMocks();
+});
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("AnalyticsProvider", () => {
+  describe("track — event dispatch", () => {
+    it("dispatches a tangle.analytics.track CustomEvent on window", async () => {
+      mockGetUser.mockResolvedValue({ id: "user-1" });
+      const { result } = renderHook(() => useAnalytics(), {
+        wrapper: makeWrapper(),
+      });
+
+      const { events, cleanup } = captureEvents();
+      act(() => result.current.track("pipeline.component_added"));
+      await waitFor(() => expect(events).toHaveLength(1));
+      cleanup();
+    });
+
+    it("includes actionType, metadata, sessionId, route, appVersion, environment in detail", async () => {
+      mockGetUser.mockResolvedValue({ id: "user-1" });
+      const { result } = renderHook(() => useAnalytics(), {
+        wrapper: makeWrapper(),
+      });
+
+      const { events, cleanup } = captureEvents();
+      act(() => result.current.track("pipeline.run.submit", { run_id: "r-1" }));
+
+      await waitFor(() => expect(events).toHaveLength(1));
+      const { detail } = events[0];
+      expect(detail.actionType).toBe("pipeline.run.submit");
+      expect(detail.metadata).toEqual({ run_id: "r-1" });
+      expect(detail.sessionId).toBeTruthy();
+      expect(detail.route).toBe(window.location.pathname);
+      expect("appVersion" in detail).toBe(true);
+      expect("environment" in detail).toBe(true);
+      cleanup();
+    });
+
+    it("omits metadata when not provided", async () => {
+      mockGetUser.mockResolvedValue({ id: "user-1" });
+      const { result } = renderHook(() => useAnalytics(), {
+        wrapper: makeWrapper(),
+      });
+
+      const { events, cleanup } = captureEvents();
+      act(() => result.current.track("pipeline.component_added"));
+      await waitFor(() => expect(events).toHaveLength(1));
+      expect(events[0].detail.metadata).toBeUndefined();
+      cleanup();
+    });
+
+    it("uses the same sessionId across multiple calls", async () => {
+      mockGetUser.mockResolvedValue({ id: "user-1" });
+      const { result } = renderHook(() => useAnalytics(), {
+        wrapper: makeWrapper(),
+      });
+
+      const { events, cleanup } = captureEvents();
+      act(() => {
+        result.current.track("pipeline.component_added");
+        result.current.track("pipeline.run.submit");
+      });
+
+      await waitFor(() => expect(events).toHaveLength(2));
+      expect(events[0].detail.sessionId).toBe(events[1].detail.sessionId);
+      cleanup();
+    });
+
+    it("uses hash:uuid session ID format after user resolves", async () => {
+      mockGetUser.mockResolvedValue({ id: "user-1" });
+      const { result } = renderHook(() => useAnalytics(), {
+        wrapper: makeWrapper(),
+      });
+
+      const { events, cleanup } = captureEvents();
+      act(() => result.current.track("pipeline.component_added"));
+      await waitFor(() => expect(events).toHaveLength(1));
+      expect(events[0].detail.sessionId).toMatch(/^[0-9a-f]{8}:[0-9a-f-]{36}$/);
+      cleanup();
+    });
+  });
+
+  describe("user resolution", () => {
+    it("waits for the user query before dispatching", async () => {
+      let resolveUser!: (value: { id: string }) => void;
+      mockGetUser.mockReturnValue(
+        new Promise<{ id: string }>((resolve) => {
+          resolveUser = resolve;
+        }),
+      );
+
+      const { result } = renderHook(() => useAnalytics(), {
+        wrapper: makeWrapper(),
+      });
+
+      const { events, cleanup } = captureEvents();
+
+      // Track before user resolves — must not dispatch yet
+      act(() => result.current.track("session.tab.start"));
+      expect(events).toHaveLength(0);
+
+      // Resolve the user — event should then dispatch
+      act(() => resolveUser({ id: "user-2" }));
+      await waitFor(() => expect(events).toHaveLength(1));
+
+      expect(events[0].detail.actionType).toBe("session.tab.start");
+      cleanup();
+    });
+
+    it("dispatches multiple pending track calls after user resolves", async () => {
+      let resolveUser!: (value: { id: string }) => void;
+      mockGetUser.mockReturnValue(
+        new Promise<{ id: string }>((resolve) => {
+          resolveUser = resolve;
+        }),
+      );
+
+      const { result } = renderHook(() => useAnalytics(), {
+        wrapper: makeWrapper(),
+      });
+
+      const { events, cleanup } = captureEvents();
+
+      act(() => {
+        result.current.track("event.first");
+        result.current.track("event.second");
+        result.current.track("event.third");
+      });
+      expect(events).toHaveLength(0);
+
+      act(() => resolveUser({ id: "user-3" }));
+      await waitFor(() => expect(events).toHaveLength(3));
+
+      expect(events.map((e) => e.detail.actionType)).toEqual([
+        "event.first",
+        "event.second",
+        "event.third",
+      ]);
+      cleanup();
+    });
+  });
+
+  describe("user identification", () => {
+    it("prefixes session ID with an 8-char hash for a real user", async () => {
+      mockGetUser.mockResolvedValue({ id: "user-1" });
+      const { result } = renderHook(() => useAnalytics(), {
+        wrapper: makeWrapper(),
+      });
+      const { events, cleanup } = captureEvents();
+      act(() => result.current.track("probe"));
+      await waitFor(() => expect(events).toHaveLength(1));
+      expect(events[0].detail.sessionId).toMatch(/^[0-9a-f]{8}:[0-9a-f-]{36}$/);
+      cleanup();
+    });
+
+    it("produces the same hash prefix for the same userId", async () => {
+      mockGetUser.mockResolvedValue({ id: "user-1" });
+      const { result: r1 } = renderHook(() => useAnalytics(), {
+        wrapper: makeWrapper(),
+      });
+      const { events: e1, cleanup: c1 } = captureEvents();
+      act(() => r1.current.track("probe"));
+      await waitFor(() => expect(e1).toHaveLength(1));
+      const prefix1 = (e1[0].detail.sessionId as string).split(":")[0];
+      c1();
+
+      sessionStorage.clear();
+      mockGetUser.mockResolvedValue({ id: "user-1" });
+      const { result: r2 } = renderHook(() => useAnalytics(), {
+        wrapper: makeWrapper(),
+      });
+      const { events: e2, cleanup: c2 } = captureEvents();
+      act(() => r2.current.track("probe"));
+      await waitFor(() => expect(e2).toHaveLength(1));
+      const prefix2 = (e2[0].detail.sessionId as string).split(":")[0];
+      c2();
+
+      expect(prefix1).toBe(prefix2);
+    });
+
+    it("produces different hash prefixes for different userIds", async () => {
+      mockGetUser.mockResolvedValue({ id: "user-1" });
+      const { result: r1 } = renderHook(() => useAnalytics(), {
+        wrapper: makeWrapper(),
+      });
+      const { events: e1, cleanup: c1 } = captureEvents();
+      act(() => r1.current.track("probe"));
+      await waitFor(() => expect(e1).toHaveLength(1));
+      const prefix1 = (e1[0].detail.sessionId as string).split(":")[0];
+      c1();
+
+      sessionStorage.clear();
+      mockGetUser.mockResolvedValue({ id: "user-999" });
+      const { result: r2 } = renderHook(() => useAnalytics(), {
+        wrapper: makeWrapper(),
+      });
+      const { events: e2, cleanup: c2 } = captureEvents();
+      act(() => r2.current.track("probe"));
+      await waitFor(() => expect(e2).toHaveLength(1));
+      const prefix2 = (e2[0].detail.sessionId as string).split(":")[0];
+      c2();
+
+      expect(prefix1).not.toBe(prefix2);
+    });
+
+    it("uses a plain UUID when user.id is 'Unknown'", async () => {
+      mockGetUser.mockResolvedValue({ id: "Unknown" });
+      const { result } = renderHook(() => useAnalytics(), {
+        wrapper: makeWrapper(),
+      });
+      const { events, cleanup } = captureEvents();
+      act(() => result.current.track("probe"));
+      await waitFor(() => expect(events).toHaveLength(1));
+      expect(events[0].detail.sessionId).toMatch(/^[0-9a-f-]{36}$/);
+      cleanup();
+    });
+  });
+});

--- a/src/providers/AnalyticsProvider.tsx
+++ b/src/providers/AnalyticsProvider.tsx
@@ -1,0 +1,101 @@
+import { useQueryClient } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { useCallback, useMemo } from "react";
+
+import {
+  createRequiredContext,
+  useRequiredContext,
+} from "@/hooks/useRequiredContext";
+import { userQueryOptions } from "@/hooks/useUserDetails";
+
+// ─── Private session & dispatch helpers ──────────────────────────────────────
+
+const SESSION_KEY = "tangle_tab_session_id";
+
+async function getUserHash(userId: string): Promise<string> {
+  const data = new TextEncoder().encode(userId);
+  const buffer = await crypto.subtle.digest("SHA-256", data);
+  return Array.from(new Uint8Array(buffer))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("")
+    .slice(0, 8);
+}
+
+async function getOrCreateSessionId(userId?: string): Promise<string> {
+  const existing = sessionStorage.getItem(SESSION_KEY);
+  if (existing) return existing;
+
+  const uuid = crypto.randomUUID();
+  const hash = userId ? await getUserHash(userId) : undefined;
+  const id = hash ? `${hash}:${uuid}` : uuid;
+  sessionStorage.setItem(SESSION_KEY, id);
+  return id;
+}
+
+function dispatchTrack(
+  sessionId: string,
+  actionType: string,
+  metadata?: Record<string, unknown>,
+): void {
+  window.dispatchEvent(
+    new CustomEvent("tangle.analytics.track", {
+      detail: {
+        actionType,
+        metadata,
+        sessionId,
+        route: window.location.pathname,
+        appVersion: import.meta.env.VITE_GIT_COMMIT as string | undefined,
+        environment: import.meta.env.VITE_TANGLE_ENV as string | undefined,
+      },
+    }),
+  );
+}
+
+// ─── Context & Provider ───────────────────────────────────────────────────────
+
+type TrackFn = (actionType: string, metadata?: Record<string, unknown>) => void;
+
+interface AnalyticsContextValue {
+  track: TrackFn;
+}
+
+const AnalyticsContext =
+  createRequiredContext<AnalyticsContextValue>("AnalyticsContext");
+
+/**
+ * Provides analytics tracking to the component tree.
+ *
+ * Each `track` call awaits `queryClient.ensureQueryData` for the current user
+ * before dispatching — returning the cached value immediately after the first
+ * fetch, or waiting for the in-flight request if it hasn't resolved yet. The
+ * session ID is created lazily on the first dispatched event and reused for
+ * the lifetime of the browser tab.
+ */
+export function AnalyticsProvider({ children }: { children: ReactNode }) {
+  const queryClient = useQueryClient();
+
+  const sessionIdPromise = useMemo(
+    () =>
+      queryClient.ensureQueryData(userQueryOptions).then((user) => {
+        const userId = user.id !== "Unknown" ? user.id : undefined;
+        return getOrCreateSessionId(userId);
+      }),
+    [queryClient],
+  );
+
+  const track = useCallback<TrackFn>(
+    (actionType, metadata) => {
+      void sessionIdPromise.then((sessionId) => {
+        dispatchTrack(sessionId, actionType, metadata);
+      });
+    },
+    [sessionIdPromise],
+  );
+
+  return <AnalyticsContext value={{ track }}>{children}</AnalyticsContext>;
+}
+
+/** @public */
+export function useAnalytics() {
+  return useRequiredContext(AnalyticsContext);
+}


### PR DESCRIPTION
## Description

Adds an analytics tracking system that dispatches custom events on the window object. The implementation includes a `track` function that emits "tangle.analytics.track" events with action type, optional metadata, and a session ID. Session IDs are generated using `crypto.randomUUID()` and persisted in sessionStorage for the duration of the tab session.

The analytics provider queues events fired before user identification and flushes them once the user is resolved. Session IDs are prefixed with an 8-character hash of the user ID for identified users, or use a plain UUID for anonymous users. The system includes comprehensive test coverage for event dispatch, queuing behavior, and user identification flows.

![image.png](https://app.graphite.com/user-attachments/assets/5a6c5fa0-277f-4745-b9e7-5a5921d75d3e.png)

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Test Instructions

1. Import the analytics hook: `import { useAnalytics } from '@/providers/AnalyticsProvider'`
2. Call `track('pipeline.component_added', { component_name: 'MyComponent' })`
3. Listen for events: `window.addEventListener('tangle.analytics.track', console.log)`
4. Verify events contain actionType, metadata, sessionId, route, appVersion, and environment properties
5. Confirm sessionId persists across multiple track calls in the same tab session
6. Verify sessionId includes user hash prefix for identified users (format: `hash:uuid`)
7. Test that events fired before user identification are queued and flushed in order