### PR TITLE
fix: v2 - rectangle selection of one node

### DIFF
--- a/src/routes/v2/shared/hooks/useSelectionBehavior.ts
+++ b/src/routes/v2/shared/hooks/useSelectionBehavior.ts
@@ -54,9 +54,18 @@ export function useSelectionBehavior(
   const onSelectionChange = ({ nodes: selected }: OnSelectionChangeParams) => {
     if (selected.length > 1) {
       debouncedSetMultiSelection(buildMultiSelection(registry, spec, selected));
-    } else {
-      debouncedSetMultiSelection.cancel();
-      editor.clearMultiSelection();
+      return;
+    }
+
+    debouncedSetMultiSelection.cancel();
+    editor.clearMultiSelection();
+
+    if (selected.length === 1) {
+      const built = buildMultiSelection(registry, spec, selected);
+      const first = built[0];
+      if (first) {
+        editor.selectNode(first.id, first.type);
+      }
     }
   };
 


### PR DESCRIPTION
## Description

When a single node is selected in the editor, `selectNode` is now explicitly called with the node's `id` and `type`. Previously, single-node selections only cleared the multi-selection state without triggering `selectNode`, which could leave the editor in an inconsistent selection state.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

Before:  
[Screen Recording 2026-05-03 at 4.30.30 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/6e80e3db-0136-4ea0-82ea-319385151670.mov" />](https://app.graphite.com/user-attachments/video/6e80e3db-0136-4ea0-82ea-319385151670.mov)

After:  
[Screen Recording 2026-05-03 at 4.31.19 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/9198a85a-28f3-423b-abda-89abd40593a2.mov" />](https://app.graphite.com/user-attachments/video/9198a85a-28f3-423b-abda-89abd40593a2.mov)

## Test Instructions

1. Open the editor and using Shift+Drag select ONE node (maybe plus edge).
2. Verify that the node becomes properly selected and its properties/details are reflected in the editor panel.
3. Select multiple nodes and confirm multi-selection behavior still works as expected.
4. Deselect all nodes and confirm the editor clears the selection state correctly.

## Additional Comments