### PR TITLE
fix: show contextual artifact unavailability message in preview dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,16 +54,16 @@ If you find you are blocked by CORS, you will, for now, need to use the manual s
 
 If you complete these steps the app will launch on `127.0.0.1:8000` with the latest build you've created on the frontend.
 
-### Reporting errors to Bugsnag (Optional)
+### Environment Variables
 
-To enable error reporting, add the following to your `.env` file:
+Add these to a `.env` file at the root of `tangle-ui`.
 
-```bash
-VITE_BUGSNAG_API_KEY=your-api-key
-VITE_TANGLE_ENV=production
-```
-
-Both variables are required for Bugsnag to initialize. `VITE_TANGLE_ENV` sets the Bugsnag `releaseStage` (e.g. `development`, `staging`, `production`). If either variable is missing, error reporting will be disabled.
+| Variable                       | Required             | Description                                                                                                                                            |
+| ------------------------------ | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `VITE_BACKEND_API_URL`         | For backend features | URL of your Tangle backend (e.g. `http://127.0.0.1:8000`).                                                                                             |
+| `VITE_ARTIFACT_RETENTION_DAYS` | No                   | Number of days artifacts are stored by your backend. When set, the UI shows artifact expiry dates and warns when artifacts may no longer be available. |
+| `VITE_BUGSNAG_API_KEY`         | No                   | Bugsnag API key. Required alongside `VITE_TANGLE_ENV` to enable error reporting.                                                                       |
+| `VITE_TANGLE_ENV`              | No                   | Release stage passed to Bugsnag (e.g. `development`, `staging`, `production`).                                                                         |
 
 ## App features:
 

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/ArtifactRetentionNotice.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/ArtifactRetentionNotice.tsx
@@ -1,0 +1,27 @@
+import { InfoBox } from "@/components/shared/InfoBox";
+
+import { getArtifactRetentionDays } from "./artifactRetentionUtils";
+
+interface ArtifactRetentionNoticeProps {
+  title: string;
+}
+
+/**
+ * Section-level banner shown when artifacts from a pipeline run may have expired.
+ * Only renders retention context when VITE_ARTIFACT_RETENTION_DAYS is configured.
+ */
+export const ArtifactRetentionNotice = ({
+  title,
+}: ArtifactRetentionNoticeProps) => {
+  const retentionDays = getArtifactRetentionDays();
+  const note =
+    retentionDays !== null
+      ? `Artifacts are expected to expire after ${retentionDays} days and may no longer be available in remote storage.`
+      : "";
+
+  return (
+    <InfoBox title={title} variant="warning" width="full">
+      {note}
+    </InfoBox>
+  );
+};

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ArtifactPreviewError.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ArtifactPreviewError.tsx
@@ -1,0 +1,34 @@
+import type { ComponentProps } from "react";
+
+import { InfoBox } from "@/components/shared/InfoBox";
+
+import { getArtifactRetentionDays } from "../../artifactRetentionUtils";
+
+interface ArtifactPreviewErrorProps {
+  title: string;
+  preamble: string;
+  variant?: ComponentProps<typeof InfoBox>["variant"];
+}
+
+/**
+ * Error state shown inside the artifact preview dialog.
+ * Appends a retention hint when VITE_ARTIFACT_RETENTION_DAYS is configured.
+ */
+export const ArtifactPreviewError = ({
+  title,
+  preamble,
+  variant = "error",
+}: ArtifactPreviewErrorProps) => {
+  const retentionDays = getArtifactRetentionDays();
+  const retentionNote =
+    retentionDays !== null
+      ? ` It may have expired — artifacts are expected to be available for up to ${retentionDays} days.`
+      : "";
+
+  return (
+    <InfoBox title={title} variant={variant} width="full">
+      {preamble}
+      {retentionNote}
+    </InfoBox>
+  );
+};

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ArtifactVisualizer.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ArtifactVisualizer.tsx
@@ -19,10 +19,12 @@ import { Text } from "@/components/ui/typography";
 import { cn } from "@/lib/utils";
 import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { useBackend } from "@/providers/BackendProvider";
