### PR TITLE
feat: v2 - mini content for collapsed docked windows

### DIFF
--- a/src/routes/v2/pages/Editor/components/ComponentLibraryWindowMiniContent.tsx
+++ b/src/routes/v2/pages/Editor/components/ComponentLibraryWindowMiniContent.tsx
@@ -1,0 +1,16 @@
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icon";
+
+export function ComponentLibraryWindowMiniContent() {
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="icon"
+      className="size-8 shrink-0 rounded-md"
+      aria-label="Components"
+    >
+      <Icon name="LayoutGrid" size="sm" className="text-gray-700" />
+    </Button>
+  );
+}

--- a/src/routes/v2/pages/Editor/components/ComponentLibraryWindowMiniContent.tsx
+++ b/src/routes/v2/pages/Editor/components/ComponentLibraryWindowMiniContent.tsx
@@ -1,0 +1,16 @@
+import TooltipButton from "@/components/shared/Buttons/TooltipButton";
+import { Icon } from "@/components/ui/icon";
+
+export function ComponentLibraryWindowMiniContent() {
+  return (
+    <TooltipButton
+      tooltip="View Component Library"
+      tooltipSide="right"
+      variant="outline"
+      size="icon"
+      aria-label="Components"
+    >
+      <Icon name="LayoutGrid" size="sm" className="text-gray-700" />
+    </TooltipButton>
+  );
+}

--- a/src/routes/v2/pages/Editor/components/EditorMenuBar/components/QuickRunButton.tsx
+++ b/src/routes/v2/pages/Editor/components/EditorMenuBar/components/QuickRunButton.tsx
@@ -1,5 +1,6 @@
 import { cva } from "class-variance-authority";
 import { observer } from "mobx-react-lite";
+import type { ComponentProps, MouseEvent } from "react";
 
 import { useAwaitAuthorization } from "@/components/shared/Authentication/useAwaitAuthorization";
 import TooltipButton from "@/components/shared/Buttons/TooltipButton";
