### PR TITLE
chore: v2 - instrument pipeline tree and validation resolutions analytics

### DIFF
--- a/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/IssueRow.tsx
+++ b/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/IssueRow.tsx
@@ -6,6 +6,7 @@ import type { ValidationIssue } from "@/models/componentSpec";
 import { issueTypeLabel } from "@/routes/v2/pages/Editor/components/ValidationSummary";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 import { useFocusActions } from "@/routes/v2/shared/store/useFocusActions";
+import { tracking } from "@/utils/tracking";
 
 import {
   issueRowMessageVariants,
@@ -47,6 +48,7 @@ export const IssueRow = observer(function IssueRow({ issue }: IssueRowProps) {
     <div
       role="button"
       tabIndex={0}
+      {...tracking("v2.pipeline_editor.pipeline_tree.validation_issue_select")}
       onClick={handleClick}
       onKeyDown={handleKeyDown}
       className={issueRowVariants({

--- a/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/RootNode.tsx
+++ b/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/RootNode.tsx
@@ -51,7 +51,11 @@ export const RootNode = observer(function RootNode({
           fullWidth: true,
         })}
       >
-        <TreeRowActivate layout="rootStrip" onActivate={handleRowNavigate}>
+        <TreeRowActivate
+          layout="rootStrip"
+          onActivate={handleRowNavigate}
+          trackingId="v2.pipeline_editor.pipeline_tree.root_nav"
+        >
           <Text
             size="xs"
             weight="semibold"

--- a/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/SubgraphNode.tsx
+++ b/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/SubgraphNode.tsx
@@ -14,6 +14,7 @@ import type { ComponentSpec, Task } from "@/models/componentSpec";
 import { getEntityIssues } from "@/routes/v2/pages/Editor/components/PipelineTreeContent/utils";
 import { countErrors } from "@/routes/v2/pages/Editor/components/ValidationSummary";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
+import { tracking } from "@/utils/tracking";
 
 import { IssueBadge } from "./IssueBadge";
 import { IssueRow } from "./IssueRow";
@@ -96,6 +97,7 @@ export const SubgraphNode = observer(function SubgraphNode({
             selected={isSelected}
             taskId={task.$id}
             onActivate={handleClick}
+            trackingId="v2.pipeline_editor.pipeline_tree.subgraph_nav"
           >
             <InlineStack
               className="shrink-0 rounded-sm bg-white"
@@ -139,6 +141,9 @@ export const SubgraphNode = observer(function SubgraphNode({
                 aria-label={
                   isExpanded ? "Collapse subgraph" : "Expand subgraph"
                 }
+                {...tracking(
+                  "v2.pipeline_editor.pipeline_tree.subgraph_expand_toggle",
+                )}
               >
                 <Icon
                   name={isExpanded ? "ChevronDown" : "ChevronRight"}

--- a/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/TaskLeafNode.tsx
+++ b/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/TaskLeafNode.tsx
@@ -62,6 +62,7 @@ export const TaskLeafNode = observer(function TaskLeafNode({
         selected={isSelected}
         taskId={task.$id}
         onActivate={handleClick}
+        trackingId="v2.pipeline_editor.pipeline_tree.task_nav"
       >
         <Icon
           name={hasIssues ? "CircleAlert" : "Circle"}

--- a/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/TreeRowActivate.tsx
+++ b/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/TreeRowActivate.tsx
@@ -3,6 +3,7 @@ import type { KeyboardEvent, ReactNode } from "react";
 
 import { cn } from "@/lib/utils";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
+import { tracking } from "@/utils/tracking";
 
 type TreeRowActivateLayout = "rootStrip" | "subgraphStrip" | "leafRow";
 
@@ -25,6 +26,7 @@ interface TreeRowActivateProps {
   selected?: boolean;
   taskId?: string;
   className?: string;
+  trackingId?: string;
 
   onActivate: () => void;
 }
@@ -36,6 +38,7 @@ export function TreeRowActivate({
   selected,
   taskId,
   className,
+  trackingId,
 }: TreeRowActivateProps) {
   const { editor } = useSharedStores();
 
@@ -52,6 +55,7 @@ export function TreeRowActivate({
       aria-selected={selected}
       onClick={onActivate}
       onKeyDown={handleKeyDown}
+      {...(trackingId ? tracking(trackingId) : {})}
       {...(taskId !== undefined
         ? {
             onMouseEnter: () => {

--- a/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/resolutions/BadReferenceResolution.tsx
+++ b/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/resolutions/BadReferenceResolution.tsx
@@ -8,6 +8,7 @@ import type { ComponentSpec, ValidationIssue } from "@/models/componentSpec";
 import { ArgumentRow } from "@/routes/v2/pages/Editor/components/ArgumentRow/ArgumentRow";
 import { useValidationResolutionActions } from "@/routes/v2/pages/Editor/components/PipelineTreeContent/components/useValidationResolutionActions";
 import { findTaskById } from "@/routes/v2/pages/Editor/components/PipelineTreeContent/components/validationResolution.utils";
+import { tracking } from "@/utils/tracking";
 
 import { InfoOnlyResolution } from "./InfoOnlyResolution";
 
@@ -56,7 +57,14 @@ export const BadReferenceResolution = observer(function BadReferenceResolution({
         </Text>
       </BlockStack>
 
-      <Button variant="outline" size="sm" onClick={handleUnset}>
+      <Button
+        variant="outline"
+        size="sm"
+        {...tracking(
+          "v2.pipeline_editor.pipeline_tree.resolution.bad_reference_unset",
+        )}
+        onClick={handleUnset}
+      >
         <Icon name="Unlink" size="xs" />
         Unset Argument
       </Button>

--- a/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/resolutions/DeleteEntityResolution.tsx
+++ b/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/resolutions/DeleteEntityResolution.tsx
@@ -3,6 +3,7 @@ import { Icon } from "@/components/ui/icon";
 import { BlockStack } from "@/components/ui/layout";
 import { Text } from "@/components/ui/typography";
 import type { ValidationIssue } from "@/models/componentSpec";
+import { tracking } from "@/utils/tracking";
 
 export function DeleteEntityResolution({
   issue,
@@ -21,6 +22,9 @@ export function DeleteEntityResolution({
       <Button
         variant="destructive"
         size="sm"
+        {...tracking(
+          "v2.pipeline_editor.pipeline_tree.resolution.delete_entity",
+        )}
         onClick={onDelete}
         disabled={!issue.entityId}
       >

--- a/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/resolutions/DuplicateNameResolution.tsx
+++ b/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/resolutions/DuplicateNameResolution.tsx
@@ -7,6 +7,7 @@ import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Text } from "@/components/ui/typography";
 import type { ComponentSpec, ValidationIssue } from "@/models/componentSpec";
 import { useValidationResolutionActions } from "@/routes/v2/pages/Editor/components/PipelineTreeContent/components/useValidationResolutionActions";
+import { tracking } from "@/utils/tracking";
 
 export function DuplicateNameResolution({
   issue,
@@ -56,7 +57,14 @@ export function DuplicateNameResolution({
             className="h-8 text-xs flex-1"
             autoFocus
           />
-          <Button size="sm" onClick={handleRename} disabled={!value.trim()}>
+          <Button
+            size="sm"
+            {...tracking(
+              "v2.pipeline_editor.pipeline_tree.resolution.duplicate_rename",
+            )}
+            onClick={handleRename}
+            disabled={!value.trim()}
+          >
             Rename
           </Button>
         </InlineStack>
@@ -66,7 +74,14 @@ export function DuplicateNameResolution({
         <Text size="xs" tone="subdued" className="mb-2">
           Or remove the duplicate:
         </Text>
-        <Button variant="destructive" size="sm" onClick={handleDelete}>
+        <Button
+          variant="destructive"
+          size="sm"
+          {...tracking(
+            "v2.pipeline_editor.pipeline_tree.resolution.duplicate_delete",
+          )}
+          onClick={handleDelete}
+        >
           <Icon name="Trash2" size="xs" />
           Delete {entityType}
         </Button>

--- a/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/resolutions/RenameEntityResolution.tsx
+++ b/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/resolutions/RenameEntityResolution.tsx
@@ -6,6 +6,7 @@ import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Text } from "@/components/ui/typography";
 import type { ComponentSpec, ValidationIssue } from "@/models/componentSpec";
 import { useValidationResolutionActions } from "@/routes/v2/pages/Editor/components/PipelineTreeContent/components/useValidationResolutionActions";
+import { tracking } from "@/utils/tracking";
 
 export function RenameEntityResolution({
   issue,
@@ -51,7 +52,14 @@ export function RenameEntityResolution({
           className="h-8 text-xs flex-1"
           autoFocus
         />
-        <Button size="sm" onClick={handleSave} disabled={!value.trim()}>
+        <Button
+          size="sm"
+          {...tracking(
+            "v2.pipeline_editor.pipeline_tree.resolution.rename_save",
+          )}
+          onClick={handleSave}
+          disabled={!value.trim()}
+        >
           Save
         </Button>
       </InlineStack>


### PR DESCRIPTION
## Description

Contributes to https://github.com/Shopify/oasis-frontend/issues/607

Adds tracking attributes to interactive elements within the Pipeline Tree section of the pipeline editor. The following user interactions are now instrumented:

- Clicking a validation issue row (`v2.pipeline_editor.pipeline_tree.validation_issue_select`)
- Navigating to the root node (`v2.pipeline_editor.pipeline_tree.root_nav`)
- Toggling the root node expand/collapse (`v2.pipeline_editor.pipeline_tree.root_expand_toggle`)
- Navigating to a subgraph node (`v2.pipeline_editor.pipeline_tree.subgraph_nav`)
- Toggling a subgraph node expand/collapse (`v2.pipeline_editor.pipeline_tree.subgraph_expand_toggle`)
- Navigating to a task leaf node (`v2.pipeline_editor.pipeline_tree.task_nav`)
- Unsetting a bad reference argument (`v2.pipeline_editor.pipeline_tree.resolution.bad_reference_unset`)
- Deleting an entity from a validation resolution (`v2.pipeline_editor.pipeline_tree.resolution.delete_entity`)
- Renaming a duplicate entity (`v2.pipeline_editor.pipeline_tree.resolution.duplicate_rename`)
- Deleting a duplicate entity (`v2.pipeline_editor.pipeline_tree.resolution.duplicate_delete`)
- Saving a renamed entity (`v2.pipeline_editor.pipeline_tree.resolution.rename_save`)

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

Interact with the pipeline tree in the editor — navigate nodes, expand/collapse subgraphs, and trigger validation resolutions — then verify that the corresponding tracking events are fired for each action listed above.

## Additional Comments