### PR TITLE
Adds colour back to nodes

### DIFF
--- a/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/TaskDetails.tsx
+++ b/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/TaskDetails.tsx
@@ -3,11 +3,12 @@ import { useEffect, useState } from "react";
 
 import { TextBlock } from "@/components/shared/ContextPanel/Blocks/TextBlock";
 import { StackingControls } from "@/components/shared/ReactFlow/FlowControls/StackingControls";
+import { ColorPicker } from "@/components/ui/color";
 import { Icon } from "@/components/ui/icon";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Separator } from "@/components/ui/separator";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Heading, Paragraph, Text } from "@/components/ui/typography";
+import { Heading, Text } from "@/components/ui/typography";
 import { AnnotationsBlock } from "@/routes/v2/pages/Editor/components/AnnotationsBlock/AnnotationsBlock";
 import { useEditorSession } from "@/routes/v2/pages/Editor/store/EditorSessionContext";
 import { useSpec } from "@/routes/v2/shared/providers/SpecContext";
@@ -20,6 +21,7 @@ import { ConfigurationSection } from "./components/ConfigurationSection";
 import { OutputsSection } from "./components/OutputsSection";
 import { TaskActionsBar } from "./components/TaskActionsBar";
 import { TaskArgumentsEditor } from "./components/TaskArgumentsEditor";
+import { useTaskConfigActions } from "./components/useTaskConfigActions";
 import { useTask } from "./hooks/useTask";
 
 const EDITOR_ANNOTATION_KEYS = [
@@ -39,6 +41,7 @@ export const TaskDetails = observer(function TaskDetails({
 }: TaskDetailsProps) {
   const { editor } = useSharedStores();
   const { undo } = useEditorSession();
+  const { setTaskColor } = useTaskConfigActions();
   const spec = useSpec();
   const task = useTask(entityId);
   const { focusedArgumentName } = editor;
@@ -61,6 +64,11 @@ export const TaskDetails = observer(function TaskDetails({
   const author = componentSpec?.metadata?.annotations?.author;
 
   const isSubgraphTask = isSubgraph(task.componentRef.spec);
+  const taskColor = task.annotations.get("tangleml.com/editor/task-color");
+
+  const handleColorChange = (color: string) => {
+    setTaskColor(task, color);
+  };
 
   const handleZIndexChange = (newZIndex: number) => {
     undo.withGroup("Update task z-index", () => {
@@ -86,7 +94,7 @@ export const TaskDetails = observer(function TaskDetails({
           >
             {isSubgraphTask && <Icon name="Workflow" size="sm" />}
             <Text size="sm" weight="semibold" className="wrap-anywhere">
-              {task.name} ---
+              {task.name}
             </Text>
           </InlineStack>
           <InlineStack gap="1" blockAlign="center" className="shrink-0">
@@ -179,9 +187,22 @@ export const TaskDetails = observer(function TaskDetails({
         {/* ── Configuration ── */}
         <TabsContent value="configuration" className={TAB_CONTENT_CLASS}>
           <BlockStack gap="4">
-            <Paragraph size="sm" tone="subdued">
-              Configure task annotations, resources and custom data.
-            </Paragraph>
+            <InlineStack
+              align="space-between"
+              blockAlign="center"
+              className="w-full"
+            >
+              <Text size="sm" className="text-gray-600">
+                Task color
+              </Text>
+              <ColorPicker
+                title="Task color"
+                color={taskColor}
+                setColor={handleColorChange}
+              />
+            </InlineStack>
+
+            <Separator />
 
             <ConfigurationSection task={task} />
 

--- a/src/routes/v2/shared/nodes/TaskNode/TaskNodeClassic.tsx
+++ b/src/routes/v2/shared/nodes/TaskNode/TaskNodeClassic.tsx
@@ -16,25 +16,17 @@ import { useSpec } from "@/routes/v2/shared/providers/SpecContext";
 
 import type { TaskNodeInput, TaskNodeViewProps } from "./TaskNode";
 
-const classicCardVariants = cva(
+const cardVariants = cva(
   "min-w-[300px] max-w-[350px] rounded-2xl border-2 p-0 drop-shadow-none cursor-pointer select-none gap-2",
   {
     variants: {
       selected: { true: "", false: "" },
       hovered: { true: "", false: "" },
-      subgraph: { true: "", false: "" },
     },
     compoundVariants: [
       {
         selected: false,
         hovered: false,
-        subgraph: false,
-        className: "border-gray-200 hover:border-slate-200",
-      },
-      {
-        selected: false,
-        hovered: false,
-        subgraph: true,
         className: "border-gray-200 hover:border-slate-200",
       },
       {
@@ -50,7 +42,6 @@ const classicCardVariants = cva(
     defaultVariants: {
       selected: false,
       hovered: false,
-      subgraph: false,
     },
   },
 );
@@ -187,19 +178,25 @@ export const TaskNodeClassic = observer(function TaskNodeClassic({
   onInputClick,
   onOutputClick,
   onHandleClick,
+  taskColor,
   cacheDisabled,
   digest,
 }: TaskNodeViewProps) {
+  const cardStyle = taskColor ? { backgroundColor: taskColor } : undefined;
+
   return (
     <Card
-      className={classicCardVariants({
+      className={cardVariants({
         selected,
         hovered: isHovered,
-        subgraph: isSubgraph,
       })}
+      style={cardStyle}
       onClick={onNodeClick}
     >
-      <CardHeader className="border-b border-slate-200 px-4 py-5">
+      <CardHeader
+        className="px-4 py-5"
+        style={taskColor ? { borderBottomColor: `${taskColor}30` } : undefined}
+      >
         <BlockStack>
           <InlineStack
             gap="2"
@@ -242,12 +239,17 @@ export const TaskNodeClassic = observer(function TaskNodeClassic({
                   <TooltipContent side="top">Cache Disabled</TooltipContent>
                 </Tooltip>
               )}
-              <CardTitle className="wrap-anywhere max-w-full text-left text-xs text-slate-900">
+              <CardTitle
+                className={cn(
+                  "wrap-anywhere max-w-full text-left text-xs",
+                  !taskColor && "text-slate-900",
+                )}
+              >
                 {taskName}
               </CardTitle>
             </InlineStack>
             {digest && (
-              <span className="text-xs font-light font-mono text-gray-400 shrink-0">
+              <span className="text-xs font-light font-mono text-gray-500 shrink-0 bg-white/60 rounded px-1">
                 {trimDigest(digest)}
               </span>
             )}


### PR DESCRIPTION
## Description

Added task color customization functionality to the TaskNode editor. Users can now set custom colors for tasks through a color picker in the configuration tab, which will be applied as the background color of the task node. The color is stored as an annotation and persists with the task configuration.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)  
  
![image.png](https://app.graphite.com/user-attachments/assets/dda94d66-063c-4868-a25b-aadba47acfcf.png)



## Test Instructions

1. Open the task editor and select any task node
2. Navigate to the "Configuration" tab in the task details panel
3. Use the color picker to select a custom color for the task
4. Verify the task node background color updates to reflect the selected color
5. Ensure the color persists when saving and reloading the workflow
6. Test that the digest text remains readable with the background styling applied

## Additional Comments

The implementation includes proper contrast handling for text elements and maintains the existing visual hierarchy while applying the custom background color. The color picker is integrated into the existing configuration section with appropriate spacing and layout.