### PR TITLE
chore: v2: Collapsible Docked Windows

### DIFF
--- a/src/routes/v2/shared/windows/components/DockedWindow.tsx
+++ b/src/routes/v2/shared/windows/components/DockedWindow.tsx
@@ -2,6 +2,11 @@ import { observer } from "mobx-react-lite";
 import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
 import { Icon } from "@/components/ui/icon";
 import { cn } from "@/lib/utils";
 import { useWindowContext } from "@/routes/v2/shared/windows/ContentWindowStateContext";
@@ -83,7 +88,7 @@ export const DockedWindow = observer(function DockedWindow() {
     return createPortal(
       <div
         ref={panelRef}
-        className="fixed inset-0 z-[45] bg-gray-100 text-gray-900 flex flex-col rounded-none overflow-hidden"
+        className="fixed inset-0 z-45 bg-gray-100 text-gray-900 flex flex-col rounded-none overflow-hidden"
         onMouseDown={handleContainerMouseDown}
         onClick={handleContainerClick}
       >
@@ -106,47 +111,59 @@ export const DockedWindow = observer(function DockedWindow() {
   }
 
   return (
-    <>
+    <Collapsible
+      className="contents"
+      open={!model.isMinimized}
+      onOpenChange={(shouldExpand) => {
+        const isExpanded = !model.isMinimized;
+        if (shouldExpand !== isExpanded) model.toggleMinimize();
+      }}
+    >
       {/* Sentinel to detect stuck state and serve as scroll target */}
       <div ref={sentinelRef} className="h-0 w-full shrink-0" />
 
       {/* Header is a direct flex item of the dock scroll container so sticky works */}
-      <div
-        ref={panelRef}
-        data-dock-window={model.id}
-        className={cn(
-          "group/window w-full sticky",
-          (isDragging || isResizing) && "select-none",
-          isDragging && "cursor-grabbing opacity-50",
-          showCollapsedStyle
-            ? "bg-purple-50 border-b border-purple-200"
-            : "bg-white border-b border-transparent",
-        )}
-        style={{ top: stickyTop, zIndex: 20 - dockIndex }}
-        onMouseDown={handleContainerMouseDown}
-        onClick={() => {
-          handleContainerClick();
-          if (isStuck) handleScrollToWindow();
-        }}
-      >
-        <WindowHeader
-          title={model.title}
-          isDragging={isDragging}
-          onMouseDown={handleHeaderMouseDown}
-          onDoubleClick={() => model.toggleMinimize()}
-          leadingIcon={
-            <Icon
-              name="GripVertical"
-              size="xs"
-              className="text-gray-400 shrink-0"
-            />
-          }
-          actions={actions}
-          actionsOnHover
-        />
-      </div>
+      <CollapsibleTrigger asChild>
+        <div
+          ref={panelRef}
+          data-dock-window={model.id}
+          className={cn(
+            "group/window w-full sticky text-left",
+            (isDragging || isResizing) && "select-none",
+            isDragging && "cursor-grabbing opacity-50",
+            showCollapsedStyle
+              ? "bg-purple-50 border-b border-purple-200"
+              : "bg-white border-b border-transparent",
+          )}
+          style={{ top: stickyTop, zIndex: 20 - dockIndex }}
+          onMouseDown={handleContainerMouseDown}
+          onClick={(e) => {
+            handleContainerClick();
+            if (isStuck) {
+              // Prefer scroll-to-window over toggling collapse when stuck.
+              e.preventDefault();
+              handleScrollToWindow();
+            }
+          }}
+        >
+          <WindowHeader
+            title={model.title}
+            isDragging={isDragging}
+            onMouseDown={handleHeaderMouseDown}
+            leadingIcon={
+              <Icon
+                name="GripVertical"
+                size="xs"
+                className="text-gray-400 shrink-0"
+              />
+            }
+            actions={actions}
+            actionsOnHover
+          />
+        </div>
+      </CollapsibleTrigger>
 
-      {!model.isMinimized && (
+      <CollapsibleContent>
         <div
           className={cn(
             "w-full bg-white text-gray-900",
@@ -164,7 +181,7 @@ export const DockedWindow = observer(function DockedWindow() {
             onMouseDown={handleResizeMouseDown}
           />
         </div>
-      )}
+      </CollapsibleContent>
 
       {isDragging &&
         snapPreview &&
@@ -172,6 +189,6 @@ export const DockedWindow = observer(function DockedWindow() {
           <SnapPreview preview={snapPreview} windowWidth={model.size.width} />,
           document.body,
         )}
-    </>
+    </Collapsible>
   );
 });

--- a/src/routes/v2/shared/windows/components/FloatingWindow.tsx
+++ b/src/routes/v2/shared/windows/components/FloatingWindow.tsx
@@ -29,7 +29,7 @@ const containerVariants = cva(
   },
 );
 
-const headerVariants = cva("py-1 bg-gray-200 border-gray-300", {
+const headerVariants = cva("py-1 bg-gray-800 border-gray-700", {
   variants: {
     maximized: { true: "cursor-default", false: "" },
   },
@@ -44,10 +44,10 @@ function getWindowStyle(model: WindowModel): CSSProperties {
   return {
     left: model.position.x,
     top: model.position.y,
-    width: model.isMinimized ? "auto" : model.size.width,
-    height: model.isMinimized ? "auto" : model.size.height,
+    width: model.size.width,
+    height: model.size.height,
     minWidth: model.minSize.width,
-    minHeight: model.isMinimized ? "auto" : model.minSize.height,
+    minHeight: model.minSize.height,
     zIndex: 20 + model.zIndex,
   };
 }
@@ -137,9 +137,6 @@ export const FloatingWindow = observer(function FloatingWindow() {
     document.addEventListener("mouseup", onMouseUp);
   };
 
-  const showContent = !model.isMinimized;
-  const showResize = !model.isMinimized && !model.isMaximized;
-
   return (
     <>
       <div
@@ -159,18 +156,19 @@ export const FloatingWindow = observer(function FloatingWindow() {
           onMouseDown={model.isMaximized ? undefined : handleHeaderMouseDown}
           actions={<WindowActions />}
           className={headerVariants({ maximized: model.isMaximized })}
+          tone="dark"
         />
 
-        {showContent && (
-          <div
-            className="flex-1 min-h-0 overflow-auto bg-gray-50"
-            style={{ height: getContentHeight(model) }}
-          >
-            {content}
-          </div>
-        )}
+        <div
+          className="flex-1 min-h-0 overflow-auto bg-gray-50"
+          style={{ height: getContentHeight(model) }}
+        >
+          {content}
+        </div>
 
-        {showResize && <ResizeHandle onMouseDown={handleResizeMouseDown} />}
+        {!model.isMaximized && (
+          <ResizeHandle onMouseDown={handleResizeMouseDown} />
+        )}
       </div>
 
       {isDragging && snapPreview && (

--- a/src/routes/v2/shared/windows/components/WindowActions.tsx
+++ b/src/routes/v2/shared/windows/components/WindowActions.tsx
@@ -4,38 +4,48 @@ import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
 import { useWindowContext } from "@/routes/v2/shared/windows/ContentWindowStateContext";
 
-const sharedButtonClassName =
-  "h-5 w-5 text-gray-700 hover:text-gray-900 hover:bg-gray-200";
+const lightButtonClassName =
+  "h-5 w-5 text-gray-700 hover:text-gray-900 hover:bg-white/50";
+const darkButtonClassName =
+  "h-5 w-5 text-gray-300 hover:text-white hover:bg-white/10";
+
+const lightCloseButtonClassName =
+  "h-5 w-5 text-gray-500 hover:text-red-500 hover:bg-gray-300";
+const darkCloseButtonClassName =
+  "h-5 w-5 text-gray-300 hover:text-red-400 hover:bg-white/10";
 
 export const WindowActions = observer(function WindowActions() {
   const { model } = useWindowContext();
+  const buttonClassName = model.isDocked
+    ? lightButtonClassName
+    : darkButtonClassName;
+  const closeButtonClassName = model.isDocked
+    ? lightCloseButtonClassName
+    : darkCloseButtonClassName;
 
   return (
     <div
       className="shrink-0 flex items-center gap-0.5"
       onMouseDown={(e) => e.stopPropagation()}
+      onClick={(e) => e.stopPropagation()}
     >
-      {!model.isActionDisabled("minimize") &&
-        !(model.dockState === "right" && !model.isMinimized) && (
-          <Button
-            variant="ghost"
-            size="icon"
-            className={sharedButtonClassName}
-            onClick={() => model.toggleMinimize()}
-            aria-label={model.isMinimized ? "Expand" : "Minimize"}
-          >
-            <Icon
-              name={model.isMinimized ? "ChevronDown" : "Minus"}
-              size="xs"
-            />
-          </Button>
-        )}
+      {!model.isActionDisabled("minimize") && model.isDocked && (
+        <Button
+          variant="ghost"
+          size="icon"
+          className={buttonClassName}
+          onClick={() => model.toggleMinimize()}
+          aria-label={model.isMinimized ? "Expand" : "Minimize"}
+        >
+          <Icon name={model.isMinimized ? "ChevronDown" : "Minus"} size="xs" />
+        </Button>
+      )}
 
       {!model.isActionDisabled("maximize") && (
         <Button
           variant="ghost"
           size="icon"
-          className={sharedButtonClassName}
+          className={buttonClassName}
           onClick={() => model.toggleMaximize()}
           aria-label={model.isMaximized ? "Restore" : "Maximize"}
         >
@@ -50,7 +60,7 @@ export const WindowActions = observer(function WindowActions() {
         <Button
           variant="ghost"
           size="icon"
-          className={sharedButtonClassName}
+          className={buttonClassName}
           onClick={() => model.hide()}
           aria-label="Hide"
         >
@@ -60,7 +70,7 @@ export const WindowActions = observer(function WindowActions() {
         <Button
           variant="ghost"
           size="icon"
-          className="h-5 w-5 text-gray-500 hover:text-red-500 hover:bg-gray-300"
+          className={closeButtonClassName}
           onClick={() => model.close()}
           aria-label="Close"
         >

--- a/src/routes/v2/shared/windows/components/WindowHeader.tsx
+++ b/src/routes/v2/shared/windows/components/WindowHeader.tsx
@@ -8,25 +8,26 @@ interface WindowHeaderProps {
   title: string;
   isDragging?: boolean;
   onMouseDown?: (e: React.MouseEvent) => void;
-  onDoubleClick?: () => void;
   leadingIcon?: ReactNode;
   actions: ReactNode;
   className?: string;
   style?: React.CSSProperties;
   /** When true, actions are hidden until the parent group/window is hovered. */
   actionsOnHover?: boolean;
+  /** Color tone of the header content; affects title text color. */
+  tone?: "light" | "dark";
 }
 
 export function WindowHeader({
   title,
   isDragging = false,
   onMouseDown,
-  onDoubleClick,
   leadingIcon,
   actions,
   className,
   style,
   actionsOnHover = false,
+  tone = "light",
 }: WindowHeaderProps) {
   return (
     <div
@@ -38,7 +39,6 @@ export function WindowHeader({
       )}
       style={style}
       onMouseDown={onMouseDown}
-      onDoubleClick={onDoubleClick}
     >
       <InlineStack
         gap="1"
@@ -47,7 +47,14 @@ export function WindowHeader({
         className="min-w-0 flex-1 overflow-hidden"
       >
         {leadingIcon}
-        <Text size="xs" weight="semibold" className="text-gray-700 truncate">
+        <Text
+          size="xs"
+          weight="semibold"
+          className={cn(
+            "truncate",
+            tone === "dark" ? "text-gray-100" : "text-gray-700",
+          )}
+        >
           {title}
         </Text>
       </InlineStack>

--- a/src/routes/v2/shared/windows/plugins/dockAreaAccordion.ts
+++ b/src/routes/v2/shared/windows/plugins/dockAreaAccordion.ts
@@ -145,8 +145,9 @@ export function initDockAreaAccordion(
       }
 
       case "window-minimized": {
+        // Manual minimize is allowed to leave the dock area fully collapsed —
+        // we intentionally don't call ensureOneVisible here.
         restoreFromStack(store, side);
-        ensureOneVisible(store, side);
         break;
       }
     }

--- a/src/routes/v2/shared/windows/windowModel.ts
+++ b/src/routes/v2/shared/windows/windowModel.ts
@@ -245,6 +245,8 @@ export class WindowModel {
     this.dockState = "none";
     this.preDockedPosition = undefined;
     this.preDockedSize = undefined;
+    // Floating windows don't render a minimized state; normalize on undock.
+    if (this.state === "minimized") this.state = "normal";
   }
 
   // -- Snapshot helpers (save/restore for minimize/maximize/hide transitions) --


### PR DESCRIPTION
## Description

Change docked windows in v2 from accordion to collapsible. This change means that all windows can be closed (previously at least one had to be open).

It feels a little more natural like this, given I can customize what sections go where. I can switch sections and compare info at will, rather than being forced into a single window at a time. It also makes it less confusing that the headers offer functionality to open but not close the section.



Additionally:

This PR also changes the docked window header to single-click open/close rather than the unintuitive double click.

Closed windows that are undocked are automatically reopened.

Undocked windows now have a dark theme header - imo it looks better than the light grey.

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

- [x] New feature
- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

![image.png](https://app.graphite.com/user-attachments/assets/1ee8c849-dbcb-4686-9a56-eebec362309b.png)

![image.png](https://app.graphite.com/user-attachments/assets/2fde8c2e-bd2a-42df-b515-4dfb8e817975.png)



<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->