### PR TITLE
fix: spacebar not working in component editor

### DIFF
--- a/src/components/shared/ComponentEditor/components/PythonComponentEditor.tsx
+++ b/src/components/shared/ComponentEditor/components/PythonComponentEditor.tsx
@@ -6,7 +6,7 @@ import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
-import { DEFAULT_MONACO_OPTIONS } from "../constants";
+import { DEFAULT_MONACO_OPTIONS, handleEditorMount } from "../constants";
 import { usePythonYamlGenerator } from "../generators/python";
 import type { YamlGeneratorOptions } from "../types";
 import { preserveComponentName } from "../utils/preserveComponentName";
@@ -122,6 +122,7 @@ export const PythonComponentEditor = withSuspenseWrapper(
                     value={pythonCode}
                     onChange={handleFunctionTextChange}
                     options={DEFAULT_MONACO_OPTIONS}
+                    onMount={handleEditorMount}
                   />
                 </div>
               </BlockStack>

--- a/src/components/shared/ComponentEditor/components/YamlComponentEditor.tsx
+++ b/src/components/shared/ComponentEditor/components/YamlComponentEditor.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { withSuspenseWrapper } from "@/components/shared/SuspenseWrapper";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 
-import { DEFAULT_MONACO_OPTIONS } from "../constants";
+import { DEFAULT_MONACO_OPTIONS, handleEditorMount } from "../constants";
 import { useComponentSpecValidator } from "../useComponentSpecValidator";
 import { ComponentSpecErrorsList } from "./ComponentSpecErrorsList";
 import { PreviewTaskNodeCard } from "./PreviewTaskNodeCard";
@@ -50,6 +50,7 @@ export const YamlComponentEditor = withSuspenseWrapper(
                 value={componentText}
                 onChange={handleComponentTextChange}
                 options={DEFAULT_MONACO_OPTIONS}
+                onMount={handleEditorMount}
               />
             </div>
           </BlockStack>

--- a/src/components/shared/ComponentEditor/constants.ts
+++ b/src/components/shared/ComponentEditor/constants.ts
@@ -12,3 +12,11 @@ export const DEFAULT_MONACO_OPTIONS: editor.IStandaloneEditorConstructionOptions
     wordWrap: "on",
     automaticLayout: true,
   };
+
+export function handleEditorMount(ed: editor.IStandaloneCodeEditor): void {
+  ed.onKeyDown((e) => {
+    if (e.browserEvent.key === " ") {
+      e.browserEvent.stopPropagation();
+    }
+  });
+}


### PR DESCRIPTION
## Description

Fixes an issues in the component editor:

cannot use spacebar: radix was capturing keypresses. stopping propagation out of the editor fixes this (but might have side effects)

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

Closes https://github.com/TangleML/tangle-ui/issues/2151

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->