### PR TITLE
chore: v2 - instrument pipeline details, tags, validation summary, and digest copy

### DIFF
--- a/src/components/shared/ContextPanel/Blocks/TextBlock.test.tsx
+++ b/src/components/shared/ContextPanel/Blocks/TextBlock.test.tsx
@@ -1,7 +1,11 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 
 import { TextBlock } from "./TextBlock";
+
+vi.mock("@/providers/AnalyticsProvider", () => ({
+  useAnalytics: vi.fn().mockReturnValue({ track: vi.fn() }),
+}));
 
 describe("<TextBlock />", () => {
   test("renders with text only", () => {

--- a/src/components/shared/CopyText/CopyText.tsx
+++ b/src/components/shared/CopyText/CopyText.tsx
@@ -5,6 +5,7 @@ import { Icon } from "@/components/ui/icon";
 import { InlineStack } from "@/components/ui/layout";
 import { Text } from "@/components/ui/typography";
 import { cn } from "@/lib/utils";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { copyToClipboard } from "@/utils/string";
 
 interface CopyTextProps {
@@ -14,6 +15,7 @@ interface CopyTextProps {
   alwaysShowButton?: boolean;
   compact?: boolean;
   size?: "xs" | "sm" | "md" | "lg" | "xl";
+  copyTrackingAction?: string;
 }
 
 export const CopyText = ({
@@ -23,13 +25,18 @@ export const CopyText = ({
   alwaysShowButton = false,
   compact = false,
   size = "md",
+  copyTrackingAction,
 }: CopyTextProps) => {
+  const { track } = useAnalytics();
   const [isCopied, setIsCopied] = useState(false);
   const [isHovered, setIsHovered] = useState(false);
 
   const handleCopy = () => {
     copyToClipboard(children);
     setIsCopied(true);
+    if (copyTrackingAction) {
+      track(`${copyTrackingAction}.click`);
+    }
   };
 
   useEffect(() => {

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/IOCell.test.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/IOCell.test.tsx
@@ -10,6 +10,10 @@ vi.mock("@/providers/BackendProvider", () => ({
   useBackend: () => ({ backendUrl: "http://localhost:8000" }),
 }));
 
+vi.mock("@/providers/AnalyticsProvider", () => ({
+  useAnalytics: vi.fn().mockReturnValue({ track: vi.fn() }),
+}));
+
 vi.mock("./ArtifactVisualizer/ArtifactVisualizer", () => ({
   default: ({
     name,

--- a/src/routes/v2/pages/Editor/components/PipelineDetailsContent/PipelineDetailsContent.tsx
+++ b/src/routes/v2/pages/Editor/components/PipelineDetailsContent/PipelineDetailsContent.tsx
@@ -6,6 +6,7 @@ import { BlockStack } from "@/components/ui/layout";
 import { Separator } from "@/components/ui/separator";
 import { Text } from "@/components/ui/typography";
 import { serializeComponentSpecToYaml } from "@/models/componentSpec";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { AnnotationsBlock } from "@/routes/v2/pages/Editor/components/AnnotationsBlock/AnnotationsBlock";
 import { ValidationSummary } from "@/routes/v2/pages/Editor/components/ValidationSummary";
 import { usePipelineActions } from "@/routes/v2/pages/Editor/store/actions/usePipelineActions";
@@ -33,6 +34,7 @@ const EXCLUDED_ANNOTATIONS = [
 
 export const PipelineDetailsContent = observer(
   function PipelineDetailsContent() {
+    const { track } = useAnalytics();
     const { navigation } = useSharedStores();
     const pipelineSpec = useSpec();
     const { updatePipelineDescription, updatePipelineNotes } =
@@ -59,6 +61,7 @@ export const PipelineDetailsContent = observer(
     const handleDescriptionCommit = (value: string | undefined) => {
       if (value !== pipelineSpec.description) {
         updatePipelineDescription(pipelineSpec, value);
+        track("v2.pipeline_editor.configuration_panel.description.updated");
       }
     };
 
@@ -67,6 +70,7 @@ export const PipelineDetailsContent = observer(
         pipelineSpec.annotations.get(PIPELINE_NOTES_ANNOTATION) || undefined;
       if (value !== currentNotes) {
         updatePipelineNotes(pipelineSpec, value);
+        track("v2.pipeline_editor.configuration_panel.notes.updated");
       }
     };
 

--- a/src/routes/v2/pages/Editor/components/PipelineDetailsContent/components/InputsBlock.tsx
+++ b/src/routes/v2/pages/Editor/components/PipelineDetailsContent/components/InputsBlock.tsx
@@ -5,6 +5,7 @@ import { Text } from "@/components/ui/typography";
 import type { ComponentSpec, Input } from "@/models/componentSpec";
 import type { TypeSpecType } from "@/models/componentSpec/entities/types";
 import { useFocusActions } from "@/routes/v2/shared/store/useFocusActions";
+import { tracking } from "@/utils/tracking";
 
 function typeSpecToString(typeSpec?: TypeSpecType): string {
   if (typeSpec === undefined) return "Any";
@@ -36,6 +37,9 @@ export function InputsBlock({ spec }: { spec: ComponentSpec }) {
                 size="xs"
                 className="truncate"
                 onClick={() => handleClick(input)}
+                {...tracking(
+                  "v2.pipeline_editor.configuration_panel.input_row",
+                )}
               >
                 {input.name}
               </Button>

--- a/src/routes/v2/pages/Editor/components/PipelineDetailsContent/components/OutputsBlock.tsx
+++ b/src/routes/v2/pages/Editor/components/PipelineDetailsContent/components/OutputsBlock.tsx
@@ -4,6 +4,7 @@ import { Text } from "@/components/ui/typography";
 import type { ComponentSpec, Output } from "@/models/componentSpec";
 import type { TypeSpecType } from "@/models/componentSpec/entities/types";
 import { useFocusActions } from "@/routes/v2/shared/store/useFocusActions";
+import { tracking } from "@/utils/tracking";
 
 function typeSpecToString(typeSpec?: TypeSpecType): string {
   if (typeSpec === undefined) return "Any";
@@ -35,6 +36,9 @@ export function OutputsBlock({ spec }: { spec: ComponentSpec }) {
                 size="xs"
                 className="truncate"
                 onClick={() => handleClick(output)}
+                {...tracking(
+                  "v2.pipeline_editor.configuration_panel.output_row",
+                )}
               >
                 {output.name}
               </Button>

--- a/src/routes/v2/pages/Editor/components/PipelineDetailsContent/components/TagsBlock.tsx
+++ b/src/routes/v2/pages/Editor/components/PipelineDetailsContent/components/TagsBlock.tsx
@@ -12,6 +12,7 @@ import type { ComponentSpec } from "@/models/componentSpec";
 import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { usePipelineActions } from "@/routes/v2/pages/Editor/store/actions/usePipelineActions";
 import { PIPELINE_TAGS_ANNOTATION } from "@/utils/annotations";
+import { tracking } from "@/utils/tracking";
 
 const TAG_LIMIT = 10;
 
@@ -37,7 +38,7 @@ export const TagsBlock = observer(function TagsBlock({
   const handleAddTag = () => {
     const trimmedTag = newTagValue.trim();
     if (trimmedTag && !tags.includes(trimmedTag) && tags.length < TAG_LIMIT) {
-      track("pipeline_editor.configuration_panel.tag_added");
+      track("v2.pipeline_editor.configuration_panel.tag_added");
       saveTags([...tags, trimmedTag]);
     }
     setNewTagValue("");
@@ -50,11 +51,12 @@ export const TagsBlock = observer(function TagsBlock({
   };
 
   const handleRemoveTag = (index: number) => {
-    track("pipeline_editor.configuration_panel.tag_removed");
+    track("v2.pipeline_editor.configuration_panel.tag_removed");
     saveTags(tags.filter((_, i) => i !== index));
   };
 
   const handleStartEdit = (index: number) => {
+    track("v2.pipeline_editor.configuration_panel.tag_edit.click");
     setEditingIndex(index);
     setEditValue(tags[index]);
   };
@@ -100,6 +102,7 @@ export const TagsBlock = observer(function TagsBlock({
             size="xs"
             onClick={() => setIsAdding(true)}
             className="my-0.5"
+            {...tracking("v2.pipeline_editor.configuration_panel.add_tag")}
           >
             <Icon name="Plus" size="sm" />
             Add Tag

--- a/src/routes/v2/pages/Editor/components/ValidationSummary.tsx
+++ b/src/routes/v2/pages/Editor/components/ValidationSummary.tsx
@@ -7,7 +7,9 @@ import { BlockStack } from "@/components/ui/layout";
 import { Text } from "@/components/ui/typography";
 import { cn } from "@/lib/utils";
 import type { ComponentSpec, ValidationIssue } from "@/models/componentSpec";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
+import { tracking } from "@/utils/tracking";
 
 export function countErrors(issues: ValidationIssue[]): number {
   return issues.filter((i) => i.severity === "error").length;
@@ -41,6 +43,7 @@ export const ValidationSummary = observer(function ValidationSummary({
   spec,
   className,
 }: ValidationSummaryProps) {
+  const { track } = useAnalytics();
   const [isExpanded, setIsExpanded] = useState(false);
   const { editor, navigation } = useSharedStores();
   const issues = spec.allValidationIssues;
@@ -68,6 +71,9 @@ export const ValidationSummary = observer(function ValidationSummary({
             : "text-amber-700 hover:bg-amber-50",
         )}
         onClick={() => setIsExpanded((prev) => !prev)}
+        {...tracking(
+          "v2.pipeline_editor.configuration_panel.validation_summary_toggle",
+        )}
       >
         <Icon
           name={isExpanded ? "ChevronDown" : "ChevronRight"}
@@ -86,6 +92,13 @@ export const ValidationSummary = observer(function ValidationSummary({
             const isSelected = editor.selectedValidationIssue === issue;
 
             const handleIssueClick = () => {
+              track(
+                "v2.pipeline_editor.configuration_panel.validation_issue.click",
+                {
+                  issue_type: issue.type,
+                  severity: issue.severity,
+                },
+              );
               if (issue.subgraphPath.length > 1 && navigation.rootSpec) {
                 const navPath = [
                   navigation.rootSpec.name,


### PR DESCRIPTION
## Description

Contributes to https://github.com/Shopify/oasis-frontend/issues/607

Adds analytics tracking to several interactions within the pipeline editor's configuration panel. The `CopyText` component now accepts an optional `copyTrackingAction` prop that fires a `.click` tracking event when content is copied. Tracking has been added for:

- Copying the pipeline digest
- Updating pipeline description and notes
- Clicking input and output rows
- Adding, editing, and removing tags
- Toggling the validation summary and clicking individual validation issues (with `issue_type` and `severity` metadata)

Existing tag tracking events have also been updated to use the `v2.` prefix for consistency with the rest of the event naming convention.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Open the pipeline editor and navigate to the configuration panel.
2. Copy the pipeline digest and confirm a `v2.pipeline_editor.configuration_panel.digest_copy.click` event is fired.
3. Update the pipeline description and notes and confirm the corresponding tracking events are fired.
4. Click an input or output row and confirm the respective tracking events are fired.
5. Add, edit, and remove tags and confirm tracking events are fired for each action.
6. Toggle the validation summary and click individual validation issues, confirming events are fired with the correct `issue_type` and `severity` properties.

## Additional Comments