### PR TITLE
fix: autofix navigation on subgraph create undo

### DIFF
--- a/src/routes/v2/pages/Editor/hooks/useSpecLifecycle.ts
+++ b/src/routes/v2/pages/Editor/hooks/useSpecLifecycle.ts
@@ -1,4 +1,4 @@
-import { autorun } from "mobx";
+import { autorun, reaction } from "mobx";
 import type { UndoStore as MobxUndoStore } from "mobx-keystone";
 import { isRootStore, unregisterRootStore } from "mobx-keystone";
 import { useEffect, useRef } from "react";
@@ -68,8 +68,21 @@ export function useSpecLifecycle(
       prevTaskEntityIdsRef.current = currentTaskIds;
     });
 
+    const disposeNavGuard = reaction(
+      () => ({
+        active: navigation.activeSpec,
+        depth: navigation.navigationPath.length,
+      }),
+      ({ active, depth }) => {
+        if (!active && depth > 1) {
+          navigation.correctInvalidNavigation();
+        }
+      },
+    );
+
     return () => {
       disposeTaskWatcher();
+      disposeNavGuard();
       autoSave.dispose();
       pipelineFileStore.dispose();
       editor.clearSelection();

--- a/src/routes/v2/shared/store/navigationStore.ts
+++ b/src/routes/v2/shared/store/navigationStore.ts
@@ -141,6 +141,25 @@ export class NavigationStore {
     return this.navigationPath.length > 1;
   }
 
+  /**
+   * Trims navigationPath to the deepest level that still resolves to a valid
+   * spec. Handles cases where undo/redo removes a subgraph the user is viewing.
+   */
+  @action correctInvalidNavigation(): void {
+    if (this.navigationPath.length <= 1) return;
+
+    let deepestValid = 0;
+    for (let i = 1; i < this.navigationPath.length; i++) {
+      if (!this.getSpecAtDepth(i)) break;
+      deepestValid = i;
+    }
+
+    if (deepestValid < this.navigationPath.length - 1) {
+      this.navigationPath = this.navigationPath.slice(0, deepestValid + 1);
+      this.editorStore.clearSelection();
+    }
+  }
+
   private getSpecAtDepth(depth: number): ComponentSpec | undefined {
     if (depth === 0) return this.rootSpec ?? undefined;
     let current: ComponentSpec | undefined = this.rootSpec ?? undefined;


### PR DESCRIPTION
## Description

When a user is navigating inside a nested subgraph and performs an undo/redo operation that removes that subgraph, the navigation path becomes invalid (i.e., `activeSpec` is `null` while the path depth is greater than 1). This leaves the editor in a broken state with no visible spec.

A `correctInvalidNavigation` action has been added to `NavigationStore` that trims the navigation path back to the deepest level that still resolves to a valid spec. A MobX `reaction` in `useSpecLifecycle` watches for this condition and triggers the correction automatically whenever it occurs.

## Related Issue and Pull requests

## Type of Change

- [x] Bug fix

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

[Screen Recording 2026-04-22 at 10.47.29 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/dc5fd440-a9d4-45f5-a61a-3386c49cf79e.mov" />](https://app.graphite.com/user-attachments/video/dc5fd440-a9d4-45f5-a61a-3386c49cf79e.mov)



## Test Instructions

1. Open a pipeline that contains at least one nested subgraph/component.
2. Navigate into the subgraph so the navigation path depth is greater than 1.
3. Perform an undo operation that removes the subgraph you are currently viewing.
4. Verify that the editor automatically navigates back to the deepest still-valid level rather than displaying a blank or broken state.
5. Confirm that redo restores the subgraph and normal navigation resumes as expected.

## Additional Comments

The `disposeNavGuard` cleanup is registered alongside the existing `disposeTaskWatcher` to ensure the reaction is torn down properly when the editor unmounts.