### PR TITLE
chore: Track pipeline count and node distribution at session start

### DIFF
--- a/src/components/layout/RootLayout.tsx
+++ b/src/components/layout/RootLayout.tsx
@@ -5,12 +5,18 @@ import { ToastContainer } from "react-toastify";
 import { useClickTracking } from "@/hooks/useClickTracking";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 import { usePageViewTracking } from "@/hooks/usePageViewTracking";
+import { useSessionPipelineStats } from "@/hooks/useSessionPipelineStats";
 import { AnalyticsProvider } from "@/providers/AnalyticsProvider";
 import { BackendProvider } from "@/providers/BackendProvider";
 import { ComponentSpecProvider } from "@/providers/ComponentSpecProvider";
 import { PipelineStorageProvider } from "@/services/pipelineStorage/PipelineStorageProvider";
 
 import AppMenu from "./AppMenu";
+
+function SessionPipelineStatsTracker() {
+  useSessionPipelineStats();
+  return null;
+}
 
 function RootLayoutContent() {
   usePageViewTracking();
@@ -20,6 +26,7 @@ function RootLayoutContent() {
     <BackendProvider>
       <ComponentSpecProvider>
         <PipelineStorageProvider>
+          <SessionPipelineStatsTracker />
           <ToastContainer />
 
           <div className="App flex flex-col min-h-screen w-full">

--- a/src/hooks/useSessionPipelineStats.ts
+++ b/src/hooks/useSessionPipelineStats.ts
@@ -1,0 +1,140 @@
+import { useEffect } from "react";
+
+import { useAnalytics } from "@/providers/AnalyticsProvider";
+import type { ComponentSpec, TaskSpec } from "@/utils/componentSpec";
+import { isGraphImplementation } from "@/utils/componentSpec";
+import { getAllComponentFilesFromList } from "@/utils/componentStore";
+import { USER_PIPELINES_LIST_NAME } from "@/utils/constants";
+import { getStorage } from "@/utils/typedStorage";
+
+// ─── Node counting ────────────────────────────────────────────────────────────
+
+/**
+ * Counts nodes in a pipeline spec, flattening any inline subgraphs recursively.
+ * Each subgraph's components (including its own IO nodes) replace the subgraph
+ * task itself in the count.
+ */
+function countPipelineNodes(spec: ComponentSpec): number {
+  if (!isGraphImplementation(spec.implementation)) return 0;
+
+  const graph = spec.implementation.graph;
+  const inputCount = spec.inputs?.length ?? 0;
+  const outputCount = spec.outputs?.length ?? 0;
+  const taskCount = Object.values(graph.tasks).reduce(
+    (sum, task) => sum + countTaskNodes(task),
+    0,
+  );
+
+  return inputCount + outputCount + taskCount;
+}
+
+function countTaskNodes(task: TaskSpec): number {
+  const inlineSpec = task.componentRef.spec;
+  if (inlineSpec && isGraphImplementation(inlineSpec.implementation)) {
+    // Decompose the inline subgraph: replace it with its own nodes recursively.
+    return countPipelineNodes(inlineSpec);
+  }
+  return 1;
+}
+
+// ─── Bucketing ────────────────────────────────────────────────────────────────
+
+// Bucket boundaries follow Fibonacci numbers (5, 13, 34, 89, 233) to give
+// fine-grained visibility at low node counts and coverage into 200+ node graphs.
+type PipelineNodeBucket =
+  | "0"
+  | "1_to_5"
+  | "6_to_13"
+  | "14_to_34"
+  | "35_to_89"
+  | "90_to_233"
+  | "234_plus";
+
+function bucketNodeCount(nodeCount: number): PipelineNodeBucket {
+  if (nodeCount === 0) return "0";
+  if (nodeCount <= 5) return "1_to_5";
+  if (nodeCount <= 13) return "6_to_13";
+  if (nodeCount <= 34) return "14_to_34";
+  if (nodeCount <= 89) return "35_to_89";
+  if (nodeCount <= 233) return "90_to_233";
+  return "234_plus";
+}
+
+// ─── Daily throttle ───────────────────────────────────────────────────────────
+
+type PipelineStatsStorageKeys = "tangle_pipeline_stats_last_fired_date";
+type PipelineStatsStorageMapping = {
+  tangle_pipeline_stats_last_fired_date: string; // ISO date, e.g. "2026-04-24"
+};
+
+const pipelineStatsStorage = getStorage<
+  PipelineStatsStorageKeys,
+  PipelineStatsStorageMapping
+>({ encode: (v) => v as string, decode: (v) => v });
+
+function todayIsoDate(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function hasAlreadyFiredToday(): boolean {
+  const lastFired = pipelineStatsStorage.getItem(
+    "tangle_pipeline_stats_last_fired_date",
+  );
+  return lastFired === todayIsoDate();
+}
+
+function markFiredToday(): void {
+  pipelineStatsStorage.setItem(
+    "tangle_pipeline_stats_last_fired_date",
+    todayIsoDate(),
+  );
+}
+
+// ─── Hook ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Fires a `session.pipeline_stats.start` event at most once per day per client
+ * with aggregate pipeline counts and a node-count distribution.
+ *
+ * Must be rendered inside `AnalyticsProvider`.
+ */
+export function useSessionPipelineStats(): void {
+  const { track } = useAnalytics();
+
+  useEffect(() => {
+    if (hasAlreadyFiredToday()) return;
+    markFiredToday();
+
+    void (async () => {
+      let total_pipelines = 0;
+      const pipeline_node_buckets: Record<PipelineNodeBucket, number> = {
+        "0": 0,
+        "1_to_5": 0,
+        "6_to_13": 0,
+        "14_to_34": 0,
+        "35_to_89": 0,
+        "90_to_233": 0,
+        "234_plus": 0,
+      };
+
+      try {
+        const pipelines = await getAllComponentFilesFromList(
+          USER_PIPELINES_LIST_NAME,
+        );
+        for (const [, entry] of pipelines) {
+          total_pipelines++;
+          const nodeCount = countPipelineNodes(entry.componentRef.spec);
+          pipeline_node_buckets[bucketNodeCount(nodeCount)]++;
+        }
+      } catch {
+        // Store unavailable — skip tracking.
+        return;
+      }
+
+      track("session.pipeline_stats.start", {
+        total_pipelines,
+        pipeline_node_buckets,
+      });
+    })();
+  }, [track]);
+}


### PR DESCRIPTION
## Impact on existing application

This tracking runs asynchronously, only once per session without interrupting the render.

## Screenshots (if applicable)

![image.png](https://app.graphite.com/user-attachments/assets/d3314efe-837c-40d2-914b-95ed6c74629b.png)

## Description

Adds a `useSessionPipelineStats` hook that fires a `session.pipeline_stats.start` analytics event once per browser-tab session. The event includes the total number of pipelines and a bucketed distribution of node counts (`0`, `1_to_5`, `6_to_20`, `21_plus`) across all pipelines found in both the current Dexie-based storage and the legacy localForage storage.

Node counting recursively flattens inline subgraphs, replacing each subgraph task with its own constituent nodes. A `sessionStorage` guard prevents duplicate fires within the same tab session.

The hook is mounted via a `SessionPipelineStatsTracker` component placed inside `PipelineStorageProvider` in `RootLayout`.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Test Instructions

1. Open the app in a new browser tab.
2. Check the analytics events being fired and confirm a `session.pipeline_stats.start` event is present with `total_pipelines` and `pipeline_node_buckets` properties.
3. Refresh the tab and confirm the event is **not** fired again within the same session.
4. Open a new tab and confirm the event fires again.
5. Verify pipelines stored in both Dexie-based and legacy localForage storage are counted without duplication.

## Additional Comments

Folders that require permission are skipped during enumeration. Pipelines that fail to parse are still counted toward `total_pipelines` to avoid undercounting. If the legacy store is unavailable, the Dexie-based count is still reported.