### PR TITLE
Update analytics tracking skill with document-level click tracking best practices

### DIFF
--- a/.claude/skills/analytics-tracking/SKILL.md
+++ b/.claude/skills/analytics-tracking/SKILL.md
@@ -5,107 +5,195 @@ description: How to track analytics events in tangle-ui and naming conventions f
 
 # Analytics Tracking
 
-## How to track an event
+## Tracking click events (preferred approach)
 
-Import `track` directly from `@/utils/analytics` and call it with an `action_type` string and optional metadata:
+For click events on interactive elements (`<button>`, `<a>`, `<summary>`, or elements with `role="button"` / `role="link"`), use the `tracking()` helper to attach data attributes. A document-level click listener (`useClickTracking`) automatically fires the analytics event — no manual `track()` call needed.
 
-```ts
-import { track } from "@/utils/analytics";
+```tsx
+import { tracking } from "@/utils/tracking";
 
-track("pipeline_run.task.artifact_preview.impression", {
-  artifact_type: "csv",
-});
+<Button onClick={handleSave} {...tracking("pipeline_editor.save_pipeline")}>
+  Save
+</Button>;
 ```
 
-The `track` function dispatches a `tangle.analytics.track` browser `CustomEvent`. In OSS deployments this is a no-op unless a consumer listens for the event. In Shopify-internal deployments a separate analytics bundle loaded via `index.html` listens for this event and forwards it to Monorail.
+The listener appends `.click` to the identifier automatically, so `"pipeline_editor.save_pipeline"` fires as `"pipeline_editor.save_pipeline.click"`.
 
-### Event detail shape
+### With metadata
+
+Pass a second argument for event-specific properties. The metadata is serialized as a `data-tracking-metadata` JSON attribute on the DOM element.
+
+```tsx
+<Button
+  onClick={() => handleLayout(algo)}
+  {...tracking("pipeline_canvas.tool_bar.auto_layout_select", {
+    selected_layout: algo,
+    page_type: "pipeline_editor",
+  })}
+>
+  {algo}
+</Button>
+```
+
+### Prop drilling for click tracking
+
+When a child component renders the interactive element but the parent owns the tracking context, prefer prop drilling or forwarding rest props so `data-tracking-id` reaches the DOM element. This is intentional — it keeps tracking declarative and avoids manual `track()` calls scattered across the codebase.
+
+```tsx
+// Parent passes tracking attributes
+<ActionButton
+  tooltip="Export Pipeline"
+  icon="FileDown"
+  onClick={handleExport}
+  {...tracking("pipeline_editor.pipeline_actions.export_pipeline")}
+/>;
+
+// ActionButton forwards rest props to the underlying <TooltipButton> → <Button> → DOM
+export const ActionButton = ({
+  tooltip,
+  onClick,
+  icon,
+  ...rest
+}: ActionButtonProps) => (
+  <TooltipButton onClick={onClick} tooltip={tooltip} {...rest}>
+    <Icon name={icon} />
+  </TooltipButton>
+);
+```
+
+For components that wrap interactive elements (e.g. Radix `asChild` patterns), spread `tracking()` on the wrapper — Radix merges props onto the child:
+
+```tsx
+<DialogTrigger
+  asChild
+  {...tracking("pipeline_editor.task_node.component_info")}
+>
+  <InfoIconButton />
+</DialogTrigger>
+```
+
+### Dynamic metadata at render time
+
+When metadata depends on component state that is known at render time, compute it inline. The data attribute updates on each render:
+
+```tsx
+<Button
+  onClick={() => toggleFavorite()}
+  {...(analyticsActionType
+    ? tracking(analyticsActionType, { new_value: !active })
+    : {})}
+>
+```
+
+## When to use manual `track()` instead
+
+Use `useAnalytics` and call `track()` directly only when the document-level click listener cannot handle the scenario:
+
+| Scenario                     | Why manual                                                                                     | Example                                                                |
+| ---------------------------- | ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| **Outcome events**           | Fire after an async operation succeeds, not on click                                           | `track("pipeline_editor.pipeline_actions.save_pipeline_as_completed")` |
+| **Impression events**        | Fire when something becomes visible (dialog, panel), not from a click                          | `track("pipeline_editor.name_pipeline_dialog_impression")`             |
+| **Debounced events**         | Fire after a delay (e.g. text field editing)                                                   | `debouncedTrack()` using `debounce` from `@/utils/debounce`            |
+| **Toggle state**             | Metadata includes the new value from an `onChange` callback argument, not known at render time | `track("settings.toggle_changed", { new_value: checked })`             |
+| **Non-interactive elements** | The click target is not a `<button>`, `<a>`, `<summary>`, or `role="button"`/`role="link"`     | React Flow's internal `Controls` callbacks (`onZoomIn`, etc.)          |
+
+```tsx
+import { useAnalytics } from "@/providers/AnalyticsProvider";
+
+const { track } = useAnalytics();
+
+// Outcome — fires after success, not on click
+const handleSave = async (name: string) => {
+  await savePipeline(name);
+  track("pipeline_editor.pipeline_actions.save_pipeline_as_completed");
+};
+
+// Impression — fires when dialog opens
+useEffect(() => {
+  if (open) {
+    track("component_editor.save.already_exists_impression");
+  }
+}, [open]);
+```
+
+## Event detail shape
 
 The dispatched `CustomEvent` carries the following `detail` fields:
 
-| Field         | Type                     | Description                                           |
-| ------------- | ------------------------ | ----------------------------------------------------- |
-| `actionType`  | `string`                 | The action type string passed to `track`              |
-| `metadata`    | `Record<string,unknown>` | Optional metadata object                              |
-| `sessionId`   | `string`                 | Anonymous tab session ID (see session tracking below) |
-| `route`       | `string`                 | `window.location.pathname` at time of call            |
-| `appVersion`  | `string \| undefined`    | `VITE_GIT_COMMIT` build variable                      |
-| `environment` | `string \| undefined`    | `VITE_TANGLE_ENV` build variable                      |
-
-## Session tracking
-
-The session ID is generated once per browser tab and stored in `sessionStorage`. It resets when the tab is closed.
-
-The format is `<userHash>:<uuid>` once the authenticated user is identified, otherwise a plain UUID. If `identifyUser` is called after the first `track` (i.e. the session was created before the user resolved), the existing plain-UUID session is upgraded in-place to `<userHash>:<uuid>` so subsequent events carry the prefix.
-
-### Identifying the user
-
-Call `identifyUser` once after the current user is known. The auth layer (`src/hooks/useUserDetails.ts`) does this automatically via a `useEffect` — **you do not need to call it yourself**:
-
-```ts
-import { identifyUser } from "@/utils/analytics";
-
-await identifyUser(userId); // hashes userId with SHA-256, stores 8-char prefix
-```
+| Field         | Type                     | Description                                                      |
+| ------------- | ------------------------ | ---------------------------------------------------------------- |
+| `actionType`  | `string`                 | The action type string (with `.click` appended for click events) |
+| `metadata`    | `Record<string,unknown>` | Optional metadata object                                         |
+| `sessionId`   | `string`                 | Anonymous tab session ID                                         |
+| `route`       | `string`                 | `window.location.pathname` at time of call                       |
+| `appVersion`  | `string \| undefined`    | `VITE_GIT_COMMIT` build variable                                 |
+| `environment` | `string \| undefined`    | `VITE_TANGLE_ENV` build variable                                 |
 
 ## `action_type` naming convention
 
-Use dot-separated, `snake_case` segments following this hierarchy:
+Use dot-separated, `snake_case` segments:
 
 ```
 <feature_area>.<entity>[.<sub_entity>].<action_verb>
 ```
 
-| Segment        | Description                                           | Examples                                                              |
-| -------------- | ----------------------------------------------------- | --------------------------------------------------------------------- |
-| `feature_area` | Top-level product area or workflow                    | `pipeline_run`, `pipeline`, `component`, `session`                    |
-| `entity`       | The primary object the user acted on                  | `task`, `node`, `artifact_preview`, `tab`                             |
-| `sub_entity`   | Narrows the entity (use only when necessary)          | `artifacts`, `inputs`, `outputs`                                      |
-| `action_verb`  | **The concrete action that occurred** — always a verb | `click`, `impression`, `hover`, `shortcut_pressed`, `submit`, `start` |
+For `tracking()` data attributes, omit the action verb — the listener appends `.click`:
+
+```
+<feature_area>.<entity>[.<sub_entity>]
+```
+
+For manual `track()` calls, include the full action verb:
+
+```
+<feature_area>.<entity>[.<sub_entity>].<action_verb>
+```
 
 ### Action verb reference
 
-| Verb               | When to use                                                                           |
-| ------------------ | ------------------------------------------------------------------------------------- |
-| `click`            | User explicitly clicked or tapped a button/link                                       |
-| `impression`       | Something became visible for the first time in a session (dialog opened, panel shown) |
-| `hover`            | User hovered over an element long enough to trigger a tooltip or preview              |
-| `shortcut_pressed` | User triggered an action via keyboard shortcut                                        |
-| `submit`           | User submitted a form or confirmed an action                                          |
-| `start`            | A lifecycle event began (session started, process initiated)                          |
+| Verb         | When to use                                                                           |
+| ------------ | ------------------------------------------------------------------------------------- |
+| `click`      | User explicitly clicked or tapped a button/link (auto-appended by click listener)     |
+| `impression` | Something became visible for the first time in a session (dialog opened, panel shown) |
+| `completed`  | An async operation finished successfully                                              |
+| `toggle`     | User toggled a switch or checkbox                                                     |
 
 ### Rules
 
 - All segments are `snake_case` — no camelCase, no hyphens.
-- The **last segment must always be an action verb** (what the user did or what happened).
-- Keep hierarchy shallow — prefer `pipeline.component.click` over `pipeline.canvas.node.component.click`.
+- The **last segment must always be an action verb** for manual `track()` calls.
+- For `tracking()` helper calls, the last segment is the entity — `.click` is appended automatically.
+- Keep hierarchy shallow — prefer `pipeline.component` over `pipeline.canvas.node.component`.
 - Do not embed counts, IDs, or dynamic values in the `action_type` string. Put them in `metadata` instead.
 
 ### Examples
 
 ```
