### PR TITLE
feat: v2: Add Delete Pipeline to File Menu

### DIFF
--- a/src/routes/v2/pages/Editor/components/EditorMenuBar/components/FileMenu.tsx
+++ b/src/routes/v2/pages/Editor/components/EditorMenuBar/components/FileMenu.tsx
@@ -1,6 +1,9 @@
 import { useState } from "react";
 
-import { PipelineNameDialog } from "@/components/shared/Dialogs";
+import {
+  ConfirmationDialog,
+  PipelineNameDialog,
+} from "@/components/shared/Dialogs";
 import ImportPipeline from "@/components/shared/ImportPipeline";
 import {
   DropdownMenu,
@@ -28,6 +31,8 @@ export function FileMenu() {
     setSaveAsDialogOpen,
     renameDialogOpen,
     setRenameDialogOpen,
+    deleteDialogOpen,
+    setDeleteDialogOpen,
     handleRename,
     getRenameInitialName,
     setImportOpen,
@@ -37,6 +42,7 @@ export function FileMenu() {
     handleSavePipelineAs,
     handleExport,
     getSaveAsInitialName,
+    handleDeletePipeline,
   } = useFileMenuState();
 
   const { pipelineFile: pipelineFileStore } = useEditorSession();
@@ -93,6 +99,14 @@ export function FileMenu() {
               </DropdownMenuItem>
             </>
           )}
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            onClick={() => setDeleteDialogOpen(true)}
+            className="text-destructive focus:text-destructive"
+          >
+            <Icon name="Trash2" size="sm" />
+            Delete pipeline
+          </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
 
@@ -131,6 +145,17 @@ export function FileMenu() {
           onMoveComplete={() => setMoveDialogOpen(false)}
         />
       )}
+
+      <ConfirmationDialog
+        isOpen={deleteDialogOpen}
+        title="Delete pipeline?"
+        description={`"${activePipeline?.storageKey ?? "This pipeline"}" will be permanently deleted. This action cannot be undone.`}
+        onConfirm={() => {
+          void handleDeletePipeline();
+          setDeleteDialogOpen(false);
+        }}
+        onCancel={() => setDeleteDialogOpen(false)}
+      />
 
       <ImportPipeline
         triggerComponent={

--- a/src/routes/v2/pages/Editor/components/EditorMenuBar/components/useFileMenuState.ts
+++ b/src/routes/v2/pages/Editor/components/EditorMenuBar/components/useFileMenuState.ts
@@ -24,6 +24,8 @@ interface FileMenuState {
   setSaveAsDialogOpen: (open: boolean) => void;
   renameDialogOpen: boolean;
   setRenameDialogOpen: (open: boolean) => void;
+  deleteDialogOpen: boolean;
+  setDeleteDialogOpen: (open: boolean) => void;
   handleRename: (name: string) => void;
   getRenameInitialName: () => string;
   setImportOpen: (open: boolean) => void;
@@ -33,6 +35,7 @@ interface FileMenuState {
   handleSavePipelineAs: (name: string) => void;
   handleExport: () => void;
   getSaveAsInitialName: () => string;
+  handleDeletePipeline: () => void;
 }
 
 export function useFileMenuState(): FileMenuState {
@@ -46,6 +49,7 @@ export function useFileMenuState(): FileMenuState {
   const [openDialogOpen, setOpenDialogOpen] = useState(false);
   const [saveAsDialogOpen, setSaveAsDialogOpen] = useState(false);
   const [renameDialogOpen, setRenameDialogOpen] = useState(false);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const importTriggerRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
@@ -114,6 +118,13 @@ export function useFileMenuState(): FileMenuState {
     exportCurrentPipeline(navigation);
   };
 
+  const handleDeletePipeline = async () => {
+    const file = pipelineFileStore.activePipelineFile;
+    if (!file) return;
+    await file.deleteFile();
+    void navigate({ to: APP_ROUTES.HOME });
+  };
+
   const getSaveAsInitialName = () => {
     const currentName = navigation.rootSpec?.name;
     return currentName
@@ -129,6 +140,8 @@ export function useFileMenuState(): FileMenuState {
     setSaveAsDialogOpen,
     renameDialogOpen,
     setRenameDialogOpen,
+    deleteDialogOpen,
+    setDeleteDialogOpen,
     handleRename,
     getRenameInitialName,
     setImportOpen,
@@ -138,5 +151,6 @@ export function useFileMenuState(): FileMenuState {
     handleSavePipelineAs,
     handleExport,
     getSaveAsInitialName,
+    handleDeletePipeline,
   };
 }


### PR DESCRIPTION
## Description

Simple change to add a "delete pipeline" action to the v2 file menu.



After a confirmation the pipeline will be removed from local storage and the user redirected home



useful when iterating externally on imported pipelines

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

- [x] New feature
- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

![image.png](https://app.graphite.com/user-attachments/assets/f8298972-b564-45f6-aae1-77ab32e89b94.png)



<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->