### PR TITLE
chore: v2: add tags to v2 editor

### DIFF
--- a/src/models/componentSpec/annotations.ts
+++ b/src/models/componentSpec/annotations.ts
@@ -37,6 +37,7 @@ interface AnnotationTypeMap {
   "tangleml.com/editor/edge-conduits": EdgeConduit[];
   "flex-nodes": FlexNodeData[];
   notes: string;
+  tags: string[];
 }
 
 type KnownAnnotationKey = keyof AnnotationTypeMap;
@@ -108,6 +109,21 @@ const codecs = {
     serialize: (value: string) => value,
     deserialize: (raw: unknown) => (typeof raw === "string" ? raw : ""),
     defaultValue: "",
+  },
+  tags: {
+    serialize: (value: string[]) =>
+      value
+        .map((t) => t.trim())
+        .filter(Boolean)
+        .join(","),
+    deserialize: (raw: unknown) =>
+      typeof raw === "string"
+        ? raw
+            .split(",")
+            .map((t) => t.trim())
+            .filter(Boolean)
+        : [],
+    defaultValue: [] as string[],
   },
 } satisfies {
   [K in KnownAnnotationKey]: AnnotationCodec<AnnotationTypeMap[K]>;

--- a/src/routes/v2/pages/Editor/components/PipelineDetailsContent/PipelineDetailsContent.tsx
+++ b/src/routes/v2/pages/Editor/components/PipelineDetailsContent/PipelineDetailsContent.tsx
@@ -13,14 +13,17 @@ import { ValidationSummary } from "@/routes/v2/pages/Editor/components/Validatio
 import { usePipelineActions } from "@/routes/v2/pages/Editor/store/actions/usePipelineActions";
 import { useSpec } from "@/routes/v2/shared/providers/SpecContext";
 import { PIPELINE_NOTES_ANNOTATION } from "@/utils/annotations";
+import { PIPELINE_TAGS_ANNOTATION } from "@/utils/annotations";
 
 import { DigestBlock } from "./components/DigestBlock";
 import { InputsBlock } from "./components/InputsBlock";
 import { MetadataBlock } from "./components/MetadataBlock";
 import { OutputsBlock } from "./components/OutputsBlock";
+import { TagsBlock } from "./components/TagsBlock";
 
 const EXCLUDED_ANNOTATIONS = [
   "notes",
+  PIPELINE_TAGS_ANNOTATION,
   "flex-nodes",
   "tangleml.com/editor/edge-conduits",
 ];
@@ -145,6 +148,8 @@ export const PipelineDetailsContent = observer(
             data-testid="pipeline-notes-input"
           />
         </ContentBlock>
+
+        <TagsBlock spec={spec} />
       </BlockStack>
     );
   },

--- a/src/routes/v2/pages/Editor/components/PipelineDetailsContent/components/TagsBlock.tsx
+++ b/src/routes/v2/pages/Editor/components/PipelineDetailsContent/components/TagsBlock.tsx
@@ -1,0 +1,134 @@
+import { observer } from "mobx-react-lite";
+import { useState } from "react";
+
+import { Tag } from "@/components/Editor/Context/Tags/Tag";
+import { TagEditor } from "@/components/Editor/Context/Tags/TagEditor";
+import { ContentBlock } from "@/components/shared/ContextPanel/Blocks/ContentBlock";
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icon";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Paragraph } from "@/components/ui/typography";
+import type { ComponentSpec } from "@/models/componentSpec";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
+import { usePipelineActions } from "@/routes/v2/pages/Editor/store/actions/usePipelineActions";
+import { PIPELINE_TAGS_ANNOTATION } from "@/utils/annotations";
+
+const TAG_LIMIT = 10;
+
+export const TagsBlock = observer(function TagsBlock({
+  spec,
+}: {
+  spec: ComponentSpec;
+}) {
+  const { updatePipelineTags } = usePipelineActions();
+  const { track } = useAnalytics();
+
+  const [isAdding, setIsAdding] = useState(false);
+  const [newTagValue, setNewTagValue] = useState("");
+  const [editingIndex, setEditingIndex] = useState<number | null>(null);
+  const [editValue, setEditValue] = useState("");
+
+  const tags = spec.annotations.get(PIPELINE_TAGS_ANNOTATION);
+
+  const saveTags = (updatedTags: string[]) => {
+    updatePipelineTags(spec, updatedTags);
+  };
+
+  const handleAddTag = () => {
+    const trimmedTag = newTagValue.trim();
+    if (trimmedTag && !tags.includes(trimmedTag) && tags.length < TAG_LIMIT) {
+      track("pipeline_editor.configuration_panel.tag_added");
+      saveTags([...tags, trimmedTag]);
+    }
+    setNewTagValue("");
+    setIsAdding(false);
+  };
+
+  const handleCancelAdd = () => {
+    setNewTagValue("");
+    setIsAdding(false);
+  };
+
+  const handleRemoveTag = (index: number) => {
+    track("pipeline_editor.configuration_panel.tag_removed");
+    saveTags(tags.filter((_, i) => i !== index));
+  };
+
+  const handleStartEdit = (index: number) => {
+    setEditingIndex(index);
+    setEditValue(tags[index]);
+  };
+
+  const handleSaveEdit = () => {
+    if (editingIndex !== null && editValue.trim()) {
+      const trimmedValue = editValue.trim();
+      const isDuplicate = tags.some(
+        (tag, idx) => tag === trimmedValue && idx !== editingIndex,
+      );
+      if (!isDuplicate) {
+        const updatedTags = [...tags];
+        updatedTags[editingIndex] = trimmedValue;
+        saveTags(updatedTags);
+      }
+    }
+    setEditingIndex(null);
+    setEditValue("");
+  };
+
+  const handleCancelEdit = () => {
+    setEditingIndex(null);
+    setEditValue("");
+  };
+
+  return (
+    <ContentBlock title="Tags">
+      <BlockStack gap="2">
+        {tags.length >= TAG_LIMIT ? (
+          <Paragraph size="xs" tone="subdued">
+            Tag limit reached ({TAG_LIMIT})
+          </Paragraph>
+        ) : isAdding ? (
+          <TagEditor
+            value={newTagValue}
+            onChange={setNewTagValue}
+            onSave={handleAddTag}
+            onCancel={handleCancelAdd}
+          />
+        ) : (
+          <Button
+            variant="outline"
+            size="xs"
+            onClick={() => setIsAdding(true)}
+            className="my-0.5"
+          >
+            <Icon name="Plus" size="sm" />
+            Add Tag
+          </Button>
+        )}
+
+        {tags.length > 0 && (
+          <InlineStack gap="2" wrap="wrap">
+            {tags.map((tag, index) =>
+              editingIndex === index ? (
+                <TagEditor
+                  key={index}
+                  value={editValue}
+                  onChange={setEditValue}
+                  onSave={handleSaveEdit}
+                  onCancel={handleCancelEdit}
+                />
+              ) : (
+                <Tag
+                  key={tag}
+                  tag={tag}
+                  onEdit={() => handleStartEdit(index)}
+                  onRemove={() => handleRemoveTag(index)}
+                />
+              ),
+            )}
+          </InlineStack>
+        )}
+      </BlockStack>
+    </ContentBlock>
+  );
+});

