### PR TITLE
chore: v2 - instrument editor menu bar, quick run, auto-save, and app menu actions

### DIFF
--- a/src/routes/v2/pages/Editor/components/EditorMenuBar/EditorMenuBar.tsx
+++ b/src/routes/v2/pages/Editor/components/EditorMenuBar/EditorMenuBar.tsx
@@ -13,6 +13,7 @@ import { useEditorSession } from "@/routes/v2/pages/Editor/store/EditorSessionCo
 import { AppMenuActions } from "@/routes/v2/shared/components/AppMenuActions";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 import { TOP_NAV_HEIGHT } from "@/utils/constants";
+import { tracking } from "@/utils/tracking";
 
 import { AutoSaveIndicator } from "./components/AutoSaveIndicator";
 import { ComponentsLibraryMenu } from "./components/ComponentsLibraryMenu";
@@ -51,7 +52,13 @@ export const EditorMenuBar = observer(function EditorMenuBar() {
           blockAlign="center"
           className="min-w-0"
         >
-          <Link href="/" aria-label="Home" variant="block" className="shrink-0">
+          <Link
+            href="/"
+            aria-label="Home"
+            variant="block"
+            className="shrink-0"
+            {...tracking("v2.pipeline_editor.menubar.home")}
+          >
             <img
               src={logo}
               alt="logo"
@@ -80,6 +87,7 @@ export const EditorMenuBar = observer(function EditorMenuBar() {
                   size="inline-xs"
                   className="shrink-0 p-0 text-stone-400 hover:bg-transparent hover:text-white opacity-0 group-hover:opacity-100 transition-opacity"
                   onClick={() => setRenameOpen(true)}
+                  {...tracking("v2.pipeline_editor.menubar.rename_pipeline")}
                 >
                   <Icon name="Pencil" size="xs" />
                 </Button>

--- a/src/routes/v2/pages/Editor/components/EditorMenuBar/components/AutoSaveIndicator.tsx
+++ b/src/routes/v2/pages/Editor/components/EditorMenuBar/components/AutoSaveIndicator.tsx
@@ -4,6 +4,7 @@ import TooltipButton from "@/components/shared/Buttons/TooltipButton";
 import { Icon } from "@/components/ui/icon";
 import { Spinner } from "@/components/ui/spinner";
 import { useEditorSession } from "@/routes/v2/pages/Editor/store/EditorSessionContext";
+import { tracking } from "@/utils/tracking";
 
 function getTooltipText(isSaving: boolean, lastSavedAt: Date | null): string {
   if (isSaving) return "Saving...";
@@ -24,6 +25,7 @@ export const AutoSaveIndicator = observer(function AutoSaveIndicator() {
       className="hover:bg-transparent"
       disabled={isSaving}
       data-testid="auto-save-button"
+      {...tracking("v2.pipeline_editor.auto_save_indicator")}
     >
       {isSaving ? (
         <Spinner size={16} />

--- a/src/routes/v2/pages/Editor/components/EditorMenuBar/components/ComponentsLibraryMenu.tsx
+++ b/src/routes/v2/pages/Editor/components/EditorMenuBar/components/ComponentsLibraryMenu.tsx
@@ -10,10 +10,13 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Icon } from "@/components/ui/icon";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { APP_ROUTES } from "@/routes/router";
 import { MenuTriggerButton } from "@/routes/v2/shared/components/MenuTriggerButton";
+import { tracking } from "@/utils/tracking";
 
 export function ComponentsLibraryMenu() {
+  const { track } = useAnalytics();
   const navigate = useNavigate();
   const importTriggerRef = useRef<HTMLButtonElement>(null);
 
@@ -21,19 +24,33 @@ export function ComponentsLibraryMenu() {
     <>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
-          <MenuTriggerButton>Components</MenuTriggerButton>
+          <MenuTriggerButton
+            {...tracking("v2.pipeline_editor.components_library_menu")}
+          >
+            Components
+          </MenuTriggerButton>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="start" sideOffset={2}>
           <DropdownMenuItem
-            onClick={() =>
-              void navigate({ to: APP_ROUTES.DASHBOARD_COMPONENTS })
-            }
+            onClick={() => {
+              track(
+                "v2.pipeline_editor.components_library_menu.explore_library.click",
+              );
+              void navigate({ to: APP_ROUTES.DASHBOARD_COMPONENTS });
+            }}
           >
             <Icon name="Library" size="sm" />
             Explore library
           </DropdownMenuItem>
           <DropdownMenuSeparator />
-          <DropdownMenuItem onClick={() => importTriggerRef.current?.click()}>
+          <DropdownMenuItem
+            onClick={() => {
+              track(
+                "v2.pipeline_editor.components_library_menu.add_component.click",
+              );
+              importTriggerRef.current?.click();
+            }}
+          >
             <Icon name="PackagePlus" size="sm" />
             Add component
           </DropdownMenuItem>

--- a/src/routes/v2/pages/Editor/components/EditorMenuBar/components/FileMenu.tsx
+++ b/src/routes/v2/pages/Editor/components/EditorMenuBar/components/FileMenu.tsx
@@ -15,16 +15,19 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Icon } from "@/components/ui/icon";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { APP_ROUTES } from "@/routes/router";
 import { useEditorSession } from "@/routes/v2/pages/Editor/store/EditorSessionContext";
 import { MenuTriggerButton } from "@/routes/v2/shared/components/MenuTriggerButton";
 import { MovePipelineDialog } from "@/routes/v2/shared/components/MovePipelineDialog";
 import { ShortcutBadge } from "@/routes/v2/shared/components/ShortcutBadge";
+import { tracking } from "@/utils/tracking";
 
 import { OpenPipelineDialog } from "./OpenPipelineDialog";
 import { useFileMenuState } from "./useFileMenuState";
 
 export function FileMenu() {
+  const { track } = useAnalytics();
   const {
     importTriggerRef,
     openDialogOpen,
@@ -57,10 +60,17 @@ export function FileMenu() {
     <>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
-          <MenuTriggerButton>File</MenuTriggerButton>
+          <MenuTriggerButton {...tracking("v2.pipeline_editor.file_menu")}>
+            File
+          </MenuTriggerButton>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="start" sideOffset={2}>
-          <DropdownMenuItem onClick={() => setOpenDialogOpen(true)}>
+          <DropdownMenuItem
+            onClick={() => {
+              track("v2.pipeline_editor.file_menu.open.click");
+              setOpenDialogOpen(true);
+            }}
+          >
             <Icon name="FolderOpen" size="sm" />
             Open
             <DropdownMenuShortcut>
@@ -68,35 +78,70 @@ export function FileMenu() {
             </DropdownMenuShortcut>
           </DropdownMenuItem>
           <DropdownMenuSeparator />
-          <DropdownMenuItem onClick={handleSave}>
+          <DropdownMenuItem
+            onClick={() => {
+              track("v2.pipeline_editor.file_menu.save.click");
+              void handleSave();
+            }}
+          >
             <Icon name="Save" size="sm" />
             Save
           </DropdownMenuItem>
-          <DropdownMenuItem onClick={() => setSaveAsDialogOpen(true)}>
+          <DropdownMenuItem
+            onClick={() => {
+              track("v2.pipeline_editor.file_menu.save_as.click");
+              setSaveAsDialogOpen(true);
+            }}
+          >
             <Icon name="SaveAll" size="sm" />
             Save as
           </DropdownMenuItem>
-          <DropdownMenuItem onClick={() => setRenameDialogOpen(true)}>
+          <DropdownMenuItem
+            onClick={() => {
+              track("v2.pipeline_editor.file_menu.rename.click");
+              setRenameDialogOpen(true);
+            }}
+          >
             <Icon name="Pencil" size="sm" />
             Rename
           </DropdownMenuItem>
           <DropdownMenuSeparator />
-          <DropdownMenuItem onClick={handleNewPipeline}>
+          <DropdownMenuItem
+            onClick={() => {
+              track("v2.pipeline_editor.file_menu.new_pipeline.click");
+              void handleNewPipeline();
+            }}
+          >
             <Icon name="Plus" size="sm" />
             New pipeline
           </DropdownMenuItem>
-          <DropdownMenuItem onClick={() => setImportOpen(true)}>
+          <DropdownMenuItem
+            onClick={() => {
+              track("v2.pipeline_editor.file_menu.import.click");
+              setImportOpen(true);
+            }}
+          >
             <Icon name="Upload" size="sm" />
             Import
           </DropdownMenuItem>
-          <DropdownMenuItem onClick={handleExport}>
+          <DropdownMenuItem
+            onClick={() => {
+              track("v2.pipeline_editor.file_menu.export.click");
+              void handleExport();
+            }}
+          >
             <Icon name="FileDown" size="sm" />
             Export
           </DropdownMenuItem>
           {canMove && (
             <>
               <DropdownMenuSeparator />
-              <DropdownMenuItem onClick={() => setMoveDialogOpen(true)}>
+              <DropdownMenuItem
+                onClick={() => {
+                  track("v2.pipeline_editor.file_menu.move_to_folder.click");
+                  setMoveDialogOpen(true);
+                }}
+              >
                 <Icon name="Folder" size="sm" />
                 Move to folder
               </DropdownMenuItem>
@@ -104,7 +149,10 @@ export function FileMenu() {
           )}
           <DropdownMenuSeparator />
           <DropdownMenuItem
-            onClick={() => setDeleteDialogOpen(true)}
+            onClick={() => {
+              track("v2.pipeline_editor.file_menu.delete_pipeline.click");
+              setDeleteDialogOpen(true);
+            }}
             className="text-destructive focus:text-destructive"
           >
             <Icon name="Trash2" size="sm" />

--- a/src/routes/v2/pages/Editor/components/EditorMenuBar/components/NodeMenu.tsx
+++ b/src/routes/v2/pages/Editor/components/EditorMenuBar/components/NodeMenu.tsx
@@ -20,11 +20,13 @@ import {
 import { Icon } from "@/components/ui/icon";
 import useToastNotification from "@/hooks/useToastNotification";
 import type { ComponentSpec } from "@/models/componentSpec";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { useTaskActions } from "@/routes/v2/pages/Editor/store/actions/useTaskActions";
 import { useEditorSession } from "@/routes/v2/pages/Editor/store/EditorSessionContext";
 import { MenuTriggerButton } from "@/routes/v2/shared/components/MenuTriggerButton";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 import { getErrorMessage } from "@/utils/string";
+import { tracking } from "@/utils/tracking";
 
 function findEntityAnnotations(spec: ComponentSpec, entityId: string) {
   for (const t of spec.tasks) if (t.$id === entityId) return t.annotations;
@@ -34,6 +36,7 @@ function findEntityAnnotations(spec: ComponentSpec, entityId: string) {
 }
 
 export const NodeMenu = observer(function NodeMenu() {
+  const { track } = useAnalytics();
   const { editor, navigation } = useSharedStores();
   const { undo } = useEditorSession();
   const spec = navigation.activeSpec;
@@ -57,6 +60,7 @@ export const NodeMenu = observer(function NodeMenu() {
 
   const handleDuplicate = () => {
     if (!task) return;
+    track("v2.pipeline_editor.node_menu.duplicate_task.click");
     const position = task.annotations.get("editor.position") ?? {
       x: 0,
       y: 0,
@@ -70,6 +74,7 @@ export const NodeMenu = observer(function NodeMenu() {
   };
 
   const handleDelete = () => {
+    track("v2.pipeline_editor.node_menu.delete_task.click");
     try {
       deleteTask(spec, entityId);
       editor.clearSelection();
@@ -80,6 +85,7 @@ export const NodeMenu = observer(function NodeMenu() {
   };
 
   const handleUnpack = () => {
+    track("v2.pipeline_editor.node_menu.unpack_subgraph.click");
     try {
       unpackSubgraphTask(spec, entityId);
       notify("Subgraph unpacked", "success");
@@ -91,6 +97,9 @@ export const NodeMenu = observer(function NodeMenu() {
   const handleZIndex = (
     operation: "front" | "back" | "forward" | "backward",
   ) => {
+    track("v2.pipeline_editor.node_menu.z_index.click", {
+      z_index_operation: operation,
+    });
     const nodes = getNodes();
     const currentNode = nodes.find((n) => n.id === entityId);
     if (!currentNode) return;
@@ -119,7 +128,9 @@ export const NodeMenu = observer(function NodeMenu() {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <MenuTriggerButton>Node</MenuTriggerButton>
+        <MenuTriggerButton {...tracking("v2.pipeline_editor.node_menu")}>
+          Node
+        </MenuTriggerButton>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" sideOffset={2}>
         {isTask && (

--- a/src/routes/v2/pages/Editor/components/EditorMenuBar/components/QuickRunButton.tsx
+++ b/src/routes/v2/pages/Editor/components/EditorMenuBar/components/QuickRunButton.tsx
@@ -8,6 +8,7 @@ import { Icon } from "@/components/ui/icon";
 import { serializeComponentSpec } from "@/models/componentSpec";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 import { deepClone } from "@/utils/deepClone";
+import { tracking } from "@/utils/tracking";
 
 const quickRunIconVariants = cva("transition-colors", {
   variants: {
@@ -69,6 +70,7 @@ export const QuickRunButton = observer(function QuickRunButton() {
         className="hover:bg-transparent"
         disabled={hasErrors}
         onClick={triggerSubmitRun}
+        {...tracking("v2.pipeline_editor.quick_run")}
       >
         <Icon
           name="Play"

--- a/src/routes/v2/pages/Editor/components/EditorMenuBar/components/RunsMenu.tsx
+++ b/src/routes/v2/pages/Editor/components/EditorMenuBar/components/RunsMenu.tsx
@@ -9,12 +9,15 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Icon } from "@/components/ui/icon";
 import { Text } from "@/components/ui/typography";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { MenuTriggerButton } from "@/routes/v2/shared/components/MenuTriggerButton";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
+import { tracking } from "@/utils/tracking";
 
 import { triggerSubmitRun, triggerSubmitWithArguments } from "./QuickRunButton";
 
 export const RunsMenu = observer(function RunsMenu() {
+  const { track } = useAnalytics();
   const { navigation } = useSharedStores();
   const rootSpec = navigation.rootSpec;
   const allIssues = rootSpec?.allValidationIssues ?? [];
@@ -24,15 +27,26 @@ export const RunsMenu = observer(function RunsMenu() {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <MenuTriggerButton>Runs</MenuTriggerButton>
+        <MenuTriggerButton {...tracking("v2.pipeline_editor.runs_menu")}>
+          Runs
+        </MenuTriggerButton>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" sideOffset={2}>
-        <DropdownMenuItem onSelect={triggerSubmitRun} disabled={hasErrors}>
+        <DropdownMenuItem
+          onSelect={() => {
+            track("v2.pipeline_editor.runs_menu.submit_run.click");
+            triggerSubmitRun();
+          }}
+          disabled={hasErrors}
+        >
           <Icon name="Play" size="sm" />
           Submit Run
         </DropdownMenuItem>
         <DropdownMenuItem
-          onSelect={triggerSubmitWithArguments}
+          onSelect={() => {
+            track("v2.pipeline_editor.runs_menu.submit_with_arguments.click");
+            triggerSubmitWithArguments();
+          }}
           disabled={hasErrors}
         >
           <Icon name="Split" size="sm" className="rotate-90" />

--- a/src/routes/v2/pages/Editor/components/EditorMenuBar/components/ViewMenu.tsx
+++ b/src/routes/v2/pages/Editor/components/EditorMenuBar/components/ViewMenu.tsx
@@ -16,9 +16,11 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Icon } from "@/components/ui/icon";
 import { serializeComponentSpecToText } from "@/models/componentSpec";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { MenuTriggerButton } from "@/routes/v2/shared/components/MenuTriggerButton";
 import { ShortcutBadge } from "@/routes/v2/shared/components/ShortcutBadge";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
+import { tracking } from "@/utils/tracking";
 
 const LAYOUT_ALGORITHMS: { key: LayoutAlgorithm; label: string }[] = [
   { key: "sugiyama", label: "Sugiyama" },
@@ -28,6 +30,7 @@ const LAYOUT_ALGORITHMS: { key: LayoutAlgorithm; label: string }[] = [
 ];
 
 export const ViewMenu = observer(function ViewMenu() {
+  const { track } = useAnalytics();
   const { keyboard, navigation } = useSharedStores();
   const autoLayoutShortcut = keyboard.getShortcut("auto-layout");
   const [showYaml, setShowYaml] = useState(false);
@@ -38,7 +41,9 @@ export const ViewMenu = observer(function ViewMenu() {
     <>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
-          <MenuTriggerButton>View</MenuTriggerButton>
+          <MenuTriggerButton {...tracking("v2.pipeline_editor.view_menu")}>
+            View
+          </MenuTriggerButton>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="start" sideOffset={2}>
           <DropdownMenuSub>
@@ -50,11 +55,14 @@ export const ViewMenu = observer(function ViewMenu() {
               {LAYOUT_ALGORITHMS.map((algo) => (
                 <DropdownMenuItem
                   key={algo.key}
-                  onSelect={() =>
+                  onSelect={() => {
+                    track("v2.pipeline_editor.view_menu.auto_layout.click", {
+                      layout_algorithm: algo.key,
+                    });
                     keyboard.invokeShortcut("auto-layout", {
                       algorithm: algo.key,
-                    })
-                  }
+                    });
+                  }}
                 >
                   {algo.label}
                   {algo.key === "sugiyama" && (
@@ -67,7 +75,13 @@ export const ViewMenu = observer(function ViewMenu() {
             </DropdownMenuSubContent>
           </DropdownMenuSub>
           <DropdownMenuSeparator />
-          <DropdownMenuItem disabled={!spec} onSelect={() => setShowYaml(true)}>
+          <DropdownMenuItem
+            disabled={!spec}
+            onSelect={() => {
+              track("v2.pipeline_editor.view_menu.view_yaml.click");
+              setShowYaml(true);
+            }}
+          >
             <Icon name="FileCode" size="sm" />
             View YAML
           </DropdownMenuItem>
@@ -80,7 +94,10 @@ export const ViewMenu = observer(function ViewMenu() {
           language="yaml"
           filename={spec.name}
           fullscreen
-          onClose={() => setShowYaml(false)}
+          onClose={() => {
+            track("v2.pipeline_editor.view_menu.view_yaml.close.click");
+            setShowYaml(false);
+          }}
         />
       )}
     </>

--- a/src/routes/v2/pages/Editor/components/EditorMenuBar/components/WindowsMenu.tsx
+++ b/src/routes/v2/pages/Editor/components/EditorMenuBar/components/WindowsMenu.tsx
@@ -12,27 +12,35 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Icon } from "@/components/ui/icon";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { MenuTriggerButton } from "@/routes/v2/shared/components/MenuTriggerButton";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 import {
   VIEW_PRESETS,
   type ViewPreset,
 } from "@/routes/v2/shared/windows/viewPresets";
+import { tracking } from "@/utils/tracking";
 
 export const WindowsMenu = observer(function WindowsMenu() {
+  const { track } = useAnalytics();
   const { windows } = useSharedStores();
   const sortedWindows = [...windows.getAllWindows()].sort((a, b) =>
     a.title.localeCompare(b.title),
   );
 
   const applyPreset = (preset: ViewPreset) => {
+    track("v2.pipeline_editor.windows_menu.view_preset.click", {
+      preset_label: preset.label,
+    });
     windows.applyViewPreset(preset);
   };
 
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <MenuTriggerButton>Windows</MenuTriggerButton>
+        <MenuTriggerButton {...tracking("v2.pipeline_editor.windows_menu")}>
+          Windows
+        </MenuTriggerButton>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" sideOffset={2}>
         {sortedWindows.map((win) => (
@@ -41,6 +49,13 @@ export const WindowsMenu = observer(function WindowsMenu() {
             checked={win.state !== "hidden"}
             onSelect={(e) => e.preventDefault()}
             onCheckedChange={(checked) => {
+              track(
+                "v2.pipeline_editor.windows_menu.window_visibility.toggle",
+                {
+                  window_id: win.id,
+                  visible: checked,
+                },
+              );
               if (checked) {
                 win.restore();
               } else {

--- a/src/routes/v2/shared/components/AppMenuActions.tsx
+++ b/src/routes/v2/shared/components/AppMenuActions.tsx
@@ -8,6 +8,7 @@ import { Icon } from "@/components/ui/icon";
 import { InlineStack } from "@/components/ui/layout";
 import { Link } from "@/components/ui/link";
 import { DOCUMENTATION_URL } from "@/utils/constants";
+import { tracking } from "@/utils/tracking";
 
 export function AppMenuActions() {
   const requiresAuthorization = isAuthorizationRequired();
@@ -21,12 +22,15 @@ export function AppMenuActions() {
     >
       <EditorVersionToggle />
       <RouterLink to="/settings/backend">
-        <TooltipButton tooltip="Settings">
+        <TooltipButton tooltip="Settings" {...tracking("v2.header.settings")}>
           <Icon name="Settings" />
         </TooltipButton>
       </RouterLink>
       <Link href={DOCUMENTATION_URL} target="_blank" rel="noopener noreferrer">
-        <TooltipButton tooltip="Documentation">
+        <TooltipButton
+          tooltip="Documentation"
+          {...tracking("v2.header.documentation")}
+        >
           <Icon name="CircleQuestionMark" />
         </TooltipButton>
       </Link>


### PR DESCRIPTION
## Description

Contributes to https://github.com/Shopify/oasis-frontend/issues/607

Adds analytics tracking to the pipeline editor menu bar and its components. Tracking events are attached to all major interactive elements across the editor, including:

- The home logo link and pipeline rename button in the menu bar
- The auto-save indicator
- All menu triggers (File, View, Node, Runs, Windows, Components Library)
- All dropdown menu items within each menu (open, save, save as, rename, new pipeline, import, export, move to folder, delete, auto layout, view YAML, submit run, submit with arguments, duplicate/delete/unpack node, z-index operations, window visibility toggles, view presets)
- The quick run button
- The settings and documentation buttons in the shared app menu actions

The `tracking()` utility is used for element-level tracking attributes, while `useAnalytics().track()` is used for click-handler-level events where additional properties (e.g. layout algorithm, window ID, z-index operation, preset label) are included.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Open the pipeline editor.
2. Interact with each menu (File, View, Node, Runs, Windows, Components Library) and verify that the corresponding analytics events are fired with the correct event names and properties.
3. Click the home link, rename button, auto-save indicator, quick run button, settings, and documentation buttons and confirm their tracking events are captured.

## Additional Comments