### PR TITLE
fix: v2: windows menu now stays open when toggling windows

### DIFF
--- a/src/routes/v2/pages/Editor/components/EditorMenuBar/components/WindowsMenu.tsx
+++ b/src/routes/v2/pages/Editor/components/EditorMenuBar/components/WindowsMenu.tsx
@@ -21,7 +21,9 @@ import {
 
 export const WindowsMenu = observer(function WindowsMenu() {
   const { windows } = useSharedStores();
-  const allWindows = windows.getAllWindows();
+  const sortedWindows = [...windows.getAllWindows()].sort((a, b) =>
+    a.title.localeCompare(b.title),
+  );
 
   const applyPreset = (preset: ViewPreset) => {
     windows.applyViewPreset(preset);
@@ -33,10 +35,11 @@ export const WindowsMenu = observer(function WindowsMenu() {
         <MenuTriggerButton>Windows</MenuTriggerButton>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" sideOffset={2}>
-        {allWindows.map((win) => (
+        {sortedWindows.map((win) => (
           <DropdownMenuCheckboxItem
             key={win.id}
             checked={win.state !== "hidden"}
+            onSelect={(e) => e.preventDefault()}
             onCheckedChange={(checked) => {
               if (checked) {
                 win.restore();


### PR DESCRIPTION
## Description

Two simple changes to the `window` top menu in v2:

1. Window list now arranged alphabetically
2. menu does not close when selecting a window (so now you can select multiple at once)

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

Closes https://github.com/Shopify/oasis-frontend/issues/615

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

![image.png](https://app.graphite.com/user-attachments/assets/8b9b61a9-c774-49a0-8c0a-5ec9b5f03615.png)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

Open `windows` menu. Items should be sorted alphabetically. You should be able to open & close multiple windows without the dropdown closing each time.

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->