### PR TITLE
chore: v2 - instrument v2 node context panels

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/FlexNode/LockToggle.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlexNode/LockToggle.tsx
@@ -1,16 +1,19 @@
-import { type MouseEvent } from "react";
+import { type ComponentProps, type MouseEvent } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
 import { cn } from "@/lib/utils";
 
-interface LockToggleProps {
+type LockToggleProps = {
   size?: "xs" | "sm" | "md" | "lg" | "xl";
   locked: boolean;
   onToggleLock: () => void;
   showOnlyOnHover?: boolean;
   className?: string;
-}
+} & Omit<
+  ComponentProps<typeof Button>,
+  "size" | "variant" | "onClick" | "children" | "className"
+>;
 
 const LockToggle = ({
   size = "md",
@@ -18,6 +21,7 @@ const LockToggle = ({
   onToggleLock,
   showOnlyOnHover = false,
   className,
+  ...rest
 }: LockToggleProps) => {
   const handleLockToggle = (e: MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
@@ -42,6 +46,7 @@ const LockToggle = ({
         !locked && showOnlyOnHover && "hidden group-hover:block hover:block",
         className,
       )}
+      {...rest}
     >
       <Icon
         name={locked ? "Lock" : "LockOpen"}

--- a/src/components/shared/ReactFlow/FlowControls/StackingControls.tsx
+++ b/src/components/shared/ReactFlow/FlowControls/StackingControls.tsx
@@ -15,9 +15,11 @@ import {
 export const StackingControls = ({
   nodeId,
   onChange,
+  trackingBase = "pipeline_editor.task_node.z_index",
 }: {
   nodeId: string;
   onChange: (newZIndex: number) => void;
+  trackingBase?: string;
 }) => {
   const { getNodes } = useReactFlow();
 
@@ -51,7 +53,7 @@ export const StackingControls = ({
     <InlineStack gap="2" data-testid="stacking-controls">
       <TooltipButton
         data-testid="stacking-move-forward"
-        {...tracking("pipeline_editor.task_node.z_index", {
+        {...tracking(trackingBase, {
           action: "move_forward",
         })}
         size="sm"
@@ -63,7 +65,7 @@ export const StackingControls = ({
       </TooltipButton>
       <TooltipButton
         data-testid="stacking-move-backward"
-        {...tracking("pipeline_editor.task_node.z_index", {
+        {...tracking(trackingBase, {
           action: "move_backward",
         })}
         size="sm"
@@ -75,7 +77,7 @@ export const StackingControls = ({
       </TooltipButton>
       <TooltipButton
         data-testid="stacking-bring-to-front"
-        {...tracking("pipeline_editor.task_node.z_index", {
+        {...tracking(trackingBase, {
           action: "bring_to_front",
         })}
         size="sm"
@@ -87,7 +89,7 @@ export const StackingControls = ({
       </TooltipButton>
       <TooltipButton
         data-testid="stacking-send-to-back"
-        {...tracking("pipeline_editor.task_node.z_index", {
+        {...tracking(trackingBase, {
           action: "send_to_back",
         })}
         size="sm"

--- a/src/routes/v2/pages/Editor/nodes/ConduitNode/context/ConduitDetails.tsx
+++ b/src/routes/v2/pages/Editor/nodes/ConduitNode/context/ConduitDetails.tsx
@@ -8,9 +8,11 @@ import { Icon } from "@/components/ui/icon";
 import { Label } from "@/components/ui/label";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Text } from "@/components/ui/typography";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { getConduits } from "@/routes/v2/pages/Editor/nodes/ConduitNode/conduits.actions";
 import { useConduitActions } from "@/routes/v2/pages/Editor/nodes/ConduitNode/useConduitActions";
 import { useSpec } from "@/routes/v2/shared/providers/SpecContext";
+import { tracking } from "@/utils/tracking";
 
 interface ConduitDetailsProps {
   entityId: string;
@@ -30,6 +32,7 @@ function edgeLabel(
 export const ConduitDetails = observer(function ConduitDetails({
   entityId,
 }: ConduitDetailsProps) {
+  const { track } = useAnalytics();
   const spec = useSpec();
   const { updateConduitColor, unassignEdgeFromConduit } = useConduitActions();
   const conduitId = entityId;
@@ -62,6 +65,9 @@ export const ConduitDetails = observer(function ConduitDetails({
             title="Guideline Color"
             color={conduit.color}
             setColor={handleColorChange}
+            onClose={() =>
+              track("v2.pipeline_editor.conduit_details.color_picker.closed")
+            }
           />
           <Text size="xs" weight="semibold">
             Guideline
@@ -94,6 +100,9 @@ export const ConduitDetails = observer(function ConduitDetails({
                     size="icon"
                     className="h-5 w-5 opacity-0 group-hover:opacity-100 transition-opacity shrink-0"
                     onClick={() => handleUnassign(binding.$id)}
+                    {...tracking(
+                      "v2.pipeline_editor.conduit_details.unassign_edge",
+                    )}
                   >
                     <Icon name="X" size="xs" />
                   </Button>
@@ -127,6 +136,7 @@ export const ConduitDetails = observer(function ConduitDetails({
 });
 
 function DeleteConduitButton({ conduitId }: { conduitId: string }) {
+  const { track } = useAnalytics();
   const spec = useSpec();
   const { removeConduit } = useConduitActions();
   const conduit = spec
@@ -137,6 +147,7 @@ function DeleteConduitButton({ conduitId }: { conduitId: string }) {
 
   const handleDelete = () => {
     removeConduit(spec, conduitId);
+    track("v2.pipeline_editor.conduit_details.delete.completed");
   };
 
   return (

--- a/src/routes/v2/pages/Editor/nodes/FlexNode/context/FlexNodeDetails.tsx
+++ b/src/routes/v2/pages/Editor/nodes/FlexNode/context/FlexNodeDetails.tsx
@@ -9,6 +9,7 @@ import { cn } from "@/lib/utils";
 import { findFlexNode } from "@/routes/v2/pages/Editor/nodes/FlexNode/flexNode.actions";
 import { useFlexNodeActions } from "@/routes/v2/pages/Editor/nodes/FlexNode/useFlexNodeActions";
 import { useSpec } from "@/routes/v2/shared/providers/SpecContext";
+import { tracking } from "@/utils/tracking";
 
 import { ColorEditor } from "./components/ColorEditor";
 import { ContentEditor } from "./components/ContentEditor";
@@ -61,6 +62,7 @@ const FlexNodeDetailsInner = observer(function FlexNodeDetailsInner({
           locked={locked}
           onToggleLock={toggleLock}
           className={cn(locked && "text-red-500 hover:text-red-500")}
+          {...tracking("v2.pipeline_editor.flex_node_details.lock_toggle")}
         />
       </InlineStack>
 

--- a/src/routes/v2/pages/Editor/nodes/FlexNode/context/components/ColorEditor.tsx
+++ b/src/routes/v2/pages/Editor/nodes/FlexNode/context/components/ColorEditor.tsx
@@ -8,6 +8,7 @@ import { DEFAULT_BORDER_COLOR } from "@/components/shared/ReactFlow/FlowCanvas/F
 import { ColorPicker } from "@/components/ui/color";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Paragraph } from "@/components/ui/typography";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 
 interface ColorEditorValue {
   color: string;
@@ -27,6 +28,7 @@ export function ColorEditor({
   readOnly,
   hasTextContent,
 }: ColorEditorProps) {
+  const { track } = useAnalytics();
   const currentBorderColor = value.borderColor ?? DEFAULT_BORDER_COLOR;
 
   const [backgroundColor, setBackgroundColor] = useState(value.color);
@@ -79,6 +81,12 @@ export function ColorEditor({
             title="Background Color"
             color={backgroundColor}
             setColor={handleBackgroundColorChange}
+            onClose={() =>
+              track(
+                "v2.pipeline_editor.flex_node_details.color_picker.closed",
+                { color_kind: "background" },
+              )
+            }
           />
           <CopyText size="xs" className="font-mono">
             {value.color}
@@ -92,6 +100,12 @@ export function ColorEditor({
               title="Border Color"
               color={borderColor}
               setColor={handleBorderColorChange}
+              onClose={() =>
+                track(
+                  "v2.pipeline_editor.flex_node_details.color_picker.closed",
+                  { color_kind: "border" },
+                )
+              }
             />
             <CopyText size="xs" className="font-mono">
               {currentBorderColor}

--- a/src/routes/v2/pages/Editor/nodes/FlexNode/context/components/ContentEditor.tsx
+++ b/src/routes/v2/pages/Editor/nodes/FlexNode/context/components/ContentEditor.tsx
@@ -7,6 +7,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Textarea } from "@/components/ui/textarea";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { FONT_SIZE_MD, FONT_SIZE_SM } from "@/utils/constants";
 
 interface ContentEditorValue {
@@ -27,6 +28,7 @@ export function ContentEditor({
   onChange,
   readOnly,
 }: ContentEditorProps) {
+  const { track } = useAnalytics();
   const [title, setTitle] = useState(value.title);
   const [content, setContent] = useState(value.content);
 
@@ -39,7 +41,11 @@ export function ContentEditor({
   };
 
   const saveChanges = () => {
+    const changed = title !== value.title || content !== value.content;
     onChange({ title, content });
+    if (changed) {
+      track("v2.pipeline_editor.flex_node_details.content.updated");
+    }
   };
 
   useEffect(() => {
@@ -78,7 +84,12 @@ export function ContentEditor({
             </Label>
             <TextSizeSelector
               value={value.titleFontSize ?? FONT_SIZE_MD}
-              onChange={(newSize) => onChange({ titleFontSize: newSize })}
+              onChange={(newSize) => {
+                track(
+                  "v2.pipeline_editor.flex_node_details.title_font_size.changed",
+                );
+                onChange({ titleFontSize: newSize });
+              }}
               className="mb-1"
             />
           </InlineStack>
@@ -106,7 +117,12 @@ export function ContentEditor({
             </Label>
             <TextSizeSelector
               value={value.contentFontSize ?? FONT_SIZE_SM}
-              onChange={(newSize) => onChange({ contentFontSize: newSize })}
+              onChange={(newSize) => {
+                track(
+                  "v2.pipeline_editor.flex_node_details.content_font_size.changed",
+                );
+                onChange({ contentFontSize: newSize });
+              }}
               className="mb-1"
             />
           </InlineStack>

--- a/src/routes/v2/pages/Editor/nodes/FlexNode/context/components/ZIndexEditor.tsx
+++ b/src/routes/v2/pages/Editor/nodes/FlexNode/context/components/ZIndexEditor.tsx
@@ -14,7 +14,11 @@ export function ZIndexEditor({
 }: ZIndexEditorProps) {
   return (
     <ContentBlock title={title}>
-      <StackingControls nodeId={nodeId} onChange={onChange} />
+      <StackingControls
+        nodeId={nodeId}
+        onChange={onChange}
+        trackingBase="v2.pipeline_editor.flex_node_details.z_index"
+      />
     </ContentBlock>
   );
 }

--- a/src/routes/v2/pages/Editor/nodes/IONode/context/InputDetails.tsx
+++ b/src/routes/v2/pages/Editor/nodes/IONode/context/InputDetails.tsx
@@ -5,6 +5,7 @@ import { Input } from "@/components/ui/input";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Textarea } from "@/components/ui/textarea";
 import { Text } from "@/components/ui/typography";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { AutoGrowTextarea } from "@/routes/v2/pages/Editor/components/AutoGrowTextArea";
 import { InputLabel } from "@/routes/v2/pages/Editor/components/InputLabel/InputLabel";
 import { useIOActions } from "@/routes/v2/pages/Editor/store/actions/useIOActions";
@@ -17,6 +18,7 @@ interface InputDetailsProps {
 export const InputDetails = observer(function InputDetails({
   entityId,
 }: InputDetailsProps) {
+  const { track } = useAnalytics();
   const ioActions = useIOActions();
   const spec = useSpec();
   const input = spec?.inputs.find((i) => i.$id === entityId);
@@ -27,6 +29,7 @@ export const InputDetails = observer(function InputDetails({
     const newName = event.target.value;
     if (newName && newName !== input.name) {
       ioActions.renameInput(spec, entityId, newName);
+      track("v2.pipeline_editor.input_details.name.updated");
     }
   };
 
@@ -35,6 +38,7 @@ export const InputDetails = observer(function InputDetails({
     const newDescription = value || undefined;
     if (newDescription !== input.description) {
       ioActions.setInputDescription(spec, entityId, newDescription);
+      track("v2.pipeline_editor.input_details.description.updated");
     }
   };
 
@@ -43,6 +47,7 @@ export const InputDetails = observer(function InputDetails({
     const newType = value || undefined;
     if (newType !== input.type) {
       ioActions.setInputType(spec, entityId, newType);
+      track("v2.pipeline_editor.input_details.type.updated");
     }
   };
 
@@ -50,6 +55,7 @@ export const InputDetails = observer(function InputDetails({
     const newDefault = value || undefined;
     if (newDefault !== input.defaultValue) {
       ioActions.setInputDefaultValue(spec, entityId, newDefault);
+      track("v2.pipeline_editor.input_details.default_value.updated");
     }
   };
 

--- a/src/routes/v2/pages/Editor/nodes/IONode/context/OutputDetails.tsx
+++ b/src/routes/v2/pages/Editor/nodes/IONode/context/OutputDetails.tsx
@@ -5,6 +5,7 @@ import { Input } from "@/components/ui/input";
 import { BlockStack } from "@/components/ui/layout";
 import { Textarea } from "@/components/ui/textarea";
 import { Text } from "@/components/ui/typography";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { InputLabel } from "@/routes/v2/pages/Editor/components/InputLabel/InputLabel";
 import { useIOActions } from "@/routes/v2/pages/Editor/store/actions/useIOActions";
 import { useSpec } from "@/routes/v2/shared/providers/SpecContext";
@@ -16,6 +17,7 @@ interface OutputDetailsProps {
 export const OutputDetails = observer(function OutputDetails({
   entityId,
 }: OutputDetailsProps) {
+  const { track } = useAnalytics();
   const ioActions = useIOActions();
   const spec = useSpec();
   const output = spec?.outputs.find((o) => o.$id === entityId);
@@ -26,6 +28,7 @@ export const OutputDetails = observer(function OutputDetails({
     const newName = event.target.value;
     if (newName && newName !== output.name) {
       ioActions.renameOutput(spec, entityId, newName);
+      track("v2.pipeline_editor.output_details.name.updated");
     }
   };
 
@@ -34,6 +37,7 @@ export const OutputDetails = observer(function OutputDetails({
     const newDescription = value || undefined;
     if (newDescription !== output.description) {
       ioActions.setOutputDescription(spec, entityId, newDescription);
+      track("v2.pipeline_editor.output_details.description.updated");
     }
   };
 

--- a/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/TaskDetails.tsx
+++ b/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/TaskDetails.tsx
@@ -13,11 +13,13 @@ import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Separator } from "@/components/ui/separator";
 import { Text } from "@/components/ui/typography";
 import useToastNotification from "@/hooks/useToastNotification";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { AnnotationsBlock } from "@/routes/v2/pages/Editor/components/AnnotationsBlock/AnnotationsBlock";
 import { useTaskActions } from "@/routes/v2/pages/Editor/store/actions/useTaskActions";
 import { useSpec } from "@/routes/v2/shared/providers/SpecContext";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 import { EDITOR_COLLAPSED_ANNOTATION } from "@/utils/annotations";
+import { tracking } from "@/utils/tracking";
 
 import { getTaskYamlText } from "./components/actions/getTaskYamlText";
 import { ComponentRefBar } from "./components/ComponentRefBar";
@@ -40,6 +42,7 @@ interface TaskDetailsProps {
 export const TaskDetails = observer(function TaskDetails({
   entityId,
 }: TaskDetailsProps) {
+  const { track } = useAnalytics();
   const { editor } = useSharedStores();
   const { renameTask } = useTaskActions();
   const notify = useToastNotification();
@@ -73,7 +76,9 @@ export const TaskDetails = observer(function TaskDetails({
     setIsRenaming(false);
     if (newName && newName !== task.name) {
       const success = renameTask(spec, entityId, newName);
-      if (!success) {
+      if (success) {
+        track("v2.pipeline_editor.task_details.rename.completed");
+      } else {
         notify("A task with that name already exists", "error");
       }
     }
@@ -127,6 +132,7 @@ export const TaskDetails = observer(function TaskDetails({
                   size="inline-xs"
                   className="shrink-0 p-0 text-muted-foreground hover:bg-transparent hover:text-foreground opacity-0 group-hover:opacity-100 transition-opacity"
                   onClick={startRename}
+                  {...tracking("v2.pipeline_editor.task_details.rename_start")}
                 >
                   <Icon name="Pencil" size="xs" />
                 </Button>
@@ -155,7 +161,12 @@ export const TaskDetails = observer(function TaskDetails({
           onOpenChange={setArgumentsOpen}
           className="w-full"
         >
-          <CollapsibleTrigger className="flex w-full items-center justify-between bg-gray-50 px-4 py-2.5 cursor-pointer border-b border-gray-100">
+          <CollapsibleTrigger
+            className="flex w-full items-center justify-between bg-gray-50 px-4 py-2.5 cursor-pointer border-b border-gray-100"
+            {...tracking(
+              "v2.pipeline_editor.task_details.arguments_section_toggle",
+            )}
+          >
             <InlineStack gap="2" blockAlign="center">
               <Icon name="Parentheses" size="xs" />
               <Text size="xs" weight="semibold">
@@ -207,7 +218,12 @@ export const TaskDetails = observer(function TaskDetails({
           onOpenChange={setConfigOpen}
           className="w-full"
         >
-          <CollapsibleTrigger className="flex w-full items-center justify-between bg-gray-50 px-4 py-2.5 cursor-pointer border-b border-gray-100">
+          <CollapsibleTrigger
+            className="flex w-full items-center justify-between bg-gray-50 px-4 py-2.5 cursor-pointer border-b border-gray-100"
+            {...tracking(
+              "v2.pipeline_editor.task_details.config_section_toggle",
+            )}
+          >
             <InlineStack gap="2" blockAlign="center">
               <Icon name="Settings" size="xs" />
               <Text size="xs" weight="semibold">

--- a/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/components/ComponentRefBar.tsx
+++ b/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/components/ComponentRefBar.tsx
@@ -21,8 +21,10 @@ import {
 import { Text } from "@/components/ui/typography";
 import useToastNotification from "@/hooks/useToastNotification";
 import type { ComponentReference as ModelComponentReference } from "@/models/componentSpec/entities/types";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { getComponentName } from "@/utils/getComponentName";
 import { isSubgraph } from "@/utils/subgraphUtils";
+import { tracking } from "@/utils/tracking";
 import {
   downloadStringAsFile,
   downloadYamlFromComponentText,
@@ -41,6 +43,7 @@ export function ComponentRefBar({
   taskName,
   pythonCode,
 }: ComponentRefBarProps) {
+  const { track } = useAnalytics();
   const notify = useToastNotification();
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
   const [showCodeViewer, setShowCodeViewer] = useState(false);
@@ -83,6 +86,9 @@ export function ComponentRefBar({
             <button
               type="button"
               className="flex min-w-0 flex-1 cursor-pointer items-center gap-1.5 rounded-sm px-1 py-0.5 hover:bg-accent"
+              {...tracking(
+                "v2.pipeline_editor.task_details.component_details_open",
+              )}
             >
               <Icon
                 name={iconName}
@@ -110,6 +116,7 @@ export function ComponentRefBar({
                 variant="ghost"
                 size="min"
                 onClick={() => setShowCodeViewer(true)}
+                {...tracking("v2.pipeline_editor.task_details.view_task_yaml")}
               >
                 <Icon name="FileCode" size="sm" />
               </Button>
@@ -121,7 +128,13 @@ export function ComponentRefBar({
             <Tooltip>
               <TooltipTrigger asChild>
                 <DropdownMenuTrigger asChild>
-                  <Button variant="ghost" size="min">
+                  <Button
+                    variant="ghost"
+                    size="min"
+                    {...tracking(
+                      "v2.pipeline_editor.task_details.component_ref_menu",
+                    )}
+                  >
                     <Icon name="EllipsisVertical" size="sm" />
                   </Button>
                 </DropdownMenuTrigger>
@@ -130,24 +143,46 @@ export function ComponentRefBar({
             </Tooltip>
 
             <DropdownMenuContent align="end">
-              <DropdownMenuItem onClick={handleDownloadYaml}>
+              <DropdownMenuItem
+                onClick={() => {
+                  track("v2.pipeline_editor.task_details.download_yaml.click");
+                  handleDownloadYaml();
+                }}
+              >
                 <Icon name="Download" size="sm" />
                 Download YAML
               </DropdownMenuItem>
 
               {pythonCode && (
-                <DropdownMenuItem onClick={handleDownloadPython}>
+                <DropdownMenuItem
+                  onClick={() => {
+                    track(
+                      "v2.pipeline_editor.task_details.download_python.click",
+                    );
+                    handleDownloadPython();
+                  }}
+                >
                   <Icon name="Download" size="sm" />
                   Download Python
                 </DropdownMenuItem>
               )}
 
-              <DropdownMenuItem onClick={handleCopyYaml}>
+              <DropdownMenuItem
+                onClick={() => {
+                  track("v2.pipeline_editor.task_details.copy_yaml.click");
+                  handleCopyYaml();
+                }}
+              >
                 <Icon name="Clipboard" size="sm" />
                 Copy YAML
               </DropdownMenuItem>
 
-              <DropdownMenuItem onClick={() => setIsEditDialogOpen(true)}>
+              <DropdownMenuItem
+                onClick={() => {
+                  track("v2.pipeline_editor.task_details.edit_component.click");
+                  setIsEditDialogOpen(true);
+                }}
+              >
                 <Icon name="FilePenLine" size="sm" />
                 Edit Component
               </DropdownMenuItem>

--- a/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/components/ConfigurationSection.tsx
+++ b/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/components/ConfigurationSection.tsx
@@ -14,6 +14,7 @@ import { Separator } from "@/components/ui/separator";
 import { Switch } from "@/components/ui/switch";
 import { Paragraph, Text } from "@/components/ui/typography";
 import type { Task } from "@/models/componentSpec";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 import type { AnnotationConfig, Annotations } from "@/types/annotations";
 import { EDITOR_COLLAPSED_ANNOTATION } from "@/utils/annotations";
 import { ISO8601_DURATION_ZERO_DAYS } from "@/utils/constants";
@@ -27,6 +28,7 @@ interface ConfigurationSectionProps {
 export const ConfigurationSection = observer(function ConfigurationSection({
   task,
 }: ConfigurationSectionProps) {
+  const { track } = useAnalytics();
   const {
     toggleCacheDisable,
     saveAnnotation,
@@ -110,6 +112,9 @@ export const ConfigurationSection = observer(function ConfigurationSection({
 
   const handleDisableCacheChange = (checked: boolean) => {
     toggleCacheDisable(task, checked);
+    track("v2.pipeline_editor.task_details.disable_cache.toggle", {
+      cache_disabled: checked,
+    });
   };
 
   const handleSave = (key: string, value: string | undefined) => {
@@ -122,6 +127,7 @@ export const ConfigurationSection = observer(function ConfigurationSection({
 
   const handleCollapsedChange = (checked: boolean) => {
     setCollapsed(task, checked);
+    track("v2.pipeline_editor.task_details.collapse_node.toggle");
   };
 
   const taskColor = task.annotations.get("tangleml.com/editor/task-color");
@@ -149,6 +155,9 @@ export const ConfigurationSection = observer(function ConfigurationSection({
           title="Task color"
           color={taskColor ?? "transparent"}
           setColor={handleColorChange}
+          onClose={() =>
+            track("v2.pipeline_editor.task_details.task_color_picker.closed")
+          }
         />
       </InlineStack>
 


### PR DESCRIPTION
## Description

Contributes to https://github.com/Shopify/oasis-frontend/issues/607

Adds analytics tracking to the v2 pipeline editor's detail panels for conduit, flex node, task, input, and output entities. Tracked interactions include:

- **Conduit details**: color picker closed, edge unassign button clicked, conduit deleted
- **Flex node details**: lock toggle clicked, background/border color pickers closed, content updated, title/content font size changed, z-index stacking controls (using a v2-namespaced `trackingBase`)
- **Task details**: rename initiated and completed, arguments/config section toggles, component details opened, YAML/Python download and copy actions, edit component clicked, view task YAML clicked, component ref menu opened, disable cache toggled, node collapsed toggled, task color picker closed
- **Input/Output details**: name, description, type, and default value updated

`StackingControls` now accepts a `trackingBase` prop so callers can supply their own analytics namespace instead of always using the v1 hardcoded string.

`LockToggle` now spreads additional `Button` props via rest props, enabling callers (such as `FlexNodeDetails`) to pass tracking attributes directly.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Open the v2 pipeline editor and interact with task, flex node, conduit, input, and output detail panels.
2. Verify analytics events are fired with the correct event names and metadata (e.g., `color_kind`, `cache_disabled`) using your analytics debugger or network inspector.
3. Confirm that stacking controls in the flex node details panel emit `v2.pipeline_editor.flex_node_details.z_index.*` events rather than the v1 `pipeline_editor.task_node.z_index.*` events.
4. Confirm existing v1 task node stacking controls still emit `pipeline_editor.task_node.z_index.*` events unchanged.

## Additional Comments

The `trackingBase` default on `StackingControls` preserves backward compatibility with existing v1 editor analytics.