### PR TITLE
chore: v2: Add Toggle for Switching Editor Version

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,7 @@ VITE_HUGGING_FACE_AUTHORIZATION=<boolean>
 
 # Dev Tools
 VITE_ENABLE_DEBUG_MODE=<boolean>
+VITE_ENABLE_V2_EDITOR_TOGGLE=<boolean>
 
 # Google Drive Integration (optional — see docs/google-drive-setup.md)
 VITE_GOOGLE_CLIENT_ID=<your-google-oauth-client-id>

--- a/src/components/layout/AppMenu.tsx
+++ b/src/components/layout/AppMenu.tsx
@@ -9,6 +9,7 @@ import logo from "/Tangle_white.png";
 import { isAuthorizationRequired } from "@/components/shared/Authentication/helpers";
 import { TopBarAuthentication } from "@/components/shared/Authentication/TopBarAuthentication";
 import { CopyText } from "@/components/shared/CopyText/CopyText";
+import { EditorVersionToggle } from "@/components/shared/EditorVersionToggle";
 import ImportPipeline from "@/components/shared/ImportPipeline";
 import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
@@ -108,6 +109,8 @@ const DefaultAppMenu = () => {
             </TooltipProvider>
             <div className="w-px h-5 bg-stone-700" />
           </div>
+
+          <EditorVersionToggle />
 
           {/* Settings & status */}
           {isOnSettingsRoute ? (

--- a/src/components/shared/EditorVersionToggle.tsx
+++ b/src/components/shared/EditorVersionToggle.tsx
@@ -1,0 +1,47 @@
+import { useLocation, useNavigate } from "@tanstack/react-router";
+
+import TooltipButton from "@/components/shared/Buttons/TooltipButton";
+import { Icon } from "@/components/ui/icon";
+import { APP_ROUTES, EDITOR_PATH } from "@/routes/router";
+
+const isEnabled = import.meta.env.VITE_ENABLE_V2_EDITOR_TOGGLE === "true";
+
+type EditorVersion = "v1" | "v2";
+
+const detectEditorVersion = (pathname: string): EditorVersion | null => {
+  if (pathname.startsWith(`${APP_ROUTES.EDITOR_V2}/`)) return "v2";
+  if (pathname.startsWith(`${EDITOR_PATH}/`)) return "v1";
+  return null;
+};
+
+export const EditorVersionToggle = () => {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  if (!isEnabled) return null;
+
+  const version = detectEditorVersion(location.pathname);
+  if (!version) return null;
+
+  const lastSegment = location.pathname.split("/").pop() ?? "";
+  const pipelineName = decodeURIComponent(lastSegment);
+  if (!pipelineName) return null;
+
+  const targetVersion = version === "v1" ? "v2" : "v1";
+  const targetPath =
+    targetVersion === "v2"
+      ? `${APP_ROUTES.EDITOR_V2}/${encodeURIComponent(pipelineName)}`
+      : `${EDITOR_PATH}/${encodeURIComponent(pipelineName)}`;
+  const tooltip =
+    targetVersion === "v2" ? "Switch to new editor" : "Switch to legacy editor";
+
+  return (
+    <TooltipButton
+      tooltip={tooltip}
+      onClick={() => navigate({ to: targetPath })}
+      aria-label={tooltip}
+    >
+      <Icon name={targetVersion === "v2" ? "Sparkles" : "History"} />
+    </TooltipButton>
+  );
+};

--- a/src/routes/v2/shared/components/AppMenuActions.tsx
+++ b/src/routes/v2/shared/components/AppMenuActions.tsx
@@ -3,6 +3,7 @@ import { Link as RouterLink } from "@tanstack/react-router";
 import { isAuthorizationRequired } from "@/components/shared/Authentication/helpers";
 import { TopBarAuthentication } from "@/components/shared/Authentication/TopBarAuthentication";
 import TooltipButton from "@/components/shared/Buttons/TooltipButton";
+import { EditorVersionToggle } from "@/components/shared/EditorVersionToggle";
 import { Icon } from "@/components/ui/icon";
 import { InlineStack } from "@/components/ui/layout";
 import { Link } from "@/components/ui/link";
@@ -18,6 +19,7 @@ export function AppMenuActions() {
       className="shrink-0"
       data-testid="app-menu-actions"
     >
+      <EditorVersionToggle />
       <RouterLink to="/settings/backend">
         <TooltipButton tooltip="Settings">
           <Icon name="Settings" />


### PR DESCRIPTION
## Description

It's very annoying having to manually edit the route every time I want to compare something in v1 vs v2. This PR adds an env variable 

```
VITE_ENABLE_V2_EDITOR_TOGGLE
```

if `true` a button will be available in the top nav on the editor route to switch between old and new editor. This is done via env variable so that the switch is not made available to the general public (since the feature hasn't been announced yet). This change is purely for developer experience.

When we begin the beta we can remove the env variable and use a beta flag instead.

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

![image.png](https://app.graphite.com/user-attachments/assets/d2b0bedb-7bd4-4623-ba93-b81b70cfdb59.png)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->