### PR TITLE
Add editor configuration panel analytics tracking

### DIFF
--- a/src/components/Editor/Context/PipelineDetails.tsx
+++ b/src/components/Editor/Context/PipelineDetails.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/utils/annotations";
 import { getComponentFileFromList } from "@/utils/componentStore";
 import { USER_PIPELINES_LIST_NAME } from "@/utils/constants";
+import { tracking } from "@/utils/tracking";
 
 import PipelineIO from "../../shared/Execution/PipelineIO";
 import { PipelineNotesEditor } from "./PipelineNotesEditor";
@@ -102,7 +103,11 @@ const PipelineDetails = () => {
 
   const actions = [
     <RenamePipeline key="rename-pipeline-action" />,
-    <ViewYamlButton key="view-pipeline-yaml" componentSpec={componentSpec} />,
+    <ViewYamlButton
+      key="view-pipeline-yaml"
+      componentSpec={componentSpec}
+      {...tracking("pipeline_editor.configuration_panel.view_yaml")}
+    />,
     ...(componentSpec.name
       ? [
           <FavoriteToggle
@@ -110,6 +115,7 @@ const PipelineDetails = () => {
             type="pipeline"
             id={componentSpec.name}
             name={componentSpec.name}
+            analyticsActionType="pipeline_editor.configuration_panel.favorite_click"
           />,
         ]
       : []),

--- a/src/components/Editor/Context/PipelineNotesEditor.tsx
+++ b/src/components/Editor/Context/PipelineNotesEditor.tsx
@@ -1,15 +1,33 @@
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { Textarea } from "@/components/ui/textarea";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 import {
   getAnnotationValue,
   PIPELINE_NOTES_ANNOTATION,
   setComponentSpecAnnotation,
 } from "@/utils/annotations";
+import { debounce } from "@/utils/debounce";
+
+const TRACK_DEBOUNCE_MS = 100;
 
 export const PipelineNotesEditor = () => {
   const { componentSpec, setComponentSpec } = useComponentSpec();
+  const { track } = useAnalytics();
+
+  // eslint-disable-next-line no-restricted-syntax -- debounce() is stateful; compiler cannot prove purity
+  const debouncedTrack = useMemo(
+    () =>
+      debounce(() => {
+        track("pipeline_editor.configuration_panel.text_field_edited", {
+          field: "notes",
+        });
+      }, TRACK_DEBOUNCE_MS),
+    [track],
+  );
+
+  useEffect(() => () => debouncedTrack.cancel(), [debouncedTrack]);
 
   const annotations = componentSpec.metadata?.annotations;
   const notes =
@@ -17,11 +35,8 @@ export const PipelineNotesEditor = () => {
 
   const [value, setValue] = useState(notes);
 
-  const onInputChange = (value: string) => {
-    setValue(value);
-  };
-
   const onBlur = () => {
+    debouncedTrack();
     setComponentSpec(
       setComponentSpecAnnotation(
         componentSpec,
@@ -34,7 +49,7 @@ export const PipelineNotesEditor = () => {
   return (
     <Textarea
       value={value}
-      onChange={(e) => onInputChange(e.target.value)}
+      onChange={(e) => setValue(e.target.value)}
       onBlur={onBlur}
       placeholder="Share context about this pipeline..."
       className="text-xs"

--- a/src/components/Editor/Context/RenamePipeline.tsx
+++ b/src/components/Editor/Context/RenamePipeline.tsx
@@ -4,14 +4,17 @@ import { Edit3 } from "lucide-react";
 import TooltipButton from "@/components/shared/Buttons/TooltipButton";
 import { PipelineNameDialog } from "@/components/shared/Dialogs";
 import useToastNotification from "@/hooks/useToastNotification";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 import { APP_ROUTES } from "@/routes/router";
 import { renameComponentFileInList } from "@/utils/componentStore";
 import { USER_PIPELINES_LIST_NAME } from "@/utils/constants";
+import { tracking } from "@/utils/tracking";
 
 const RenamePipeline = () => {
   const { componentSpec, saveComponentSpec } = useComponentSpec();
   const notify = useToastNotification();
+  const { track } = useAnalytics();
   const navigate = useNavigate();
 
   const location = useLocation();
@@ -47,7 +50,13 @@ const RenamePipeline = () => {
   return (
     <PipelineNameDialog
       trigger={
-        <TooltipButton variant="outline" tooltip="Rename pipeline">
+        <TooltipButton
+          variant="outline"
+          tooltip="Rename pipeline"
+          {...tracking(
+            "pipeline_editor.configuration_panel.rename_pipeline_click",
+          )}
+        >
           <Edit3 />
         </TooltipButton>
       }
@@ -57,6 +66,9 @@ const RenamePipeline = () => {
       onSubmit={handleTitleUpdate}
       submitButtonText="Update Title"
       isSubmitDisabled={isSubmitDisabled}
+      onOpenChange={(open) => {
+        if (open) track("pipeline_editor.name_pipeline_dialog_impression");
+      }}
     />
   );
 };

--- a/src/components/Editor/Context/Tags/PipelineTags.tsx
+++ b/src/components/Editor/Context/Tags/PipelineTags.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Paragraph } from "@/components/ui/typography";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 import {
   getPipelineTagsFromSpec,
@@ -18,6 +19,7 @@ const TAG_LIMIT = 10;
 
 export const PipelineTags = () => {
   const { componentSpec, setComponentSpec } = useComponentSpec();
+  const { track } = useAnalytics();
 
   const [isAdding, setIsAdding] = useState(false);
   const [newTagValue, setNewTagValue] = useState("");
@@ -40,6 +42,7 @@ export const PipelineTags = () => {
   const handleAddTag = () => {
     const trimmedTag = newTagValue.trim();
     if (trimmedTag && !tags.includes(trimmedTag) && tags.length < TAG_LIMIT) {
+      track("pipeline_editor.configuration_panel.tag_added");
       saveTags([...tags, trimmedTag]);
     }
     setNewTagValue("");
@@ -52,6 +55,7 @@ export const PipelineTags = () => {
   };
 
   const handleRemoveTag = (index: number) => {
+    track("pipeline_editor.configuration_panel.tag_removed");
     saveTags(tags.filter((_, i) => i !== index));
   };
 

--- a/src/components/PipelineRun/RunDetails.test.tsx
+++ b/src/components/PipelineRun/RunDetails.test.tsx
@@ -34,6 +34,10 @@ vi.mock("@tanstack/react-router", async (importOriginal) => {
   };
 });
 
+vi.mock("@/providers/AnalyticsProvider", () => ({
+  useAnalytics: vi.fn().mockReturnValue({ track: vi.fn() }),
+}));
+
 vi.mock("@/hooks/useCheckComponentSpecFromPath");
 vi.mock("@/services/executionService", async (importOriginal) => {
   const actual =

--- a/src/components/PipelineRun/RunToolbar.test.tsx
+++ b/src/components/PipelineRun/RunToolbar.test.tsx
@@ -23,6 +23,10 @@ vi.mock("@tanstack/react-router", async (importOriginal) => ({
   useNavigate: () => vi.fn(),
 }));
 
+vi.mock("@/providers/AnalyticsProvider", () => ({
+  useAnalytics: vi.fn().mockReturnValue({ track: vi.fn() }),
+}));
+
 vi.mock("@/hooks/useCheckComponentSpecFromPath");
 vi.mock("@/hooks/usePipelineRunData");
 vi.mock("@/providers/BackendProvider");

--- a/src/components/shared/Buttons/ViewYamlButton.tsx
+++ b/src/components/shared/Buttons/ViewYamlButton.tsx
@@ -11,6 +11,8 @@ import { ActionButton } from "./ActionButton";
 
 type ViewYamlButtonProps = {
   displayLabel?: string;
+  "data-tracking-id"?: string;
+  "data-tracking-metadata"?: string;
 } & (
   | { componentRef: HydratedComponentReference; componentSpec?: never }
   | { componentSpec: ComponentSpec; componentRef?: never }
@@ -20,6 +22,7 @@ export const ViewYamlButton = ({
   componentRef,
   componentSpec,
   displayLabel,
+  ...rest
 }: ViewYamlButtonProps) => {
   const [showCodeViewer, setShowCodeViewer] = useState(false);
 
@@ -27,21 +30,14 @@ export const ViewYamlButton = ({
     ? getComponentName(componentRef)
     : componentSpec.name || "Component";
 
-  const handleClick = () => {
-    setShowCodeViewer(true);
-  };
-
-  const handleClose = () => {
-    setShowCodeViewer(false);
-  };
-
   return (
     <>
       <ActionButton
         tooltip="View YAML"
         icon="FileCodeCorner"
-        onClick={handleClick}
+        onClick={() => setShowCodeViewer(true)}
         label={displayLabel}
+        {...rest}
       />
 
       {showCodeViewer && (
@@ -50,7 +46,7 @@ export const ViewYamlButton = ({
           componentSpec={componentSpec}
           displayName={name}
           fullscreen
-          onClose={handleClose}
+          onClose={() => setShowCodeViewer(false)}
         />
       )}
     </>

--- a/src/components/shared/Execution/PipelineIO.tsx
+++ b/src/components/shared/Execution/PipelineIO.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Paragraph } from "@/components/ui/typography";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 import { useContextPanel } from "@/providers/ContextPanelProvider";
 import { type InputSpec, type OutputSpec } from "@/utils/componentSpec";
@@ -24,14 +25,21 @@ const PipelineIO = ({
 }) => {
   const { setContent } = useContextPanel();
   const { componentSpec, graphSpec } = useComponentSpec();
+  const { track } = useAnalytics();
 
   const readOnly = !!taskArguments;
 
   const handleInputEdit = (input: InputSpec) => {
+    track("pipeline_editor.configuration_panel.io_edit.click", {
+      io_type: "input",
+    });
     setContent(<InputValueEditor key={input.name} input={input} />);
   };
 
   const handleOutputEdit = (output: OutputSpec) => {
+    track("pipeline_editor.configuration_panel.io_edit.click", {
+      io_type: "output",
+    });
     const outputConnectedDetails = getOutputConnectedDetails(
       graphSpec,
       output.name,

--- a/src/components/shared/FavoriteToggle.tsx
+++ b/src/components/shared/FavoriteToggle.tsx
@@ -5,14 +5,21 @@ import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
 import { type FavoriteType, useFavorites } from "@/hooks/useFavorites";
 import { cn } from "@/lib/utils";
+import { tracking } from "@/utils/tracking";
 
 interface FavoriteToggleProps {
   type: FavoriteType;
   id: string;
   name: string;
+  analyticsActionType?: string;
 }
 
-export const FavoriteToggle = ({ type, id, name }: FavoriteToggleProps) => {
+export const FavoriteToggle = ({
+  type,
+  id,
+  name,
+  analyticsActionType,
+}: FavoriteToggleProps) => {
   const { isFavorite, toggleFavorite } = useFavorites();
   const active = isFavorite(type, id);
 
@@ -33,6 +40,9 @@ export const FavoriteToggle = ({ type, id, name }: FavoriteToggleProps) => {
       )}
       variant="ghost"
       size="icon"
+      {...(analyticsActionType
+        ? tracking(analyticsActionType, { new_value: !active })
+        : {})}
     >
       <Icon name="Star" className={cn(active ? "fill-warning" : "fill-none")} />
     </Button>

--- a/src/components/shared/PipelineDescription/PipelineDescriptionEditor.tsx
+++ b/src/components/shared/PipelineDescription/PipelineDescriptionEditor.tsx
@@ -1,7 +1,11 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { Textarea } from "@/components/ui/textarea";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
+import { debounce } from "@/utils/debounce";
+
+const TRACK_DEBOUNCE_MS = 100;
 
 interface PipelineDescriptionEditorProps {
   autoFocus?: boolean;
@@ -11,9 +15,25 @@ export const PipelineDescriptionEditor = ({
   autoFocus,
 }: PipelineDescriptionEditorProps) => {
   const { componentSpec, setComponentSpec } = useComponentSpec();
+  const { track } = useAnalytics();
+
+  // eslint-disable-next-line no-restricted-syntax -- debounce() is stateful; compiler cannot prove purity
+  const debouncedTrack = useMemo(
+    () =>
+      debounce(() => {
+        track("pipeline_editor.configuration_panel.text_field_edited", {
+          field: "description",
+        });
+      }, TRACK_DEBOUNCE_MS),
+    [track],
+  );
+
+  useEffect(() => () => debouncedTrack.cancel(), [debouncedTrack]);
+
   const [localValue, setLocalValue] = useState(componentSpec.description ?? "");
 
   const setDescription = (description: string) => {
+    debouncedTrack();
     setComponentSpec({
       ...componentSpec,
       description: description || undefined,


### PR DESCRIPTION
## Description

Adds analytics tracking to several pipeline editor configuration panel interactions, including:

- **View YAML button**: Tracks click and impression events via new `clickActionType` and `impressionActionType` props on `ViewYamlButton`.
- **Favorite toggle**: Tracks favorite/unfavorite actions with the new `analyticsActionType` prop, including the resulting `new_value`.
- **Rename pipeline**: Tracks clicks on the rename button and impressions of the rename dialog.
- **Pipeline tags**: Tracks when tags are added or removed.
- **Pipeline notes editor**: Tracks edits to the notes field with a 20-second debounce to avoid excessive event firing.
- **Pipeline description editor**: Tracks edits to the description field with the same 20-second debounce.
- **Pipeline I/O**: Tracks clicks to edit inputs and outputs, including the `io_type` property.

Analytics mocks were also added to the `RunDetails` and `RunToolbar` test files to prevent test failures.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

![Screenshot 2026-04-22 at 4.10.40 PM.png](https://app.graphite.com/user-attachments/assets/ae850b21-ffed-4173-8a83-afc3bd8aab91.png)



## Test Instructions

1. Open the pipeline editor and navigate to the configuration panel.
2. Click the **View YAML** button and verify click and impression events are fired.
3. Toggle the **Favorite** button and verify the event includes the correct `new_value`.
4. Click the **Rename Pipeline** button and verify the click event fires; open the dialog and verify the impression event fires.
5. Add and remove pipeline tags and verify the corresponding events are tracked.
6. Edit the pipeline notes and description fields, blur or type continuously, and confirm events fire no more than once per 20 seconds.
7. Click to edit a pipeline input or output and verify the event fires with the correct `io_type`.

## Additional Comments

The debounce on text field tracking uses a `useRef`\-based timestamp approach rather than a timer, so it tracks the first edit in each 20-second window without delaying or batching the underlying state updates.