### PR TITLE
fix: v2 - disable run pipeline button on invalid pipelines

### DIFF
--- a/src/routes/v2/pages/Editor/components/EditorMenuBar/components/QuickRunButton.tsx
+++ b/src/routes/v2/pages/Editor/components/EditorMenuBar/components/QuickRunButton.tsx
@@ -12,7 +12,9 @@ export const QuickRunButton = observer(function QuickRunButton() {
   const { navigation } = useSharedStores();
   const { isAuthorized } = useAwaitAuthorization();
   const rootSpec = navigation.rootSpec;
-  const hasErrors = rootSpec ? !rootSpec.isValid : false;
+  const allIssues = rootSpec?.allValidationIssues ?? [];
+  const errorCount = allIssues.filter((i) => i.severity === "error").length;
+  const hasErrors = errorCount > 0;
 
   let legacySpec: ReturnType<typeof serializeComponentSpec> | undefined;
   try {
@@ -34,6 +36,7 @@ export const QuickRunButton = observer(function QuickRunButton() {
       <TooltipButton
         tooltip={tooltip}
         className="hover:bg-transparent"
+        disabled={hasErrors}
         onClick={triggerSubmitRun}
       >
         <Icon name="Play" className={`${iconColor} transition-colors`} />
@@ -43,7 +46,7 @@ export const QuickRunButton = observer(function QuickRunButton() {
           <TangleSubmitter
             componentSpec={legacySpec}
             isComponentTreeValid={rootSpec?.isValid}
-            onlyFixableIssues
+            onlyFixableIssues={!hasErrors && allIssues.length > 0}
           />
         </div>
       )}

--- a/src/routes/v2/pages/Editor/components/EditorMenuBar/components/RunsMenu.tsx
+++ b/src/routes/v2/pages/Editor/components/EditorMenuBar/components/RunsMenu.tsx
@@ -19,6 +19,7 @@ export const RunsMenu = observer(function RunsMenu() {
   const rootSpec = navigation.rootSpec;
   const allIssues = rootSpec?.allValidationIssues ?? [];
   const errorCount = allIssues.filter((i) => i.severity === "error").length;
+  const hasErrors = errorCount > 0;
 
   return (
     <DropdownMenu>
@@ -26,11 +27,14 @@ export const RunsMenu = observer(function RunsMenu() {
         <MenuTriggerButton>Runs</MenuTriggerButton>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" sideOffset={2}>
-        <DropdownMenuItem onSelect={triggerSubmitRun}>
+        <DropdownMenuItem onSelect={triggerSubmitRun} disabled={hasErrors}>
           <Icon name="Play" size="sm" />
           Submit Run
         </DropdownMenuItem>
-        <DropdownMenuItem onSelect={triggerSubmitWithArguments}>
+        <DropdownMenuItem
+          onSelect={triggerSubmitWithArguments}
+          disabled={hasErrors}
+        >
           <Icon name="Split" size="sm" className="rotate-90" />
           Submit with Arguments
         </DropdownMenuItem>


### PR DESCRIPTION
## Description

Closes https://github.com/Shopify/oasis-frontend/issues/591

The Quick Run button and Runs menu items are now disabled when the pipeline has validation errors (issues with severity `"error"`). Previously, the Quick Run button relied on `rootSpec.isValid` to determine if there were errors, which did not distinguish between error-level and other severity issues.

The `onlyFixableIssues` prop on `TangleSubmitter` is now conditionally set to `true` only when there are no errors but other validation issues exist, rather than being always `true`.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Open a pipeline in the Editor with validation errors (severity `"error"`).
2. Verify that the Quick Run button is disabled and cannot be clicked.
3. Verify that the "Submit Run" and "Submit with Arguments" options in the Runs menu are also disabled.
4. Open a pipeline with no validation errors and confirm all run actions remain enabled and functional.
5. Open a pipeline with non-error validation issues (e.g., warnings) and confirm run actions are still enabled.

## Additional Comments