### PR TITLE
fix: history redo entries display order

### DIFF
--- a/src/routes/v2/pages/Editor/components/HistoryContent/HistoryContent.tsx
+++ b/src/routes/v2/pages/Editor/components/HistoryContent/HistoryContent.tsx
@@ -35,7 +35,7 @@ export const HistoryContent = observer(function HistoryContent() {
   const undoQueue = undoManager?.undoQueue ?? [];
   const redoQueue = undoManager?.redoQueue ?? [];
 
-  const redoEntries = [...redoQueue].reverse();
+  const redoEntries = [...redoQueue];
   const undoEntries = [...undoQueue].reverse();
 
   const handleInitialClick = () => {
@@ -71,7 +71,7 @@ export const HistoryContent = observer(function HistoryContent() {
                   isCurrent={false}
                   isInFuture={true}
                   onClick={() => {
-                    const stepsForward = displayIndex + 1;
+                    const stepsForward = redoEntries.length - displayIndex;
                     for (let i = 0; i < stepsForward; i++) {
                       undo.redo();
                     }


### PR DESCRIPTION
## Description

Fixes incorrect redo step calculation in the history panel. Previously, the redo queue was being reversed before display, and the number of steps forward was calculated using `displayIndex + 1`. The redo queue is no longer reversed, and the steps forward calculation is corrected to `redoEntries.length - displayIndex`, ensuring that clicking a redo entry in the history panel navigates to the correct position in the history.

## Related Issue and Pull requests

## Type of Change

- [x] Bug fix

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

[Screen Recording 2026-04-22 at 7.56.16 AM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/0d1c7233-5f32-4e6a-a7ec-6fd1f1719fbe.mov" />](https://app.graphite.com/user-attachments/video/0d1c7233-5f32-4e6a-a7ec-6fd1f1719fbe.mov)



## Test Instructions

1. Open the editor and make several changes to create a history.
2. Undo multiple steps to populate the redo queue.
3. Open the history panel and click on various redo entries.
4. Verify that clicking each entry navigates to the correct point in the history.

## Additional Comments