### PR TITLE
fix: remove unused type exports flagged by Knip upgrade

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -5,8 +5,7 @@
     "src/api/**",
     "src/components/ui/**",
     "src/config/announcements.ts",
-    "src/components/shared/BetaFeatureWrapper/BetaFeatureWrapper.tsx",
-    "src/utils/tracking.ts"
+    "src/components/shared/BetaFeatureWrapper/BetaFeatureWrapper.tsx"
   ],
   "ignoreDependencies": [
     "@tanstack/react-query-devtools",

--- a/src/components/Home/PipelineSection/usePipelineFilters.ts
+++ b/src/components/Home/PipelineSection/usePipelineFilters.ts
@@ -5,7 +5,7 @@ import { isGraphImplementation } from "@/utils/componentSpec";
 import type { ComponentFileEntry } from "@/utils/componentStore";
 
 export type PipelineSortField = "modified_at" | "name";
-export type PipelineSortDirection = "asc" | "desc";
+type PipelineSortDirection = "asc" | "desc";
 
 export interface MatchedField {
   label: string;

--- a/src/models/componentSpec/validation/types.ts
+++ b/src/models/componentSpec/validation/types.ts
@@ -1,6 +1,6 @@
-export type ValidationIssueType = "graph" | "task" | "input" | "output";
+type ValidationIssueType = "graph" | "task" | "input" | "output";
 
-export type ValidationSeverity = "error" | "warning";
+type ValidationSeverity = "error" | "warning";
 
 export type ValidationIssueCode =
   | "MISSING_REQUIRED_INPUT"

--- a/src/routes/v2/pages/Editor/components/ArgumentRow/components/ThunderMenu/thunderMenu.utils.ts
+++ b/src/routes/v2/pages/Editor/components/ArgumentRow/components/ThunderMenu/thunderMenu.utils.ts
@@ -4,7 +4,7 @@ import type {
   TypeSpecType,
 } from "@/models/componentSpec";
 
-export interface QuickConnectPort {
+interface QuickConnectPort {
   entityId: string;
   portName: string;
   portType?: TypeSpecType;

--- a/src/routes/v2/shared/nodes/types.ts
+++ b/src/routes/v2/shared/nodes/types.ts
@@ -38,7 +38,7 @@ export interface NodeSnapshot<TData = unknown> {
   data: TData;
 }
 
-export interface NodeSnapshotHandler {
+interface NodeSnapshotHandler {
   snapshot(spec: ComponentSpec, entityId: string): NodeSnapshot | null;
 }
 
@@ -53,7 +53,7 @@ export interface BindingSnapshot {
 // Clone handler types (re-exported for use in manifests)
 // ---------------------------------------------------------------------------
 
-export interface NodeCloneHandler {
+interface NodeCloneHandler {
   snapshot(spec: ComponentSpec, entityId: string): NodeSnapshot | null;
   clone(
     spec: ComponentSpec,
@@ -102,7 +102,7 @@ export interface GuidelineInfo {
   edgeTotal: number;
 }
 
-export type DropHandler = (
+type DropHandler = (
   spec: ComponentSpec,
   data: unknown,
   position: XYPosition,

--- a/src/routes/v2/shared/shortcuts/keys.ts
+++ b/src/routes/v2/shared/shortcuts/keys.ts
@@ -9,9 +9,9 @@ const ENTER = "ENTER" as const;
 const SPACE = "SPACE" as const;
 const TAB = "TAB" as const;
 
-export type ModifierKey = typeof CMDALT | typeof CTRL | typeof SHIFT;
+type ModifierKey = typeof CMDALT | typeof CTRL | typeof SHIFT;
 
-export type SpecialKey =
+type SpecialKey =
   | typeof ESCAPE
   | typeof DELETE
   | typeof BACKSPACE

--- a/src/routes/v2/shared/windows/dockAreaPlugins.ts
+++ b/src/routes/v2/shared/windows/dockAreaPlugins.ts
@@ -6,7 +6,7 @@
  * without the store needing any knowledge of plugin behavior.
  */
 
-export type DockAreaEventType =
+type DockAreaEventType =
   | "window-docked"
   | "window-expanded"
   | "window-closing"

--- a/src/services/googleDrive/types.ts
+++ b/src/services/googleDrive/types.ts
@@ -41,7 +41,7 @@ interface GoogleAccountsOAuth2 {
 
 // --- Google Picker types ---
 
-export interface PickerDocument {
+interface PickerDocument {
   id: string;
   name: string;
   mimeType: string;

--- a/src/types/composerSchema.ts
+++ b/src/types/composerSchema.ts
@@ -55,12 +55,12 @@ interface BlockDescriptorBase {
   displayFor?: string[];
 }
 
-export interface TextBlockDescriptor extends BlockDescriptorBase {
+interface TextBlockDescriptor extends BlockDescriptorBase {
   blockType: BlockType.TextBlock;
   properties: TextBlockProperties;
 }
 
-export interface LinkBlockDescriptor extends BlockDescriptorBase {
+interface LinkBlockDescriptor extends BlockDescriptorBase {
   blockType: BlockType.LinkBlock;
   properties: LinkBlockProperties;
 }

--- a/src/utils/componentSpec.ts
+++ b/src/utils/componentSpec.ts
@@ -421,7 +421,7 @@ export interface SecretArgument {
  * Represents dynamic data from system sources (e.g., multi-node execution context).
  * The key is the data identifier (e.g., "system/multi_node/node_index").
  */
-export type SystemDataArgument = {
+type SystemDataArgument = {
   [key: string]: Record<string, unknown>;
 };
 


### PR DESCRIPTION
## Why did these errors start happening now?

Knip 6.6.2 tightened its unused type detection — specifically, it started flagging exported types/interfaces that are only used within the same file they're declared in (i.e. never imported elsewhere). The older version didn't catch those. The 14 types we fixed were all in that category: exported but never consumed by any other module.

Two things landed in sequence:

1. **Knip was upgraded** (`21cfb9a4`) — the newer version started detecting exported types that are never imported by any other file.
2. **`tracking.ts`** **was in the knip.json ignore list** —  this was a stale entry that was causing a config hint, which in the newer version causes a non-zero exit code.

## Description

Several types and interfaces that were only used internally within their respective modules have been changed from `export` to module-local declarations. This reduces the public API surface of these modules and prevents unnecessary exposure of implementation details. Additionally, `src/utils/tracking.ts` has been removed from the knip ignore list, meaning it will now be subject to unused export analysis.

**Fixes:**

```
Unused exported types (14)
PipelineSortDirection  type       src/components/Home/PipelineSection/usePipelineFilters.ts:8:13                                    
ValidationIssueType    type       src/models/componentSpec/validation/types.ts:1:13                                                 
ValidationSeverity     type       src/models/componentSpec/validation/types.ts:3:13                                                 
QuickConnectPort       interface  src/routes/v2/pages/Editor/components/ArgumentRow/components/ThunderMenu/thunderMenu.utils.ts:7:18
NodeSnapshotHandler    interface  src/routes/v2/shared/nodes/types.ts:41:18                                                         
NodeCloneHandler       interface  src/routes/v2/shared/nodes/types.ts:56:18                                                         
DropHandler            type       src/routes/v2/shared/nodes/types.ts:105:13                                                        
ModifierKey            type       src/routes/v2/shared/shortcuts/keys.ts:12:13                                                      
SpecialKey             type       src/routes/v2/shared/shortcuts/keys.ts:14:13                                                      
DockAreaEventType      type       src/routes/v2/shared/windows/dockAreaPlugins.ts:9:13                                              
PickerDocument         interface  src/services/googleDrive/types.ts:44:18                                                           
TextBlockDescriptor    interface  src/types/composerSchema.ts:58:18                                                                 
LinkBlockDescriptor    interface  src/types/composerSchema.ts:63:18                                                                 
SystemDataArgument     type       src/utils/componentSpec.ts:424:13                                                                 
Configuration hints (1)
src/utils/tracking.ts    knip.json  Remove from ignore
```

## Related Issue and Pull requests

## Test Instructions

Verify that no compilation errors are introduced and that all affected modules continue to function as expected.

## Additional Comments

The types and interfaces affected include `PipelineSortDirection`, `ValidationIssueType`, `ValidationSeverity`, `QuickConnectPort`, `NodeSnapshotHandler`, `NodeCloneHandler`, `DropHandler`, `ModifierKey`, `SpecialKey`, `DockAreaEventType`, `PickerDocument`, `TextBlockDescriptor`, `LinkBlockDescriptor`, and `SystemDataArgument`.