### PR TITLE
Add page_view analytics tracking on route changes

### DIFF
--- a/src/components/layout/RootLayout.tsx
+++ b/src/components/layout/RootLayout.tsx
@@ -3,6 +3,7 @@ import { TanStackRouterDevtools } from "@tanstack/router-devtools";
 import { ToastContainer } from "react-toastify";
 
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+import { usePageViewTracking } from "@/hooks/usePageViewTracking";
 import { AnalyticsProvider } from "@/providers/AnalyticsProvider";
 import { BackendProvider } from "@/providers/BackendProvider";
 import { ComponentSpecProvider } from "@/providers/ComponentSpecProvider";
@@ -10,29 +11,37 @@ import { PipelineStorageProvider } from "@/services/pipelineStorage/PipelineStor
 
 import AppMenu from "./AppMenu";
 
+function RootLayoutContent() {
+  usePageViewTracking();
+
+  return (
+    <BackendProvider>
+      <ComponentSpecProvider>
+        <PipelineStorageProvider>
+          <ToastContainer />
+
+          <div className="App flex flex-col min-h-screen w-full">
+            <AppMenu />
+
+            <main className="flex-1 grid">
+              <Outlet />
+            </main>
+
+            {import.meta.env.VITE_ENABLE_ROUTER_DEVTOOLS === "true" && (
+              <TanStackRouterDevtools />
+            )}
+          </div>
+        </PipelineStorageProvider>
+      </ComponentSpecProvider>
+    </BackendProvider>
+  );
+}
+
 const RootLayout = () => {
   useDocumentTitle();
   return (
     <AnalyticsProvider>
-      <BackendProvider>
-        <ComponentSpecProvider>
-          <PipelineStorageProvider>
-            <ToastContainer />
-
-            <div className="App flex flex-col min-h-screen w-full">
-              <AppMenu />
-
-              <main className="flex-1 grid">
-                <Outlet />
-              </main>
-
-              {import.meta.env.VITE_ENABLE_ROUTER_DEVTOOLS === "true" && (
-                <TanStackRouterDevtools />
-              )}
-            </div>
-          </PipelineStorageProvider>
-        </ComponentSpecProvider>
-      </BackendProvider>
+      <RootLayoutContent />
     </AnalyticsProvider>
   );
 };

--- a/src/hooks/usePageViewTracking.ts
+++ b/src/hooks/usePageViewTracking.ts
@@ -1,0 +1,26 @@
+import { useAnalytics } from "@/providers/AnalyticsProvider";
+
+import { useRouteChangeTracking } from "./useRouteChangeTracking";
+
+/**
+ * Tracks a `page_view` analytics event whenever the route changes.
+ *
+ * Delegates to `useRouteChangeTracking` for navigation detection and maps the
+ * full payload into an analytics event with route metadata.
+ *
+ * Must be rendered inside the AnalyticsProvider.
+ */
+export function usePageViewTracking(): void {
+  const { track } = useAnalytics();
+
+  useRouteChangeTracking((payload) => {
+    track("page_view", {
+      from: payload.from,
+      to: payload.to,
+      search: payload.search,
+      hash: payload.hash,
+      href: payload.href,
+      route_pattern: payload.leafRoute,
+    });
+  });
+}

--- a/src/hooks/useRouteChangeTracking.ts
+++ b/src/hooks/useRouteChangeTracking.ts
@@ -1,0 +1,44 @@
+import { useRouter } from "@tanstack/react-router";
+import { useEffect } from "react";
+
+type TrackingPayload = {
+  from?: string;
+  to: string;
+  search: Record<string, unknown>;
+  hash: string;
+  href: string;
+  leafRoute: string;
+};
+
+export function useRouteChangeTracking(
+  onRouteChange: (payload: TrackingPayload) => void,
+) {
+  const router = useRouter();
+
+  useEffect(() => {
+    const unsubscribe = router.subscribe(
+      "onResolved",
+      ({ fromLocation, toLocation }) => {
+        if (fromLocation?.href === toLocation.href) return;
+
+        const currentMatches = router.state.matches;
+        const leafMatch = currentMatches[currentMatches.length - 1];
+        const leafRoute = leafMatch
+          ? (router.routesById[leafMatch.routeId]?.fullPath ??
+            leafMatch.routeId)
+          : toLocation.pathname;
+
+        onRouteChange({
+          from: fromLocation?.pathname,
+          to: toLocation.pathname,
+          search: toLocation.search as Record<string, unknown>,
+          hash: toLocation.hash,
+          href: toLocation.href,
+          leafRoute,
+        });
+      },
+    );
+
+    return unsubscribe;
+  }, [router, onRouteChange]);
+}

