### PR TITLE
chore: v2: windows are resizeable in any direction

### DIFF
--- a/src/routes/v2/shared/windows/components/FloatingWindow.tsx
+++ b/src/routes/v2/shared/windows/components/FloatingWindow.tsx
@@ -57,24 +57,44 @@ function getContentHeight(model: WindowModel): string | number {
   return model.size.height - HEADER_HEIGHT;
 }
 
-function ResizeHandle({
-  onMouseDown,
+type ResizeDirection = "n" | "s" | "e" | "w" | "ne" | "nw" | "se" | "sw";
+
+const resizeHandleClasses: Record<ResizeDirection, string> = {
+  n: "absolute top-0 left-3 right-3 h-1 cursor-n-resize",
+  s: "absolute bottom-0 left-3 right-3 h-1 cursor-s-resize",
+  e: "absolute right-0 top-3 bottom-3 w-1 cursor-e-resize",
+  w: "absolute left-0 top-3 bottom-3 w-1 cursor-w-resize",
+  ne: "absolute top-0 right-0 w-3 h-3 cursor-ne-resize",
+  nw: "absolute top-0 left-0 w-3 h-3 cursor-nw-resize",
+  se: "absolute bottom-0 right-0 w-3 h-3 cursor-se-resize hover:bg-gray-300 rounded-tl-sm transition-colors",
+  sw: "absolute bottom-0 left-0 w-3 h-3 cursor-sw-resize",
+};
+
+function ResizeHandles({
+  onResizeStart,
 }: {
-  onMouseDown: React.MouseEventHandler;
+  onResizeStart: (direction: ResizeDirection) => React.MouseEventHandler;
 }) {
   return (
-    <div
-      className="absolute bottom-0 right-0 w-3 h-3 cursor-se-resize hover:bg-gray-300 rounded-tl-sm transition-colors"
-      onMouseDown={onMouseDown}
-    >
-      <svg
-        className="w-full h-full text-gray-400"
-        viewBox="0 0 16 16"
-        fill="currentColor"
-      >
-        <path d="M14 14H12V12H14V14ZM14 10H12V8H14V10ZM10 14H8V12H10V14Z" />
-      </svg>
-    </div>
+    <>
+      {(Object.keys(resizeHandleClasses) as ResizeDirection[]).map((dir) => (
+        <div
+          key={dir}
+          className={resizeHandleClasses[dir]}
+          onMouseDown={onResizeStart(dir)}
+        >
+          {dir === "se" && (
+            <svg
+              className="w-full h-full text-gray-400"
+              viewBox="0 0 16 16"
+              fill="currentColor"
+            >
+              <path d="M14 14H12V12H14V14ZM14 10H12V8H14V10ZM10 14H8V12H10V14Z" />
+            </svg>
+          )}
+        </div>
+      ))}
+    </>
   );
 }
 
@@ -105,37 +125,62 @@ export const FloatingWindow = observer(function FloatingWindow() {
 
   const [isResizing, setIsResizing] = useState(false);
 
-  const handleResizeMouseDown = (e: React.MouseEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    setIsResizing(true);
+  const handleResizeMouseDown =
+    (direction: ResizeDirection) => (e: React.MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      setIsResizing(true);
 
-    const startX = e.clientX;
-    const startY = e.clientY;
-    const startWidth = model.size.width;
-    const startHeight = model.size.height;
+      const startX = e.clientX;
+      const startY = e.clientY;
+      const startWidth = model.size.width;
+      const startHeight = model.size.height;
+      const startPosX = model.position.x;
+      const startPosY = model.position.y;
 
-    const onMouseMove = (moveE: MouseEvent) => {
-      const newWidth = Math.max(
-        model.minSize.width,
-        startWidth + (moveE.clientX - startX),
-      );
-      const newHeight = Math.max(
-        model.minSize.height,
-        startHeight + (moveE.clientY - startY),
-      );
-      model.updateSize({ width: newWidth, height: newHeight });
+      const resizeRight = direction.includes("e");
+      const resizeLeft = direction.includes("w");
+      const resizeBottom = direction.includes("s");
+      const resizeTop = direction.includes("n");
+
+      const onMouseMove = (moveE: MouseEvent) => {
+        const dx = moveE.clientX - startX;
+        const dy = moveE.clientY - startY;
+
+        let newWidth = startWidth;
+        let newHeight = startHeight;
+        let newX = startPosX;
+        let newY = startPosY;
+
+        if (resizeRight) {
+          newWidth = Math.max(model.minSize.width, startWidth + dx);
+        } else if (resizeLeft) {
+          newWidth = Math.max(model.minSize.width, startWidth - dx);
+          newX = startPosX + (startWidth - newWidth);
+        }
+
+        if (resizeBottom) {
+          newHeight = Math.max(model.minSize.height, startHeight + dy);
+        } else if (resizeTop) {
+          newHeight = Math.max(model.minSize.height, startHeight - dy);
+          newY = startPosY + (startHeight - newHeight);
+        }
+
+        model.updateSize({ width: newWidth, height: newHeight });
+        if (resizeLeft || resizeTop) {
+          model.updatePosition({ x: newX, y: newY });
+        }
+      };
+
+      const onMouseUp = () => {
+        setIsResizing(false);
+        document.removeEventListener("mousemove", onMouseMove);
+        document.removeEventListener("mouseup", onMouseUp);
+      };
+
+      document.addEventListener("mousemove", onMouseMove);
+      document.addEventListener("mouseup", onMouseUp);
     };
-
-    const onMouseUp = () => {
-      setIsResizing(false);
-      document.removeEventListener("mousemove", onMouseMove);
-      document.removeEventListener("mouseup", onMouseUp);
-    };
-
-    document.addEventListener("mousemove", onMouseMove);
-    document.addEventListener("mouseup", onMouseUp);
-  };
 
   return (
     <>
@@ -167,7 +212,7 @@ export const FloatingWindow = observer(function FloatingWindow() {
         </div>
 
         {!model.isMaximized && (
-          <ResizeHandle onMouseDown={handleResizeMouseDown} />
+          <ResizeHandles onResizeStart={handleResizeMouseDown} />
         )}
       </div>
 

--- a/src/routes/v2/shared/windows/components/FloatingWindow.tsx
+++ b/src/routes/v2/shared/windows/components/FloatingWindow.tsx
@@ -1,6 +1,6 @@
 import { cva } from "class-variance-authority";
 import { observer } from "mobx-react-lite";
-import { type CSSProperties, useState } from "react";
+import { type CSSProperties, type MouseEventHandler, useState } from "react";
 import { createPortal } from "react-dom";
 
 import { useWindowContext } from "@/routes/v2/shared/windows/ContentWindowStateContext";
@@ -57,24 +57,44 @@ function getContentHeight(model: WindowModel): string | number {
   return model.size.height - HEADER_HEIGHT;
 }
 
-function ResizeHandle({
-  onMouseDown,
+type ResizeDirection = "n" | "s" | "e" | "w" | "ne" | "nw" | "se" | "sw";
+
+const resizeHandleClasses: Record<ResizeDirection, string> = {
+  n: "absolute top-0 left-3 right-3 h-1 cursor-n-resize",
+  s: "absolute bottom-0 left-3 right-3 h-1 cursor-s-resize",
+  e: "absolute right-0 top-3 bottom-3 w-1 cursor-e-resize",
+  w: "absolute left-0 top-3 bottom-3 w-1 cursor-w-resize",
+  ne: "absolute top-0 right-0 w-3 h-3 cursor-ne-resize",
+  nw: "absolute top-0 left-0 w-3 h-3 cursor-nw-resize",
+  se: "absolute bottom-0 right-0 w-3 h-3 cursor-se-resize hover:bg-gray-300 rounded-tl-sm transition-colors",
+  sw: "absolute bottom-0 left-0 w-3 h-3 cursor-sw-resize",
+};
+
+function ResizeHandles({
+  onResizeStart,
 }: {
-  onMouseDown: React.MouseEventHandler;
+  onResizeStart: (direction: ResizeDirection) => MouseEventHandler;
 }) {
   return (
-    <div
-      className="absolute bottom-0 right-0 w-3 h-3 cursor-se-resize hover:bg-gray-300 rounded-tl-sm transition-colors"
-      onMouseDown={onMouseDown}
-    >
-      <svg
-        className="w-full h-full text-gray-400"
-        viewBox="0 0 16 16"
-        fill="currentColor"
-      >
-        <path d="M14 14H12V12H14V14ZM14 10H12V8H14V10ZM10 14H8V12H10V14Z" />
-      </svg>
-    </div>
+    <>
+      {(Object.keys(resizeHandleClasses) as ResizeDirection[]).map((dir) => (
+        <div
+          key={dir}
+          className={resizeHandleClasses[dir]}
+          onMouseDown={onResizeStart(dir)}
+        >
+          {dir === "se" && (
+            <svg
+              className="w-full h-full text-gray-400"
+              viewBox="0 0 16 16"
+              fill="currentColor"
+            >
+              <path d="M14 14H12V12H14V14ZM14 10H12V8H14V10ZM10 14H8V12H10V14Z" />
+            </svg>
+          )}
+        </div>
+      ))}
+    </>
   );
 }
 
@@ -105,37 +125,63 @@ export const FloatingWindow = observer(function FloatingWindow() {
 
   const [isResizing, setIsResizing] = useState(false);
 
-  const handleResizeMouseDown = (e: React.MouseEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    setIsResizing(true);
+  const handleResizeMouseDown =
+    (direction: ResizeDirection): MouseEventHandler =>
+    (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      setIsResizing(true);
 
-    const startX = e.clientX;
-    const startY = e.clientY;
-    const startWidth = model.size.width;
-    const startHeight = model.size.height;
+      const startX = e.clientX;
+      const startY = e.clientY;
+      const startWidth = model.size.width;
+      const startHeight = model.size.height;
+      const startPosX = model.position.x;
+      const startPosY = model.position.y;
 
-    const onMouseMove = (moveE: MouseEvent) => {
-      const newWidth = Math.max(
-        model.minSize.width,
-        startWidth + (moveE.clientX - startX),
-      );
-      const newHeight = Math.max(
-        model.minSize.height,
-        startHeight + (moveE.clientY - startY),
-      );
-      model.updateSize({ width: newWidth, height: newHeight });
+      const resizeRight = direction.includes("e");
+      const resizeLeft = direction.includes("w");
+      const resizeBottom = direction.includes("s");
+      const resizeTop = direction.includes("n");
+
+      const onMouseMove = (moveE: MouseEvent) => {
+        const dx = moveE.clientX - startX;
+        const dy = moveE.clientY - startY;
+
+        let newWidth = startWidth;
+        let newHeight = startHeight;
+        let newX = startPosX;
+        let newY = startPosY;
+
+        if (resizeRight) {
+          newWidth = Math.max(model.minSize.width, startWidth + dx);
+        } else if (resizeLeft) {
+          newWidth = Math.max(model.minSize.width, startWidth - dx);
+          newX = startPosX + (startWidth - newWidth);
+        }
+
+        if (resizeBottom) {
+          newHeight = Math.max(model.minSize.height, startHeight + dy);
+        } else if (resizeTop) {
+          newHeight = Math.max(model.minSize.height, startHeight - dy);
+          newY = startPosY + (startHeight - newHeight);
+        }
+
+        model.updateSize({ width: newWidth, height: newHeight });
+        if (resizeLeft || resizeTop) {
+          model.updatePosition({ x: newX, y: newY });
+        }
+      };
+
+      const onMouseUp = () => {
+        setIsResizing(false);
+        document.removeEventListener("mousemove", onMouseMove);
+        document.removeEventListener("mouseup", onMouseUp);
+      };
+
+      document.addEventListener("mousemove", onMouseMove);
+      document.addEventListener("mouseup", onMouseUp);
     };
-
-    const onMouseUp = () => {
-      setIsResizing(false);
-      document.removeEventListener("mousemove", onMouseMove);
-      document.removeEventListener("mouseup", onMouseUp);
-    };
-
-    document.addEventListener("mousemove", onMouseMove);
-    document.addEventListener("mouseup", onMouseUp);
-  };
 
   return (
     <>
@@ -167,7 +213,7 @@ export const FloatingWindow = observer(function FloatingWindow() {
         </div>
 
         {!model.isMaximized && (
-          <ResizeHandle onMouseDown={handleResizeMouseDown} />
+          <ResizeHandles onResizeStart={handleResizeMouseDown} />
         )}
       </div>
 


### PR DESCRIPTION
## Description

Floating windows can now be resized from any edge or corner (previously it was just the bottom right).

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

Closes https://github.com/Shopify/oasis-frontend/issues/610

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

Go to v2 editor

create a floating window

confirm you can resize it along any edge or corner

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->