### PR TITLE
fix: display any validation issues including warnings in v2

### DIFF
--- a/src/models/componentSpec/entities/componentSpec.ts
+++ b/src/models/componentSpec/entities/componentSpec.ts
@@ -311,6 +311,11 @@ export class ComponentSpec extends Model({
   }
 
   @computed
+  get hasValidationIssues(): boolean {
+    return this.allValidationIssues.length > 0;
+  }
+
+  @computed
   get issuesByEntityId(): Map<string, ValidationIssue[]> {
     const map = new Map<string, ValidationIssue[]>();
     for (const issue of this.validationIssues) {

--- a/src/routes/v2/pages/Editor/components/PipelineDetailsContent/PipelineDetailsContent.tsx
+++ b/src/routes/v2/pages/Editor/components/PipelineDetailsContent/PipelineDetailsContent.tsx
@@ -125,12 +125,12 @@ export const PipelineDetailsContent = observer(
         />
 
         <ContentBlock title="Validations">
-          {spec.isValid ? (
+          {spec.hasValidationIssues ? (
+            <ValidationSummary spec={spec} />
+          ) : (
             <InfoBox variant="success" title="No validation issues">
               Pipeline is ready for submission
             </InfoBox>
-          ) : (
-            <ValidationSummary spec={spec} />
           )}
         </ContentBlock>
 


### PR DESCRIPTION
## Description

Adds a `hasValidationIssues` computed property to `ComponentSpec` that returns `true` when any validation issues exist, regardless of severity. This replaces the use of `isValid` in the `PipelineDetailsContent` validations section, which was incorrectly showing the "No validation issues" success box when only warnings (non-error severity issues) were present.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Open a pipeline in the editor that has validation warnings (non-error severity issues).
2. Navigate to the Pipeline Details panel and check the Validations section.
3. Confirm that the "No validation issues" success box is no longer shown when warnings are present.
4. Confirm that the success box still appears when there are truly no validation issues.

## Additional Comments

`isValid` only checks for `error` severity issues, meaning pipelines with warnings would incorrectly display the "No validation issues" message. The new `hasValidationIssues` property checks all issues regardless of severity to ensure accurate feedback is shown to the user.