### PR TITLE
Adds inline rename for pipelines and tasks

### DIFF
--- a/src/routes/v2/pages/Editor/components/EditorMenuBar/EditorMenuBar.tsx
+++ b/src/routes/v2/pages/Editor/components/EditorMenuBar/EditorMenuBar.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 
 import logo from "/Tangle_Icon_White.png";
 import { PipelineNameDialog } from "@/components/shared/Dialogs";
+import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Link } from "@/components/ui/link";
@@ -75,13 +76,14 @@ export const EditorMenuBar = observer(function EditorMenuBar() {
                 >
                   {pipelineName}
                 </Text>
-                <button
-                  type="button"
-                  className="shrink-0 text-stone-400 hover:text-white cursor-pointer opacity-0 group-hover:opacity-100 transition-opacity"
+                <Button
+                  variant="ghost"
+                  size="inline-xs"
+                  className="shrink-0 p-0 text-stone-400 hover:bg-transparent hover:text-white opacity-0 group-hover:opacity-100 transition-opacity"
                   onClick={() => setRenameOpen(true)}
                 >
                   <Icon name="Pencil" size="xs" />
-                </button>
+                </Button>
               </InlineStack>
               <PipelineNameDialog
                 open={renameOpen}

--- a/src/routes/v2/pages/Editor/components/EditorMenuBar/EditorMenuBar.tsx
+++ b/src/routes/v2/pages/Editor/components/EditorMenuBar/EditorMenuBar.tsx
@@ -1,9 +1,13 @@
 import { observer } from "mobx-react-lite";
+import { useState } from "react";
 
 import logo from "/Tangle_Icon_White.png";
+import { PipelineNameDialog } from "@/components/shared/Dialogs";
+import { Icon } from "@/components/ui/icon";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Link } from "@/components/ui/link";
 import { Text } from "@/components/ui/typography";
+import { usePipelineRename } from "@/routes/v2/pages/Editor/hooks/usePipelineRename";
 import { useEditorSession } from "@/routes/v2/pages/Editor/store/EditorSessionContext";
 import { AppMenuActions } from "@/routes/v2/shared/components/AppMenuActions";
 import { MenuTriggerButton } from "@/routes/v2/shared/components/MenuTriggerButton";
@@ -22,10 +26,12 @@ import { WindowsMenu } from "./components/WindowsMenu";
 export const EditorMenuBar = observer(function EditorMenuBar() {
   const { navigation, windows } = useSharedStores();
   const { pipelineFile } = useEditorSession();
+  const handlePipelineRename = usePipelineRename();
   const spec = navigation.activeSpec;
   const pipelineName = spec?.name ?? "Untitled pipeline";
 
   const displayMenu = Boolean(pipelineFile.activePipelineFile);
+  const [renameOpen, setRenameOpen] = useState(false);
 
   return (
     <div
@@ -55,14 +61,37 @@ export const EditorMenuBar = observer(function EditorMenuBar() {
 
           {displayMenu && (
             <BlockStack gap="0" className="min-w-0">
-              <Text
-                as="span"
-                size="sm"
-                weight="semibold"
-                className="text-white truncate max-w-64 lg:max-w-md leading-tight ml-1"
+              <InlineStack
+                gap="1"
+                blockAlign="center"
+                wrap="nowrap"
+                className="group min-w-0 ml-1"
               >
-                {pipelineName}
-              </Text>
+                <Text
+                  as="span"
+                  size="sm"
+                  weight="semibold"
+                  className="text-white truncate max-w-64 lg:max-w-md leading-tight"
+                >
+                  {pipelineName}
+                </Text>
+                <button
+                  type="button"
+                  className="shrink-0 text-stone-400 hover:text-white cursor-pointer opacity-0 group-hover:opacity-100 transition-opacity"
+                  onClick={() => setRenameOpen(true)}
+                >
+                  <Icon name="Pencil" size="xs" />
+                </button>
+              </InlineStack>
+              <PipelineNameDialog
+                open={renameOpen}
+                onOpenChange={setRenameOpen}
+                title="Rename Pipeline"
+                initialName={pipelineName}
+                onSubmit={handlePipelineRename}
+                submitButtonText="Rename"
+                isSubmitDisabled={(name) => name === pipelineName}
+              />
 
               <InlineStack gap="0" wrap="nowrap" blockAlign="center">
                 <FileMenu />

--- a/src/routes/v2/pages/Editor/components/EditorMenuBar/components/FileMenu.tsx
+++ b/src/routes/v2/pages/Editor/components/EditorMenuBar/components/FileMenu.tsx
@@ -35,7 +35,7 @@ export function FileMenu() {
     setRenameDialogOpen,
     deleteDialogOpen,
     setDeleteDialogOpen,
-    handleRename,
+    renamePipeline,
     getRenameInitialName,
     setImportOpen,
     handleSave,
@@ -134,7 +134,7 @@ export function FileMenu() {
         onOpenChange={setRenameDialogOpen}
         title="Rename Pipeline"
         initialName={getRenameInitialName()}
-        onSubmit={handleRename}
+        onSubmit={renamePipeline}
         submitButtonText="Rename"
         isSubmitDisabled={(name) => name === getRenameInitialName()}
       />

--- a/src/routes/v2/pages/Editor/components/EditorMenuBar/components/useFileMenuState.ts
+++ b/src/routes/v2/pages/Editor/components/EditorMenuBar/components/useFileMenuState.ts
@@ -3,7 +3,7 @@ import { type RefObject, useEffect, useRef, useState } from "react";
 
 import useToastNotification from "@/hooks/useToastNotification";
 import { APP_ROUTES } from "@/routes/router";
-import { usePipelineActions } from "@/routes/v2/pages/Editor/store/actions/usePipelineActions";
+import { usePipelineRename } from "@/routes/v2/pages/Editor/hooks/usePipelineRename";
 import { useEditorSession } from "@/routes/v2/pages/Editor/store/EditorSessionContext";
 import { CTRL } from "@/routes/v2/shared/shortcuts/keys";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
@@ -26,7 +26,7 @@ interface FileMenuState {
   setRenameDialogOpen: (open: boolean) => void;
   deleteDialogOpen: boolean;
   setDeleteDialogOpen: (open: boolean) => void;
-  handleRename: (name: string) => void;
+  renamePipeline: (name: string) => void;
   getRenameInitialName: () => string;
   setImportOpen: (open: boolean) => void;
   handleSave: () => void;
@@ -41,7 +41,7 @@ interface FileMenuState {
 export function useFileMenuState(): FileMenuState {
   const { keyboard, navigation } = useSharedStores();
   const { autoSave, pipelineFile: pipelineFileStore } = useEditorSession();
-  const { renamePipeline } = usePipelineActions();
+  const renamePipeline = usePipelineRename();
   const storage = usePipelineStorage();
   const navigate = useNavigate();
   const notify = useToastNotification();
@@ -100,19 +100,6 @@ export function useFileMenuState(): FileMenuState {
     });
   };
 
-  const handleRename = async (newName: string) => {
-    const spec = navigation.rootSpec;
-    if (!spec) return;
-    await pipelineFileStore.activePipelineFile?.rename(newName);
-    renamePipeline(spec, newName);
-    await autoSave.save();
-    await navigate({
-      to: APP_ROUTES.EDITOR_V2_PIPELINE,
-      params: { pipelineName: newName },
-      search: { fileId: pipelineFileStore.activePipelineFile?.id },
-    });
-  };
-
   const getRenameInitialName = () => navigation.rootSpec?.name ?? "";
 
   const handleExport = () => {
@@ -143,7 +130,7 @@ export function useFileMenuState(): FileMenuState {
     setRenameDialogOpen,
     deleteDialogOpen,
     setDeleteDialogOpen,
-    handleRename,
+    renamePipeline,
     getRenameInitialName,
     setImportOpen,
     handleSave,

--- a/src/routes/v2/pages/Editor/hooks/usePipelineRename.ts
+++ b/src/routes/v2/pages/Editor/hooks/usePipelineRename.ts
@@ -1,0 +1,26 @@
+import { useNavigate } from "@tanstack/react-router";
+
+import { APP_ROUTES } from "@/routes/router";
+import { usePipelineActions } from "@/routes/v2/pages/Editor/store/actions/usePipelineActions";
+import { useEditorSession } from "@/routes/v2/pages/Editor/store/EditorSessionContext";
+import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
+
+export function usePipelineRename() {
+  const { navigation } = useSharedStores();
+  const { autoSave, pipelineFile: pipelineFileStore } = useEditorSession();
+  const { renamePipeline } = usePipelineActions();
+  const navigate = useNavigate();
+
+  return async (newName: string) => {
+    const spec = navigation.rootSpec;
+    if (!spec) return;
+    await pipelineFileStore.activePipelineFile?.rename(newName);
+    renamePipeline(spec, newName);
+    await autoSave.save();
+    await navigate({
+      to: APP_ROUTES.EDITOR_V2_PIPELINE,
+      params: { pipelineName: newName },
+      search: { fileId: pipelineFileStore.activePipelineFile?.id },
+    });
+  };
+}

--- a/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/TaskDetails.tsx
+++ b/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/TaskDetails.tsx
@@ -1,5 +1,5 @@
 import { observer } from "mobx-react-lite";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import {
   Collapsible,
@@ -7,10 +7,13 @@ import {
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
 import { Icon } from "@/components/ui/icon";
+import { Input } from "@/components/ui/input";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Separator } from "@/components/ui/separator";
 import { Heading, Text } from "@/components/ui/typography";
+import useToastNotification from "@/hooks/useToastNotification";
 import { AnnotationsBlock } from "@/routes/v2/pages/Editor/components/AnnotationsBlock/AnnotationsBlock";
+import { useTaskActions } from "@/routes/v2/pages/Editor/store/actions/useTaskActions";
 import { useSpec } from "@/routes/v2/shared/providers/SpecContext";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 import { EDITOR_COLLAPSED_ANNOTATION } from "@/utils/annotations";
@@ -37,12 +40,16 @@ export const TaskDetails = observer(function TaskDetails({
   entityId,
 }: TaskDetailsProps) {
   const { editor } = useSharedStores();
+  const { renameTask } = useTaskActions();
+  const notify = useToastNotification();
   const spec = useSpec();
   const task = useTask(entityId);
   const { focusedArgumentName } = editor;
 
   const [argumentsOpen, setArgumentsOpen] = useState(true);
   const [configOpen, setConfigOpen] = useState(true);
+  const [isRenaming, setIsRenaming] = useState(false);
+  const renameInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     if (focusedArgumentName && !argumentsOpen) {
@@ -60,6 +67,25 @@ export const TaskDetails = observer(function TaskDetails({
 
   const isSubgraphTask = task.subgraphSpec !== undefined;
 
+  const handleRenameSubmit = () => {
+    const newName = renameInputRef.current?.value.trim();
+    setIsRenaming(false);
+    if (newName && newName !== task.name) {
+      const success = renameTask(spec, entityId, newName);
+      if (!success) {
+        notify("A task with that name already exists", "error");
+      }
+    }
+  };
+
+  const startRename = () => {
+    setIsRenaming(true);
+    requestAnimationFrame(() => {
+      renameInputRef.current?.focus();
+      renameInputRef.current?.select();
+    });
+  };
+
   return (
     <BlockStack gap="0" className="w-full h-full">
       {/* ── Header ── */}
@@ -72,16 +98,38 @@ export const TaskDetails = observer(function TaskDetails({
         >
           <InlineStack
             gap="2"
-            blockAlign="center"
+            blockAlign="start"
             wrap="nowrap"
             className="min-w-0"
           >
             {isSubgraphTask && (
               <Icon name="Workflow" size="sm" className="shrink-0" />
             )}
-            <Text size="md" weight="semibold" className="wrap-anywhere">
-              {task.name}
-            </Text>
+            {isRenaming ? (
+              <Input
+                ref={renameInputRef}
+                defaultValue={task.name}
+                className="h-7 text-sm font-semibold flex-1 min-w-0"
+                onBlur={handleRenameSubmit}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") handleRenameSubmit();
+                  if (e.key === "Escape") setIsRenaming(false);
+                }}
+              />
+            ) : (
+              <div className="group min-w-0 flex items-baseline gap-1">
+                <Text size="md" weight="semibold" className="wrap-anywhere">
+                  {task.name}
+                </Text>
+                <button
+                  type="button"
+                  className="shrink-0 text-muted-foreground hover:text-foreground cursor-pointer opacity-0 group-hover:opacity-100 transition-opacity"
+                  onClick={startRename}
+                >
+                  <Icon name="Pencil" size="xs" />
+                </button>
+              </div>
+            )}
           </InlineStack>
         </InlineStack>
 

--- a/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/TaskDetails.tsx
+++ b/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/TaskDetails.tsx
@@ -1,6 +1,7 @@
 import { observer } from "mobx-react-lite";
 import { useEffect, useRef, useState } from "react";
 
+import { Button } from "@/components/ui/button";
 import {
   Collapsible,
   CollapsibleContent,
@@ -121,13 +122,14 @@ export const TaskDetails = observer(function TaskDetails({
                 <Text size="md" weight="semibold" className="wrap-anywhere">
                   {task.name}
                 </Text>
-                <button
-                  type="button"
-                  className="shrink-0 text-muted-foreground hover:text-foreground cursor-pointer opacity-0 group-hover:opacity-100 transition-opacity"
+                <Button
+                  variant="ghost"
+                  size="inline-xs"
+                  className="shrink-0 p-0 text-muted-foreground hover:bg-transparent hover:text-foreground opacity-0 group-hover:opacity-100 transition-opacity"
                   onClick={startRename}
                 >
                   <Icon name="Pencil" size="xs" />
-                </button>
+                </Button>
               </div>
             )}
           </InlineStack>


### PR DESCRIPTION
## Description

Adds inline rename functionality for both pipelines and tasks in the editor.

For pipelines, a pencil icon appears next to the pipeline name in the menu bar on hover. Clicking it opens a `PipelineNameDialog` that allows the user to rename the pipeline, update the file, and navigate to the new route.

For tasks, a pencil icon appears next to the task name in the `TaskDetails` panel on hover. Clicking it replaces the name with an inline `Input` field. The rename is committed on blur or Enter, and cancelled on Escape.

## Related Issue and Pull requests

Resolves #31

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## ![image.png](https://app.graphite.com/user-attachments/assets/6d6dbb26-aeff-4e2d-bc0e-4e982cc63f1d.png)

  
![image.png](https://app.graphite.com/user-attachments/assets/c1b72192-2db4-4aa1-8a7c-57aaa8f55b07.png)



## Test Instructions

1. Open a pipeline in the editor.
2. Hover over the pipeline name in the menu bar — a pencil icon should appear.
3. Click the pencil icon, enter a new name, and confirm — the pipeline should be renamed and the route updated.
4. Open a task's detail panel by clicking a task node.
5. Hover over the task name — a pencil icon should appear.
6. Click the pencil icon and edit the name inline. Press Enter or click away to confirm, or press Escape to cancel.

## Additional Comments