### PR TITLE
fix: v2 - reduced height of runs and submissions

### DIFF
--- a/src/routes/v2/shared/windows/types.ts
+++ b/src/routes/v2/shared/windows/types.ts
@@ -114,7 +114,7 @@ export const COLLAPSED_DOCK_AREA_WIDTH = 36;
 export const DEFAULT_DOCKED_HEIGHT = 300;
 
 /** Minimum height for a docked window (px) */
-export const MIN_DOCKED_HEIGHT = 100;
+export const MIN_DOCKED_HEIGHT = 50;
 
 /** Distance from dock area edge to trigger dock insert preview (px) */
 export const DOCK_AREA_SNAP_THRESHOLD = 40;


### PR DESCRIPTION
## Description

Reduces the minimum height for docked windows from 100px to 50px, allowing users to resize docked windows to a smaller height.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

![image.png](https://app.graphite.com/user-attachments/assets/a4d4ac67-25b1-45ea-b620-fe81e1465195.png)



## Test Instructions

1. Dock a window to the dock area.
2. Attempt to resize the docked window by dragging its edge downward to reduce its height.
3. Verify that the window can now be resized down to 50px in height, whereas previously it would stop at 100px.

## Additional Comments

This change provides more flexibility for users who prefer a more compact docked window layout.