### PR TITLE
fix: Copy-Paste Bypassing Monaco Editor

### DIFF
--- a/src/hooks/useCopyPaste.ts
+++ b/src/hooks/useCopyPaste.ts
@@ -17,7 +17,8 @@ export function useCopyPaste({ onCopy, onPaste }: UseCopyPasteProps) {
       const isEditable =
         target instanceof HTMLInputElement ||
         target instanceof HTMLTextAreaElement ||
-        target.isContentEditable;
+        target.isContentEditable ||
+        target.closest(".monaco-editor") !== null;
 
       // Check if there is a text selection
       const selection = window.getSelection();


### PR DESCRIPTION
## Description

Fixes an issue where the copy+paste logic was bypassing the Monaco Editor, making it impossible to ctrl + c to copy from the Monaco Editor

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

Closes https://github.com/TangleML/tangle-ui/issues/2075

Closes https://github.com/Shopify/oasis-frontend/issues/575

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

Confirm that you can now select text inside the Monaco Editor (esp. fullscreen mode) and copy it with ctrl+c

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->