-pipeline_run.task.artifact_preview.impression  ✓  artifact preview dialog became visible
-pipeline.component.click                       ✓  user clicked to add a component
-pipeline.run.submit                            ✓  user submitted a pipeline run
-pipeline_run.task.logs.impression              ✓  user expanded task logs panel
-session.tab.start                              ✓  new tab session started
+# tracking() helper (click listener appends .click)
+tracking("header.settings")                                    → header.settings.click
+tracking("pipeline_editor.task_node.z_index", { action: "move_forward" })
+                                                               → pipeline_editor.task_node.z_index.click
 
-pipeline_run.task.artifacts.csv_preview        ✗  artifact type belongs in metadata
-pipelineRun.task.artifactsPreview              ✗  camelCase not allowed
-pipeline.run.submit.clicked                    ✗  too many segments; "clicked" is redundant with "submit"
-pipeline_run.task.artifacts.preview            ✗  "preview" is a noun, not an action verb — use "impression"
+# Manual track() calls
+track("pipeline_editor.pipeline_actions.save_pipeline_as_completed")    ✓  outcome
+track("pipeline_editor.name_pipeline_dialog_impression")                ✓  impression
+track("settings.toggle_changed", { flag_name: "dashboard" })           ✓  toggle
+track("session.tab.start", { flags: { ... } })                         ✓  lifecycle
+
+# Bad
+track("header.settings_click")                    ✗  use tracking() helper instead
+track("pipeline.run.submit.clicked")              ✗  "clicked" is redundant
 ```
 
 ## Metadata
 
 Pass an object as the second argument for event-specific properties. Keys should be `snake_case`. Values must never contain PII (no emails, names, user IDs, or free-form user input).
 
-```ts
-track("pipeline_run.task.artifact_preview.impression", {
-  artifact_type: "csv",
+```tsx
+tracking("pipeline_canvas.tool_bar.auto_layout_select", {
+  selected_layout: "sugiyama",
+  page_type: "pipeline_editor",
 });
-track("pipeline.component.click", { component_name: "XGBoostTrainer" });
-track("session.tab.start", {
-  flags: { dashboard: true, "input-aggregator": false },
-});
+
+track("settings.secrets.secret_mutated", { action: "created" });
 ```


### PR DESCRIPTION
## Description

Updates the analytics tracking skill documentation to reflect the preferred `tracking()` helper pattern for click events. The updated guide explains how the document-level `useClickTracking` listener automatically fires analytics events when `data-tracking-id` attributes are present on interactive elements, eliminating the need for manual `track()` calls in most click scenarios.

Key additions include:

- How to use `tracking()` with and without metadata
- Prop drilling patterns for forwarding tracking attributes through component hierarchies
- Radix `asChild` usage with `tracking()`
- A clear decision table for when manual `track()` calls are still appropriate (outcome events, impressions, debounced events, toggle state, non-interactive elements)
- Updated naming convention rules distinguishing `tracking()` identifiers (no action verb — `.click` is appended automatically) from manual `track()` identifiers (full action verb required)
- Revised action verb reference table reflecting the new patterns (`completed`, `toggle` added; `hover`, `shortcut_pressed`, `submit`, `start` removed)
- Updated examples showing correct and incorrect usage under the new approach

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [x] Documentation update

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

Review the updated `.claude/skills/analytics-tracking/SKILL.md` to verify the documentation accurately reflects the `tracking()` helper and `useClickTracking` patterns used in the codebase.

## Additional Comments