--- a/tests/e2e/navigation-tracking.spec.ts
+++ b/tests/e2e/navigation-tracking.spec.ts
@@ -1,0 +1,86 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Navigation tracking", () => {
+  test("emits page_view events with route metadata on navigation", async ({
+    page,
+  }) => {
+    await page.addInitScript(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (window as any).__analyticsEvents = [];
+      window.addEventListener("tangle.analytics.track", (e) => {
+        const detail = (e as CustomEvent).detail;
+        if (detail.actionType === "page_view") {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (window as any).__analyticsEvents.push(detail);
+        }
+      });
+    });
+
+    await page.goto("/");
+    await expect(
+      page.locator("[data-testid='app-menu-actions']"),
+    ).toBeVisible();
+
+    await page.getByRole("link", { name: "Settings" }).click();
+    await expect(page).toHaveURL(/\/settings/);
+
+    const events = await page.evaluate(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      () => (window as any).__analyticsEvents,
+    );
+
+    expect(events.length).toBeGreaterThanOrEqual(2);
+
+    const [initial, navigation] = events;
+
+    // First page_view from landing on /
+    expect(initial.actionType).toBe("page_view");
+    expect(initial.metadata).toMatchObject({
+      to: "/",
+      route_pattern: expect.any(String),
+    });
+
+    // Second page_view from navigating to settings
+    expect(navigation.actionType).toBe("page_view");
+    expect(navigation.metadata).toMatchObject({
+      from: "/",
+      to: expect.stringContaining("/settings"),
+      route_pattern: expect.any(String),
+    });
+  });
+
+  test("captures search params in page_view metadata", async ({ page }) => {
+    await page.addInitScript(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (window as any).__analyticsEvents = [];
+      window.addEventListener("tangle.analytics.track", (e) => {
+        const detail = (e as CustomEvent).detail;
+        if (detail.actionType === "page_view") {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (window as any).__analyticsEvents.push(detail);
+        }
+      });
+    });
+
+    await page.goto("/settings/backend?region=us-east-1&mode=verbose");
+    await expect(
+      page.locator("[data-testid='app-menu-actions']"),
+    ).toBeVisible();
+
+    const events = await page.evaluate(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      () => (window as any).__analyticsEvents,
+    );
+
+    expect(events.length).toBeGreaterThanOrEqual(1);
+
+    const event = events[0];
+    expect(event.metadata).toMatchObject({
+      to: "/settings/backend",
+      search: expect.objectContaining({
+        region: "us-east-1",
+        mode: "verbose",
+      }),
+    });
+  });
+});


### PR DESCRIPTION
## Description

Adds automatic page view tracking that fires a `page_view` analytics event whenever the route pathname changes. A new `usePageViewTracking` hook reads the current pathname and the deepest matched route's `fullPath` (e.g. `/runs/$id`) to provide a low-cardinality `route_pattern` property alongside the full pathname already captured by the analytics provider.

To make the hook work inside `AnalyticsProvider`, the inner layout content has been extracted into a `RootLayoutContent` component, which is rendered as a child of `AnalyticsProvider` in `RootLayout`.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Screenshots (if applicable)

![image.png](https://app.graphite.com/user-attachments/assets/4a63e62a-3930-4264-810c-a74d6b7daf05.png)



## Test Instructions

1. Navigate between different routes in the application.
2. Verify that a `page_view` event is fired for each unique pathname change, with a `route_pattern` value reflecting the matched route pattern (e.g. `/runs/$id` rather than `/runs/123`).
3. Confirm no duplicate events are fired when re-rendering without a pathname change.

## Additional Comments

The `previousPathname` ref guard ensures that re-renders that do not change the pathname do not emit duplicate `page_view` events.