### PR TITLE
chore: v2 - analytics display in debug panel

### DIFF
--- a/src/routes/v2/pages/Editor/components/AnalyticsDebugTap.tsx
+++ b/src/routes/v2/pages/Editor/components/AnalyticsDebugTap.tsx
@@ -1,0 +1,123 @@
+import { useEffect, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
+
+const ANALYTICS_TRACK_EVENT = "tangle.analytics.track";
+const MAX_ANALYTICS_EVENTS = 500;
+
+interface AnalyticsDebugEntry {
+  id: string;
+  receivedAtIso: string;
+  detail: Record<string, unknown>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Listens for `tangle.analytics.track` (same as AnalyticsProvider) and shows a capped log for local debugging.
+ */
+export function AnalyticsDebugTap() {
+  const [entries, setEntries] = useState<AnalyticsDebugEntry[]>([]);
+
+  useEffect(() => {
+    function handleTrack(ev: Event) {
+      if (!(ev instanceof CustomEvent)) return;
+      const raw = ev.detail;
+      if (!isRecord(raw)) return;
+
+      const id = `${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
+      const receivedAtIso = new Date().toISOString();
+
+      setEntries((prev) => {
+        const next: AnalyticsDebugEntry[] = [
+          { id, receivedAtIso, detail: { ...raw } },
+          ...prev,
+        ];
+        return next.slice(0, MAX_ANALYTICS_EVENTS);
+      });
+    }
+
+    window.addEventListener(ANALYTICS_TRACK_EVENT, handleTrack);
+    return () => {
+      window.removeEventListener(ANALYTICS_TRACK_EVENT, handleTrack);
+    };
+  }, []);
+
+  const handleClear = () => {
+    setEntries([]);
+  };
+
+  const handleCopyRow = async (entry: AnalyticsDebugEntry) => {
+    const text = JSON.stringify(
+      { receivedAtIso: entry.receivedAtIso, ...entry.detail },
+      null,
+      2,
+    );
+    await navigator.clipboard.writeText(text);
+  };
+
+  return (
+    <BlockStack gap="3" className="p-3 h-full min-h-0">
+      <InlineStack gap="2" blockAlign="center" align="space-between">
+        <Text size="xs" tone="subdued">
+          Last {MAX_ANALYTICS_EVENTS} events (newest first)
+        </Text>
+        <Button type="button" variant="outline" size="xs" onClick={handleClear}>
+          Clear
+        </Button>
+      </InlineStack>
+
+      <BlockStack
+        as="ul"
+        gap="2"
+        className="flex-1 min-h-0 overflow-y-auto list-none p-0 m-0"
+      >
+        {entries.length === 0 ? (
+          <Text size="xs" tone="subdued">
+            No analytics events yet. Interact with the app or open other tabs.
+          </Text>
+        ) : (
+          entries.map((entry) => {
+            const actionType =
+              typeof entry.detail.actionType === "string"
+                ? entry.detail.actionType
+                : "(unknown)";
+            return (
+              <li
+                key={entry.id}
+                className="rounded-md border border-border bg-muted/40 p-2"
+              >
+                <BlockStack gap="1">
+                  <InlineStack gap="2" blockAlign="start" align="space-between">
+                    <Text size="xs" weight="semibold" className="break-all">
+                      {actionType}
+                    </Text>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="xs"
+                      className="shrink-0"
+                      onClick={() => void handleCopyRow(entry)}
+                    >
+                      Copy
+                    </Button>
+                  </InlineStack>
+                  <Text size="xs" tone="subdued">
+                    {entry.receivedAtIso}
+                  </Text>
+                  <pre className="text-[10px] leading-snug overflow-x-auto whitespace-pre-wrap break-all max-h-40 overflow-y-auto rounded bg-background p-2 border border-border">
+                    {JSON.stringify(entry.detail, null, 2)}
+                  </pre>
+                </BlockStack>
+              </li>
+            );
+          })
+        )}
+      </BlockStack>
+    </BlockStack>
+  );
+}

--- a/src/routes/v2/pages/Editor/components/DebugPanel.tsx
+++ b/src/routes/v2/pages/Editor/components/DebugPanel.tsx
@@ -13,6 +13,7 @@ import { ShortcutBadge } from "@/routes/v2/shared/components/ShortcutBadge";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 import { tracking } from "@/utils/tracking";
 
+import { AnalyticsDebugTap } from "./AnalyticsDebugTap";
 import { getSelectedInfo, getSpecStats, getSpecYaml } from "./debugPanel.utils";
 import { PressedKeysList } from "./PressedKeysList";
 import { StatGroup, StatItem } from "./StatComponents";
@@ -51,6 +52,9 @@ const DebugPanelContent = observer(function DebugPanelContent() {
           {...tracking("v2.pipeline_editor.debug_panel.tab_yaml")}
         >
           YAML
+        </TabsTrigger>
+        <TabsTrigger value="analytics" className="text-xs!">
+          Analytics
         </TabsTrigger>
       </TabsList>
 
@@ -122,6 +126,10 @@ const DebugPanelContent = observer(function DebugPanelContent() {
         <div className="m-2 h-full rounded-md overflow-hidden bg-gray-50 border border-gray-200">
           <CodeSyntaxHighlighter code={specYaml} language="yaml" />
         </div>
+      </TabsContent>
+
+      <TabsContent value="analytics" className="flex-1 min-h-0 flex flex-col">
+        <AnalyticsDebugTap />
       </TabsContent>
     </Tabs>
   );


### PR DESCRIPTION
## Description

Contributes to https://github.com/Shopify/oasis-frontend/issues/607

Adds an **Analytics** tab to the Editor's Debug Panel that captures and displays `tangle.analytics.track` custom events in real time. The tab shows the last 500 events (newest first), with each entry displaying the `actionType`, timestamp, and full event payload. Individual entries can be copied to the clipboard as formatted JSON, and the entire log can be cleared with a single button.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Open the Editor and launch the Debug Panel.
2. Navigate to the new **Analytics** tab.
3. Interact with the app (e.g., trigger actions, open other tabs) and confirm events appear in the list, newest first.
4. Click **Copy** on an entry and verify the clipboard contains the correctly formatted JSON payload.
5. Click **Clear** and confirm the list empties.
6. Verify that the list never exceeds 500 entries under heavy event volume.

## Additional Comments

The component listens on the same `tangle.analytics.track` custom event used by `AnalyticsProvider`, so no changes to the analytics pipeline are required. This is intended for local debugging only.