@@ -12,6 +13,7 @@ import { tracking } from "@/utils/tracking";
 
 const quickRunIconVariants = cva("transition-colors", {
   variants: {
+    variant: { menubar: "", mini: "" },
     hasErrors: { true: "", false: "" },
     onlyWarnings: { true: "", false: "" },
   },
@@ -32,6 +34,7 @@ const quickRunIconVariants = cva("transition-colors", {
     },
   ],
   defaultVariants: {
+    variant: "menubar",
     hasErrors: false,
     onlyWarnings: false,
   },
@@ -43,7 +46,19 @@ function tooltipLabel(hasErrors: boolean, onlyWarnings: boolean) {
   return "Submit Run";
 }
 
-export const QuickRunButton = observer(function QuickRunButton() {
+interface QuickRunButtonProps {
+  variant?: "menubar" | "mini";
+  renderSubmitter?: boolean;
+  trackingKey?: string;
+}
+
+export const QuickRunButton = observer(function QuickRunButton({
+  variant = "menubar",
+  renderSubmitter = true,
+  trackingKey = "v2.pipeline_editor.quick_run",
+  ...tooltipButtonProps
+}: QuickRunButtonProps &
+  Omit<ComponentProps<typeof TooltipButton>, "tooltip" | "variant" | "size">) {
   const { navigation } = useSharedStores();
   const { isAuthorized } = useAwaitAuthorization();
   const rootSpec = navigation.rootSpec;
@@ -52,35 +67,52 @@ export const QuickRunButton = observer(function QuickRunButton() {
   const hasErrors = errorCount > 0;
   const onlyWarnings = allIssues.length > 0 && errorCount === 0;
 
-  let legacySpec: ReturnType<typeof serializeComponentSpec> | undefined;
+  let serializedPipelineSpec:
+    | ReturnType<typeof serializeComponentSpec>
+    | undefined;
   try {
-    legacySpec = rootSpec
+    serializedPipelineSpec = rootSpec
       ? deepClone(serializeComponentSpec(rootSpec))
       : undefined;
   } catch {
-    legacySpec = undefined;
+    serializedPipelineSpec = undefined;
   }
 
   const tooltip = tooltipLabel(hasErrors, onlyWarnings);
+  const isMini = variant === "mini";
+
+  const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
+    if (isMini) event.stopPropagation();
+    triggerSubmitRun();
+  };
 
   return (
     <>
       <TooltipButton
+        {...tooltipButtonProps}
         tooltip={tooltip}
-        className="hover:bg-transparent"
+        variant={isMini ? "outline" : undefined}
+        size={isMini ? "icon" : undefined}
+        className={
+          isMini
+            ? "relative size-8 shrink-0 rounded-md"
+            : "hover:bg-transparent"
+        }
+        aria-label={isMini ? tooltip : undefined}
         disabled={hasErrors}
-        onClick={triggerSubmitRun}
-        {...tracking("v2.pipeline_editor.quick_run")}
+        onClick={handleClick}
+        {...tracking(trackingKey)}
       >
         <Icon
           name="Play"
-          className={quickRunIconVariants({ hasErrors, onlyWarnings })}
+          size={isMini ? "sm" : undefined}
+          className={quickRunIconVariants({ variant, hasErrors, onlyWarnings })}
         />
       </TooltipButton>
-      {legacySpec && isAuthorized && (
+      {renderSubmitter && serializedPipelineSpec && isAuthorized && (
         <div data-quick-run className="sr-only">
           <TangleSubmitter
-            componentSpec={legacySpec}
+            componentSpec={serializedPipelineSpec}
             isComponentTreeValid={rootSpec?.isValid}
             onlyFixableIssues={!hasErrors && allIssues.length > 0}
           />

--- a/src/routes/v2/pages/Editor/components/PipelineTreeContent/PipelineTreeWindowMiniContent.tsx
+++ b/src/routes/v2/pages/Editor/components/PipelineTreeContent/PipelineTreeWindowMiniContent.tsx
@@ -1,0 +1,45 @@
+import { observer } from "mobx-react-lite";
+
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icon";
+import {
+  countErrors,
+  countWarnings,
+} from "@/routes/v2/pages/Editor/components/ValidationSummary";
+import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
+
+import { IssueBadge } from "./components/IssueBadge";
+
+export const PipelineTreeWindowMiniContent = observer(
+  function PipelineTreeWindowMiniContent() {
+    const { navigation } = useSharedStores();
+    const rootSpec = navigation.rootSpec;
+    const issues = rootSpec?.allValidationIssues ?? [];
+    const errorCount = countErrors(issues);
+    const warningCount = countWarnings(issues);
+    const hasIssues = errorCount > 0 || warningCount > 0;
+    const showValidBadge = rootSpec !== undefined && !hasIssues;
+
+    return (
+      <Button
+        type="button"
+        variant="outline"
+        size="icon"
+        className="relative size-8 shrink-0 rounded-md"
+        aria-label="Pipeline Structure"
+      >
+        <Icon name="GitBranch" size="sm" className="text-gray-700" />
+        {showValidBadge ? (
+          <span className="pointer-events-none absolute -bottom-0.5 -right-0.5 flex size-3.5 items-center justify-center rounded-full bg-white shadow-sm ring-1 ring-green-200">
+            <Icon name="CircleCheck" size="xs" className="text-green-600" />
+          </span>
+        ) : null}
+        {rootSpec && hasIssues ? (
+          <span className="pointer-events-none absolute -top-1 -right-1">
+            <IssueBadge issues={issues} />
+          </span>
+        ) : null}
+      </Button>
+    );
+  },
+);

--- a/src/routes/v2/pages/Editor/components/PipelineTreeContent/PipelineTreeWindowMiniContent.tsx
+++ b/src/routes/v2/pages/Editor/components/PipelineTreeContent/PipelineTreeWindowMiniContent.tsx
@@ -1,0 +1,46 @@
+import { observer } from "mobx-react-lite";
+
+import TooltipButton from "@/components/shared/Buttons/TooltipButton";
+import { Icon } from "@/components/ui/icon";
+import {
+  countErrors,
+  countWarnings,
+} from "@/routes/v2/pages/Editor/components/ValidationSummary";
+import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
+
+import { IssueBadge } from "./components/IssueBadge";
+
+export const PipelineTreeWindowMiniContent = observer(
+  function PipelineTreeWindowMiniContent() {
+    const { navigation } = useSharedStores();
+    const rootSpec = navigation.rootSpec;
+    const issues = rootSpec?.allValidationIssues ?? [];
+    const errorCount = countErrors(issues);
+    const warningCount = countWarnings(issues);
+    const hasIssues = errorCount > 0 || warningCount > 0;
+    const showValidBadge = rootSpec !== undefined && !hasIssues;
+
+    return (
+      <TooltipButton
+        tooltip="View Pipeline Structure"
+        tooltipSide="right"
+        variant="outline"
+        size="icon"
+        className="relative"
+        aria-label="Pipeline Structure"
+      >
+        <Icon name="GitBranch" size="sm" className="text-gray-700" />
+        {showValidBadge && (
+          <span className="pointer-events-none absolute -bottom-0.5 -right-0.5 flex size-3.5 items-center justify-center rounded-full bg-white shadow-sm ring-1 ring-green-200">
+            <Icon name="CircleCheck" size="xs" className="text-green-600" />
+          </span>
+        )}
+        {rootSpec && hasIssues && (
+          <span className="pointer-events-none absolute -top-1 -right-1">
+            <IssueBadge issues={issues} />
+          </span>
+        )}
+      </TooltipButton>
+    );
+  },
+);

--- a/src/routes/v2/pages/Editor/components/RunsAndSubmissionWindowMiniContent.tsx
+++ b/src/routes/v2/pages/Editor/components/RunsAndSubmissionWindowMiniContent.tsx
@@ -1,0 +1,17 @@
+import { observer } from "mobx-react-lite";
+
+import { QuickRunButton } from "@/routes/v2/pages/Editor/components/EditorMenuBar/components/QuickRunButton";
+
+export const RunsAndSubmissionWindowMiniContent = observer(
+  function RunsAndSubmissionWindowMiniContent() {
+    return (
+      <QuickRunButton
+        variant="mini"
+        tooltipSide="right"
+        renderSubmitter={false}
+        trackingKey="v2.pipeline_editor.quick_run_mini"
+        onPointerDown={(event) => event.stopPropagation()}
+      />
+    );
+  },
+);

--- a/src/routes/v2/pages/Editor/hooks/useComponentLibraryWindow.tsx
+++ b/src/routes/v2/pages/Editor/hooks/useComponentLibraryWindow.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 
 import { ComponentLibraryContent } from "@/routes/v2/pages/Editor/components/ComponentLibraryContent";
+import { ComponentLibraryWindowMiniContent } from "@/routes/v2/pages/Editor/components/ComponentLibraryWindowMiniContent";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 
 const COMPONENT_LIBRARY_WINDOW_ID = "component-library";
@@ -8,6 +9,7 @@ const COMPONENT_LIBRARY_WINDOW_ID = "component-library";
 export function useComponentLibraryWindow() {
   const { windows } = useSharedStores();
   useEffect(() => {
+    const miniContent = <ComponentLibraryWindowMiniContent />;
     if (!windows.getWindowById(COMPONENT_LIBRARY_WINDOW_ID)) {
       windows.openWindow(<ComponentLibraryContent />, {
         id: COMPONENT_LIBRARY_WINDOW_ID,
@@ -17,7 +19,10 @@ export function useComponentLibraryWindow() {
         disabledActions: ["close"],
         persisted: true,
         defaultDockState: "left",
+        miniContent,
       });
+      return;
     }
+    windows.setWindowMiniContent(COMPONENT_LIBRARY_WINDOW_ID, miniContent);
   }, [windows]);
 }

--- a/src/routes/v2/pages/Editor/hooks/useComponentLibraryWindow.tsx
+++ b/src/routes/v2/pages/Editor/hooks/useComponentLibraryWindow.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 
 import { ComponentLibraryContent } from "@/routes/v2/pages/Editor/components/ComponentLibraryContent";
+import { ComponentLibraryWindowMiniContent } from "@/routes/v2/pages/Editor/components/ComponentLibraryWindowMiniContent";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 
 const COMPONENT_LIBRARY_WINDOW_ID = "component-library";
@@ -8,16 +9,16 @@ const COMPONENT_LIBRARY_WINDOW_ID = "component-library";
 export function useComponentLibraryWindow() {
   const { windows } = useSharedStores();
   useEffect(() => {
-    if (!windows.getWindowById(COMPONENT_LIBRARY_WINDOW_ID)) {
-      windows.openWindow(<ComponentLibraryContent />, {
-        id: COMPONENT_LIBRARY_WINDOW_ID,
-        title: "Components",
-        position: { x: 0, y: 100 },
-        size: { width: 280, height: 350 },
-        disabledActions: ["close"],
-        persisted: true,
-        defaultDockState: "left",
-      });
-    }
+    if (windows.getWindowById(COMPONENT_LIBRARY_WINDOW_ID)) return;
+    windows.openWindow(<ComponentLibraryContent />, {
+      id: COMPONENT_LIBRARY_WINDOW_ID,
+      title: "Components",
+      position: { x: 0, y: 100 },
+      size: { width: 280, height: 350 },
+      disabledActions: ["close"],
+      persisted: true,
+      defaultDockState: "left",
+      miniContent: <ComponentLibraryWindowMiniContent />,
+    });
   }, [windows]);
 }

--- a/src/routes/v2/pages/Editor/hooks/usePipelineTreeWindow.tsx
+++ b/src/routes/v2/pages/Editor/hooks/usePipelineTreeWindow.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 
 import { PipelineTreeContent } from "@/routes/v2/pages/Editor/components/PipelineTreeContent/PipelineTreeContent";
+import { PipelineTreeWindowMiniContent } from "@/routes/v2/pages/Editor/components/PipelineTreeContent/PipelineTreeWindowMiniContent";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 
 const PIPELINE_TREE_WINDOW_ID = "pipeline-tree";
@@ -8,6 +9,7 @@ const PIPELINE_TREE_WINDOW_ID = "pipeline-tree";
 export function usePipelineTreeWindow() {
   const { windows } = useSharedStores();
   useEffect(() => {
+    const miniContent = <PipelineTreeWindowMiniContent />;
     if (!windows.getWindowById(PIPELINE_TREE_WINDOW_ID)) {
       windows.openWindow(<PipelineTreeContent />, {
         id: PIPELINE_TREE_WINDOW_ID,
@@ -17,7 +19,10 @@ export function usePipelineTreeWindow() {
         disabledActions: ["close"],
         persisted: true,
         defaultDockState: "left",
+        miniContent,
       });
+      return;
     }
+    windows.setWindowMiniContent(PIPELINE_TREE_WINDOW_ID, miniContent);
   }, [windows]);
 }

--- a/src/routes/v2/pages/Editor/hooks/usePipelineTreeWindow.tsx
+++ b/src/routes/v2/pages/Editor/hooks/usePipelineTreeWindow.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 
 import { PipelineTreeContent } from "@/routes/v2/pages/Editor/components/PipelineTreeContent/PipelineTreeContent";
+import { PipelineTreeWindowMiniContent } from "@/routes/v2/pages/Editor/components/PipelineTreeContent/PipelineTreeWindowMiniContent";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 
 const PIPELINE_TREE_WINDOW_ID = "pipeline-tree";
@@ -8,16 +9,16 @@ const PIPELINE_TREE_WINDOW_ID = "pipeline-tree";
 export function usePipelineTreeWindow() {
   const { windows } = useSharedStores();
   useEffect(() => {
-    if (!windows.getWindowById(PIPELINE_TREE_WINDOW_ID)) {
-      windows.openWindow(<PipelineTreeContent />, {
-        id: PIPELINE_TREE_WINDOW_ID,
-        title: "Pipeline Structure",
-        position: { x: 300, y: 100 },
-        size: { width: 280, height: 400 },
-        disabledActions: ["close"],
-        persisted: true,
-        defaultDockState: "left",
-      });
-    }
+    if (windows.getWindowById(PIPELINE_TREE_WINDOW_ID)) return;
+    windows.openWindow(<PipelineTreeContent />, {
+      id: PIPELINE_TREE_WINDOW_ID,
+      title: "Pipeline Structure",
+      position: { x: 300, y: 100 },
+      size: { width: 280, height: 400 },
+      disabledActions: ["close"],
+      persisted: true,
+      defaultDockState: "left",
+      miniContent: <PipelineTreeWindowMiniContent />,
+    });
   }, [windows]);
 }

--- a/src/routes/v2/pages/Editor/hooks/useRunsAndSubmissionWindow.tsx
+++ b/src/routes/v2/pages/Editor/hooks/useRunsAndSubmissionWindow.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 
 import { RunsAndSubmissionContent } from "@/routes/v2/pages/Editor/components/RunsAndSubmissionContent";
+import { RunsAndSubmissionWindowMiniContent } from "@/routes/v2/pages/Editor/components/RunsAndSubmissionWindowMiniContent";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 
 const RUNS_AND_SUBMISSION_WINDOW_ID = "runs-and-submission";
@@ -8,20 +9,20 @@ const RUNS_AND_SUBMISSION_WINDOW_ID = "runs-and-submission";
 export function useRunsAndSubmissionWindow() {
   const { windows } = useSharedStores();
   useEffect(() => {
-    if (!windows.getWindowById(RUNS_AND_SUBMISSION_WINDOW_ID)) {
-      windows.openWindow(<RunsAndSubmissionContent />, {
-        id: RUNS_AND_SUBMISSION_WINDOW_ID,
-        title: "Runs & Submissions",
-        position: { x: 100, y: 460 },
-        size: { width: 280, height: 50 },
-        minSize: {
-          width: 280,
-          height: 50,
-        },
-        disabledActions: ["close"],
-        persisted: true,
-        defaultDockState: "left",
-      });
-    }
+    if (windows.getWindowById(RUNS_AND_SUBMISSION_WINDOW_ID)) return;
+    windows.openWindow(<RunsAndSubmissionContent />, {
+      id: RUNS_AND_SUBMISSION_WINDOW_ID,
+      title: "Runs & Submissions",
+      position: { x: 100, y: 460 },
+      size: { width: 280, height: 50 },
+      minSize: {
+        width: 280,
+        height: 50,
+      },
+      disabledActions: ["close"],
+      persisted: true,
+      defaultDockState: "left",
+      miniContent: <RunsAndSubmissionWindowMiniContent />,
+    });
   }, [windows]);
 }

--- a/src/routes/v2/shared/windows/CollapsedDockWindowMini.tsx
+++ b/src/routes/v2/shared/windows/CollapsedDockWindowMini.tsx
@@ -1,0 +1,79 @@
+import { observer } from "mobx-react-lite";
+import type { CSSProperties } from "react";
+
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Text } from "@/components/ui/typography";
+import { cn } from "@/lib/utils";
+import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
+
+import { WindowContextProvider } from "./ContentWindowStateContext";
+import { MAX_DOCK_AREA_WIDTH } from "./types";
+
+interface CollapsedDockWindowMiniProps {
+  windowId: string;
+  dockSide: "left" | "right";
+}
+
+export const CollapsedDockWindowMini = observer(
+  function CollapsedDockWindowMini({
+    windowId,
+    dockSide,
+  }: CollapsedDockWindowMiniProps) {
+    const { windows } = useSharedStores();
+    const model = windows.getWindowById(windowId);
+    const mini = windows.getWindowMiniContent(windowId);
+    const content = windows.getWindowContent(windowId);
+
+    if (!model || model.state === "hidden" || !mini || !content) {
+      return null;
+    }
+
+    const popoverSide = dockSide === "left" ? "right" : "left";
+    const panelWidth = Math.min(model.size.width, MAX_DOCK_AREA_WIDTH);
+
+    return (
+      <Popover>
+        {/*
+          Radix asChild merges ref and listeners onto one DOM node. Mini content
+          is often a MobX observer() component that does not forwardRef to a host
+          element, so we wrap it in a div that receives the trigger props.
+        */}
+        <PopoverTrigger asChild>
+          <div className="relative z-20 flex w-full shrink-0 justify-center outline-none">
+            {mini}
+          </div>
+        </PopoverTrigger>
+        <PopoverContent
+          side={popoverSide}
+          align="start"
+          sideOffset={6}
+          collisionPadding={12}
+          className={cn(
+            "p-0 overflow-hidden flex flex-col border shadow-lg z-50",
+            "max-h-[min(70vh,720px)] w-[min(92vw,var(--dock-mini-popover-w))]",
+          )}
+          style={
+            {
+              "--dock-mini-popover-w": `${panelWidth}px`,
+            } as CSSProperties
+          }
+        >
+          <div className="shrink-0 border-b bg-white px-2 py-1.5">
+            <Text size="xs" weight="semibold" className="truncate">
+              {model.title}
+            </Text>
+          </div>
+          <div className="min-h-0 flex-1 overflow-auto bg-white">
+            <WindowContextProvider value={{ model, content }}>
+              {content}
+            </WindowContextProvider>
+          </div>
+        </PopoverContent>
+      </Popover>
+    );
+  },
+);

--- a/src/routes/v2/shared/windows/DockArea.tsx
+++ b/src/routes/v2/shared/windows/DockArea.tsx
@@ -7,6 +7,7 @@ import { cn } from "@/lib/utils";
 import { focusModeStore } from "@/routes/v2/shared/hooks/useFocusMode";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 
+import { CollapsedDockWindowMini } from "./CollapsedDockWindowMini";
 import { registerDockAreaElement } from "./snapUtils";
 import {
   COLLAPSED_DOCK_AREA_WIDTH,
@@ -28,6 +29,10 @@ export const DockArea = observer(function DockArea({ side }: DockAreaProps) {
   const visibleWindows = windowOrder.filter((id) => {
     const win = windows.getWindowById(id);
     return win && win.state !== "hidden";
+  });
+  const visibleWindowsWithMini = visibleWindows.filter((id) => {
+    void windows.miniContentSignature;
+    return Boolean(windows.getWindowMiniContent(id));
   });
   const isEmpty = visibleWindows.length === 0;
 
@@ -76,9 +81,22 @@ export const DockArea = observer(function DockArea({ side }: DockAreaProps) {
       <div
         ref={setRef}
         data-dock-area={side}
-        className={cn("relative shrink-0 bg-gray-100")}
+        className={cn("relative shrink-0 bg-gray-100 flex flex-col")}
         style={{ width: COLLAPSED_DOCK_AREA_WIDTH }}
       >
+        <BlockStack
+          gap="1"
+          align="center"
+          className="relative z-20 min-h-0 flex-1 overflow-y-auto overflow-x-hidden hide-scrollbar py-1 px-0.5"
+        >
+          {visibleWindowsWithMini.map((windowId) => (
+            <CollapsedDockWindowMini
+              key={windowId}
+              windowId={windowId}
+              dockSide={side}
+            />
+          ))}
+        </BlockStack>
         <VerticalResizeHandle
           side={handleSide}
           minWidth={COLLAPSED_DOCK_AREA_WIDTH}

--- a/src/routes/v2/shared/windows/DockArea.tsx
+++ b/src/routes/v2/shared/windows/DockArea.tsx
@@ -7,6 +7,7 @@ import { cn } from "@/lib/utils";
 import { focusModeStore } from "@/routes/v2/shared/hooks/useFocusMode";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 
+import { CollapsedDockWindowMini } from "./CollapsedDockWindowMini";
 import { registerDockAreaElement } from "./snapUtils";
 import {
   COLLAPSED_DOCK_AREA_WIDTH,
@@ -38,6 +39,9 @@ export const DockArea = observer(function DockArea({ side }: DockAreaProps) {
     }
     return true;
   });
+  const visibleWindowsWithMini = visibleWindows.filter((id) =>
+    Boolean(windows.getWindowMiniContent(id)),
+  );
   const isEmpty = visibleWindows.length === 0;
 
   useEffect(() => {
@@ -85,9 +89,22 @@ export const DockArea = observer(function DockArea({ side }: DockAreaProps) {
       <div
         ref={setRef}
         data-dock-area={side}
-        className={cn("relative shrink-0 bg-gray-100")}
+        className={cn("relative shrink-0 bg-gray-100 flex flex-col")}
         style={{ width: COLLAPSED_DOCK_AREA_WIDTH }}
       >
+        <BlockStack
+          gap="1"
+          align="center"
+          className="relative z-20 min-h-0 flex-1 overflow-y-auto overflow-x-hidden hide-scrollbar py-1 px-0.5"
+        >
+          {visibleWindowsWithMini.map((windowId) => (
+            <CollapsedDockWindowMini
+              key={windowId}
+              windowId={windowId}
+              dockSide={side}
+            />
+          ))}
+        </BlockStack>
         <VerticalResizeHandle
           side={handleSide}
           minWidth={COLLAPSED_DOCK_AREA_WIDTH}

--- a/src/routes/v2/shared/windows/types.ts
+++ b/src/routes/v2/shared/windows/types.ts
@@ -1,3 +1,5 @@
+import type { ReactNode } from "react";
+
 /** Window display state */
 export type WindowState = "normal" | "maximized" | "minimized" | "hidden";
 
@@ -79,6 +81,11 @@ export interface WindowOptions {
   defaultDockState?: "left" | "right";
   /** Callback to invoke when the window is closed */
   onClose?: () => void;
+  /**
+   * Optional compact control shown when the window is docked and its dock area
+   * is collapsed. Typically an icon button; click opens full content in a popover.
+   */
+  miniContent?: ReactNode;
 }
 
 /** Default window dimensions */

--- a/src/routes/v2/shared/windows/types.ts
+++ b/src/routes/v2/shared/windows/types.ts
@@ -1,3 +1,5 @@
+import type { ReactNode } from "react";
+
 /** Window display state */
 export type WindowState = "normal" | "maximized" | "minimized" | "hidden";
 
@@ -79,6 +81,16 @@ export interface WindowOptions {
   defaultDockState?: "left" | "right";
   /** Callback to invoke when the window is closed */
   onClose?: () => void;
+  /**
+   * Optional compact control shown when the window is docked and its dock area
+   * is collapsed. Typically an icon button; click opens full content in a popover.
+   *
+   * NOTE: If omitted, the window is filtered out of the collapsed dock strip and
+   * becomes inaccessible while its dock area is collapsed (the user must expand
+   * the dock to reach it). Provide `miniContent` for any dockable window that
+   * should remain reachable while collapsed.
+   */
+  miniContent?: ReactNode;
 }
 
 /** Default window dimensions */

--- a/src/routes/v2/shared/windows/windowStore.ts
+++ b/src/routes/v2/shared/windows/windowStore.ts
@@ -26,6 +26,7 @@ export class WindowStoreImpl implements WindowStoreRef {
    * React Compiler issues. React elements must never be stored in an observable.
    */
   private contentMap = new Map<string, ReactNode>();
+  private miniContentMap = new Map<string, ReactNode>();
   @observable.shallow accessor windows: Record<string, WindowModel> = {};
   @observable.shallow accessor windowOrder: string[] = [];
   @observable accessor dockAreas: {
@@ -44,9 +45,18 @@ export class WindowStoreImpl implements WindowStoreRef {
     },
   };
   @observable accessor enabledDockSides: Set<"left" | "right"> = new Set();
+  /**
+   * Bumped when mini content entries change so observers can re-query the
+   * non-observable miniContentMap (e.g. registering mini on persisted windows).
+   */
+  @observable accessor miniContentSignature = 0;
 
   constructor() {
     makeObservable(this);
+  }
+
+  private bumpMiniContentSignature(): void {
+    this.miniContentSignature++;
   }
 
   private calculateNewPosition(): Position {
@@ -61,8 +71,13 @@ export class WindowStoreImpl implements WindowStoreRef {
     id: string,
     content: ReactNode,
     existing: WindowModel,
+    options: WindowOptions,
   ): WindowRef {
     this.contentMap.set(id, content);
+    if (options.miniContent !== undefined) {
+      this.miniContentMap.set(id, options.miniContent);
+      this.bumpMiniContentSignature();
+    }
     this.bringToFront(id);
     if (existing.state === "hidden" || existing.isMinimized) {
       existing.restore();
@@ -85,10 +100,14 @@ export class WindowStoreImpl implements WindowStoreRef {
 
     const existing = this.windows[id];
     if (existing) {
-      return this.focusExistingWindow(id, content, existing);
+      return this.focusExistingWindow(id, content, existing, options);
     }
 
     this.contentMap.set(id, content);
+    if (options.miniContent !== undefined) {
+      this.miniContentMap.set(id, options.miniContent);
+      this.bumpMiniContentSignature();
+    }
     const init = buildWindowModelInit(id, options, this.calculateNewPosition());
     const model = new WindowModel(init, this);
 
@@ -115,6 +134,9 @@ export class WindowStoreImpl implements WindowStoreRef {
     this.removeFromDockAreaOrder(id);
     delete this.windows[id];
     this.contentMap.delete(id);
+    if (this.miniContentMap.delete(id)) {
+      this.bumpMiniContentSignature();
+    }
 
     const index = this.windowOrder.indexOf(id);
     if (index !== -1) {
@@ -278,6 +300,17 @@ export class WindowStoreImpl implements WindowStoreRef {
 
   getWindowContent(id: string): ReactNode | undefined {
     return this.contentMap.get(id);
+  }
+
+  getWindowMiniContent(id: string): ReactNode | undefined {
+    return this.miniContentMap.get(id);
+  }
+
+  /** Register or replace mini content for an existing window (no z-order change). */
+  @action setWindowMiniContent(id: string, miniContent: ReactNode): void {
+    if (!this.windows[id]) return;
+    this.miniContentMap.set(id, miniContent);
+    this.bumpMiniContentSignature();
   }
 
   // -- Query helpers --

--- a/src/routes/v2/shared/windows/windowStore.ts
+++ b/src/routes/v2/shared/windows/windowStore.ts
@@ -26,6 +26,7 @@ export class WindowStoreImpl implements WindowStoreRef {
    * React Compiler issues. React elements must never be stored in an observable.
    */
   private contentMap = new Map<string, ReactNode>();
+  private miniContentMap = new Map<string, ReactNode>();
   @observable.shallow accessor windows: Record<string, WindowModel> = {};
   @observable.shallow accessor windowOrder: string[] = [];
   @observable accessor dockAreas: {
@@ -89,6 +90,9 @@ export class WindowStoreImpl implements WindowStoreRef {
     }
 
     this.contentMap.set(id, content);
+    if (options.miniContent !== undefined) {
+      this.miniContentMap.set(id, options.miniContent);
+    }
     const init = buildWindowModelInit(id, options, this.calculateNewPosition());
     const model = new WindowModel(init, this);
 
@@ -115,6 +119,7 @@ export class WindowStoreImpl implements WindowStoreRef {
     this.removeFromDockAreaOrder(id);
     delete this.windows[id];
     this.contentMap.delete(id);
+    this.miniContentMap.delete(id);
 
     const index = this.windowOrder.indexOf(id);
     if (index !== -1) {
@@ -346,6 +351,10 @@ export class WindowStoreImpl implements WindowStoreRef {
 
   getWindowContent(id: string): ReactNode | undefined {
     return this.contentMap.get(id);
+  }
+
+  getWindowMiniContent(id: string): ReactNode | undefined {
+    return this.miniContentMap.get(id);
   }
 
   // -- Query helpers --


### PR DESCRIPTION
## Description

Adds "mini content" support for docked windows that are in a collapsed dock area. When a dock panel is collapsed, each window that has registered mini content renders a compact icon button in the collapsed dock strip. Clicking the button opens a popover showing the full window content without expanding the dock.

- `ComponentLibraryWindowMiniContent` renders a `LayoutGrid` icon button as the collapsed representation of the Component Library panel.
- `PipelineTreeWindowMiniContent` renders a `GitBranch` icon button with a live validation badge overlay — a green check when the pipeline is valid, or an issue badge showing error/warning counts.
- `RunsAndSubmissionWindowMiniContent` renders a `Play` icon button that triggers a quick run directly, with color variants reflecting validation state (green for valid, amber for warnings, red for errors). Click propagation is stopped to prevent the surrounding popover trigger from firing when the action is intended.
- `CollapsedDockWindowMini` wraps each mini button in a Radix `Popover` that displays the full panel content (with a title header) when triggered, sized to match the panel's configured width and opening to the opposite side of the dock.
- `DockArea` renders the list of `CollapsedDockWindowMini` components in the collapsed strip, filtered to only windows that have registered mini content.
- `WindowStoreImpl` stores mini content in a separate `miniContentMap` (keeping React nodes out of observables), exposes `getWindowMiniContent`, and cleans up on window close.
- `useComponentLibraryWindow`, `usePipelineTreeWindow`, and `useRunsAndSubmissionWindow` each pass `miniContent` when opening their respective windows.

## Related Issue and Pull Requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

[Mini Content Demo.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/50e9d0c7-872c-4522-89a4-3a6b8c77de3f.mov" />](https://app.graphite.com/user-attachments/video/50e9d0c7-872c-4522-89a4-3a6b8c77de3f.mov)



## Test Instructions

1. Open the editor and collapse the left dock area.
2. Confirm that the Component Library, Pipeline Structure, and Runs & Submissions panels each show a compact icon button in the collapsed strip.
3. Click the Component Library button and verify the full component library content appears in a popover.
4. Click the Pipeline Structure button and verify the full pipeline tree appears in a popover.
5. Click the Runs & Submissions play button and verify a quick run is triggered without opening a popover.
6. Introduce a validation error in the pipeline and confirm the issue badge appears on the Pipeline Structure mini button and the play button is disabled and red while the dock is collapsed.
7. Resolve all issues and confirm the green check badge appears on the Pipeline Structure mini button and the play button returns to green.
8. Expand the dock and confirm normal panel behavior is unaffected.