### PR TITLE
chore: v2: Make View YAML the Default Action

### DIFF
--- a/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/components/ComponentRefBar.tsx
+++ b/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/components/ComponentRefBar.tsx
@@ -108,12 +108,12 @@ export function ComponentRefBar({
               <Button
                 variant="ghost"
                 size="min"
-                onClick={() => setIsEditDialogOpen(true)}
+                onClick={() => setShowCodeViewer(true)}
               >
-                <Icon name="FilePenLine" size="sm" />
+                <Icon name="FileCode" size="sm" />
               </Button>
             </TooltipTrigger>
-            <TooltipContent>Edit Component Definition</TooltipContent>
+            <TooltipContent>View YAML</TooltipContent>
           </Tooltip>
 
           <DropdownMenu>
@@ -146,9 +146,9 @@ export function ComponentRefBar({
                 Copy YAML
               </DropdownMenuItem>
 
-              <DropdownMenuItem onClick={() => setShowCodeViewer(true)}>
-                <Icon name="FileCode" size="sm" />
-                View YAML
+              <DropdownMenuItem onClick={() => setIsEditDialogOpen(true)}>
+                <Icon name="FilePenLine" size="sm" />
+                Edit Component
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>


### PR DESCRIPTION
## Description

Swaps the Edit Component Defintion and View YAML buttons so now View YAML is the default and outside the dropdown and edit component is inside

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

before:

![image.png](https://app.graphite.com/user-attachments/assets/d6048689-e8d5-4ae4-a138-5f17e5ae7ef4.png)

after:

![image.png](https://app.graphite.com/user-attachments/assets/496aa3f3-01d1-4a21-9c8c-3cc590b5004f.png)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->