### PR TITLE
fix: restore auto-scaling for collapsed nodes in v2

### DIFF
--- a/src/routes/v2/shared/flowCanvasDefaults.ts
+++ b/src/routes/v2/shared/flowCanvasDefaults.ts
@@ -2,6 +2,7 @@ import { SelectionMode } from "@xyflow/react";
 
 export const GRID_SIZE = 10;
 export const ZOOM_THRESHOLD = 0.3;
+export const MAX_COLLAPSED_SCALE = 7;
 
 /**
  * Shared ReactFlow props that are identical across Editor and RunView canvases.

--- a/src/routes/v2/shared/hooks/useViewportScaling.ts
+++ b/src/routes/v2/shared/hooks/useViewportScaling.ts
@@ -1,10 +1,17 @@
 import type { Viewport } from "@xyflow/react";
 import { useRef } from "react";
 
+import {
+  MAX_COLLAPSED_SCALE,
+  ZOOM_THRESHOLD,
+} from "@/routes/v2/shared/flowCanvasDefaults";
+
 export function useViewportScaling() {
   const containerRef = useRef<HTMLDivElement>(null);
 
   const handleViewportChange = ({ zoom }: Viewport) => {
+    const scale = Math.min(ZOOM_THRESHOLD / zoom, MAX_COLLAPSED_SCALE);
+    containerRef.current?.style.setProperty("--collapsed-scale", String(scale));
     containerRef.current?.style.setProperty("--zoom-level", String(zoom));
   };
 

--- a/src/routes/v2/shared/nodes/TaskNode/TaskNodeCollapsed.tsx
+++ b/src/routes/v2/shared/nodes/TaskNode/TaskNodeCollapsed.tsx
@@ -8,6 +8,7 @@ import { getContrastTextColor } from "@/routes/v2/shared/nodes/TaskNode/color.ut
 import type { TaskNodeViewProps } from "./TaskNode";
 import { createTaskNodeCardVariants } from "./taskNode.variants";
 
+const PERCEIVED_FONT_SIZE = "36px";
 const s = "var(--collapsed-scale, 1)";
 
 const collapsedCardVariants = createTaskNodeCardVariants(
@@ -90,7 +91,10 @@ export function TaskNodeCollapsed({
             "font-semibold break-words min-w-0",
             !taskColor && "text-slate-900",
           )}
-          style={{ fontSize: `calc(${s} * 32px)`, lineHeight: 1.2 }}
+          style={{
+            fontSize: `calc(${s} * ${PERCEIVED_FONT_SIZE})`,
+            lineHeight: 1.2,
+          }}
         >
           {taskName}
         </span>


### PR DESCRIPTION
## Description

Introduces a maximum scale cap (`MAX_COLLAPSED_SCALE = 7`) for collapsed task nodes to prevent them from scaling indefinitely when zooming out. The `--collapsed-scale` CSS variable is now computed as `min(ZOOM_THRESHOLD / zoom, MAX_COLLAPSED_SCALE)` and applied alongside the existing `--zoom-level` variable. Additionally, the perceived font size for collapsed node labels has been increased from `32px` to `36px` to improve readability at collapsed scale.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Open the flow canvas editor or run view.
2. Zoom out past the `ZOOM_THRESHOLD` (0.3) to trigger collapsed node rendering.
3. Continue zooming out to verify that collapsed node labels no longer grow beyond the capped scale.
4. Confirm that label text remains legible and does not overflow node boundaries at various zoom levels.

## Additional Comments

The `MAX_COLLAPSED_SCALE` constant is defined in `flowCanvasDefaults.ts` to keep it consistent and reusable across both the Editor and RunView canvases.