### PR TITLE
chore: rm support for runs/{root_execution_id}

### DIFF
--- a/src/hooks/usePipelineRunData.ts
+++ b/src/hooks/usePipelineRunData.ts
@@ -16,18 +16,8 @@ const useRootExecutionId = (id: string) => {
   const { backendUrl } = useBackend();
   const { data: rootExecutionId } = useQuery({
     queryKey: ["pipeline-run-execution-id", id],
-    queryFn: async () => {
-      const rootExecutionId = await fetchPipelineRun(id, backendUrl)
-        .then((res) => res.root_execution_id)
-        .catch((_) => undefined);
-
-      if (rootExecutionId) {
-        return rootExecutionId;
-      }
-
-      // assuming id is root_execution_id
-      return id;
-    },
+    queryFn: () =>
+      fetchPipelineRun(id, backendUrl).then((res) => res.root_execution_id),
     enabled: !!id && id.length > 0,
     staleTime: Infinity,
   });
@@ -35,7 +25,7 @@ const useRootExecutionId = (id: string) => {
   return rootExecutionId;
 };
 
-/* Accepts root_execution_id or run_id and returns execution details and state */
+/* Accepts run_id and returns execution details and state */
 export const usePipelineRunData = (id: string) => {
   const { backendUrl } = useBackend();
 

--- a/src/providers/ExecutionDataProvider.tsx
+++ b/src/providers/ExecutionDataProvider.tsx
@@ -152,11 +152,7 @@ export function ExecutionDataProvider({
   const { details: rootDetails, state: rootState } = executionData ?? {};
   const runId = rootDetails?.pipeline_run_id;
 
-  const metadataQueryId =
-    runId ??
-    (rootExecutionId && pipelineRunId === rootExecutionId
-      ? undefined
-      : pipelineRunId);
+  const metadataQueryId = runId ?? pipelineRunId;
 
   const {
     data: metadata,


### PR DESCRIPTION
## Description

As per discussions, this PR removes support for run navigation via `runs/{root_execution_id}` all runs must now be accessed via `runs/{run_id}`

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

- [x] Cleanup/Refactor
- [x] Breaking change

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

Confirm that runs load properly via `runs/{run_id}`

Confirm that runs do not load via `runs/{root_execution_id}`

Confirm that any link copying or run sharing uses run_id and not root_excecution_id

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->