### PR TITLE
fix: v2: New Windows fit to content

### DIFF
--- a/src/routes/v2/shared/windows/components/FloatingWindow.tsx
+++ b/src/routes/v2/shared/windows/components/FloatingWindow.tsx
@@ -1,9 +1,14 @@
 import { cva } from "class-variance-authority";
 import { observer } from "mobx-react-lite";
-import { type CSSProperties, useState } from "react";
+import { type CSSProperties, useRef } from "react";
 import { createPortal } from "react-dom";
 
 import { useWindowContext } from "@/routes/v2/shared/windows/ContentWindowStateContext";
+import { useFitWindowToContent } from "@/routes/v2/shared/windows/hooks/useFitWindowToContent";
+import {
+  type ResizeDirection,
+  useFloatingWindowResize,
+} from "@/routes/v2/shared/windows/hooks/useFloatingWindowResize";
 import { useWindowDrag } from "@/routes/v2/shared/windows/hooks/useWindowDrag";
 import { SnapPreview } from "@/routes/v2/shared/windows/SnapPreview";
 import type { WindowModel } from "@/routes/v2/shared/windows/windowModel";
@@ -56,8 +61,6 @@ function getContentHeight(model: WindowModel): string | number {
   if (model.isMaximized) return `calc(100vh - ${HEADER_HEIGHT}px)`;
   return model.size.height - HEADER_HEIGHT;
 }
