### PR TITLE
feat: Favourite Pipelines on My Pipelines Dashboard

### DIFF
--- a/src/routes/Dashboard/DashboardHomeView.tsx
+++ b/src/routes/Dashboard/DashboardHomeView.tsx
@@ -2,8 +2,6 @@ import { Link } from "@tanstack/react-router";
 
 import { RunSection } from "@/components/Home/RunSection/RunSection";
 import { AnnouncementBanners } from "@/components/shared/AnnouncementBanners";
-import { Button } from "@/components/ui/button";
-import { Icon } from "@/components/ui/icon";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import {
   Tooltip,
@@ -11,7 +9,6 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { Heading, Paragraph, Text } from "@/components/ui/typography";
-import { type FavoriteItem, useFavorites } from "@/hooks/useFavorites";
 import {
   type RecentlyViewedItem,
   useRecentlyViewed,
@@ -20,7 +17,8 @@ import { APP_ROUTES } from "@/routes/router";
 import { formatRelativeTime } from "@/utils/date";
 import { tracking } from "@/utils/tracking";
 
-import { getFavoriteUrl, getRecentlyViewedUrl, TypePill } from "./TypePill";
+import { FavoritesPreview } from "./FavoritesPreview";
+import { getRecentlyViewedUrl, TypePill } from "./TypePill";
 
 const PREVIEW_COUNT = 5;
 
@@ -42,45 +40,6 @@ const SectionHeader = ({
       className="text-xs text-muted-foreground hover:text-foreground"
     >
       {viewAllLabel} →
-    </Link>
-  </InlineStack>
-);
-
-const FavoritePreviewRow = ({
-  item,
-  onRemove,
-}: {
-  item: FavoriteItem;
-  onRemove: () => void;
-}) => (
-  <InlineStack gap="2" className="min-w-0 overflow-hidden">
-    <Link
-      to={getFavoriteUrl(item)}
-      {...tracking("homepage.favorites.item")}
-      className="group flex w-full items-center gap-3 px-4 py-3 hover:bg-muted/50 no-underline"
-    >
-      <TypePill type={item.type} />
-      <Tooltip>
-        <TooltipTrigger className="flex-1 min-w-0 overflow-hidden text-left">
-          <Text size="sm" className="truncate block">
-            {item.name}
-          </Text>
-        </TooltipTrigger>
-        <TooltipContent>{item.name}</TooltipContent>
-      </Tooltip>
-      <Button
-        variant="ghost"
-        size="icon"
-        onClick={(e) => {
-          e.preventDefault();
-          e.stopPropagation();
-          onRemove();
-        }}
-        className="shrink-0 size-5 opacity-0 group-hover:opacity-100 text-muted-foreground hover:text-foreground"
-        aria-label="Remove from favorites"
-      >
-        <Icon name="X" size="sm" />
-      </Button>
     </Link>
   </InlineStack>
 );
@@ -107,37 +66,6 @@ const RecentlyViewedPreviewRow = ({ item }: { item: RecentlyViewedItem }) => (
     </Link>
   </InlineStack>
 );
-
-const FavoritesPreview = () => {
-  const { favorites, removeFavorite } = useFavorites();
-  const preview = favorites.slice(0, PREVIEW_COUNT);
-
-  return (
-    <BlockStack gap="4" className="min-w-0">
-      <SectionHeader
-        title="Favorites"
-        viewAllTo={APP_ROUTES.DASHBOARD_FAVORITES}
-      />
-      <div className="w-full border border-border rounded-lg overflow-hidden divide-y divide-border">
-        {preview.length === 0 ? (
-          <div className="px-4 py-3">
-            <Paragraph tone="subdued" size="sm">
-              No favorites yet. Star a pipeline or run to pin it here.
-            </Paragraph>
-          </div>
-        ) : (
-          preview.map((item) => (
-            <FavoritePreviewRow
-              key={`${item.type}-${item.id}`}
-              item={item}
-              onRemove={() => removeFavorite(item.type, item.id)}
-            />
-          ))
-        )}
-      </div>
-    </BlockStack>
-  );
-};
 
 const RecentlyViewedPreview = () => {
   const { recentlyViewed } = useRecentlyViewed();

--- a/src/routes/Dashboard/DashboardPipelinesView.tsx
+++ b/src/routes/Dashboard/DashboardPipelinesView.tsx
@@ -2,11 +2,21 @@ import { PipelineSection } from "@/components/Home/PipelineSection/PipelineSecti
 import { BlockStack } from "@/components/ui/layout";
 import { Heading } from "@/components/ui/typography";
 
+import { FavoritesPreview } from "./FavoritesPreview";
+
 export function DashboardPipelinesView() {
   return (
-    <BlockStack gap="4">
-      <Heading level={2}>Pipelines</Heading>
-      <PipelineSection />
+    <BlockStack gap="6">
+      <FavoritesPreview
+        title="Favorite Pipelines"
+        typeFilter="pipeline"
+        hideWhenEmpty
+        trackingId="pipelines.favorites.item"
+      />
+      <BlockStack gap="4">
+        <Heading level={2}>Pipelines</Heading>
+        <PipelineSection />
+      </BlockStack>
     </BlockStack>
   );
 }

--- a/src/routes/Dashboard/FavoritesPreview.tsx
+++ b/src/routes/Dashboard/FavoritesPreview.tsx
@@ -1,0 +1,119 @@
+import { Link } from "@tanstack/react-router";
+
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icon";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { Heading, Paragraph, Text } from "@/components/ui/typography";
+import {
+  type FavoriteItem,
+  type FavoriteType,
+  useFavorites,
+} from "@/hooks/useFavorites";
+import { APP_ROUTES } from "@/routes/router";
+import { tracking } from "@/utils/tracking";
+
+import { getFavoriteUrl, TypePill } from "./TypePill";
+
+const PREVIEW_COUNT = 5;
+
+const FavoritePreviewRow = ({
+  item,
+  onRemove,
+  trackingId,
+}: {
+  item: FavoriteItem;
+  onRemove: () => void;
+  trackingId: string;
+}) => (
+  <InlineStack gap="2" className="min-w-0 overflow-hidden">
+    <Link
+      to={getFavoriteUrl(item)}
+      {...tracking(trackingId)}
+      className="group flex w-full items-center gap-3 px-4 py-3 hover:bg-muted/50 no-underline"
+    >
+      <TypePill type={item.type} />
+      <Tooltip>
+        <TooltipTrigger className="flex-1 min-w-0 overflow-hidden text-left">
+          <Text size="sm" className="truncate block">
+            {item.name}
+          </Text>
+        </TooltipTrigger>
+        <TooltipContent>{item.name}</TooltipContent>
+      </Tooltip>
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          onRemove();
+        }}
+        className="shrink-0 size-5 opacity-0 group-hover:opacity-100 text-muted-foreground hover:text-foreground"
+        aria-label="Remove from favorites"
+      >
+        <Icon name="X" size="sm" />
+      </Button>
+    </Link>
+  </InlineStack>
+);
+
+interface FavoritesPreviewProps {
+  title?: string;
+  typeFilter?: FavoriteType;
+  emptyMessage?: string;
+  hideWhenEmpty?: boolean;
+  trackingId?: string;
+}
+
+export const FavoritesPreview = ({
+  title = "Favorites",
+  typeFilter,
+  emptyMessage = "No favorites yet. Star a pipeline or run to pin it here.",
+  hideWhenEmpty = false,
+  trackingId = "homepage.favorites.item",
+}: FavoritesPreviewProps) => {
+  const { favorites, removeFavorite } = useFavorites();
+  const filtered = typeFilter
+    ? favorites.filter((f) => f.type === typeFilter)
+    : favorites;
+  const preview = filtered.slice(0, PREVIEW_COUNT);
+
+  if (hideWhenEmpty && preview.length === 0) return null;
+
+  return (
+    <BlockStack gap="4" className="min-w-0">
+      <InlineStack gap="3" blockAlign="center" className="min-w-0">
+        <Heading level={2}>{title}</Heading>
+        <Link
+          to={APP_ROUTES.DASHBOARD_FAVORITES}
+          className="text-xs text-muted-foreground hover:text-foreground"
+        >
+          View all →
+        </Link>
+      </InlineStack>
+      <div className="w-full border border-border rounded-lg overflow-hidden divide-y divide-border">
+        {preview.length === 0 ? (
+          <div className="px-4 py-3">
+            <Paragraph tone="subdued" size="sm">
+              {emptyMessage}
+            </Paragraph>
+          </div>
+        ) : (
+          preview.map((item) => (
+            <FavoritePreviewRow
+              key={`${item.type}-${item.id}`}
+              item={item}
+              onRemove={() => removeFavorite(item.type, item.id)}
+              trackingId={trackingId}
+            />
+          ))
+        )}
+      </div>
+    </BlockStack>
+  );
+};


### PR DESCRIPTION
## Description

Small QOL change to add favourited pipelines to the "My pipelines" dashboard



Favourites Component in Homepage Dashboard is moved to its own file so it can be reused across dashboards.

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

- [x] New feature
- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

![image.png](https://app.graphite.com/user-attachments/assets/5a316dff-b08a-4995-8725-3752650349e7.png)



<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->