### PR TITLE
fix: v2 - deselect task on delete via button

### DIFF
--- a/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/components/actions/DeleteTaskButton.tsx
+++ b/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/components/actions/DeleteTaskButton.tsx
@@ -4,6 +4,7 @@ import { ActionButton } from "@/components/shared/Buttons/ActionButton";
 import useToastNotification from "@/hooks/useToastNotification";
 import { useTaskActions } from "@/routes/v2/pages/Editor/store/actions/useTaskActions";
 import { useSpec } from "@/routes/v2/shared/providers/SpecContext";
+import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 import { getErrorMessage } from "@/utils/string";
 
 interface DeleteTaskButtonProps {
@@ -14,11 +15,16 @@ export function DeleteTaskButton({ entityId }: DeleteTaskButtonProps) {
   const spec = useSpec();
   const { deleteTask } = useTaskActions();
   const notify = useToastNotification();
+  const { editor } = useSharedStores();
 
   const { mutate, isPending } = useMutation({
     mutationFn: async () => {
       if (!spec) throw new Error("No spec available");
       deleteTask(spec, entityId);
+
+      // deselect removed nodes
+      editor.clearSelection();
+      editor.clearMultiSelection();
     },
     onError: (error) =>
       notify("Failed to delete task: " + getErrorMessage(error), "error"),


### PR DESCRIPTION
## Description

Closes https://github.com/Shopify/oasis-frontend/issues/594

When a task is deleted, the editor's selection state is now cleared to prevent stale selections from persisting after the node has been removed. This calls `clearSelection` and `clearMultiSelection` on the editor store as part of the delete mutation.

## Related Issue and Pull requests

## Type of Change

- [x] Bug fix

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Open the editor and select a task node.
2. Delete the selected task using the delete button.
3. Verify that the node is removed and no selection state remains in the editor.
4. Repeat with multiple nodes selected to confirm multi-selection is also cleared.

## Additional Comments