### PR TITLE
chore: v2: tooltip audit

### DIFF
--- a/src/components/shared/Dialogs/ComponentDetailsDialog.tsx
+++ b/src/components/shared/Dialogs/ComponentDetailsDialog.tsx
@@ -143,7 +143,7 @@ const ComponentDetailsDialogContent = withSuspenseWrapper(
                 <TaskIO componentSpec={componentSpec} />
               </TabsContent>
 
-              <TabsContent value="implementation">
+              <TabsContent value="implementation" className="h-full">
                 <TaskImplementation
                   displayName={displayName}
                   componentRef={componentRef}

--- a/src/components/shared/ManageComponent/PublishedComponentDetails.tsx
+++ b/src/components/shared/ManageComponent/PublishedComponentDetails.tsx
@@ -67,7 +67,11 @@ function PublishedComponentDetailsContent({
         <BlockStack className="w-[85%]">
           <Heading level={2}>This is a published component</Heading>
           <InlineStack gap="1" align="center">
-            <TrimmedDigest digest={component.digest} tone="info" />
+            <TrimmedDigest
+              digest={component.digest}
+              tooltip={false}
+              tone="info"
+            />
             <ComponentUsageCount digest={component.digest}>
               {(count) => (
                 <Text size="xs" tone="subdued">

--- a/src/components/shared/ManageComponent/TrimmedDigest.tsx
+++ b/src/components/shared/ManageComponent/TrimmedDigest.tsx
@@ -11,10 +11,20 @@ import { trimDigest } from "./utils/digest";
 
 export const TrimmedDigest = ({
   digest,
+  tooltip = true,
   ...props
 }: {
   digest: string;
+  tooltip?: boolean;
 } & ComponentProps<typeof Text>) => {
+  if (!tooltip) {
+    return (
+      <Text size="xs" font="mono" {...props}>
+        {trimDigest(digest)}
+      </Text>
+    );
+  }
+
   return (
     <Tooltip>
       <TooltipTrigger asChild>

--- a/src/components/shared/ReactFlow/FlowSidebar/components/PublishedComponentsSearch.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/components/PublishedComponentsSearch.tsx
@@ -24,11 +24,6 @@ import { RadioGroup, RadioGroupItem } from "@/components/ui/radiogroup";
 import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 import { Text } from "@/components/ui/typography";
 import { cn } from "@/lib/utils";
 import { useBackend } from "@/providers/BackendProvider";
@@ -189,45 +184,40 @@ const SearchRequestInput = ({ value, onChange }: SearchRequestProps) => {
   return (
     <InlineStack align="space-between" gap="2" className="w-full">
       <div className="relative flex-1">
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <InputGroup
-              className="px-2 gap-2"
-              prefixElement={
-                <div className="inset-y-0 left-0 flex items-center pointer-events-none">
-                  <Icon name="Search" size="sm" className="text-gray-400" />
-                </div>
-              }
-              suffixElement={
-                <Button
-                  variant="ghost"
-                  size="min"
-                  className={cn(
-                    isValidFilterRequest(searchRequest) ? "visible" : "hidden",
-                  )}
-                  onClick={() => {
-                    dispatch({ type: "SET_SEARCH_TERM", payload: "" });
-                  }}
-                >
-                  <Icon name="X" className="size-3 text-muted-foreground" />
-                </Button>
-              }
+        <InputGroup
+          className="px-2 gap-2"
+          prefixElement={
+            <div className="inset-y-0 left-0 flex items-center pointer-events-none">
+              <Icon name="Search" size="sm" className="text-gray-400" />
+            </div>
+          }
+          suffixElement={
+            <Button
+              variant="ghost"
+              size="min"
+              className={cn(
+                isValidFilterRequest(searchRequest) ? "visible" : "hidden",
+              )}
+              onClick={() => {
+                dispatch({ type: "SET_SEARCH_TERM", payload: "" });
+              }}
             >
-              <Input
-                id="search-input"
-                variant="noBorder"
-                type="text"
-                data-testid="search-input"
-                placeholder="Search components..."
-                className="w-full text-xs p-0"
-                value={searchRequest.searchTerm}
-                autoComplete="off"
-                onChange={handleChange}
-              />
-            </InputGroup>
-          </TooltipTrigger>
-          <TooltipContent>Search components - min 3 characters</TooltipContent>
-        </Tooltip>
+              <Icon name="X" className="size-3 text-muted-foreground" />
+            </Button>
+          }
+        >
+          <Input
+            id="search-input"
+            variant="noBorder"
+            type="text"
+            data-testid="search-input"
+            placeholder="Search components..."
+            className="w-full text-xs p-0"
+            value={searchRequest.searchTerm}
+            autoComplete="off"
+            onChange={handleChange}
+          />
+        </InputGroup>
       </div>
       <SearchFilter onFiltersChange={onFiltersChange} />
     </InlineStack>

--- a/src/routes/v2/pages/Editor/components/FlowCanvas/components/SelectionToolbar.tsx
+++ b/src/routes/v2/pages/Editor/components/FlowCanvas/components/SelectionToolbar.tsx
@@ -2,7 +2,7 @@ import type { icons } from "lucide-react";
 import { observer } from "mobx-react-lite";
 import { useState } from "react";
 
-import TooltipButton from "@/components/shared/Buttons/TooltipButton";
+import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
 import { InlineStack } from "@/components/ui/layout";
 import {
@@ -118,8 +118,7 @@ function ToolbarButton({
   testId?: string;
 }) {
   return (
-    <TooltipButton
-      tooltip={label}
+    <Button
       variant="ghost"
       size="sm"
       className={cn("gap-1.5 px-2", {
@@ -132,6 +131,6 @@ function ToolbarButton({
       <Text size="xs" weight="semibold">
         {label}
       </Text>
-    </TooltipButton>
+    </Button>
   );
 }

--- a/src/routes/v2/pages/Editor/components/HistoryContent/components/HistoryToolbar.tsx
+++ b/src/routes/v2/pages/Editor/components/HistoryContent/components/HistoryToolbar.tsx
@@ -43,9 +43,7 @@ export function HistoryToolbar({
                 <Icon name="Undo2" size="xs" />
               </Button>
             </TooltipTrigger>
-            <TooltipContent side="bottom">
-              <Text size="xs">Undo (⌘Z)</Text>
-            </TooltipContent>
+            <TooltipContent side="bottom">Undo (⌘Z)</TooltipContent>
           </Tooltip>
         </TooltipProvider>
 
@@ -62,9 +60,7 @@ export function HistoryToolbar({
                 <Icon name="Redo2" size="xs" />
               </Button>
             </TooltipTrigger>
-            <TooltipContent side="bottom">
-              <Text size="xs">Redo (⌘⇧Z)</Text>
-            </TooltipContent>
+            <TooltipContent side="bottom">Redo (⌘⇧Z)</TooltipContent>
           </Tooltip>
         </TooltipProvider>
       </div>
@@ -81,14 +77,11 @@ export function HistoryToolbar({
               size="sm"
               className="h-5 w-5 p-0 text-slate-500 hover:text-red-500"
               onClick={onClear}
-              title="Clear history"
             >
               <Icon name="Trash2" size="xs" />
             </Button>
           </TooltipTrigger>
-          <TooltipContent side="bottom">
-            <Text size="xs">Clear history</Text>
-          </TooltipContent>
+          <TooltipContent side="bottom">Clear history</TooltipContent>
         </Tooltip>
       </TooltipProvider>
     </div>

--- a/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/components/ComponentRefBar.tsx
+++ b/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/components/ComponentRefBar.tsx
@@ -95,6 +95,7 @@ export function ComponentRefBar({
               {componentRef.digest && (
                 <TrimmedDigest
                   digest={componentRef.digest}
+                  tooltip={false}
                   className="shrink-0 text-muted-foreground"
                 />
               )}

--- a/src/routes/v2/shared/nodes/TaskNode/TaskNodeCard.tsx
+++ b/src/routes/v2/shared/nodes/TaskNode/TaskNodeCard.tsx
@@ -151,21 +151,14 @@ const ClassicInputHandle = observer(function ClassicInputHandle({
         </div>
         {showValueDisplay && (
           <div className="flex w-fit max-w-1/2 min-w-0 items-center gap-1">
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <div
-                  className={cn(
-                    "text-xs text-gray-800 truncate inline-block text-right pr-2",
-                    !hasValue && "text-gray-400 italic",
-                  )}
-                >
-                  {hasValue ? displayValue : input.default}
-                </div>
-              </TooltipTrigger>
-              <TooltipContent side="top">
-                {hasValue ? displayValue : input.default}
-              </TooltipContent>
-            </Tooltip>
+            <div
+              className={cn(
+                "text-xs text-gray-800 truncate inline-block text-right pr-2",
+                !hasValue && "text-gray-400 italic",
+              )}
+            >
+              {hasValue ? displayValue : input.default}
+            </div>
           </div>
         )}
       </InlineStack>


### PR DESCRIPTION
## Description

Passover the v2 editor and clean up unwanted or long tooltips. This may affect v1 in some places.

Tooltips removed:

- Component search
- Task Card input & output
- Trimmed Digest (Task Details and Published Component Details)
- Multiselect toolbar buttons

Also fixed tooltips with invisible text in the History Window.

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

Closes https://github.com/Shopify/oasis-frontend/issues/616

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->