### PR TITLE
fix: v2: simplified node scaling

### DIFF
--- a/src/routes/v2/pages/Editor/nodes/FlexNode/components/FlexNodeSimplified.tsx
+++ b/src/routes/v2/pages/Editor/nodes/FlexNode/components/FlexNodeSimplified.tsx
@@ -3,10 +3,12 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { Paragraph } from "@/components/ui/typography";
 import { cn } from "@/lib/utils";
 
 import { flexNodeVariants, type FlexNodeViewProps } from "./FlexNode";
+
+const PERCEIVED_FONT_SIZE = "28px";
+const s = "var(--simplified-scale, 1)";
 
 export function FlexNodeSimplified({
   id,
@@ -44,12 +46,15 @@ export function FlexNodeSimplified({
         )}
       >
         {title && (
-          <Paragraph
-            weight="semibold"
-            className="whitespace-pre-wrap line-clamp-3 wrap-break-word w-full text-[calc(var(--simplified-scale,1)*24px)] leading-tight"
+          <p
+            className="font-semibold whitespace-pre-wrap line-clamp-3 wrap-break-word w-full leading-tight"
+            style={{
+              fontSize: `calc(${s} * ${PERCEIVED_FONT_SIZE})`,
+              lineHeight: 1.25,
+            }}
           >
             {title}
-          </Paragraph>
+          </p>
         )}
       </div>
     </div>

--- a/src/routes/v2/shared/hooks/useViewportScaling.ts
+++ b/src/routes/v2/shared/hooks/useViewportScaling.ts
@@ -11,7 +11,10 @@ export function useViewportScaling() {
 
   const handleViewportChange = ({ zoom }: Viewport) => {
     const scale = Math.min(ZOOM_THRESHOLD / zoom, MAX_COLLAPSED_SCALE);
-    containerRef.current?.style.setProperty("--collapsed-scale", String(scale));
+    containerRef.current?.style.setProperty(
+      "--simplified-scale",
+      String(scale),
+    );
     containerRef.current?.style.setProperty("--zoom-level", String(zoom));
   };
 

--- a/src/routes/v2/shared/nodes/IONode/IONodeSimplified.tsx
+++ b/src/routes/v2/shared/nodes/IONode/IONodeSimplified.tsx
@@ -11,6 +11,7 @@ import { cn } from "@/lib/utils";
 
 import type { IONodeViewProps } from "./IONode";
 
+const PERCEIVED_FONT_SIZE = "28px";
 const s = "var(--simplified-scale, 1)";
 
 export function IONodeSimplified({
@@ -35,7 +36,7 @@ export function IONodeSimplified({
   return (
     <Card
       className={cn(
-        "border-2 p-0 cursor-pointer transition-all flex flex-row items-center justify-start",
+        "border-2 p-0 cursor-pointer flex flex-row items-center justify-start",
         bgColor,
         borderColor,
       )}
@@ -67,7 +68,7 @@ export function IONodeSimplified({
           <span
             className="font-medium min-w-0 line-clamp-2 wrap-break-word text-slate-900 text-left"
             style={{
-              fontSize: `calc(${s} * 24px)`,
+              fontSize: `calc(${s} * ${PERCEIVED_FONT_SIZE})`,
               lineHeight: 1.25,
             }}
           >

--- a/src/routes/v2/shared/nodes/TaskNode/TaskNodeCard.tsx
+++ b/src/routes/v2/shared/nodes/TaskNode/TaskNodeCard.tsx
@@ -82,6 +82,7 @@ interface ClassicInputHandleProps {
   input: TaskNodeInput;
   entityId: string;
   displayValue: string | undefined;
+  hideValue?: boolean;
   onInputClick: (name: string, event: ReactMouseEvent) => void;
   onHandleClick: (handleId: string, event: ReactMouseEvent) => void;
 }
@@ -90,6 +91,7 @@ const ClassicInputHandle = observer(function ClassicInputHandle({
   input,
   entityId,
   displayValue,
+  hideValue,
   onInputClick,
   onHandleClick,
 }: ClassicInputHandleProps) {
@@ -101,6 +103,9 @@ const ClassicInputHandle = observer(function ClassicInputHandle({
 
   const hasValue = displayValue !== undefined && displayValue !== "";
   const hasDefault = input.default !== undefined && input.default !== "";
+  const showValueDisplay = !hideValue && (hasValue || hasDefault);
+  const labelHasValue = hideValue ? true : hasValue;
+  const labelHasDefault = hideValue ? false : hasDefault;
 
   return (
     <div
@@ -130,13 +135,13 @@ const ClassicInputHandle = observer(function ClassicInputHandle({
         <div
           className={cn(
             "flex w-fit min-w-0",
-            !hasValue ? "max-w-full" : "max-w-3/4",
+            !showValueDisplay ? "max-w-full" : "max-w-3/4",
           )}
         >
           <div
             className={classicInputLabelVariants({
-              hasValue,
-              hasDefault,
+              hasValue: labelHasValue,
+              hasDefault: labelHasDefault,
               optional: input.optional ?? false,
             })}
             title={`${input.name}${input.type ? `: ${input.type}` : ""}`}
@@ -144,7 +149,7 @@ const ClassicInputHandle = observer(function ClassicInputHandle({
             {input.name.replace(/_/g, " ")}
           </div>
         </div>
-        {(hasValue || hasDefault) && (
+        {showValueDisplay && (
           <div className="flex w-fit max-w-1/2 min-w-0 items-center gap-1">
             <Tooltip>
               <TooltipTrigger asChild>
@@ -330,10 +335,13 @@ export const TaskNodeCard = observer(function TaskNodeCard({
                   input={input}
                   entityId={entityId}
                   displayValue={
-                    showCondensedInputs && index === 0
-                      ? `+${hiddenInputCount} more ${pluralize(hiddenInputCount, "input")}`
+                    showCondensedInputs
+                      ? index === 0
+                        ? `+${hiddenInputCount} more ${pluralize(hiddenInputCount, "input")}`
+                        : undefined
                       : inputDisplayValues[input.name]
                   }
+                  hideValue={showCondensedInputs && index !== 0}
                   onInputClick={onInputClick}
                   onHandleClick={onHandleClick}
                 />

--- a/src/routes/v2/shared/nodes/TaskNode/TaskNodeSimplified.tsx
+++ b/src/routes/v2/shared/nodes/TaskNode/TaskNodeSimplified.tsx
@@ -16,6 +16,7 @@ import {
 import type { TaskNodeViewProps } from "./TaskNode";
 import { createTaskNodeCardVariants } from "./taskNode.variants";
 
+const PERCEIVED_FONT_SIZE = "28px";
 const s = "var(--simplified-scale, 1)";
 
 const simplifiedCardVariants = createTaskNodeCardVariants(
@@ -102,7 +103,10 @@ export function TaskNodeSimplified({
                 "font-medium min-w-0 line-clamp-2 wrap-break-word",
                 !taskColor && "text-slate-900",
               )}
-              style={{ fontSize: `calc(${s} * 28px)`, lineHeight: 1.25 }}
+              style={{
+                fontSize: `calc(${s} * ${PERCEIVED_FONT_SIZE})`,
+                lineHeight: 1.25,
+              }}
             >
               {taskName}
             </span>


### PR DESCRIPTION
## Description

Node size will now scale when zoomed out as originally intended.

Also fixes an unrelated issue in collapsed nodes where a collapsed node's inputs will still display the value (should be hidden as per v1)

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

collapsed nodes no longer show values inline, as originally intended

![image.png](https://app.graphite.com/user-attachments/assets/b6d30227-64e9-45f1-844f-c575be90f9b8.png)



<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->