### PR TITLE
Fix session.tab.start to fire once per browser tab, not per page load

### DIFF
--- a/src/providers/AnalyticsProvider.test.tsx
+++ b/src/providers/AnalyticsProvider.test.tsx
@@ -239,18 +239,19 @@ describe("AnalyticsProvider", () => {
       cleanup();
     });
 
-    it("fires session.tab.start only once per provider mount", async () => {
+    it("does not fire session.tab.start when a session ID already exists in sessionStorage", async () => {
+      sessionStorage.setItem("tangle_tab_session_id", "existing-session");
       mockGetUser.mockResolvedValue({ id: "user-1" });
       const { events, cleanup } = captureEvents();
-      renderHook(() => useAnalytics(), { wrapper: makeWrapper() });
-      await waitFor(() =>
-        expect(
-          events.some((e) => e.detail.actionType === "session.tab.start"),
-        ).toBe(true),
-      );
+      const { result } = renderHook(() => useAnalytics(), {
+        wrapper: makeWrapper(),
+      });
+      // Trigger a manual track to confirm events are working
+      act(() => result.current.track("probe"));
+      await waitFor(() => expect(nonSessionEvents(events)).toHaveLength(1));
       expect(
         events.filter((e) => e.detail.actionType === "session.tab.start"),
-      ).toHaveLength(1);
+      ).toHaveLength(0);
       cleanup();
     });
   });

--- a/src/providers/AnalyticsProvider.tsx
+++ b/src/providers/AnalyticsProvider.tsx
@@ -97,6 +97,10 @@ export function AnalyticsProvider({ children }: { children: ReactNode }) {
   );
 
   useEffect(() => {
+    // sessionStorage persists across refreshes within the same tab. If the key
+    // already exists this is a page reload, not a new tab session — skip.
+    if (sessionStorage.getItem(SESSION_KEY)) return;
+
     const flags = Object.fromEntries(
       Object.keys(ExistingFlags).map((key) => [
         key,


### PR DESCRIPTION
## Description

Fixed an issue where the `session.tab.start` analytics event was being fired on every page reload within the same browser tab. The provider now checks if a session ID already exists in sessionStorage before firing the event, ensuring it only triggers for genuine new tab sessions rather than page refreshes.

## Related Issue and Pull requests

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Open the application in a new browser tab
2. Verify that `session.tab.start` event is fired
3. Refresh the page in the same tab
4. Verify that `session.tab.start` event is NOT fired again
5. Open the application in a completely new tab
6. Verify that `session.tab.start` event is fired for the new tab

## Additional Comments

The fix adds a simple check for an existing session ID in sessionStorage before initializing a new tab session. This prevents duplicate session start events while maintaining the correct behavior for actual new tab sessions.