### PR TITLE
fix: v2: subgraph and multiselection fixes

### DIFF
--- a/src/routes/v2/pages/Editor/components/ContextPanel/components/MultiSelectionDetails/MultiSelectionDetails.tsx
+++ b/src/routes/v2/pages/Editor/components/ContextPanel/components/MultiSelectionDetails/MultiSelectionDetails.tsx
@@ -1,17 +1,16 @@
 import { useReactFlow } from "@xyflow/react";
 import { observer } from "mobx-react-lite";
-import { useEffect, useState } from "react";
 
 import { autoLayoutNodes } from "@/components/shared/ReactFlow/FlowCanvas/utils/autolayout";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
-import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Separator } from "@/components/ui/separator";
 import { Text } from "@/components/ui/typography";
 import type { Task } from "@/models/componentSpec";
+import { CreateSubgraphForm } from "@/routes/v2/pages/Editor/components/CreateSubgraphForm";
 import { usePipelineActions } from "@/routes/v2/pages/Editor/store/actions/usePipelineActions";
 import { useTaskActions } from "@/routes/v2/pages/Editor/store/actions/useTaskActions";
 import { useSpec } from "@/routes/v2/shared/providers/SpecContext";
@@ -34,8 +33,6 @@ export const MultiSelectionDetails = observer(function MultiSelectionDetails() {
   const { createSubgraph } = usePipelineActions();
   const { applyAutoLayoutPositions } = useTaskActions();
 
-  const [subgraphName, setSubgraphName] = useState("");
-
   const selectedTasks = multiSelection.filter((node) => node.type === "task");
   const canCreateSubgraph = selectedTasks.length >= 2;
 
@@ -47,14 +44,8 @@ export const MultiSelectionDetails = observer(function MultiSelectionDetails() {
 
   const aggregatedArgs = computeAggregatedArguments(resolvedTasks);
 
-  useEffect(() => {
-    if (canCreateSubgraph) {
-      setSubgraphName(`Subgraph (${selectedTasks.length} tasks)`);
-    }
-  }, [canCreateSubgraph, selectedTasks.length]);
-
-  const handleCreateSubgraph = () => {
-    if (!subgraphName.trim() || !canCreateSubgraph || !spec) return;
+  const handleCreateSubgraph = (name: string) => {
+    if (!canCreateSubgraph || !spec) return;
 
     const taskIds = selectedTasks.map((node) => node.id);
 
@@ -65,13 +56,12 @@ export const MultiSelectionDetails = observer(function MultiSelectionDetails() {
       selectedTasks.reduce((sum, node) => sum + node.position.y, 0) /
       selectedTasks.length;
 
-    const result = createSubgraph(spec, taskIds, subgraphName.trim(), {
+    const result = createSubgraph(spec, taskIds, name, {
       x: centerX,
       y: centerY,
     });
 
     if (result) {
-      setSubgraphName("");
       editor.clearMultiSelection();
     }
   };
@@ -154,32 +144,10 @@ export const MultiSelectionDetails = observer(function MultiSelectionDetails() {
         {canCreateSubgraph && (
           <>
             <Separator />
-            <BlockStack gap="3">
-              <BlockStack gap="1">
-                <Label className="text-gray-600">Create Subgraph</Label>
-                <Text size="xs" className="text-gray-400">
-                  Group {selectedTasks.length} tasks into a reusable component
-                </Text>
-              </BlockStack>
-
-              <BlockStack gap="2">
-                <Input
-                  value={subgraphName}
-                  onChange={(e) => setSubgraphName(e.target.value)}
-                  placeholder="Subgraph name..."
-                  className="text-sm"
-                />
-                <Button
-                  onClick={handleCreateSubgraph}
-                  disabled={!subgraphName.trim()}
-                  className="w-full gap-1.5"
-                  size="sm"
-                >
-                  <Icon name="FolderInput" size="sm" />
-                  Create Subgraph
-                </Button>
-              </BlockStack>
-            </BlockStack>
+            <CreateSubgraphForm
+              selectedTaskCount={selectedTasks.length}
+              onSubmit={handleCreateSubgraph}
+            />
           </>
         )}
       </BlockStack>

--- a/src/routes/v2/pages/Editor/components/CreateSubgraphForm.tsx
+++ b/src/routes/v2/pages/Editor/components/CreateSubgraphForm.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icon";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { BlockStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
+
+interface CreateSubgraphFormProps {
+  selectedTaskCount: number;
+  onSubmit: (name: string) => void;
+  autoFocus?: boolean;
+}
+
+export function CreateSubgraphForm({
+  selectedTaskCount,
+  onSubmit,
+  autoFocus,
+}: CreateSubgraphFormProps) {
+  const defaultName = `Subgraph (${selectedTaskCount} tasks)`;
+  const [name, setName] = useState(defaultName);
+
+  useEffect(() => {
+    setName(`Subgraph (${selectedTaskCount} tasks)`);
+  }, [selectedTaskCount]);
+
+  const handleSubmit = () => {
+    if (!name.trim()) return;
+    onSubmit(name.trim());
+  };
+
+  return (
+    <BlockStack gap="3">
+      <BlockStack gap="1">
+        <Label className="text-gray-600">Create Subgraph</Label>
+        <Text size="xs" className="text-gray-400">
+          Group {selectedTaskCount} tasks into a reusable component
+        </Text>
+      </BlockStack>
+      <BlockStack gap="2">
+        <Input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Subgraph name..."
+          className="text-sm"
+          autoFocus={autoFocus}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") handleSubmit();
+          }}
+        />
+        <Button
+          onClick={handleSubmit}
+          disabled={!name.trim()}
+          className="w-full gap-1.5"
+          size="sm"
+        >
+          <Icon name="Layers" size="sm" />
+          Create Subgraph
+        </Button>
+      </BlockStack>
+    </BlockStack>
+  );
+}

--- a/src/routes/v2/pages/Editor/components/FlowCanvas/components/FloatingSelectionToolbar.tsx
+++ b/src/routes/v2/pages/Editor/components/FlowCanvas/components/FloatingSelectionToolbar.tsx
@@ -51,12 +51,14 @@ export const FloatingSelectionToolbar = observer(
     const selectedTasks = multiSelection.filter((n) => n.type === "task");
 
     const handleCreateSubgraph = (name: string) => {
-      if (!spec) return;
+      if (!spec || selectedTasks.length === 0) return;
       const taskIds = selectedTasks.map((n) => n.id);
-      if (taskIds.length === 0) return;
-      const viewport = reactFlow.getViewport();
-      const centerX = (window.innerWidth / 2 - viewport.x) / viewport.zoom;
-      const centerY = (window.innerHeight / 2 - viewport.y) / viewport.zoom;
+      const centerX =
+        selectedTasks.reduce((sum, n) => sum + n.position.x, 0) /
+        selectedTasks.length;
+      const centerY =
+        selectedTasks.reduce((sum, n) => sum + n.position.y, 0) /
+        selectedTasks.length;
       createSubgraph(spec, taskIds, name, { x: centerX, y: centerY });
     };
 

--- a/src/routes/v2/pages/Editor/components/FlowCanvas/components/SelectionToolbar.tsx
+++ b/src/routes/v2/pages/Editor/components/FlowCanvas/components/SelectionToolbar.tsx
@@ -1,13 +1,10 @@
 import type { icons } from "lucide-react";
 import { observer } from "mobx-react-lite";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 import TooltipButton from "@/components/shared/Buttons/TooltipButton";
-import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { InlineStack } from "@/components/ui/layout";
 import {
   Popover,
   PopoverContent,
@@ -16,6 +13,7 @@ import {
 import { Separator } from "@/components/ui/separator";
 import { Text } from "@/components/ui/typography";
 import { cn } from "@/lib/utils";
+import { CreateSubgraphForm } from "@/routes/v2/pages/Editor/components/CreateSubgraphForm";
 import { useEditorSession } from "@/routes/v2/pages/Editor/store/EditorSessionContext";
 
 interface SelectionToolbarProps {
@@ -37,19 +35,11 @@ export const SelectionToolbar = observer(function SelectionToolbar({
 }: SelectionToolbarProps) {
   const { clipboard } = useEditorSession();
   const [popoverOpen, setPopoverOpen] = useState(false);
-  const [subgraphName, setSubgraphName] = useState("");
 
-  useEffect(() => {
-    if (popoverOpen && selectedTaskCount >= 2) {
-      setSubgraphName(`Subgraph (${selectedTaskCount} tasks)`);
-    }
-  }, [popoverOpen, selectedTaskCount]);
-
-  const handleCreate = () => {
-    if (!subgraphName.trim() || !onCreateSubgraph) return;
-    onCreateSubgraph(subgraphName.trim());
+  const handleCreate = (name: string) => {
+    if (!onCreateSubgraph) return;
+    onCreateSubgraph(name);
     setPopoverOpen(false);
-    setSubgraphName("");
   };
 
   return (
@@ -85,7 +75,7 @@ export const SelectionToolbar = observer(function SelectionToolbar({
             <PopoverTrigger asChild>
               <div>
                 <ToolbarButton
-                  label="Convert to Subgraph"
+                  label="Create Subgraph"
                   icon="Layers"
                   onClick={() => setPopoverOpen(true)}
                   testId="selection-create-subgraph"
@@ -93,35 +83,11 @@ export const SelectionToolbar = observer(function SelectionToolbar({
               </div>
             </PopoverTrigger>
             <PopoverContent side="bottom" align="end" className="w-64">
-              <BlockStack gap="3">
-                <BlockStack gap="1">
-                  <Label className="text-gray-600">Create Subgraph</Label>
-                  <Text size="xs" className="text-gray-400">
-                    Group {selectedTaskCount} tasks into a reusable component
-                  </Text>
-                </BlockStack>
-                <BlockStack gap="2">
-                  <Input
-                    value={subgraphName}
-                    onChange={(e) => setSubgraphName(e.target.value)}
-                    placeholder="Subgraph name..."
-                    className="text-sm"
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter") handleCreate();
-                    }}
-                    autoFocus
-                  />
-                  <Button
-                    onClick={handleCreate}
-                    disabled={!subgraphName.trim()}
-                    className="w-full gap-1.5"
-                    size="sm"
-                  >
-                    <Icon name="FolderInput" size="sm" />
-                    Create Subgraph
-                  </Button>
-                </BlockStack>
-              </BlockStack>
+              <CreateSubgraphForm
+                selectedTaskCount={selectedTaskCount}
+                onSubmit={handleCreate}
+                autoFocus
+              />
             </PopoverContent>
           </Popover>
         </>

--- a/src/routes/v2/shared/flowCanvasDefaults.ts
+++ b/src/routes/v2/shared/flowCanvasDefaults.ts
@@ -20,7 +20,7 @@ export const FLOW_CANVAS_DEFAULT_PROPS = {
   fitViewOptions: { maxZoom: 1, padding: 0.2 },
   proOptions: { hideAttribution: true },
   selectionOnDrag: false,
-  selectionMode: SelectionMode.Partial,
+  selectionMode: SelectionMode.Full,
   panOnDrag: true,
   zIndexMode: "manual" as const,
   defaultEdgeOptions: { style: { stroke: "#6b7280", strokeWidth: 4 } },

--- a/src/routes/v2/shared/hooks/useFlowCanvasState.ts
+++ b/src/routes/v2/shared/hooks/useFlowCanvasState.ts
@@ -80,7 +80,7 @@ export function useFlowCanvasState({
 
   useEdgeSelectionHighlightOverlay();
 
-  const selectionBehavior = useSelectionBehavior(spec);
+  const selectionBehavior = useSelectionBehavior(spec, metaKeyPressed);
 
   return {
     displayNodes,

--- a/src/routes/v2/shared/hooks/useSelectionBehavior.ts
+++ b/src/routes/v2/shared/hooks/useSelectionBehavior.ts
@@ -3,6 +3,7 @@ import type {
   OnSelectionChangeParams,
   ReactFlowProps,
 } from "@xyflow/react";
+import { SelectionMode } from "@xyflow/react";
 import { useEffect, useMemo } from "react";
 
 import type { ComponentSpec } from "@/models/componentSpec/entities/componentSpec";
@@ -31,7 +32,8 @@ function buildMultiSelection(
 
 export function useSelectionBehavior(
   spec: ComponentSpec | null,
-): Required<Pick<ReactFlowProps, "onSelectionChange">> {
+  metaKeyPressed = false,
+): Required<Pick<ReactFlowProps, "onSelectionChange" | "selectionMode">> {
   const registry = useNodeRegistry();
   const { editor } = useSharedStores();
 
@@ -58,5 +60,8 @@ export function useSelectionBehavior(
     }
   };
 
-  return { onSelectionChange };
+  return {
+    onSelectionChange,
+    selectionMode: metaKeyPressed ? SelectionMode.Partial : SelectionMode.Full,
+  };
 }

--- a/src/routes/v2/shared/nodes/TaskNode/TaskNode.tsx
+++ b/src/routes/v2/shared/nodes/TaskNode/TaskNode.tsx
@@ -5,7 +5,7 @@ import {
   useStore,
 } from "@xyflow/react";
 import { observer } from "mobx-react-lite";
-import type { ReactElement } from "react";
+import type { MouseEvent, ReactElement } from "react";
 
 import { Card } from "@/components/ui/card";
 import { Text } from "@/components/ui/typography";
@@ -190,7 +190,7 @@ export const TaskNode = observer(function TaskNode({
   const { description, inputs, outputs } =
     getComponentSpecDefaults(componentSpec);
 
-  const handleClick = (event: React.MouseEvent) => {
+  const handleClick = (event: MouseEvent) => {
     editor.selectNode(id, "task", { shiftKey: event.shiftKey, entityId });
   };
 
@@ -205,18 +205,18 @@ export const TaskNode = observer(function TaskNode({
     );
   };
 
-  const handleInputClick = (inputName: string, e: React.MouseEvent) => {
+  const handleInputClick = (inputName: string, e: MouseEvent) => {
     e.stopPropagation();
     editor.selectNode(id, "task", { entityId });
     editor.setFocusedArgument(inputName);
   };
 
-  const handleOutputClick = (_outputName: string, e: React.MouseEvent) => {
+  const handleOutputClick = (_outputName: string, e: MouseEvent) => {
     e.stopPropagation();
     editor.selectNode(id, "task", { entityId });
   };
 
-  const handleHandleClick = (handleId: string, e: React.MouseEvent) => {
+  const handleHandleClick = (handleId: string, e: MouseEvent) => {
     e.stopPropagation();
     selectEdgesByHandle(handleId);
   };

--- a/src/routes/v2/shared/overlays/edgeSelectionHighlight/useEdgeSelectionHighlightOverlay.ts
+++ b/src/routes/v2/shared/overlays/edgeSelectionHighlight/useEdgeSelectionHighlightOverlay.ts
@@ -11,7 +11,7 @@ import type {
 const OVERLAY_ID = "edge-selection-highlight";
 
 const HIGHLIGHT_EFFECT: NodeOverlayEffect = {
-  className: "ring-4 ring-edge-selected/60 rounded-xl",
+  className: "ring-4 ring-edge-selected/60 rounded-2xl",
 };
 
 const DIMMED_EFFECT: NodeOverlayEffect = {
@@ -19,18 +19,22 @@ const DIMMED_EFFECT: NodeOverlayEffect = {
 };
 
 /**
- * Serialises the set of entity IDs connected to selected edges into a
- * stable comma-separated key. Returns `null` when no edge is selected,
- * so the overlay is deactivated.
+ * Serialises the set of entity IDs connected to selected edges, plus any
+ * selected nodes (so they keep the highlight effect rather than being
+ * dimmed), into a stable comma-separated key. Returns `null` when no edge
+ * is selected, so the overlay is deactivated.
  */
 function selectConnectedKey(state: ReactFlowState): string | null {
-  const selected = state.edges.filter((e: Edge) => e.selected);
-  if (selected.length === 0) return null;
+  const selectedEdges = state.edges.filter((e: Edge) => e.selected);
+  if (selectedEdges.length === 0) return null;
 
   const ids = new Set<string>();
-  for (const edge of selected) {
+  for (const edge of selectedEdges) {
     ids.add(edge.source);
     ids.add(edge.target);
+  }
+  for (const node of state.nodes) {
+    if (node.selected) ids.add(node.id);
   }
   return [...ids].sort().join(",");
 }


### PR DESCRIPTION
## Description

v2 editor fixes related to multiselect & subgraphs.

Fixes inconsistent messaging and iconography for subgraph creation: "Create Subgraph" now always uses that text + Layers icon. Both subgraph creation flows have been consolidated into one `CreateSubgraphForm` component.

Adds v1 editor multiselection modes to v2 editor (SHIFT + DRAG to full select & SHIFT + CMD + DRAG to partial select). We can reverse the modes->key shortcuts if we prefer.

Fixes an issue where created subgraphs would appear at arbitrary coordinates rather than in the same location of where the nodes were.

Fixes an issue where nodes that are part of a selection but not connected to anything will be faded out if other elements in the selection are connected to something

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

Also closes https://github.com/Shopify/oasis-frontend/issues/595

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix
- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

subgraph creation input

![image.png](https://app.graphite.com/user-attachments/assets/f906d3b8-a809-47d7-986a-0a22ffafcd87.png)

subgraph creation position BEFORE

![image.png](https://app.graphite.com/user-attachments/assets/0abe30e1-78f3-4c46-b72d-764d076d8949.png)

subgraph creation position AFTER

![image.png](https://app.graphite.com/user-attachments/assets/d39b58d4-aef8-4d93-a0c6-85efe14f010d.png)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

Fixes to node highlighting and no longer dimming when selected

![image.png](https://app.graphite.com/user-attachments/assets/012c4dd2-6fe7-4547-b6a2-e2b4004aaa81.png)





## Test Instructions

Confirm that multiselection (shift+drag) looks and works as expected

Confirm that creating a usbgraph places the new node inline with where the existing ones were, rather than some arbitrary other location

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->