### PR TITLE
fix: subgraph create should deduplicated bindings on name conflict

### DIFF
--- a/src/models/componentSpec/__tests__/actions/unpackSubgraph.test.ts
+++ b/src/models/componentSpec/__tests__/actions/unpackSubgraph.test.ts
@@ -1,0 +1,440 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { createSubgraph } from "../../actions/createSubgraph";
+import { unpackSubgraph } from "../../actions/unpackSubgraph";
+import { Annotations } from "../../annotations";
+import { Binding } from "../../entities/binding";
+import { ComponentSpec } from "../../entities/componentSpec";
+import { Input } from "../../entities/input";
+import { Output } from "../../entities/output";
+import { Task } from "../../entities/task";
+import { IncrementingIdGenerator } from "../../factories/idGenerator";
+
+function positionAnnotation(x: number, y: number): Annotations {
+  return Annotations.from([{ key: "editor.position", value: { x, y } }]);
+}
+
+function makeTask(
+  idGen: IncrementingIdGenerator,
+  name: string,
+  overrides: Partial<{
+    componentRef: Record<string, unknown>;
+    isEnabled: unknown;
+    executionOptions: Record<string, unknown>;
+    arguments: Array<{ name: string; value?: unknown }>;
+    position: { x: number; y: number };
+  }> = {},
+): Task {
+  const pos = overrides.position ?? { x: 0, y: 0 };
+  const annotations = positionAnnotation(pos.x, pos.y);
+  if (overrides.arguments) {
+    const args = overrides.arguments as any[];
+    return new Task({
+      $id: idGen.next("task"),
+      name,
+      componentRef: overrides.componentRef ?? {},
+      isEnabled: overrides.isEnabled as never,
+      executionOptions: overrides.executionOptions as never,
+      annotations,
+      arguments: args,
+    });
+  }
+  return new Task({
+    $id: idGen.next("task"),
+    name,
+    componentRef: overrides.componentRef ?? {},
+    isEnabled: overrides.isEnabled as never,
+    executionOptions: overrides.executionOptions as never,
+    annotations,
+  });
+}
+
+function makeBinding(
+  idGen: IncrementingIdGenerator,
+  sourceEntityId: string,
+  sourcePortName: string,
+  targetEntityId: string,
+  targetPortName: string,
+): Binding {
+  return new Binding({
+    $id: idGen.next("binding"),
+    sourceEntityId,
+    sourcePortName,
+    targetEntityId,
+    targetPortName,
+  });
+}
+
+interface BindingEdge {
+  sourcePortName: string;
+  targetPortName: string;
+  sourceName: string;
+  targetName: string;
+}
+
+function snapshotBindingEdges(spec: ComponentSpec): BindingEdge[] {
+  const entityNameMap = new Map<string, string>();
+  for (const t of spec.tasks) entityNameMap.set(t.$id, t.name);
+  for (const i of spec.inputs) entityNameMap.set(i.$id, i.name);
+  for (const o of spec.outputs) entityNameMap.set(o.$id, o.name);
+
+  return spec.bindings
+    .map((b) => ({
+      sourcePortName: b.sourcePortName,
+      targetPortName: b.targetPortName,
+      sourceName: entityNameMap.get(b.sourceEntityId) ?? "UNKNOWN",
+      targetName: entityNameMap.get(b.targetEntityId) ?? "UNKNOWN",
+    }))
+    .sort(
+      (a, b) =>
+        a.sourceName.localeCompare(b.sourceName) ||
+        a.targetName.localeCompare(b.targetName) ||
+        a.sourcePortName.localeCompare(b.sourcePortName),
+    );
+}
+
+function allEntityIds(spec: ComponentSpec): Set<string> {
+  const ids = new Set<string>();
+  for (const t of spec.tasks) ids.add(t.$id);
+  for (const i of spec.inputs) ids.add(i.$id);
+  for (const o of spec.outputs) ids.add(o.$id);
+  return ids;
+}
+
+function roundtrip(
+  spec: ComponentSpec,
+  selectedTaskIds: string[],
+  idGen: IncrementingIdGenerator,
+): boolean {
+  const result = createSubgraph({
+    spec,
+    selectedTaskIds,
+    subgraphName: "Subgraph",
+    idGen,
+  });
+  if (!result) return false;
+
+  return unpackSubgraph({
+    spec,
+    taskId: result.replacementTask.$id,
+    idGen,
+  });
+}
+
+describe("unpackSubgraph roundtrip", () => {
+  let idGen: IncrementingIdGenerator;
+
+  beforeEach(() => {
+    idGen = new IncrementingIdGenerator();
+  });
+
+  it("single task roundtrip preserves task count and properties", () => {
+    const spec = new ComponentSpec({
+      $id: idGen.next("spec"),
+      name: "Main",
+    });
+    const task = makeTask(idGen, "T1", {
+      componentRef: { name: "MyComp" },
+    });
+    spec.addTask(task);
+
+    const origTaskCount = spec.tasks.length;
+    const origBindingCount = spec.bindings.length;
+
+    expect(roundtrip(spec, [task.$id], idGen)).toBe(true);
+
+    expect(spec.tasks.length).toBe(origTaskCount);
+    expect(spec.bindings.length).toBe(origBindingCount);
+
+    const restored = spec.tasks.find((t) => t.name === "T1");
+    expect(restored).toBeDefined();
+    expect(restored?.componentRef).toEqual({ name: "MyComp" });
+  });
+
+  it("two connected tasks roundtrip preserves binding connectivity", () => {
+    const spec = new ComponentSpec({
+      $id: idGen.next("spec"),
+      name: "Main",
+    });
+    const t1 = makeTask(idGen, "T1", { position: { x: 0, y: 0 } });
+    const t2 = makeTask(idGen, "T2", { position: { x: 200, y: 0 } });
+    spec.addTask(t1);
+    spec.addTask(t2);
+    spec.addBinding(makeBinding(idGen, t1.$id, "out", t2.$id, "in"));
+
+    const origEdges = snapshotBindingEdges(spec);
+
+    expect(roundtrip(spec, [t1.$id, t2.$id], idGen)).toBe(true);
+
+    expect(spec.tasks.length).toBe(2);
+    expect(spec.bindings.length).toBe(1);
+    expect(snapshotBindingEdges(spec)).toEqual(origEdges);
+  });
+
+  it("external incoming binding preserved after roundtrip", () => {
+    const spec = new ComponentSpec({
+      $id: idGen.next("spec"),
+      name: "Main",
+    });
+    const input = new Input({ $id: idGen.next("input"), name: "data" });
+    const t1 = makeTask(idGen, "T1");
+    const t2 = makeTask(idGen, "T2", { position: { x: 200, y: 0 } });
+    spec.addInput(input);
+    spec.addTask(t1);
+    spec.addTask(t2);
+    spec.addBinding(makeBinding(idGen, input.$id, "data", t1.$id, "data"));
+    spec.addBinding(makeBinding(idGen, t1.$id, "result", t2.$id, "input"));
+
+    const origEdges = snapshotBindingEdges(spec);
+
+    expect(roundtrip(spec, [t1.$id], idGen)).toBe(true);
+
+    expect(spec.tasks.length).toBe(2);
+    expect(spec.bindings.length).toBe(2);
+    expect(snapshotBindingEdges(spec)).toEqual(origEdges);
+  });
+
+  it("external outgoing binding preserved after roundtrip", () => {
+    const spec = new ComponentSpec({
+      $id: idGen.next("spec"),
+      name: "Main",
+    });
+    const t1 = makeTask(idGen, "T1", { position: { x: 0, y: 0 } });
+    const t2 = makeTask(idGen, "T2", { position: { x: 200, y: 0 } });
+    const t3 = makeTask(idGen, "T3", { position: { x: 400, y: 0 } });
+    spec.addTask(t1);
+    spec.addTask(t2);
+    spec.addTask(t3);
+    spec.addBinding(makeBinding(idGen, t1.$id, "out", t2.$id, "in"));
+    spec.addBinding(makeBinding(idGen, t2.$id, "out", t3.$id, "in"));
+
+    const origEdges = snapshotBindingEdges(spec);
+
+    expect(roundtrip(spec, [t2.$id], idGen)).toBe(true);
+
+    expect(spec.tasks.length).toBe(3);
+    expect(spec.bindings.length).toBe(2);
+    expect(snapshotBindingEdges(spec)).toEqual(origEdges);
+  });
+
+  it("binding count preserved with complex graph (no ghost or extra bindings)", () => {
+    const spec = new ComponentSpec({
+      $id: idGen.next("spec"),
+      name: "Main",
+    });
+    const input = new Input({ $id: idGen.next("input"), name: "src" });
+    const output = new Output({ $id: idGen.next("output"), name: "sink" });
+    const t1 = makeTask(idGen, "T1", { position: { x: 0, y: 0 } });
+    const t2 = makeTask(idGen, "T2", { position: { x: 200, y: 0 } });
+    const t3 = makeTask(idGen, "T3", { position: { x: 200, y: 200 } });
+
+    spec.addInput(input);
+    spec.addOutput(output);
+    spec.addTask(t1);
+    spec.addTask(t2);
+    spec.addTask(t3);
+
+    spec.addBinding(makeBinding(idGen, input.$id, "src", t1.$id, "data"));
+    spec.addBinding(makeBinding(idGen, t1.$id, "out", t2.$id, "in"));
+    spec.addBinding(makeBinding(idGen, t2.$id, "result", output.$id, "sink"));
+    spec.addBinding(makeBinding(idGen, t1.$id, "alt", t3.$id, "in"));
+
+    const origEdges = snapshotBindingEdges(spec);
+
+    expect(roundtrip(spec, [t1.$id, t2.$id], idGen)).toBe(true);
+
+    expect(spec.tasks.length).toBe(3);
+    expect(spec.bindings.length).toBe(4);
+    expect(snapshotBindingEdges(spec)).toEqual(origEdges);
+  });
+
+  it("executionOptions with maxCacheStaleness preserved after roundtrip", () => {
+    const spec = new ComponentSpec({
+      $id: idGen.next("spec"),
+      name: "Main",
+    });
+    const task = makeTask(idGen, "CachedTask", {
+      componentRef: { name: "Comp" },
+      executionOptions: {
+        cachingStrategy: { maxCacheStaleness: "P1D" },
+      },
+    });
+    spec.addTask(task);
+
+    expect(roundtrip(spec, [task.$id], idGen)).toBe(true);
+
+    const restored = spec.tasks.find((t) => t.name === "CachedTask");
+    expect(restored).toBeDefined();
+    expect(restored?.executionOptions).toEqual({
+      cachingStrategy: { maxCacheStaleness: "P1D" },
+    });
+  });
+
+  it("executionOptions with retryStrategy preserved after roundtrip", () => {
+    const spec = new ComponentSpec({
+      $id: idGen.next("spec"),
+      name: "Main",
+    });
+    const task = makeTask(idGen, "RetryTask", {
+      componentRef: { name: "Comp" },
+      executionOptions: {
+        retryStrategy: { maxRetries: 3 },
+      },
+    });
+    spec.addTask(task);
+
+    expect(roundtrip(spec, [task.$id], idGen)).toBe(true);
+
+    const restored = spec.tasks.find((t) => t.name === "RetryTask");
+    expect(restored).toBeDefined();
+    expect(restored?.executionOptions).toEqual({
+      retryStrategy: { maxRetries: 3 },
+    });
+  });
+
+  it("executionOptions with both cachingStrategy and retryStrategy preserved", () => {
+    const spec = new ComponentSpec({
+      $id: idGen.next("spec"),
+      name: "Main",
+    });
+    const task = makeTask(idGen, "FullOptionsTask", {
+      executionOptions: {
+        cachingStrategy: { maxCacheStaleness: "PT12H" },
+        retryStrategy: { maxRetries: 5 },
+      },
+    });
+    spec.addTask(task);
+
+    expect(roundtrip(spec, [task.$id], idGen)).toBe(true);
+
+    const restored = spec.tasks.find((t) => t.name === "FullOptionsTask");
+    expect(restored?.executionOptions).toEqual({
+      cachingStrategy: { maxCacheStaleness: "PT12H" },
+      retryStrategy: { maxRetries: 5 },
+    });
+  });
+
+  it("isEnabled predicate preserved after roundtrip", () => {
+    const spec = new ComponentSpec({
+      $id: idGen.next("spec"),
+      name: "Main",
+    });
+    const predicate = { "==": { op1: "a", op2: "b" } };
+    const task = makeTask(idGen, "ConditionalTask", {
+      isEnabled: predicate,
+    });
+    spec.addTask(task);
+
+    expect(roundtrip(spec, [task.$id], idGen)).toBe(true);
+
+    const restored = spec.tasks.find((t) => t.name === "ConditionalTask");
+    expect(restored).toBeDefined();
+    expect(restored?.isEnabled).toEqual(predicate);
+  });
+
+  it("static arguments preserved after roundtrip", () => {
+    const spec = new ComponentSpec({
+      $id: idGen.next("spec"),
+      name: "Main",
+    });
+    const task = makeTask(idGen, "ArgTask", {
+      arguments: [
+        { name: "param", value: "hello" },
+        { name: "count", value: 42 },
+      ],
+    });
+    spec.addTask(task);
+
+    expect(roundtrip(spec, [task.$id], idGen)).toBe(true);
+
+    const restored = spec.tasks.find((t) => t.name === "ArgTask");
+    expect(restored).toBeDefined();
+
+    const paramArg = restored?.arguments.find((a) => a.name === "param");
+    expect(paramArg?.value).toBe("hello");
+
+    const countArg = restored?.arguments.find((a) => a.name === "count");
+    expect(countArg?.value).toBe(42);
+  });
+
+  it("no ghost bindings after unpack (all binding endpoints reference real entities)", () => {
+    const spec = new ComponentSpec({
+      $id: idGen.next("spec"),
+      name: "Main",
+    });
+    const input = new Input({ $id: idGen.next("input"), name: "data" });
+    const output = new Output({ $id: idGen.next("output"), name: "result" });
+    const t1 = makeTask(idGen, "T1", { position: { x: 0, y: 0 } });
+    const t2 = makeTask(idGen, "T2", { position: { x: 200, y: 0 } });
+
+    spec.addInput(input);
+    spec.addOutput(output);
+    spec.addTask(t1);
+    spec.addTask(t2);
+    spec.addBinding(makeBinding(idGen, input.$id, "data", t1.$id, "data"));
+    spec.addBinding(makeBinding(idGen, t1.$id, "out", t2.$id, "in"));
+    spec.addBinding(makeBinding(idGen, t2.$id, "out", output.$id, "result"));
+
+    expect(roundtrip(spec, [t1.$id, t2.$id], idGen)).toBe(true);
+
+    const validIds = allEntityIds(spec);
+    for (const binding of spec.bindings) {
+      expect(
+        validIds.has(binding.sourceEntityId),
+        `binding source ${binding.sourceEntityId} should reference a real entity`,
+      ).toBe(true);
+      expect(
+        validIds.has(binding.targetEntityId),
+        `binding target ${binding.targetEntityId} should reference a real entity`,
+      ).toBe(true);
+    }
+  });
+
+  it("no duplicate bindings when different sources feed same-named ports on different selected tasks", () => {
+    const spec = new ComponentSpec({
+      $id: idGen.next("spec"),
+      name: "Main",
+    });
+
+    const extA = makeTask(idGen, "ExtA", { position: { x: 0, y: 0 } });
+    const extB = makeTask(idGen, "ExtB", { position: { x: 0, y: 200 } });
+    const t1 = makeTask(idGen, "T1", { position: { x: 200, y: 0 } });
+    const t2 = makeTask(idGen, "T2", { position: { x: 200, y: 200 } });
+    const t3 = makeTask(idGen, "T3", { position: { x: 400, y: 100 } });
+
+    spec.addTask(extA);
+    spec.addTask(extB);
+    spec.addTask(t1);
+    spec.addTask(t2);
+    spec.addTask(t3);
+
+    spec.addBinding(
+      makeBinding(idGen, extA.$id, "result", t1.$id, "trainer_name"),
+    );
+    spec.addBinding(
+      makeBinding(idGen, extB.$id, "name", t2.$id, "trainer_name"),
+    );
+    spec.addBinding(makeBinding(idGen, t1.$id, "out", t3.$id, "in"));
+    spec.addBinding(makeBinding(idGen, t2.$id, "out", t3.$id, "in2"));
+
+    const origEdges = snapshotBindingEdges(spec);
+    const origBindingCount = spec.bindings.length;
+
+    expect(roundtrip(spec, [t1.$id, t2.$id], idGen)).toBe(true);
+
+    expect(spec.bindings.length).toBe(origBindingCount);
+    expect(snapshotBindingEdges(spec)).toEqual(origEdges);
+
+    const validIds = allEntityIds(spec);
+    for (const binding of spec.bindings) {
+      expect(
+        validIds.has(binding.sourceEntityId),
+        `binding source ${binding.sourceEntityId} should reference a real entity`,
+      ).toBe(true);
+      expect(
+        validIds.has(binding.targetEntityId),
+        `binding target ${binding.targetEntityId} should reference a real entity`,
+      ).toBe(true);
+    }
+  });
+});

