### PR TITLE
chore: v2: Improve Simplified Nodes

### DIFF
--- a/src/routes/v2/pages/Editor/EditorV2.tsx
+++ b/src/routes/v2/pages/Editor/EditorV2.tsx
@@ -1,4 +1,5 @@
 import "@xyflow/react/dist/style.css";
+import "@/styles/editor.css";
 
 import { useParams, useSearch } from "@tanstack/react-router";
 import { ReactFlowProvider } from "@xyflow/react";

--- a/src/routes/v2/pages/Editor/components/FlowCanvas/FlowCanvas.tsx
+++ b/src/routes/v2/pages/Editor/components/FlowCanvas/FlowCanvas.tsx
@@ -19,6 +19,7 @@ import { useDoubleClickBehavior } from "@/routes/v2/shared/hooks/useDoubleClickB
 import { useFitViewOnFocus } from "@/routes/v2/shared/hooks/useFitViewOnFocus";
 import { useFlowCanvasState } from "@/routes/v2/shared/hooks/useFlowCanvasState";
 import { focusModeStore } from "@/routes/v2/shared/hooks/useFocusMode";
+import { useIsDetailedView } from "@/routes/v2/shared/hooks/useIsDetailedView";
 import { useViewportScaling } from "@/routes/v2/shared/hooks/useViewportScaling";
 import { useNodeRegistry } from "@/routes/v2/shared/nodes/NodeRegistryContext";
 import { CMDALT, SHIFT } from "@/routes/v2/shared/shortcuts/keys";
