### PR TITLE
Add document-level click tracking via data-trackingid attributes

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -5,7 +5,8 @@
     "src/api/**",
     "src/components/ui/**",
     "src/config/announcements.ts",
-    "src/components/shared/BetaFeatureWrapper/BetaFeatureWrapper.tsx"
+    "src/components/shared/BetaFeatureWrapper/BetaFeatureWrapper.tsx",
+    "src/utils/tracking.ts"
   ],
   "ignoreDependencies": [
     "@tanstack/react-query-devtools",

--- a/src/components/layout/RootLayout.tsx
+++ b/src/components/layout/RootLayout.tsx
@@ -2,6 +2,7 @@ import { Outlet } from "@tanstack/react-router";
 import { TanStackRouterDevtools } from "@tanstack/router-devtools";
 import { ToastContainer } from "react-toastify";
 
+import { useClickTracking } from "@/hooks/useClickTracking";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 import { usePageViewTracking } from "@/hooks/usePageViewTracking";
 import { AnalyticsProvider } from "@/providers/AnalyticsProvider";
@@ -13,6 +14,7 @@ import AppMenu from "./AppMenu";
 
 function RootLayoutContent() {
   usePageViewTracking();
+  useClickTracking();
 
   return (
     <BackendProvider>

--- a/src/components/shared/Buttons/ActionButton.tsx
+++ b/src/components/shared/Buttons/ActionButton.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode } from "react";
+import { type ComponentPropsWithoutRef, type ReactNode } from "react";
 
 import { Icon, type IconName } from "@/components/ui/icon";
 import { Paragraph } from "@/components/ui/typography";
@@ -13,13 +13,19 @@ type AlwaysTooltipOrLabel =
   | { tooltip: string; label?: string }
   | { tooltip?: string; label: string };
 
-type ActionButtonProps = {
+type ActionButtonOwnProps = {
   destructive?: boolean;
   disabled?: boolean;
   onClick: () => void;
   className?: string;
 } & IconOrChildren &
   AlwaysTooltipOrLabel;
+
+type ActionButtonProps = ActionButtonOwnProps &
+  Omit<
+    ComponentPropsWithoutRef<typeof TooltipButton>,
+    keyof ActionButtonOwnProps | "variant" | "size"
+  >;
 
 export const ActionButton = ({
   tooltip,
@@ -30,6 +36,7 @@ export const ActionButton = ({
   className,
   icon,
   children,
+  ...rest
 }: ActionButtonProps) => {
   return (
     <TooltipButton
@@ -40,6 +47,7 @@ export const ActionButton = ({
       disabled={disabled}
       className={className}
       size="sm"
+      {...rest}
     >
       {children === undefined && icon ? <Icon name={icon} /> : children}
       {label && <Paragraph>{label}</Paragraph>}

--- a/src/hooks/useClickTracking.ts
+++ b/src/hooks/useClickTracking.ts
@@ -1,0 +1,71 @@
+import { useEffect } from "react";
+
+import { useAnalytics } from "@/providers/AnalyticsProvider";
+
+const INTERACTIVE_ELEMENTS: Set<string> = new Set(["a", "button", "summary"]);
+
+const TRACKING_ATTR = "data-tracking-id";
+
+function findTrackedInteractiveElement(
+  target: EventTarget | null,
+): HTMLElement | null {
+  let node = target instanceof HTMLElement ? target : null;
+
+  while (node && node !== document.documentElement) {
+    const tag = node.tagName.toLowerCase();
+    const role = node.getAttribute("role");
+
+    const isInteractive =
+      INTERACTIVE_ELEMENTS.has(tag) || role === "button" || role === "link";
+
+    if (isInteractive && node.hasAttribute(TRACKING_ATTR)) {
+      return node;
+    }
+
+    node = node.parentElement;
+  }
+
+  return null;
+}
+
+/** @public */
+export function getTrackingAttributes(domElement: HTMLElement) {
+  const actionType = domElement.getAttribute("data-tracking-id");
+  const metadata = domElement.dataset["trackingMetadata"]
+    ? JSON.parse(domElement.dataset["trackingMetadata"])
+    : undefined;
+
+  return {
+    actionType,
+    metadata,
+  };
+}
+
+/**
+ * Listens for click events on `document` and automatically emits an analytics
+ * event when the click originates from an interactive element that carries a
+ * `data-tracking-id` attribute. The attribute value is used as the `action_type`,
+ * with `.click` automatically appended (e.g. `data-tracking-id="header.settings"`
+ * fires as `header.settings.click`).
+ */
+export function useClickTracking() {
+  const { track } = useAnalytics();
+
+  useEffect(() => {
+    function handleClick(event: MouseEvent) {
+      const element = findTrackedInteractiveElement(event.target);
+      if (!element) return;
+
+      const { actionType, metadata } = getTrackingAttributes(element);
+
+      if (!actionType) return;
+
+      track(`${actionType}.click`, metadata);
+    }
+
+    document.addEventListener("click", handleClick, { capture: true });
+    return () => {
+      document.removeEventListener("click", handleClick, { capture: true });
+    };
+  }, [track]);
+}

--- a/src/utils/tracking.ts
+++ b/src/utils/tracking.ts
@@ -1,0 +1,29 @@
+/**
+ * Returns HTML data attributes that the document-level click tracker
+ * (`useClickTracking`) reads to fire an analytics event automatically.
+ *
+ * Spread the result onto any interactive element (`<button>`, `<a>`, etc.):
+ *
+ * ```tsx
+ * <Button {...tracking("header.settings")} onClick={navigate} />
+ * ```
+ *
+ * The document-level click listener appends `.click` to the action type
+ * automatically, so only provide the identifier here.
+ */
+/** @public */
+export function tracking(
+  actionType: string,
+  metadata?: Record<string, unknown>,
+): { "data-tracking-id": string; "data-tracking-metadata"?: string } {
+  const attrs: {
+    "data-tracking-id": string;
+    "data-tracking-metadata"?: string;
+  } = {
+    "data-tracking-id": actionType,
+  };
+  if (metadata !== undefined) {
+    attrs["data-tracking-metadata"] = JSON.stringify(metadata);
+  }
+  return attrs;
+}


### PR DESCRIPTION
## Description

Introduces a declarative, attribute-driven click tracking system. A new `useClickTracking` hook attaches a single document-level click listener that walks up the DOM from the click target, looking for an interactive element (`button`, `a`, `summary`, or elements with `role="button"/"link"`) that carries a `data-tracking-id` attribute. When found, it fires an analytics event using the attribute value as the action type with `.click` appended (e.g. `data-tracking-id="header.settings"` → `header.settings.click`), along with any optional metadata from `data-tracking-metadata`.

A companion `tracking()` utility function in `src/utils/tracking.ts` makes it easy to attach these attributes to any interactive element by spreading its return value:

```tsx
<Button {...tracking("header.settings")} onClick={navigate} />
```

The hook is registered in `RootLayoutContent` alongside the existing `usePageViewTracking` hook so it runs globally. `ActionButton` is also updated to forward arbitrary props to the underlying `TooltipButton`, enabling `data-tracking-*` attributes to be passed through without additional wiring.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Spread `tracking("some.action")` onto any `button` or `a` element in the app.
2. Click the element and verify an analytics event named `some.action.click` is fired.
3. Confirm that clicks on elements without `data-tracking-id` do not produce spurious events.
4. Verify that optional metadata is correctly serialised and included in the event payload.

## Additional Comments

`src/utils/tracking.ts` has been added to the `knip.json` ignore list since it is intended to be used externally and would otherwise be flagged as an unused export.