### PR TITLE
fix: unable to use spacebar in syntax highlighter

### DIFF
--- a/src/components/shared/Dialogs/MultilineTextInputDialog.tsx
+++ b/src/components/shared/Dialogs/MultilineTextInputDialog.tsx
@@ -165,7 +165,10 @@ export const MultilineTextInputDialog = ({
           )}
         </InlineStack>
         {highlightSyntax && selectedLanguage !== "plaintext" ? (
-          <div className={cn(isFullscreen ? "flex-1 min-h-0" : "h-64")}>
+          <div
+            className={cn(isFullscreen ? "flex-1 min-h-0" : "h-64")}
+            onKeyDown={(e) => e.stopPropagation()}
+          >
             <CodeEditor
               key={String(isFullscreen)}
               value={value}


### PR DESCRIPTION
## Description

Simple fix. Radix UI Dialog was capturing and blocking spcebar before the Monaco Editor could use it, resulting in spacebar not working in the multiline editor

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

Can now use spacebar in the multiline editor / syntax highlighter

![image.png](https://app.graphite.com/user-attachments/assets/260ff613-7639-4544-99e0-218541d700df.png)



<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->