### PR TITLE
fix: v2 - fix validation rules

### DIFF
--- a/src/models/componentSpec/__tests__/entities/componentSpecProxy.test.ts
+++ b/src/models/componentSpec/__tests__/entities/componentSpecProxy.test.ts
@@ -76,6 +76,21 @@ describe("createComponentSpecProxy", () => {
       ]);
     });
 
+    it("maps input pipeline value to InputSpec", () => {
+      const spec = makeMinimalSpec();
+      spec.addInput(
+        new Input({
+          $id: "in_1",
+          name: "data",
+          value: "42",
+        }),
+      );
+
+      const proxy = createComponentSpecProxy(spec);
+
+      expect(proxy.inputs).toEqual([{ name: "data", value: "42" }]);
+    });
+
     it("returns empty array when no inputs", () => {
       const proxy = createComponentSpecProxy(makeMinimalSpec());
       expect(proxy.inputs).toEqual([]);

--- a/src/models/componentSpec/__tests__/entities/input.test.ts
+++ b/src/models/componentSpec/__tests__/entities/input.test.ts
@@ -64,4 +64,12 @@ describe("Input", () => {
 
     expect(input.type).toBe("number");
   });
+
+  it("setValue updates pipeline value", () => {
+    const input = new Input({ $id: "input_1", name: "x" });
+
+    input.setValue("42");
+
+    expect(input.value).toBe("42");
+  });
 });

--- a/src/models/componentSpec/__tests__/serialization/jsonSerializer.test.ts
+++ b/src/models/componentSpec/__tests__/serialization/jsonSerializer.test.ts
@@ -146,6 +146,27 @@ describe("JsonSerializer", () => {
     });
   });
 
