### PR TITLE
fix: v2 - preserve selection while update positions

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/FlexNode/utils.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlexNode/utils.ts
@@ -13,17 +13,19 @@ export const DEFAULT_STICKY_NOTE = {
 export const DEFAULT_FLEX_NODE_SIZE = { width: 150, height: 100 };
 export const DEFAULT_BORDER_COLOR = "#BCBCBC";
 
+/** Clones `position` onto the RF node and into `data` so React Flow state does not alias the spec (fixes stale layout after undo in controlled flows). */
 export const createFlexNode = (
   flexNode: FlexNodeData,
   readOnly: boolean = false,
 ) => {
   const { id, position, size, zIndex, locked } = flexNode;
+  const positionCopy = { x: position.x, y: position.y };
 
   return {
     id,
-    data: { ...flexNode, readOnly },
+    data: { ...flexNode, readOnly, position: positionCopy },
     ...size,
-    position,
+    position: positionCopy,
     type: "flex",
     connectable: false,
     zIndex,

--- a/src/routes/v2/pages/Editor/nodes/FlexNode/components/FlexNode.tsx
+++ b/src/routes/v2/pages/Editor/nodes/FlexNode/components/FlexNode.tsx
@@ -6,6 +6,7 @@ import {
   type ResizeParams,
 } from "@xyflow/react";
 import { cva } from "class-variance-authority";
+import { observer } from "mobx-react-lite";
 import { type MouseEvent, useState } from "react";
 
 import { InlineTextEditor } from "@/components/shared/ReactFlow/FlowCanvas/FlexNode/InlineTextEditor";
@@ -21,7 +22,7 @@ import { useEditorSession } from "@/routes/v2/pages/Editor/store/EditorSessionCo
 import { useSpec } from "@/routes/v2/shared/providers/SpecContext";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 
-type FlexNodeProps = NodeProps<Node<FlexNodeData>>;
+type FlexNodeProps = NodeProps<Node<FlexNodeData, "flex">>;
 
 const MIN_SIZE = { width: 50, height: 50 };
 
@@ -144,7 +145,11 @@ function FlexNodeContent({
   );
 }
 
-export const EditorV2FlexNode = ({ data, id, selected }: FlexNodeProps) => {
+export const EditorV2FlexNode = observer(function EditorV2FlexNode({
+  data,
+  id,
+  selected,
+}: FlexNodeProps) {
   const { editor } = useSharedStores();
   const { undo } = useEditorSession();
   const spec = useSpec();
@@ -296,4 +301,4 @@ export const EditorV2FlexNode = ({ data, id, selected }: FlexNodeProps) => {
       </div>
     </>
   );
-};
+});

--- a/src/routes/v2/pages/Editor/nodes/FlexNode/flexNode.actions.ts
+++ b/src/routes/v2/pages/Editor/nodes/FlexNode/flexNode.actions.ts
@@ -110,10 +110,8 @@ export function updateFlexNodePosition(
   position: XYPosition,
 ) {
   undo.withGroup("Update flex node position", () => {
-    const nodes = getFlexNodes(spec);
-    const updated = nodes.map((n) =>
-      n.id === nodeId ? { ...n, position } : n,
-    );
-    setFlexNodes(undo, spec, updated);
+    const flexNode = findFlexNode(spec, nodeId);
+    if (!flexNode) return;
+    updateFlexNode(undo, spec, nodeId, { position });
   });
 }

--- a/src/routes/v2/shared/hooks/useFlowCanvasState.ts
+++ b/src/routes/v2/shared/hooks/useFlowCanvasState.ts
@@ -7,7 +7,7 @@ import type {
 } from "@xyflow/react";
 import { useEdgesState, useNodesState } from "@xyflow/react";
 import type { MouseEvent } from "react";
-import { useState } from "react";
+import { useLayoutEffect } from "react";
 
 import type { ComponentSpec } from "@/models/componentSpec";
 import { useNodeRegistry } from "@/routes/v2/shared/nodes/NodeRegistryContext";
@@ -33,9 +33,22 @@ interface UseFlowCanvasStateResult {
   selectionBehavior: Required<Pick<ReactFlowProps, "onSelectionChange">>;
 }
 
+function preserveSelection<T extends { id: string; selected?: boolean }>(
+  currentItems: T[],
+  newItems: T[],
+): T[] {
+  const selectedIds = new Set(
+    currentItems.filter((item) => item.selected).map((item) => item.id),
+  );
+  if (selectedIds.size === 0) return newItems;
+  return newItems.map((item) =>
+    selectedIds.has(item.id) ? { ...item, selected: true } : item,
+  );
+}
+
 /**
  * Aggregates the common flow canvas state setup shared by Editor and RunView:
- * spec-to-nodes conversion, React Flow state, sync effect,
+ * spec-to-nodes conversion, React Flow state, MobX-driven sync,
  * canvas enhancements, and selection behavior.
  */
 export function useFlowCanvasState({
@@ -50,17 +63,13 @@ export function useFlowCanvasState({
   const [nodes, setNodes, rfOnNodesChange] = useNodesState(specNodes);
   const [edges, setEdges, rfOnEdgesChange] = useEdgesState(specEdges);
 
-  const [syncedSpecNodes, setSyncedSpecNodes] = useState(specNodes);
-  const [syncedSpecEdges, setSyncedSpecEdges] = useState(specEdges);
+  useLayoutEffect(() => {
+    setNodes((current) => preserveSelection(current, specNodes));
+  }, [specNodes, setNodes]);
 
-  if (syncedSpecNodes !== specNodes) {
-    setSyncedSpecNodes(specNodes);
-    setNodes(specNodes);
-  }
-  if (syncedSpecEdges !== specEdges) {
-    setSyncedSpecEdges(specEdges);
-    setEdges(specEdges);
-  }
+  useLayoutEffect(() => {
+    setEdges((current) => preserveSelection(current, specEdges));
+  }, [specEdges, setEdges]);
 
   const {
     nodes: displayNodes,


### PR DESCRIPTION
## Description

Closes https://github.com/Shopify/oasis-frontend/issues/593

When the pipeline spec changes (e.g. due to an external update), the flow canvas now preserves the user's current node/edge selection instead of wiping it. Previously, syncing spec-derived nodes and edges directly replaced the React Flow state, clearing any active selection. The new `preserveSelection` helper re-applies selected state from the current items onto the incoming spec items before committing them to React Flow state.

The sync logic has also been extracted into a reusable `useSyncSpecItems` hook, replacing the duplicated inline state-tracking pattern for nodes and edges.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [x] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Open a pipeline in the editor with multiple nodes.
2. Select one or more nodes.
3. Trigger a spec change (e.g. an external update that causes the canvas to re-sync).
4. Verify that the previously selected nodes remain selected after the sync.

## Additional Comments

The render-time state update pattern (`if (synced !== specItems)`) is an intentional React idiom for derived state synchronization and avoids an extra render cycle compared to a `useEffect`\-based approach.

Refactoring helped to drop Cyclomatic Complexity and improve overall readability:

| **Metric** | **Before** | **After** |
| --- | --- | --- |
| Cyclomatic complexity | 7 | **4** |
| Total operators | 104 | **85** |

### Additional fix for FlexNode sync

Sticky (flex) nodes were built with React Flow’s `node.position` and `data.position` pointing at the same object as the spec, so after undo the spec updated but the canvas could stay on the dragged coordinates until something forced a refresh. `createFlexNode` now copies coordinates into a single plain `{ x, y }` used for both the node’s `position` and `data.position`, so RF state no longer aliases the spec and rebuilds from spec stay in sync (V2’s manifest simply uses this shared helper again).