### PR TITLE
fix: import pipeline in v2 should navigate to a proper file

### DIFF
--- a/src/components/shared/ImportPipeline.tsx
+++ b/src/components/shared/ImportPipeline.tsx
@@ -25,47 +25,65 @@ import {
   importPipelineFromYaml,
   type ImportResult,
 } from "@/services/pipelineService";
+import { usePipelineStorage } from "@/services/pipelineStorage/PipelineStorageProvider";
+import type { PipelineRef } from "@/services/pipelineStorage/types";
 
 interface ImportPipelineProps {
   triggerComponent?: ReactElement<{ onClick?: () => void }>;
+  onImportComplete?: (pipeline: PipelineRef) => void;
 }
 
-const ImportPipeline = ({ triggerComponent }: ImportPipelineProps) => {
+const ImportPipeline = ({
+  triggerComponent,
+  onImportComplete,
+}: ImportPipelineProps) => {
   const { track } = useAnalytics();
   const [isOpen, setIsOpen] = useState(false);
-  const [newPipelineName, setNewPipelineName] = useState<string | null>(null);
+  const [importedPipeline, setImportedPipeline] = useState<PipelineRef | null>(
+    null,
+  );
   const [yamlContent, setYamlContent] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const navigate = useNavigate();
+  const storage = usePipelineStorage();
 
   const navigateToPipeline = () => {
-    if (newPipelineName) {
-      setIsOpen(false);
-      setNewPipelineName(null);
-      setIsLoading(false);
-      setError(null);
-      setSuccessMessage(null);
-      navigate({ to: `${EDITOR_PATH}/${encodeURIComponent(newPipelineName)}` });
+    if (!importedPipeline) return;
+
+    setIsOpen(false);
+    setImportedPipeline(null);
+    setIsLoading(false);
+    setError(null);
+    setSuccessMessage(null);
+
+    if (onImportComplete) {
+      onImportComplete(importedPipeline);
+    } else {
+      navigate({
+        to: `${EDITOR_PATH}/${encodeURIComponent(importedPipeline.name)}`,
+      });
     }
   };
 
-  const handleImportResult = (result: ImportResult) => {
-    if (result.successful) {
-      if (result.errorMessage?.includes("was renamed")) {
-        setSuccessMessage(result.errorMessage);
-      } else if (result.successful) {
-        setSuccessMessage(`Pipeline "${result.name}" imported successfully.`);
-      }
-      setNewPipelineName(result.name);
-    } else {
+  const handleImportResult = async (result: ImportResult) => {
+    if (!result.successful) {
       throw new Error(
         result.errorMessage ||
           "Failed to import pipeline. Please check that the YAML is valid.",
       );
     }
+
+    if (result.errorMessage?.includes("was renamed")) {
+      setSuccessMessage(result.errorMessage);
+    } else {
+      setSuccessMessage(`Pipeline "${result.name}" imported successfully.`);
+    }
+
+    const file = await storage.rootFolder.assignFile(result.name);
+    setImportedPipeline({ name: result.name, fileId: file.id });
   };
 
   const handleFileChange = async (e: ChangeEvent<HTMLInputElement>) => {
@@ -78,7 +96,7 @@ const ImportPipeline = ({ triggerComponent }: ImportPipelineProps) => {
 
     try {
       const result = await importPipelineFromFile(files[0]);
-      handleImportResult(result);
+      await handleImportResult(result);
       if (result.successful) {
         track("pipeline_editor.pipeline_actions.import_pipeline_completed", {
           method: "file",
@@ -109,7 +127,7 @@ const ImportPipeline = ({ triggerComponent }: ImportPipelineProps) => {
 
     try {
       const result = await importPipelineFromYaml(yamlContent);
-      handleImportResult(result);
+      await handleImportResult(result);
       if (result.successful) {
         track("pipeline_editor.pipeline_actions.import_pipeline_completed", {
           method: "content",
@@ -130,6 +148,7 @@ const ImportPipeline = ({ triggerComponent }: ImportPipelineProps) => {
     setError(null);
     setSuccessMessage(null);
     setYamlContent("");
+    setImportedPipeline(null);
   };
 
   const ButtonComponent = triggerComponent ? (

--- a/src/routes/v2/pages/Editor/components/EditorMenuBar/components/FileMenu.tsx
+++ b/src/routes/v2/pages/Editor/components/EditorMenuBar/components/FileMenu.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
 
 import {
@@ -14,6 +15,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Icon } from "@/components/ui/icon";
+import { APP_ROUTES } from "@/routes/router";
 import { useEditorSession } from "@/routes/v2/pages/Editor/store/EditorSessionContext";
 import { MenuTriggerButton } from "@/routes/v2/shared/components/MenuTriggerButton";
 import { MovePipelineDialog } from "@/routes/v2/shared/components/MovePipelineDialog";
@@ -45,6 +47,7 @@ export function FileMenu() {
     handleDeletePipeline,
   } = useFileMenuState();
 
+  const navigate = useNavigate();
   const { pipelineFile: pipelineFileStore } = useEditorSession();
   const activePipeline = pipelineFileStore.activePipelineFile;
   const [moveDialogOpen, setMoveDialogOpen] = useState(false);
@@ -166,6 +169,13 @@ export function FileMenu() {
             tabIndex={-1}
           />
         }
+        onImportComplete={(pipeline) => {
+          navigate({
+            to: APP_ROUTES.EDITOR_V2_PIPELINE,
+            params: { pipelineName: pipeline.name },
+            search: { fileId: pipeline.fileId },
+          });
+        }}
       />
     </>
   );

--- a/src/routes/v2/pages/Editor/hooks/useLoadSpec.ts
+++ b/src/routes/v2/pages/Editor/hooks/useLoadSpec.ts
@@ -16,6 +16,8 @@ import {
   createUndoStoreWithEvents,
   loadUndoHistory,
 } from "@/routes/v2/pages/Editor/utils/undoHistoryStorage";
+import { RootFolderDbStorageDriver } from "@/services/pipelineStorage/drivers/RootFolderDbStorageDriver";
+import type { PipelineFile } from "@/services/pipelineStorage/PipelineFile";
 import { usePipelineStorage } from "@/services/pipelineStorage/PipelineStorageProvider";
 import type { PipelineStorageService } from "@/services/pipelineStorage/PipelineStorageService";
 import type { PipelineRef } from "@/services/pipelineStorage/types";
@@ -33,13 +35,29 @@ function deserializeSpec(data: unknown, idGen?: IdGenerator): ComponentSpec {
   return spec;
 }
 
+async function backfillFromLegacyStore(
+  name: string,
+  storage: PipelineStorageService,
+): Promise<PipelineFile | undefined> {
+  const legacyDriver = new RootFolderDbStorageDriver();
+
+  const existsInLegacy = await legacyDriver.hasKey(name);
+  if (!existsInLegacy) return undefined;
+
+  return storage.rootFolder.assignFile(name);
+}
+
 async function resolveSpecData(
   ref: PipelineRef,
   storage: PipelineStorageService,
 ): Promise<unknown> {
-  const pipelineFile = ref.fileId
+  let pipelineFile = ref.fileId
     ? await storage.findPipelineById(ref.fileId)
     : await storage.resolvePipelineByName(ref.name);
+
+  if (!pipelineFile) {
+    pipelineFile = await backfillFromLegacyStore(ref.name, storage);
+  }
 
   if (!pipelineFile) {
     throw new Error(`Pipeline "${ref.name}" not found`);


### PR DESCRIPTION
## Description

After importing a pipeline, the editor now navigates using both the pipeline name and its file ID (via `PipelineRef`). This ensures the editor can reliably locate the correct file rather than relying solely on the name.

An `onImportComplete` callback has been added to `ImportPipeline`, allowing callers to override the default post-import navigation behavior. The `FileMenu` in the v2 editor uses this callback to navigate with the full `PipelineRef`, including the `fileId` as a search parameter.

A backfill path has also been introduced in `useLoadSpec` so that pipelines stored in the legacy `RootFolderDbStorageDriver` are automatically migrated to the new storage layer when accessed by name, preventing "pipeline not found" errors for existing pipelines that haven't yet been assigned a file ID.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Import a pipeline using the File menu in the v2 editor.
2. Confirm the editor navigates to the imported pipeline and the URL includes the `fileId` search parameter.
3. Open a pipeline that was previously saved under the legacy storage driver (no `fileId`) and confirm it loads correctly without a "not found" error.
4. Verify that renaming during import still shows the appropriate success message.

## Additional Comments

The backfill logic in `useLoadSpec` is a compatibility shim for pipelines that exist in the legacy store but have not yet been assigned a file ID in the new storage layer. It assigns the file on first access, so subsequent loads will resolve by ID.