+  it("serializes inputs with pipeline value", () => {
+    const spec = new ComponentSpec({
+      $id: idGen.next("spec"),
+      name: "Pipeline",
+    });
+    spec.addInput(
+      new Input({
+        $id: idGen.next("input"),
+        name: "data",
+        value: "run-time",
+      }),
+    );
+
+    const json = serializer.serialize(spec);
+
+    expect(json.inputs![0]).toMatchObject({
+      name: "data",
+      value: "run-time",
+    });
+  });
+
   it("serializes outputs", () => {
     const spec = new ComponentSpec({
       $id: idGen.next("spec"),

--- a/src/models/componentSpec/__tests__/serialization/yamlDeserializer.test.ts
+++ b/src/models/componentSpec/__tests__/serialization/yamlDeserializer.test.ts
@@ -56,6 +56,17 @@ describe("YamlDeserializer", () => {
     expect(spec.inputs.at(0)?.defaultValue).toBe("default_value");
   });
 
+  it("deserializes input with pipeline value", () => {
+    const yaml = {
+      name: "Spec",
+      inputs: [{ name: "data", value: "42" }],
+    };
+
+    const spec = deserializer.deserialize(yaml);
+
+    expect(spec.inputs.at(0)?.value).toBe("42");
+  });
+
   it("deserializes spec with outputs", () => {
     const yaml = {
       name: "SpecWithOutputs",

--- a/src/models/componentSpec/__tests__/validation/collectIssues.test.ts
+++ b/src/models/componentSpec/__tests__/validation/collectIssues.test.ts
@@ -17,6 +17,7 @@ function makeTask(id: string, name: string, spec?: ComponentSpecJson): Task {
     const idGen = new IncrementingIdGenerator();
     const deserializer = new YamlDeserializer(idGen);
     const subgraphSpec = deserializer.deserialize(spec);
+    subgraphSpec.setEmbeddedSubgraph(true);
     return new Task({
       $id: id,
       name,

--- a/src/models/componentSpec/__tests__/validation/validateSpec.test.ts
+++ b/src/models/componentSpec/__tests__/validation/validateSpec.test.ts
@@ -172,6 +172,92 @@ describe("validateSpec", () => {
 
       expect(unconnectedInputs).toHaveLength(0);
     });
+
+    it("reports warning when required pipeline input has no default or value (root only)", () => {
+      const spec = makeSpec("Pipeline");
+      spec.addTask(makeTask("t1", "TaskA"));
+      const input = new Input({
+        $id: "i1",
+        name: "param",
+        optional: false,
+      });
+      spec.addInput(input);
+
+      const issues = validateSpec(spec);
+
+      expect(issues).toContainEqual(
+        expect.objectContaining({
+          type: "input",
+          message: "Required input missing value",
+          entityId: "i1",
+          severity: "warning",
+          issueCode: "MISSING_PIPELINE_INPUT_VALUE",
+          argumentName: "param",
+        }),
+      );
+    });
+
+    it("does not report missing pipeline input value when defaultValue is set", () => {
+      const spec = makeSpec("Pipeline");
+      spec.addTask(makeTask("t1", "TaskA"));
+      spec.addInput(
+        new Input({
+          $id: "i1",
+          name: "param",
+          optional: false,
+          defaultValue: "x",
+        }),
+      );
+
+      const issues = validateSpec(spec).filter(
+        (i) => i.issueCode === "MISSING_PIPELINE_INPUT_VALUE",
+      );
+      expect(issues).toHaveLength(0);
+    });
+
+    it("does not report missing pipeline input value when value is set", () => {
+      const spec = makeSpec("Pipeline");
+      spec.addTask(makeTask("t1", "TaskA"));
+      spec.addInput(
+        new Input({
+          $id: "i1",
+          name: "param",
+          optional: false,
+          value: "42",
+        }),
+      );
+
+      const issues = validateSpec(spec).filter(
+        (i) => i.issueCode === "MISSING_PIPELINE_INPUT_VALUE",
+      );
+      expect(issues).toHaveLength(0);
+    });
+
+    it("does not report missing pipeline input value when input is optional", () => {
+      const spec = makeSpec("Pipeline");
+      spec.addTask(makeTask("t1", "TaskA"));
+      spec.addInput(makeInput("i1", "param", true));
+
+      const issues = validateSpec(spec).filter(
+        (i) => i.issueCode === "MISSING_PIPELINE_INPUT_VALUE",
+      );
+      expect(issues).toHaveLength(0);
+    });
+
+    it("skips pipeline input value warnings for embedded subgraph specs", () => {
+      const spec = new ComponentSpec({
+        $id: "spec_embed",
+        name: "Inner",
+        isEmbeddedSubgraph: true,
+      });
+      spec.addTask(makeTask("t1", "TaskA"));
+      spec.addInput(new Input({ $id: "i1", name: "p", optional: false }));
+
+      const issues = validateSpec(spec).filter(
+        (i) => i.issueCode === "MISSING_PIPELINE_INPUT_VALUE",
+      );
+      expect(issues).toHaveLength(0);
+    });
   });
 
   describe("output rules", () => {

--- a/src/models/componentSpec/actions/createSubgraph.ts
+++ b/src/models/componentSpec/actions/createSubgraph.ts
@@ -225,6 +225,7 @@ export function createSubgraph({
       ...subgraphOutputBindings,
     ],
   });
+  subgraphSpec.setEmbeddedSubgraph(true);
 
   const replacementTaskArgs: Argument[] = inputGroups.map(({ input }) => ({
     name: input.name,

--- a/src/models/componentSpec/entities/componentSpec.ts
+++ b/src/models/componentSpec/entities/componentSpec.ts
@@ -24,6 +24,7 @@ export class ComponentSpec extends Model({
   tasks: prop<Task[]>(() => []),
   bindings: prop<Binding[]>(() => []),
   annotations: prop<Annotations>(() => new Annotations({})),
+  isEmbeddedSubgraph: prop<boolean | undefined>(undefined),
 }) {
   // --- Task mutations ---
 
@@ -267,6 +268,11 @@ export class ComponentSpec extends Model({
   @modelAction
   setDescription(description: string | undefined) {
     this.description = description;
+  }
+
+  @modelAction
+  setEmbeddedSubgraph(isEmbedded: boolean | undefined) {
+    this.isEmbeddedSubgraph = isEmbedded;
   }
 
   // --- Computed helpers ---

--- a/src/models/componentSpec/entities/componentSpecProxy.ts
+++ b/src/models/componentSpec/entities/componentSpecProxy.ts
@@ -59,13 +59,17 @@ export function createComponentSpecProxy(
 }
 
 function inputModelToSpec(input: Input): InputSpec {
-  return {
+  const spec: InputSpec = {
     name: input.name,
     type: input.type,
     description: input.description,
     default: input.defaultValue,
     optional: input.optional,
   };
+  if (input.value !== undefined) {
+    spec.value = input.value;
+  }
+  return spec;
 }
 
 function outputModelToSpec(output: Output): OutputSpec {

--- a/src/models/componentSpec/entities/input.ts
+++ b/src/models/componentSpec/entities/input.ts
@@ -10,6 +10,7 @@ export class Input extends Model({
   type: prop<TypeSpecType | undefined>(undefined),
   description: prop<string | undefined>(undefined),
   defaultValue: prop<string | undefined>(undefined),
+  value: prop<string | undefined>(undefined),
   optional: prop<boolean | undefined>(undefined),
   annotations: prop<Annotations>(() => new Annotations({})),
 }) {
@@ -31,6 +32,11 @@ export class Input extends Model({
   @modelAction
   setDefaultValue(defaultValue: string | undefined) {
     this.defaultValue = defaultValue;
+  }
+
+  @modelAction
+  setValue(value: string | undefined) {
+    this.value = value;
   }
 
   @modelAction

--- a/src/models/componentSpec/entities/task.ts
+++ b/src/models/componentSpec/entities/task.ts
@@ -33,6 +33,9 @@ export class Task extends Model({
 
   @modelAction
   setSubgraphSpec(spec: ComponentSpec | undefined) {
+    if (spec) {
+      spec.setEmbeddedSubgraph(true);
+    }
     this.subgraphSpec = spec;
   }
 
@@ -44,7 +47,8 @@ export class Task extends Model({
   @modelAction
   setComponentRef(ref: ComponentReference) {
     if (ref.spec && isGraphImplementation(ref.spec.implementation)) {
-      this.subgraphSpec = deserializeSubgraphSpec(ref.spec);
+      const subgraph = deserializeSubgraphSpec(ref.spec);
+      this.subgraphSpec = subgraph;
       this.componentRef = { ...ref, spec: undefined };
     } else {
       this.subgraphSpec = undefined;

--- a/src/models/componentSpec/entities/taskSubgraphHelper.ts
+++ b/src/models/componentSpec/entities/taskSubgraphHelper.ts
@@ -13,5 +13,7 @@ export function deserializeSubgraphSpec(
 ): ComponentSpec {
   const idGen = new IncrementingIdGenerator();
   const deserializer = new YamlDeserializer(idGen);
-  return deserializer.deserialize(specJson);
+  const spec = deserializer.deserialize(specJson);
+  spec.setEmbeddedSubgraph(true);
+  return spec;
 }

--- a/src/models/componentSpec/serialization/jsonSerializer.ts
+++ b/src/models/componentSpec/serialization/jsonSerializer.ts
@@ -161,6 +161,9 @@ export class JsonSerializer {
     if (input.type) result.type = input.type;
     if (input.description) result.description = input.description;
     if (input.defaultValue) result.default = input.defaultValue;
+    if (input.value !== undefined) {
+      result.value = input.value;
+    }
     if (input.optional !== undefined) result.optional = input.optional;
 
     const annotations = this.serializeAnnotations(input.annotations);

--- a/src/models/componentSpec/serialization/yamlDeserializer.ts
+++ b/src/models/componentSpec/serialization/yamlDeserializer.ts
@@ -78,6 +78,7 @@ export class YamlDeserializer {
         type: inputJson.type,
         description: inputJson.description,
         defaultValue: inputJson.default,
+        value: inputJson.value,
         optional: inputJson.optional,
         annotations: Annotations.from(annotationItems),
       });
@@ -161,7 +162,9 @@ export class YamlDeserializer {
   ): ComponentSpec | undefined {
     if (!ref.spec?.implementation) return undefined;
     if (!isGraphImplementation(ref.spec.implementation)) return undefined;
-    return this.deserialize(ref.spec);
+    const inner = this.deserialize(ref.spec);
+    inner.setEmbeddedSubgraph(true);
+    return inner;
   }
 
   private buildBindings(

--- a/src/models/componentSpec/validation/collectIssues.ts
+++ b/src/models/componentSpec/validation/collectIssues.ts
@@ -14,14 +14,12 @@ export function collectValidationIssues(
 ): ComponentValidationIssue[] {
   return collectRecursive(spec, {
     subgraphPath: [ROOT_PATH_ID],
-    skipInputConnectionValidation: false,
     visitedSpecIds: new Set(),
   });
 }
 
 interface CollectionContext {
   subgraphPath: string[];
-  skipInputConnectionValidation: boolean;
   visitedSpecIds: Set<string>;
 }
 
@@ -43,7 +41,6 @@ function collectRecursive(
     if (!task.subgraphSpec) return [];
     return collectRecursive(task.subgraphSpec, {
       subgraphPath: [...subgraphPath, task.name],
-      skipInputConnectionValidation: true,
       visitedSpecIds: context.visitedSpecIds,
     });
   });

--- a/src/models/componentSpec/validation/pipelineInputValue.ts
+++ b/src/models/componentSpec/validation/pipelineInputValue.ts
@@ -1,0 +1,19 @@
+/**
+ * Shared rule for whether a pipeline-level input still needs a configured value
+ * (default or runtime value). Aligns with legacy `validateInputsAndOutputs` and
+ * `validateArguments` trim semantics.
+ */
+export function isPipelineInputMissingConfiguredValue(input: {
+  optional?: boolean;
+  default?: string;
+  value?: string;
+}): boolean {
+  if (input.optional) return false;
+  if (hasNonEmptyConfiguredString(input.default)) return false;
+  if (hasNonEmptyConfiguredString(input.value)) return false;
+  return true;
+}
+
+function hasNonEmptyConfiguredString(s: string | undefined): boolean {
+  return String(s ?? "").trim().length > 0;
+}

--- a/src/models/componentSpec/validation/types.ts
+++ b/src/models/componentSpec/validation/types.ts
@@ -3,6 +3,8 @@ type ValidationIssueType = "graph" | "task" | "input" | "output";
 type ValidationSeverity = "error" | "warning";
 
 export type ValidationIssueCode =
+  | "MISSING_PIPELINE_INPUT_VALUE"
+  | "MISSING_REQUIRED_ANNOTATION"
   | "MISSING_REQUIRED_INPUT"
   | "EMPTY_TASK_NAME"
   | "MISSING_COMPONENT_REF"

--- a/src/models/componentSpec/validation/validateSpec.ts
+++ b/src/models/componentSpec/validation/validateSpec.ts
@@ -1,3 +1,10 @@
+import {
+  getCloudProviderConfig,
+  getCommonAnnotations,
+  getProviderSchema,
+  launcherTaskAnnotationSchema,
+  parseSchemaToAnnotationConfig,
+} from "@/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/utils";
 import { isInvalidComponentReference } from "@/utils/componentSpec";
 
 import type { Binding } from "../entities/binding";
@@ -7,6 +14,7 @@ import type { Output } from "../entities/output";
 import type { Task } from "../entities/task";
 import type { InputSpec } from "../entities/types";
 import { isGraphInputArgument, isTaskOutputArgument } from "../entities/types";
+import { isPipelineInputMissingConfiguredValue } from "./pipelineInputValue";
 import type { ValidationIssue } from "./types";
 
 /**
@@ -17,6 +25,9 @@ export function validateSpec(spec: ComponentSpec): ValidationIssue[] {
   return [
     ...validateGraphLevel(spec),
     ...validateInputs(spec),
+    ...(spec.isEmbeddedSubgraph !== true
+      ? validatePipelineInputConfiguredValues(spec)
+      : []),
     ...validateOutputs(spec),
     ...validateTasks(spec),
     ...validateBindings(spec),
@@ -47,6 +58,38 @@ function validateGraphLevel(spec: ComponentSpec): ValidationIssue[] {
       severity: "error",
       issueCode: "NO_TASKS",
     });
+  }
+
+  return issues;
+}
+
+/**
+ * Root pipeline only (skipped when `spec.isEmbeddedSubgraph` is true).
+ * Required inputs without a non-empty default or pipeline value are warnings so
+ * runs can still be gated on errors only.
+ */
+function validatePipelineInputConfiguredValues(
+  spec: ComponentSpec,
+): ValidationIssue[] {
+  const issues: ValidationIssue[] = [];
+
+  for (const input of spec.inputs) {
+    if (
+      isPipelineInputMissingConfiguredValue({
+        optional: input.optional,
+        default: input.defaultValue,
+        value: input.value,
+      })
+    ) {
+      issues.push({
+        type: "input",
+        message: "Required input missing value",
+        entityId: input.$id,
+        severity: "warning",
+        issueCode: "MISSING_PIPELINE_INPUT_VALUE",
+        argumentName: input.name,
+      });
+    }
   }
 
   return issues;
@@ -174,6 +217,69 @@ function validateSingleTask(
 
   issues.push(...validateTaskArguments(task, spec));
   issues.push(...validateTaskRequiredInputs(task, spec));
+  issues.push(...validateLauncherTaskAnnotations(task));
+
+  return issues;
+}
+
+function taskAnnotationsAsStringRecord(task: Task): Record<string, string> {
+  const taskAnnotations: Record<string, string> = {};
+  for (const a of task.annotations.items) {
+    const v = a.value;
+    taskAnnotations[a.key] =
+      typeof v === "string"
+        ? v
+        : v === undefined || v === null
+          ? ""
+          : String(v);
+  }
+  return taskAnnotations;
+}
+
+function validateLauncherTaskAnnotations(task: Task): ValidationIssue[] {
+  const issues: ValidationIssue[] = [];
+  const taskAnnotations = taskAnnotationsAsStringRecord(task);
+
+  const cloudProviderAnnotation = getCloudProviderConfig(
+    launcherTaskAnnotationSchema,
+  )?.annotation;
+  const selectedProvider = cloudProviderAnnotation
+    ? taskAnnotations[cloudProviderAnnotation]
+    : undefined;
+
+  const providerSchema =
+    selectedProvider &&
+    getProviderSchema(launcherTaskAnnotationSchema, selectedProvider);
+
+  if (providerSchema) {
+    for (const config of parseSchemaToAnnotationConfig(providerSchema)) {
+      if (!config.required) continue;
+      if (taskAnnotations[config.annotation]?.trim()) continue;
+      issues.push({
+        type: "task",
+        message: `Required annotation "${config.label}" is missing`,
+        entityId: task.$id,
+        severity: "error",
+        issueCode: "MISSING_REQUIRED_ANNOTATION",
+        argumentName: config.annotation,
+        referencedName: config.label,
+      });
+    }
+  }
+
+  for (const config of getCommonAnnotations(launcherTaskAnnotationSchema)) {
+    if (config.required && !taskAnnotations[config.annotation]?.trim()) {
+      issues.push({
+        type: "task",
+        message: `Required annotation "${config.label}" is missing`,
+        entityId: task.$id,
+        severity: "error",
+        issueCode: "MISSING_REQUIRED_ANNOTATION",
+        argumentName: config.annotation,
+        referencedName: config.label,
+      });
+    }
+  }
 
   return issues;
 }

--- a/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/ValidationIssueResolutionCard.tsx
+++ b/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/ValidationIssueResolutionCard.tsx
@@ -138,6 +138,14 @@ function renderInfoResolution(message: string): ReactNode {
 }
 
 const RESOLUTION_MAP: Record<ValidationIssueCode, ResolutionResolver> = {
+  MISSING_PIPELINE_INPUT_VALUE: () =>
+    renderInfoResolution(
+      "Set a default or pipeline value on this input in pipeline details, or mark the input as optional.",
+    ),
+  MISSING_REQUIRED_ANNOTATION: () =>
+    renderInfoResolution(
+      "Open the task and fill in the required launcher annotation in the task settings.",
+    ),
   MISSING_REQUIRED_INPUT: (p) => (
     <MissingRequiredInputResolution issue={p.issue} spec={p.spec} />
   ),

--- a/src/utils/validations.ts
+++ b/src/utils/validations.ts
@@ -5,6 +5,7 @@ import {
   launcherTaskAnnotationSchema,
   parseSchemaToAnnotationConfig,
 } from "@/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/utils";
+import { isPipelineInputMissingConfiguredValue } from "@/models/componentSpec/validation/pipelineInputValue";
 
 import {
   type ArgumentType,
@@ -164,9 +165,11 @@ const validateInputsAndOutputs = (
       // Check that required inputs have a value or default
       if (
         !skipInputValueValidation &&
-        !input.optional &&
-        !input.default &&
-        !input.value
+        isPipelineInputMissingConfiguredValue({
+          optional: input.optional,
+          default: input.default,
+          value: input.value,
+        })
       ) {
         errors.push({
           type: "argument",


### PR DESCRIPTION
## Description

Adds a pipeline-level `value` field to `Input` that is distinct from `defaultValue`. This field represents a runtime-configured value set directly on a pipeline input (via YAML `value`), and is now round-tripped through serialization/deserialization, exposed through the component spec proxy, and validated.

A new validation rule (`MISSING_PIPELINE_INPUT_VALUE`) emits a warning when a required root pipeline input has neither a `defaultValue` nor a `value` set. This check is skipped for embedded subgraph specs (nested pipelines), which are now explicitly flagged via a new `isEmbeddedSubgraph` property on `ComponentSpec`. The `setEmbeddedSubgraph(true)` call is applied consistently wherever subgraph specs are created or deserialized.

Additionally, a new validation rule (`MISSING_REQUIRED_ANNOTATION`) is introduced to flag required launcher task annotations that are missing or empty, surfacing these as errors on the relevant task.

The shared `isPipelineInputMissingConfiguredValue` helper consolidates the trim-aware "has a configured value" check, replacing the previous inline logic in `validations.ts` and aligning it with the new model-layer validation.

Resolution guidance for both new issue codes is wired into the `ValidationIssueResolutionCard`.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

Previously "missed value" was ignore, now it is "warning"

| Before | After |
| --- | --- |
| ![image.png](https://app.graphite.com/user-attachments/assets/9f5cc7f8-c6c1-4f28-a5e8-3356f4d74d9a.png)<br> | ![image.png](https://app.graphite.com/user-attachments/assets/447e8954-9653-4168-a18f-15ffa582acda.png)<br> |

[Screen Recording 2026-05-05 at 12.28.22 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/1f70be0d-20a3-4728-b487-3b11f509b85d.mov" />](https://app.graphite.com/user-attachments/video/1f70be0d-20a3-4728-b487-3b11f509b85d.mov)

## Test Instructions

1. Open a pipeline with a required input that has no default or value set — confirm a `MISSING_PIPELINE_INPUT_VALUE` warning appears in the validation panel with the suggested resolution.
2. Set either a `defaultValue` or `value` on that input — confirm the warning clears.
3. Create input on root level without default value — confirm no warning is raised.
4. Open a pipeline containing a subgraph task — confirm no `MISSING_PIPELINE_INPUT_VALUE` warnings are raised for inputs inside the subgraph.
5. Add a launcher task with a required annotation left blank — confirm a `MISSING_REQUIRED_ANNOTATION` error appears.
6. Fill in the required annotation — confirm the error clears.
7. Serialize and deserialize a pipeline YAML containing `value` on an input — confirm the field is preserved.

## Additional Comments

The `isEmbeddedSubgraph` flag replaces the previous `skipInputConnectionValidation` context flag that was threaded through `collectIssues`. Subgraph specs now carry this state intrinsically rather than relying on call-site context.