### PR TITLE
fix: v2 - rename pipeline name and file name

### DIFF
--- a/src/routes/v2/pages/Editor/components/EditorMenuBar/components/useFileMenuState.ts
+++ b/src/routes/v2/pages/Editor/components/EditorMenuBar/components/useFileMenuState.ts
@@ -105,6 +105,7 @@ export function useFileMenuState(): FileMenuState {
     if (!spec) return;
     await pipelineFileStore.activePipelineFile?.rename(newName);
     renamePipeline(spec, newName);
+    await autoSave.save();
     await navigate({
       to: APP_ROUTES.EDITOR_V2_PIPELINE,
       params: { pipelineName: newName },


### PR DESCRIPTION
## Description

When renaming a pipeline, an auto-save is now triggered after the rename operation completes but before navigating to the new pipeline route. This ensures that the renamed pipeline's state is persisted immediately upon renaming, preventing potential data loss if the save had not yet occurred.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

[Screen Recording 2026-04-24 at 10.44.56 AM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/a008d549-2321-48bf-9519-6bcae4ce69ed.mov" />](https://app.graphite.com/user-attachments/video/a008d549-2321-48bf-9519-6bcae4ce69ed.mov)



## Test Instructions

1. Open a pipeline in the editor.
2. Rename the pipeline via the File menu.
3. Confirm the pipeline is saved with the new name and navigation to the renamed pipeline route succeeds without data loss.

## Additional Comments