### PR TITLE
fix: v2: rm scrollbar from autogrowtextarea

### DIFF
--- a/src/routes/v2/pages/Editor/components/ArgumentRow/components/ArgumentValueDisplay.tsx
+++ b/src/routes/v2/pages/Editor/components/ArgumentRow/components/ArgumentValueDisplay.tsx
@@ -75,7 +75,7 @@ export function ArgumentValueDisplay({
       highlightSyntax
       placeholder={isBound ? bindingLabel || "" : placeholder}
       className={cn(
-        "min-h-2 text-xs! font-mono mt-1 rounded-lg",
+        "min-h-4 text-xs! font-mono mt-1 rounded-lg",
         isBound && "text-blue-600",
         isUnset && "border-dashed border-gray-300",
       )}

--- a/src/routes/v2/pages/Editor/components/AutoGrowTextArea.tsx
+++ b/src/routes/v2/pages/Editor/components/AutoGrowTextArea.tsx
@@ -9,6 +9,7 @@ import {
 } from "react";
 
 import { MultilineTextInputDialog } from "@/components/shared/Dialogs/MultilineTextInputDialog";
+import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
@@ -20,8 +21,12 @@ function heightFormula(maxGrowHeight: string): string {
 function measureContentHeight(el: HTMLTextAreaElement, formula: string): void {
   el.style.setProperty("height", "0px", "important");
   const scrollH = el.scrollHeight;
+  const cs = window.getComputedStyle(el);
+  const borderY =
+    (parseFloat(cs.borderTopWidth) || 0) +
+    (parseFloat(cs.borderBottomWidth) || 0);
   el.style.setProperty("height", formula);
-  el.style.setProperty("--content-h", `${scrollH}px`);
+  el.style.setProperty("--content-h", `${scrollH + borderY}px`);
 }
 
 interface AutoGrowTextareaProps extends Omit<
@@ -153,7 +158,7 @@ export function AutoGrowTextarea({
         <Textarea
           ref={setDefaultRef}
           className={cn(
-            "field-sizing-fixed resize-y overflow-y-auto",
+            "field-sizing-fixed resize-y overflow-y-auto subtle-scrollbar",
             className,
           )}
           style={{
@@ -170,15 +175,16 @@ export function AutoGrowTextarea({
           {...props}
         />
         {showExpandButton && (
-          <button
-            type="button"
-            className="absolute top-1 right-1 rounded p-0.5 text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-hover/expand:opacity-100"
+          <Button
+            variant="ghost"
+            size="min"
+            className="absolute top-1 right-1 text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-hover/expand:opacity-100"
             onPointerDown={(e) => e.preventDefault()}
             onClick={handleExpandClick}
             tabIndex={-1}
           >
             <Icon name="Maximize2" size="xs" />
-          </button>
+          </Button>
         )}
       </div>
       {showExpandButton && (

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -199,6 +199,43 @@ code {
   .hide-scrollbar::-webkit-scrollbar {
     display: none; /* Chrome, Safari, Opera */
   }
+
+  /* Thin, translucent scrollbar that overlays content without grabbing attention. */
+  .subtle-scrollbar {
+    scrollbar-width: thin;
+    scrollbar-color: color-mix(
+        in oklch,
+        var(--muted-foreground) 30%,
+        transparent
+      )
+      transparent;
+  }
+
+  .subtle-scrollbar::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+
+  .subtle-scrollbar::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  .subtle-scrollbar::-webkit-scrollbar-thumb {
+    background-color: color-mix(
+      in oklch,
+      var(--muted-foreground) 25%,
+      transparent
+    );
+    border-radius: 3px;
+  }
+
+  .subtle-scrollbar::-webkit-scrollbar-thumb:hover {
+    background-color: color-mix(
+      in oklch,
+      var(--muted-foreground) 50%,
+      transparent
+    );
+  }
 }
 
 /* Dialog stack transition animations */


### PR DESCRIPTION
## Description

Resizes the argument input boxes so they don't have tiny scrollbars. Also adds a new `subtle scrollbar` cass so when the scrollbars do appear they are not so imposing.

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

![image.png](https://app.graphite.com/user-attachments/assets/eac818e8-407c-4870-83b2-1a773757dc8b.png)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->