### PR TITLE
feat: v2 - runs and submissions - add latest run

### DIFF
--- a/src/routes/v2/pages/Editor/components/RunsAndSubmissionContent.tsx
+++ b/src/routes/v2/pages/Editor/components/RunsAndSubmissionContent.tsx
@@ -2,11 +2,15 @@ import { observer } from "mobx-react-lite";
 
 import { useAwaitAuthorization } from "@/components/shared/Authentication/useAwaitAuthorization";
 import { HuggingFaceAuthButton } from "@/components/shared/HuggingFaceAuth/HuggingFaceAuthButton";
+import { PipelineRunsList } from "@/components/shared/PipelineRunDisplay/PipelineRunsList";
+import { usePipelineRuns } from "@/components/shared/PipelineRunDisplay/usePipelineRuns";
 import GoogleCloudSubmissionDialog from "@/components/shared/Submitters/GoogleCloud/GoogleCloudSubmissionDialog";
 import TangleSubmitter from "@/components/shared/Submitters/Tangle/TangleSubmitter";
+import { withSuspenseWrapper } from "@/components/shared/SuspenseWrapper";
 import { Icon } from "@/components/ui/icon";
-import { BlockStack } from "@/components/ui/layout";
-import { Text } from "@/components/ui/typography";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Separator } from "@/components/ui/separator";
+import { Heading, Text } from "@/components/ui/typography";
 import { serializeComponentSpec } from "@/models/componentSpec";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 import { ENABLE_GOOGLE_CLOUD_SUBMITTER } from "@/utils/constants";
@@ -61,6 +65,7 @@ export const RunsAndSubmissionContent = observer(() => {
           />
         )}
       </BlockStack>
+      <MostRecentRun pipelineName={rootSpec?.name} />
     </BlockStack>
   );
 });
@@ -75,3 +80,39 @@ function EmptyState() {
     </BlockStack>
   );
 }
+
+const MostRecentRun = withSuspenseWrapper(function MostRecentRun({
+  pipelineName,
+}: {
+  pipelineName?: string;
+}) {
+  const { data: pipelineRuns } = usePipelineRuns(pipelineName);
+
+  if (!pipelineRuns || pipelineRuns.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      <Separator />
+      <BlockStack className="p-2">
+        <InlineStack align="space-between" className="w-full">
+          <Heading level={3}>The most recent run:</Heading>
+        </InlineStack>
+        <div className="flex-1 min-h-0 overflow-y-auto w-full">
+          <PipelineRunsList
+            pipelineName={pipelineName}
+            showTitle={false}
+            defaultShowingRuns={1}
+            showMoreButton={false}
+            overviewConfig={{
+              showName: false,
+              showDescription: true,
+              showTaskStatusBar: false,
+            }}
+          />
+        </div>
+      </BlockStack>
+    </>
+  );
+});


### PR DESCRIPTION
## Description

Contributes to https://github.com/Shopify/oasis-frontend/issues/613

Adds a "most recent run" section to the `RunsAndSubmissionContent` panel in the Editor. This displays the latest pipeline run directly within the runs and submission sidebar, along with a "Show all runs" button that opens the full recent executions list when a pipeline name is available.

UX: the most recent run appears immediately , so it is easier to reach compared to toast message. 

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

| Before | After |
| --- | --- |
| ![image.png](https://app.graphite.com/user-attachments/assets/b056b724-18b8-4ac0-b673-f12e334c3dae.png)<br> | ![image.png](https://app.graphite.com/user-attachments/assets/ddc550aa-72d1-4397-a44d-bb07443270aa.png)<br><br> |

## Test Instructions

1. Open a pipeline in the Editor with a named root spec.
2. Navigate to the Runs & Submission panel.
3. Verify that the "The most recent run" section appears below the submission options, showing the latest run.

## Additional Comments

The `PipelineRunsList` is configured to show only 1 run by default, with the name and task status bar hidden, but the description visible.