### PR TITLE
Add task node panel analytics tracking

### DIFF
--- a/src/components/shared/Dialogs/ComponentDetailsDialog.tsx
+++ b/src/components/shared/Dialogs/ComponentDetailsDialog.tsx
@@ -15,6 +15,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useHydrateComponentReference } from "@/hooks/useHydrateComponentReference";
 import type { ComponentReference } from "@/utils/componentSpec";
+import { tracking } from "@/utils/tracking";
 
 import InfoIconButton from "../Buttons/InfoIconButton";
 import { ComponentFavoriteToggle } from "../FavoriteComponentToggle";
@@ -200,7 +201,12 @@ const ComponentDetails = ({
 
   return (
     <Dialog modal={false} open={open} onOpenChange={onOpenChange}>
-      <DialogTrigger asChild>{dialogTriggerButton}</DialogTrigger>
+      <DialogTrigger
+        asChild
+        {...tracking("pipeline_editor.task_node.component_info")}
+      >
+        {dialogTriggerButton}
+      </DialogTrigger>
 
       <DialogPortal>
         {open && (

--- a/src/components/shared/FavoriteComponentToggle.tsx
+++ b/src/components/shared/FavoriteComponentToggle.tsx
@@ -22,6 +22,7 @@ import { hydrateComponentReference } from "@/services/componentService";
 import { type ComponentReference } from "@/utils/componentSpec";
 import { MINUTES } from "@/utils/constants";
 import { getComponentName } from "@/utils/getComponentName";
+import { tracking } from "@/utils/tracking";
 
 import { withSuspenseWrapper } from "./SuspenseWrapper";
 
@@ -84,9 +85,13 @@ const FavoriteStarButton = ({ active, onClick }: StateButtonProps) => {
   );
 };
 
-const AddToLibraryButton = ({ active, onClick }: StateButtonProps) => {
+const AddToLibraryButton = ({
+  active,
+  onClick,
+  ...props
+}: StateButtonProps) => {
   return (
-    <IconStateButton active={active} onClick={onClick}>
+    <IconStateButton active={active} onClick={onClick} {...props}>
       <PackagePlus className="h-4 w-4" />
     </IconStateButton>
   );
@@ -232,7 +237,10 @@ const ComponentFavoriteToggleInternal = ({
   return (
     <>
       {!isInLibrary && !isUserComponent && (
-        <AddToLibraryButton onClick={openConfirmationDialog} />
+        <AddToLibraryButton
+          onClick={openConfirmationDialog}
+          {...tracking("pipeline_editor.task_node.add_to_component_library")}
+        />
       )}
 
       {isInLibrary && <FavoriteToggleButton component={component} />}

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/AnnotationsSection.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/AnnotationsSection.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { BlockStack } from "@/components/ui/layout";
 import { Separator } from "@/components/ui/separator";
 import useToastNotification from "@/hooks/useToastNotification";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 import type { AnnotationConfig, Annotations } from "@/types/annotations";
 import { getAnnotationValue, HIDDEN_ANNOTATIONS } from "@/utils/annotations";
 import type { TaskSpec } from "@/utils/componentSpec";
@@ -28,6 +29,7 @@ export const AnnotationsSection = ({
   onApply,
 }: AnnotationsSectionProps) => {
   const notify = useToastNotification();
+  const { track } = useAnalytics();
 
   const rawAnnotations = taskSpec.annotations ?? {};
 
@@ -83,6 +85,7 @@ export const AnnotationsSection = ({
   const handleNewRowBlur = useCallback(
     (newRow: NewAnnotationRowData) => {
       if (newRow.key.trim() && !(newRow.key in annotations)) {
+        track("pipeline_editor.task_node.annotation_added");
         const newAnnotations = {
           ...annotations,
           [newRow.key]: newRow.value,

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/ArgumentInputField.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/ArgumentInputField.tsx
@@ -29,12 +29,14 @@ import { Paragraph } from "@/components/ui/typography";
 import { useCallbackOnUnmount } from "@/hooks/useCallbackOnUnmount";
 import useToastNotification from "@/hooks/useToastNotification";
 import { cn } from "@/lib/utils";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 import type { ArgumentInput } from "@/types/arguments";
 import {
   isDynamicDataArgument,
   isGraphImplementation,
 } from "@/utils/componentSpec";
+import { tracking } from "@/utils/tracking";
 
 import { ArgumentInputDialog } from "./ArgumentInputDialog";
 import { DynamicDataArgumentInput } from "./DynamicDataArgumentInput";
@@ -152,6 +154,9 @@ const PlainArgumentInput = ({
           size="xs"
           tooltip="Multiline Editor"
           data-testid="multiline-editor-button"
+          {...tracking("pipeline_editor.task_node.input_action", {
+            action: "multiline_editor",
+          })}
         >
           <Icon name="Maximize2" />
         </TooltipButton>
@@ -165,6 +170,9 @@ const PlainArgumentInput = ({
             variant="ghost"
             size="xs"
             tooltip="Copy Value"
+            {...tracking("pipeline_editor.task_node.input_action", {
+              action: "copy_value",
+            })}
           >
             <Icon name="Copy" />
           </TooltipButton>
@@ -179,6 +187,9 @@ const PlainArgumentInput = ({
             variant="ghost"
             size="xs"
             tooltip="Reset to Default"
+            {...tracking("pipeline_editor.task_node.input_action", {
+              action: "reset_to_default",
+            })}
           >
             <Icon name="ListRestart" />
           </TooltipButton>
@@ -190,6 +201,11 @@ const PlainArgumentInput = ({
           size="xs"
           className={ACTIONS_BASE_CLASS}
           tooltip={argument.isRemoved ? "Include Argument" : "Exclude Argument"}
+          {...tracking("pipeline_editor.task_node.input_action", {
+            action: argument.isRemoved
+              ? "include_argument"
+              : "exclude_argument",
+          })}
         >
           {argument.isRemoved ? (
             <Icon name="SquarePlus" />
@@ -214,6 +230,7 @@ export const ArgumentInputField = ({
   onSave: (argument: ArgumentInput) => void;
 }) => {
   const notify = useToastNotification();
+  const { track } = useAnalytics();
   const { currentSubgraphSpec } = useComponentSpec();
 
   const [inputValue, setInputValue] = useState(getInputValue(argument) ?? "");
@@ -305,7 +322,6 @@ export const ArgumentInputField = ({
 
   const handleExpand = useCallback(() => {
     if (disabled) return;
-
     setIsTextareaDialogOpen(true);
   }, [disabled]);
 
@@ -325,8 +341,12 @@ export const ArgumentInputField = ({
 
   const handleOpenSecretDialog = useCallback(() => {
     if (disabled) return;
+    track("pipeline_editor.task_node.input_action.click", {
+      action: "use_dynamic_data",
+    });
+    track("pipeline_editor.task_node.select_secret_impression");
     setIsSelectSecretDialogOpen(true);
-  }, [disabled]);
+  }, [disabled, track]);
 
   const handleSecretSelect = useCallback(
     (selectedSecretName: string) => {
@@ -456,6 +476,9 @@ export const ArgumentInputField = ({
                   tooltip="Description"
                   variant="ghost"
                   size="icon"
+                  {...tracking("pipeline_editor.task_node.input_action", {
+                    action: "description",
+                  })}
                 >
                   <Icon name="Info" />
                 </TooltipButton>

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/TaskConfiguration.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/TaskConfiguration.tsx
@@ -3,6 +3,7 @@ import { useCallback } from "react";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Switch } from "@/components/ui/switch";
 import { Heading, Paragraph } from "@/components/ui/typography";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { type TaskNodeContextType } from "@/providers/TaskNodeProvider";
 import { isCacheDisabled } from "@/utils/cache";
 import { ISO8601_DURATION_ZERO_DAYS } from "@/utils/constants";
@@ -13,14 +14,18 @@ interface TaskConfigurationProps {
 
 const TaskConfiguration = ({ taskNode }: TaskConfigurationProps) => {
   const { taskSpec, callbacks } = taskNode;
+  const { track } = useAnalytics();
 
   const handleDisableCacheChange = useCallback(
     (checked: boolean) => {
+      track("pipeline_editor.task_node.disable_cache_toggle", {
+        new_value: checked,
+      });
       callbacks.setCacheStaleness(
         checked ? ISO8601_DURATION_ZERO_DAYS : undefined,
       );
     },
-    [callbacks],
+    [callbacks, track],
   );
 
   if (!taskSpec) {
@@ -47,7 +52,12 @@ const TaskConfiguration = ({ taskNode }: TaskConfigurationProps) => {
         </Paragraph>
         <Switch
           checked={taskNode.state.isCollapsed}
-          onCheckedChange={taskNode.callbacks.setCollapsed}
+          onCheckedChange={(checked) => {
+            track("pipeline_editor.task_node.collapse_node_toggle", {
+              new_value: checked,
+            });
+            taskNode.callbacks.setCollapsed(checked);
+          }}
         />
       </InlineStack>
     </BlockStack>

--- a/src/components/shared/ReactFlow/FlowControls/StackingControls.tsx
+++ b/src/components/shared/ReactFlow/FlowControls/StackingControls.tsx
@@ -2,6 +2,7 @@ import { useReactFlow } from "@xyflow/react";
 
 import { Icon } from "@/components/ui/icon";
 import { InlineStack } from "@/components/ui/layout";
+import { tracking } from "@/utils/tracking";
 
 import TooltipButton from "../../Buttons/TooltipButton";
 import {
@@ -50,6 +51,9 @@ export const StackingControls = ({
     <InlineStack gap="2" data-testid="stacking-controls">
       <TooltipButton
         data-testid="stacking-move-forward"
+        {...tracking("pipeline_editor.task_node.z_index", {
+          action: "move_forward",
+        })}
         size="sm"
         variant="outline"
         onClick={() => updateZIndex("forward")}
@@ -59,6 +63,9 @@ export const StackingControls = ({
       </TooltipButton>
       <TooltipButton
         data-testid="stacking-move-backward"
+        {...tracking("pipeline_editor.task_node.z_index", {
+          action: "move_backward",
+        })}
         size="sm"
         variant="outline"
         onClick={() => updateZIndex("backward")}
@@ -68,6 +75,9 @@ export const StackingControls = ({
       </TooltipButton>
       <TooltipButton
         data-testid="stacking-bring-to-front"
+        {...tracking("pipeline_editor.task_node.z_index", {
+          action: "bring_to_front",
+        })}
         size="sm"
         variant="outline"
         onClick={() => updateZIndex("front")}
@@ -77,6 +87,9 @@ export const StackingControls = ({
       </TooltipButton>
       <TooltipButton
         data-testid="stacking-send-to-back"
+        {...tracking("pipeline_editor.task_node.z_index", {
+          action: "send_to_back",
+        })}
         size="sm"
         variant="outline"
         onClick={() => updateZIndex("back")}

--- a/src/components/shared/TaskDetails/Actions.tsx
+++ b/src/components/shared/TaskDetails/Actions.tsx
@@ -1,6 +1,7 @@
 import { type TaskNodeContextType } from "@/providers/TaskNodeProvider";
 import type { HydratedComponentReference } from "@/utils/componentSpec";
 import { isSubgraph } from "@/utils/subgraphUtils";
+import { tracking } from "@/utils/tracking";
 
 import { LinkNodeButton } from "../Buttons/LinkNodeButton";
 import { ViewYamlButton } from "../Buttons/ViewYamlButton";
@@ -43,7 +44,14 @@ const TaskActions = ({
     <DownloadPythonButton componentRef={componentRef} />
   );
   const copyYaml = <CopyYamlButton componentRef={componentRef} />;
-  const viewYaml = <ViewYamlButton componentRef={componentRef} />;
+  const viewYaml = (
+    <ViewYamlButton
+      componentRef={componentRef}
+      {...tracking("pipeline_editor.task_node.yaml_action", {
+        action: "view",
+      })}
+    />
+  );
   const editComponent = !readOnly && (
     <EditComponentButton componentRef={componentRef} />
   );

--- a/src/components/shared/TaskDetails/Actions/CopyYamlButton.tsx
+++ b/src/components/shared/TaskDetails/Actions/CopyYamlButton.tsx
@@ -1,5 +1,6 @@
 import useToastNotification from "@/hooks/useToastNotification";
 import type { HydratedComponentReference } from "@/utils/componentSpec";
+import { tracking } from "@/utils/tracking";
 
 import { ActionButton } from "../../Buttons/ActionButton";
 
@@ -20,6 +21,13 @@ export const CopyYamlButton = ({ componentRef }: CopyYamlButtonProps) => {
   };
 
   return (
-    <ActionButton tooltip="Copy YAML" icon="Clipboard" onClick={handleClick} />
+    <ActionButton
+      tooltip="Copy YAML"
+      icon="Clipboard"
+      onClick={handleClick}
+      {...tracking("pipeline_editor.task_node.yaml_action", {
+        action: "copy",
+      })}
+    />
   );
 };

--- a/src/components/shared/TaskDetails/Actions/DeleteComponentButton.tsx
+++ b/src/components/shared/TaskDetails/Actions/DeleteComponentButton.tsx
@@ -1,4 +1,5 @@
 import useToastNotification from "@/hooks/useToastNotification";
+import { tracking } from "@/utils/tracking";
 
 import { ActionButton } from "../../Buttons/ActionButton";
 
@@ -26,6 +27,7 @@ export const DeleteComponentButton = ({
       icon="Trash"
       onClick={handleClick}
       destructive
+      {...tracking("pipeline_editor.task_node.delete_component")}
     />
   );
 };

--- a/src/components/shared/TaskDetails/Actions/DownloadYamlButton.tsx
+++ b/src/components/shared/TaskDetails/Actions/DownloadYamlButton.tsx
@@ -1,5 +1,6 @@
 import type { HydratedComponentReference } from "@/utils/componentSpec";
 import { getComponentName } from "@/utils/getComponentName";
+import { tracking } from "@/utils/tracking";
 import { downloadYamlFromComponentText } from "@/utils/URL";
 
 import { ActionButton } from "../../Buttons/ActionButton";
@@ -21,6 +22,9 @@ export const DownloadYamlButton = ({
       tooltip="Download YAML"
       icon="Download"
       onClick={handleClick}
+      {...tracking("pipeline_editor.task_node.yaml_action", {
+        action: "download",
+      })}
     />
   );
 };

--- a/src/components/shared/TaskDetails/Actions/DuplicateTaskButton.tsx
+++ b/src/components/shared/TaskDetails/Actions/DuplicateTaskButton.tsx
@@ -1,3 +1,5 @@
+import { tracking } from "@/utils/tracking";
+
 import { ActionButton } from "../../Buttons/ActionButton";
 
 interface DuplicateTaskButtonProps {
@@ -8,6 +10,11 @@ export const DuplicateTaskButton = ({
   onDuplicate,
 }: DuplicateTaskButtonProps) => {
   return (
-    <ActionButton tooltip="Duplicate Task" icon="Copy" onClick={onDuplicate} />
+    <ActionButton
+      tooltip="Duplicate Task"
+      icon="Copy"
+      onClick={onDuplicate}
+      {...tracking("pipeline_editor.task_node.duplicate_task")}
+    />
   );
 };

--- a/src/components/shared/TaskDetails/Actions/EditComponentButton.tsx
+++ b/src/components/shared/TaskDetails/Actions/EditComponentButton.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 
 import type { HydratedComponentReference } from "@/utils/componentSpec";
+import { tracking } from "@/utils/tracking";
 
 import { ActionButton } from "../../Buttons/ActionButton";
 import { ComponentEditorDialog } from "../../ComponentEditor/ComponentEditorDialog";
@@ -14,23 +15,19 @@ export const EditComponentButton = ({
 }: EditComponentButtonProps) => {
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
 
-  const handleClick = () => {
-    setIsEditDialogOpen(true);
-  };
-
-  const handleClose = () => {
-    setIsEditDialogOpen(false);
-  };
-
   return (
     <>
       <ActionButton
         tooltip="Edit Component Definition"
         icon="FilePenLine"
-        onClick={handleClick}
+        onClick={() => setIsEditDialogOpen(true)}
+        {...tracking("pipeline_editor.task_node.edit_component")}
       />
       {isEditDialogOpen && (
-        <ComponentEditorDialog text={componentRef.text} onClose={handleClose} />
+        <ComponentEditorDialog
+          text={componentRef.text}
+          onClose={() => setIsEditDialogOpen(false)}
+        />
       )}
     </>
   );

--- a/src/components/shared/TaskDetails/Actions/UpgradeTaskButton.tsx
+++ b/src/components/shared/TaskDetails/Actions/UpgradeTaskButton.tsx
@@ -1,3 +1,5 @@
+import { tracking } from "@/utils/tracking";
+
 import { ActionButton } from "../../Buttons/ActionButton";
 
 interface UpgradeTaskButtonProps {
@@ -10,6 +12,7 @@ export const UpgradeTaskButton = ({ onUpgrade }: UpgradeTaskButtonProps) => {
       tooltip="Update Task from Source URL"
       icon="CircleFadingArrowUp"
       onClick={onUpgrade}
+      {...tracking("pipeline_editor.task_node.update_task_from_source_url")}
     />
   );
 };


### PR DESCRIPTION
## Description

Adds analytics tracking to various task node interactions in the pipeline editor. The following user actions are now tracked:

- Opening the component details dialog (click and impression events)
- Adding a component to the component library (click and impression events)
- Adding annotations to a task node
- Input field actions: exclude/include argument, reset to default, multiline editor, use dynamic data (secret), copy value, and description
- Disabling/enabling cache and collapsing/expanding a node
- Z-index stacking control operations (move forward, move backward, bring to front, send to back)
- YAML actions: view, copy, and download
- Deleting, duplicating, editing, and upgrading a task component

`ViewYamlButton` now accepts an optional `clickMetadata` prop to pass additional metadata alongside the click tracking event.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

![Screenshot 2026-04-22 at 4.12.51 PM.png](https://app.graphite.com/user-attachments/assets/23830efb-bbaf-40e0-97e7-211d913445f3.png)

![Screenshot 2026-04-22 at 4.14.06 PM.png](https://app.graphite.com/user-attachments/assets/add39e05-e1dc-4cb5-91db-d57a37d4afaa.png)

![Screenshot 2026-04-22 at 4.15.24 PM.png](https://app.graphite.com/user-attachments/assets/c8e26b1b-93ce-454a-bbe7-034a4ba6221c.png)

## Test Instructions

1. Open the pipeline editor and interact with a task node.
2. Trigger each tracked action (open component details, toggle cache, collapse node, copy/view/download YAML, duplicate, edit, upgrade, delete, add annotation, use input field actions, adjust z-index, add to component library).
3. Verify that the corresponding analytics events are fired with the correct action names and metadata.

## Additional Comments