### PR TITLE
Instrument first analytics event on artifact preview click

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ArtifactVisualizer.test.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ArtifactVisualizer.test.tsx
@@ -7,6 +7,11 @@ import type { ArtifactNodeResponse } from "@/api/types.gen";
 
 import ArtifactVisualizer from "./ArtifactVisualizer";
 
+const mockTrack = vi.hoisted(() => vi.fn());
+vi.mock("@/providers/AnalyticsProvider", () => ({
+  useAnalytics: () => ({ track: mockTrack }),
+}));
+
 vi.mock("@/providers/BackendProvider", () => ({
   useBackend: () => ({ backendUrl: "http://localhost:8000" }),
 }));
@@ -83,6 +88,7 @@ const makeArtifact = (
 
 beforeEach(() => {
   queryClient.clear();
+  mockTrack.mockClear();
 });
 
 describe("ArtifactVisualizer", () => {
@@ -248,6 +254,41 @@ describe("ArtifactVisualizer", () => {
       await waitFor(() => {
         expect(screen.getByTestId("parquet-visualizer")).toBeInTheDocument();
       });
+    });
+  });
+
+  describe("analytics", () => {
+    it("tracks pipeline_run.task.artifact_preview.impression with artifact_type when preview is opened", async () => {
+      renderWithQuery(
+        <ArtifactVisualizer
+          artifact={makeArtifact()}
+          name="output"
+          type="CSV"
+        />,
+      );
+
+      await userEvent.click(screen.getByText("Preview"));
+
+      expect(mockTrack).toHaveBeenCalledWith(
+        "pipeline_run.task.artifact_preview.impression",
+        { artifact_type: "csv" },
+      );
+    });
+
+    it("does not track when the dialog is closed", async () => {
+      renderWithQuery(
+        <ArtifactVisualizer
+          artifact={makeArtifact()}
+          name="output"
+          type="CSV"
+        />,
+      );
+
+      await userEvent.click(screen.getByText("Preview"));
+      mockTrack.mockClear();
+      await userEvent.keyboard("{Escape}");
+
+      expect(mockTrack).not.toHaveBeenCalled();
     });
   });
 

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ArtifactVisualizer.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ArtifactVisualizer.tsx
@@ -17,6 +17,7 @@ import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Text } from "@/components/ui/typography";
 import { cn } from "@/lib/utils";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { useBackend } from "@/providers/BackendProvider";
 import { getArtifactSignedUrl } from "@/services/executionService";
 import { HOURS } from "@/utils/constants";
@@ -69,6 +70,7 @@ const ArtifactVisualizer = ({
   type,
   value,
 }: ArtifactVisualizerProps) => {
+  const { track } = useAnalytics();
   const [isFullscreen, setIsFullscreen] = useState(false);
 
   const rawType = type?.toLowerCase().replace(/\s/g, "") ?? "text";
@@ -76,6 +78,10 @@ const ArtifactVisualizer = ({
 
   const handleOpenChange = (open: boolean) => {
     if (!open) setIsFullscreen(false);
+    if (open)
+      track("pipeline_run.task.artifact_preview.impression", {
+        artifact_type: normalizedType,
+      });
   };
 
   if (!isVisualizableType(normalizedType) && !value) return null;


### PR DESCRIPTION
## Description

Added analytics tracking to the ArtifactVisualizer component to monitor when users preview artifacts. The tracking event `pipeline_run.task.artifact_preview.impression` is fired when the preview dialog is opened, including the artifact type as metadata.

![image.png](https://app.graphite.com/user-attachments/assets/9b560d35-d12c-41e5-8645-79897c29b1b4.png)

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Test Instructions

1. Navigate to a pipeline run with artifacts
2. Click the "Preview" button on any artifact
3. Verify that the analytics event is tracked with the correct artifact type
4. Close the dialog and verify no additional tracking events are fired

## Additional Comments

The tracking only occurs when the dialog is opened, not when it's closed, to avoid duplicate events and focus on user engagement with the preview feature.