### PR TITLE
Add settings analytics tracking for toggle changes and secrets CRUD

### DIFF
--- a/src/components/shared/SecretsManagement/components/AddSecretView.tsx
+++ b/src/components/shared/SecretsManagement/components/AddSecretView.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "@tanstack/react-router";
 import { BlockStack } from "@/components/ui/layout";
 import { Separator } from "@/components/ui/separator";
 import useToastNotification from "@/hooks/useToastNotification";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 
 import { AddSecretForm } from "./AddSecretForm";
 import { SecretsBreadcrumbs } from "./SecretsBreadcrumbs";
@@ -10,12 +11,14 @@ import { SecretsBreadcrumbs } from "./SecretsBreadcrumbs";
 export function AddSecretView() {
   const notify = useToastNotification();
   const navigate = useNavigate();
+  const { track } = useAnalytics();
 
   const navigateToList = () => {
     navigate({ to: "/settings/secrets", replace: true });
   };
 
   const handleSuccess = () => {
+    track("settings.secrets.secret_mutated", { action: "created" });
     notify("Secret added successfully", "success");
     navigateToList();
   };

--- a/src/components/shared/SecretsManagement/components/ReplaceSecretView.tsx
+++ b/src/components/shared/SecretsManagement/components/ReplaceSecretView.tsx
@@ -6,6 +6,7 @@ import { BlockStack } from "@/components/ui/layout";
 import { Separator } from "@/components/ui/separator";
 import { Paragraph } from "@/components/ui/typography";
 import useToastNotification from "@/hooks/useToastNotification";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 
 import { fetchSecretsList } from "../secretsStorage";
 import { SecretsQueryKeys } from "../types";
@@ -16,6 +17,7 @@ export function ReplaceSecretView() {
   const { secretId } = useParams({ strict: false });
   const notify = useToastNotification();
   const navigate = useNavigate();
+  const { track } = useAnalytics();
 
   const { data: secrets } = useSuspenseQuery({
     queryKey: SecretsQueryKeys.All(),
@@ -39,6 +41,7 @@ export function ReplaceSecretView() {
   }
 
   const handleSuccess = () => {
+    track("settings.secrets.secret_mutated", { action: "updated" });
     notify(`Secret "${secret.name}" updated successfully`, "success");
     navigateToList();
   };

--- a/src/components/shared/SecretsManagement/components/SecretsListView.tsx
+++ b/src/components/shared/SecretsManagement/components/SecretsListView.tsx
@@ -6,13 +6,17 @@ import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Separator } from "@/components/ui/separator";
 import { Heading, Paragraph } from "@/components/ui/typography";
 import useToastNotification from "@/hooks/useToastNotification";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
+import { tracking } from "@/utils/tracking";
 
 import { SecretsList } from "./SecretsList";
 
 export function SecretsListView() {
   const notify = useToastNotification();
+  const { track } = useAnalytics();
 
   const handleRemoveSuccess = () => {
+    track("settings.secrets.secret_mutated", { action: "deleted" });
     notify("Secret removed", "success");
   };
 
@@ -33,7 +37,12 @@ export function SecretsListView() {
       <Separator />
 
       <InlineStack align="end" fill>
-        <Link to="/settings/secrets/add" replace data-testid="add-secret-link">
+        <Link
+          to="/settings/secrets/add"
+          replace
+          data-testid="add-secret-link"
+          {...tracking("settings.secrets.add_secret")}
+        >
           <Button variant="secondary">
             <Icon name="Plus" />
             Add Secret

--- a/src/routes/Settings/sections/BetaFeaturesSettings.tsx
+++ b/src/routes/Settings/sections/BetaFeaturesSettings.tsx
@@ -1,9 +1,20 @@
 import { BetaFeatures } from "@/components/shared/Settings/BetaFeatures";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 
 import { useSettingsFlags } from "../SettingsFlagsContext";
 
 export function BetaFeaturesSettings() {
   const { betaFlags, handleSetFlag } = useSettingsFlags();
+  const { track } = useAnalytics();
 
-  return <BetaFeatures betaFlags={betaFlags} onChange={handleSetFlag} />;
+  const handleChange = (key: string, enabled: boolean) => {
+    track("settings.toggle_changed", {
+      section: "beta_features",
+      flag_name: key,
+      new_value: enabled,
+    });
+    handleSetFlag(key, enabled);
+  };
+
+  return <BetaFeatures betaFlags={betaFlags} onChange={handleChange} />;
 }

--- a/src/routes/Settings/sections/PreferencesSettings.tsx
+++ b/src/routes/Settings/sections/PreferencesSettings.tsx
@@ -1,9 +1,20 @@
 import { Settings } from "@/components/shared/Settings/Settings";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 
 import { useSettingsFlags } from "../SettingsFlagsContext";
 
 export function PreferencesSettings() {
   const { settings, handleSetFlag } = useSettingsFlags();
+  const { track } = useAnalytics();
 
-  return <Settings settings={settings} onChange={handleSetFlag} />;
+  const handleChange = (key: string, enabled: boolean) => {
+    track("settings.toggle_changed", {
+      section: "preferences",
+      flag_name: key,
+      new_value: enabled,
+    });
+    handleSetFlag(key, enabled);
+  };
+
+  return <Settings settings={settings} onChange={handleChange} />;
 }


### PR DESCRIPTION
## Description

Adds analytics tracking to the Secrets Management and Settings sections. The following events are now tracked:

- `settings.secrets.add_secret_click` — when a user clicks the "Add Secret" button
- `settings.secrets.secret_mutated` — when a secret is created, updated, or deleted (with an `action` property indicating which)
- `settings.toggle_changed` — when a toggle is changed in the Preferences or Beta Features settings sections (with `section`, `flag_name`, and `new_value` properties)

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

![Screenshot 2026-04-22 at 4.01.33 PM.png](https://app.graphite.com/user-attachments/assets/d8e74ac1-d316-41e5-9c72-e4366a9d55d8.png)![Screenshot 2026-04-22 at 4.02.31 PM.png](https://app.graphite.com/user-attachments/assets/e52cf6ad-a047-40d8-b0a1-c80d8827e05f.png)

## Test Instructions

1. Navigate to Settings > Secrets
2. Click "Add Secret" and verify the `settings.secrets.add_secret_click` event is fired
3. Create a new secret and verify `settings.secrets.secret_mutated` is fired with `action: "created"`
4. Update an existing secret and verify `settings.secrets.secret_mutated` is fired with `action: "updated"`
5. Delete a secret and verify `settings.secrets.secret_mutated` is fired with `action: "deleted"`
6. Toggle a preference in the Preferences section and verify `settings.toggle_changed` is fired with `section: "preferences"`
7. Toggle a flag in the Beta Features section and verify `settings.toggle_changed` is fired with `section: "beta_features"`

## Additional Comments