### PR TITLE
Improves task node color palette derivation and picker UX

### DIFF
--- a/src/components/ui/color.tsx
+++ b/src/components/ui/color.tsx
@@ -3,6 +3,10 @@ import { HexColorPicker } from "react-colorful";
 
 import { useDebouncedState } from "@/hooks/useDebouncedState";
 import { cn } from "@/lib/utils";
+import {
+  deriveColorPalette,
+  getContrastTextColor,
+} from "@/routes/v2/shared/nodes/TaskNode/color.utils";
 
 import { Button } from "./button";
 import {
@@ -14,7 +18,7 @@ import { Icon } from "./icon";
 import { Input } from "./input";
 import { BlockStack, InlineStack } from "./layout";
 import { Popover, PopoverContent, PopoverTrigger } from "./popover";
-import { Heading } from "./typography";
+import { Heading, Text } from "./typography";
 
 const PRESET_COLORS = [
   "#FFF9C4",
@@ -70,14 +74,28 @@ export const ColorPicker = ({
     updatePreviousState(preset);
   };
 
+  const palette = deriveColorPalette(color);
+  const triggerBackground = palette?.background ?? "white";
+  const triggerBorder = palette?.border ?? "var(--color-gray-300)";
+  const triggerIconColor = palette
+    ? getContrastTextColor(palette.background)
+    : "var(--color-gray-400)";
+
   return (
     <Popover open={open} onOpenChange={handleOpenChange}>
-      <PopoverTrigger>
-        <div
-          className="aspect-square h-4 rounded-full border border-muted-foreground cursor-pointer"
+      <PopoverTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-7 rounded-full border-2 hover:bg-transparent"
           data-testid={`color-picker-trigger-${title?.toLowerCase().replace(/\s+/g, "-") ?? "default"}`}
-          style={{ backgroundColor: color }}
-        />
+          style={{
+            backgroundColor: triggerBackground,
+            borderColor: triggerBorder,
+          }}
+        >
+          <Icon name="Pipette" size="sm" style={{ color: triggerIconColor }} />
+        </Button>
       </PopoverTrigger>
       <PopoverContent className="w-fit" data-testid="color-picker-popover">
         <BlockStack gap="4" align="center">
@@ -105,10 +123,31 @@ export const ColorPicker = ({
             ))}
           </InlineStack>
           <div className="relative w-full">
-            <Input
-              value={localColor}
-              onChange={(e) => setLocalColor(e.target.value)}
-            />
+            <InlineStack
+              blockAlign="center"
+              wrap="nowrap"
+              gap="1"
+              className="rounded-md border border-input bg-background"
+            >
+              <Text
+                size="sm"
+                className="pl-3 text-muted-foreground select-none"
+              >
+                {localColor === "transparent" ? "" : "#"}
+              </Text>
+              <Input
+                value={
+                  localColor === "transparent"
+                    ? ""
+                    : localColor.replace(/^#/, "")
+                }
+                onChange={(e) => {
+                  const raw = e.target.value.replace(/^#/, "");
+                  setLocalColor(`#${raw}`);
+                }}
+                className="border-0 shadow-none focus-visible:ring-0 pl-0"
+              />
+            </InlineStack>
             <Collapsible>
               <InlineStack blockAlign="center" gap="1">
                 <CollapsibleTrigger asChild>

--- a/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/TaskDetails.tsx
+++ b/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/TaskDetails.tsx
@@ -7,7 +7,6 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
-import { ColorPicker } from "@/components/ui/color";
 import { Icon } from "@/components/ui/icon";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Separator } from "@/components/ui/separator";
@@ -24,7 +23,6 @@ import { ConfigurationSection } from "./components/ConfigurationSection";
 import { OutputsSection } from "./components/OutputsSection";
 import { TaskActionsBar } from "./components/TaskActionsBar";
 import { TaskArgumentsEditor } from "./components/TaskArgumentsEditor";
-import { useTaskConfigActions } from "./components/useTaskConfigActions";
 import { useTask } from "./hooks/useTask";
 
 const EDITOR_ANNOTATION_KEYS = [
@@ -42,7 +40,6 @@ export const TaskDetails = observer(function TaskDetails({
 }: TaskDetailsProps) {
   const { editor } = useSharedStores();
   const { undo } = useEditorSession();
-  const { setTaskColor } = useTaskConfigActions();
   const spec = useSpec();
   const task = useTask(entityId);
   const { focusedArgumentName } = editor;
@@ -65,11 +62,6 @@ export const TaskDetails = observer(function TaskDetails({
   const pythonCode = componentSpec?.metadata?.annotations?.python_original_code;
 
   const isSubgraphTask = isSubgraph(task.componentRef.spec);
-  const taskColor = task.annotations.get("tangleml.com/editor/task-color");
-
-  const handleColorChange = (color: string) => {
-    setTaskColor(task, color);
-  };
 
   const handleZIndexChange = (newZIndex: number) => {
     undo.withGroup("Update task z-index", () => {
@@ -93,8 +85,10 @@ export const TaskDetails = observer(function TaskDetails({
             wrap="nowrap"
             className="min-w-0"
           >
-            {isSubgraphTask && <Icon name="Workflow" size="sm" />}
-            <Text size="sm" weight="semibold" className="wrap-anywhere">
+            {isSubgraphTask && (
+              <Icon name="Workflow" size="sm" className="shrink-0" />
+            )}
+            <Text size="md" weight="semibold" className="wrap-anywhere">
               {task.name}
             </Text>
           </InlineStack>
@@ -169,23 +163,6 @@ export const TaskDetails = observer(function TaskDetails({
           </CollapsibleTrigger>
           <CollapsibleContent className="px-4 py-3">
             <BlockStack gap="4">
-              <InlineStack
-                align="space-between"
-                blockAlign="center"
-                className="w-full"
-              >
-                <Text size="sm" className="text-gray-600">
-                  Task color
-                </Text>
-                <ColorPicker
-                  title="Task color"
-                  color={taskColor}
-                  setColor={handleColorChange}
-                />
-              </InlineStack>
-
-              <Separator />
-
               <ConfigurationSection task={task} />
 
               <Separator />

--- a/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/components/ConfigurationSection.tsx
+++ b/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/components/ConfigurationSection.tsx
@@ -8,6 +8,7 @@ import {
   launcherTaskAnnotationSchema,
   parseSchemaToAnnotationConfig,
 } from "@/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/utils";
+import { ColorPicker } from "@/components/ui/color";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Separator } from "@/components/ui/separator";
 import { Switch } from "@/components/ui/switch";
@@ -27,8 +28,12 @@ interface ConfigurationSectionProps {
 export const ConfigurationSection = observer(function ConfigurationSection({
   task,
 }: ConfigurationSectionProps) {
-  const { toggleCacheDisable, saveAnnotation, clearProviderAnnotations } =
-    useTaskConfigActions();
+  const {
+    toggleCacheDisable,
+    saveAnnotation,
+    setTaskColor,
+    clearProviderAnnotations,
+  } = useTaskConfigActions();
   const componentSpec = task.componentRef.spec as ComponentSpecJson | undefined;
   const isSubgraph = componentSpec?.implementation
     ? isGraphImplementation(componentSpec.implementation)
@@ -114,12 +119,30 @@ export const ConfigurationSection = observer(function ConfigurationSection({
     saveAnnotation(task, key, value);
   };
 
+  const taskColor = task.annotations.get("tangleml.com/editor/task-color");
+
+  const handleColorChange = (color: string) => {
+    setTaskColor(task, color);
+  };
+
   return (
     <BlockStack gap="3">
       <Heading level={1}>Configuration</Heading>
 
+      <InlineStack align="space-between" gap="2" className="w-full">
+        <Paragraph size="sm" tone="subdued">
+          Task color
+        </Paragraph>
+        <ColorPicker
+          title="Task color"
+          color={taskColor ?? "transparent"}
+          setColor={handleColorChange}
+        />
+      </InlineStack>
+
       {!isSubgraph && (
         <>
+          <Separator />
           <InlineStack align="space-between" gap="2" className="w-full">
             <Paragraph size="sm" tone="subdued">
               Disable cache
@@ -129,9 +152,10 @@ export const ConfigurationSection = observer(function ConfigurationSection({
               onCheckedChange={handleDisableCacheChange}
             />
           </InlineStack>
-          <Separator />
         </>
       )}
+
+      <Separator />
 
       <ComputeResourcesEditor
         cloudProviderConfig={cloudProviderConfig}

--- a/src/routes/v2/shared/nodes/TaskNode/TaskNodeCard.tsx
+++ b/src/routes/v2/shared/nodes/TaskNode/TaskNodeCard.tsx
@@ -15,10 +15,11 @@ import {
 import { cn } from "@/lib/utils";
 import { useSpec } from "@/routes/v2/shared/providers/SpecContext";
 
+import { deriveColorPalette } from "./color.utils";
 import type { TaskNodeInput, TaskNodeViewProps } from "./TaskNode";
 
 const cardVariants = cva(
-  "min-w-[300px] max-w-[350px] rounded-2xl border-2 p-0 drop-shadow-none cursor-pointer select-none gap-2",
+  "min-w-[300px] max-w-[350px] rounded-2xl border-2 p-0 drop-shadow-none cursor-pointer select-none gap-2 transition-shadow",
   {
     variants: {
       selected: { true: "", false: "" },
@@ -37,7 +38,7 @@ const cardVariants = cva(
       },
       {
         selected: true,
-        className: "border-gray-500",
+        className: "ring-4 ring-blue-500/60",
       },
     ],
     defaultVariants: {
@@ -183,7 +184,13 @@ export const TaskNodeCard = observer(function TaskNodeCard({
   cacheDisabled,
   digest,
 }: TaskNodeViewProps) {
-  const cardStyle = taskColor ? { backgroundColor: taskColor } : undefined;
+  const palette = taskColor ? deriveColorPalette(taskColor) : undefined;
+  const cardStyle = palette
+    ? {
+        backgroundColor: palette.background,
+        ...(isHovered ? {} : { borderColor: palette.border }),
+      }
+    : undefined;
 
   return (
     <Card
@@ -196,7 +203,9 @@ export const TaskNodeCard = observer(function TaskNodeCard({
     >
       <CardHeader
         className="px-4 pt-3 pb-0"
-        style={taskColor ? { borderBottomColor: `${taskColor}30` } : undefined}
+        style={
+          palette ? { borderBottomColor: `${palette.border}30` } : undefined
+        }
       >
         <BlockStack>
           <InlineStack
@@ -245,12 +254,16 @@ export const TaskNodeCard = observer(function TaskNodeCard({
                   "wrap-anywhere max-w-full text-left text-xs",
                   !taskColor && "text-slate-900",
                 )}
+                style={palette ? { color: palette.text } : undefined}
               >
                 {taskName}
               </CardTitle>
             </InlineStack>
             {digest && (
-              <span className="text-xs font-light font-mono text-gray-600 shrink-0">
+              <span
+                className="text-xs font-light font-mono shrink-0"
+                style={{ color: palette?.text ?? "#4b5563" }}
+              >
                 {trimDigest(digest)}
               </span>
             )}
@@ -260,51 +273,61 @@ export const TaskNodeCard = observer(function TaskNodeCard({
 
       <CardContent className="p-2 flex flex-col gap-2">
         {inputs.length > 0 && (
-          <BlockStack gap="3" className="p-2 bg-gray-200/50 rounded-lg">
-            {inputs.map((input) => (
-              <ClassicInputHandle
-                key={input.name}
-                input={input}
-                entityId={entityId}
-                displayValue={inputDisplayValues[input.name]}
-                onInputClick={onInputClick}
-                onHandleClick={onHandleClick}
-              />
-            ))}
-          </BlockStack>
+          <div
+            className={cn("p-2 rounded-lg", !palette && "bg-gray-200/50")}
+            style={palette ? { backgroundColor: palette.sectionBg } : undefined}
+          >
+            <BlockStack gap="3">
+              {inputs.map((input) => (
+                <ClassicInputHandle
+                  key={input.name}
+                  input={input}
+                  entityId={entityId}
+                  displayValue={inputDisplayValues[input.name]}
+                  onInputClick={onInputClick}
+                  onHandleClick={onHandleClick}
+                />
+              ))}
+            </BlockStack>
+          </div>
         )}
 
         {outputs.length > 0 && (
-          <BlockStack gap="3" className="p-2 bg-gray-200/50 rounded-lg">
-            {outputs.map((output) => (
-              <div
-                key={output.name}
-                className="flex items-center justify-end w-full cursor-pointer"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onOutputClick(output.name, e);
-                }}
-              >
-                <div className="flex flex-row-reverse w-full gap-0.5 items-center justify-between">
-                  <div className="translate-x-3 min-w-0 inline-block max-w-full">
-                    <div
-                      className="text-xs text-gray-800 rounded-md px-2 py-1 truncate bg-black/5 hover:bg-black/10"
-                      title={`${output.name}${output.type ? `: ${output.type}` : ""}`}
-                    >
-                      {output.name.replace(/_/g, " ")}
+          <div
+            className={cn("p-2 rounded-lg", !palette && "bg-gray-200/50")}
+            style={palette ? { backgroundColor: palette.sectionBg } : undefined}
+          >
+            <BlockStack gap="3">
+              {outputs.map((output) => (
+                <div
+                  key={output.name}
+                  className="flex items-center justify-end w-full cursor-pointer"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onOutputClick(output.name, e);
+                  }}
+                >
+                  <div className="flex flex-row-reverse w-full gap-0.5 items-center justify-between">
+                    <div className="translate-x-3 min-w-0 inline-block max-w-full">
+                      <div
+                        className="text-xs text-gray-800 rounded-md px-2 py-1 truncate bg-black/5 hover:bg-black/10"
+                        title={`${output.name}${output.type ? `: ${output.type}` : ""}`}
+                      >
+                        {output.name.replace(/_/g, " ")}
+                      </div>
                     </div>
                   </div>
+                  <Handle
+                    type="source"
+                    position={Position.Right}
+                    id={`output_${output.name}`}
+                    className="relative! border-0! w-3! h-3! transform-none! translate-x-6 bg-gray-500!"
+                    onClick={(e) => onHandleClick(`output_${output.name}`, e)}
+                  />
                 </div>
-                <Handle
-                  type="source"
-                  position={Position.Right}
-                  id={`output_${output.name}`}
-                  className="relative! border-0! w-3! h-3! transform-none! translate-x-6 bg-gray-500!"
-                  onClick={(e) => onHandleClick(`output_${output.name}`, e)}
-                />
-              </div>
-            ))}
-          </BlockStack>
+              ))}
+            </BlockStack>
+          </div>
         )}
       </CardContent>
     </Card>

--- a/src/routes/v2/shared/nodes/TaskNode/TaskNodeCollapsed.tsx
+++ b/src/routes/v2/shared/nodes/TaskNode/TaskNodeCollapsed.tsx
@@ -3,7 +3,10 @@ import { Handle, Position } from "@xyflow/react";
 import { Card } from "@/components/ui/card";
 import { Icon } from "@/components/ui/icon";
 import { cn } from "@/lib/utils";
-import { getContrastTextColor } from "@/routes/v2/shared/nodes/TaskNode/color.utils";
+import {
+  deriveColorPalette,
+  getContrastTextColor,
+} from "@/routes/v2/shared/nodes/TaskNode/color.utils";
 
 import type { TaskNodeViewProps } from "./TaskNode";
 import { createTaskNodeCardVariants } from "./taskNode.variants";
@@ -25,6 +28,7 @@ export function TaskNodeCollapsed({
   taskColor,
   onNodeClick,
 }: TaskNodeViewProps) {
+  const palette = taskColor ? deriveColorPalette(taskColor) : undefined;
   const headerTextColor = taskColor
     ? getContrastTextColor(taskColor)
     : undefined;
@@ -41,7 +45,11 @@ export function TaskNodeCollapsed({
         maxWidth: `calc(${s} * 280px)`,
         minHeight: `calc(${s} * 100px)`,
         ...(taskColor
-          ? { backgroundColor: taskColor, color: headerTextColor }
+          ? {
+              backgroundColor: taskColor,
+              color: headerTextColor,
+              borderColor: palette?.border,
+            }
           : {}),
       }}
       onClick={onNodeClick}

--- a/src/routes/v2/shared/nodes/TaskNode/color.utils.ts
+++ b/src/routes/v2/shared/nodes/TaskNode/color.utils.ts
@@ -1,3 +1,41 @@
+interface TaskColorPalette {
+  /** The original selected color */
+  background: string;
+  /** Darker accent for borders — same hue, higher saturation, lower lightness */
+  border: string;
+  /** Subtle tinted background for input/output sections */
+  sectionBg: string;
+  /** WCAG-appropriate text color (black or white) */
+  text: string;
+}
+
+/**
+ * Derives a cohesive color palette from a single base hex color.
+ * Returns undefined for transparent/invalid input so callers fall back to defaults.
+ */
+export function deriveColorPalette(hex: string): TaskColorPalette | undefined {
+  if (!hex || hex === "transparent") return undefined;
+  const rgb = parseHexToRgb(hex);
+  if (!rgb) return undefined;
+
+  const [h, s, l] = rgbToHsl(rgb.r, rgb.g, rgb.b);
+
+  // Border: darken by 35% of current lightness, boost saturation slightly
+  const borderL = Math.max(l * 0.35, 0.12);
+  const borderS = Math.min(s * 1.2, 1);
+
+  // Section background: desaturate and lighten toward white
+  const sectionL = Math.min(l + (1 - l) * 0.7, 0.92);
+  const sectionS = s * 0.35;
+
+  return {
+    background: hex,
+    border: hslToHex(h, borderS, borderL),
+    sectionBg: hslToHex(h, sectionS, sectionL),
+    text: getContrastTextColor(hex),
+  };
+}
+
 /**
  * Returns "#000000" or "#FFFFFF" depending on which provides better contrast
  * against the given background color. Uses WCAG relative luminance formula.
@@ -29,6 +67,58 @@ function parseHexToRgb(
     };
   }
   return null;
+}
+
+function rgbToHsl(
+  r: number,
+  g: number,
+  b: number,
+): [h: number, s: number, l: number] {
+  r /= 255;
+  g /= 255;
+  b /= 255;
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const l = (max + min) / 2;
+
+  if (max === min) return [0, 0, l];
+
+  const d = max - min;
+  const s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+  let h = 0;
+  if (max === r) h = ((g - b) / d + (g < b ? 6 : 0)) / 6;
+  else if (max === g) h = ((b - r) / d + 2) / 6;
+  else h = ((r - g) / d + 4) / 6;
+
+  return [h, s, l];
+}
+
+function hslToHex(h: number, s: number, l: number): string {
+  const hueToRgb = (p: number, q: number, t: number) => {
+    if (t < 0) t += 1;
+    if (t > 1) t -= 1;
+    if (t < 1 / 6) return p + (q - p) * 6 * t;
+    if (t < 1 / 2) return q;
+    if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+    return p;
+  };
+
+  let r: number, g: number, b: number;
+  if (s === 0) {
+    r = g = b = l;
+  } else {
+    const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+    const p = 2 * l - q;
+    r = hueToRgb(p, q, h + 1 / 3);
+    g = hueToRgb(p, q, h);
+    b = hueToRgb(p, q, h - 1 / 3);
+  }
+
+  const toHex = (c: number) =>
+    Math.round(c * 255)
+      .toString(16)
+      .padStart(2, "0");
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
 }
 
 function linearize(channel: number): number {


### PR DESCRIPTION
## Description

Introduces a `deriveColorPalette` utility that computes a cohesive set of colors (background, border, section background, and WCAG-appropriate text) from a single base hex color. This replaces the previous approach of using the raw selected color directly as the card background, and instead applies the derived palette across the task node card, collapsed node, and task details panel for a more polished and accessible appearance.

The color picker in the task details header is replaced with a custom circular trigger button that previews the derived palette (background, border, and pencil icon color), and the color picker input field now strips and re-adds the `#` prefix so users type only the hex digits. The `renderTrigger` prop was added to `ColorPicker` to support this custom trigger pattern.

The task color picker has also been moved out of the collapsible configuration section and into the task name header row, making it more immediately accessible.

## Related Issue and Pull requests

Resolves #2119
Resolves #2120

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)



![image.png](https://app.graphite.com/user-attachments/assets/06d76b17-b071-420a-971e-a4356386f0ed.png)



## Test Instructions

1. Open a pipeline in the editor and select a task node.
2. Use the color picker button in the task name header to assign a color.
3. Verify the task node card reflects the derived palette: background, border, section backgrounds, and text colors all update cohesively.
4. Verify the collapsed task node also shows the correct border color.
5. Confirm the color picker hex input accepts input without a leading `#` and applies correctly.
6. Test with light and dark preset colors to confirm WCAG text contrast is applied correctly.

## Additional Comments

The `deriveColorPalette` function performs HSL-space transformations: the border is darkened and slightly more saturated, while the section background is desaturated and lightened toward white. These values were chosen to produce visually consistent results across the full range of preset colors.