### PR TITLE
fix: Submit with Run Arguments Dialog is stale the first time it's opened

### DIFF
--- a/src/components/shared/Submitters/Tangle/components/SubmitTaskArgumentsDialog.tsx
+++ b/src/components/shared/Submitters/Tangle/components/SubmitTaskArgumentsDialog.tsx
@@ -107,6 +107,15 @@ export const SubmitTaskArgumentsDialog = ({
   };
 
   useEffect(() => {
+    if (open) {
+      const freshArgs = getArgumentsFromInputs(componentSpec);
+      setTaskArguments(freshArgs);
+      setRunNotes("");
+      setHighlightedArgs(new Map());
+    }
+  }, [open, componentSpec]);
+
+  useEffect(() => {
     setIsValidToSubmit(validateArguments(inputs, taskArguments));
   }, [inputs, taskArguments]);
 


### PR DESCRIPTION
## Description

Fix an issue with the "Submit Run with Arguments" dialog where the first time it's opened the input values would be stale and not accurately reflect the actual input nodes.

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

1. Open a pipeline that has an input node with a value
2. Delete the value on the input node
3. Submit run with arguments
4. Opened dialog should show an empty input field for the node you deleted the value of -- (previously this wouldf still show the old value)

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->