--- a/src/models/componentSpec/actions/createSubgraph.ts
+++ b/src/models/componentSpec/actions/createSubgraph.ts
@@ -10,6 +10,7 @@ import type {
   Annotation,
   Argument,
   ComponentReference,
+  ExecutionOptionsSpec,
   PredicateType,
 } from "../entities/types";
 import type { IdGenerator } from "../factories/idGenerator";
@@ -34,6 +35,7 @@ interface TaskSnapshot {
   isEnabled?: PredicateType;
   annotations: Annotation[];
   arguments: Argument[];
+  executionOptions?: ExecutionOptionsSpec;
 }
 
 interface BindingSnapshot {
@@ -52,6 +54,9 @@ function snapshotTask(t: Task): TaskSnapshot {
     isEnabled: t.isEnabled ? deepClone(t.isEnabled) : undefined,
     annotations: t.annotations.items.map((a) => deepClone(a)),
     arguments: t.arguments.map((a) => deepClone(a)),
+    executionOptions: t.executionOptions
+      ? deepClone(t.executionOptions)
+      : undefined,
   };
 }
 
@@ -121,9 +126,10 @@ export function createSubgraph({
 
   const subgraphInputs: Input[] = [];
   const inputGroups: Array<{ input: Input; bindings: BindingSnapshot[] }> = [];
+  const usedInputNames = new Set<string>();
   for (const [, bindings] of Object.entries(incomingBySource)) {
     const first = bindings[0];
-    const inputName = first.targetPortName;
+    const inputName = deduplicatePortName(first.targetPortName, usedInputNames);
     const input = new Input({
       $id: idGen.next("input"),
       name: inputName,
@@ -140,9 +146,13 @@ export function createSubgraph({
   const subgraphOutputs: Output[] = [];
   const outputGroups: Array<{ output: Output; bindings: BindingSnapshot[] }> =
     [];
+  const usedOutputNames = new Set<string>();
   for (const [, bindings] of Object.entries(outgoingBySource)) {
     const first = bindings[0];
-    const outputName = first.sourcePortName;
+    const outputName = deduplicatePortName(
+      first.sourcePortName,
+      usedOutputNames,
+    );
     const output = new Output({
       $id: idGen.next("output"),
       name: outputName,
@@ -171,6 +181,7 @@ export function createSubgraph({
         isEnabled: t.isEnabled,
         annotations: Annotations.from(t.annotations),
         arguments: t.arguments,
+        executionOptions: t.executionOptions,
       }),
   );
 
@@ -274,4 +285,16 @@ function groupBy<T>(
     result[key].push(item);
   }
   return result;
+}
+
+function deduplicatePortName(baseName: string, usedNames: Set<string>): string {
+  if (!usedNames.has(baseName)) {
+    usedNames.add(baseName);
+    return baseName;
+  }
+  let counter = 2;
+  while (usedNames.has(`${baseName}_${counter}`)) counter++;
+  const unique = `${baseName}_${counter}`;
+  usedNames.add(unique);
+  return unique;
 }


### PR DESCRIPTION
## Description

Closes https://github.com/TangleML/tangle-ui/issues/2123

Fixes two bugs in the `createSubgraph` action and adds comprehensive roundtrip tests to verify correctness of `createSubgraph` followed by `unpackSubgraph`.

**Bug 1 – Duplicate port names when grouping external bindings:** When multiple external bindings targeted different selected tasks but shared the same port name (e.g., two tasks both receiving a `trainer_name` input), the subgraph would generate duplicate input/output port names. A `deduplicatePortName` helper is introduced to append a numeric suffix (`_2`, `_3`, …) when a name collision is detected, preventing ghost or duplicate bindings after an unpack.

**Bug 2 –** **`executionOptions`** **not preserved through subgraph creation:** Task `executionOptions` (caching strategy, retry strategy, etc.) were not included in the task snapshot taken during `createSubgraph`, causing them to be silently dropped. The snapshot and task reconstruction now carry `executionOptions` through correctly.

## Related Issue and Pull requests

## Type of Change

- [x] Bug fix
- [x] New feature

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

The new test suite in `unpackSubgraph.test.ts` covers the following scenarios and can be run directly:

1. Single task roundtrip preserves task count and `componentRef`.
2. Two connected tasks roundtrip preserves binding connectivity.
3. External incoming and outgoing bindings are preserved after roundtrip.
4. Complex graphs with inputs, outputs, and branching produce no ghost or extra bindings.
5. `executionOptions` with `maxCacheStaleness`, `retryStrategy`, or both are preserved.
6. `isEnabled` predicates are preserved.
7. Static `arguments` are preserved.
8. No ghost bindings remain after unpack (all binding endpoints reference real entities).
9. No duplicate bindings when different external sources feed same-named ports on different selected tasks.

## Additional Comments

The `deduplicatePortName` helper is intentionally simple: it tries the base name first, then appends `_2`, `_3`, etc. This matches the convention used elsewhere in the codebase for name collision resolution.