### PR TITLE
fix: v2 - sync visual selected state of the node

### DIFF
--- a/src/routes/v2/pages/Editor/nodes/FlexNode/components/FlexNode.tsx
+++ b/src/routes/v2/pages/Editor/nodes/FlexNode/components/FlexNode.tsx
@@ -11,6 +11,7 @@ import {
 import { useEditorSession } from "@/routes/v2/pages/Editor/store/EditorSessionContext";
 import { useIsDetailedView } from "@/routes/v2/shared/hooks/useIsDetailedView";
 import { useSpec } from "@/routes/v2/shared/providers/SpecContext";
+import { isEditorVisualNodeSelected } from "@/routes/v2/shared/store/isEditorVisualNodeSelected";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 
 import { FlexNodeCard } from "./FlexNodeCard";
@@ -123,6 +124,8 @@ export const EditorV2FlexNode = observer(function EditorV2FlexNode({
   const isBorderTransparent = borderColor === "transparent";
   const hasContent = !!title || !!content;
 
+  const isSelected = isEditorVisualNodeSelected(editor, id, !!selected);
+
   const viewProps: FlexNodeViewProps = {
     id,
     title,
@@ -133,7 +136,7 @@ export const EditorV2FlexNode = observer(function EditorV2FlexNode({
     contentFontSize,
     locked,
     readOnly: !!readOnly,
-    selected: !!selected,
+    selected: isSelected,
     isTransparent,
     isBorderTransparent,
     hasContent,

--- a/src/routes/v2/shared/nodes/IONode/IONode.tsx
+++ b/src/routes/v2/shared/nodes/IONode/IONode.tsx
@@ -4,6 +4,7 @@ import { observer } from "mobx-react-lite";
 import { useIsDetailedView } from "@/routes/v2/shared/hooks/useIsDetailedView";
 import type { IONodeData } from "@/routes/v2/shared/nodes/types";
 import { useSpec } from "@/routes/v2/shared/providers/SpecContext";
+import { isEditorVisualNodeSelected } from "@/routes/v2/shared/store/isEditorVisualNodeSelected";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 
 import { IONodeCard } from "./IONodeCard";
@@ -79,6 +80,8 @@ export const IONode = observer(function IONode({
       ? (entity.defaultValue ?? undefined)
       : undefined;
 
+  const isSelected = isEditorVisualNodeSelected(editor, id, !!selected);
+
   const viewProps: IONodeViewProps = {
     entityId,
     name,
@@ -87,7 +90,7 @@ export const IONode = observer(function IONode({
     defaultValue,
     connectedValue,
     isInput,
-    selected: !!selected,
+    selected: isSelected,
     isHovered,
     onNodeClick: handleClick,
   };

--- a/src/routes/v2/shared/nodes/TaskNode/TaskNode.tsx
+++ b/src/routes/v2/shared/nodes/TaskNode/TaskNode.tsx
@@ -16,6 +16,7 @@ import { useIsDetailedView } from "@/routes/v2/shared/hooks/useIsDetailedView";
 import type { TaskNodeData } from "@/routes/v2/shared/nodes/types";
 import { useSpec } from "@/routes/v2/shared/providers/SpecContext";
 import type { NodeOverlayEffect } from "@/routes/v2/shared/store/canvasOverlay.types";
+import { isEditorVisualNodeSelected } from "@/routes/v2/shared/store/isEditorVisualNodeSelected";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 import { AggregatorOutputType } from "@/types/aggregator";
 import {
@@ -262,6 +263,8 @@ export const TaskNode = observer(function TaskNode({
 
   const connectedPorts = resolveConnectedPortNames(entityId, spec);
 
+  const isSelected = isEditorVisualNodeSelected(editor, id, !!selected);
+
   const handleOutputTypeChange = (value: AggregatorOutputType) => {
     task.setArgument("output_type", value);
   };
@@ -270,7 +273,7 @@ export const TaskNode = observer(function TaskNode({
     id,
     entityId,
     taskName: task.name,
-    selected: !!selected,
+    selected: isSelected,
     isHovered: editor.hoveredEntityId === entityId,
     isSubgraph: isTaskSubgraph(componentSpec),
     collapsed: isManuallyCollapsed,

--- a/src/routes/v2/shared/store/isEditorVisualNodeSelected.ts
+++ b/src/routes/v2/shared/store/isEditorVisualNodeSelected.ts
@@ -1,0 +1,27 @@
+import type { EditorStore } from "@/routes/v2/shared/store/editorStore";
+
+/**
+ * Whether a canvas node should render the "selected" ring.
+ *
+ * When `editor.selectedNodeId` is set (single selection from store), only
+ * that node is highlighted — React Flow's `selected` prop can lag one frame
+ * after switching nodes, which would otherwise show two rings if OR'd
+ * blindly with the store.
+ *
+ * When `editor.multiSelection` is non-empty, the store list is authoritative.
+ * Otherwise fall back to React Flow's `selected` (rectangle drag before
+ * debounced multi-selection sync, or RF-only state).
+ */
+export function isEditorVisualNodeSelected(
+  editor: EditorStore,
+  nodeId: string,
+  rfSelected: boolean,
+): boolean {
+  if (editor.selectedNodeId !== null) {
+    return editor.selectedNodeId === nodeId;
+  }
+  if (editor.multiSelection.length > 0) {
+    return editor.multiSelection.some((n) => n.id === nodeId);
+  }
+  return rfSelected;
+}


### PR DESCRIPTION
## Description

Fix-try

Fixes a visual bug where two nodes could simultaneously display the "selected" ring when switching between nodes. React Flow's `selected` prop can lag one frame behind the store's `selectedNodeId`, causing both the previously selected and newly selected nodes to appear highlighted at the same time.

A new utility function `isEditorVisualNodeSelected` is introduced to determine the correct selected state for a node by using the editor store as the source of truth:

- If `editor.selectedNodeId` is set, only that node is highlighted.
- If `editor.multiSelection` is non-empty, the store's list is used.
- Otherwise, React Flow's `selected` prop is used as a fallback (e.g., during rectangle drag before multi-selection sync).

This logic is applied to `TaskNode`, `IONode`, and `EditorV2FlexNode`.

## Related Issue and Pull requests

## Type of Change

- [x] Bug fix

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Open the editor canvas with multiple nodes.
2. Click one node to select it, then immediately click another node.
3. Verify that only the newly clicked node shows the selected ring, with no lingering highlight on the previously selected node.
4. Test rectangle drag selection to confirm multi-select still highlights all selected nodes correctly.

## Selection ring vs context panel (v2 canvas)

### Root cause

Canvas nodes were styling “selected” from React Flow’s `selected` prop, while the context panel and most editor behavior use `EditorStore` (`selectedNodeId`, `multiSelection`). Those two sources can diverge briefly:

1. **`useFlowCanvasState`** syncs spec-derived nodes in a `useLayoutEffect` via `preserveSelection(current, specNodes)`. If a MobX-driven `specNodes` refresh runs close to a click, `current` may not yet include React Flow’s latest `select` change, so `preserveSelection` sees no selected ids and reapplies nodes **without** `selected: true`. The store updates from `onSelectionChange` / click handlers (context panel looks correct), but the ring can disappear until selection changes again.
2. A naive fix (**OR** `!!selected` with `editor.selectedNodeId === id`) fixed the missing ring but introduced **two rings** on fast sequential clicks: `editor.selectNode(newId)` updates immediately, while the previous node can still receive `selected: true` from React Flow for a frame—so both old (RF) and new (store) appeared selected.

### Options considered

| Approach | Pros | Cons |
| --- | --- | --- |
| **Fix in`useFlowCanvasState`only** (e.g. fold `editor.selectedNodeId` into `preserveSelection`, or restore render-time sync) | Addresses divergence at the source | Touches all canvas consumers; higher regression risk; trickier ordering vs RF internals |
| **Visual selection = store only** | Single source of truth in UI | Rectangle multi-select is debounced in `useSelectionBehavior`; rings would lag until `multiSelection` updates |
| **Precedence helper**`isEditorVisualNodeSelected` | Scoped to node views; keeps immediate rect-drag feedback from RF; fixes both “no ring” and “double ring” | Extra helper + call sites; precedence rules must stay documented |

### What we chose and why

We added **`isEditorVisualNodeSelected(editor, nodeId, rfSelected)`** with explicit precedence:

1. If **`editor.selectedNodeId`** is set → only that node is visually selected (stale RF `selected` on other nodes is ignored — fixes double ring).
2. Else if **`editor.multiSelection`** is non-empty → visuals follow the store list (post-debounce multi-select truth).
3. Else → use **React Flow’s** **`selected`** (rectangle drag before debounced multi-sync, empty store, etc.).

This aligns single-select visuals with the store (and the context panel), preserves **immediate** multi-select feedback from RF before debounce, and avoids a larger, riskier refactor of the global canvas sync pipeline for this change.