### PR TITLE
fix: track subgraph history

### DIFF
--- a/src/models/componentSpec/__tests__/entities/componentSpecProxy.test.ts
+++ b/src/models/componentSpec/__tests__/entities/componentSpecProxy.test.ts
@@ -1,0 +1,406 @@
+import { describe, expect, it } from "vitest";
+
+import { Binding } from "../../entities/binding";
+import { ComponentSpec } from "../../entities/componentSpec";
+import { createComponentSpecProxy } from "../../entities/componentSpecProxy";
+import { Input } from "../../entities/input";
+import { Output } from "../../entities/output";
+import { Task } from "../../entities/task";
+import type { GraphImplementation } from "../../entities/types";
+
+function makeMinimalSpec(
+  overrides?: Partial<ConstructorParameters<typeof ComponentSpec>[0]>,
+): ComponentSpec {
+  return new ComponentSpec({
+    $id: "spec_1",
+    name: "TestPipeline",
+    ...overrides,
+  });
+}
+
+function getGraph(
+  proxy: ReturnType<typeof createComponentSpecProxy>,
+): GraphImplementation["graph"] {
+  if ("graph" in proxy.implementation) {
+    return proxy.implementation.graph;
+  }
+  throw new Error("Expected graph implementation");
+}
+
+describe("createComponentSpecProxy", () => {
+  describe("name", () => {
+    it("returns spec name", () => {
+      const proxy = createComponentSpecProxy(makeMinimalSpec());
+      expect(proxy.name).toBe("TestPipeline");
+    });
+  });
+
+  describe("description", () => {
+    it("returns spec description", () => {
+      const proxy = createComponentSpecProxy(
+        makeMinimalSpec({ description: "A test pipeline" }),
+      );
+      expect(proxy.description).toBe("A test pipeline");
+    });
+
+    it("returns undefined when description is absent", () => {
+      const proxy = createComponentSpecProxy(makeMinimalSpec());
+      expect(proxy.description).toBeUndefined();
+    });
+  });
+
+  describe("inputs", () => {
+    it("maps input models to InputSpec shape", () => {
+      const spec = makeMinimalSpec();
+      spec.addInput(
+        new Input({
+          $id: "in_1",
+          name: "data",
+          type: "string",
+          description: "Input data",
+          defaultValue: "hello",
+          optional: true,
+        }),
+      );
+
+      const proxy = createComponentSpecProxy(spec);
+
+      expect(proxy.inputs).toEqual([
+        {
+          name: "data",
+          type: "string",
+          description: "Input data",
+          default: "hello",
+          optional: true,
+        },
+      ]);
+    });
+
+    it("returns empty array when no inputs", () => {
+      const proxy = createComponentSpecProxy(makeMinimalSpec());
+      expect(proxy.inputs).toEqual([]);
+    });
+  });
+
+  describe("outputs", () => {
+    it("maps output models to OutputSpec shape", () => {
+      const spec = makeMinimalSpec();
+      spec.addOutput(
+        new Output({
+          $id: "out_1",
+          name: "result",
+          type: "object",
+          description: "The result",
+        }),
+      );
+
+      const proxy = createComponentSpecProxy(spec);
+
+      expect(proxy.outputs).toEqual([
+        {
+          name: "result",
+          type: "object",
+          description: "The result",
+        },
+      ]);
+    });
+
+    it("returns empty array when no outputs", () => {
+      const proxy = createComponentSpecProxy(makeMinimalSpec());
+      expect(proxy.outputs).toEqual([]);
+    });
+  });
+
+  describe("implementation", () => {
+    it("returns a graph implementation", () => {
+      const proxy = createComponentSpecProxy(makeMinimalSpec());
+      expect("graph" in proxy.implementation).toBe(true);
+    });
+
+    it("serializes tasks with componentRef", () => {
+      const spec = makeMinimalSpec();
+      spec.addTask(
+        new Task({
+          $id: "task_1",
+          name: "Train",
+          componentRef: { name: "TrainerComponent" },
+        }),
+      );
+
+      const graph = getGraph(createComponentSpecProxy(spec));
+
+      expect(graph.tasks).toHaveProperty("Train");
+      expect(graph.tasks["Train"].componentRef).toEqual({
+        name: "TrainerComponent",
+      });
+    });
+
+    it("serializes multiple tasks keyed by name", () => {
+      const spec = makeMinimalSpec();
+      spec.addTask(
+        new Task({
+          $id: "task_1",
+          name: "Load",
+          componentRef: { name: "Loader" },
+        }),
+      );
+      spec.addTask(
+        new Task({
+          $id: "task_2",
+          name: "Process",
+          componentRef: { name: "Processor" },
+        }),
+      );
+
+      const graph = getGraph(createComponentSpecProxy(spec));
+
+      expect(Object.keys(graph.tasks)).toEqual(
+        expect.arrayContaining(["Load", "Process"]),
+      );
+    });
+
+    it("serializes literal task arguments", () => {
+      const spec = makeMinimalSpec();
+      const task = new Task({
+        $id: "task_1",
+        name: "Train",
+        componentRef: {},
+      });
+      task.addArgument({ name: "epochs", value: "10" });
+      task.addArgument({ name: "lr", value: "0.01" });
+      spec.addTask(task);
+
+      const graph = getGraph(createComponentSpecProxy(spec));
+
+      expect(graph.tasks["Train"].arguments).toEqual({
+        epochs: "10",
+        lr: "0.01",
+      });
+    });
+
+    it("serializes bindings from inputs as graphInput arguments", () => {
+      const spec = makeMinimalSpec();
+      const input = new Input({ $id: "in_1", name: "data" });
+      spec.addInput(input);
+      const task = new Task({
+        $id: "task_1",
+        name: "Train",
+        componentRef: {},
+      });
+      spec.addTask(task);
+      spec.addBinding(
+        new Binding({
+          $id: "b_1",
+          sourceEntityId: "in_1",
+          targetEntityId: "task_1",
+          sourcePortName: "data",
+          targetPortName: "input_data",
+        }),
+      );
+
+      const graph = getGraph(createComponentSpecProxy(spec));
+
+      expect(graph.tasks["Train"].arguments).toEqual({
+        input_data: { graphInput: { inputName: "data" } },
+      });
+    });
+
+    it("serializes bindings between tasks as taskOutput arguments", () => {
+      const spec = makeMinimalSpec();
+      const taskA = new Task({
+        $id: "task_a",
+        name: "Load",
+        componentRef: {},
+      });
+      const taskB = new Task({
+        $id: "task_b",
+        name: "Train",
+        componentRef: {},
+      });
+      spec.addTask(taskA);
+      spec.addTask(taskB);
+      spec.addBinding(
+        new Binding({
+          $id: "b_1",
+          sourceEntityId: "task_a",
+          targetEntityId: "task_b",
+          sourcePortName: "output",
+          targetPortName: "dataset",
+        }),
+      );
+
+      const graph = getGraph(createComponentSpecProxy(spec));
+
+      expect(graph.tasks["Train"].arguments).toEqual({
+        dataset: { taskOutput: { taskId: "Load", outputName: "output" } },
+      });
+    });
+
+    it("serializes graph output values", () => {
+      const spec = makeMinimalSpec();
+      const task = new Task({
+        $id: "task_1",
+        name: "Train",
+        componentRef: {},
+      });
+      const output = new Output({ $id: "out_1", name: "model" });
+      spec.addTask(task);
+      spec.addOutput(output);
+      spec.addBinding(
+        new Binding({
+          $id: "b_1",
+          sourceEntityId: "task_1",
+          targetEntityId: "out_1",
+          sourcePortName: "trained_model",
+          targetPortName: "model",
+        }),
+      );
+
+      const graph = getGraph(createComponentSpecProxy(spec));
+
+      expect(graph.outputValues).toEqual({
+        model: {
+          taskOutput: { taskId: "Train", outputName: "trained_model" },
+        },
+      });
+    });
+
+    it("omits outputValues when there are no output bindings", () => {
+      const spec = makeMinimalSpec();
+      spec.addTask(new Task({ $id: "task_1", name: "T", componentRef: {} }));
+
+      const graph = getGraph(createComponentSpecProxy(spec));
+
+      expect(graph.outputValues).toBeUndefined();
+    });
+
+    it("serializes isEnabled on tasks", () => {
+      const spec = makeMinimalSpec();
+      spec.addTask(
+        new Task({
+          $id: "task_1",
+          name: "T",
+          componentRef: {},
+          isEnabled: { "==": { op1: "a", op2: "b" } },
+        }),
+      );
+
+      const graph = getGraph(createComponentSpecProxy(spec));
+
+      expect(graph.tasks["T"].isEnabled).toEqual({
+        "==": { op1: "a", op2: "b" },
+      });
+    });
+
+    it("serializes executionOptions on tasks", () => {
+      const spec = makeMinimalSpec();
+      spec.addTask(
+        new Task({
+          $id: "task_1",
+          name: "T",
+          componentRef: {},
+          executionOptions: {
+            cachingStrategy: { maxCacheStaleness: "P0D" },
+          },
+        }),
+      );
+
+      const graph = getGraph(createComponentSpecProxy(spec));
+
+      expect(graph.tasks["T"].executionOptions).toEqual({
+        cachingStrategy: { maxCacheStaleness: "P0D" },
+      });
+    });
+
+    it("serializes subgraph spec recursively", () => {
+      const innerSpec = makeMinimalSpec({
+        $id: "inner_spec",
+        name: "InnerPipeline",
+      });
+      innerSpec.addTask(
+        new Task({
+          $id: "inner_task",
+          name: "InnerStep",
+          componentRef: { name: "InnerComponent" },
+        }),
+      );
+
+      const outerSpec = makeMinimalSpec({
+        $id: "outer_spec",
+        name: "OuterPipeline",
+      });
+      const outerTask = new Task({
+        $id: "task_1",
+        name: "SubgraphTask",
+        componentRef: {},
+      });
+      outerTask.setSubgraphSpec(innerSpec);
+      outerSpec.addTask(outerTask);
+
+      const graph = getGraph(createComponentSpecProxy(outerSpec));
+
+      const taskSpec = graph.tasks["SubgraphTask"];
+      expect(taskSpec.componentRef.spec).toBeDefined();
+      expect(taskSpec.componentRef.spec?.name).toBe("InnerPipeline");
+      expect(
+        "graph" in (taskSpec.componentRef.spec?.implementation ?? {}),
+      ).toBe(true);
+    });
+
+    it("returns empty tasks for a spec with no tasks", () => {
+      const graph = getGraph(createComponentSpecProxy(makeMinimalSpec()));
+      expect(graph.tasks).toEqual({});
+    });
+  });
+
+  describe("metadata", () => {
+    it("serializes annotations as metadata", () => {
+      const spec = makeMinimalSpec();
+      spec.setMetadata("author", "Alice");
+
+      const proxy = createComponentSpecProxy(spec);
+
+      expect(proxy.metadata).toEqual({
+        annotations: { author: "Alice" },
+      });
+    });
+
+    it("returns undefined when no annotations", () => {
+      const proxy = createComponentSpecProxy(makeMinimalSpec());
+      expect(proxy.metadata).toBeUndefined();
+    });
+  });
+
+  describe("has trap", () => {
+    it("returns true for known keys", () => {
+      const proxy = createComponentSpecProxy(makeMinimalSpec());
+      const knownKeys = [
+        "name",
+        "description",
+        "inputs",
+        "outputs",
+        "implementation",
+        "metadata",
+      ];
+
+      for (const key of knownKeys) {
+        expect(key in proxy).toBe(true);
+      }
+    });
+
+    it("returns false for unknown keys", () => {
+      const proxy = createComponentSpecProxy(makeMinimalSpec());
+      expect("foo" in proxy).toBe(false);
+      expect("tasks" in proxy).toBe(false);
+      expect("bindings" in proxy).toBe(false);
+    });
+  });
+
+  describe("unknown properties", () => {
+    it("returns undefined for unrecognized properties", () => {
+      const proxy = createComponentSpecProxy(makeMinimalSpec());
+
+      expect((proxy as any).nonexistent).toBeUndefined();
+    });
+  });
+});

