### PR TITLE
chore: v2 - update top menu in editor

### DIFF
--- a/src/routes/v2/pages/Editor/components/EditorMenuBar/EditorMenuBar.tsx
+++ b/src/routes/v2/pages/Editor/components/EditorMenuBar/EditorMenuBar.tsx
@@ -11,7 +11,6 @@ import { Text } from "@/components/ui/typography";
 import { usePipelineRename } from "@/routes/v2/pages/Editor/hooks/usePipelineRename";
 import { useEditorSession } from "@/routes/v2/pages/Editor/store/EditorSessionContext";
 import { AppMenuActions } from "@/routes/v2/shared/components/AppMenuActions";
-import { MenuTriggerButton } from "@/routes/v2/shared/components/MenuTriggerButton";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 import { TOP_NAV_HEIGHT } from "@/utils/constants";
 
@@ -25,7 +24,7 @@ import { ViewMenu } from "./components/ViewMenu";
 import { WindowsMenu } from "./components/WindowsMenu";
 
 export const EditorMenuBar = observer(function EditorMenuBar() {
-  const { navigation, windows } = useSharedStores();
+  const { navigation } = useSharedStores();
   const { pipelineFile } = useEditorSession();
   const handlePipelineRename = usePipelineRename();
   const spec = navigation.activeSpec;
@@ -99,11 +98,6 @@ export const EditorMenuBar = observer(function EditorMenuBar() {
                 <FileMenu />
                 <ViewMenu />
                 <RunsMenu />
-                <MenuTriggerButton
-                  onClick={() => windows.restoreWindow("pipeline-details")}
-                >
-                  Notes
-                </MenuTriggerButton>
                 <ComponentsLibraryMenu />
                 <WindowsMenu />
                 <NodeMenu />

--- a/src/routes/v2/pages/Editor/components/EditorMenuBar/components/ComponentsLibraryMenu.tsx
+++ b/src/routes/v2/pages/Editor/components/EditorMenuBar/components/ComponentsLibraryMenu.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from "@tanstack/react-router";
 import { useRef } from "react";
 
 import { ImportComponent } from "@/components/shared/ReactFlow/FlowSidebar/components";
@@ -9,11 +10,11 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Icon } from "@/components/ui/icon";
+import { APP_ROUTES } from "@/routes/router";
 import { MenuTriggerButton } from "@/routes/v2/shared/components/MenuTriggerButton";
-import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 
 export function ComponentsLibraryMenu() {
-  const { windows } = useSharedStores();
+  const navigate = useNavigate();
   const importTriggerRef = useRef<HTMLButtonElement>(null);
 
   return (
@@ -24,16 +25,12 @@ export function ComponentsLibraryMenu() {
         </DropdownMenuTrigger>
         <DropdownMenuContent align="start" sideOffset={2}>
           <DropdownMenuItem
-            onClick={() => windows.restoreWindow("component-library")}
+            onClick={() =>
+              void navigate({ to: APP_ROUTES.DASHBOARD_COMPONENTS })
+            }
           >
             <Icon name="Library" size="sm" />
             Explore library
-          </DropdownMenuItem>
-          <DropdownMenuItem
-            onClick={() => windows.restoreWindow("component-library")}
-          >
-            <Icon name="User" size="sm" />
-            My components
           </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuItem onClick={() => importTriggerRef.current?.click()}>


### PR DESCRIPTION
## Description

Closes https://github.com/Shopify/oasis-frontend/issues/606

Closes https://github.com/Shopify/oasis-frontend/issues/614

Removes the "Notes" menu button from the editor menu bar and replaces the `ComponentsLibraryMenu`'s window-based navigation with route-based navigation using `useNavigate`. The "Explore library" option now navigates to `APP_ROUTES.DASHBOARD_COMPONENTS` instead of restoring a floating window, and the "My components" menu item has been removed entirely.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [x] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Open the editor and verify the "Notes" button no longer appears in the menu bar.
2. Open the "Components Library" menu and confirm only "Explore library" and the import option are present.
3. Click "Explore library" and verify it navigates to the dashboard components route instead of opening a floating window.

## Additional Comments