### PR TITLE
chore: v2 - instrument task arguments and code editor analytics

### DIFF
--- a/src/hooks/useClickTracking.ts
+++ b/src/hooks/useClickTracking.ts
@@ -4,6 +4,15 @@ import { useAnalytics } from "@/providers/AnalyticsProvider";
 
 const INTERACTIVE_ELEMENTS: Set<string> = new Set(["a", "button", "summary"]);
 
+/** Radix/shadcn menus use these roles; they support `{...tracking()}` like buttons. */
+const INTERACTIVE_ROLES: Set<string> = new Set([
+  "button",
+  "link",
+  "menuitem",
+  "menuitemcheckbox",
+  "menuitemradio",
+]);
+
 const TRACKING_ATTR = "data-tracking-id";
 
 function findTrackedInteractiveElement(
@@ -16,7 +25,8 @@ function findTrackedInteractiveElement(
     const role = node.getAttribute("role");
 
     const isInteractive =
-      INTERACTIVE_ELEMENTS.has(tag) || role === "button" || role === "link";
+      INTERACTIVE_ELEMENTS.has(tag) ||
+      (role !== null && INTERACTIVE_ROLES.has(role));
 
     if (isInteractive && node.hasAttribute(TRACKING_ATTR)) {
       return node;
@@ -46,7 +56,8 @@ export function getTrackingAttributes(domElement: HTMLElement) {
  * event when the click originates from an interactive element that carries a
  * `data-tracking-id` attribute. The attribute value is used as the `action_type`,
  * with `.click` automatically appended (e.g. `data-tracking-id="header.settings"`
- * fires as `header.settings.click`).
+ * fires as `header.settings.click`). Elements with `role="menuitem"` (and related
+ * menu roles) are included so shadcn `DropdownMenuItem` can use `{...tracking()}`.
  */
 export function useClickTracking() {
   const { track } = useAnalytics();

--- a/src/routes/v2/pages/Editor/components/ArgumentCodeEditor.tsx
+++ b/src/routes/v2/pages/Editor/components/ArgumentCodeEditor.tsx
@@ -14,6 +14,7 @@ import {
 import { Text } from "@/components/ui/typography";
 import type { ComponentSpec, InputSpec, Task } from "@/models/componentSpec";
 import type { TypeSpecType } from "@/models/componentSpec/entities/types";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 
 import { useArgumentActions } from "./ArgumentRow/useArgumentActions";
 
@@ -62,6 +63,7 @@ export function ArgumentCodeEditor({
   task,
   spec,
 }: ArgumentCodeEditorProps) {
+  const { track } = useAnalytics();
   const { setArgument, removeArgument } = useArgumentActions();
   const autoLanguage = getLanguageForType(inputSpec.type);
   const [language, setLanguage] = useState(autoLanguage);
@@ -111,7 +113,15 @@ export function ArgumentCodeEditor({
         <Text size="xs" weight="semibold" className="text-gray-700">
           {inputSpec.name}
         </Text>
-        <Select value={language} onValueChange={setLanguage}>
+        <Select
+          value={language}
+          onValueChange={(next) => {
+            setLanguage(next);
+            track(
+              "v2.pipeline_editor.task_arguments.code_editor.language.changed",
+            );
+          }}
+        >
           <SelectTrigger className="h-6 text-xs px-2 py-0 min-w-25">
             <SelectValue />
           </SelectTrigger>

--- a/src/routes/v2/pages/Editor/components/ArgumentRow/ArgumentRow.tsx
+++ b/src/routes/v2/pages/Editor/components/ArgumentRow/ArgumentRow.tsx
@@ -11,6 +11,7 @@ import type {
   InputSpec,
   Task,
 } from "@/models/componentSpec";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { useIOActions } from "@/routes/v2/pages/Editor/store/actions/useIOActions";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 import type { DynamicDataArgument } from "@/utils/componentSpec";
@@ -57,6 +58,7 @@ export const ArgumentRow = observer(function ArgumentRow({
   externalEditor,
   onSelectionChanged,
 }: ArgumentRowProps) {
+  const { track } = useAnalytics();
   const { editor } = useSharedStores();
   const {
     setArgument,
@@ -94,6 +96,7 @@ export const ArgumentRow = observer(function ArgumentRow({
 
   const handleClick = () => {
     if (isDynamic) return;
+    track("v2.pipeline_editor.task_arguments.argument_row.edit_started");
     onSelectionChanged?.(inputSpec.name);
     if (externalEditor) {
       editor.setFocusedArgument(inputSpec.name);
@@ -113,8 +116,10 @@ export const ArgumentRow = observer(function ArgumentRow({
     const trimmed = value.trim();
     const action = resolveArgumentChange(trimmed, currentValue, isSet, isBound);
     if (action === "remove") {
+      track("v2.pipeline_editor.task_arguments.argument_row.value_removed");
       removeArgument(task, inputSpec.name);
     } else if (action === "set") {
+      track("v2.pipeline_editor.task_arguments.argument_row.value_updated");
       setArgument(spec, task.$id, inputSpec.name, trimmed);
     }
     handleBlur();

--- a/src/routes/v2/pages/Editor/components/ArgumentRow/components/ThunderMenu/ThunderMenu.tsx
+++ b/src/routes/v2/pages/Editor/components/ArgumentRow/components/ThunderMenu/ThunderMenu.tsx
@@ -19,8 +19,10 @@ import {
 import { Icon } from "@/components/ui/icon";
 import { cn } from "@/lib/utils";
 import type { TypeSpecType } from "@/models/componentSpec";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { useSpec } from "@/routes/v2/shared/providers/SpecContext";
 import type { DynamicDataArgument } from "@/utils/componentSpec";
+import { tracking } from "@/utils/tracking";
 
 import { DynamicDataSubmenu } from "./components/DynamicDataSubmenu";
 import { QuickConnectSubmenu } from "./components/QuickConnectSubmenu";
@@ -54,6 +56,7 @@ export const ThunderMenu = observer(function ThunderMenu({
   onQuickConnect,
   onCreateInputAndConnect,
 }: ThunderMenuProps) {
+  const { track } = useAnalytics();
   const spec = useSpec();
   const [isOpen, setIsOpen] = useState(false);
   const [isSecretDialogOpen, setIsSecretDialogOpen] = useState(false);
@@ -75,6 +78,9 @@ export const ThunderMenu = observer(function ThunderMenu({
 
   const handleSecretSelect = (secretName: string) => {
     setIsSecretDialogOpen(false);
+    track(
+      "v2.pipeline_editor.task_arguments.thunder_menu.dynamic_data.secret_apply.completed",
+    );
     onSelectDynamicData(createSecretArgument(secretName));
   };
 
@@ -95,6 +101,7 @@ export const ThunderMenu = observer(function ThunderMenu({
               isOpen ? "visible" : "invisible group-hover:visible",
             )}
             data-testid="thunder-menu-trigger"
+            {...tracking("v2.pipeline_editor.task_arguments.thunder_menu")}
           >
             <Icon
               name="Zap"
@@ -109,12 +116,24 @@ export const ThunderMenu = observer(function ThunderMenu({
           sideOffset={4}
           className="w-56 z-[9999]"
         >
-          <DropdownMenuItem disabled={!canReset} onClick={onResetToDefault}>
+          <DropdownMenuItem
+            disabled={!canReset}
+            {...tracking(
+              "v2.pipeline_editor.task_arguments.thunder_menu.reset_to_default",
+            )}
+            onClick={onResetToDefault}
+          >
             <Icon name="RotateCcw" size="sm" />
             Reset to Default
           </DropdownMenuItem>
 
-          <DropdownMenuItem disabled={!canUnset} onClick={onUnset}>
+          <DropdownMenuItem
+            disabled={!canUnset}
+            {...tracking(
+              "v2.pipeline_editor.task_arguments.thunder_menu.unset",
+            )}
+            onClick={onUnset}
+          >
             <Icon name="Trash2" size="sm" />
             Unset Argument
           </DropdownMenuItem>
@@ -143,7 +162,12 @@ export const ThunderMenu = observer(function ThunderMenu({
           {onCreateInputAndConnect && (
             <>
               <DropdownMenuSeparator />
-              <DropdownMenuItem onClick={onCreateInputAndConnect}>
+              <DropdownMenuItem
+                {...tracking(
+                  "v2.pipeline_editor.task_arguments.thunder_menu.create_input",
+                )}
+                onClick={onCreateInputAndConnect}
+              >
                 <Icon name="Plus" size="sm" className="text-green-600" />
                 Create Input
               </DropdownMenuItem>

--- a/src/routes/v2/pages/Editor/components/ArgumentRow/components/ThunderMenu/components/DynamicDataSubmenu.tsx
+++ b/src/routes/v2/pages/Editor/components/ArgumentRow/components/ThunderMenu/components/DynamicDataSubmenu.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Icon } from "@/components/ui/icon";
 import { InlineStack } from "@/components/ui/layout";
+import { tracking } from "@/utils/tracking";
 
 type DynamicDataGroup = ReturnType<typeof getDynamicDataGroups>[number];
 
@@ -41,7 +42,12 @@ export function DynamicDataSubmenu({
               </InlineStack>
             </DropdownMenuLabel>
             {group.requiresDialog ? (
-              <DropdownMenuItem onClick={onOpenSecretDialog}>
+              <DropdownMenuItem
+                {...tracking(
+                  "v2.pipeline_editor.task_arguments.thunder_menu.dynamic_data.secret_dialog_open",
+                )}
+                onClick={onOpenSecretDialog}
+              >
                 <Icon name="Lock" size="sm" className="text-amber-600" />
                 Select Secret...
               </DropdownMenuItem>
@@ -49,6 +55,9 @@ export function DynamicDataSubmenu({
               group.options.map((option) => (
                 <DropdownMenuItem
                   key={option.key}
+                  {...tracking(
+                    "v2.pipeline_editor.task_arguments.thunder_menu.dynamic_data.system_option",
+                  )}
                   onClick={() => onSelectSystemData(option.key)}
                 >
                   <Icon name={group.icon} size="sm" className="text-blue-600" />

--- a/src/routes/v2/pages/Editor/components/ArgumentRow/components/ThunderMenu/components/QuickConnectSubmenu.tsx
+++ b/src/routes/v2/pages/Editor/components/ArgumentRow/components/ThunderMenu/components/QuickConnectSubmenu.tsx
@@ -14,6 +14,7 @@ import {
   type QuickConnectGroup,
   typeSpecToString,
 } from "@/routes/v2/pages/Editor/components/ArgumentRow/components/ThunderMenu/thunderMenu.utils";
+import { tracking } from "@/utils/tracking";
 
 interface QuickConnectSubmenuProps {
   groups: QuickConnectGroup[];
@@ -52,6 +53,9 @@ export function QuickConnectSubmenu({
               return (
                 <DropdownMenuItem
                   key={`${port.entityId}::${port.portName}`}
+                  {...tracking(
+                    "v2.pipeline_editor.task_arguments.thunder_menu.quick_connect",
+                  )}
                   onClick={() => onQuickConnect(port.entityId, port.portName)}
                 >
                   <Text size="xs" className="truncate flex-1">

--- a/src/utils/tracking.ts
+++ b/src/utils/tracking.ts
@@ -2,7 +2,8 @@
  * Returns HTML data attributes that the document-level click tracker
  * (`useClickTracking`) reads to fire an analytics event automatically.
  *
- * Spread the result onto any interactive element (`<button>`, `<a>`, etc.):
+ * Spread the result onto any interactive element (`<button>`, `<a>`, shadcn
+ * `DropdownMenuItem` / `role="menuitem"`, etc.):
  *
  * ```tsx
  * <Button {...tracking("header.settings")} onClick={navigate} />


### PR DESCRIPTION
## Description

Contributes to https://github.com/Shopify/oasis-frontend/issues/607

Extends analytics tracking coverage across the pipeline editor's task argument components.

`useClickTracking` now recognises Radix/shadcn menu roles (`menuitem`, `menuitemcheckbox`, `menuitemradio`) in addition to the previously supported `button` and `link` roles, allowing `{...tracking()}` to be spread directly onto `DropdownMenuItem` components.

The following interactions are now tracked:

- **ThunderMenu** – opening the menu trigger, clicking "Reset to Default", "Unset Argument", and "Create Input" items
- **DynamicDataSubmenu** – opening the secret selection dialog and selecting a system data option
- **QuickConnectSubmenu** – selecting a quick-connect port
- **ThunderMenu secret flow** – completing a secret apply
- **ArgumentRow** – starting an edit, updating a value, and removing a value
- **ArgumentCodeEditor** – changing the code language selector

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Open the pipeline editor and select a task with arguments.
2. Click an argument row and verify `v2.pipeline_editor.task_arguments.argument_row.edit_started` fires.
3. Update or clear an argument value and verify the corresponding `value_updated` / `value_removed` event fires.
4. Open the ThunderMenu (⚡ icon) and verify `v2.pipeline_editor.task_arguments.thunder_menu` fires on open.
5. Click each menu item (Reset to Default, Unset Argument, Create Input, dynamic data options, quick-connect options) and confirm the corresponding tracking events fire.
6. Change the language in the code editor selector and verify `v2.pipeline_editor.task_arguments.code_editor.language.changed` fires.

## Additional Comments

The `tracking()` utility docstring and `useClickTracking` JSDoc have been updated to reflect that `DropdownMenuItem` (and any element with a menu-related ARIA role) is a supported target.