### PR TITLE
feat: v2: Migrate Collapsible Nodes to v2 Editor

### DIFF
--- a/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/TaskDetails.tsx
+++ b/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/TaskDetails.tsx
@@ -15,6 +15,7 @@ import { AnnotationsBlock } from "@/routes/v2/pages/Editor/components/Annotation
 import { useEditorSession } from "@/routes/v2/pages/Editor/store/EditorSessionContext";
 import { useSpec } from "@/routes/v2/shared/providers/SpecContext";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
+import { EDITOR_COLLAPSED_ANNOTATION } from "@/utils/annotations";
 
 import { getTaskYamlText } from "./components/actions/getTaskYamlText";
 import { ComponentRefBar } from "./components/ComponentRefBar";
@@ -28,6 +29,7 @@ const EDITOR_ANNOTATION_KEYS = [
   "editor.position",
   "tangleml.com/editor/task-color",
   "tangleml.com/editor/edge-conduits",
+  EDITOR_COLLAPSED_ANNOTATION,
 ];
 
 interface TaskDetailsProps {

--- a/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/components/ConfigurationSection.tsx
+++ b/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/components/ConfigurationSection.tsx
@@ -15,6 +15,7 @@ import { Switch } from "@/components/ui/switch";
 import { Heading, Paragraph } from "@/components/ui/typography";
 import type { Task } from "@/models/componentSpec";
 import type { AnnotationConfig, Annotations } from "@/types/annotations";
+import { EDITOR_COLLAPSED_ANNOTATION } from "@/utils/annotations";
 import { ISO8601_DURATION_ZERO_DAYS } from "@/utils/constants";
 
 import { useTaskConfigActions } from "./useTaskConfigActions";
@@ -31,6 +32,7 @@ export const ConfigurationSection = observer(function ConfigurationSection({
     saveAnnotation,
     setTaskColor,
     clearProviderAnnotations,
+    setCollapsed,
   } = useTaskConfigActions();
   const isSubgraph = task.subgraphSpec !== undefined;
 
@@ -114,11 +116,17 @@ export const ConfigurationSection = observer(function ConfigurationSection({
     saveAnnotation(task, key, value);
   };
 
-  const taskColor = task.annotations.get("tangleml.com/editor/task-color");
-
   const handleColorChange = (color: string) => {
     setTaskColor(task, color);
   };
+
+  const handleCollapsedChange = (checked: boolean) => {
+    setCollapsed(task, checked);
+  };
+
+  const taskColor = task.annotations.get("tangleml.com/editor/task-color");
+  const isCollapsed =
+    task.annotations.get(EDITOR_COLLAPSED_ANNOTATION) === "true";
 
   return (
     <BlockStack gap="3">
@@ -149,6 +157,13 @@ export const ConfigurationSection = observer(function ConfigurationSection({
           </InlineStack>
         </>
       )}
+
+      <InlineStack align="space-between" gap="2" className="w-full">
+        <Paragraph size="sm" tone="subdued">
+          Collapse node
+        </Paragraph>
+        <Switch checked={isCollapsed} onCheckedChange={handleCollapsedChange} />
+      </InlineStack>
 
       <Separator />
 

--- a/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/components/taskConfig.actions.ts
+++ b/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/components/taskConfig.actions.ts
@@ -1,6 +1,7 @@
 import type { Task } from "@/models/componentSpec";
 import type { UndoGroupable } from "@/routes/v2/shared/nodes/types";
 import type { AnnotationConfig } from "@/types/annotations";
+import { EDITOR_COLLAPSED_ANNOTATION } from "@/utils/annotations";
 import { ISO8601_DURATION_ZERO_DAYS } from "@/utils/constants";
 
 const TASK_COLOR_ANNOTATION = "tangleml.com/editor/task-color";
@@ -36,6 +37,20 @@ export function setTaskColor(undo: UndoGroupable, task: Task, color: string) {
       task.annotations.remove(TASK_COLOR_ANNOTATION);
     } else {
       task.annotations.set(TASK_COLOR_ANNOTATION, color);
+    }
+  });
+}
+
+export function setCollapsed(
+  undo: UndoGroupable,
+  task: Task,
+  collapsed: boolean,
+) {
+  undo.withGroup("Toggle collapse node", () => {
+    if (collapsed) {
+      task.annotations.set(EDITOR_COLLAPSED_ANNOTATION, "true");
+    } else {
+      task.annotations.remove(EDITOR_COLLAPSED_ANNOTATION);
     }
   });
 }

--- a/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/components/useTaskConfigActions.ts
+++ b/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/components/useTaskConfigActions.ts
@@ -3,6 +3,7 @@ import { useEditorSession } from "@/routes/v2/pages/Editor/store/EditorSessionCo
 import {
   clearProviderAnnotations,
   saveAnnotation,
+  setCollapsed,
   setTaskColor,
   toggleCacheDisable,
 } from "./taskConfig.actions";
@@ -14,6 +15,7 @@ export function useTaskConfigActions() {
     toggleCacheDisable: toggleCacheDisable.bind(null, undo),
     saveAnnotation: saveAnnotation.bind(null, undo),
     setTaskColor: setTaskColor.bind(null, undo),
+    setCollapsed: setCollapsed.bind(null, undo),
     clearProviderAnnotations: clearProviderAnnotations.bind(null, undo),
   };
 }

--- a/src/routes/v2/pages/Editor/nodes/TaskNode/taskNode.manifest.ts
+++ b/src/routes/v2/pages/Editor/nodes/TaskNode/taskNode.manifest.ts
@@ -62,6 +62,9 @@ export const taskManifest: NodeTypeManifest = {
           : undefined,
         annotations,
         arguments: deepClone(snapshot.data.arguments),
+        executionOptions: snapshot.data.executionOptions
+          ? deepClone(snapshot.data.executionOptions)
+          : undefined,
       });
 
       spec.addTask(task);

--- a/src/routes/v2/shared/nodes/TaskNode/TaskNode.tsx
+++ b/src/routes/v2/shared/nodes/TaskNode/TaskNode.tsx
@@ -21,10 +21,11 @@ import type { TaskNodeData } from "@/routes/v2/shared/nodes/types";
 import { useSpec } from "@/routes/v2/shared/providers/SpecContext";
 import type { NodeOverlayEffect } from "@/routes/v2/shared/store/canvasOverlay.types";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
+import { EDITOR_COLLAPSED_ANNOTATION } from "@/utils/annotations";
 import { ISO8601_DURATION_ZERO_DAYS } from "@/utils/constants";
 
 import { TaskNodeCard } from "./TaskNodeCard";
-import { TaskNodeCollapsed } from "./TaskNodeCollapsed";
+import { TaskNodeSimplified } from "./TaskNodeSimplified";
 
 type TaskNodeType = Node<TaskNodeData, "task">;
 type TaskNodeProps = NodeProps<TaskNodeType>;
@@ -48,9 +49,12 @@ export interface TaskNodeViewProps {
   selected: boolean;
   isHovered: boolean;
   isSubgraph: boolean;
+  collapsed: boolean;
   description: string;
   inputs: TaskNodeInput[];
   outputs: TaskNodeOutput[];
+  connectedInputNames: Set<string>;
+  connectedOutputNames: Set<string>;
   annotations: { key: string }[];
   taskColor?: string;
   cacheDisabled: boolean;
@@ -111,6 +115,27 @@ function resolveInputDisplayValues(
   }
 
   return values;
+}
+
+function resolveConnectedPortNames(
+  entityId: string,
+  spec: ComponentSpec | null,
+): { inputs: Set<string>; outputs: Set<string> } {
+  const inputs = new Set<string>();
+  const outputs = new Set<string>();
+
+  if (!spec) return { inputs, outputs };
+
+  for (const binding of spec.bindings) {
+    if (binding.targetEntityId === entityId) {
+      inputs.add(binding.targetPortName);
+    }
+    if (binding.sourceEntityId === entityId) {
+      outputs.add(binding.sourcePortName);
+    }
+  }
+
+  return { inputs, outputs };
 }
 
 function resolveTaskColor(task: Task): string | undefined {
@@ -189,6 +214,8 @@ export const TaskNode = observer(function TaskNode({
   const componentSpec = task.resolvedComponentSpec;
   const { description, inputs, outputs } =
     getComponentSpecDefaults(componentSpec);
+  const isManuallyCollapsed =
+    task.annotations.get(EDITOR_COLLAPSED_ANNOTATION) === "true";
 
   const handleClick = (event: MouseEvent) => {
     editor.selectNode(id, "task", { shiftKey: event.shiftKey, entityId });
@@ -221,6 +248,8 @@ export const TaskNode = observer(function TaskNode({
     selectEdgesByHandle(handleId);
   };
 
+  const connectedPorts = resolveConnectedPortNames(entityId, spec);
+
   const viewProps: TaskNodeViewProps = {
     id,
     entityId,
@@ -228,9 +257,12 @@ export const TaskNode = observer(function TaskNode({
     selected: !!selected,
     isHovered: editor.hoveredEntityId === entityId,
     isSubgraph: isTaskSubgraph(componentSpec),
+    collapsed: isManuallyCollapsed,
     description,
     inputs,
     outputs,
+    connectedInputNames: connectedPorts.inputs,
+    connectedOutputNames: connectedPorts.outputs,
     annotations: task.annotations.map((a) => ({ key: a.key })),
     taskColor: resolveTaskColor(task),
     cacheDisabled:
@@ -256,7 +288,7 @@ export const TaskNode = observer(function TaskNode({
   if (!showContent) {
     return (
       <NodeEffectWrapper effect={nodeEffect}>
-        <TaskNodeCollapsed {...viewProps} />
+        <TaskNodeSimplified {...viewProps} />
       </NodeEffectWrapper>
     );
   }

--- a/src/routes/v2/shared/nodes/TaskNode/TaskNodeCard.tsx
+++ b/src/routes/v2/shared/nodes/TaskNode/TaskNodeCard.tsx
@@ -1,7 +1,7 @@
 import { Handle, Position } from "@xyflow/react";
 import { cva } from "class-variance-authority";
 import { observer } from "mobx-react-lite";
-import type { MouseEvent as ReactMouseEvent } from "react";
+import { type MouseEvent as ReactMouseEvent, useEffect, useState } from "react";
 
 import { trimDigest } from "@/components/shared/ManageComponent/utils/digest";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -14,6 +14,7 @@ import {
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { useSpec } from "@/routes/v2/shared/providers/SpecContext";
+import { pluralize } from "@/utils/string";
 
 import { deriveColorPalette } from "./color.utils";
 import type { TaskNodeInput, TaskNodeViewProps } from "./TaskNode";
@@ -173,8 +174,11 @@ export const TaskNodeCard = observer(function TaskNodeCard({
   selected,
   isHovered,
   isSubgraph,
+  collapsed,
   inputs,
   outputs,
+  connectedInputNames,
+  connectedOutputNames,
   inputDisplayValues,
   onNodeClick,
   onInputClick,
@@ -191,6 +195,34 @@ export const TaskNodeCard = observer(function TaskNodeCard({
         ...(isHovered ? {} : { borderColor: palette.border }),
       }
     : undefined;
+
+  const [inputsExpanded, setInputsExpanded] = useState(false);
+  const [outputsExpanded, setOutputsExpanded] = useState(false);
+
+  useEffect(() => {
+    if (collapsed) {
+      setInputsExpanded(false);
+      setOutputsExpanded(false);
+    }
+  }, [collapsed]);
+
+  const condensedInputs =
+    inputs.length > 0 && connectedInputNames.size > 0
+      ? inputs.filter((input) => connectedInputNames.has(input.name))
+      : inputs.slice(0, 1);
+  const hiddenInputCount = inputs.length - condensedInputs.length;
+  const showCondensedInputs =
+    collapsed && !inputsExpanded && hiddenInputCount > 0;
+  const visibleInputs = showCondensedInputs ? condensedInputs : inputs;
+
+  const condensedOutputs =
+    outputs.length > 0 && connectedOutputNames.size > 0
+      ? outputs.filter((output) => connectedOutputNames.has(output.name))
+      : outputs.slice(0, 1);
+  const hiddenOutputCount = outputs.length - condensedOutputs.length;
+  const showCondensedOutputs =
+    collapsed && !outputsExpanded && hiddenOutputCount > 0;
+  const visibleOutputs = showCondensedOutputs ? condensedOutputs : outputs;
 
   return (
     <Card
@@ -274,40 +306,83 @@ export const TaskNodeCard = observer(function TaskNodeCard({
       <CardContent className="p-2 flex flex-col gap-2">
         {inputs.length > 0 && (
           <div
-            className={cn("p-2 rounded-lg", !palette && "bg-gray-200/50")}
+            className={cn(
+              "p-2 rounded-lg",
+              !palette && "bg-gray-200/50",
+              collapsed &&
+                hiddenInputCount > 0 &&
+                "cursor-pointer hover:bg-gray-200/80",
+            )}
             style={palette ? { backgroundColor: palette.sectionBg } : undefined}
+            onClickCapture={
+              collapsed && hiddenInputCount > 0
+                ? (e) => {
+                    e.stopPropagation();
+                    setInputsExpanded((prev) => !prev);
+                  }
+                : undefined
+            }
           >
             <BlockStack gap="3">
-              {inputs.map((input) => (
+              {visibleInputs.map((input, index) => (
                 <ClassicInputHandle
                   key={input.name}
                   input={input}
                   entityId={entityId}
-                  displayValue={inputDisplayValues[input.name]}
+                  displayValue={
+                    showCondensedInputs && index === 0
+                      ? `+${hiddenInputCount} more ${pluralize(hiddenInputCount, "input")}`
+                      : inputDisplayValues[input.name]
+                  }
                   onInputClick={onInputClick}
                   onHandleClick={onHandleClick}
                 />
               ))}
+              {collapsed && inputsExpanded && hiddenInputCount > 0 && (
+                <span className="text-xs text-gray-400 text-center">
+                  (Click to collapse)
+                </span>
+              )}
             </BlockStack>
           </div>
         )}
 
         {outputs.length > 0 && (
           <div
-            className={cn("p-2 rounded-lg", !palette && "bg-gray-200/50")}
+            className={cn(
+              "p-2 rounded-lg",
+              !palette && "bg-gray-200/50",
+              collapsed &&
+                hiddenOutputCount > 0 &&
+                "cursor-pointer hover:bg-gray-200/80",
+            )}
             style={palette ? { backgroundColor: palette.sectionBg } : undefined}
+            onClickCapture={
+              collapsed && hiddenOutputCount > 0
+                ? (e) => {
+                    e.stopPropagation();
+                    setOutputsExpanded((prev) => !prev);
+                  }
+                : undefined
+            }
           >
             <BlockStack gap="3">
-              {outputs.map((output) => (
+              {visibleOutputs.map((output, index) => (
                 <div
                   key={output.name}
                   className="flex items-center justify-end w-full cursor-pointer"
                   onClick={(e) => {
+                    if (collapsed) return;
                     e.stopPropagation();
                     onOutputClick(output.name, e);
                   }}
                 >
                   <div className="flex flex-row-reverse w-full gap-0.5 items-center justify-between">
+                    {showCondensedOutputs && index === 0 && (
+                      <div className="text-xs text-gray-500 italic px-2">
+                        {`+${hiddenOutputCount} more ${pluralize(hiddenOutputCount, "output")}`}
+                      </div>
+                    )}
                     <div className="translate-x-3 min-w-0 inline-block max-w-full">
                       <div
                         className="text-xs text-gray-800 rounded-md px-2 py-1 truncate bg-black/5 hover:bg-black/10"
@@ -326,6 +401,11 @@ export const TaskNodeCard = observer(function TaskNodeCard({
                   />
                 </div>
               ))}
+              {collapsed && outputsExpanded && hiddenOutputCount > 0 && (
+                <span className="text-xs text-gray-400 text-center">
+                  (Click to collapse)
+                </span>
+              )}
             </BlockStack>
           </div>
         )}

--- a/src/routes/v2/shared/nodes/TaskNode/TaskNodeSimplified.tsx
+++ b/src/routes/v2/shared/nodes/TaskNode/TaskNodeSimplified.tsx
@@ -12,13 +12,13 @@ import type { TaskNodeViewProps } from "./TaskNode";
 import { createTaskNodeCardVariants } from "./taskNode.variants";
 
 const PERCEIVED_FONT_SIZE = "36px";
-const s = "var(--collapsed-scale, 1)";
+const s = "var(--simplified-scale, 1)";
 
-const collapsedCardVariants = createTaskNodeCardVariants(
+const simplifiedCardVariants = createTaskNodeCardVariants(
   "flex flex-col justify-center rounded-xl border-2 p-0 drop-shadow-sm cursor-pointer select-none transition-[border-color,box-shadow]",
 );
 
-export function TaskNodeCollapsed({
+export function TaskNodeSimplified({
   taskName,
   inputs,
   outputs,
@@ -35,7 +35,7 @@ export function TaskNodeCollapsed({
 
   return (
     <Card
-      className={collapsedCardVariants({
+      className={simplifiedCardVariants({
         selected,
         hovered: isHovered,
         subgraph: isSubgraph,

--- a/src/routes/v2/shared/nodes/TaskNode/taskManifestBase.ts
+++ b/src/routes/v2/shared/nodes/TaskNode/taskManifestBase.ts
@@ -23,7 +23,7 @@ import { TaskNode } from "./TaskNode";
 
 type TaskSnapshotData = Pick<
   Task,
-  "componentRef" | "isEnabled" | "arguments"
+  "componentRef" | "isEnabled" | "arguments" | "executionOptions"
 > & {
   annotations: Annotation[];
 };
@@ -35,8 +35,8 @@ export function snapshotTask(
   const task = spec.tasks.find((t) => t.$id === entityId);
   if (!task) return null;
 
-  const nonEditorAnnotations = task.annotations.items
-    .filter((a) => !a.key.startsWith("editor."))
+  const preservedAnnotations = task.annotations.items
+    .filter((a) => a.key !== "editor.position")
     .map((a) => deepClone(a));
 
   return {
@@ -48,7 +48,10 @@ export function snapshotTask(
       componentRef: deepClone(task.componentRef),
       isEnabled: task.isEnabled ? deepClone(task.isEnabled) : undefined,
       arguments: task.arguments.map((a) => deepClone(a)),
-      annotations: nonEditorAnnotations,
+      executionOptions: task.executionOptions
+        ? deepClone(task.executionOptions)
+        : undefined,
+      annotations: preservedAnnotations,
     },
   };
 }

--- a/src/routes/v2/shared/nodes/TaskNode/taskNode.variants.ts
+++ b/src/routes/v2/shared/nodes/TaskNode/taskNode.variants.ts
@@ -2,7 +2,7 @@ import { cva } from "class-variance-authority";
 
 /**
  * Factory for the `selected > hovered > subgraph > default` card border
- * cascade used by TaskNodeCollapsed.
+ * cascade used by TaskNodeSimplified.
  *
  * Each consumer provides its own base classes (sizing, rounding, etc.)
  * while the compound variant logic (border color + ring) stays DRY.


### PR DESCRIPTION
## Description

This PR introduces the v1 "Collapsible Nodes" functionality in the v2 editor. Feature parity should be identical. Collapsed state is toggleable via Task Configuration and should be visually the same and functionally the same as v1.

To facilitate this I have renamed the existing v2 "collapsed" nodes (which are the nodes rendered when greatly zxoomed out) to "simplified" nodes. I have done this to reduce in-code confusion about which feature is which (and thus leading to erroneous AI programming).



This PR also fixes an issue where annotations were not carried over when duplicating/copy-pasting a node.

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

Closes https://github.com/Shopify/oasis-frontend/issues/596

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix
- [x] New feature
- [x] Improvement
- [x] Cleanup/Refactor

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

![image.png](https://app.graphite.com/user-attachments/assets/0fb25615-cf3c-4596-af05-ad2d1eefc2b0.png)

![image.png](https://app.graphite.com/user-attachments/assets/e621f060-16f5-4454-b576-8850f26e3100.png)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

Select  a task in v2 editor. Go to configuration section and toggle "Collapse Node" on. Confirm that collapsed Node behaviour is identical to v1 editor. (unused inputs & outputs are hidden & collapsed state can be expanded by clicking the row).

Additionally, confirm that the existing v2 "collapse" functionality (now renamed to "simplified") also continues to work as expected - i.e. when zooming out the simplified node style will be rendered.

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->