### PR TITLE
fix: windows state persistence and default layout

### DIFF
--- a/src/routes/v2/pages/Editor/components/DebugPanel.tsx
+++ b/src/routes/v2/pages/Editor/components/DebugPanel.tsx
@@ -131,7 +131,6 @@ export function useDebugPanelWindow() {
         persisted: true,
         defaultDockState: "left",
       });
-      windows.hideWindow(DEBUG_PANEL_WINDOW_ID);
     }
   }, [windows]);
 }

--- a/src/routes/v2/pages/Editor/hooks/useHistoryWindow.tsx
+++ b/src/routes/v2/pages/Editor/hooks/useHistoryWindow.tsx
@@ -18,7 +18,6 @@ export function useHistoryWindow() {
         persisted: true,
         defaultDockState: "left",
       });
-      windows.hideWindow(HISTORY_WINDOW_ID);
     }
   }, [windows]);
 }

--- a/src/routes/v2/pages/Editor/hooks/usePipelineTreeWindow.tsx
+++ b/src/routes/v2/pages/Editor/hooks/usePipelineTreeWindow.tsx
@@ -18,7 +18,6 @@ export function usePipelineTreeWindow() {
         persisted: true,
         defaultDockState: "left",
       });
-      windows.hideWindow(PIPELINE_TREE_WINDOW_ID);
     }
   }, [windows]);
 }

--- a/src/routes/v2/shared/windows/viewPresets.ts
+++ b/src/routes/v2/shared/windows/viewPresets.ts
@@ -16,13 +16,15 @@ const DEFAULT_DOCK_POSITIONS: Record<string, "left" | "right"> = {
   "context-panel": "right",
 };
 
+export const DEFAULT_VIEW_PRESET: ViewPreset = {
+  label: "Default",
+  description: "Components, Recent Runs, Pipeline Details",
+  visible: new Set(["component-library", "recent-runs", "pipeline-details"]),
+  dockPositions: DEFAULT_DOCK_POSITIONS,
+};
+
 export const VIEW_PRESETS: ViewPreset[] = [
-  {
-    label: "Default",
-    description: "Components, Recent Runs, Pipeline Details",
-    visible: new Set(["component-library", "recent-runs", "pipeline-details"]),
-    dockPositions: DEFAULT_DOCK_POSITIONS,
-  },
+  DEFAULT_VIEW_PRESET,
   {
     label: "All",
     description: "All windows visible",

--- a/src/routes/v2/shared/windows/windowPersistence.ts
+++ b/src/routes/v2/shared/windows/windowPersistence.ts
@@ -131,6 +131,14 @@ function loadWindowLayout(): PersistedWindowLayout | null {
 }
 
 /**
+ * Returns true when a valid persisted layout exists in localStorage.
+ * Used to distinguish first-time users (no data) from returning users.
+ */
+export function hasPersistedLayout(): boolean {
+  return loadWindowLayout() !== null;
+}
+
+/**
  * Get persisted state for a specific window ID.
  */
 export function getPersistedWindowState(

--- a/src/routes/v2/shared/windows/windowStore.utils.ts
+++ b/src/routes/v2/shared/windows/windowStore.utils.ts
@@ -7,8 +7,12 @@ import {
   type WindowOptions,
   type WindowState,
 } from "./types";
+import { DEFAULT_VIEW_PRESET } from "./viewPresets";
 import type { WindowModelInit } from "./windowModel";
-import { getPersistedWindowState } from "./windowPersistence";
+import {
+  getPersistedWindowState,
+  hasPersistedLayout,
+} from "./windowPersistence";
 
 type PersistedState = ReturnType<typeof getPersistedWindowState>;
 
@@ -20,7 +24,7 @@ export function buildWindowModelInit(
   const persisted = options.persisted ? getPersistedWindowState(id) : null;
   const geo = resolveGeometry(persisted, options, defaultPosition);
   const docked = resolveDockedOverrides(persisted, options.defaultDockState);
-  const initial = resolveInitialState(persisted, options, docked.dockState);
+  const initial = resolveInitialState(persisted, options, docked.dockState, id);
 
   return {
     id,
@@ -43,19 +47,30 @@ function resolveInitialState(
   persisted: PersistedState,
   options: WindowOptions,
   dockState: DockState,
+  id: string,
 ): { state: WindowState; needsPreviousState: boolean } {
-  const shouldStartHidden = !!persisted?.isHidden && !options.startVisible;
-  const shouldStartMinimized =
-    !shouldStartHidden && !!persisted?.isMinimized && dockState !== "none";
+  if (persisted) {
+    const shouldStartHidden = !!persisted.isHidden && !options.startVisible;
+    const shouldStartMinimized =
+      !shouldStartHidden && !!persisted.isMinimized && dockState !== "none";
 
-  return {
-    state: shouldStartHidden
-      ? "hidden"
-      : shouldStartMinimized
-        ? "minimized"
-        : "normal",
-    needsPreviousState: shouldStartHidden || shouldStartMinimized,
-  };
+    return {
+      state: shouldStartHidden
+        ? "hidden"
+        : shouldStartMinimized
+          ? "minimized"
+          : "normal",
+      needsPreviousState: shouldStartHidden || shouldStartMinimized,
+    };
+  }
+
+  if (options.persisted && !hasPersistedLayout()) {
+    if (!DEFAULT_VIEW_PRESET.visible.has(id)) {
+      return { state: "hidden", needsPreviousState: true };
+    }
+  }
+
+  return { state: "normal", needsPreviousState: false };
 }
 function resolveGeometry(
   persisted: PersistedState,


### PR DESCRIPTION
## Description

First-time users now see only the default preset windows (component-library, recent-runs, pipeline-details) visible on initial load, rather than all windows being shown. This is achieved by checking whether a persisted layout exists in localStorage — if none is found, windows not included in the default view preset are initialized as hidden.

Previously, the debug panel, history, and pipeline tree windows were being explicitly hidden immediately after registration via `windows.hideWindow(...)`. These calls have been removed in favor of the new first-load visibility logic, which handles initial window states more cleanly through `resolveInitialState`.

`DEFAULT_VIEW_PRESET` has been exported so it can be referenced during window initialization, and `hasPersistedLayout()` has been introduced to distinguish first-time users from returning users.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Clear localStorage to simulate a first-time user.
2. Open the editor and verify that only the component-library, recent-runs, and pipeline-details windows are visible.
3. Reload the page and verify that the window layout is restored from the persisted state.
4. As a returning user with an existing layout in localStorage, verify that all previously visible/hidden windows retain their saved states.

## Additional Comments