### PR TITLE
chore: v2 - instrument pipeline canvas, minimap controls, selection toolbar, and replace confirmation

### DIFF
--- a/src/routes/v2/pages/Editor/components/FlowCanvas/FlowCanvas.tsx
+++ b/src/routes/v2/pages/Editor/components/FlowCanvas/FlowCanvas.tsx
@@ -12,6 +12,7 @@ import { useState } from "react";
 import { BlockStack } from "@/components/ui/layout";
 import { cn } from "@/lib/utils";
 import type { ComponentSpec } from "@/models/componentSpec";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { useAutoLayout } from "@/routes/v2/pages/Editor/hooks/useAutoLayout";
 import { SubgraphBreadcrumbs } from "@/routes/v2/shared/components/SubgraphBreadcrumbs";
 import { FLOW_CANVAS_DEFAULT_PROPS } from "@/routes/v2/shared/flowCanvasDefaults";
@@ -43,6 +44,7 @@ export const FlowCanvas = observer(function FlowCanvas({
   spec,
   className,
 }: FlowCanvasProps) {
+  const { track } = useAnalytics();
   const registry = useNodeRegistry();
   const nodeTypes = registry.getNodeTypes();
   const edgeTypes = registry.getEdgeTypes();
@@ -120,8 +122,24 @@ export const FlowCanvas = observer(function FlowCanvas({
       >
         <FloatingSelectionToolbar spec={spec} />
         <Background gap={10} className="bg-slate-50!" />
-        <Controls position="bottom-right" />
-        <MiniMap position="bottom-left" pannable zoomable />
+        <Controls
+          position="bottom-right"
+          onZoomIn={() => track("v2.pipeline_canvas.controls.zoom_in.click")}
+          onZoomOut={() => track("v2.pipeline_canvas.controls.zoom_out.click")}
+          onFitView={() => track("v2.pipeline_canvas.controls.fit_view.click")}
+          onInteractiveChange={(interactive) =>
+            track("v2.pipeline_canvas.controls.interactive.toggle", {
+              interactive,
+            })
+          }
+        />
+        <MiniMap
+          position="bottom-left"
+          pannable
+          zoomable
+          onClick={() => track("v2.pipeline_canvas.minimap.click")}
+          onNodeClick={() => track("v2.pipeline_canvas.minimap.node.click")}
+        />
       </ReactFlow>
     </BlockStack>
   );

--- a/src/routes/v2/pages/Editor/components/FlowCanvas/components/ReplaceConfirmationDialog.tsx
+++ b/src/routes/v2/pages/Editor/components/FlowCanvas/components/ReplaceConfirmationDialog.tsx
@@ -9,6 +9,7 @@ import type { InputSpec } from "@/models/componentSpec";
 import type { OutputSpec } from "@/models/componentSpec/entities/types";
 import type { DialogProps } from "@/providers/DialogProvider/types";
 import type { EntityDiff } from "@/routes/v2/pages/Editor/store/actions/task.utils";
+import { tracking } from "@/utils/tracking";
 
 import { ReplaceConfirmationContent } from "./ReplaceConfirmationContent";
 
@@ -42,10 +43,18 @@ export function ReplaceConfirmationDialog({
         outputDiff={outputDiff}
       />
       <DialogFooter>
-        <Button variant="outline" onClick={cancel}>
+        <Button
+          variant="outline"
+          onClick={cancel}
+          {...tracking("v2.pipeline_canvas.replace_confirmation.cancel")}
+        >
           Cancel
         </Button>
-        <Button onClick={() => close(true)} autoFocus>
+        <Button
+          onClick={() => close(true)}
+          autoFocus
+          {...tracking("v2.pipeline_canvas.replace_confirmation.continue")}
+        >
           Continue
         </Button>
       </DialogFooter>

--- a/src/routes/v2/pages/Editor/components/FlowCanvas/components/SelectionToolbar.tsx
+++ b/src/routes/v2/pages/Editor/components/FlowCanvas/components/SelectionToolbar.tsx
@@ -15,6 +15,7 @@ import { Text } from "@/components/ui/typography";
 import { cn } from "@/lib/utils";
 import { CreateSubgraphForm } from "@/routes/v2/pages/Editor/components/CreateSubgraphForm";
 import { useEditorSession } from "@/routes/v2/pages/Editor/store/EditorSessionContext";
+import { tracking } from "@/utils/tracking";
 
 interface SelectionToolbarProps {
   onDuplicate: () => void;
@@ -53,12 +54,14 @@ export const SelectionToolbar = observer(function SelectionToolbar({
         icon="Copy"
         onClick={onDuplicate}
         testId="selection-duplicate"
+        trackingAction="v2.pipeline_canvas.selection_toolbar.duplicate"
       />
       <ToolbarButton
         label="Copy"
         icon="ClipboardCopy"
         onClick={onCopy}
         testId="selection-copy"
+        trackingAction="v2.pipeline_canvas.selection_toolbar.copy"
       />
       {clipboard.hasContent && onPaste && (
         <ToolbarButton
@@ -66,6 +69,7 @@ export const SelectionToolbar = observer(function SelectionToolbar({
           icon="ClipboardPaste"
           onClick={onPaste}
           testId="selection-paste"
+          trackingAction="v2.pipeline_canvas.selection_toolbar.paste"
         />
       )}
       {onCreateSubgraph && selectedTaskCount >= 2 && (
@@ -79,6 +83,7 @@ export const SelectionToolbar = observer(function SelectionToolbar({
                   icon="Layers"
                   onClick={() => setPopoverOpen(true)}
                   testId="selection-create-subgraph"
+                  trackingAction="v2.pipeline_canvas.selection_toolbar.create_subgraph"
                 />
               </div>
             </PopoverTrigger>
@@ -99,6 +104,7 @@ export const SelectionToolbar = observer(function SelectionToolbar({
         onClick={onDelete}
         dangerous
         testId="selection-delete"
+        trackingAction="v2.pipeline_canvas.selection_toolbar.delete"
       />
     </InlineStack>
   );
@@ -110,12 +116,14 @@ function ToolbarButton({
   onClick,
   dangerous,
   testId,
+  trackingAction,
 }: {
   label: string;
   icon: keyof typeof icons;
   onClick: () => void;
   dangerous?: boolean;
   testId?: string;
+  trackingAction: string;
 }) {
   return (
     <Button
@@ -126,6 +134,7 @@ function ToolbarButton({
       })}
       onClick={onClick}
       data-testid={testId}
+      {...tracking(trackingAction)}
     >
       <Icon name={icon} size="sm" />
       <Text size="xs" weight="semibold">

--- a/src/routes/v2/pages/Editor/components/FlowCanvas/hooks/useReplaceDropHandler.tsx
+++ b/src/routes/v2/pages/Editor/components/FlowCanvas/hooks/useReplaceDropHandler.tsx
@@ -3,6 +3,7 @@ import { useRef } from "react";
 
 import { isPositionInNode } from "@/components/shared/ReactFlow/FlowCanvas/utils/geometry";
 import type { ComponentSpec } from "@/models/componentSpec";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { useDialog } from "@/providers/DialogProvider/hooks/useDialog";
 import { convertCancelErrorTo } from "@/providers/DialogProvider/utils";
 import { ReplaceConfirmationDialog } from "@/routes/v2/pages/Editor/components/FlowCanvas/components/ReplaceConfirmationDialog";
@@ -50,6 +51,7 @@ export function useReplaceDropHandler(
   spec: ComponentSpec | null,
   reactFlowInstance: ReactFlowInstance | null,
 ) {
+  const { track } = useAnalytics();
   const { canvasOverlay } = useSharedStores();
   const { replaceTask } = useTaskActions();
   const { open: openDialog } = useDialog();
@@ -146,6 +148,9 @@ export function useReplaceDropHandler(
     if (!canReplace) return;
 
     replaceTask(spec, targetEntityId, newComponentRef);
+    track("v2.pipeline_canvas.replace_drop.completed", {
+      had_breaking_change_prompt: hasBreakingChanges,
+    });
   };
 
   return {


### PR DESCRIPTION
## Description

Contributes to https://github.com/Shopify/oasis-frontend/issues/607

Adds analytics tracking to several pipeline canvas interactions:

- Zoom in, zoom out, fit view, and interactive toggle controls on the flow canvas
- MiniMap clicks and node clicks within the minimap
- Cancel and Continue buttons in the replace confirmation dialog
- Selection toolbar actions: duplicate, copy, paste, create subgraph, and delete
- Successful completion of a replace drop operation, including whether a breaking change prompt was shown

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

Interact with the pipeline canvas controls (zoom, fit view, interactive toggle), minimap, selection toolbar buttons, and the replace confirmation dialog to verify that the corresponding analytics events are fired as expected.

## Additional Comments