### PR TITLE
Add homepage analytics tracking for favorites, recently viewed, and recently used components

### DIFF
--- a/src/routes/Dashboard/DashboardHomeView.tsx
+++ b/src/routes/Dashboard/DashboardHomeView.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/hooks/useRecentlyViewed";
 import { APP_ROUTES } from "@/routes/router";
 import { formatRelativeTime } from "@/utils/date";
+import { tracking } from "@/utils/tracking";
 
 import { getFavoriteUrl, getRecentlyViewedUrl, TypePill } from "./TypePill";
 
@@ -55,6 +56,7 @@ const FavoritePreviewRow = ({
   <InlineStack gap="2" className="min-w-0 overflow-hidden">
     <Link
       to={getFavoriteUrl(item)}
+      {...tracking("homepage.favorites.item")}
       className="group flex w-full items-center gap-3 px-4 py-3 hover:bg-muted/50 no-underline"
     >
       <TypePill type={item.type} />
@@ -87,6 +89,7 @@ const RecentlyViewedPreviewRow = ({ item }: { item: RecentlyViewedItem }) => (
   <InlineStack gap="2" className="min-w-0 overflow-hidden">
     <Link
       to={getRecentlyViewedUrl(item)}
+      {...tracking("homepage.recently_viewed_pipelines.item")}
       className="flex w-full items-center gap-3 px-4 py-3 hover:bg-muted/50 no-underline"
     >
       <TypePill type={item.type} />
@@ -173,6 +176,7 @@ const RecentComponentPreviewRow = ({ item }: { item: RecentlyViewedItem }) => (
     <Link
       to={APP_ROUTES.DASHBOARD_COMPONENTS}
       search={{ component: item.id }}
+      {...tracking("homepage.recently_used_components.item")}
       className="flex w-full items-center gap-3 px-4 py-3 hover:bg-muted/50 no-underline"
     >
       <TypePill type="component" />


### PR DESCRIPTION
## Description

Adds analytics tracking to the three homepage preview row components (`FavoritePreviewRow`, `RecentlyViewedPreviewRow`, and `RecentComponentPreviewRow`). Clicking an item in the Favorites section fires `homepage.favorites.item_click`, clicking a recently viewed pipeline fires `homepage.recently_viewed_pipelines.item_click`, and clicking a recently used component fires `homepage.recently_used_components.item_click`.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Screenshots (if applicable)

![Screenshot 2026-04-22 at 3.59.52 PM.png](https://app.graphite.com/user-attachments/assets/a63170bd-6851-420c-9174-948fab18de45.png)

## Test Instructions

1. Navigate to the Dashboard home page.
2. Click an item in the Favorites section and verify the `homepage.favorites.item_click` event is fired in your analytics provider.
3. Click an item in the Recently Viewed Pipelines section and verify the `homepage.recently_viewed_pipelines.item_click` event is fired.
4. Click an item in the Recently Used Components section and verify the `homepage.recently_used_components.item_click` event is fired.

## Additional Comments