+import { ArtifactFetchError } from "@/services/executionService";
 import { getArtifactSignedUrl } from "@/services/executionService";
 import { HOURS } from "@/utils/constants";
 
 import ArtifactURI from "../ArtifactURI";
+import { ArtifactPreviewError } from "./ArtifactPreviewError";
 import { CsvVisualizerRemote, CsvVisualizerValue } from "./CsvVisualizer";
 import ImageVisualizer from "./ImageVisualizer";
 import { JsonVisualizerRemote, JsonVisualizerValue } from "./JsonVisualizer";
@@ -155,7 +157,35 @@ const ArtifactVisualizer = ({
               isFullscreen={isFullscreen}
             />
           ) : (
-            <SuspenseWrapper fallback={<PreviewSkeleton />}>
+            <SuspenseWrapper
+              fallback={<PreviewSkeleton />}
+              errorFallback={({ error }) => {
+                if (
+                  error instanceof ArtifactFetchError &&
+                  error.status === 404 &&
+                  import.meta.env.VITE_ARTIFACT_RETENTION_DAYS
+                ) {
+                  return (
+                    <ArtifactPreviewError
+                      title="Artifact unavailable"
+                      preamble="This artifact could not be found."
+                      variant="warning"
+                    />
+                  );
+                }
+
+                const statusDetail =
+                  error instanceof ArtifactFetchError
+                    ? ` (${error.status}${error.statusText ? ` ${error.statusText}` : ""})`
+                    : "";
+                return (
+                  <ArtifactPreviewError
+                    title="Failed to load artifact"
+                    preamble={`An unexpected error occurred${statusDetail}.`}
+                  />
+                );
+              }}
+            >
               <PreviewContent
                 name={name}
                 artifactId={artifact.id}

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/useArtifactFetch.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/useArtifactFetch.tsx
@@ -1,10 +1,12 @@
 import { useSuspenseQuery } from "@tanstack/react-query";
 
+import { ArtifactFetchError } from "@/services/executionService";
 import { HOURS } from "@/utils/constants";
 
 /**
  * Fetches artifact content from a signed URL using suspense mode.
  * Loading and error states are handled by the nearest SuspenseWrapper.
+ * Throws ArtifactFetchError on non-2xx responses so callers can branch on status.
  */
 export function useArtifactFetch<T>(
   queryKey: string,
@@ -16,7 +18,11 @@ export function useArtifactFetch<T>(
     queryFn: async () => {
       const response = await fetch(signedUrl);
       if (!response.ok) {
-        throw new Error(`(${response.status}) Failed to fetch artifact.`);
+        throw new ArtifactFetchError(
+          response.status,
+          response.statusText,
+          "Failed to fetch artifact.",
+        );
       }
 
       return transform(response);

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOSection.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOSection.tsx
@@ -9,8 +9,10 @@ import { useExecutionData } from "@/providers/ExecutionDataProvider";
 import { getExecutionArtifacts } from "@/services/executionService";
 import { getBackendStatusString } from "@/utils/backend";
 import type { TaskSpec } from "@/utils/componentSpec";
-import { isOlderThanDays } from "@/utils/date";
+import { addDays, formatDate, isOlderThanDays } from "@/utils/date";
 
+import { ArtifactRetentionNotice } from "./ArtifactRetentionNotice";
+import { getArtifactRetentionDays } from "./artifactRetentionUtils";
 import IOExtras from "./IOExtras";
 import IOInputs from "./IOInputs";
 import IOOutputs from "./IOOutputs";
@@ -77,18 +79,33 @@ const IOSection = ({ taskSpec, executionId, readOnly }: IOSectionProps) => {
     ? ["inputs", "outputs", "other"]
     : ["outputs", "inputs", "other"];
 
-  const isOlderThan30Days =
-    metadata?.created_at && isOlderThanDays(metadata.created_at, 30);
+  const retentionDays = getArtifactRetentionDays();
+
+  const isOlderThanRetentionPeriod =
+    retentionDays !== null &&
+    metadata?.created_at &&
+    isOlderThanDays(metadata.created_at, retentionDays);
+
+  const expiryDate =
+    retentionDays !== null &&
+    metadata?.created_at &&
+    !isOlderThanRetentionPeriod
+      ? formatDate(addDays(metadata.created_at, retentionDays), {
+          month: "long",
+          day: "numeric",
+          year: "numeric",
+        })
+      : null;
 
   return (
     <BlockStack gap="4" className="w-full">
-      {isOlderThan30Days && (
-        <InfoBox title="Artifact Storage" variant="warning">
-          Remote artifacts may be unavailable for runs older than 30 days. To
-          keep an artifact, download it using the provided link before it
-          expires.
+      {isOlderThanRetentionPeriod ? (
+        <ArtifactRetentionNotice title="Artifact Storage" />
+      ) : expiryDate ? (
+        <InfoBox title="Artifact Storage" variant="info" width="full">
+          Artifacts from this run expire on {expiryDate}.
         </InfoBox>
-      )}
+      ) : null}
       {order.map((section) => {
         if (section === "inputs") {
           return (

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOSection.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOSection.tsx
@@ -9,8 +9,10 @@ import { useExecutionData } from "@/providers/ExecutionDataProvider";
 import { getExecutionArtifacts } from "@/services/executionService";
 import { getBackendStatusString } from "@/utils/backend";
 import type { TaskSpec } from "@/utils/componentSpec";
-import { isOlderThanDays } from "@/utils/date";
+import { addDays, formatDate, isOlderThanDays } from "@/utils/date";
 
+import { ArtifactRetentionNotice } from "./ArtifactRetentionNotice";
+import { getArtifactRetentionDays } from "./artifactRetentionUtils";
 import IOExtras from "./IOExtras";
 import IOInputs from "./IOInputs";
 import IOOutputs from "./IOOutputs";
@@ -77,16 +79,37 @@ const IOSection = ({ taskSpec, executionId, readOnly }: IOSectionProps) => {
     ? ["inputs", "outputs", "other"]
     : ["outputs", "inputs", "other"];
 
-  const isOlderThan30Days =
-    metadata?.created_at && isOlderThanDays(metadata.created_at, 30);
+  const retentionDays = getArtifactRetentionDays();
+
+  type StorageStatus =
+    | { expired: true }
+    | { expired: false; expiryDate: string }
+    | null;
+
+  let storageStatus: StorageStatus = null;
+  if (retentionDays !== null && metadata?.created_at) {
+    if (isOlderThanDays(metadata.created_at, retentionDays)) {
+      storageStatus = { expired: true };
+    } else {
+      storageStatus = {
+        expired: false,
+        expiryDate: formatDate(addDays(metadata.created_at, retentionDays), {
+          month: "long",
+          day: "numeric",
+          year: "numeric",
+        }),
+      };
+    }
+  }
 
   return (
     <BlockStack gap="4" className="w-full">
-      {isOlderThan30Days && (
-        <InfoBox title="Artifact Storage" variant="warning">
-          Remote artifacts may be unavailable for runs older than 30 days. To
-          keep an artifact, download it using the provided link before it
-          expires.
+      {storageStatus?.expired === true && (
+        <ArtifactRetentionNotice title="Artifact Storage" />
+      )}
+      {storageStatus?.expired === false && (
+        <InfoBox title="Artifact Storage" variant="info" width="full">
+          Artifacts from this run expire on {storageStatus.expiryDate}.
         </InfoBox>
       )}
       {order.map((section) => {

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/artifactRetentionUtils.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/artifactRetentionUtils.ts
@@ -1,0 +1,9 @@
+/**
+ * Returns the configured artifact retention period in days, or null if unset.
+ * When null, retention-related UI should be suppressed.
+ */
+export function getArtifactRetentionDays(): number | null {
+  return import.meta.env.VITE_ARTIFACT_RETENTION_DAYS
+    ? Number(import.meta.env.VITE_ARTIFACT_RETENTION_DAYS)
+    : null;
+}

--- a/src/services/executionService.ts
+++ b/src/services/executionService.ts
@@ -119,6 +119,18 @@ export const fetchExecutionStatusLight = rateLimit(
   },
 );
 
+export class ArtifactFetchError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly statusText: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ArtifactFetchError";
+    Object.setPrototypeOf(this, ArtifactFetchError.prototype);
+  }
+}
+
 export const getArtifactSignedUrl = async (
   artifactId: string,
   backendUrl: string,
@@ -127,7 +139,11 @@ export const getArtifactSignedUrl = async (
     `${backendUrl}/api/artifacts/${artifactId}/signed_artifact_url`,
   );
   if (!response.ok) {
-    throw new Error(`(${response.status}) Failed to get signed URL.`);
+    throw new ArtifactFetchError(
+      response.status,
+      response.statusText,
+      "Failed to get signed URL.",
+    );
   }
   return response.json();
 };

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -77,6 +77,15 @@ export const formatDuration = (startTime: string, endTime: string): string => {
 };
 
 /**
+ * Return a new Date offset by the given number of days.
+ */
+export const addDays = (date: string | Date, days: number): Date => {
+  const result = new Date(date);
+  result.setDate(result.getDate() + days);
+  return result;
+};
+
+/**
  * Check whether a date is older than a given number of calendar days ago.
  * @param date - Date string or object to check
  * @param days - Number of calendar days to compare against


### PR DESCRIPTION
## Description

Introduces a typed `ArtifactFetchError` class that carries HTTP `status` and `statusText`, replacing generic `Error` throws in both `getArtifactSignedUrl` and `useArtifactFetch`. This allows the artifact visualizer to distinguish between 404 (not found) and other failure states and render appropriate inline notices.

Adds a new `ArtifactRetentionNotice` component that displays a configurable warning or error `InfoBox` with a message driven by the `VITE_ARTIFACT_RETENTION_DAYS` environment variable. When the variable is set, the message includes the specific number of days; otherwise it falls back to a generic expiry message.

The existing hardcoded 30-day retention warning in `IOSection` is replaced with this new component, now respecting `VITE_ARTIFACT_RETENTION_DAYS` instead of a fixed threshold. The artifact visualizer's `SuspenseWrapper` now uses an `errorFallback` that renders a retention notice on 404 and an error-variant notice for all other failures.

##  

## Related Issue and Pull requests

## Type of Change

- [x] Bug fix
- [x] Improvement

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Before screenshots

![image.png](https://app.graphite.com/user-attachments/assets/e9a531ee-6e66-43c9-a258-51a83041e04f.png)

![image.png](https://app.graphite.com/user-attachments/assets/08a2c129-919a-4848-ad8b-f6837818ca18.png)

## After screenshots

![Screenshot 2026-04-29 at 4.29.25 PM.png](https://app.graphite.com/user-attachments/assets/42fcbece-acd4-4db2-a8e0-2399aa08f0c5.png)

![image.png](https://app.graphite.com/user-attachments/assets/6f2138f4-46c6-4590-8c8a-c4f245dcd5e5.png)

![image.png](https://app.graphite.com/user-attachments/assets/46abd7c8-f1a9-4d7c-aa94-1d221b1dc4c7.png)

## Test Instructions

1. Open a task node with artifact outputs on a run older than the configured retention period and verify the `ArtifactRetentionNotice` warning appears in the IO section.
2. Open an artifact visualizer for an artifact that returns a 404 and confirm the "Artifact unavailable" warning notice is shown.
3. Simulate a non-404 fetch failure and confirm the "Failed to load artifact" error notice is shown with the HTTP status detail.
4. Set `VITE_ARTIFACT_RETENTION_DAYS` to a specific value and verify the expiry message includes that number of days.
5. Unset `VITE_ARTIFACT_RETENTION_DAYS` and verify the generic expiry message is shown instead.

## Additional Comments

The `Object.setPrototypeOf` call in `ArtifactFetchError` ensures `instanceof` checks work correctly when targeting ES5 in TypeScript.