--- a/src/models/componentSpec/__tests__/serialization/persistentUndo.test.ts
+++ b/src/models/componentSpec/__tests__/serialization/persistentUndo.test.ts
@@ -44,6 +44,64 @@ const COMPLEX_YAML = {
   },
 };
 
+const SUBGRAPH_YAML = {
+  name: "PipelineWithSubgraph",
+  inputs: [{ name: "data" }],
+  outputs: [{ name: "result" }],
+  implementation: {
+    graph: {
+      tasks: {
+        Preprocess: {
+          componentRef: { name: "Preprocessor" },
+          arguments: { input: "{{inputs.data}}" },
+        },
+        SubgraphTask: {
+          componentRef: {
+            spec: {
+              name: "InnerPipeline",
+              inputs: [{ name: "inner_in" }],
+              outputs: [{ name: "inner_out" }],
+              implementation: {
+                graph: {
+                  tasks: {
+                    InnerStep: {
+                      componentRef: { name: "InnerComponent" },
+                      arguments: {
+                        x: { graphInput: { inputName: "inner_in" } },
+                      },
+                    },
+                  },
+                  outputValues: {
+                    inner_out: {
+                      taskOutput: {
+                        taskId: "InnerStep",
+                        outputName: "out",
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          arguments: {
+            inner_in: {
+              taskOutput: {
+                taskId: "Preprocess",
+                outputName: "preprocessed",
+              },
+            },
+          },
+        },
+      },
+      outputValues: {
+        result: {
+          taskOutput: { taskId: "SubgraphTask", outputName: "inner_out" },
+        },
+      },
+    },
+  },
+};
+
 describe("ReplayIdGenerator", () => {
   it("replays IDs from the stack in order", () => {
     const stack = ["id_a", "id_b", "id_c"];
@@ -124,6 +182,33 @@ describe("collectIdStack", () => {
     const ids = collectIdStack(spec);
     expect(ids).toHaveLength(1);
     expect(ids[0]).toBe(spec.$id);
+  });
+
+  it("includes subgraph entity IDs before the parent task ID", () => {
+    const idGen = new IncrementingIdGenerator();
+    const deserializer = new YamlDeserializer(idGen);
+    const spec = deserializer.deserialize(SUBGRAPH_YAML);
+
+    const ids = collectIdStack(spec);
+
+    const subgraphTask = spec.tasks.find((t) => t.subgraphSpec !== undefined);
+    expect(subgraphTask).toBeDefined();
+
+    const subgraphSpec = subgraphTask!.subgraphSpec!;
+    const parentTaskIdx = ids.indexOf(subgraphTask!.$id);
+    const subgraphSpecIdx = ids.indexOf(subgraphSpec.$id);
+
+    expect(subgraphSpecIdx).toBeLessThan(parentTaskIdx);
+
+    for (const input of subgraphSpec.inputs) {
+      expect(ids.indexOf(input.$id)).toBeLessThan(parentTaskIdx);
+    }
+    for (const task of subgraphSpec.tasks) {
+      expect(ids.indexOf(task.$id)).toBeLessThan(parentTaskIdx);
+    }
+    for (const binding of subgraphSpec.bindings) {
+      expect(ids.indexOf(binding.$id)).toBeLessThan(parentTaskIdx);
+    }
   });
 });
 
@@ -212,6 +297,76 @@ describe("ID Replay round-trip", () => {
       expect(spec2.bindings[i].targetEntityId).toBe(
         spec1.bindings[i].targetEntityId,
       );
+    }
+  });
+
+  it("produces identical IDs when replaying a spec with subgraphs", () => {
+    const idGen1 = new IncrementingIdGenerator();
+    const spec1 = new YamlDeserializer(idGen1).deserialize(SUBGRAPH_YAML);
+    const idStack = collectIdStack(spec1);
+
+    const replayGen = new ReplayIdGenerator(idStack);
+    const spec2 = new YamlDeserializer(replayGen).deserialize(SUBGRAPH_YAML);
+
+    expect(spec2.$id).toBe(spec1.$id);
+
+    for (let i = 0; i < spec1.inputs.length; i++) {
+      expect(spec2.inputs[i].$id).toBe(spec1.inputs[i].$id);
+    }
+    for (let i = 0; i < spec1.outputs.length; i++) {
+      expect(spec2.outputs[i].$id).toBe(spec1.outputs[i].$id);
+    }
+    for (let i = 0; i < spec1.tasks.length; i++) {
+      expect(spec2.tasks[i].$id).toBe(spec1.tasks[i].$id);
+
+      const sub1 = spec1.tasks[i].subgraphSpec;
+      const sub2 = spec2.tasks[i].subgraphSpec;
+      if (sub1 && sub2) {
+        expect(sub2.$id).toBe(sub1.$id);
+        for (let j = 0; j < sub1.tasks.length; j++) {
+          expect(sub2.tasks[j].$id).toBe(sub1.tasks[j].$id);
+        }
+        for (let j = 0; j < sub1.inputs.length; j++) {
+          expect(sub2.inputs[j].$id).toBe(sub1.inputs[j].$id);
+        }
+        for (let j = 0; j < sub1.bindings.length; j++) {
+          expect(sub2.bindings[j].$id).toBe(sub1.bindings[j].$id);
+        }
+      }
+    }
+    for (let i = 0; i < spec1.bindings.length; i++) {
+      expect(spec2.bindings[i].$id).toBe(spec1.bindings[i].$id);
+    }
+
+    expect(replayGen.isExhausted).toBe(true);
+  });
+
+  it("preserves correct ID prefixes for subgraph entities after replay", () => {
+    const idGen1 = new IncrementingIdGenerator();
+    const spec1 = new YamlDeserializer(idGen1).deserialize(SUBGRAPH_YAML);
+    const idStack = collectIdStack(spec1);
+
+    const spec2 = new YamlDeserializer(
+      new ReplayIdGenerator(idStack),
+    ).deserialize(SUBGRAPH_YAML);
+
+    for (const task of spec2.tasks) {
+      expect(task.$id).toMatch(/^task_/);
+      if (task.subgraphSpec) {
+        expect(task.subgraphSpec.$id).toMatch(/^spec_/);
+        for (const innerTask of task.subgraphSpec.tasks) {
+          expect(innerTask.$id).toMatch(/^task_/);
+        }
+        for (const innerInput of task.subgraphSpec.inputs) {
+          expect(innerInput.$id).toMatch(/^input_/);
+        }
+        for (const innerOutput of task.subgraphSpec.outputs) {
+          expect(innerOutput.$id).toMatch(/^output_/);
+        }
+        for (const innerBinding of task.subgraphSpec.bindings) {
+          expect(innerBinding.$id).toMatch(/^binding_/);
+        }
+      }
     }
   });
 

--- a/src/models/componentSpec/__tests__/validation/collectIssues.test.ts
+++ b/src/models/componentSpec/__tests__/validation/collectIssues.test.ts
@@ -3,6 +3,9 @@ import { describe, expect, it } from "vitest";
 import { ComponentSpec } from "../../entities/componentSpec";
 import { Task } from "../../entities/task";
 import type { ComponentSpecJson } from "../../entities/types";
+import { isGraphImplementation } from "../../entities/types";
+import { IncrementingIdGenerator } from "../../factories/idGenerator";
+import { YamlDeserializer } from "../../serialization/yamlDeserializer";
 import { collectValidationIssues } from "../../validation/collectIssues";
 
 function makeSpec(name = "TestPipeline"): ComponentSpec {
@@ -10,6 +13,17 @@ function makeSpec(name = "TestPipeline"): ComponentSpec {
 }
 
 function makeTask(id: string, name: string, spec?: ComponentSpecJson): Task {
+  if (spec && isGraphImplementation(spec.implementation)) {
+    const idGen = new IncrementingIdGenerator();
+    const deserializer = new YamlDeserializer(idGen);
+    const subgraphSpec = deserializer.deserialize(spec);
+    return new Task({
+      $id: id,
+      name,
+      componentRef: { name: `component-${name}` },
+      subgraphSpec,
+    });
+  }
   return new Task({
     $id: id,
     name,

--- a/src/models/componentSpec/actions/createSubgraph.ts
+++ b/src/models/componentSpec/actions/createSubgraph.ts
@@ -14,7 +14,6 @@ import type {
   PredicateType,
 } from "../entities/types";
 import type { IdGenerator } from "../factories/idGenerator";
-import { serializeComponentSpec } from "../serialization/serialize";
 
 interface CreateSubgraphParams {
   spec: ComponentSpec;
@@ -227,8 +226,6 @@ export function createSubgraph({
     ],
   });
 
-  const subgraphSpecJson = deepClone(serializeComponentSpec(subgraphSpec));
-
   const replacementTaskArgs: Argument[] = inputGroups.map(({ input }) => ({
     name: input.name,
   }));
@@ -236,7 +233,8 @@ export function createSubgraph({
   const replacementTask = new Task({
     $id: idGen.next("task"),
     name: subgraphName,
-    componentRef: { name: subgraphName, spec: subgraphSpecJson },
+    componentRef: { name: subgraphName },
+    subgraphSpec,
     arguments: replacementTaskArgs,
   });
 

--- a/src/models/componentSpec/actions/unpackSubgraph.ts
+++ b/src/models/componentSpec/actions/unpackSubgraph.ts
@@ -4,9 +4,8 @@ import { Annotations, deserializeAnnotationValue } from "../annotations";
 import { Binding } from "../entities/binding";
 import type { ComponentSpec } from "../entities/componentSpec";
 import { Task } from "../entities/task";
-import { type Annotation, isGraphImplementation } from "../entities/types";
+import type { Annotation } from "../entities/types";
 import type { IdGenerator } from "../factories/idGenerator";
-import { YamlDeserializer } from "../serialization/yamlDeserializer";
 
 interface UnpackSubgraphParams {
   spec: ComponentSpec;
@@ -27,16 +26,8 @@ export function unpackSubgraph({
   const task = spec.tasks.find((t) => t.$id === taskId);
   if (!task) return false;
 
-  const subgraphSpecJson = task.componentRef.spec;
-
-  if (!isGraphImplementation(subgraphSpecJson?.implementation)) return false;
-
-  // Deep-clone to strip MobX Keystone observable wrappers; the
-  // YamlDeserializer expects plain JS objects for Object.entries() etc.
-  const plainSpecJson = deepClone(subgraphSpecJson);
-
-  const deserializer = new YamlDeserializer(idGen);
-  const innerModel = deserializer.deserialize(plainSpecJson);
+  const innerModel = task.subgraphSpec;
+  if (!innerModel) return false;
 
   const innerInputIds = new Set(innerModel.inputs.map((i) => i.$id));
   const innerOutputIds = new Set(innerModel.outputs.map((o) => o.$id));

--- a/src/models/componentSpec/entities/componentSpecProxy.ts
+++ b/src/models/componentSpec/entities/componentSpecProxy.ts
@@ -1,0 +1,88 @@
+import type { Annotations } from "../annotations";
+import { serializeAnnotationValue } from "../annotations";
+import { JsonSerializer } from "../serialization/jsonSerializer";
+import type { ComponentSpec } from "./componentSpec";
+import type { Input } from "./input";
+import type { Output } from "./output";
+import type {
+  ComponentSpecJson,
+  InputSpec,
+  MetadataSpec,
+  OutputSpec,
+} from "./types";
+
+const serializer = new JsonSerializer();
+
+const PROXY_KEYS = new Set([
+  "name",
+  "description",
+  "inputs",
+  "outputs",
+  "implementation",
+  "metadata",
+]);
+
+/**
+ * Creates a lazy ES Proxy over a live ComponentSpec keystone model that
+ * presents itself as a ComponentSpecJson. Properties are only read from
+ * the model when accessed -- zero upfront serialization cost.
+ *
+ * Not suitable for full serialization (JSON.stringify / yaml.dump).
+ * For that, use `serializeComponentSpec()` directly.
+ */
+export function createComponentSpecProxy(
+  spec: ComponentSpec,
+): ComponentSpecJson {
+  return new Proxy({} as ComponentSpecJson, {
+    get(_target, prop) {
+      switch (prop) {
+        case "name":
+          return spec.name;
+        case "description":
+          return spec.description;
+        case "inputs":
+          return spec.inputs.map(inputModelToSpec);
+        case "outputs":
+          return spec.outputs.map(outputModelToSpec);
+        case "implementation":
+          return serializer.serialize(spec).implementation;
+        case "metadata":
+          return annotationsToMetadata(spec.annotations);
+        default:
+          return undefined;
+      }
+    },
+    has(_target, prop) {
+      return PROXY_KEYS.has(prop as string);
+    },
+  });
+}
+
+function inputModelToSpec(input: Input): InputSpec {
+  return {
+    name: input.name,
+    type: input.type,
+    description: input.description,
+    default: input.defaultValue,
+    optional: input.optional,
+  };
+}
+
+function outputModelToSpec(output: Output): OutputSpec {
+  return {
+    name: output.name,
+    type: output.type,
+    description: output.description,
+  };
+}
+
+function annotationsToMetadata(
+  annotations: Annotations,
+): MetadataSpec | undefined {
+  if (annotations.items.length === 0) return undefined;
+  const record: Record<string, unknown> = {};
+  for (const a of annotations.items) {
+    record[a.key] = serializeAnnotationValue(a.key, a.value);
+  }
+  return { annotations: record };
+}

--- a/src/models/componentSpec/entities/task.ts
+++ b/src/models/componentSpec/entities/task.ts
@@ -1,19 +1,26 @@
+import { computed } from "mobx";
 import { idProp, Model, model, modelAction, prop } from "mobx-keystone";
 
 import { Annotations } from "../annotations";
+import type { ComponentSpec } from "./componentSpec";
+import { createComponentSpecProxy } from "./componentSpecProxy";
+import { deserializeSubgraphSpec } from "./taskSubgraphHelper";
 import type {
   Argument,
   ArgumentType,
   ComponentReference,
+  ComponentSpecJson,
   ExecutionOptionsSpec,
   PredicateType,
 } from "./types";
+import { isGraphImplementation } from "./types";
 
 @model("spec/Task")
 export class Task extends Model({
   $id: idProp,
   name: prop<string>(),
   componentRef: prop<ComponentReference>(),
+  subgraphSpec: prop<ComponentSpec | undefined>(undefined),
   isEnabled: prop<PredicateType | undefined>(undefined),
   annotations: prop<Annotations>(() => new Annotations({})),
   arguments: prop<Argument[]>(() => []),
@@ -25,8 +32,32 @@ export class Task extends Model({
   }
 
   @modelAction
+  setSubgraphSpec(spec: ComponentSpec | undefined) {
+    this.subgraphSpec = spec;
+  }
+
+  /**
+   * Guard: if the incoming ref has an inline graph spec, promote it to
+   * `subgraphSpec` and strip it from `componentRef`. This ensures a graph
+   * spec never stays as plain JSON at runtime.
+   */
+  @modelAction
   setComponentRef(ref: ComponentReference) {
-    this.componentRef = ref;
+    if (ref.spec && isGraphImplementation(ref.spec.implementation)) {
+      this.subgraphSpec = deserializeSubgraphSpec(ref.spec);
+      this.componentRef = { ...ref, spec: undefined };
+    } else {
+      this.subgraphSpec = undefined;
+      this.componentRef = ref;
+    }
+  }
+
+  @computed
+  get resolvedComponentSpec(): ComponentSpecJson | undefined {
+    if (this.subgraphSpec) {
+      return createComponentSpecProxy(this.subgraphSpec);
+    }
+    return this.componentRef.spec;
   }
 
   @modelAction

--- a/src/models/componentSpec/entities/taskSubgraphHelper.ts
+++ b/src/models/componentSpec/entities/taskSubgraphHelper.ts
@@ -1,0 +1,17 @@
+import { IncrementingIdGenerator } from "../factories/idGenerator";
+import { YamlDeserializer } from "../serialization/yamlDeserializer";
+import type { ComponentSpec } from "./componentSpec";
+import type { ComponentSpecJson } from "./types";
+
+/**
+ * Fallback deserializer for the `setComponentRef` guard.
+ * Uses a fresh id generator since primary entry points
+ * (YamlDeserializer, createSubgraph) pass models directly.
+ */
+export function deserializeSubgraphSpec(
+  specJson: ComponentSpecJson,
+): ComponentSpec {
+  const idGen = new IncrementingIdGenerator();
+  const deserializer = new YamlDeserializer(idGen);
+  return deserializer.deserialize(specJson);
+}

--- a/src/models/componentSpec/serialization/collectIdStack.ts
+++ b/src/models/componentSpec/serialization/collectIdStack.ts
@@ -2,15 +2,24 @@ import type { ComponentSpec } from "../entities/componentSpec";
 
 /**
  * Collects all entity $id values from a ComponentSpec in the exact order
- * that YamlDeserializer calls idGen.next(): inputs, outputs, tasks, bindings, spec.
+ * that YamlDeserializer calls idGen.next():
+ *   inputs, outputs, (for each task: subgraph IDs recursively, then task $id), bindings, spec.
  *
  * This ordering contract is critical for ReplayIdGenerator to work correctly.
  * The spec ID comes last because YamlDeserializer builds child entities first,
  * then creates the ComponentSpec with idGen.next("spec") as the final call.
+ *
+ * For tasks with subgraphs, YamlDeserializer.buildTasks calls
+ * maybeDeserializeSubgraph (which recursively deserializes the subgraph)
+ * BEFORE generating the parent task's $id.
  */
 export function collectIdStack(spec: ComponentSpec): string[] {
   const ids: string[] = [];
+  collectIds(spec, ids);
+  return ids;
+}
 
+function collectIds(spec: ComponentSpec, ids: string[]): void {
   for (const input of spec.inputs) {
     ids.push(input.$id);
   }
@@ -20,6 +29,9 @@ export function collectIdStack(spec: ComponentSpec): string[] {
   }
 
   for (const task of spec.tasks) {
+    if (task.subgraphSpec) {
+      collectIds(task.subgraphSpec, ids);
+    }
     ids.push(task.$id);
   }
 
@@ -28,6 +40,4 @@ export function collectIdStack(spec: ComponentSpec): string[] {
   }
 
   ids.push(spec.$id);
-
-  return ids;
 }

--- a/src/models/componentSpec/serialization/jsonSerializer.ts
+++ b/src/models/componentSpec/serialization/jsonSerializer.ts
@@ -85,8 +85,12 @@ export class JsonSerializer {
     );
     const args = this.serializeArguments(task.arguments, taskBindings, spec);
 
+    const componentRef = task.subgraphSpec
+      ? { ...task.componentRef, spec: this.serialize(task.subgraphSpec) }
+      : task.componentRef;
+
     const result: TaskSpec = {
-      componentRef: task.componentRef,
+      componentRef,
     };
 
     if (Object.keys(args).length > 0) {

--- a/src/models/componentSpec/serialization/yamlDeserializer.ts
+++ b/src/models/componentSpec/serialization/yamlDeserializer.ts
@@ -8,6 +8,7 @@ import type {
   Annotation,
   Argument,
   ArgumentType,
+  ComponentReference,
   ComponentSpecJson,
   GraphSpec,
   ImplementationType,
@@ -16,6 +17,7 @@ import type {
   OutputSpec,
   TaskSpec,
 } from "../entities/types";
+import { isGraphImplementation } from "../entities/types";
 import type { IdGenerator } from "../factories/idGenerator";
 
 const GRAPH_INPUT_REGEX = /^\{\{inputs\.([^}]+)\}\}$/;
@@ -136,16 +138,30 @@ export class YamlDeserializer {
         }
       }
 
+      const subgraphSpec = this.maybeDeserializeSubgraph(taskJson.componentRef);
+      const componentRef = subgraphSpec
+        ? { ...taskJson.componentRef, spec: undefined }
+        : taskJson.componentRef;
+
       return new Task({
         $id: this.idGen.next("task"),
         name: taskName,
-        componentRef: taskJson.componentRef,
+        componentRef,
+        subgraphSpec,
         isEnabled: taskJson.isEnabled,
         executionOptions: taskJson.executionOptions,
         annotations: Annotations.from(annotationItems),
         arguments: args,
       });
     });
+  }
+
+  private maybeDeserializeSubgraph(
+    ref: ComponentReference,
+  ): ComponentSpec | undefined {
+    if (!ref.spec?.implementation) return undefined;
+    if (!isGraphImplementation(ref.spec.implementation)) return undefined;
+    return this.deserialize(ref.spec);
   }
 
   private buildBindings(

--- a/src/models/componentSpec/validation/collectIssues.ts
+++ b/src/models/componentSpec/validation/collectIssues.ts
@@ -1,8 +1,4 @@
 import type { ComponentSpec } from "../entities/componentSpec";
-import type { ComponentSpecJson } from "../entities/types";
-import { isGraphImplementation } from "../entities/types";
-import { IncrementingIdGenerator } from "../factories/idGenerator";
-import { YamlDeserializer } from "../serialization/yamlDeserializer";
 import type { ComponentValidationIssue, ValidationIssue } from "./types";
 import { validateSpec } from "./validateSpec";
 
@@ -44,16 +40,8 @@ function collectRecursive(
   );
 
   const nestedIssues = spec.tasks.flatMap((task) => {
-    const nestedSpecJson = task.componentRef.spec as
-      | ComponentSpecJson
-      | undefined;
-    if (!nestedSpecJson?.implementation) return [];
-    if (!isGraphImplementation(nestedSpecJson.implementation)) return [];
-
-    const nestedSpec = deserializeNested(nestedSpecJson);
-    if (!nestedSpec) return [];
-
-    return collectRecursive(nestedSpec, {
+    if (!task.subgraphSpec) return [];
+    return collectRecursive(task.subgraphSpec, {
       subgraphPath: [...subgraphPath, task.name],
       skipInputConnectionValidation: true,
       visitedSpecIds: context.visitedSpecIds,
@@ -61,20 +49,6 @@ function collectRecursive(
   });
 
   return [...currentIssues, ...nestedIssues];
-}
-
-function deserializeNested(
-  specJson: ComponentSpecJson,
-): ComponentSpec | undefined {
-  try {
-    const idGen = new IncrementingIdGenerator();
-    const deserializer = new YamlDeserializer(idGen);
-    return deserializer.deserialize(
-      JSON.parse(JSON.stringify(specJson)) as ComponentSpecJson,
-    );
-  } catch {
-    return undefined;
-  }
 }
 
 function toComponentIssue(

--- a/src/models/componentSpec/validation/validateSpec.ts
+++ b/src/models/componentSpec/validation/validateSpec.ts
@@ -162,7 +162,7 @@ function validateSingleTask(
     });
   }
 
-  if (isInvalidComponentReference(task.componentRef)) {
+  if (!task.subgraphSpec && isInvalidComponentReference(task.componentRef)) {
     issues.push({
       type: "task",
       message: "Missing component reference",
@@ -222,8 +222,8 @@ function validateTaskArguments(
           argumentName: arg.name,
           referencedName: refTaskName,
         });
-      } else if (refTask.componentRef.spec) {
-        const refSpec = refTask.componentRef.spec;
+      } else if (refTask.resolvedComponentSpec) {
+        const refSpec = refTask.resolvedComponentSpec;
         const outputExists = refSpec.outputs?.some(
           (o) => o.name === refOutputName,
         );
@@ -254,7 +254,7 @@ function validateTaskRequiredInputs(
   spec: ComponentSpec,
 ): ValidationIssue[] {
   const issues: ValidationIssue[] = [];
-  const taskSpec = task.componentRef.spec;
+  const taskSpec = task.resolvedComponentSpec;
 
   if (!taskSpec?.inputs) return issues;
 

--- a/src/routes/v2/pages/Editor/components/ArgumentRow/components/ThunderMenu/thunderMenu.utils.ts
+++ b/src/routes/v2/pages/Editor/components/ArgumentRow/components/ThunderMenu/thunderMenu.utils.ts
@@ -1,8 +1,4 @@
-import type {
-  ComponentSpec,
-  ComponentSpecJson,
-  TypeSpecType,
-} from "@/models/componentSpec";
+import type { ComponentSpec, TypeSpecType } from "@/models/componentSpec";
 
 interface QuickConnectPort {
   entityId: string;
@@ -62,9 +58,7 @@ export function getQuickConnectGroups(
   for (const task of spec.tasks) {
     if (excludeSet.has(task.$id)) continue;
 
-    const componentSpec = task.componentRef.spec as
-      | ComponentSpecJson
-      | undefined;
+    const componentSpec = task.resolvedComponentSpec;
     const outputs = componentSpec?.outputs ?? [];
 
     const compatibleOutputs = outputs.filter((output) =>

--- a/src/routes/v2/pages/Editor/components/ContextPanel/components/MultiSelectionDetails/utils.ts
+++ b/src/routes/v2/pages/Editor/components/ContextPanel/components/MultiSelectionDetails/utils.ts
@@ -1,9 +1,4 @@
-import type {
-  ComponentSpec,
-  ComponentSpecJson,
-  Task,
-  TypeSpecType,
-} from "@/models/componentSpec";
+import type { ComponentSpec, Task, TypeSpecType } from "@/models/componentSpec";
 import type { NodeTypeRegistry } from "@/routes/v2/shared/nodes/registry";
 import type { SelectedNode } from "@/routes/v2/shared/store/editorStore";
 
@@ -47,9 +42,7 @@ export function computeAggregatedArguments(
   >();
 
   for (const task of tasks) {
-    const componentSpec = task.componentRef.spec as
-      | ComponentSpecJson
-      | undefined;
+    const componentSpec = task.resolvedComponentSpec;
     const inputs = componentSpec?.inputs ?? [];
 
     for (const inputSpec of inputs) {

--- a/src/routes/v2/pages/Editor/components/FlowCanvas/hooks/useNodeEdgeChanges.ts
+++ b/src/routes/v2/pages/Editor/components/FlowCanvas/hooks/useNodeEdgeChanges.ts
@@ -13,7 +13,7 @@ export function useNodeEdgeChanges(
   rfOnEdgesChange: (changes: EdgeChange[]) => void,
 ): Required<Pick<ReactFlowProps, "onNodesChange" | "onEdgesChange">> {
   const registry = useNodeRegistry();
-  const { editor } = useSharedStores();
+  const { editor, navigation } = useSharedStores();
   const { undo } = useEditorSession();
 
   const onNodesChange = (changes: NodeChange[]) => {
@@ -44,7 +44,7 @@ export function useNodeEdgeChanges(
         const manifest = registry.getByNodeId(spec, change.id);
         // todo: move action to a separate file
         undo.withGroup("Delete node", () => {
-          manifest?.deleteNode(undo, spec, change.id);
+          manifest?.deleteNode(undo, spec, change.id, navigation.parentContext);
         });
 
         // deselect removed nodes

--- a/src/routes/v2/pages/Editor/components/FlowCanvas/hooks/useReplaceDropHandler.tsx
+++ b/src/routes/v2/pages/Editor/components/FlowCanvas/hooks/useReplaceDropHandler.tsx
@@ -124,7 +124,7 @@ export function useReplaceDropHandler(
     if (!task) return;
 
     const { inputDiff, outputDiff } = computeDiffComponentSpecs(
-      task.componentRef.spec,
+      task.resolvedComponentSpec,
       newComponentRef.spec,
     );
 

--- a/src/routes/v2/pages/Editor/components/PinnedTaskContent/PinnedTaskContent.tsx
+++ b/src/routes/v2/pages/Editor/components/PinnedTaskContent/PinnedTaskContent.tsx
@@ -5,6 +5,7 @@ import { Icon } from "@/components/ui/icon";
 import { BlockStack } from "@/components/ui/layout";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Text } from "@/components/ui/typography";
+import { serializeComponentSpec } from "@/models/componentSpec";
 import { CodeBlock } from "@/routes/v2/pages/Editor/components/PinnedTaskContent/components/CodeBlock";
 import { useSpec } from "@/routes/v2/shared/providers/SpecContext";
 import { componentSpecToText } from "@/utils/yaml";
@@ -34,14 +35,18 @@ export const PinnedTaskContent = observer(function PinnedTaskContent({
   }
 
   const componentRef = task.componentRef;
-  const componentSpec = componentRef.spec;
-  const code =
-    componentRef.text ??
-    (componentSpec
+  const componentSpec = task.resolvedComponentSpec;
+  const code = (() => {
+    if (componentRef.text) return componentRef.text;
+    if (task.subgraphSpec) {
+      return componentSpecToText(serializeComponentSpec(task.subgraphSpec));
+    }
+    return componentRef.spec
       ? componentSpecToText(
-          componentSpec as Parameters<typeof componentSpecToText>[0],
+          componentRef.spec as Parameters<typeof componentSpecToText>[0],
         )
-      : "");
+      : "";
+  })();
 
   return (
     <BlockStack className="h-full w-full bg-white overflow-hidden">

--- a/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/RootNode.tsx
+++ b/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/RootNode.tsx
@@ -6,7 +6,6 @@ import { BlockStack } from "@/components/ui/layout";
 import { Text } from "@/components/ui/typography";
 import { cn } from "@/lib/utils";
 import type { ComponentSpec } from "@/models/componentSpec";
-import { isSubgraphTask } from "@/routes/v2/pages/Editor/components/PipelineTreeContent/utils";
 import { countErrors } from "@/routes/v2/pages/Editor/components/ValidationSummary";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 
@@ -125,26 +124,11 @@ export const RootNode = observer(function RootNode({
         <BlockStack gap="0" className="ml-4 border-l border-slate-200">
           <div className="-ml-1.5">
             {tasks.map((task) => {
-              const isTaskASubgraph = isSubgraphTask(task);
-
-              if (isTaskASubgraph) {
-                const nestedSpec = navigation.nestedSpecs.get(task.name);
-
-                if (!nestedSpec) {
-                  return (
-                    <TaskLeafNode
-                      key={task.$id}
-                      task={task}
-                      parentSpec={spec}
-                      parentNavigationPath={navigationPath}
-                    />
-                  );
-                }
-
+              if (task.subgraphSpec) {
                 return (
                   <SubgraphNode
                     key={task.$id}
-                    spec={nestedSpec}
+                    spec={task.subgraphSpec}
                     task={task}
                     navigationPath={[...navigationPath, task.name]}
                     currentNavPath={currentNavPath}

--- a/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/SubgraphNode.tsx
+++ b/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/SubgraphNode.tsx
@@ -6,10 +6,7 @@ import { BlockStack } from "@/components/ui/layout";
 import { Text } from "@/components/ui/typography";
 import { cn } from "@/lib/utils";
 import type { ComponentSpec, Task } from "@/models/componentSpec";
-import {
-  getEntityIssues,
-  isSubgraphTask,
-} from "@/routes/v2/pages/Editor/components/PipelineTreeContent/utils";
+import { getEntityIssues } from "@/routes/v2/pages/Editor/components/PipelineTreeContent/utils";
 import { countErrors } from "@/routes/v2/pages/Editor/components/ValidationSummary";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 
@@ -146,32 +143,11 @@ export const SubgraphNode = observer(function SubgraphNode({
         <BlockStack gap="0" className="ml-4 border-l border-slate-200 pl-2">
           <div className="-ml-3.5">
             {tasks.map((childTask) => {
-              const isChildSubgraph = isSubgraphTask(childTask);
-
-              if (isChildSubgraph) {
-                const childPathKey =
-                  navigationPath.slice(1).join("/") + "/" + childTask.name;
-                const nestedSpec = navigation.nestedSpecs.get(
-                  childPathKey.startsWith("/")
-                    ? childPathKey.slice(1)
-                    : childPathKey,
-                );
-
-                if (!nestedSpec) {
-                  return (
-                    <TaskLeafNode
-                      key={childTask.$id}
-                      task={childTask}
-                      parentSpec={spec}
-                      parentNavigationPath={navigationPath}
-                    />
-                  );
-                }
-
+              if (childTask.subgraphSpec) {
                 return (
                   <SubgraphNode
                     key={childTask.$id}
-                    spec={nestedSpec}
+                    spec={childTask.subgraphSpec}
                     task={childTask}
                     navigationPath={[...navigationPath, childTask.name]}
                     currentNavPath={currentNavPath}

--- a/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/resolutions/BadReferenceResolution.tsx
+++ b/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/resolutions/BadReferenceResolution.tsx
@@ -4,15 +4,10 @@ import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
 import { BlockStack } from "@/components/ui/layout";
 import { Text } from "@/components/ui/typography";
-import type {
-  ComponentSpec,
-  ComponentSpecJson,
-  ValidationIssue,
-} from "@/models/componentSpec";
+import type { ComponentSpec, ValidationIssue } from "@/models/componentSpec";
 import { ArgumentRow } from "@/routes/v2/pages/Editor/components/ArgumentRow/ArgumentRow";
 import { useValidationResolutionActions } from "@/routes/v2/pages/Editor/components/PipelineTreeContent/components/useValidationResolutionActions";
 import { findTaskById } from "@/routes/v2/pages/Editor/components/PipelineTreeContent/components/validationResolution.utils";
-import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 
 import { InfoOnlyResolution } from "./InfoOnlyResolution";
 
@@ -23,7 +18,6 @@ export const BadReferenceResolution = observer(function BadReferenceResolution({
   issue: ValidationIssue;
   spec: ComponentSpec;
 }) {
-  const { navigation } = useSharedStores();
   const { unsetBadReference } = useValidationResolutionActions();
 
   if (!issue.entityId || !issue.argumentName) {
@@ -32,14 +26,14 @@ export const BadReferenceResolution = observer(function BadReferenceResolution({
     );
   }
 
-  const task = findTaskById(spec, issue.entityId, navigation.nestedSpecs);
+  const task = findTaskById(spec, issue.entityId);
   if (!task) {
     return (
       <InfoOnlyResolution message="Task not found in the current graph." />
     );
   }
 
-  const componentSpec = task.componentRef.spec as ComponentSpecJson | undefined;
+  const componentSpec = task.resolvedComponentSpec;
   const inputSpec = componentSpec?.inputs?.find(
     (i) => i.name === issue.argumentName,
   );

--- a/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/resolutions/MissingRequiredInputResolution.tsx
+++ b/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/resolutions/MissingRequiredInputResolution.tsx
@@ -2,14 +2,9 @@ import { observer } from "mobx-react-lite";
 
 import { BlockStack } from "@/components/ui/layout";
 import { Text } from "@/components/ui/typography";
-import type {
-  ComponentSpec,
-  ComponentSpecJson,
-  ValidationIssue,
-} from "@/models/componentSpec";
+import type { ComponentSpec, ValidationIssue } from "@/models/componentSpec";
 import { ArgumentRow } from "@/routes/v2/pages/Editor/components/ArgumentRow/ArgumentRow";
 import { findTaskById } from "@/routes/v2/pages/Editor/components/PipelineTreeContent/components/validationResolution.utils";
-import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 
 import { InfoOnlyResolution } from "./InfoOnlyResolution";
 
@@ -21,24 +16,20 @@ export const MissingRequiredInputResolution = observer(
     issue: ValidationIssue;
     spec: ComponentSpec;
   }) {
-    const { navigation } = useSharedStores();
-
     if (!issue.entityId || !issue.argumentName) {
       return (
         <InfoOnlyResolution message="Cannot resolve: missing entity or argument information." />
       );
     }
 
-    const task = findTaskById(spec, issue.entityId, navigation.nestedSpecs);
+    const task = findTaskById(spec, issue.entityId);
     if (!task) {
       return (
         <InfoOnlyResolution message="Task not found in the current graph." />
       );
     }
 
-    const componentSpec = task.componentRef.spec as
-      | ComponentSpecJson
-      | undefined;
+    const componentSpec = task.resolvedComponentSpec;
     const inputSpec = componentSpec?.inputs?.find(
       (i) => i.name === issue.argumentName,
     );

--- a/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/validationResolution.utils.ts
+++ b/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/validationResolution.utils.ts
@@ -3,14 +3,14 @@ import type { ComponentSpec, Task } from "@/models/componentSpec";
 export function findTaskById(
   spec: ComponentSpec,
   entityId: string,
-  nestedSpecs: ReadonlyMap<string, ComponentSpec>,
 ): Task | undefined {
   const directTask = spec.tasks.find((t) => t.$id === entityId);
   if (directTask) return directTask;
 
-  for (const [, nestedSpec] of nestedSpecs) {
-    const nestedTask = nestedSpec.tasks.find((t) => t.$id === entityId);
-    if (nestedTask) return nestedTask;
+  for (const task of spec.tasks) {
+    if (!task.subgraphSpec) continue;
+    const found = findTaskById(task.subgraphSpec, entityId);
+    if (found) return found;
   }
   return undefined;
 }

--- a/src/routes/v2/pages/Editor/components/PipelineTreeContent/utils.ts
+++ b/src/routes/v2/pages/Editor/components/PipelineTreeContent/utils.ts
@@ -1,19 +1,4 @@
-import type {
-  ComponentSpec,
-  ComponentSpecJson,
-  Task,
-  ValidationIssue,
-} from "@/models/componentSpec";
-
-export function isSubgraphTask(task: Task): boolean {
-  const componentSpec = task.componentRef.spec as ComponentSpecJson | undefined;
-  if (!componentSpec?.implementation) {
-    return false;
-  }
-
-  // todo: typeguard
-  return "graph" in componentSpec.implementation;
-}
+import type { ComponentSpec, ValidationIssue } from "@/models/componentSpec";
 
 export function getEntityIssues(
   spec: ComponentSpec,

--- a/src/routes/v2/pages/Editor/hooks/useSpecLifecycle.ts
+++ b/src/routes/v2/pages/Editor/hooks/useSpecLifecycle.ts
@@ -1,10 +1,9 @@
-import { autorun, reaction } from "mobx";
+import { autorun } from "mobx";
 import type { UndoStore as MobxUndoStore } from "mobx-keystone";
 import { isRootStore, unregisterRootStore } from "mobx-keystone";
 import { useEffect, useRef } from "react";
 
 import type { ComponentSpec } from "@/models/componentSpec";
-import { serializeComponentSpecToText } from "@/models/componentSpec";
 import { useEditorSession } from "@/routes/v2/pages/Editor/store/EditorSessionContext";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 import { usePipelineStorage } from "@/services/pipelineStorage/PipelineStorageProvider";
@@ -57,25 +56,6 @@ export function useSpecLifecycle(
 
     prevTaskEntityIdsRef.current = new Set(rootSpec.tasks.map((t) => t.$id));
 
-    // When the active spec is a nested subgraph, sync its changes back to
-    // the root spec whenever it changes. This mutates the root's task
-    // componentRef.spec, which the existing autoSave reaction picks up.
-    const disposeNestedSync = reaction(
-      () => {
-        const active = navigation.activeSpec;
-        if (!active || active === rootSpec) return null;
-        try {
-          return serializeComponentSpecToText(active);
-        } catch {
-          return null;
-        }
-      },
-      () => {
-        navigation.syncNestedSpecs();
-      },
-      { fireImmediately: false },
-    );
-
     const disposeTaskWatcher = autorun(() => {
       const currentTaskIds = new Set(rootSpec.tasks.map((t) => t.$id));
 
@@ -89,7 +69,6 @@ export function useSpecLifecycle(
     });
 
     return () => {
-      disposeNestedSync();
       disposeTaskWatcher();
       autoSave.dispose();
       pipelineFileStore.dispose();

--- a/src/routes/v2/pages/Editor/nodes/GhostNode/hooks/useGhostNode.ts
+++ b/src/routes/v2/pages/Editor/nodes/GhostNode/hooks/useGhostNode.ts
@@ -55,9 +55,7 @@ function buildGhostNode(
   const portName = extractPortName(handleId, ioType);
 
   const task = spec.tasks.find((t) => t.$id === fromHandle.nodeId);
-  const taskComponentSpec = task?.componentRef.spec as
-    | ComponentSpecJson
-    | undefined;
+  const taskComponentSpec = task?.resolvedComponentSpec;
   const dataType = lookupPortType(taskComponentSpec, portName, ioType);
 
   return {

--- a/src/routes/v2/pages/Editor/nodes/IONode/inputNode.manifest.ts
+++ b/src/routes/v2/pages/Editor/nodes/IONode/inputNode.manifest.ts
@@ -1,6 +1,7 @@
 import { Annotations } from "@/models/componentSpec/annotations";
 import { Input } from "@/models/componentSpec/entities/input";
 import { addInput } from "@/routes/v2/pages/Editor/store/actions";
+import { deleteInput } from "@/routes/v2/pages/Editor/store/actions/io.actions";
 import { generateUniqueInputName } from "@/routes/v2/pages/Editor/store/nameUtils";
 import {
   inputManifestBase,
@@ -26,8 +27,8 @@ export const inputManifest: NodeTypeManifest = {
     spec.updateNodePosition(nodeId, position);
   },
 
-  deleteNode(_undo, spec, nodeId) {
-    spec.deleteInputById(nodeId);
+  deleteNode(undo, spec, nodeId, parentContext) {
+    deleteInput(undo, spec, nodeId, parentContext);
   },
 
   contextPanelComponent: InputDetails,

--- a/src/routes/v2/pages/Editor/nodes/IONode/outputNode.manifest.ts
+++ b/src/routes/v2/pages/Editor/nodes/IONode/outputNode.manifest.ts
@@ -1,6 +1,7 @@
 import { Annotations } from "@/models/componentSpec/annotations";
 import { Output } from "@/models/componentSpec/entities/output";
 import { addOutput } from "@/routes/v2/pages/Editor/store/actions";
+import { deleteOutput } from "@/routes/v2/pages/Editor/store/actions/io.actions";
 import { generateUniqueOutputName } from "@/routes/v2/pages/Editor/store/nameUtils";
 import {
   isOutputSnapshot,
@@ -26,8 +27,8 @@ export const outputManifest: NodeTypeManifest = {
     spec.updateNodePosition(nodeId, position);
   },
 
-  deleteNode(_undo, spec, nodeId) {
-    spec.deleteOutputById(nodeId);
+  deleteNode(undo, spec, nodeId, parentContext) {
+    deleteOutput(undo, spec, nodeId, parentContext);
   },
 
   contextPanelComponent: OutputDetails,

--- a/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/TaskDetails.tsx
+++ b/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/TaskDetails.tsx
@@ -15,7 +15,6 @@ import { AnnotationsBlock } from "@/routes/v2/pages/Editor/components/Annotation
 import { useEditorSession } from "@/routes/v2/pages/Editor/store/EditorSessionContext";
 import { useSpec } from "@/routes/v2/shared/providers/SpecContext";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
-import { isSubgraph } from "@/utils/subgraphUtils";
 
 import { getTaskYamlText } from "./components/actions/getTaskYamlText";
 import { ComponentRefBar } from "./components/ComponentRefBar";
@@ -57,11 +56,11 @@ export const TaskDetails = observer(function TaskDetails({
     return null;
   }
 
-  const componentSpec = task.componentRef.spec;
+  const componentSpec = task.resolvedComponentSpec;
   const yamlText = getTaskYamlText(task);
   const pythonCode = componentSpec?.metadata?.annotations?.python_original_code;
 
-  const isSubgraphTask = isSubgraph(task.componentRef.spec);
+  const isSubgraphTask = task.subgraphSpec !== undefined;
 
   const handleZIndexChange = (newZIndex: number) => {
     undo.withGroup("Update task z-index", () => {
@@ -99,7 +98,11 @@ export const TaskDetails = observer(function TaskDetails({
         </InlineStack>
 
         <ComponentRefBar
-          componentRef={task.componentRef}
+          componentRef={
+            task.subgraphSpec
+              ? { ...task.componentRef, spec: componentSpec }
+              : task.componentRef
+          }
           yamlText={yamlText}
           taskName={task.name}
           pythonCode={pythonCode}

--- a/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/components/ConfigurationSection.tsx
+++ b/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/components/ConfigurationSection.tsx
@@ -14,8 +14,6 @@ import { Separator } from "@/components/ui/separator";
 import { Switch } from "@/components/ui/switch";
 import { Heading, Paragraph } from "@/components/ui/typography";
 import type { Task } from "@/models/componentSpec";
-import type { ComponentSpecJson } from "@/models/componentSpec/entities/types";
-import { isGraphImplementation } from "@/models/componentSpec/entities/types";
 import type { AnnotationConfig, Annotations } from "@/types/annotations";
 import { ISO8601_DURATION_ZERO_DAYS } from "@/utils/constants";
 
@@ -34,10 +32,7 @@ export const ConfigurationSection = observer(function ConfigurationSection({
     setTaskColor,
     clearProviderAnnotations,
   } = useTaskConfigActions();
-  const componentSpec = task.componentRef.spec as ComponentSpecJson | undefined;
-  const isSubgraph = componentSpec?.implementation
-    ? isGraphImplementation(componentSpec.implementation)
-    : false;
+  const isSubgraph = task.subgraphSpec !== undefined;
 
   const cacheDisabled =
     task.executionOptions?.cachingStrategy?.maxCacheStaleness ===

--- a/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/components/TaskArgumentsEditor.tsx
+++ b/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/components/TaskArgumentsEditor.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef } from "react";
 
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Text } from "@/components/ui/typography";
-import type { ComponentSpecJson, Task } from "@/models/componentSpec";
+import type { Task } from "@/models/componentSpec";
 import { ArgumentCodeEditor } from "@/routes/v2/pages/Editor/components/ArgumentCodeEditor";
 import { ArgumentRow } from "@/routes/v2/pages/Editor/components/ArgumentRow/ArgumentRow";
 import { useSpec } from "@/routes/v2/shared/providers/SpecContext";
@@ -22,7 +22,7 @@ export const TaskArgumentsEditor = observer(function TaskArgumentsEditor({
   const spec = useSpec();
   const windowCtx = useOptionalWindowContext();
   const isMaximized = windowCtx?.model.isMaximized ?? false;
-  const componentSpec = task.componentRef.spec as ComponentSpecJson | undefined;
+  const componentSpec = task.resolvedComponentSpec;
   const inputs = componentSpec?.inputs ?? [];
   const lastSelectedArgRef = useRef<string | null>(null);
 

--- a/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/components/actions/UnpackSubgraphButton.tsx
+++ b/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/components/actions/UnpackSubgraphButton.tsx
@@ -5,7 +5,6 @@ import useToastNotification from "@/hooks/useToastNotification";
 import { useTask } from "@/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/hooks/useTask";
 import { useTaskActions } from "@/routes/v2/pages/Editor/store/actions/useTaskActions";
 import { useSpec } from "@/routes/v2/shared/providers/SpecContext";
-import { isGraphImplementation } from "@/utils/componentSpec";
 import { getErrorMessage } from "@/utils/string";
 
 interface UnpackSubgraphButtonProps {
@@ -29,8 +28,7 @@ export function UnpackSubgraphButton({ entityId }: UnpackSubgraphButtonProps) {
   });
 
   if (!task) return null;
-  if (!isGraphImplementation(task.componentRef.spec?.implementation))
-    return null;
+  if (!task.subgraphSpec) return null;
 
   return (
     <ActionButton

--- a/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/components/actions/getTaskYamlText.ts
+++ b/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/components/actions/getTaskYamlText.ts
@@ -1,9 +1,12 @@
+import { serializeComponentSpec } from "@/models/componentSpec";
 import type { Task } from "@/models/componentSpec/entities/task";
 import { componentSpecToText } from "@/utils/yaml";
 
 export function getTaskYamlText(task: Task): string {
-  return (
-    task.componentRef.text ??
-    (task.componentRef.spec ? componentSpecToText(task.componentRef.spec) : "")
-  );
+  if (task.componentRef.text) return task.componentRef.text;
+  if (task.subgraphSpec) {
+    return componentSpecToText(serializeComponentSpec(task.subgraphSpec));
+  }
+  const spec = task.componentRef.spec;
+  return spec ? componentSpecToText(spec) : "";
 }

--- a/src/routes/v2/pages/Editor/store/actions/__tests__/io.parentPropagation.test.ts
+++ b/src/routes/v2/pages/Editor/store/actions/__tests__/io.parentPropagation.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from "vitest";
+
+import { Binding } from "@/models/componentSpec/entities/binding";
+import { ComponentSpec } from "@/models/componentSpec/entities/componentSpec";
+import { Input } from "@/models/componentSpec/entities/input";
+import { Output } from "@/models/componentSpec/entities/output";
+import { Task } from "@/models/componentSpec/entities/task";
+import {
+  propagateInputDelete,
+  propagateInputRename,
+  propagateOutputDelete,
+  propagateOutputRename,
+} from "@/routes/v2/pages/Editor/store/actions/io.parentPropagation";
+import type { ParentContext } from "@/routes/v2/shared/store/navigationStore";
+
+function buildSubgraphSetup() {
+  const subgraphInput = new Input({ $id: "sub_input_1", name: "data" });
+  const subgraphOutput = new Output({ $id: "sub_output_1", name: "result" });
+  const subgraphSpec = new ComponentSpec({
+    $id: "sub_spec",
+    name: "SubPipeline",
+    inputs: [subgraphInput],
+    outputs: [subgraphOutput],
+  });
+
+  const parentTask = new Task({
+    $id: "task_A",
+    name: "SubPipeline",
+    componentRef: { name: "SubPipeline" },
+    subgraphSpec,
+    arguments: [{ name: "data", value: "some_value" }],
+  });
+
+  const parentSpec = new ComponentSpec({
+    $id: "parent_spec",
+    name: "ParentPipeline",
+    tasks: [parentTask],
+    bindings: [
+      new Binding({
+        $id: "bind_in",
+        sourceEntityId: "parent_input_1",
+        sourcePortName: "parent_input_1",
+        targetEntityId: "task_A",
+        targetPortName: "data",
+      }),
+      new Binding({
+        $id: "bind_out",
+        sourceEntityId: "task_A",
+        sourcePortName: "result",
+        targetEntityId: "parent_output_1",
+        targetPortName: "parent_output_1",
+      }),
+      new Binding({
+        $id: "bind_unrelated",
+        sourceEntityId: "other_input",
+        sourcePortName: "other_input",
+        targetEntityId: "other_task",
+        targetPortName: "other_port",
+      }),
+    ],
+  });
+
+  const parentContext: ParentContext = {
+    parentSpec,
+    taskId: "task_A",
+  };
+
+  return { subgraphSpec, parentSpec, parentTask, parentContext };
+}
+
+describe("propagateInputRename", () => {
+  it("updates parent binding targetPortName", () => {
+    const { parentSpec, parentContext } = buildSubgraphSetup();
+
+    propagateInputRename(parentContext, "data", "payload");
+
+    const binding = parentSpec.bindings.find((b) => b.$id === "bind_in");
+    expect(binding?.targetPortName).toBe("payload");
+  });
+
+  it("updates parent task argument name", () => {
+    const { parentTask, parentContext } = buildSubgraphSetup();
+
+    propagateInputRename(parentContext, "data", "payload");
+
+    expect(parentTask.arguments.find((a) => a.name === "data")).toBeUndefined();
+    const newArg = parentTask.arguments.find((a) => a.name === "payload");
+    expect(newArg).toBeDefined();
+    expect(newArg?.value).toBe("some_value");
+  });
+
+  it("does not affect unrelated bindings", () => {
+    const { parentSpec, parentContext } = buildSubgraphSetup();
+
+    propagateInputRename(parentContext, "data", "payload");
+
+    const unrelated = parentSpec.bindings.find(
+      (b) => b.$id === "bind_unrelated",
+    );
+    expect(unrelated?.targetPortName).toBe("other_port");
+  });
+
+  it("does not affect output bindings on the same task", () => {
+    const { parentSpec, parentContext } = buildSubgraphSetup();
+
+    propagateInputRename(parentContext, "data", "payload");
+
+    const outBinding = parentSpec.bindings.find((b) => b.$id === "bind_out");
+    expect(outBinding?.sourcePortName).toBe("result");
+  });
+});
+
+describe("propagateOutputRename", () => {
+  it("updates parent binding sourcePortName", () => {
+    const { parentSpec, parentContext } = buildSubgraphSetup();
+
+    propagateOutputRename(parentContext, "result", "output_data");
+
+    const binding = parentSpec.bindings.find((b) => b.$id === "bind_out");
+    expect(binding?.sourcePortName).toBe("output_data");
+  });
+
+  it("does not affect unrelated bindings", () => {
+    const { parentSpec, parentContext } = buildSubgraphSetup();
+
+    propagateOutputRename(parentContext, "result", "output_data");
+
+    const unrelated = parentSpec.bindings.find(
+      (b) => b.$id === "bind_unrelated",
+    );
+    expect(unrelated?.sourcePortName).toBe("other_input");
+  });
+
+  it("does not affect input bindings on the same task", () => {
+    const { parentSpec, parentContext } = buildSubgraphSetup();
+
+    propagateOutputRename(parentContext, "result", "output_data");
+
+    const inBinding = parentSpec.bindings.find((b) => b.$id === "bind_in");
+    expect(inBinding?.targetPortName).toBe("data");
+  });
+});
+
+describe("propagateInputDelete", () => {
+  it("removes parent bindings targeting the deleted input", () => {
+    const { parentSpec, parentContext } = buildSubgraphSetup();
+
+    propagateInputDelete(parentContext, "data");
+
+    expect(
+      parentSpec.bindings.find((b) => b.$id === "bind_in"),
+    ).toBeUndefined();
+  });
+
+  it("removes the parent task argument for the deleted input", () => {
+    const { parentTask, parentContext } = buildSubgraphSetup();
+
+    propagateInputDelete(parentContext, "data");
+
+    expect(parentTask.arguments.find((a) => a.name === "data")).toBeUndefined();
+  });
+
+  it("preserves unrelated bindings and output bindings", () => {
+    const { parentSpec, parentContext } = buildSubgraphSetup();
+
+    propagateInputDelete(parentContext, "data");
+
+    expect(parentSpec.bindings.find((b) => b.$id === "bind_out")).toBeDefined();
+    expect(
+      parentSpec.bindings.find((b) => b.$id === "bind_unrelated"),
+    ).toBeDefined();
+  });
+});
+
+describe("propagateOutputDelete", () => {
+  it("removes parent bindings sourcing from the deleted output", () => {
+    const { parentSpec, parentContext } = buildSubgraphSetup();
+
+    propagateOutputDelete(parentContext, "result");
+
+    expect(
+      parentSpec.bindings.find((b) => b.$id === "bind_out"),
+    ).toBeUndefined();
+  });
+
+  it("preserves unrelated bindings and input bindings", () => {
+    const { parentSpec, parentContext } = buildSubgraphSetup();
+
+    propagateOutputDelete(parentContext, "result");
+
+    expect(parentSpec.bindings.find((b) => b.$id === "bind_in")).toBeDefined();
+    expect(
+      parentSpec.bindings.find((b) => b.$id === "bind_unrelated"),
+    ).toBeDefined();
+  });
+
+  it("does not affect parent task arguments", () => {
+    const { parentTask, parentContext } = buildSubgraphSetup();
+
+    propagateOutputDelete(parentContext, "result");
+
+    expect(parentTask.arguments.find((a) => a.name === "data")).toBeDefined();
+  });
+});

--- a/src/routes/v2/pages/Editor/store/actions/io.actions.ts
+++ b/src/routes/v2/pages/Editor/store/actions/io.actions.ts
@@ -11,7 +11,14 @@ import {
   generateUniqueOutputName,
 } from "@/routes/v2/pages/Editor/store/nameUtils";
 import type { UndoGroupable } from "@/routes/v2/shared/nodes/types";
+import type { ParentContext } from "@/routes/v2/shared/store/navigationStore";
 
+import {
+  propagateInputDelete,
+  propagateInputRename,
+  propagateOutputDelete,
+  propagateOutputRename,
+} from "./io.parentPropagation";
 import { idGen } from "./utils";
 
 export function addInput(
@@ -61,10 +68,17 @@ export function renameInput(
   spec: ComponentSpec,
   entityId: string,
   newName: string,
+  parentContext?: ParentContext | null,
 ): boolean {
-  return undo.withGroup("Rename input", () =>
-    spec.renameInput(entityId, newName),
-  );
+  return undo.withGroup("Rename input", () => {
+    const input = spec.inputs.find((i) => i.$id === entityId);
+    const oldName = input?.name;
+    const success = spec.renameInput(entityId, newName);
+    if (success && parentContext && oldName) {
+      propagateInputRename(parentContext, oldName, newName);
+    }
+    return success;
+  });
 }
 
 export function renameOutput(
@@ -72,10 +86,17 @@ export function renameOutput(
   spec: ComponentSpec,
   entityId: string,
   newName: string,
+  parentContext?: ParentContext | null,
 ): boolean {
-  return undo.withGroup("Rename output", () =>
-    spec.renameOutput(entityId, newName),
-  );
+  return undo.withGroup("Rename output", () => {
+    const output = spec.outputs.find((o) => o.$id === entityId);
+    const oldName = output?.name;
+    const success = spec.renameOutput(entityId, newName);
+    if (success && parentContext && oldName) {
+      propagateOutputRename(parentContext, oldName, newName);
+    }
+    return success;
+  });
 }
 
 export function setInputDescription(
@@ -126,6 +147,40 @@ export function setOutputDescription(
   });
 }
 
+export function deleteInput(
+  undo: UndoGroupable,
+  spec: ComponentSpec,
+  entityId: string,
+  parentContext?: ParentContext | null,
+): boolean {
+  return undo.withGroup("Delete input", () => {
+    const input = spec.inputs.find((i) => i.$id === entityId);
+    const inputName = input?.name;
+    const success = spec.deleteInputById(entityId);
+    if (success && parentContext && inputName) {
+      propagateInputDelete(parentContext, inputName);
+    }
+    return success;
+  });
+}
+
+export function deleteOutput(
+  undo: UndoGroupable,
+  spec: ComponentSpec,
+  entityId: string,
+  parentContext?: ParentContext | null,
+): boolean {
+  return undo.withGroup("Delete output", () => {
+    const output = spec.outputs.find((o) => o.$id === entityId);
+    const outputName = output?.name;
+    const success = spec.deleteOutputById(entityId);
+    if (success && parentContext && outputName) {
+      propagateOutputDelete(parentContext, outputName);
+    }
+    return success;
+  });
+}
+
 export function createConnectedIONode(
   undo: UndoGroupable,
   spec: ComponentSpec,
@@ -142,7 +197,7 @@ export function createConnectedIONode(
   const task = spec.tasks.find((t) => t.$id === taskEntityId);
   if (!task) return;
 
-  const taskComponentSpec = task.componentRef.spec;
+  const taskComponentSpec = task.resolvedComponentSpec;
 
   undo.withGroup("Create connected IO node", () => {
     if (ioType === "input") {

--- a/src/routes/v2/pages/Editor/store/actions/io.parentPropagation.ts
+++ b/src/routes/v2/pages/Editor/store/actions/io.parentPropagation.ts
@@ -1,0 +1,77 @@
+import type { ParentContext } from "@/routes/v2/shared/store/navigationStore";
+
+/**
+ * After renaming an input inside a subgraph, update the parent spec's
+ * bindings and task arguments that reference the old port name.
+ */
+export function propagateInputRename(
+  { parentSpec, taskId }: ParentContext,
+  oldName: string,
+  newName: string,
+): void {
+  for (const binding of parentSpec.bindings) {
+    if (
+      binding.targetEntityId === taskId &&
+      binding.targetPortName === oldName
+    ) {
+      binding.setTargetPortName(newName);
+    }
+  }
+
+  const parentTask = parentSpec.tasks.find((t) => t.$id === taskId);
+  if (!parentTask) return;
+
+  const argIdx = parentTask.arguments.findIndex((a) => a.name === oldName);
+  if (argIdx >= 0) {
+    parentTask.setArgument(newName, parentTask.arguments[argIdx].value);
+    parentTask.removeArgumentByName(oldName);
+  }
+}
+
+/**
+ * After renaming an output inside a subgraph, update the parent spec's
+ * bindings that reference the old port name.
+ */
+export function propagateOutputRename(
+  { parentSpec, taskId }: ParentContext,
+  oldName: string,
+  newName: string,
+): void {
+  for (const binding of parentSpec.bindings) {
+    if (
+      binding.sourceEntityId === taskId &&
+      binding.sourcePortName === oldName
+    ) {
+      binding.setSourcePortName(newName);
+    }
+  }
+}
+
+/**
+ * After deleting an input inside a subgraph, remove the parent spec's
+ * bindings targeting that port and the corresponding task argument.
+ */
+export function propagateInputDelete(
+  { parentSpec, taskId }: ParentContext,
+  inputName: string,
+): void {
+  parentSpec.removeAllBindingsBy(
+    (b) => b.targetEntityId === taskId && b.targetPortName === inputName,
+  );
+
+  const parentTask = parentSpec.tasks.find((t) => t.$id === taskId);
+  parentTask?.removeArgumentByName(inputName);
+}
+
+/**
+ * After deleting an output inside a subgraph, remove the parent spec's
+ * bindings sourcing from that port.
+ */
+export function propagateOutputDelete(
+  { parentSpec, taskId }: ParentContext,
+  outputName: string,
+): void {
+  parentSpec.removeAllBindingsBy(
+    (b) => b.sourceEntityId === taskId && b.sourcePortName === outputName,
+  );
+}

--- a/src/routes/v2/pages/Editor/store/actions/task.actions.ts
+++ b/src/routes/v2/pages/Editor/store/actions/task.actions.ts
@@ -13,6 +13,7 @@ import type { ClipboardStore } from "@/routes/v2/pages/Editor/store/clipboardSto
 import { generateUniqueTaskName } from "@/routes/v2/pages/Editor/store/nameUtils";
 import type { UndoGroupable } from "@/routes/v2/shared/nodes/types";
 import type { SelectedNode } from "@/routes/v2/shared/store/editorStore";
+import type { ParentContext } from "@/routes/v2/shared/store/navigationStore";
 
 import { computeDiffComponentSpecs } from "./task.utils";
 import { idGen, TASK_COLOR_ANNOTATION } from "./utils";
@@ -87,13 +88,14 @@ export function deleteSelectedNodes(
   undo: UndoGroupable,
   spec: ComponentSpec,
   selectedNodes: SelectedNode[],
+  parentContext?: ParentContext | null,
 ) {
   if (selectedNodes.length === 0) return;
 
   undo.withGroup("Delete selected nodes", () => {
     for (const node of selectedNodes) {
       const manifest = editorRegistry.getByNodeId(spec, node.id);
-      manifest?.deleteNode(undo, spec, node.id);
+      manifest?.deleteNode(undo, spec, node.id, parentContext);
     }
   });
 }
@@ -142,7 +144,7 @@ export function replaceTask(
     if (!task) return { lostInputs: [] };
 
     const { inputDiff, outputDiff } = computeDiffComponentSpecs(
-      task.componentRef.spec,
+      task.resolvedComponentSpec,
       newComponentRef.spec,
     );
 

--- a/src/routes/v2/pages/Editor/store/actions/useIOActions.ts
+++ b/src/routes/v2/pages/Editor/store/actions/useIOActions.ts
@@ -1,10 +1,14 @@
+import type { ComponentSpec } from "@/models/componentSpec";
 import { useEditorSession } from "@/routes/v2/pages/Editor/store/EditorSessionContext";
+import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 
 import {
   addInput,
   addOutput,
   createConnectedIONode,
   createInputAndConnect,
+  deleteInput,
+  deleteOutput,
   renameInput,
   renameOutput,
   setInputDefaultValue,
@@ -15,12 +19,19 @@ import {
 
 export function useIOActions() {
   const { undo } = useEditorSession();
+  const { navigation } = useSharedStores();
 
   return {
     addInput: addInput.bind(null, undo),
     addOutput: addOutput.bind(null, undo),
-    renameInput: renameInput.bind(null, undo),
-    renameOutput: renameOutput.bind(null, undo),
+    renameInput: (spec: ComponentSpec, entityId: string, newName: string) =>
+      renameInput(undo, spec, entityId, newName, navigation.parentContext),
+    renameOutput: (spec: ComponentSpec, entityId: string, newName: string) =>
+      renameOutput(undo, spec, entityId, newName, navigation.parentContext),
+    deleteInput: (spec: ComponentSpec, entityId: string) =>
+      deleteInput(undo, spec, entityId, navigation.parentContext),
+    deleteOutput: (spec: ComponentSpec, entityId: string) =>
+      deleteOutput(undo, spec, entityId, navigation.parentContext),
     setInputDescription: setInputDescription.bind(null, undo),
     setInputType: setInputType.bind(null, undo),
     setInputDefaultValue: setInputDefaultValue.bind(null, undo),

--- a/src/routes/v2/pages/Editor/store/actions/useTaskActions.ts
+++ b/src/routes/v2/pages/Editor/store/actions/useTaskActions.ts
@@ -20,7 +20,7 @@ import {
 
 export function useTaskActions() {
   const { undo, clipboard } = useEditorSession();
-  const { editor } = useSharedStores();
+  const { editor, navigation } = useSharedStores();
 
   return {
     addTask: addTask.bind(null, undo),
@@ -33,7 +33,7 @@ export function useTaskActions() {
       spec: ComponentSpec,
       selectedNodes: SelectedNode[],
     ) => {
-      deleteSelectedNodes(undo, spec, selectedNodes);
+      deleteSelectedNodes(undo, spec, selectedNodes, navigation.parentContext);
       editor.clearSelection();
       editor.clearMultiSelection();
     },

--- a/src/routes/v2/pages/Editor/utils/undoHistoryStorage.ts
+++ b/src/routes/v2/pages/Editor/utils/undoHistoryStorage.ts
@@ -5,7 +5,7 @@ import Dexie, { type EntityTable } from "dexie";
 import type { UndoEvent, UndoManager } from "mobx-keystone";
 import { UndoStore } from "mobx-keystone";
 
-const CURRENT_VERSION = 1;
+const CURRENT_VERSION = 2;
 const MAX_UNDO_EVENTS = 10;
 
 interface StoredUndoHistory {

--- a/src/routes/v2/pages/RunView/nodes/TaskNode/context/RunViewTaskDetails.tsx
+++ b/src/routes/v2/pages/RunView/nodes/TaskNode/context/RunViewTaskDetails.tsx
@@ -46,9 +46,7 @@ export const RunViewTaskDetails = observer(function RunViewTaskDetails({
     executionData?.details?.child_task_execution_ids?.[task.name];
 
   const componentRef = task.componentRef;
-  const isSubgraphTask =
-    !!task.componentRef.spec?.implementation &&
-    "graph" in task.componentRef.spec.implementation;
+  const isSubgraphTask = task.subgraphSpec !== undefined;
 
   const taskSpecForIO = { componentRef } as TaskSpec;
 

--- a/src/routes/v2/shared/nodes/TaskNode/TaskNode.tsx
+++ b/src/routes/v2/shared/nodes/TaskNode/TaskNode.tsx
@@ -186,7 +186,7 @@ export const TaskNode = observer(function TaskNode({
   if (!task) return <TaskNodeNotFound entityId={entityId} />;
   if (nodeEffect?.hidden) return null;
 
-  const componentSpec = task.componentRef.spec;
+  const componentSpec = task.resolvedComponentSpec;
   const { description, inputs, outputs } =
     getComponentSpecDefaults(componentSpec);
 

--- a/src/routes/v2/shared/nodes/types.ts
+++ b/src/routes/v2/shared/nodes/types.ts
@@ -15,7 +15,10 @@ import type {
   SelectedNode,
 } from "@/routes/v2/shared/store/editorStore";
 import type { KeyboardStore } from "@/routes/v2/shared/store/keyboardStore";
-import type { NavigationStore } from "@/routes/v2/shared/store/navigationStore";
+import type {
+  NavigationStore,
+  ParentContext,
+} from "@/routes/v2/shared/store/navigationStore";
 import type { WindowStoreImpl } from "@/routes/v2/shared/windows/windowStore";
 
 /**
@@ -165,7 +168,12 @@ export interface NodeTypeManifest {
     position: XYPosition,
   ): void;
 
-  deleteNode(undo: UndoGroupable, spec: ComponentSpec, nodeId: string): void;
+  deleteNode(
+    undo: UndoGroupable,
+    spec: ComponentSpec,
+    nodeId: string,
+    parentContext?: ParentContext | null,
+  ): void;
 
   findEntity?(spec: ComponentSpec, entityId: string): unknown | undefined;
 

--- a/src/routes/v2/shared/store/navigationStore.ts
+++ b/src/routes/v2/shared/store/navigationStore.ts
@@ -1,13 +1,6 @@
 import { action, computed, makeObservable, observable } from "mobx";
 
-import type { ComponentSpec, ComponentSpecJson } from "@/models/componentSpec";
-import {
-  IncrementingIdGenerator,
-  serializeComponentSpec,
-  YamlDeserializer,
-} from "@/models/componentSpec";
-import { isGraphImplementation } from "@/utils/componentSpec";
-import { deepClone } from "@/utils/deepClone";
+import type { ComponentSpec } from "@/models/componentSpec";
 
 import type { EditorStore } from "./editorStore";
 
@@ -16,12 +9,15 @@ interface NavigationEntry {
   displayName: string;
 }
 
+export interface ParentContext {
+  parentSpec: ComponentSpec;
+  taskId: string;
+}
+
 export class NavigationStore {
   @observable.ref accessor rootSpec: ComponentSpec | null = null;
-  @observable.ref accessor nestedSpecs = new Map<string, ComponentSpec>();
   @observable.shallow accessor navigationPath: NavigationEntry[] = [];
   @observable accessor requestedPipelineName: string | null = null;
-  private nestedIdGen = new IncrementingIdGenerator();
 
   constructor(private editorStore: EditorStore) {
     makeObservable(this);
@@ -36,20 +32,18 @@ export class NavigationStore {
     this.navigationPath = [
       { specId: rootSpec.$id, displayName: rootSpec.name },
     ];
-    this.nestedSpecs = new Map();
-    this.nestedIdGen = new IncrementingIdGenerator();
   }
 
   @action clearNavigation() {
     this.rootSpec = null;
     this.navigationPath = [];
-    this.nestedSpecs = new Map();
   }
 
-  isTaskSubgraph(spec: ComponentSpec, taskEntityId: string): boolean {
-    const task = spec.tasks.find((t) => t.$id === taskEntityId);
-    if (!task?.componentRef.spec) return false;
-    return isGraphImplementation(task.componentRef.spec?.implementation);
+  isTaskSubgraph(_spec: ComponentSpec, taskEntityId: string): boolean {
+    const active = this.activeSpec;
+    if (!active) return false;
+    const task = active.tasks.find((t) => t.$id === taskEntityId);
+    return task?.subgraphSpec !== undefined;
   }
 
   @action navigateToSubgraph(
@@ -59,43 +53,15 @@ export class NavigationStore {
     if (!this.rootSpec) return null;
 
     const task = currentSpec.tasks.find((t) => t.$id === taskEntityId);
-    if (!task) return null;
-
-    if (
-      !task.componentRef.spec ||
-      !isGraphImplementation(task.componentRef.spec?.implementation)
-    ) {
-      return null;
-    }
-
-    const pathKey =
-      this.navigationPath.length > 1
-        ? this.navigationPath
-            .slice(1)
-            .map((e) => e.displayName)
-            .join("/") +
-          "/" +
-          task.name
-        : task.name;
-
-    let nestedSpec = this.nestedSpecs.get(pathKey);
-
-    if (!nestedSpec) {
-      // Deep-clone to detach from the keystone tree before deserializing
-      const specJsonClone = JSON.parse(
-        JSON.stringify(task.componentRef.spec),
-      ) as ComponentSpecJson;
-      nestedSpec = this.deserializeNestedSpec(specJsonClone, pathKey);
-      if (!nestedSpec) return null;
-    }
+    if (!task?.subgraphSpec) return null;
 
     this.navigationPath = [
       ...this.navigationPath,
-      { specId: nestedSpec.$id, displayName: task.name },
+      { specId: task.subgraphSpec.$id, displayName: task.name },
     ];
 
     this.editorStore.clearSelection();
-    return nestedSpec;
+    return task.subgraphSpec;
   }
 
   @action navigateBack(): ComponentSpec | null {
@@ -131,21 +97,13 @@ export class NavigationStore {
     for (let i = 1; i < pathNames.length; i++) {
       const taskName = pathNames[i];
       const task = currentSpec.tasks.find((t) => t.name === taskName);
-      if (!task?.componentRef.spec) return null;
+      if (!task?.subgraphSpec) return null;
 
-      const pathKey = pathNames.slice(1, i + 1).join("/");
-      let nestedSpec = this.nestedSpecs.get(pathKey);
-
-      if (!nestedSpec) {
-        const specJsonClone = JSON.parse(
-          JSON.stringify(task.componentRef.spec),
-        ) as ComponentSpecJson;
-        nestedSpec = this.deserializeNestedSpec(specJsonClone, pathKey);
-        if (!nestedSpec) return null;
-      }
-
-      newPath.push({ specId: nestedSpec.$id, displayName: taskName });
-      currentSpec = nestedSpec;
+      newPath.push({
+        specId: task.subgraphSpec.$id,
+        displayName: taskName,
+      });
+      currentSpec = task.subgraphSpec;
     }
 
     this.navigationPath = newPath;
@@ -158,6 +116,23 @@ export class NavigationStore {
     return this.getSpecAtDepth(this.navigationPath.length - 1) ?? null;
   }
 
+  /**
+   * Resolves the parent spec and the task that owns the current subgraph.
+   * Returns null when at the root level (no parent exists).
+   */
+  @computed get parentContext(): ParentContext | null {
+    if (this.navigationPath.length <= 1) return null;
+    const parentSpec = this.getSpecAtDepth(this.navigationPath.length - 2);
+    if (!parentSpec) return null;
+
+    const taskName =
+      this.navigationPath[this.navigationPath.length - 1].displayName;
+    const task = parentSpec.tasks.find((t) => t.name === taskName);
+    if (!task) return null;
+
+    return { parentSpec, taskId: task.$id };
+  }
+
   @computed get navigationDepth(): number {
     return this.navigationPath.length - 1;
   }
@@ -166,66 +141,14 @@ export class NavigationStore {
     return this.navigationPath.length > 1;
   }
 
-  /**
-   * Serialize each active nested spec and write it back into the parent
-   * task's componentRef.spec so the root serialization includes subgraph edits.
-   * Processes deepest-first so inner subgraphs sync before their parents.
-   */
-  @action syncNestedSpecs(): void {
-    if (!this.rootSpec) return;
-
-    const sortedPaths = [...this.nestedSpecs.keys()].sort(
-      (a, b) => b.split("/").length - a.split("/").length,
-    );
-
-    for (const pathKey of sortedPaths) {
-      const nestedSpec = this.nestedSpecs.get(pathKey);
-      if (!nestedSpec) continue;
-
-      const segments = pathKey.split("/");
-      const taskName = segments[segments.length - 1];
-
-      let parentSpec: ComponentSpec;
-      if (segments.length === 1) {
-        parentSpec = this.rootSpec;
-      } else {
-        const parentPathKey = segments.slice(0, -1).join("/");
-        const found = this.nestedSpecs.get(parentPathKey);
-        if (!found) continue;
-        parentSpec = found;
-      }
-
-      const task = parentSpec.tasks.find((t) => t.name === taskName);
-      if (!task) continue;
-
-      const serialized = deepClone(serializeComponentSpec(nestedSpec));
-      task.setComponentRef({ ...task.componentRef, spec: serialized });
-    }
-  }
-
   private getSpecAtDepth(depth: number): ComponentSpec | undefined {
     if (depth === 0) return this.rootSpec ?? undefined;
-    const pathKey = this.navigationPath
-      .slice(1, depth + 1)
-      .map((e) => e.displayName)
-      .join("/");
-    return this.nestedSpecs.get(pathKey);
-  }
-
-  private deserializeNestedSpec(
-    specJson: ComponentSpecJson,
-    pathKey: string,
-  ): ComponentSpec | undefined {
-    try {
-      const deserializer = new YamlDeserializer(this.nestedIdGen);
-      const nestedSpec = deserializer.deserialize(specJson);
-      const updated = new Map(this.nestedSpecs);
-      updated.set(pathKey, nestedSpec);
-      this.nestedSpecs = updated;
-      return nestedSpec;
-    } catch (error) {
-      console.error("[deserializeNestedSpec] Failed to deserialize:", error);
-      return undefined;
+    let current: ComponentSpec | undefined = this.rootSpec ?? undefined;
+    for (let i = 1; i <= depth && current; i++) {
+      const taskName = this.navigationPath[i]?.displayName;
+      const task = current.tasks.find((t) => t.name === taskName);
+      current = task?.subgraphSpec;
     }
+    return current;
   }
 }


### PR DESCRIPTION
## Description

Subgraph specs are now stored as live `ComponentSpec` model instances directly on the `Task` entity (`task.subgraphSpec`) rather than as serialized JSON embedded in `task.componentRef.spec`. A new `task.resolvedComponentSpec` computed property provides a unified read path that returns either a lazy proxy over the live subgraph model or the plain JSON spec from `componentRef.spec`.

Key changes:

- `Task` gains a `subgraphSpec: ComponentSpec | undefined` prop and a `setSubgraphSpec` action. `setComponentRef` now automatically promotes any inline graph spec JSON to a live model via `deserializeSubgraphSpec`, keeping raw JSON out of the runtime model tree.
- `YamlDeserializer` calls `maybeDeserializeSubgraph` before generating a task's `$id`, so subgraph entity IDs are always allocated before the parent task ID — preserving the `collectIdStack` / `ReplayIdGenerator` ordering contract.
- `collectIdStack` recurses into `task.subgraphSpec` before pushing the parent task's `$id`, matching the new deserializer ordering.
- `JsonSerializer` re-attaches the serialized subgraph into `componentRef.spec` at serialization time, so the wire format is unchanged.
- `createComponentSpecProxy` provides a lazy ES Proxy over a live `ComponentSpec` that presents as `ComponentSpecJson`, used by `resolvedComponentSpec` to avoid upfront serialization cost.
- `NavigationStore` no longer maintains a separate `nestedSpecs` map or a `syncNestedSpecs` reaction. Navigation into subgraphs now directly returns `task.subgraphSpec`, and `getSpecAtDepth` walks the live model tree. A new `parentContext` computed property exposes the parent spec and task ID when navigating inside a subgraph.
- IO actions (`renameInput`, `renameOutput`, `deleteInput`, `deleteOutput`) now accept an optional `ParentContext` and propagate port renames and deletions to the parent spec's bindings and task arguments via new `io.parentPropagation` helpers.
- `deleteNode` on `NodeTypeManifest` now accepts an optional `ParentContext` so input and output node deletions can propagate to the parent spec.
- `collectValidationIssues`, `unpackSubgraph`, `createSubgraph`, and all UI components (`TaskDetails`, `RootNode`, `SubgraphNode`, `PipelineTreeContent`, resolution components, etc.) are updated to use `task.subgraphSpec` and `task.resolvedComponentSpec` instead of casting `task.componentRef.spec`.
- The `isSubgraphTask` utility function and related `nestedSpecs` lookups are removed in favour of the direct `task.subgraphSpec !== undefined` check.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [x] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## [Screen Recording 2026-04-22 at 10.21.26 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/c2009a67-9b7f-45ff-886a-d17d8ad69e12.mov" />](https://app.graphite.com/user-attachments/video/c2009a67-9b7f-45ff-886a-d17d8ad69e12.mov)





## Test Instructions

1. Load a pipeline that contains nested subgraphs and verify the tree view renders correctly.
2. Navigate into a subgraph, rename or delete an input or output, navigate back, and confirm the parent spec's bindings and task arguments are updated correctly.
3. Use "Create Subgraph" on a selection of tasks and verify the resulting subgraph task serializes correctly to YAML.
4. Use "Unpack Subgraph" and verify the inner tasks are correctly inlined into the parent spec.
5. Run the unit tests for `componentSpecProxy`, `persistentUndo`, `io.parentPropagation`, and `collectIssues` to confirm ID replay round-trips and parent propagation work correctly for specs with subgraphs.

## Additional Comments