--- a/src/routes/v2/pages/Editor/store/actions/pipeline.actions.ts
+++ b/src/routes/v2/pages/Editor/store/actions/pipeline.actions.ts
@@ -8,6 +8,7 @@ import {
 import { generateUniqueTaskName } from "@/routes/v2/pages/Editor/store/nameUtils";
 import type { UndoGroupable } from "@/routes/v2/shared/nodes/types";
 import { PIPELINE_NOTES_ANNOTATION } from "@/utils/annotations";
+import { PIPELINE_TAGS_ANNOTATION } from "@/utils/annotations";
 
 import { idGen } from "./utils";
 
@@ -43,6 +44,22 @@ export function updatePipelineNotes(
       spec.annotations.set(PIPELINE_NOTES_ANNOTATION, notes);
     } else {
       spec.annotations.remove(PIPELINE_NOTES_ANNOTATION);
+    }
+    return true;
+  });
+}
+
+export function updatePipelineTags(
+  undo: UndoGroupable,
+  spec: ComponentSpec,
+  tags: string[],
+): boolean {
+  return undo.withGroup("Update pipeline tags", () => {
+    const cleaned = tags.map((t) => t.trim()).filter(Boolean);
+    if (cleaned.length > 0) {
+      spec.annotations.set(PIPELINE_TAGS_ANNOTATION, cleaned);
+    } else {
+      spec.annotations.remove(PIPELINE_TAGS_ANNOTATION);
     }
     return true;
   });

--- a/src/routes/v2/pages/Editor/store/actions/usePipelineActions.ts
+++ b/src/routes/v2/pages/Editor/store/actions/usePipelineActions.ts
@@ -5,6 +5,7 @@ import {
   renamePipeline,
   updatePipelineDescription,
   updatePipelineNotes,
+  updatePipelineTags,
 } from "./pipeline.actions";
 
 export function usePipelineActions() {
@@ -14,6 +15,7 @@ export function usePipelineActions() {
     renamePipeline: renamePipeline.bind(null, undo),
     updatePipelineDescription: updatePipelineDescription.bind(null, undo),
     updatePipelineNotes: updatePipelineNotes.bind(null, undo),
+    updatePipelineTags: updatePipelineTags.bind(null, undo),
     createSubgraph: createSubgraph.bind(null, undo),
   };
 }

--- a/src/routes/v2/pages/RunView/components/RunDetailsContent.tsx
+++ b/src/routes/v2/pages/RunView/components/RunDetailsContent.tsx
@@ -112,15 +112,7 @@ function RunDetailsContentLoaded({
   const specAnnotations = spec.annotations;
   const pipelineNotes = specAnnotations.get(PIPELINE_NOTES_ANNOTATION);
 
-  const tagsRaw = specAnnotations.get(PIPELINE_TAGS_ANNOTATION) as
-    | string
-    | undefined;
-  const tags = tagsRaw
-    ? tagsRaw
-        .split(",")
-        .map((t) => t.trim())
-        .filter(Boolean)
-    : [];
+  const tags = specAnnotations.get(PIPELINE_TAGS_ANNOTATION);
 
   const displayedAnnotations = specAnnotations
     .filter((a) => !EXCLUDED_ANNOTATIONS.includes(a.key))


### PR DESCRIPTION
## Description

adds pipeline tags feature from v1 to v2 editor.

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

Closes https://github.com/TangleML/tangle-ui/issues/2124

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

- [x] Improvement
- [x] Breaking Change

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

![image.png](https://app.graphite.com/user-attachments/assets/8d306369-66b2-4022-ad2e-aa889ec44173.png)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

Confirm that you can add, edit and delete tags on both v1 and v2 editor

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->