-
-type ResizeDirection = "n" | "s" | "e" | "w" | "ne" | "nw" | "se" | "sw";
 
 const resizeHandleClasses: Record<ResizeDirection, string> = {
   n: "absolute top-0 left-3 right-3 h-1 cursor-n-resize",
@@ -123,64 +126,9 @@ export const FloatingWindow = observer(function FloatingWindow() {
     handleContainerClick,
   } = useWindowDrag({ docked: false });
 
-  const [isResizing, setIsResizing] = useState(false);
-
-  const handleResizeMouseDown =
-    (direction: ResizeDirection) => (e: React.MouseEvent) => {
-      e.preventDefault();
-      e.stopPropagation();
-      setIsResizing(true);
-
-      const startX = e.clientX;
-      const startY = e.clientY;
-      const startWidth = model.size.width;
-      const startHeight = model.size.height;
-      const startPosX = model.position.x;
-      const startPosY = model.position.y;
-
-      const resizeRight = direction.includes("e");
-      const resizeLeft = direction.includes("w");
-      const resizeBottom = direction.includes("s");
-      const resizeTop = direction.includes("n");
-
-      const onMouseMove = (moveE: MouseEvent) => {
-        const dx = moveE.clientX - startX;
-        const dy = moveE.clientY - startY;
-
-        let newWidth = startWidth;
-        let newHeight = startHeight;
-        let newX = startPosX;
-        let newY = startPosY;
-
-        if (resizeRight) {
-          newWidth = Math.max(model.minSize.width, startWidth + dx);
-        } else if (resizeLeft) {
-          newWidth = Math.max(model.minSize.width, startWidth - dx);
-          newX = startPosX + (startWidth - newWidth);
-        }
-
-        if (resizeBottom) {
-          newHeight = Math.max(model.minSize.height, startHeight + dy);
-        } else if (resizeTop) {
-          newHeight = Math.max(model.minSize.height, startHeight - dy);
-          newY = startPosY + (startHeight - newHeight);
-        }
-
-        model.updateSize({ width: newWidth, height: newHeight });
-        if (resizeLeft || resizeTop) {
-          model.updatePosition({ x: newX, y: newY });
-        }
-      };
-
-      const onMouseUp = () => {
-        setIsResizing(false);
-        document.removeEventListener("mousemove", onMouseMove);
-        document.removeEventListener("mouseup", onMouseUp);
-      };
-
-      document.addEventListener("mousemove", onMouseMove);
-      document.addEventListener("mouseup", onMouseUp);
-    };
+  const contentRef = useRef<HTMLDivElement>(null);
+  const { isResizing, handleResizeStart } = useFloatingWindowResize(model);
+  useFitWindowToContent(model, contentRef, HEADER_HEIGHT);
 
   return (
     <>
@@ -205,6 +153,7 @@ export const FloatingWindow = observer(function FloatingWindow() {
         />
 
         <div
+          ref={contentRef}
           className="flex-1 min-h-0 overflow-auto bg-gray-50"
           style={{ height: getContentHeight(model) }}
         >
@@ -212,7 +161,7 @@ export const FloatingWindow = observer(function FloatingWindow() {
         </div>
 
         {!model.isMaximized && (
-          <ResizeHandles onResizeStart={handleResizeMouseDown} />
+          <ResizeHandles onResizeStart={handleResizeStart} />
         )}
       </div>
 

--- a/src/routes/v2/shared/windows/hooks/useFitWindowToContent.ts
+++ b/src/routes/v2/shared/windows/hooks/useFitWindowToContent.ts
@@ -1,0 +1,58 @@
+import { type RefObject, useLayoutEffect } from "react";
+
+import type { WindowModel } from "@/routes/v2/shared/windows/windowModel";
+
+const AUTO_FIT_MAX_WIDTH = 720;
+const AUTO_FIT_MAX_HEIGHT = 720;
+const VIEWPORT_MARGIN = 16;
+
+/**
+ * On first mount, when `model.autoSize` is set, resize the window to fit its
+ * content (clamped between `model.minSize` and a viewport-relative max), nudge
+ * the position so the window stays in the viewport, then disable auto-sizing.
+ * No-op for docked/maximized windows.
+ */
+export function useFitWindowToContent(
+  model: WindowModel,
+  contentRef: RefObject<HTMLElement | null>,
+  headerHeight: number,
+) {
+  useLayoutEffect(() => {
+    if (!model.autoSize) return;
+    if (model.isDocked || model.isMaximized) return;
+
+    const el = contentRef.current;
+    if (!el) return;
+
+    const naturalWidth = el.scrollWidth;
+    const naturalHeight = el.scrollHeight + headerHeight;
+
+    const maxW = Math.min(AUTO_FIT_MAX_WIDTH, window.innerWidth * 0.8);
+    const maxH = Math.min(AUTO_FIT_MAX_HEIGHT, window.innerHeight * 0.8);
+
+    const width = Math.min(Math.max(naturalWidth, model.minSize.width), maxW);
+    const height = Math.min(
+      Math.max(naturalHeight, model.minSize.height),
+      maxH,
+    );
+
+    model.updateSize({ width, height });
+
+    const maxX = window.innerWidth - width - VIEWPORT_MARGIN;
+    const maxY = window.innerHeight - height - VIEWPORT_MARGIN;
+    const x = Math.max(VIEWPORT_MARGIN, Math.min(model.position.x, maxX));
+    const y = Math.max(VIEWPORT_MARGIN, Math.min(model.position.y, maxY));
+    if (x !== model.position.x || y !== model.position.y) {
+      model.updatePosition({ x, y });
+    }
+
+    model.disableAutoSize();
+  }, [
+    model,
+    model.autoSize,
+    model.isDocked,
+    model.isMaximized,
+    contentRef,
+    headerHeight,
+  ]);
+}

--- a/src/routes/v2/shared/windows/hooks/useFloatingWindowResize.ts
+++ b/src/routes/v2/shared/windows/hooks/useFloatingWindowResize.ts
@@ -1,0 +1,74 @@
+import { useState } from "react";
+
+import type { WindowModel } from "@/routes/v2/shared/windows/windowModel";
+
+export type ResizeDirection = "n" | "s" | "e" | "w" | "ne" | "nw" | "se" | "sw";
+
+/**
+ * 8-direction mouse-driven resize for a floating window. Updates `size` and
+ * (for top/left handles) `position` on the model, clamped by `model.minSize`.
+ * Disables auto-fit on first interaction.
+ */
+export function useFloatingWindowResize(model: WindowModel) {
+  const [isResizing, setIsResizing] = useState(false);
+
+  const handleResizeStart =
+    (direction: ResizeDirection) => (e: React.MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      setIsResizing(true);
+      model.disableAutoSize();
+
+      const startX = e.clientX;
+      const startY = e.clientY;
+      const startWidth = model.size.width;
+      const startHeight = model.size.height;
+      const startPosX = model.position.x;
+      const startPosY = model.position.y;
+
+      const resizeRight = direction.includes("e");
+      const resizeLeft = direction.includes("w");
+      const resizeBottom = direction.includes("s");
+      const resizeTop = direction.includes("n");
+
+      const onMouseMove = (moveE: MouseEvent) => {
+        const dx = moveE.clientX - startX;
+        const dy = moveE.clientY - startY;
+
+        let newWidth = startWidth;
+        let newHeight = startHeight;
+        let newX = startPosX;
+        let newY = startPosY;
+
+        if (resizeRight) {
+          newWidth = Math.max(model.minSize.width, startWidth + dx);
+        } else if (resizeLeft) {
+          newWidth = Math.max(model.minSize.width, startWidth - dx);
+          newX = startPosX + (startWidth - newWidth);
+        }
+
+        if (resizeBottom) {
+          newHeight = Math.max(model.minSize.height, startHeight + dy);
+        } else if (resizeTop) {
+          newHeight = Math.max(model.minSize.height, startHeight - dy);
+          newY = startPosY + (startHeight - newHeight);
+        }
+
+        model.updateSize({ width: newWidth, height: newHeight });
+        if (resizeLeft || resizeTop) {
+          model.updatePosition({ x: newX, y: newY });
+        }
+      };
+
+      const onMouseUp = () => {
+        setIsResizing(false);
+        document.removeEventListener("mousemove", onMouseMove);
+        document.removeEventListener("mouseup", onMouseUp);
+      };
+
+      document.addEventListener("mousemove", onMouseMove);
+      document.addEventListener("mouseup", onMouseUp);
+    };
+
+  return { isResizing, handleResizeStart };
+}

--- a/src/routes/v2/shared/windows/windowModel.ts
+++ b/src/routes/v2/shared/windows/windowModel.ts
@@ -43,6 +43,7 @@ export interface WindowModelInit {
   dockedHeight?: number;
   dockState: DockState;
   persisted: boolean;
+  autoSize?: boolean;
   onClose?: () => void;
 }
 
@@ -68,6 +69,7 @@ export class WindowModel {
   @observable accessor dockedHeight: number | undefined;
   @observable accessor dockState: DockState;
   @observable accessor persisted: boolean;
+  @observable accessor autoSize: boolean;
 
   readonly onClose: (() => void) | undefined;
   private readonly store: WindowStoreRef;
@@ -89,6 +91,7 @@ export class WindowModel {
     this.dockedHeight = init.dockedHeight;
     this.dockState = init.dockState;
     this.persisted = init.persisted;
+    this.autoSize = init.autoSize ?? false;
     this.onClose = init.onClose;
     this.store = store;
     makeObservable(this);
@@ -211,6 +214,10 @@ export class WindowModel {
 
   @action updateSize(newSize: Size): void {
     this.size = newSize;
+  }
+
+  @action disableAutoSize(): void {
+    this.autoSize = false;
   }
 
   @action updateDockedHeight(height: number): void {

--- a/src/routes/v2/shared/windows/windowStore.utils.ts
+++ b/src/routes/v2/shared/windows/windowStore.utils.ts
@@ -40,6 +40,7 @@ export function buildWindowModelInit(
       : undefined,
     previousSize: initial.needsPreviousState ? { ...geo.size } : undefined,
     persisted: !!options.persisted,
+    autoSize: geo.autoSize,
     onClose: options.onClose,
   };
 }
@@ -76,11 +77,12 @@ function resolveGeometry(
   persisted: PersistedState,
   options: WindowOptions,
   defaultPosition: Position,
-): { position: Position; size: Size; minSize: Size } {
+): { position: Position; size: Size; minSize: Size; autoSize: boolean } {
   return {
     position: persisted?.position ?? options.position ?? defaultPosition,
     size: persisted?.size ?? options.size ?? { ...DEFAULT_WINDOW_SIZE },
     minSize: options.minSize ?? { ...DEFAULT_MIN_SIZE },
+    autoSize: !persisted?.size && !options.size,
   };
 }
 function resolveDockedOverrides(


### PR DESCRIPTION
## Description

Small improvement to floating windows so that they fit size (within reason) to their content when first created. This is to avoid giant empty windows being created over the top of the canvas, as well as ludicrously small windows that are not helpful.



Additionally, this PR moves the resizable and content fitting logic into separate hooks for better readability and future reuse.

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

Closes https://github.com/Shopify/oasis-frontend/issues/611

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

before

![image.png](https://app.graphite.com/user-attachments/assets/133427c4-f1af-4acf-8b19-18a7e8f813f2.png)

after

![image.png](https://app.graphite.com/user-attachments/assets/0a9846e6-0270-41de-9891-e1ae322348ea.png)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

Create some new floating windows and confirm they are reasonably sized.

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->