### PR TITLE
chore: v2 - instrument context panel multi-selection (batch args, color, subgraph, auto-layout)

### DIFF
--- a/src/routes/v2/pages/Editor/components/ContextPanel/components/MultiSelectionDetails/MultiSelectionDetails.tsx
+++ b/src/routes/v2/pages/Editor/components/ContextPanel/components/MultiSelectionDetails/MultiSelectionDetails.tsx
@@ -10,11 +10,13 @@ import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Separator } from "@/components/ui/separator";
 import { Text } from "@/components/ui/typography";
 import type { Task } from "@/models/componentSpec";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { CreateSubgraphForm } from "@/routes/v2/pages/Editor/components/CreateSubgraphForm";
 import { usePipelineActions } from "@/routes/v2/pages/Editor/store/actions/usePipelineActions";
 import { useTaskActions } from "@/routes/v2/pages/Editor/store/actions/useTaskActions";
 import { useSpec } from "@/routes/v2/shared/providers/SpecContext";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
+import { tracking } from "@/utils/tracking";
 
 import { BatchArgumentRow } from "./components/BatchArgumentRow";
 import { BatchTaskColor } from "./components/BatchTaskColor";
@@ -26,6 +28,7 @@ import { computeAggregatedArguments } from "./utils";
  * Shows list of selected nodes, common argument editing, and Create Subgraph section.
  */
 export const MultiSelectionDetails = observer(function MultiSelectionDetails() {
+  const { track } = useAnalytics();
   const { editor } = useSharedStores();
   const { multiSelection } = editor;
   const spec = useSpec();
@@ -62,6 +65,12 @@ export const MultiSelectionDetails = observer(function MultiSelectionDetails() {
     });
 
     if (result) {
+      track(
+        "v2.pipeline_editor.context_panel.multi_selection.create_subgraph.completed",
+        {
+          task_count: selectedTasks.length,
+        },
+      );
       editor.clearMultiSelection();
     }
   };
@@ -80,6 +89,12 @@ export const MultiSelectionDetails = observer(function MultiSelectionDetails() {
 
     const layoutedNodes = autoLayoutNodes(selectedRFNodes, connectedEdges);
     applyAutoLayoutPositions(spec, layoutedNodes);
+    track(
+      "v2.pipeline_editor.context_panel.multi_selection.auto_layout.completed",
+      {
+        node_count: multiSelection.length,
+      },
+    );
   };
 
   if (multiSelection.length === 0) {
@@ -134,6 +149,9 @@ export const MultiSelectionDetails = observer(function MultiSelectionDetails() {
               size="sm"
               className="w-full gap-1.5"
               onClick={handleAutoLayoutSelection}
+              {...tracking(
+                "v2.pipeline_editor.context_panel.multi_selection.auto_layout",
+              )}
             >
               <Icon name="LayoutDashboard" size="sm" />
               Auto Layout Selection
@@ -147,6 +165,7 @@ export const MultiSelectionDetails = observer(function MultiSelectionDetails() {
             <CreateSubgraphForm
               selectedTaskCount={selectedTasks.length}
               onSubmit={handleCreateSubgraph}
+              submitTrackingAction="v2.pipeline_editor.context_panel.multi_selection.create_subgraph"
             />
           </>
         )}

--- a/src/routes/v2/pages/Editor/components/ContextPanel/components/MultiSelectionDetails/components/BatchArgumentRow.tsx
+++ b/src/routes/v2/pages/Editor/components/ContextPanel/components/MultiSelectionDetails/components/BatchArgumentRow.tsx
@@ -6,6 +6,7 @@ import { InlineStack } from "@/components/ui/layout";
 import { Text } from "@/components/ui/typography";
 import { cn } from "@/lib/utils";
 import type { ArgumentType, ComponentSpec } from "@/models/componentSpec";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { ThunderMenu } from "@/routes/v2/pages/Editor/components/ArgumentRow/components/ThunderMenu/ThunderMenu";
 import type { AggregatedArgument } from "@/routes/v2/pages/Editor/components/ContextPanel/components/MultiSelectionDetails/utils";
 import { useIOActions } from "@/routes/v2/pages/Editor/store/actions/useIOActions";
@@ -21,6 +22,7 @@ export const BatchArgumentRow = observer(function BatchArgumentRow({
   aggArg,
   spec,
 }: BatchArgumentRowProps) {
+  const { track } = useAnalytics();
   const { undo } = useEditorSession();
   const { createInputAndConnect } = useIOActions();
   const [editing, setEditing] = useState(false);
@@ -42,6 +44,9 @@ export const BatchArgumentRow = observer(function BatchArgumentRow({
   }, [editing]);
 
   const handleClick = () => {
+    track(
+      "v2.pipeline_editor.context_panel.multi_selection.batch_argument.edit_started",
+    );
     setEditing(true);
   };
 
@@ -80,6 +85,12 @@ export const BatchArgumentRow = observer(function BatchArgumentRow({
         }
       }
     });
+    track(
+      "v2.pipeline_editor.context_panel.multi_selection.batch_argument.updated",
+      {
+        task_count: aggArg.taskIds.length,
+      },
+    );
   };
 
   const handleResetToDefault = () => {
@@ -90,6 +101,10 @@ export const BatchArgumentRow = observer(function BatchArgumentRow({
       }
     });
     setInputValue(defaultVal);
+    track(
+      "v2.pipeline_editor.context_panel.multi_selection.batch_argument.reset_to_default",
+      { task_count: aggArg.taskIds.length },
+    );
   };
 
   const handleUnset = () => {
@@ -104,6 +119,12 @@ export const BatchArgumentRow = observer(function BatchArgumentRow({
       }
     });
     setInputValue("");
+    track(
+      "v2.pipeline_editor.context_panel.multi_selection.batch_argument.unset",
+      {
+        task_count: aggArg.taskIds.length,
+      },
+    );
   };
 
   const handleSelectDynamicData = (value: DynamicDataArgument) => {
@@ -115,6 +136,10 @@ export const BatchArgumentRow = observer(function BatchArgumentRow({
       }
     });
     setInputValue("");
+    track(
+      "v2.pipeline_editor.context_panel.multi_selection.batch_argument.dynamic_data_set",
+      { task_count: aggArg.taskIds.length },
+    );
   };
 
   const handleQuickConnect = (
@@ -130,11 +155,19 @@ export const BatchArgumentRow = observer(function BatchArgumentRow({
       }
     });
     setInputValue("");
+    track(
+      "v2.pipeline_editor.context_panel.multi_selection.batch_argument.quick_connect",
+      { task_count: aggArg.taskIds.length },
+    );
   };
 
   const handleCreateInputAndConnect = () => {
     createInputAndConnect(spec, aggArg.taskIds, aggArg.name, aggArg.type);
     setInputValue("");
+    track(
+      "v2.pipeline_editor.context_panel.multi_selection.batch_argument.create_input_and_connect",
+      { task_count: aggArg.taskIds.length },
+    );
   };
 
   return (

--- a/src/routes/v2/pages/Editor/components/ContextPanel/components/MultiSelectionDetails/components/BatchTaskColor.tsx
+++ b/src/routes/v2/pages/Editor/components/ContextPanel/components/MultiSelectionDetails/components/BatchTaskColor.tsx
@@ -5,6 +5,7 @@ import { InlineStack } from "@/components/ui/layout";
 import { Separator } from "@/components/ui/separator";
 import { Text } from "@/components/ui/typography";
 import type { Task } from "@/models/componentSpec";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { useTaskActions } from "@/routes/v2/pages/Editor/store/actions/useTaskActions";
 
 const TASK_COLOR_ANNOTATION = "tangleml.com/editor/task-color";
@@ -14,6 +15,7 @@ export const BatchTaskColor = observer(function BatchTaskColor({
 }: {
   tasks: Task[];
 }) {
+  const { track } = useAnalytics();
   const { batchSetTaskColor } = useTaskActions();
 
   if (tasks.length === 0) return null;
@@ -43,6 +45,12 @@ export const BatchTaskColor = observer(function BatchTaskColor({
           title="Task color"
           color={displayColor}
           setColor={(color) => batchSetTaskColor(tasks, color)}
+          onClose={() =>
+            track(
+              "v2.pipeline_editor.context_panel.multi_selection.batch_task_color_picker.closed",
+              { task_count: tasks.length },
+            )
+          }
         />
       </InlineStack>
     </>

--- a/src/routes/v2/pages/Editor/components/CreateSubgraphForm.tsx
+++ b/src/routes/v2/pages/Editor/components/CreateSubgraphForm.tsx
@@ -6,17 +6,20 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { BlockStack } from "@/components/ui/layout";
 import { Text } from "@/components/ui/typography";
+import { tracking } from "@/utils/tracking";
 
 interface CreateSubgraphFormProps {
   selectedTaskCount: number;
   onSubmit: (name: string) => void;
   autoFocus?: boolean;
+  submitTrackingAction?: string;
 }
 
 export function CreateSubgraphForm({
   selectedTaskCount,
   onSubmit,
   autoFocus,
+  submitTrackingAction,
 }: CreateSubgraphFormProps) {
   const defaultName = `Subgraph (${selectedTaskCount} tasks)`;
   const [name, setName] = useState(defaultName);
@@ -54,6 +57,7 @@ export function CreateSubgraphForm({
           disabled={!name.trim()}
           className="w-full gap-1.5"
           size="sm"
+          {...(submitTrackingAction ? tracking(submitTrackingAction) : {})}
         >
           <Icon name="Layers" size="sm" />
           Create Subgraph


### PR DESCRIPTION
## Description

Contributes to https://github.com/Shopify/oasis-frontend/issues/607

Adds analytics tracking to the multi-selection panel in the pipeline editor. The following user interactions are now tracked:

- **Auto Layout Selection** – click event on the button and a completion event including the number of nodes laid out.
- **Create Subgraph** – submit button click (via `submitTrackingAction` prop on `CreateSubgraphForm`) and a completion event including the number of tasks selected.
- **Batch Argument Row** – edit started, value updated, reset to default, unset, dynamic data set, quick connect, and create-input-and-connect, each reporting the number of affected tasks.
- **Batch Task Color Picker** – closed event reporting the number of tasks whose color was changed.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Open the pipeline editor and select multiple nodes.
2. Trigger each tracked action (auto layout, create subgraph, edit/reset/unset a batch argument, change task color, etc.).
3. Verify the corresponding analytics events appear in the analytics provider with the correct event names and properties (`task_count`, `node_count`).

## Additional Comments

The `CreateSubgraphForm` component now accepts an optional `submitTrackingAction` prop so callers can attach a tracking identifier to the submit button without coupling the form itself to a specific event name.