### PR TITLE
fix: annotations in configuration section respect ignore keys list

### DIFF
--- a/src/routes/v2/pages/Editor/components/AnnotationsBlock/AnnotationsBlock.tsx
+++ b/src/routes/v2/pages/Editor/components/AnnotationsBlock/AnnotationsBlock.tsx
@@ -114,11 +114,21 @@ function AnnotationRow({ annotation, index, annotations }: AnnotationRowProps) {
     useAnnotationActions();
 
   const handleUpdateKey = (event: ChangeEvent<HTMLInputElement>) => {
-    updateAnnotationKey(annotations, index, event.target.value);
+    const newKey = event.target.value;
+    if (newKey !== annotation.key) {
+      updateAnnotationKey(annotations, index, newKey);
+    }
   };
 
   const handleUpdateValue = (event: ChangeEvent<HTMLInputElement>) => {
-    updateAnnotationValue(annotations, index, String(event.target.value));
+    const newValue = String(event.target.value);
+    const currentValue =
+      typeof annotation.value === "object"
+        ? JSON.stringify(annotation.value)
+        : String(annotation.value ?? "");
+    if (newValue !== currentValue) {
+      updateAnnotationValue(annotations, index, newValue);
+    }
   };
 
   const handleRemove = () => {

--- a/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/TaskDetails.tsx
+++ b/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/TaskDetails.tsx
@@ -27,6 +27,12 @@ import { TaskArgumentsEditor } from "./components/TaskArgumentsEditor";
 import { useTaskConfigActions } from "./components/useTaskConfigActions";
 import { useTask } from "./hooks/useTask";
 
+const EDITOR_ANNOTATION_KEYS = [
+  "editor.position",
+  "tangleml.com/editor/task-color",
+  "tangleml.com/editor/edge-conduits",
+];
+
 interface TaskDetailsProps {
   entityId: string;
 }
@@ -184,7 +190,11 @@ export const TaskDetails = observer(function TaskDetails({
 
               <Separator />
 
-              <AnnotationsBlock annotations={task.annotations} defaultEditing />
+              <AnnotationsBlock
+                annotations={task.annotations}
+                defaultEditing
+                ignoreAnnotationKeys={EDITOR_ANNOTATION_KEYS}
+              />
             </BlockStack>
           </CollapsibleContent>
         </Collapsible>


### PR DESCRIPTION
## Description

Annotation updates in the editor now only trigger when the value has actually changed. For key updates, the new key is compared against the existing key before calling `updateAnnotationKey`. For value updates, the new value is compared against the current value (with object values serialized via `JSON.stringify`) before calling `updateAnnotationValue`. This prevents unnecessary updates from firing on every input event when the content hasn't changed.

Additionally, the `AnnotationsBlock` in `TaskDetails` now receives `ignoreAnnotationKeys={EDITOR_ANNOTATION_KEYS}`, filtering out internal editor annotation keys from the user-facing annotations panel.

## Related Issue and Pull requests

## Type of Change

- [x] Bug fix
- [x] Improvement

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Open a task in the editor and navigate to the annotations tab.
2. Edit an annotation key or value and confirm that updates only fire when the content has actually changed.
3. Verify that annotation keys defined in `EDITOR_ANNOTATION_KEYS` are not displayed in the annotations panel.

## Additional Comments