### PR TITLE
chore: v2: standardize font size across windows

### DIFF
--- a/src/components/shared/ContextPanel/Blocks/Attribute.tsx
+++ b/src/components/shared/ContextPanel/Blocks/Attribute.tsx
@@ -24,7 +24,7 @@ export const Attribute = ({
 
   const labelContent =
     copyable && label ? (
-      <CopyText className="text-xs truncate" compact>
+      <CopyText size="xs" className="truncate" compact>
         {label}
       </CopyText>
     ) : (
@@ -56,8 +56,9 @@ export const Attribute = ({
           </Link>
         ) : copyable ? (
           <CopyText
+            size="xs"
             className={cn(
-              "text-xs truncate",
+              "truncate",
               critical ? "text-destructive" : "text-muted-foreground",
             )}
             compact

--- a/src/components/shared/CopyText/CopyText.tsx
+++ b/src/components/shared/CopyText/CopyText.tsx
@@ -58,7 +58,7 @@ export const CopyText = ({
         <Text
           size={size}
           className={cn(
-            "transition-all duration-150",
+            "min-w-0 transition-all duration-150",
             className,
             isCopied && "text-emerald-400!",
           )}

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/ComputeResourcesEditor.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/ComputeResourcesEditor.tsx
@@ -30,10 +30,10 @@ export const ComputeResourcesEditor = ({
 }: ComputeResourcesEditorProps) => {
   return (
     <BlockStack gap="2">
-      <Heading level={1}>Compute Resources</Heading>
+      <Heading level={3}>Compute Resources</Heading>
 
       {!cloudProviderConfig && resources.length === 0 && (
-        <Paragraph size="sm" tone="subdued">
+        <Paragraph size="xs" tone="subdued">
           No compute resources available
         </Paragraph>
       )}

--- a/src/routes/v2/pages/Editor/components/AnnotationsBlock/AnnotationsBlock.tsx
+++ b/src/routes/v2/pages/Editor/components/AnnotationsBlock/AnnotationsBlock.tsx
@@ -138,14 +138,14 @@ function AnnotationRow({ annotation, index, annotations }: AnnotationRowProps) {
   return (
     <BlockStack gap="1" className="group w-full">
       <Input
-        className="w-full font-mono text-xs h-6 border-none px-0 shadow-none text-gray-500"
+        className="w-full font-mono text-xs! h-6 border-none px-0 shadow-none text-gray-500"
         placeholder="Key"
         defaultValue={annotation.key}
         onBlur={handleUpdateKey}
       />
       <InlineStack gap="1" wrap="nowrap" className="w-full">
         <Input
-          className="w-full font-mono text-sm"
+          className="w-full font-mono text-xs!"
           placeholder="Value"
           defaultValue={
             typeof annotation.value === "object"

--- a/src/routes/v2/pages/Editor/components/ArgumentRow/ArgumentRow.tsx
+++ b/src/routes/v2/pages/Editor/components/ArgumentRow/ArgumentRow.tsx
@@ -163,7 +163,7 @@ export const ArgumentRow = observer(function ArgumentRow({
     <div ref={rowRef} className={rowVariants()} onClick={handleClick}>
       <InlineStack gap="2" blockAlign="center" className="w-full">
         <Text
-          size="sm"
+          size="xs"
           weight="semibold"
           className={nameVariants({ unset: !isSet && !isBound })}
         >

--- a/src/routes/v2/pages/Editor/components/ArgumentRow/components/ArgumentValueDisplay.tsx
+++ b/src/routes/v2/pages/Editor/components/ArgumentRow/components/ArgumentValueDisplay.tsx
@@ -75,7 +75,7 @@ export function ArgumentValueDisplay({
       highlightSyntax
       placeholder={isBound ? bindingLabel || "" : placeholder}
       className={cn(
-        "min-h-2 text-sm font-mono mt-1 rounded-lg",
+        "min-h-2 text-xs! font-mono mt-1 rounded-lg",
         isBound && "text-blue-600",
         isUnset && "border-dashed border-gray-300",
       )}

--- a/src/routes/v2/pages/Editor/components/ComponentLibraryContent.tsx
+++ b/src/routes/v2/pages/Editor/components/ComponentLibraryContent.tsx
@@ -8,7 +8,7 @@ import { BlockStack } from "@/components/ui/layout";
  */
 export function ComponentLibraryContent() {
   return (
-    <BlockStack className="h-full overflow-y-auto">
+    <BlockStack className="h-full overflow-y-auto [&_.text-sm]:text-xs!">
       <GraphComponents />
     </BlockStack>
   );

--- a/src/routes/v2/pages/Editor/components/DebugPanel.tsx
+++ b/src/routes/v2/pages/Editor/components/DebugPanel.tsx
@@ -37,8 +37,12 @@ const DebugPanelContent = observer(function DebugPanelContent() {
   return (
     <Tabs defaultValue="stats" className="h-full flex flex-col">
       <TabsList className="mx-3 mt-2 shrink-0">
-        <TabsTrigger value="stats">Stats</TabsTrigger>
-        <TabsTrigger value="yaml">YAML</TabsTrigger>
+        <TabsTrigger value="stats" className="text-xs!">
+          Stats
+        </TabsTrigger>
+        <TabsTrigger value="yaml" className="text-xs!">
+          YAML
+        </TabsTrigger>
       </TabsList>
 
       <TabsContent value="stats" className="flex-1 min-h-0 overflow-y-auto">

--- a/src/routes/v2/pages/Editor/components/InputLabel/InputLabel.tsx
+++ b/src/routes/v2/pages/Editor/components/InputLabel/InputLabel.tsx
@@ -1,16 +1,21 @@
 import type { ComponentProps } from "react";
 
 import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
 
 import { CopyValueButton } from "./components/CopyValueButton";
 
 export function InputLabel({
   children,
   onCopy,
+  className,
   ...rest
 }: ComponentProps<typeof Label> & { onCopy?: () => string | undefined }) {
   return (
-    <Label {...rest} className="text-muted-foreground group">
+    <Label
+      {...rest}
+      className={cn("text-xs! text-muted-foreground group", className)}
+    >
       {children}
       {Boolean(onCopy) && (
         <CopyValueButton

--- a/src/routes/v2/pages/Editor/components/PipelineDetailsContent/PipelineDetailsContent.tsx
+++ b/src/routes/v2/pages/Editor/components/PipelineDetailsContent/PipelineDetailsContent.tsx
@@ -60,7 +60,7 @@ export const PipelineDetailsContent = observer(
       return (
         <BlockStack className="h-full items-center justify-center p-4">
           <Icon name="FileQuestionMark" size="lg" className="text-gray-300" />
-          <Text size="sm" tone="subdued" className="text-center mt-2">
+          <Text size="xs" tone="subdued" className="text-center mt-2">
             No pipeline loaded
           </Text>
         </BlockStack>
@@ -131,7 +131,11 @@ export const PipelineDetailsContent = observer(
           {spec.hasValidationIssues ? (
             <ValidationSummary spec={spec} />
           ) : (
-            <InfoBox variant="success" title="No validation issues">
+            <InfoBox
+              variant="success"
+              title="No validation issues"
+              className="text-xs"
+            >
               Pipeline is ready for submission
             </InfoBox>
           )}

--- a/src/routes/v2/pages/Editor/components/PipelineDetailsContent/components/DigestBlock.tsx
+++ b/src/routes/v2/pages/Editor/components/PipelineDetailsContent/components/DigestBlock.tsx
@@ -3,7 +3,6 @@ import { useQuery } from "@tanstack/react-query";
 import { ContentBlock } from "@/components/shared/ContextPanel/Blocks/ContentBlock";
 import { CopyText } from "@/components/shared/CopyText/CopyText";
 import { withSuspenseWrapper } from "@/components/shared/SuspenseWrapper";
-import { BlockStack } from "@/components/ui/layout";
 import { generateDigest } from "@/utils/componentStore";
 
 export const DigestBlock = withSuspenseWrapper(function DigestBlock({
@@ -21,9 +20,11 @@ export const DigestBlock = withSuspenseWrapper(function DigestBlock({
 
   return (
     <ContentBlock title="Digest">
-      <BlockStack className="bg-secondary p-2 rounded-md border truncate text-sm">
-        <CopyText className="font-mono truncate">{digest}</CopyText>
-      </BlockStack>
+      <div className="bg-secondary p-2 rounded-md border">
+        <CopyText size="xs" className="font-mono truncate">
+          {digest}
+        </CopyText>
+      </div>
     </ContentBlock>
   );
 });

--- a/src/routes/v2/pages/Editor/components/PipelineTreeContent/PipelineTreeContent.tsx
+++ b/src/routes/v2/pages/Editor/components/PipelineTreeContent/PipelineTreeContent.tsx
@@ -73,7 +73,7 @@ export const PipelineTreeContent = observer(function PipelineTreeContent() {
   if (!rootSpec) {
     return (
       <BlockStack className="p-4">
-        <Text size="sm" tone="subdued">
+        <Text size="xs" tone="subdued">
           No pipeline loaded
         </Text>
       </BlockStack>

--- a/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/RootNode.tsx
+++ b/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/RootNode.tsx
@@ -88,10 +88,10 @@ export const RootNode = observer(function RootNode({
         />
 
         <Text
-          size="sm"
+          size="xs"
           weight={isCurrentGraph ? "semibold" : "regular"}
           className={cn(
-            "break-words min-w-0 flex-1",
+            "wrap-break-word min-w-0 flex-1",
             isCurrentGraph && "text-blue-900",
           )}
         >

--- a/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/SubgraphNode.tsx
+++ b/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/SubgraphNode.tsx
@@ -118,10 +118,10 @@ export const SubgraphNode = observer(function SubgraphNode({
         />
 
         <Text
-          size="sm"
+          size="xs"
           weight={isCurrentGraph ? "semibold" : "regular"}
           className={cn(
-            "break-words min-w-0 flex-1",
+            "wrap-break-word min-w-0 flex-1",
             isCurrentGraph && "text-blue-900",
           )}
         >

--- a/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/TaskLeafNode.tsx
+++ b/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/TaskLeafNode.tsx
@@ -78,7 +78,7 @@ export const TaskLeafNode = observer(function TaskLeafNode({
                 : "text-slate-400",
           )}
         />
-        <Text size="sm" className="break-words min-w-0 flex-1">
+        <Text size="xs" className="wrap-break-word min-w-0 flex-1">
           {task.name}
         </Text>
         <IssueBadge issues={issues} />

--- a/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/ValidationIssueResolutionCard.tsx
+++ b/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/ValidationIssueResolutionCard.tsx
@@ -55,7 +55,7 @@ function IssueHeader({ issue }: { issue: ValidationIssue }) {
     <BlockStack gap="2">
       <InlineStack gap="2" blockAlign="center">
         <Icon name={severityIcon} size="sm" className={severityColor} />
-        <Text size="sm" weight="semibold" className={severityColor}>
+        <Text size="xs" weight="semibold" className={severityColor}>
           {issue.severity === "error" ? "Error" : "Warning"}
         </Text>
       </InlineStack>

--- a/src/routes/v2/pages/Editor/components/PressedKeysList.tsx
+++ b/src/routes/v2/pages/Editor/components/PressedKeysList.tsx
@@ -18,15 +18,20 @@ export const PressedKeysList = function PressedKeysList() {
   return (
     <BlockStack>
       <Text
+        as="h3"
         size="xs"
         weight="semibold"
-        className="uppercase tracking-wider text-blue-600"
+        tone="subdued"
+        role="heading"
+        aria-level={3}
       >
         Pressed Keys ({pressedKeys.length})
       </Text>
       <InlineStack gap="2" blockAlign="center">
         {pressedKeys.map((key) => (
-          <Text key={key}>{key}</Text>
+          <Text key={key} size="xs">
+            {key}
+          </Text>
         ))}
       </InlineStack>
     </BlockStack>

--- a/src/routes/v2/pages/Editor/components/RecentRunsContent.tsx
+++ b/src/routes/v2/pages/Editor/components/RecentRunsContent.tsx
@@ -9,7 +9,7 @@ export const RecentRunsContent = observer(function RecentRunsContent() {
   const rootSpec = navigation.rootSpec;
 
   return (
-    <BlockStack className="p-2">
+    <BlockStack className="p-2 [&_.text-sm]:text-xs!">
       <PipelineRunsList
         pipelineName={rootSpec?.name}
         showTitle={false}

--- a/src/routes/v2/pages/Editor/components/StatComponents.tsx
+++ b/src/routes/v2/pages/Editor/components/StatComponents.tsx
@@ -30,9 +30,12 @@ export function StatGroup({ title, children }: StatGroupProps) {
   return (
     <BlockStack gap="1">
       <Text
+        as="h3"
         size="xs"
         weight="semibold"
-        className="uppercase tracking-wider text-blue-600"
+        tone="subdued"
+        role="heading"
+        aria-level={3}
       >
         {title}
       </Text>

--- a/src/routes/v2/pages/Editor/nodes/ConduitNode/context/ConduitDetails.tsx
+++ b/src/routes/v2/pages/Editor/nodes/ConduitNode/context/ConduitDetails.tsx
@@ -63,7 +63,7 @@ export const ConduitDetails = observer(function ConduitDetails({
             color={conduit.color}
             setColor={handleColorChange}
           />
-          <Text size="sm" weight="semibold">
+          <Text size="xs" weight="semibold">
             Guideline
           </Text>
           <Text size="xs" tone="subdued">
@@ -72,7 +72,7 @@ export const ConduitDetails = observer(function ConduitDetails({
         </InlineStack>
 
         <BlockStack gap="2">
-          <Label className="text-gray-600">
+          <Label className="text-xs! text-gray-600">
             Assigned Edges ({assignedBindings.length})
           </Label>
 

--- a/src/routes/v2/pages/Editor/nodes/FlexNode/context/FlexNodeDetails.tsx
+++ b/src/routes/v2/pages/Editor/nodes/FlexNode/context/FlexNodeDetails.tsx
@@ -52,9 +52,9 @@ const FlexNodeDetailsInner = observer(function FlexNodeDetailsInner({
   };
 
   return (
-    <BlockStack gap="4" className="h-full px-2">
+    <BlockStack gap="4" className="p-3 [&_.text-sm]:text-xs!">
       <InlineStack gap="2" blockAlign="center">
-        <Text size="lg" weight="semibold" className="wrap-anywhere">
+        <Text size="md" weight="semibold" className="wrap-anywhere">
           Sticky Note
         </Text>
         <LockToggle

--- a/src/routes/v2/pages/Editor/nodes/FlexNode/context/components/ColorEditor.tsx
+++ b/src/routes/v2/pages/Editor/nodes/FlexNode/context/components/ColorEditor.tsx
@@ -80,7 +80,9 @@ export function ColorEditor({
             color={backgroundColor}
             setColor={handleBackgroundColorChange}
           />
-          <CopyText className="text-xs font-mono">{value.color}</CopyText>
+          <CopyText size="xs" className="font-mono">
+            {value.color}
+          </CopyText>
         </InlineStack>
 
         {isTransparent && (
@@ -91,7 +93,7 @@ export function ColorEditor({
               color={borderColor}
               setColor={handleBorderColorChange}
             />
-            <CopyText className="text-xs font-mono">
+            <CopyText size="xs" className="font-mono">
               {currentBorderColor}
             </CopyText>
           </InlineStack>

--- a/src/routes/v2/pages/Editor/nodes/FlexNode/context/components/ContentEditor.tsx
+++ b/src/routes/v2/pages/Editor/nodes/FlexNode/context/components/ContentEditor.tsx
@@ -72,7 +72,7 @@ export function ContentEditor({
           >
             <Label
               htmlFor="flex-node-title"
-              className="text-muted-foreground text-xs"
+              className="text-muted-foreground text-xs!"
             >
               Title
             </Label>
@@ -87,7 +87,7 @@ export function ContentEditor({
             value={title}
             onChange={handleTitleChange}
             onBlur={saveChanges}
-            className="text-sm"
+            className="text-xs!"
           />
         </BlockStack>
         <BlockStack>
@@ -100,7 +100,7 @@ export function ContentEditor({
           >
             <Label
               htmlFor="flex-node-content"
-              className="text-muted-foreground text-xs"
+              className="text-muted-foreground text-xs!"
             >
               Note
             </Label>
@@ -115,7 +115,7 @@ export function ContentEditor({
             value={content}
             onChange={handleContentChange}
             onBlur={saveChanges}
-            className="text-xs"
+            className="text-xs!"
           />
         </BlockStack>
       </BlockStack>

--- a/src/routes/v2/pages/Editor/nodes/IONode/context/InputDetails.tsx
+++ b/src/routes/v2/pages/Editor/nodes/IONode/context/InputDetails.tsx
@@ -65,7 +65,7 @@ export const InputDetails = observer(function InputDetails({
             id="input-name"
             defaultValue={input.name}
             onBlur={handleNameChange}
-            className="font-mono text-sm"
+            className="font-mono text-xs!"
           />
         </BlockStack>
 
@@ -82,7 +82,7 @@ export const InputDetails = observer(function InputDetails({
             defaultValue={input.type ? String(input.type) : ""}
             placeholder="e.g. String, Integer, Float"
             onBlur={handleTypeChange}
-            className="font-mono text-sm"
+            className="font-mono text-xs!"
           />
         </BlockStack>
 
@@ -99,7 +99,7 @@ export const InputDetails = observer(function InputDetails({
             defaultValue={input.description ?? ""}
             placeholder="Describe this input..."
             onBlur={handleDescriptionChange}
-            className="text-sm"
+            className="text-xs!"
             rows={2}
           />
         </BlockStack>

--- a/src/routes/v2/pages/Editor/nodes/IONode/context/OutputDetails.tsx
+++ b/src/routes/v2/pages/Editor/nodes/IONode/context/OutputDetails.tsx
@@ -49,7 +49,7 @@ export const OutputDetails = observer(function OutputDetails({
             id="output-name"
             defaultValue={output.name}
             onBlur={handleNameChange}
-            className="font-mono text-sm"
+            className="font-mono text-xs!"
           />
         </BlockStack>
 
@@ -61,7 +61,7 @@ export const OutputDetails = observer(function OutputDetails({
             >
               Type
             </InputLabel>
-            <Text size="sm" className="font-mono text-gray-500">
+            <Text size="xs" className="font-mono text-gray-500">
               {String(output.type)}
             </Text>
           </BlockStack>
@@ -80,7 +80,7 @@ export const OutputDetails = observer(function OutputDetails({
             defaultValue={output.description ?? ""}
             placeholder="Describe this output..."
             onBlur={handleDescriptionChange}
-            className="text-sm"
+            className="text-xs!"
             rows={2}
           />
         </BlockStack>

--- a/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/TaskDetails.tsx
+++ b/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/TaskDetails.tsx
@@ -11,7 +11,7 @@ import { Icon } from "@/components/ui/icon";
 import { Input } from "@/components/ui/input";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Separator } from "@/components/ui/separator";
-import { Heading, Text } from "@/components/ui/typography";
+import { Text } from "@/components/ui/typography";
 import useToastNotification from "@/hooks/useToastNotification";
 import { AnnotationsBlock } from "@/routes/v2/pages/Editor/components/AnnotationsBlock/AnnotationsBlock";
 import { useTaskActions } from "@/routes/v2/pages/Editor/store/actions/useTaskActions";
@@ -158,7 +158,7 @@ export const TaskDetails = observer(function TaskDetails({
           <CollapsibleTrigger className="flex w-full items-center justify-between bg-gray-50 px-4 py-2.5 cursor-pointer border-b border-gray-100">
             <InlineStack gap="2" blockAlign="center">
               <Icon name="Parentheses" size="xs" />
-              <Text size="sm" weight="semibold">
+              <Text size="xs" weight="semibold">
                 Arguments
               </Text>
             </InlineStack>
@@ -171,12 +171,30 @@ export const TaskDetails = observer(function TaskDetails({
           <CollapsibleContent className="px-4 py-3">
             <BlockStack gap="4">
               <BlockStack gap="2">
-                <Heading level={3}>Inputs</Heading>
+                <Text
+                  as="h3"
+                  size="xs"
+                  weight="semibold"
+                  tone="subdued"
+                  role="heading"
+                  aria-level={3}
+                >
+                  Inputs
+                </Text>
                 <TaskArgumentsEditor task={task} />
               </BlockStack>
               <Separator />
               <BlockStack gap="2">
-                <Heading level={3}>Outputs</Heading>
+                <Text
+                  as="h3"
+                  size="xs"
+                  weight="semibold"
+                  tone="subdued"
+                  role="heading"
+                  aria-level={3}
+                >
+                  Outputs
+                </Text>
                 <OutputsSection componentSpec={componentSpec} />
               </BlockStack>
             </BlockStack>
@@ -192,7 +210,7 @@ export const TaskDetails = observer(function TaskDetails({
           <CollapsibleTrigger className="flex w-full items-center justify-between bg-gray-50 px-4 py-2.5 cursor-pointer border-b border-gray-100">
             <InlineStack gap="2" blockAlign="center">
               <Icon name="Settings" size="xs" />
-              <Text size="sm" weight="semibold">
+              <Text size="xs" weight="semibold">
                 Config
               </Text>
             </InlineStack>

--- a/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/components/ConfigurationSection.tsx
+++ b/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/components/ConfigurationSection.tsx
@@ -12,7 +12,7 @@ import { ColorPicker } from "@/components/ui/color";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Separator } from "@/components/ui/separator";
 import { Switch } from "@/components/ui/switch";
-import { Heading, Paragraph } from "@/components/ui/typography";
+import { Paragraph, Text } from "@/components/ui/typography";
 import type { Task } from "@/models/componentSpec";
 import type { AnnotationConfig, Annotations } from "@/types/annotations";
 import { EDITOR_COLLAPSED_ANNOTATION } from "@/utils/annotations";
@@ -130,10 +130,19 @@ export const ConfigurationSection = observer(function ConfigurationSection({
 
   return (
     <BlockStack gap="3">
-      <Heading level={1}>Configuration</Heading>
+      <Text
+        as="h3"
+        size="xs"
+        weight="semibold"
+        tone="subdued"
+        role="heading"
+        aria-level={3}
+      >
+        Configuration
+      </Text>
 
       <InlineStack align="space-between" gap="2" className="w-full">
-        <Paragraph size="sm" tone="subdued">
+        <Paragraph size="xs" tone="subdued">
           Task color
         </Paragraph>
         <ColorPicker
@@ -147,7 +156,7 @@ export const ConfigurationSection = observer(function ConfigurationSection({
         <>
           <Separator />
           <InlineStack align="space-between" gap="2" className="w-full">
-            <Paragraph size="sm" tone="subdued">
+            <Paragraph size="xs" tone="subdued">
               Disable cache
             </Paragraph>
             <Switch
@@ -159,7 +168,7 @@ export const ConfigurationSection = observer(function ConfigurationSection({
       )}
 
       <InlineStack align="space-between" gap="2" className="w-full">
-        <Paragraph size="sm" tone="subdued">
+        <Paragraph size="xs" tone="subdued">
           Collapse node
         </Paragraph>
         <Switch checked={isCollapsed} onCheckedChange={handleCollapsedChange} />

--- a/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/components/TaskArgumentsEditor.tsx
+++ b/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/components/TaskArgumentsEditor.tsx
@@ -129,7 +129,7 @@ export const TaskArgumentsEditor = observer(function TaskArgumentsEditor({
             inlineAlign="center"
             className="h-full text-gray-400"
           >
-            <Text size="sm" tone="subdued">
+            <Text size="xs" tone="subdued">
               Select an argument to edit
             </Text>
           </BlockStack>


### PR DESCRIPTION
## Description

Font size passover to standardize down to `text-xs` through all v2 windows. Text size and heirarchy should now be more consistent.



Note: this reduces the header size for the "Compute Resources" section in v1 editor, but I feel it's a minor/superficial change.

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

Closes https://github.com/Shopify/oasis-frontend/issues/612

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

before

![image.png](https://app.graphite.com/user-attachments/assets/2cd3e5bc-963d-4ca7-ad6c-ee060986820e.png)

after

![image.png](https://app.graphite.com/user-attachments/assets/14fa5c12-7e67-451e-8297-3083b981dd5e.png)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->