### PR TITLE
fix: Component Digest Not Found Error When Loading a Run

### DIFF
--- a/src/providers/ComponentLibraryProvider/libraries/publishedComponentsLibrary.test.ts
+++ b/src/providers/ComponentLibraryProvider/libraries/publishedComponentsLibrary.test.ts
@@ -4,7 +4,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type {
   ComponentReferenceInput,
-  ComponentResponse,
   HttpValidationError,
   PublishedComponentResponse,
 } from "@/api/types.gen";
@@ -156,18 +155,14 @@ describe("PublishedComponentsLibrary", () => {
   });
 
   describe("hasComponent", () => {
-    it("should return true if component exists in backend", async () => {
+    it("should return true if component exists in published list", async () => {
       // Arrange
       const component = createMockComponentReference();
-      const componentText = yaml.dump(mockComponentSpec);
 
-      const mockComponentResponse: ComponentResponse = {
-        digest: "test-digest-123",
-        text: componentText,
-      };
-
-      mockGetApiComponentsDigestGet.mockResolvedValue(
-        createMockApiResponse(mockComponentResponse),
+      mockListApiPublishedComponentsGet.mockResolvedValue(
+        createMockApiResponse({
+          published_components: [createMockPublishedComponent()],
+        }),
       );
 
       // Act
@@ -175,17 +170,15 @@ describe("PublishedComponentsLibrary", () => {
 
       // Assert
       expect(result).toBe(true);
-      expect(mockGetApiComponentsDigestGet).toHaveBeenCalledWith({
-        path: { digest: component.digest },
-      });
+      expect(mockListApiPublishedComponentsGet).toHaveBeenCalledWith({});
     });
 
-    it("should return false if component does not exist (404)", async () => {
+    it("should return false if component is not in published list", async () => {
       // Arrange
       const component = createMockComponentReference();
 
-      mockGetApiComponentsDigestGet.mockResolvedValue(
-        createMockApiErrorResponse(404),
+      mockListApiPublishedComponentsGet.mockResolvedValue(
+        createMockApiResponse({ published_components: [] }),
       );
 
       // Act
@@ -193,9 +186,7 @@ describe("PublishedComponentsLibrary", () => {
 
       // Assert
       expect(result).toBe(false);
-      expect(mockGetApiComponentsDigestGet).toHaveBeenCalledWith({
-        path: { digest: component.digest },
-      });
+      expect(mockListApiPublishedComponentsGet).toHaveBeenCalledWith({});
     });
 
     it("should use cached digest to return true without API call", async () => {
@@ -205,42 +196,43 @@ describe("PublishedComponentsLibrary", () => {
         digest: await generateDigest(componentText),
       });
 
-      // First call to cache the digest
-      const mockComponentResponse: ComponentResponse = {
-        digest: await generateDigest(componentText),
-        text: componentText,
-      };
-      mockGetApiComponentsDigestGet.mockResolvedValue(
-        createMockApiResponse(mockComponentResponse),
+      mockListApiPublishedComponentsGet.mockResolvedValue(
+        createMockApiResponse({
+          published_components: [
+            createMockPublishedComponent({
+              digest: await generateDigest(componentText),
+            }),
+          ],
+        }),
       );
 
       const firstResult = await library.hasComponent(component);
       expect(firstResult).toBe(true);
-      expect(mockGetApiComponentsDigestGet).toHaveBeenCalledTimes(1);
+      expect(mockListApiPublishedComponentsGet).toHaveBeenCalledTimes(1);
 
-      // Act - second call should use cache
+      // Act - second call should use #knownDigests cache
       const result = await library.hasComponent(component);
 
-      // Assert - the API should have been called only once (during first call)
+      // Assert - list API should have been called only once
       expect(result).toBe(true);
-      expect(mockGetApiComponentsDigestGet).toHaveBeenCalledTimes(1);
+      expect(mockListApiPublishedComponentsGet).toHaveBeenCalledTimes(1);
     });
 
-    it("should throw InvalidComponentReferenceError for invalid component", async () => {
+    it("should return false for invalid component reference without API call", async () => {
       // Arrange
       const invalidComponent = { name: "invalid" } as ComponentReference;
 
       // Act & Assert
       const result = await library.hasComponent(invalidComponent);
       expect(result).toBe(false);
-      expect(mockGetApiComponentsDigestGet).not.toHaveBeenCalled();
+      expect(mockListApiPublishedComponentsGet).not.toHaveBeenCalled();
     });
 
     it("should throw BackendLibraryError for unexpected status codes", async () => {
       // Arrange
       const component = createMockComponentReference();
 
-      mockGetApiComponentsDigestGet.mockResolvedValue(
+      mockListApiPublishedComponentsGet.mockResolvedValue(
         createMockApiErrorResponse(500),
       );
 
@@ -254,7 +246,7 @@ describe("PublishedComponentsLibrary", () => {
       // Arrange
       const component = createMockComponentReference();
 
-      mockGetApiComponentsDigestGet.mockResolvedValue({
+      mockListApiPublishedComponentsGet.mockResolvedValue({
         data: undefined,
         error: undefined,
         request: new Request("http://test.com"),
@@ -268,24 +260,6 @@ describe("PublishedComponentsLibrary", () => {
       // Act & Assert
       await expect(library.hasComponent(component)).rejects.toThrow(
         "No data returned from server",
-      );
-    });
-
-    it("should throw BackendLibraryError when hydration fails", async () => {
-      // Arrange
-      const component = createMockComponentReference();
-
-      const mockComponentResponse: ComponentResponse = {
-        digest: "test-digest-123",
-        text: "invalid: yaml: content: {{{",
-      };
-      mockGetApiComponentsDigestGet.mockResolvedValue(
-        createMockApiResponse(mockComponentResponse),
-      );
-
-      // Act & Assert
-      await expect(library.hasComponent(component)).rejects.toThrow(
-        `Failed to hydrate component: ${component.digest}`,
       );
     });
   });

--- a/src/providers/ComponentLibraryProvider/libraries/publishedComponentsLibrary.ts
+++ b/src/providers/ComponentLibraryProvider/libraries/publishedComponentsLibrary.ts
@@ -1,7 +1,6 @@
 import type { QueryClient } from "@tanstack/react-query";
 
 import {
-  getApiComponentsDigestGet,
   listApiPublishedComponentsGet,
   publishApiPublishedComponentsPost,
   updateApiPublishedComponentsDigestPut,
@@ -75,49 +74,35 @@ export class PublishedComponentsLibrary implements Library {
       return false;
     }
 
-    if (isDiscoverable && this.#knownDigests.has(component.digest)) {
+    if (this.#knownDigests.has(component.digest)) {
       return true;
     }
 
-    const getComponentResult = await this.#queryClient.fetchQuery({
-      queryKey: ["componentDigest", component.digest],
-      queryFn: () =>
-        getApiComponentsDigestGet({
-          path: { digest: component.digest },
-        }),
+    // Fetch the full published list once (shared TanStack Query cache) instead of
+    // making N individual GET requests that return 404 for unpublished components.
+    const listResult = await this.#queryClient.fetchQuery({
+      queryKey: ["publishedComponentsList"],
+      queryFn: () => listApiPublishedComponentsGet({}),
       staleTime: TWENTY_FOUR_HOURS_IN_MS,
     });
 
-    if (getComponentResult.response.status !== 200) {
-      switch (getComponentResult.response.status) {
-        case 404:
-          return false;
-        default:
-          console.error(getComponentResult.error);
-          throw new BackendLibraryError(
-            `Unexpected status code: ${getComponentResult.response.status}`,
-          );
-      }
-    }
-
-    if (!getComponentResult.data) {
-      throw new BackendLibraryError("No data returned from server");
-    }
-
-    const hydratedComponent = await hydrateComponentReference({
-      text: getComponentResult.data.text,
-      url: component.url,
-    });
-
-    if (!hydratedComponent) {
+    if (listResult.response.status !== 200) {
+      console.error(listResult.error);
       throw new BackendLibraryError(
-        `Failed to hydrate component: ${component.digest}`,
+        `Unexpected status code: ${listResult.response.status}`,
       );
     }
 
-    this.#knownDigests.add(hydratedComponent.digest);
+    if (!listResult.data) {
+      throw new BackendLibraryError("No data returned from server");
+    }
 
-    return true;
+    // Warm the in-memory cache from the list so subsequent calls skip the fetch.
+    (listResult.data.published_components ?? []).forEach((c) =>
+      this.#knownDigests.add(c.digest),
+    );
+
+    return this.#knownDigests.has(component.digest);
   }
 
   /**


### PR DESCRIPTION
## Description

Fixes a non-critical error where component digest was not immediately readable upon loading a run, causing an error to appear in the browser console. Specifically, this was happening for unpublished components.

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

Fixes this:

![image.png](https://app.graphite.com/user-attachments/assets/275d7f5b-58de-4655-989e-782fedff19c4.png)



<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

Load a run with unpublished components -> no error in console

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->