### PR TITLE
fix: v2: run->runs

### DIFF
--- a/src/components/layout/AppMenu.tsx
+++ b/src/components/layout/AppMenu.tsx
@@ -172,8 +172,6 @@ const DefaultAppMenu = () => {
   );
 };
 
-const RUN_V2_BASE_PATH = "/run-v2";
-
 const AppMenu = () => {
   const { pathname } = useLocation();
 
@@ -181,7 +179,7 @@ const AppMenu = () => {
     return null;
   }
 
-  if (pathname.startsWith(RUN_V2_BASE_PATH)) {
+  if (pathname.startsWith(APP_ROUTES.RUNS_V2)) {
     return null;
   }
 

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -49,6 +49,8 @@ declare module "@tanstack/react-router" {
 export const EDITOR_PATH = "/editor";
 export const RUNS_BASE_PATH = "/runs";
 export const QUICK_START_PATH = "/quick-start";
+const EDITOR_V2_BASE_PATH = "/editor-v2";
+const RUNS_V2_BASE_PATH = "/runs-v2";
 const SETTINGS_PATH = "/settings";
 const IMPORT_PATH = "/app/editor/import-pipeline";
 export const APP_ROUTES = {
@@ -74,10 +76,11 @@ export const APP_ROUTES = {
   SETTINGS_SECRETS_REPLACE: `${SETTINGS_PATH}/secrets/$secretId/replace`,
   GITHUB_AUTH_CALLBACK: "/authorize/github",
   HUGGINGFACE_AUTH_CALLBACK: "/authorize/huggingface",
-  EDITOR_V2: "/editor-v2",
-  EDITOR_V2_PIPELINE: "/editor-v2/$pipelineName",
-  RUN_V2: "/run-v2/$id",
-  RUN_V2_WITH_SUBGRAPH: "/run-v2/$id/$subgraphExecutionId",
+  EDITOR_V2: EDITOR_V2_BASE_PATH,
+  EDITOR_V2_PIPELINE: `${EDITOR_V2_BASE_PATH}/$pipelineName`,
+  RUNS_V2: RUNS_V2_BASE_PATH,
+  RUN_DETAIL_V2: `${RUNS_V2_BASE_PATH}/$id`,
+  RUN_DETAIL_V2_WITH_SUBGRAPH: `${RUNS_V2_BASE_PATH}/$id/$subgraphExecutionId`,
   PIPELINE_FOLDERS: "/pipeline-folders",
   PLAYGROUND: "/playground",
 } as const;
@@ -275,13 +278,13 @@ const editorV2PipelineRoute = createRoute({
 
 const runV2Route = createRoute({
   getParentRoute: () => mainLayout,
-  path: APP_ROUTES.RUN_V2,
+  path: APP_ROUTES.RUN_DETAIL_V2,
   component: RunViewV2,
 });
 
 const runV2WithSubgraphRoute = createRoute({
   getParentRoute: () => mainLayout,
-  path: APP_ROUTES.RUN_V2_WITH_SUBGRAPH,
+  path: APP_ROUTES.RUN_DETAIL_V2_WITH_SUBGRAPH,
   component: RunViewV2,
 });
 


### PR DESCRIPTION
## Description

for the editor we have  
`/editor/` (v1) -> `/editor-v2/` (v2)

and for runs we have  
`/runs/` (v1) -> `/run-v2/` (v2)

the missing `s` on the v2 runs route is immensely annoying - especially when manually editing the url to get to the new view. this pr fixes that.  
  
Additionally, while in the route I cleaned up some inconsistencies in how routes were defined

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix
- [x] Improvement
- [x] Cleanup/Refactor
- [x] Breaking change
- [x] Documentation update

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->