### PR TITLE
Add canvas toolbar analytics tracking for tool clicks and auto layout selection

### DIFF
--- a/src/components/Editor/PipelineEditor.tsx
+++ b/src/components/Editor/PipelineEditor.tsx
@@ -74,6 +74,7 @@ const PipelineEditor = () => {
                       updateConfig={updateFlowConfig}
                       onAutoLayout={handleAutoLayout}
                       showInteractive={false}
+                      pageType="pipeline_editor"
                     />
                     <Background gap={GRID_SIZE} className="bg-slate-50!" />
                   </FlowCanvas>

--- a/src/components/PipelineRun/PipelineRunPage.tsx
+++ b/src/components/PipelineRun/PipelineRunPage.tsx
@@ -60,6 +60,7 @@ const PipelineRunPage = () => {
                 updateConfig={updateFlowConfig}
                 onAutoLayout={handleAutoLayout}
                 showInteractive={false}
+                pageType="pipeline_run"
               />
               <Background gap={GRID_SIZE} className="bg-slate-50!" />
             </FlowCanvas>

--- a/src/components/shared/ReactFlow/FlowControls/FlowControls.tsx
+++ b/src/components/shared/ReactFlow/FlowControls/FlowControls.tsx
@@ -22,6 +22,8 @@ import {
 import { Spinner } from "@/components/ui/spinner";
 import { Text } from "@/components/ui/typography";
 import { cn } from "@/lib/utils";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
+import { tracking } from "@/utils/tracking";
 
 import type { LayoutAlgorithm } from "../FlowCanvas/utils/autolayout";
 
@@ -29,6 +31,7 @@ interface FlowControlsProps extends ControlProps {
   config: ReactFlowProps;
   updateConfig: (config: Partial<ReactFlowProps>) => void;
   onAutoLayout?: (algorithm: LayoutAlgorithm) => void;
+  pageType?: "pipeline_editor" | "pipeline_run";
 }
 
 const LAYOUT_ALGORITHMS: {
@@ -50,12 +53,21 @@ export default function FlowControls({
   config,
   updateConfig,
   onAutoLayout,
+  pageType = "pipeline_editor",
   ...props
 }: FlowControlsProps) {
+  const { track } = useAnalytics();
   const [multiSelectActive, setMultiSelectActive] = useState(false);
   const [lockActive, setLockActive] = useState(!config.nodesDraggable);
   const [layoutPopoverOpen, setLayoutPopoverOpen] = useState(false);
   const [isLayouting, setIsLayouting] = useState(false);
+
+  const trackTool = (tool: string) => {
+    track("pipeline_canvas.tool_bar.tool.click", {
+      tool,
+      page_type: pageType,
+    });
+  };
 
   const onClickMultiSelect = useCallback(() => {
     updateConfig({
@@ -87,11 +99,20 @@ export default function FlowControls({
   };
 
   return (
-    <Controls {...props}>
+    <Controls
+      {...props}
+      onZoomIn={() => trackTool("zoom_in")}
+      onZoomOut={() => trackTool("zoom_out")}
+      onFitView={() => trackTool("fit_view")}
+    >
       {!props.showInteractive && (
         <ControlButton
           onClick={handleLockChange}
           className={cn(lockActive && "bg-gray-100!")}
+          {...tracking("pipeline_canvas.tool_bar.tool", {
+            tool: "lock_unlock",
+            page_type: pageType,
+          })}
         >
           {lockActive ? (
             <LockKeyhole className="fill-none! -scale-x-120 scale-y-120" />
@@ -103,6 +124,10 @@ export default function FlowControls({
       <ControlButton
         onClick={onClickMultiSelect}
         className={cn(multiSelectActive && "bg-gray-100!")}
+        {...tracking("pipeline_canvas.tool_bar.tool", {
+          tool: "area_select",
+          page_type: pageType,
+        })}
       >
         <SquareDashedMousePointerIcon className="scale-120" />
       </ControlButton>
@@ -130,6 +155,10 @@ export default function FlowControls({
                   className="w-full justify-start"
                   onClick={() => handleLayoutSelect(algo.value)}
                   disabled={isLayouting}
+                  {...tracking("pipeline_canvas.tool_bar.auto_layout_select", {
+                    selected_layout: algo.value,
+                    page_type: pageType,
+                  })}
                 >
                   <Text>{algo.label}</Text>
                   <Text tone="subdued">({algo.description})</Text>


### PR DESCRIPTION
## Description

Adds analytics tracking to the pipeline canvas toolbar interactions. When users interact with toolbar controls (zoom in, zoom out, fit view, area select, lock/unlock, and auto layout), a tracking event is fired with the tool name and the page context (`pipeline_editor` or `pipeline_run`).

The `FlowControls` component now accepts a `pageType` prop to distinguish between the pipeline editor and pipeline run views, which is included in all tracking events.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

![Screenshot 2026-04-22 at 4.09.27 PM.png](https://app.graphite.com/user-attachments/assets/d5240d75-28db-445f-8e3e-56281b6dcc4d.png)![Screenshot 2026-04-22 at 4.09.46 PM.png](https://app.graphite.com/user-attachments/assets/fec5270f-b472-484e-bdd5-3c3f602d42ff.png)



## Test Instructions

1. Open the pipeline editor and interact with the toolbar controls (zoom in, zoom out, fit view, area select, lock/unlock, auto layout).
2. Verify that `pipeline_canvas.tool_bar.tool_click` events are fired with the correct `tool` and `page_type` values.
3. Repeat on the pipeline run page and confirm `page_type` is `pipeline_run`.
4. Select an auto layout algorithm and verify a `pipeline_canvas.tool_bar.auto_layout_select` event is fired with the correct `selected_layout` and `page_type`.

## Additional Comments