### PR TITLE
Add keyboard shortcuts for layout presets

### DIFF
--- a/src/routes/v2/pages/Editor/components/EditorMenuBar/components/WindowsMenu.tsx
+++ b/src/routes/v2/pages/Editor/components/EditorMenuBar/components/WindowsMenu.tsx
@@ -6,6 +6,7 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator,
+  DropdownMenuShortcut,
   DropdownMenuSub,
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
@@ -13,11 +14,18 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Icon } from "@/components/ui/icon";
 import { MenuTriggerButton } from "@/routes/v2/shared/components/MenuTriggerButton";
+import { ShortcutBadge } from "@/routes/v2/shared/components/ShortcutBadge";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 import {
   VIEW_PRESETS,
   type ViewPreset,
 } from "@/routes/v2/shared/windows/viewPresets";
+
+const PRESET_SHORTCUT_IDS: Record<string, string> = {
+  Default: "layout-default",
+  Minimal: "layout-minimal",
+  All: "layout-all",
+};
 
 export const WindowsMenu = observer(function WindowsMenu() {
   const { windows } = useSharedStores();
@@ -61,6 +69,11 @@ export const WindowsMenu = observer(function WindowsMenu() {
                 onSelect={() => applyPreset(preset)}
               >
                 {preset.label}
+                {PRESET_SHORTCUT_IDS[preset.label] && (
+                  <DropdownMenuShortcut>
+                    <ShortcutBadge id={PRESET_SHORTCUT_IDS[preset.label]} />
+                  </DropdownMenuShortcut>
+                )}
               </DropdownMenuItem>
             ))}
           </DropdownMenuSubContent>

--- a/src/routes/v2/shared/hooks/useFocusMode.ts
+++ b/src/routes/v2/shared/hooks/useFocusMode.ts
@@ -4,24 +4,37 @@ import { useEffect } from "react";
 import { CMDALT } from "@/routes/v2/shared/shortcuts/keys";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 import { VIEW_PRESETS } from "@/routes/v2/shared/windows/viewPresets";
+import type { WindowStoreImpl } from "@/routes/v2/shared/windows/windowStore";
 
 class FocusModeStore {
   @observable accessor active = false;
+  private previousVisibleIds: string[] = [];
 
   constructor() {
     makeObservable(this);
   }
 
-  @action setActive(value: boolean): void {
-    this.active = value;
+  /** Snapshot which windows are currently visible, then enter minimal. */
+  @action enterMinimal(windows: WindowStoreImpl): void {
+    this.previousVisibleIds = windows
+      .getAllWindows()
+      .filter((w) => w.state !== "hidden")
+      .map((w) => w.id);
+    this.active = true;
   }
 
-  @action toggle(): void {
-    this.active = !this.active;
+  /** Restore the windows that were visible before entering minimal. */
+  @action exitMinimal(windows: WindowStoreImpl): void {
+    for (const id of this.previousVisibleIds) {
+      windows.restoreWindow(id);
+    }
+    this.previousVisibleIds = [];
+    this.active = false;
   }
 
   @action reset(): void {
     this.active = false;
+    this.previousVisibleIds = [];
   }
 }
 
@@ -29,8 +42,9 @@ export const focusModeStore = new FocusModeStore();
 
 /**
  * Registers keyboard shortcuts for view presets:
- * - Cmd+Alt+/ : Toggle Minimal layout (hide all panels)
- * - Cmd+Alt+D : Default layout
+ * - Cmd+Alt+1 : Default layout
+ * - Cmd+Alt+2 : Toggle Minimal layout (restores previous state on exit)
+ * - Cmd+Alt+3 : All windows
  */
 export function useFocusMode(): void {
   const { keyboard, windows } = useSharedStores();
@@ -42,28 +56,44 @@ export function useFocusMode(): void {
   };
 
   useEffect(() => {
-    const unregisterMinimal = keyboard.registerShortcut({
-      id: "focus-mode",
-      keys: [CMDALT, "/"],
-      label: "Minimal layout",
+    const unregisterDefault = keyboard.registerShortcut({
+      id: "layout-default",
+      keys: [CMDALT, "1"],
+      label: "Default layout",
       action: () => {
-        const allHidden = windows
-          .getAllWindows()
-          .every((w) => w.state === "hidden");
-        applyPreset(allHidden ? "Default" : "Minimal");
+        applyPreset("Default");
+        focusModeStore.reset();
       },
     });
 
-    const unregisterDefault = keyboard.registerShortcut({
-      id: "default-layout",
-      keys: [CMDALT, "D"],
-      label: "Default layout",
-      action: () => applyPreset("Default"),
+    const unregisterMinimal = keyboard.registerShortcut({
+      id: "layout-minimal",
+      keys: [CMDALT, "2"],
+      label: "Minimal layout",
+      action: () => {
+        if (focusModeStore.active) {
+          focusModeStore.exitMinimal(windows);
+        } else {
+          focusModeStore.enterMinimal(windows);
+          applyPreset("Minimal");
+        }
+      },
+    });
+
+    const unregisterAll = keyboard.registerShortcut({
+      id: "layout-all",
+      keys: [CMDALT, "3"],
+      label: "All windows",
+      action: () => {
+        applyPreset("All");
+        focusModeStore.reset();
+      },
     });
 
     return () => {
-      unregisterMinimal();
       unregisterDefault();
+      unregisterMinimal();
+      unregisterAll();
     };
   }, [keyboard, windows]);
 }

--- a/src/routes/v2/shared/windows/viewPresets.ts
+++ b/src/routes/v2/shared/windows/viewPresets.ts
@@ -24,6 +24,11 @@ export const VIEW_PRESETS: ViewPreset[] = [
     dockPositions: DEFAULT_DOCK_POSITIONS,
   },
   {
+    label: "Minimal",
+    description: "Hide all panels",
+    visible: new Set<string>(),
+  },
+  {
     label: "All",
     description: "All windows visible",
     visible: new Set([
@@ -35,10 +40,5 @@ export const VIEW_PRESETS: ViewPreset[] = [
       "recent-runs",
     ]),
     dockPositions: DEFAULT_DOCK_POSITIONS,
-  },
-  {
-    label: "Minimal",
-    description: "Hide all panels",
-    visible: new Set<string>(),
   },
 ];


### PR DESCRIPTION
## Description

Enhanced the Windows menu and layout shortcuts with improved keyboard navigation and state management. Added keyboard shortcuts for layout presets (Cmd+Alt+1 for Default, Cmd+Alt+2 for Minimal, Cmd+Alt+3 for All) and displayed these shortcuts in the Windows menu dropdown. Improved the minimal layout toggle to remember and restore the previous window state when exiting minimal mode. Reordered view presets to place Minimal between Default and All for better logical grouping.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Open the Editor and access the Windows menu
2. Verify that keyboard shortcuts are displayed next to Default, Minimal, and All layout options
3. Test the keyboard shortcuts:
   - Press Cmd+Alt+1 to apply Default layout
   - Press Cmd+Alt+2 to toggle Minimal layout (should hide all panels)
   - Press Cmd+Alt+2 again to restore previous window state
   - Press Cmd+Alt+3 to show All windows
4. Verify that the minimal layout toggle properly remembers and restores the previous window configuration

## Additional Comments

The focus mode store now tracks which windows were visible before entering minimal mode, allowing for proper state restoration when toggling back. This provides a more intuitive user experience when quickly switching between focused and normal editing modes.