### PR TITLE
fix: Clear Multiselect Panel after using delete button

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
@@ -1212,6 +1212,8 @@ const FlowCanvasContent = ({
         />,
       );
       setOpen(true);
+    } else if (nodes.length === 0) {
+      clearContent();
     }
   }, [currentSubgraphSpec, selectedNodeIds, readOnly, canUpgrade, canGroup]);
 


### PR DESCRIPTION
## Description

Fixes an issue where the multiselect panel would stay op[en after deleting selected nodes.

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

Select a group of nodes

Delete them via the delete button in the multiselect panel

Panel should close

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->