### PR TITLE
Add editor left panel analytics tracking for components, pipeline actions, and recent runs

### DIFF
--- a/src/components/shared/ComponentEditor/ComponentEditorDialog.test.tsx
+++ b/src/components/shared/ComponentEditor/ComponentEditorDialog.test.tsx
@@ -18,6 +18,10 @@ vi.mock("@/hooks/useToastNotification", () => ({
   default: vi.fn(),
 }));
 
+vi.mock("@/providers/AnalyticsProvider", () => ({
+  useAnalytics: vi.fn().mockReturnValue({ track: vi.fn() }),
+}));
+
 vi.mock("@/providers/ComponentLibraryProvider", () => ({
   useComponentLibrary: vi.fn(),
 }));

--- a/src/components/shared/ComponentEditor/ComponentEditorDialog.tsx
+++ b/src/components/shared/ComponentEditor/ComponentEditorDialog.tsx
@@ -8,6 +8,7 @@ import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Heading, Paragraph } from "@/components/ui/typography";
 import useToastNotification from "@/hooks/useToastNotification";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { useComponentLibrary } from "@/providers/ComponentLibraryProvider";
 import { hydrateComponentReference } from "@/services/componentService";
 import { isContainerImplementation } from "@/utils/componentSpec";
@@ -77,6 +78,7 @@ export const ComponentEditorDialog = withSuspenseWrapper(
     onClose: () => void;
   }) => {
     const notify = useToastNotification();
+    const { track } = useAnalytics();
     const { addToComponentLibrary } = useComponentLibrary();
 
     const { data: templateCode } = useTemplateCodeByName(templateName);
@@ -169,6 +171,9 @@ export const ComponentEditorDialog = withSuspenseWrapper(
 
         await addToComponentLibrary(hydratedComponent);
 
+        track("component_editor.component_created", {
+          selected_template: templateName,
+        });
         notify(
           `Component ${hydratedComponent.name} imported successfully`,
           "success",

--- a/src/components/shared/Dialogs/ComponentDuplicateDialog.test.tsx
+++ b/src/components/shared/Dialogs/ComponentDuplicateDialog.test.tsx
@@ -54,6 +54,11 @@ const createMockComponentLibraryContext = (
   };
 };
 
+// Mock the AnalyticsProvider
+vi.mock("@/providers/AnalyticsProvider", () => ({
+  useAnalytics: vi.fn().mockReturnValue({ track: vi.fn() }),
+}));
+
 // Mock the ComponentLibraryProvider
 vi.mock("@/providers/ComponentLibraryProvider", () => ({
   useComponentLibrary: vi.fn(),

--- a/src/components/shared/Dialogs/ComponentDuplicateDialog.tsx
+++ b/src/components/shared/Dialogs/ComponentDuplicateDialog.tsx
@@ -13,6 +13,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { BlockStack } from "@/components/ui/layout";
 import { Text } from "@/components/ui/typography";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { useComponentLibrary } from "@/providers/ComponentLibraryProvider";
 import type { HydratedComponentReference } from "@/utils/componentSpec";
 import {
@@ -66,6 +67,7 @@ const ComponentDuplicateDialog = ({
   handleImportComponent: (content: string) => Promise<void>;
 }) => {
   const validateName = useNameValidation();
+  const { track } = useAnalytics();
   const [newName, setNewName] = useState("");
   const [newDigest, setNewDigest] = useState("");
   const [errors, setErrors] = useState<string[]>([]);
@@ -82,6 +84,12 @@ const ComponentDuplicateDialog = ({
     },
     [setClose, setErrors],
   );
+
+  useEffect(() => {
+    if (open) {
+      track("component_editor.save.already_exists_impression");
+    }
+  }, [open]);
 
   useEffect(() => {
     if (newComponent && open) {

--- a/src/components/shared/ImportPipeline.tsx
+++ b/src/components/shared/ImportPipeline.tsx
@@ -18,6 +18,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { EDITOR_PATH } from "@/routes/router";
 import {
   importPipelineFromFile,
@@ -30,6 +31,7 @@ interface ImportPipelineProps {
 }
 
 const ImportPipeline = ({ triggerComponent }: ImportPipelineProps) => {
+  const { track } = useAnalytics();
   const [isOpen, setIsOpen] = useState(false);
   const [newPipelineName, setNewPipelineName] = useState<string | null>(null);
   const [yamlContent, setYamlContent] = useState("");
@@ -77,6 +79,11 @@ const ImportPipeline = ({ triggerComponent }: ImportPipelineProps) => {
     try {
       const result = await importPipelineFromFile(files[0]);
       handleImportResult(result);
+      if (result.successful) {
+        track("pipeline_editor.pipeline_actions.import_pipeline_completed", {
+          method: "file",
+        });
+      }
     } catch (err) {
       setError(
         (err as Error).message ||
@@ -103,6 +110,11 @@ const ImportPipeline = ({ triggerComponent }: ImportPipelineProps) => {
     try {
       const result = await importPipelineFromYaml(yamlContent);
       handleImportResult(result);
+      if (result.successful) {
+        track("pipeline_editor.pipeline_actions.import_pipeline_completed", {
+          method: "content",
+        });
+      }
     } catch (err) {
       setError(
         (err as Error).message ||

--- a/src/components/shared/ReactFlow/FlowSidebar/components/ImportComponent.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/components/ImportComponent.tsx
@@ -28,6 +28,7 @@ import { Label } from "@/components/ui/label";
 import { Spinner } from "@/components/ui/spinner";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import useToastNotification from "@/hooks/useToastNotification";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { useComponentLibrary } from "@/providers/ComponentLibraryProvider";
 import { hydrateComponentReference } from "@/services/componentService";
 import { getStringFromData } from "@/utils/string";
@@ -44,6 +45,7 @@ const ImportComponent = ({
   triggerComponent?: ReactNode;
 }) => {
   const notify = useToastNotification();
+  const { track } = useAnalytics();
   const { addToComponentLibrary } = useComponentLibrary();
 
   const [url, setUrl] = useState("");
@@ -57,6 +59,13 @@ const ImportComponent = ({
 
   const [componentEditorTemplateSelected, setComponentEditorTemplateSelected] =
     useState<SupportedTemplate | undefined>();
+
+  const handleTemplateSelected = (template: SupportedTemplate) => {
+    track("pipeline_editor.add_component.new.begin", {
+      selected_template: template,
+    });
+    setComponentEditorTemplateSelected(template);
+  };
 
   const handleComponentEditorDialogClose = () => {
     setComponentEditorTemplateSelected(undefined);
@@ -124,6 +133,9 @@ const ImportComponent = ({
       setSelectedFileName("");
 
       if (result) {
+        track("pipeline_editor.add_component.import_completed", {
+          method: tab === TabType.File ? "file" : "url",
+        });
         notify("Component imported successfully", "success");
       }
     },
@@ -275,7 +287,7 @@ const ImportComponent = ({
               </TabsContent>
               <TabsContent value={TabType.New}>
                 <NewComponentTemplateSelector
-                  onTemplateSelected={setComponentEditorTemplateSelected}
+                  onTemplateSelected={handleTemplateSelected}
                 />
               </TabsContent>
             </Tabs>

--- a/src/components/shared/ReactFlow/FlowSidebar/components/RecentExecutionsButton.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/components/RecentExecutionsButton.tsx
@@ -17,6 +17,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { tracking } from "@/utils/tracking";
 
 export const RecentExecutionsButton = withSuspenseWrapper(
   ({
@@ -39,7 +40,11 @@ export const RecentExecutionsButton = withSuspenseWrapper(
         <Popover>
           <Tooltip>
             <TooltipTrigger asChild>
-              <PopoverTrigger asChild data-popover-trigger>
+              <PopoverTrigger
+                asChild
+                data-popover-trigger
+                {...tracking("pipeline_editor.recent_pipeline_runs")}
+              >
                 {trigger ?? defaultTrigger}
               </PopoverTrigger>
             </TooltipTrigger>

--- a/src/components/shared/ReactFlow/FlowSidebar/sections/components/ExportPipelineButton.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/sections/components/ExportPipelineButton.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo } from "react";
 
 import { ActionButton } from "@/components/shared/Buttons/ActionButton";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
+import { tracking } from "@/utils/tracking";
 import { componentSpecToYaml } from "@/utils/yaml";
 
 export const ExportPipelineButton = () => {
@@ -25,6 +26,7 @@ export const ExportPipelineButton = () => {
       tooltip="Export Pipeline"
       icon="FileDown"
       onClick={handleExport}
+      {...tracking("pipeline_editor.pipeline_actions.export_pipeline")}
     />
   );
 };

--- a/src/components/shared/ReactFlow/FlowSidebar/sections/components/ImportPipelineButton.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/sections/components/ImportPipelineButton.tsx
@@ -1,5 +1,6 @@
 import { ActionButton } from "@/components/shared/Buttons/ActionButton";
 import ImportPipeline from "@/components/shared/ImportPipeline";
+import { tracking } from "@/utils/tracking";
 
 export const ImportPipelineButton = () => {
   return (
@@ -9,6 +10,7 @@ export const ImportPipelineButton = () => {
           tooltip="Import Pipeline"
           icon="FileUp"
           onClick={() => {}}
+          {...tracking("pipeline_editor.pipeline_actions.import_pipeline")}
         />
       }
     />

--- a/src/components/shared/ReactFlow/FlowSidebar/sections/components/SavePipelineAsButton.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/sections/components/SavePipelineAsButton.tsx
@@ -4,9 +4,11 @@ import { useCallback } from "react";
 import { ActionButton } from "@/components/shared/Buttons/ActionButton";
 import { PipelineNameDialog } from "@/components/shared/Dialogs";
 import useToastNotification from "@/hooks/useToastNotification";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 import { EDITOR_PATH } from "@/routes/router";
 import { useSavePipeline } from "@/services/pipelineService";
+import { tracking } from "@/utils/tracking";
 
 interface SavePipelineAsButtonProps {
   onSaveComplete?: (name: string) => void;
@@ -18,6 +20,7 @@ export const SavePipelineAsButton = ({
   const { componentSpec } = useComponentSpec();
   const { savePipeline } = useSavePipeline(componentSpec);
   const notify = useToastNotification();
+  const { track } = useAnalytics();
   const navigate = useNavigate();
 
   const getDuplicatePipelineName = useCallback(() => {
@@ -29,6 +32,7 @@ export const SavePipelineAsButton = ({
   const handleSavePipelineAs = useCallback(
     async (name: string) => {
       await savePipeline(name);
+      track("pipeline_editor.pipeline_actions.save_pipeline_as_completed");
       notify(`Pipeline saved as "${name}"`, "success");
       onSaveComplete?.(name);
 
@@ -36,7 +40,7 @@ export const SavePipelineAsButton = ({
         to: `${EDITOR_PATH}/${encodeURIComponent(name)}`,
       });
     },
-    [navigate, savePipeline, notify, onSaveComplete],
+    [navigate, savePipeline, notify, onSaveComplete, track],
   );
 
   return (
@@ -46,6 +50,7 @@ export const SavePipelineAsButton = ({
           tooltip="Save Pipeline As"
           icon="SaveAll"
           onClick={() => {}}
+          {...tracking("pipeline_editor.pipeline_actions.save_pipeline_as")}
         />
       }
       title="Save Pipeline As"

--- a/src/components/shared/ReactFlow/FlowSidebar/sections/components/SavePipelineButton.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/sections/components/SavePipelineButton.tsx
@@ -4,6 +4,7 @@ import { ActionButton } from "@/components/shared/Buttons/ActionButton";
 import useToastNotification from "@/hooks/useToastNotification";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 import { useSavePipeline } from "@/services/pipelineService";
+import { tracking } from "@/utils/tracking";
 
 interface SavePipelineButtonProps {
   onSaveComplete?: () => void;
@@ -30,6 +31,7 @@ export const SavePipelineButton = ({
       tooltip="Save Pipeline"
       icon="Save"
       onClick={handleSavePipeline}
+      {...tracking("pipeline_editor.pipeline_actions.save_pipeline")}
     />
   );
 };


### PR DESCRIPTION
## Description

Adds analytics tracking events across several pipeline editor and component editor actions. The following events are now tracked:

- `component_editor.component_created` — when a new component is successfully imported via the component editor, including the selected template
- `component_editor.save.already_exists_impression` — when the duplicate component dialog is opened
- `pipeline_editor.add_component.new.begin` — when a template is selected to create a new component, including the selected template
- `pipeline_editor.add_component.import_completed` — when a component is successfully imported via file or URL
- `pipeline_editor.pipeline_actions.import_pipeline_click` — when the import pipeline button is clicked
- `pipeline_editor.pipeline_actions.import_pipeline_completed` — when a pipeline is successfully imported via file or YAML content
- `pipeline_editor.pipeline_actions.export_pipeline_click` — when the export pipeline button is clicked
- `pipeline_editor.pipeline_actions.save_pipeline_click` — when the save pipeline button is clicked
- `pipeline_editor.pipeline_actions.save_pipeline_as_click` — when the save pipeline as button is clicked
- `pipeline_editor.pipeline_actions.save_pipeline_as_completed` — when a pipeline is successfully saved under a new name
- `pipeline_editor.recent_pipeline_runs_click` — when the recent executions popover is opened

Test mocks for `useAnalytics` have been added to the relevant test files.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

![Screenshot 2026-04-22 at 4.04.08 PM.png](https://app.graphite.com/user-attachments/assets/b3551b94-91fb-456b-aa42-9b61c95c9574.png)![Screenshot 2026-04-22 at 4.04.49 PM.png](https://app.graphite.com/user-attachments/assets/29af676d-59d4-4858-a935-7a315ee9f91d.png)

![Screenshot 2026-04-22 at 4.06.17 PM.png](https://app.graphite.com/user-attachments/assets/2df89797-d096-4736-b07b-e1a2d1f7d229.png)

![Screenshot 2026-04-22 at 4.08.29 PM.png](https://app.graphite.com/user-attachments/assets/aeff8b62-f058-498b-8797-5a1f26e06957.png)

## Test Instructions

1. Open the pipeline editor and trigger each of the tracked actions (save, save as, import, export, add component, view recent runs).
2. Verify that the corresponding analytics events are fired with the expected properties.
3. Run the existing test suite to confirm no regressions from the added `useAnalytics` mocks.

## Additional Comments