@@ -55,6 +56,7 @@ export const FlowCanvas = observer(function FlowCanvas({
   const metaKeyPressed = keyboard.pressed.has(CMDALT);
   const shiftKeyPressed = keyboard.pressed.has(SHIFT);
   const isConnecting = useConnection((c) => c.inProgress);
+  const isDetailedView = useIsDetailedView();
 
   const {
     displayNodes,
@@ -96,6 +98,8 @@ export const FlowCanvas = observer(function FlowCanvas({
         edgeTypes={edgeTypes}
         nodes={displayNodes}
         edges={displayEdges}
+        nodesConnectable={isDetailedView}
+        edgesReconnectable={isDetailedView}
         {...selectionBehavior}
         {...nodeEdgeBehavior}
         {...connectionBehavior}
@@ -107,7 +111,10 @@ export const FlowCanvas = observer(function FlowCanvas({
         onViewportChange={handleViewportChange}
         connectionLineComponent={ConnectionLine}
         deleteKeyCode={DELETE_KEY_CODE}
-        className={cn(shiftKeyPressed && !isConnecting && "cursor-crosshair")}
+        className={cn(
+          shiftKeyPressed && !isConnecting && "cursor-crosshair",
+          !isDetailedView && "connections-disabled",
+        )}
       >
         <FloatingSelectionToolbar spec={spec} />
         <Background gap={10} className="bg-slate-50!" />

--- a/src/routes/v2/pages/Editor/nodes/FlexNode/components/FlexNode.tsx
+++ b/src/routes/v2/pages/Editor/nodes/FlexNode/components/FlexNode.tsx
@@ -1,32 +1,24 @@
-import {
-  type Node,
-  type NodeProps,
-  NodeResizer,
-  type ResizeDragEvent,
-  type ResizeParams,
-} from "@xyflow/react";
+import { type Node, type NodeProps } from "@xyflow/react";
 import { cva } from "class-variance-authority";
 import { observer } from "mobx-react-lite";
-import { type MouseEvent, useState } from "react";
+import { type MouseEvent } from "react";
 
-import { InlineTextEditor } from "@/components/shared/ReactFlow/FlowCanvas/FlexNode/InlineTextEditor";
-import LockToggle from "@/components/shared/ReactFlow/FlowCanvas/FlexNode/LockToggle";
 import type { FlexNodeData } from "@/components/shared/ReactFlow/FlowCanvas/FlexNode/types";
-import { BlockStack } from "@/components/ui/layout";
-import { cn } from "@/lib/utils";
 import {
   updateFlexNode,
   updateFlexNodeProperties,
 } from "@/routes/v2/pages/Editor/nodes/FlexNode/flexNode.actions";
 import { useEditorSession } from "@/routes/v2/pages/Editor/store/EditorSessionContext";
+import { useIsDetailedView } from "@/routes/v2/shared/hooks/useIsDetailedView";
 import { useSpec } from "@/routes/v2/shared/providers/SpecContext";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 
+import { FlexNodeCard } from "./FlexNodeCard";
+import { FlexNodeSimplified } from "./FlexNodeSimplified";
+
 type FlexNodeProps = NodeProps<Node<FlexNodeData, "flex">>;
 
-const MIN_SIZE = { width: 50, height: 50 };
-
-const flexNodeVariants = cva("p-1 rounded-lg h-full w-full group", {
+export const flexNodeVariants = cva("p-1 rounded-lg h-full w-full group", {
   variants: {
     readOnlySelected: { true: "ring-2 ring-ring", false: "" },
     locked: { true: "cursor-grab", false: "" },
@@ -62,87 +54,26 @@ const flexNodeVariants = cva("p-1 rounded-lg h-full w-full group", {
   },
 });
 
-function FlexNodeTitle({
-  title,
-  fontSize,
-  editing,
-  locked,
-  onSave,
-  onCancel,
-  onTab,
-  onDoubleClick,
-}: {
+export interface FlexNodeViewProps {
+  id: string;
   title: string;
-  fontSize: number;
-  editing: boolean;
-  locked: boolean;
-  onSave: (value: string) => void;
-  onCancel: () => void;
-  onTab: () => void;
-  onDoubleClick: (e: MouseEvent<HTMLParagraphElement>) => void;
-}) {
-  if (!title) return null;
-
-  if (editing) {
-    return (
-      <InlineTextEditor
-        value={title}
-        placeholder="Enter title..."
-        textSize={fontSize}
-        onSave={onSave}
-        onCancel={onCancel}
-        onTab={onTab}
-        className="font-bold"
-      />
-    );
-  }
-
-  // Raw <p> required: user-configurable fontSize needs inline style which Text doesn't accept
-  return (
-    <p
-      style={{ fontSize }}
-      className="font-bold whitespace-pre-wrap w-full"
-      onDoubleClick={locked ? undefined : onDoubleClick}
-    >
-      {title}
-    </p>
-  );
-}
-
-function FlexNodeContent({
-  content,
-  fontSize,
-  editing,
-  onSave,
-  onCancel,
-  onTab,
-}: {
   content: string;
-  fontSize: number;
-  editing: boolean;
-  onSave: (value: string) => void;
-  onCancel: () => void;
-  onTab: () => void;
-}) {
-  if (editing) {
-    return (
-      <InlineTextEditor
-        value={content}
-        placeholder="Enter text..."
-        textSize={fontSize}
-        onSave={onSave}
-        onCancel={onCancel}
-        onTab={onTab}
-      />
-    );
-  }
-
-  // Raw <p> required: user-configurable fontSize needs inline style which Text doesn't accept
-  return (
-    <p style={{ fontSize }} className="whitespace-pre-wrap">
-      {content}
-    </p>
-  );
+  color: string;
+  borderColor?: string;
+  titleFontSize: number;
+  contentFontSize: number;
+  locked: boolean;
+  readOnly: boolean;
+  selected: boolean;
+  isTransparent: boolean;
+  isBorderTransparent: boolean;
+  hasContent: boolean;
+  onNodeClick: (e: MouseEvent) => void;
+  onUpdateProperties: (
+    propertyUpdates: Partial<FlexNodeData["properties"]>,
+  ) => void;
+  onUpdateNode: (updates: Partial<FlexNodeData>) => void;
+  onToggleLock: () => void;
 }
 
 export const EditorV2FlexNode = observer(function EditorV2FlexNode({
@@ -153,6 +84,7 @@ export const EditorV2FlexNode = observer(function EditorV2FlexNode({
   const { editor } = useSharedStores();
   const { undo } = useEditorSession();
   const spec = useSpec();
+  const showContent = useIsDetailedView();
 
   const { properties, readOnly, locked = false } = data;
   const {
@@ -164,23 +96,20 @@ export const EditorV2FlexNode = observer(function EditorV2FlexNode({
     contentFontSize = 10,
   } = properties;
 
-  const [isInlineEditingContent, setIsInlineEditingContent] = useState(false);
-  const [isInlineEditingTitle, setIsInlineEditingTitle] = useState(false);
-
-  const updateCurrentFlexNode = (updates: Partial<FlexNodeData>) => {
+  const handleUpdateNode = (updates: Partial<FlexNodeData>) => {
     if (!spec) return;
     updateFlexNode(undo, spec, id, updates);
   };
 
-  const updateProperties = (
+  const handleUpdateProperties = (
     propertyUpdates: Partial<FlexNodeData["properties"]>,
   ) => {
     if (!spec) return;
     updateFlexNodeProperties(undo, spec, id, propertyUpdates);
   };
 
-  const toggleLock = () => {
-    updateCurrentFlexNode({ locked: !locked });
+  const handleToggleLock = () => {
+    handleUpdateNode({ locked: !locked });
   };
 
   const handleClick = (e: MouseEvent) => {
@@ -190,115 +119,33 @@ export const EditorV2FlexNode = observer(function EditorV2FlexNode({
     }
   };
 
-  const handleDoubleClick = (e: MouseEvent) => {
-    e.stopPropagation();
-    e.preventDefault();
-    if (locked || readOnly) return;
-    setIsInlineEditingTitle(false);
-    setIsInlineEditingContent(true);
-  };
-
-  const handleDoubleClickTitle = (e: MouseEvent<HTMLParagraphElement>) => {
-    e.stopPropagation();
-    if (locked) {
-      toggleLock();
-      return;
-    }
-    if (!readOnly) {
-      setIsInlineEditingContent(false);
-      setIsInlineEditingTitle(true);
-    }
-  };
-
-  const handleResizeEnd = (_: ResizeDragEvent, params: ResizeParams) => {
-    updateCurrentFlexNode({
-      size: {
-        width: Math.max(params.width, MIN_SIZE.width),
-        height: Math.max(params.height, MIN_SIZE.height),
-      },
-      position: { x: params.x, y: params.y },
-    });
-  };
-
-  const switchEditor = () => {
-    setIsInlineEditingTitle((prev) => !prev);
-    setIsInlineEditingContent((prev) => !prev);
-  };
-
   const isTransparent = color === "transparent";
   const isBorderTransparent = borderColor === "transparent";
   const hasContent = !!title || !!content;
 
-  return (
-    <>
-      {!readOnly && (
-        <NodeResizer
-          color="var(--edge-selected)"
-          isVisible={selected}
-          minWidth={50}
-          minHeight={50}
-          onResizeEnd={handleResizeEnd}
-        />
-      )}
-      <div
-        key={id}
-        className={flexNodeVariants({
-          readOnlySelected: !!(readOnly && selected),
-          locked,
-          transparent: isTransparent,
-          hasContent,
-          borderTransparent: isBorderTransparent,
-        })}
-        style={{
-          backgroundColor: color,
-          borderColor: isTransparent ? borderColor : undefined,
-        }}
-        onClick={handleClick}
-        onDoubleClick={handleDoubleClick}
-      >
-        <div
-          className={cn(
-            "rounded-sm p-1 h-full w-full overflow-hidden",
-            isTransparent ? "bg-transparent" : "bg-white/40",
-          )}
-        >
-          <BlockStack gap="1" className="w-full">
-            <LockToggle
-              size="xs"
-              locked={locked}
-              onToggleLock={toggleLock}
-              showOnlyOnHover
-              className="absolute top-1 right-1"
-            />
+  const viewProps: FlexNodeViewProps = {
+    id,
+    title,
+    content,
+    color,
+    borderColor,
+    titleFontSize,
+    contentFontSize,
+    locked,
+    readOnly: !!readOnly,
+    selected: !!selected,
+    isTransparent,
+    isBorderTransparent,
+    hasContent,
+    onNodeClick: handleClick,
+    onUpdateProperties: handleUpdateProperties,
+    onUpdateNode: handleUpdateNode,
+    onToggleLock: handleToggleLock,
+  };
 
-            <FlexNodeTitle
-              title={title}
-              fontSize={titleFontSize}
-              editing={isInlineEditingTitle}
-              locked={locked}
-              onSave={(newTitle) => {
-                updateProperties({ title: newTitle });
-                setIsInlineEditingTitle(false);
-              }}
-              onCancel={() => setIsInlineEditingTitle(false)}
-              onTab={switchEditor}
-              onDoubleClick={handleDoubleClickTitle}
-            />
+  if (!showContent) {
+    return <FlexNodeSimplified {...viewProps} />;
+  }
 
-            <FlexNodeContent
-              content={content}
-              fontSize={contentFontSize}
-              editing={isInlineEditingContent}
-              onSave={(newContent) => {
-                updateProperties({ content: newContent });
-                setIsInlineEditingContent(false);
-              }}
-              onCancel={() => setIsInlineEditingContent(false)}
-              onTab={switchEditor}
-            />
-          </BlockStack>
-        </div>
-      </div>
-    </>
-  );
+  return <FlexNodeCard {...viewProps} />;
 });

--- a/src/routes/v2/pages/Editor/nodes/FlexNode/components/FlexNodeCard.tsx
+++ b/src/routes/v2/pages/Editor/nodes/FlexNode/components/FlexNodeCard.tsx
@@ -1,0 +1,229 @@
+import {
+  NodeResizer,
+  type ResizeDragEvent,
+  type ResizeParams,
+} from "@xyflow/react";
+import { type MouseEvent, useState } from "react";
+
+import { InlineTextEditor } from "@/components/shared/ReactFlow/FlowCanvas/FlexNode/InlineTextEditor";
+import LockToggle from "@/components/shared/ReactFlow/FlowCanvas/FlexNode/LockToggle";
+import { BlockStack } from "@/components/ui/layout";
+import { cn } from "@/lib/utils";
+
+import { flexNodeVariants, type FlexNodeViewProps } from "./FlexNode";
+
+const MIN_SIZE = { width: 50, height: 50 };
+
+function FlexNodeTitle({
+  title,
+  fontSize,
+  editing,
+  locked,
+  onSave,
+  onCancel,
+  onTab,
+  onDoubleClick,
+}: {
+  title: string;
+  fontSize: number;
+  editing: boolean;
+  locked: boolean;
+  onSave: (value: string) => void;
+  onCancel: () => void;
+  onTab: () => void;
+  onDoubleClick: (e: MouseEvent<HTMLParagraphElement>) => void;
+}) {
+  if (!title) return null;
+
+  if (editing) {
+    return (
+      <InlineTextEditor
+        value={title}
+        placeholder="Enter title..."
+        textSize={fontSize}
+        onSave={onSave}
+        onCancel={onCancel}
+        onTab={onTab}
+        className="font-bold"
+      />
+    );
+  }
+
+  // Raw <p> required: user-configurable fontSize needs inline style which Text doesn't accept
+  return (
+    <p
+      style={{ fontSize }}
+      className="font-bold whitespace-pre-wrap w-full"
+      onDoubleClick={locked ? undefined : onDoubleClick}
+    >
+      {title}
+    </p>
+  );
+}
+
+function FlexNodeContent({
+  content,
+  fontSize,
+  editing,
+  onSave,
+  onCancel,
+  onTab,
+}: {
+  content: string;
+  fontSize: number;
+  editing: boolean;
+  onSave: (value: string) => void;
+  onCancel: () => void;
+  onTab: () => void;
+}) {
+  if (editing) {
+    return (
+      <InlineTextEditor
+        value={content}
+        placeholder="Enter text..."
+        textSize={fontSize}
+        onSave={onSave}
+        onCancel={onCancel}
+        onTab={onTab}
+      />
+    );
+  }
+
+  // Raw <p> required: user-configurable fontSize needs inline style which Text doesn't accept
+  return (
+    <p style={{ fontSize }} className="whitespace-pre-wrap">
+      {content}
+    </p>
+  );
+}
+
+export function FlexNodeCard({
+  id,
+  title,
+  content,
+  color,
+  borderColor,
+  titleFontSize,
+  contentFontSize,
+  locked,
+  readOnly,
+  selected,
+  isTransparent,
+  isBorderTransparent,
+  hasContent,
+  onNodeClick,
+  onUpdateProperties,
+  onUpdateNode,
+  onToggleLock,
+}: FlexNodeViewProps) {
+  const [isInlineEditingContent, setIsInlineEditingContent] = useState(false);
+  const [isInlineEditingTitle, setIsInlineEditingTitle] = useState(false);
+
+  const handleDoubleClick = (e: MouseEvent) => {
+    e.stopPropagation();
+    e.preventDefault();
+    if (locked || readOnly) return;
+    setIsInlineEditingTitle(false);
+    setIsInlineEditingContent(true);
+  };
+
+  const handleDoubleClickTitle = (e: MouseEvent<HTMLParagraphElement>) => {
+    e.stopPropagation();
+    if (locked) {
+      onToggleLock();
+      return;
+    }
+    if (!readOnly) {
+      setIsInlineEditingContent(false);
+      setIsInlineEditingTitle(true);
+    }
+  };
+
+  const handleResizeEnd = (_: ResizeDragEvent, params: ResizeParams) => {
+    onUpdateNode({
+      size: {
+        width: Math.max(params.width, MIN_SIZE.width),
+        height: Math.max(params.height, MIN_SIZE.height),
+      },
+      position: { x: params.x, y: params.y },
+    });
+  };
+
+  const switchEditor = () => {
+    setIsInlineEditingTitle((prev) => !prev);
+    setIsInlineEditingContent((prev) => !prev);
+  };
+
+  return (
+    <>
+      {!readOnly && (
+        <NodeResizer
+          color="var(--edge-selected)"
+          isVisible={selected}
+          minWidth={MIN_SIZE.width}
+          minHeight={MIN_SIZE.height}
+          onResizeEnd={handleResizeEnd}
+        />
+      )}
+      <div
+        key={id}
+        className={flexNodeVariants({
+          readOnlySelected: !!(readOnly && selected),
+          locked,
+          transparent: isTransparent,
+          hasContent,
+          borderTransparent: isBorderTransparent,
+        })}
+        style={{
+          backgroundColor: color,
+          borderColor: isTransparent ? borderColor : undefined,
+        }}
+        onClick={onNodeClick}
+        onDoubleClick={handleDoubleClick}
+      >
+        <div
+          className={cn(
+            "rounded-sm p-1 h-full w-full overflow-hidden",
+            isTransparent ? "bg-transparent" : "bg-white/40",
+          )}
+        >
+          <BlockStack gap="1" className="w-full">
+            <LockToggle
+              size="xs"
+              locked={locked}
+              onToggleLock={onToggleLock}
+              showOnlyOnHover
+              className="absolute top-1 right-1"
+            />
+
+            <FlexNodeTitle
+              title={title}
+              fontSize={titleFontSize}
+              editing={isInlineEditingTitle}
+              locked={locked}
+              onSave={(newTitle) => {
+                onUpdateProperties({ title: newTitle });
+                setIsInlineEditingTitle(false);
+              }}
+              onCancel={() => setIsInlineEditingTitle(false)}
+              onTab={switchEditor}
+              onDoubleClick={handleDoubleClickTitle}
+            />
+
+            <FlexNodeContent
+              content={content}
+              fontSize={contentFontSize}
+              editing={isInlineEditingContent}
+              onSave={(newContent) => {
+                onUpdateProperties({ content: newContent });
+                setIsInlineEditingContent(false);
+              }}
+              onCancel={() => setIsInlineEditingContent(false)}
+              onTab={switchEditor}
+            />
+          </BlockStack>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/routes/v2/pages/Editor/nodes/FlexNode/components/FlexNodeSimplified.tsx
+++ b/src/routes/v2/pages/Editor/nodes/FlexNode/components/FlexNodeSimplified.tsx
@@ -1,0 +1,66 @@
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { Paragraph } from "@/components/ui/typography";
+import { cn } from "@/lib/utils";
+
+import { flexNodeVariants, type FlexNodeViewProps } from "./FlexNode";
+
+export function FlexNodeSimplified({
+  id,
+  title,
+  color,
+  borderColor,
+  locked,
+  readOnly,
+  selected,
+  isTransparent,
+  isBorderTransparent,
+  hasContent,
+  onNodeClick,
+}: FlexNodeViewProps) {
+  const node = (
+    <div
+      key={id}
+      className={flexNodeVariants({
+        readOnlySelected: !!(readOnly && selected),
+        locked,
+        transparent: isTransparent,
+        hasContent,
+        borderTransparent: isBorderTransparent,
+      })}
+      style={{
+        backgroundColor: color,
+        borderColor: isTransparent ? borderColor : undefined,
+      }}
+      onClick={onNodeClick}
+    >
+      <div
+        className={cn(
+          "rounded-sm h-full w-full p-2 overflow-hidden flex items-start",
+          isTransparent ? "bg-transparent" : "bg-white/40",
+        )}
+      >
+        {title && (
+          <Paragraph
+            weight="semibold"
+            className="whitespace-pre-wrap line-clamp-3 wrap-break-word w-full text-[calc(var(--simplified-scale,1)*24px)] leading-tight"
+          >
+            {title}
+          </Paragraph>
+        )}
+      </div>
+    </div>
+  );
+
+  if (!title) return node;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{node}</TooltipTrigger>
+      <TooltipContent side="top">{title}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/src/routes/v2/shared/hooks/useIsDetailedView.ts
+++ b/src/routes/v2/shared/hooks/useIsDetailedView.ts
@@ -1,0 +1,15 @@
+import { useStore } from "@xyflow/react";
+
+import { ZOOM_THRESHOLD } from "@/routes/v2/shared/flowCanvasDefaults";
+
+const zoomSelector = (s: { transform: [number, number, number] }) =>
+  s.transform[2] >= ZOOM_THRESHOLD;
+
+/**
+ * Returns true when the canvas is zoomed in enough to render the full,
+ * detailed view of nodes and edges. When false, consumers should render
+ * a simplified representation (larger text, fewer details, thicker edges).
+ */
+export function useIsDetailedView(): boolean {
+  return useStore(zoomSelector);
+}

--- a/src/routes/v2/shared/nodes/ConduitNode/edges/ConduitEdge.tsx
+++ b/src/routes/v2/shared/nodes/ConduitNode/edges/ConduitEdge.tsx
@@ -1,11 +1,14 @@
 import type { EdgeProps } from "@xyflow/react";
 import type { CSSProperties } from "react";
 
+import { useIsDetailedView } from "@/routes/v2/shared/hooks/useIsDetailedView";
 import type { ConduitEdgeData } from "@/routes/v2/shared/nodes/types";
 
 import { buildConduitPath } from "./conduitPathUtils";
 
 const DEBUG_POINTS = false;
+
+const SIMPLIFIED_STROKE_MULTIPLIER = 1.5;
 
 interface EdgeStyleParams {
   baseStyle: CSSProperties | undefined;
@@ -14,6 +17,7 @@ interface EdgeStyleParams {
   isAssigned: boolean;
   activeColor: string | undefined;
   selected: boolean | undefined;
+  strokeMultiplier: number;
 }
 
 function computeEdgeStyle({
@@ -23,17 +27,21 @@ function computeEdgeStyle({
   isAssigned,
   activeColor,
   selected,
+  strokeMultiplier,
 }: EdgeStyleParams): CSSProperties {
+  const baseWidth = 4 * strokeMultiplier;
+  const emphasisWidth = 5 * strokeMultiplier;
+
   let edgeStyle: CSSProperties = conduitColor
-    ? { ...baseStyle, stroke: conduitColor, strokeWidth: 4 }
-    : { ...baseStyle, stroke: "#6b7280", strokeWidth: 4 };
+    ? { ...baseStyle, stroke: conduitColor, strokeWidth: baseWidth }
+    : { ...baseStyle, stroke: "#6b7280", strokeWidth: baseWidth };
 
   if (isInAssignmentMode) {
     if (isAssigned && activeColor) {
       edgeStyle = {
         ...edgeStyle,
         stroke: activeColor,
-        strokeWidth: 5,
+        strokeWidth: emphasisWidth,
         opacity: 1,
       };
     } else {
@@ -45,7 +53,7 @@ function computeEdgeStyle({
     edgeStyle = {
       ...edgeStyle,
       stroke: "#5b2ef4",
-      strokeWidth: 5,
+      strokeWidth: emphasisWidth,
       opacity: 1,
     };
   }
@@ -80,6 +88,9 @@ export function ConduitEdge({
   style,
   selected,
 }: EdgeProps) {
+  const showContent = useIsDetailedView();
+  const strokeMultiplier = showContent ? 1 : SIMPLIFIED_STROKE_MULTIPLIER;
+
   const {
     guidelines,
     conduitColor,
@@ -106,6 +117,7 @@ export function ConduitEdge({
     isAssigned,
     activeColor,
     selected,
+    strokeMultiplier,
   });
 
   const edgeColor = (edgeStyle.stroke as string) ?? "#6b7280";

--- a/src/routes/v2/shared/nodes/IONode/IONode.tsx
+++ b/src/routes/v2/shared/nodes/IONode/IONode.tsx
@@ -1,16 +1,29 @@
-import { Handle, type Node, type NodeProps, Position } from "@xyflow/react";
+import { type Node, type NodeProps } from "@xyflow/react";
 import { observer } from "mobx-react-lite";
 
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { BlockStack, InlineStack } from "@/components/ui/layout";
-import { Paragraph } from "@/components/ui/typography";
-import { cn } from "@/lib/utils";
+import { useIsDetailedView } from "@/routes/v2/shared/hooks/useIsDetailedView";
 import type { IONodeData } from "@/routes/v2/shared/nodes/types";
 import { useSpec } from "@/routes/v2/shared/providers/SpecContext";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 
+import { IONodeCard } from "./IONodeCard";
+import { IONodeSimplified } from "./IONodeSimplified";
+
 type IONodeType = Node<IONodeData, "input" | "output">;
 type IONodeProps = NodeProps<IONodeType>;
+
+export interface IONodeViewProps {
+  entityId: string;
+  name: string;
+  type?: string;
+  description?: string;
+  defaultValue?: string;
+  connectedValue: string | null;
+  isInput: boolean;
+  selected: boolean;
+  isHovered: boolean;
+  onNodeClick: (event: React.MouseEvent) => void;
+}
 
 function typeToString(type: unknown): string | undefined {
   if (type === undefined || type === null) return undefined;
@@ -25,6 +38,7 @@ export const IONode = observer(function IONode({
 }: IONodeProps) {
   const { entityId, ioType } = data;
   const { editor } = useSharedStores();
+  const showContent = useIsDetailedView();
 
   const spec = useSpec();
   const isInput = ioType === "input";
@@ -45,7 +59,6 @@ export const IONode = observer(function IONode({
   const description = entity?.description;
   const isHovered = editor.hoveredEntityId === entityId;
 
-  // For outputs, find the connected task and port name
   let connectedValue: string | null = null;
   if (!isInput && spec && entity) {
     const binding = [...spec.bindings].find(
@@ -61,73 +74,27 @@ export const IONode = observer(function IONode({
     }
   }
 
-  const bgColor = isInput ? "bg-blue-100" : "bg-violet-100";
-  const borderColor = selected
-    ? isInput
-      ? "border-blue-500"
-      : "border-violet-500"
-    : isHovered
-      ? "border-amber-400 ring-2 ring-amber-300"
-      : isInput
-        ? "border-blue-300 hover:border-blue-400"
-        : "border-violet-300 hover:border-violet-400";
+  const defaultValue =
+    isInput && entity && "defaultValue" in entity
+      ? (entity.defaultValue ?? undefined)
+      : undefined;
 
-  return (
-    <Card
-      className={cn(
-        "border-2 max-w-60 p-0 cursor-pointer transition-all",
-        bgColor,
-        borderColor,
-      )}
-      onClick={handleClick}
-    >
-      <CardHeader className="p-2">
-        <CardTitle className="wrap-break-word text-sm">{name}</CardTitle>
-        {description && (
-          <Paragraph tone="subdued" className="italic truncate text-xs">
-            {description}
-          </Paragraph>
-        )}
-      </CardHeader>
-      <CardContent className="p-2 max-w-60">
-        <BlockStack gap="2">
-          <Paragraph size="xs" font="mono" className="truncate text-slate-700">
-            <span className="font-bold">Type:</span> {type ?? "Any"}
-          </Paragraph>
+  const viewProps: IONodeViewProps = {
+    entityId,
+    name,
+    type,
+    description,
+    defaultValue,
+    connectedValue,
+    isInput,
+    selected: !!selected,
+    isHovered,
+    onNodeClick: handleClick,
+  };
 
-          <InlineStack gap="1" className="p-2 bg-white rounded-lg w-full">
-            <Paragraph
-              size="xs"
-              font="mono"
-              weight="bold"
-              className="text-slate-700"
-            >
-              Value:
-            </Paragraph>
-            <Paragraph
-              size="xs"
-              font="mono"
-              tone="subdued"
-              className="truncate"
-            >
-              {isInput
-                ? ((entity && "defaultValue" in entity
-                    ? entity.defaultValue
-                    : null) ?? "No value")
-                : (connectedValue ?? "No value")}
-            </Paragraph>
-          </InlineStack>
-        </BlockStack>
-        <Handle
-          type={isInput ? "source" : "target"}
-          position={isInput ? Position.Right : Position.Left}
-          id={isInput ? `output_${entityId}` : `input_${entityId}`}
-          className={cn(
-            "w-3! h-3! border-0! transform-none! bg-gray-500!",
-            isInput ? "translate-x-1.5" : "-translate-x-1.5",
-          )}
-        />
-      </CardContent>
-    </Card>
-  );
+  if (!showContent) {
+    return <IONodeSimplified {...viewProps} />;
+  }
+
+  return <IONodeCard {...viewProps} />;
 });

--- a/src/routes/v2/shared/nodes/IONode/IONodeCard.tsx
+++ b/src/routes/v2/shared/nodes/IONode/IONodeCard.tsx
@@ -1,0 +1,89 @@
+import { Handle, Position } from "@xyflow/react";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Paragraph } from "@/components/ui/typography";
+import { cn } from "@/lib/utils";
+
+import type { IONodeViewProps } from "./IONode";
+
+export function IONodeCard({
+  entityId,
+  name,
+  type,
+  description,
+  defaultValue,
+  connectedValue,
+  isInput,
+  selected,
+  isHovered,
+  onNodeClick,
+}: IONodeViewProps) {
+  const bgColor = isInput ? "bg-blue-100" : "bg-violet-100";
+  const borderColor = selected
+    ? isInput
+      ? "border-blue-500"
+      : "border-violet-500"
+    : isHovered
+      ? "border-amber-400 ring-2 ring-amber-300"
+      : isInput
+        ? "border-blue-300 hover:border-blue-400"
+        : "border-violet-300 hover:border-violet-400";
+
+  return (
+    <Card
+      className={cn(
+        "border-2 max-w-60 p-0 cursor-pointer transition-all",
+        bgColor,
+        borderColor,
+      )}
+      onClick={onNodeClick}
+    >
+      <CardHeader className="p-2">
+        <CardTitle className="wrap-break-word text-sm">{name}</CardTitle>
+        {description && (
+          <Paragraph tone="subdued" className="italic truncate text-xs">
+            {description}
+          </Paragraph>
+        )}
+      </CardHeader>
+      <CardContent className="p-2 max-w-60">
+        <BlockStack gap="2">
+          <Paragraph size="xs" font="mono" className="truncate text-slate-700">
+            <span className="font-bold">Type:</span> {type ?? "Any"}
+          </Paragraph>
+
+          <InlineStack gap="1" className="p-2 bg-white rounded-lg w-full">
+            <Paragraph
+              size="xs"
+              font="mono"
+              weight="bold"
+              className="text-slate-700"
+            >
+              Value:
+            </Paragraph>
+            <Paragraph
+              size="xs"
+              font="mono"
+              tone="subdued"
+              className="truncate"
+            >
+              {isInput
+                ? (defaultValue ?? "No value")
+                : (connectedValue ?? "No value")}
+            </Paragraph>
+          </InlineStack>
+        </BlockStack>
+        <Handle
+          type={isInput ? "source" : "target"}
+          position={isInput ? Position.Right : Position.Left}
+          id={isInput ? `output_${entityId}` : `input_${entityId}`}
+          className={cn(
+            "w-3! h-3! border-0! transform-none! bg-gray-500!",
+            isInput ? "translate-x-1.5" : "-translate-x-1.5",
+          )}
+        />
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/routes/v2/shared/nodes/IONode/IONodeSimplified.tsx
+++ b/src/routes/v2/shared/nodes/IONode/IONodeSimplified.tsx
@@ -1,0 +1,95 @@
+import { Handle, Position } from "@xyflow/react";
+
+import { Card } from "@/components/ui/card";
+import { Icon } from "@/components/ui/icon";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+
+import type { IONodeViewProps } from "./IONode";
+
+const s = "var(--simplified-scale, 1)";
+
+export function IONodeSimplified({
+  entityId,
+  name,
+  isInput,
+  selected,
+  isHovered,
+  onNodeClick,
+}: IONodeViewProps) {
+  const bgColor = isInput ? "bg-blue-100" : "bg-violet-100";
+  const borderColor = selected
+    ? isInput
+      ? "border-blue-500"
+      : "border-violet-500"
+    : isHovered
+      ? "border-amber-400 ring-2 ring-amber-300"
+      : isInput
+        ? "border-blue-300 hover:border-blue-400"
+        : "border-violet-300 hover:border-violet-400";
+
+  return (
+    <Card
+      className={cn(
+        "border-2 p-0 cursor-pointer transition-all flex flex-row items-center justify-start",
+        bgColor,
+        borderColor,
+      )}
+      style={{
+        width: `calc(${s} * 220px)`,
+        height: `calc(${s} * 80px)`,
+        padding: `calc(${s} * 12px) calc(${s} * 16px)`,
+        gap: `calc(${s} * 10px)`,
+      }}
+      onClick={onNodeClick}
+    >
+      <div
+        className="shrink-0"
+        style={{
+          width: `calc(${s} * 32px)`,
+          height: `calc(${s} * 32px)`,
+        }}
+      >
+        <Icon
+          name={isInput ? "SquareArrowRightEnter" : "SquareArrowRightExit"}
+          className={cn(
+            "h-full! w-full!",
+            isInput ? "text-blue-600" : "text-violet-600",
+          )}
+        />
+      </div>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span
+            className="font-medium min-w-0 line-clamp-2 wrap-break-word text-slate-900 text-left"
+            style={{
+              fontSize: `calc(${s} * 24px)`,
+              lineHeight: 1.25,
+            }}
+          >
+            {name}
+          </span>
+        </TooltipTrigger>
+        <TooltipContent side="top">{name}</TooltipContent>
+      </Tooltip>
+      <Handle
+        type={isInput ? "source" : "target"}
+        position={isInput ? Position.Right : Position.Left}
+        id={isInput ? `output_${entityId}` : `input_${entityId}`}
+        style={{
+          top: "50%",
+          width: `calc(${s} * 12px)`,
+          height: `calc(${s} * 12px)`,
+          ...(isInput
+            ? { right: `calc(${s} * -4px)` }
+            : { left: `calc(${s} * -4px)` }),
+        }}
+        className="bg-gray-500! border-0!"
+      />
+    </Card>
+  );
+}

--- a/src/routes/v2/shared/nodes/TaskNode/TaskNode.tsx
+++ b/src/routes/v2/shared/nodes/TaskNode/TaskNode.tsx
@@ -1,9 +1,4 @@
-import {
-  type Node,
-  type NodeProps,
-  useReactFlow,
-  useStore,
-} from "@xyflow/react";
+import { type Node, type NodeProps, useReactFlow } from "@xyflow/react";
 import { observer } from "mobx-react-lite";
 import type { MouseEvent, ReactElement } from "react";
 
@@ -16,7 +11,7 @@ import type {
   Task,
   TypeSpecType,
 } from "@/models/componentSpec";
-import { ZOOM_THRESHOLD } from "@/routes/v2/shared/flowCanvasDefaults";
+import { useIsDetailedView } from "@/routes/v2/shared/hooks/useIsDetailedView";
 import type { TaskNodeData } from "@/routes/v2/shared/nodes/types";
 import { useSpec } from "@/routes/v2/shared/providers/SpecContext";
 import type { NodeOverlayEffect } from "@/routes/v2/shared/store/canvasOverlay.types";
@@ -65,9 +60,6 @@ export interface TaskNodeViewProps {
   onOutputClick: (outputName: string, event: React.MouseEvent) => void;
   onHandleClick: (handleId: string, event: React.MouseEvent) => void;
 }
-
-const zoomSelector = (s: { transform: [number, number, number] }) =>
-  s.transform[2] >= ZOOM_THRESHOLD;
 
 function isTaskSubgraph(componentSpec: ComponentSpecJson | undefined): boolean {
   const implementation = componentSpec?.implementation;
@@ -202,7 +194,7 @@ export const TaskNode = observer(function TaskNode({
   const { entityId } = data;
   const { editor, canvasOverlay } = useSharedStores();
   const { getEdges, setEdges } = useReactFlow();
-  const showContent = useStore(zoomSelector);
+  const showContent = useIsDetailedView();
 
   const spec = useSpec();
   const task = spec?.tasks.find((t) => t.$id === entityId);

--- a/src/routes/v2/shared/nodes/TaskNode/TaskNodeSimplified.tsx
+++ b/src/routes/v2/shared/nodes/TaskNode/TaskNodeSimplified.tsx
@@ -2,6 +2,11 @@ import { Handle, Position } from "@xyflow/react";
 
 import { Card } from "@/components/ui/card";
 import { Icon } from "@/components/ui/icon";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import {
   deriveColorPalette,
@@ -11,7 +16,6 @@ import {
 import type { TaskNodeViewProps } from "./TaskNode";
 import { createTaskNodeCardVariants } from "./taskNode.variants";
 
-const PERCEIVED_FONT_SIZE = "36px";
 const s = "var(--simplified-scale, 1)";
 
 const simplifiedCardVariants = createTaskNodeCardVariants(
@@ -41,9 +45,8 @@ export function TaskNodeSimplified({
         subgraph: isSubgraph,
       })}
       style={{
-        minWidth: `calc(${s} * 180px)`,
-        maxWidth: `calc(${s} * 280px)`,
-        minHeight: `calc(${s} * 100px)`,
+        width: `calc(${s} * 240px)`,
+        height: `calc(${s} * 96px)`,
         ...(taskColor
           ? {
               backgroundColor: taskColor,
@@ -66,46 +69,46 @@ export function TaskNodeSimplified({
             height: `calc(${s} * 12px)`,
             left: `calc(${s} * -4px)`,
           }}
-          className="!bg-blue-400 !border-2 !border-white"
+          className="bg-gray-500! border-0!"
         />
       ))}
 
       <div
-        className="flex items-start"
+        className="flex items-center w-full h-full"
         style={{
-          padding: `calc(${s} * 12px)`,
-          gap: `calc(${s} * 8px)`,
+          padding: `calc(${s} * 14px) calc(${s} * 18px)`,
+          gap: `calc(${s} * 10px)`,
         }}
       >
-        <div
-          className="shrink-0"
-          style={{
-            width: `calc(${s} * 16px)`,
-            height: `calc(${s} * 16px)`,
-            marginTop: `calc(${s} * 3.2px)`,
-            ...(taskColor ? { color: headerTextColor } : {}),
-          }}
-        >
-          <Icon
-            name={isSubgraph ? "Layers" : "Circle"}
-            className={cn(
-              "!h-full !w-full",
-              !taskColor && (isSubgraph ? "text-purple-600" : "text-blue-600"),
-            )}
-          />
-        </div>
-        <span
-          className={cn(
-            "font-semibold break-words min-w-0",
-            !taskColor && "text-slate-900",
-          )}
-          style={{
-            fontSize: `calc(${s} * ${PERCEIVED_FONT_SIZE})`,
-            lineHeight: 1.2,
-          }}
-        >
-          {taskName}
-        </span>
+        {isSubgraph && (
+          <div
+            className="shrink-0"
+            style={{
+              width: `calc(${s} * 32px)`,
+              height: `calc(${s} * 32px)`,
+              ...(taskColor ? { color: headerTextColor } : {}),
+            }}
+          >
+            <Icon
+              name="Workflow"
+              className={cn("h-full! w-full!", !taskColor && "text-blue-600")}
+            />
+          </div>
+        )}
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span
+              className={cn(
+                "font-medium min-w-0 line-clamp-2 wrap-break-word",
+                !taskColor && "text-slate-900",
+              )}
+              style={{ fontSize: `calc(${s} * 28px)`, lineHeight: 1.25 }}
+            >
+              {taskName}
+            </span>
+          </TooltipTrigger>
+          <TooltipContent side="top">{taskName}</TooltipContent>
+        </Tooltip>
       </div>
 
       {outputs.map((output) => (
@@ -120,7 +123,7 @@ export function TaskNodeSimplified({
             height: `calc(${s} * 12px)`,
             right: `calc(${s} * -4px)`,
           }}
-          className="!bg-green-400 !border-2 !border-white"
+          className="bg-gray-500! border-0!"
         />
       ))}
     </Card>

--- a/src/styles/editor.css
+++ b/src/styles/editor.css
@@ -15,6 +15,10 @@ details > * {
   cursor: crosshair;
 }
 
+.react-flow.connections-disabled .react-flow__handle {
+  cursor: inherit;
+}
+
 /* Input and output nodes reset styles */
 .react-flow__node-input,
 .react-flow__node-output,


### PR DESCRIPTION
## Description

Just a couple of small improvements to the zoomed-out node state to make it a little nicer to look at and work with.

Namely:

- Reduced font weight and font size of the text
- Fixed node size and truncated long names. Added a tooltip to compensate for truncated text
- Removed the weird circle thing
- Recoloured the input/output handles to the usual grey
- Edges are 50% thicker when zoomed out
- Added a zoomed-out view for Input and Output nodes: shows only node name
- Added a zoomed-out view for Flex Nodes: shows title only
- Nodes cannot be connected together when zoomed out

These changes do not affect v1 editor - only v2.

Also adds a shared utility `useIsDetailedView`.

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

Resolves https://github.com/Shopify/oasis-frontend/issues/600

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

before

![image.png](https://app.graphite.com/user-attachments/assets/06179cdf-e8ed-4b10-b291-72f381ca242c.png)

after

![image.png](https://app.graphite.com/user-attachments/assets/4789df4e-680d-4ca2-b6f5-36a5e2c72427.png)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

Open v2 editor with a variety of nodes.

Zoom out.

If you like the way it looks, approve the PR :)

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments