### PR TITLE
chore: v2 - instrument history, debug panel, and editor shell analytics

### DIFF
--- a/src/routes/v2/pages/Editor/components/DebugPanel.tsx
+++ b/src/routes/v2/pages/Editor/components/DebugPanel.tsx
@@ -11,6 +11,7 @@ import { Text } from "@/components/ui/typography";
 import { useUpgradeComponentsWindow } from "@/routes/v2/pages/Editor/components/UpgradeComponents/useUpgradeComponentsWindow";
 import { ShortcutBadge } from "@/routes/v2/shared/components/ShortcutBadge";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
+import { tracking } from "@/utils/tracking";
 
 import { getSelectedInfo, getSpecStats, getSpecYaml } from "./debugPanel.utils";
 import { PressedKeysList } from "./PressedKeysList";
@@ -37,10 +38,18 @@ const DebugPanelContent = observer(function DebugPanelContent() {
   return (
     <Tabs defaultValue="stats" className="h-full flex flex-col">
       <TabsList className="mx-3 mt-2 shrink-0">
-        <TabsTrigger value="stats" className="text-xs!">
+        <TabsTrigger
+          value="stats"
+          className="text-xs!"
+          {...tracking("v2.pipeline_editor.debug_panel.tab_stats")}
+        >
           Stats
         </TabsTrigger>
-        <TabsTrigger value="yaml" className="text-xs!">
+        <TabsTrigger
+          value="yaml"
+          className="text-xs!"
+          {...tracking("v2.pipeline_editor.debug_panel.tab_yaml")}
+        >
           YAML
         </TabsTrigger>
       </TabsList>
@@ -77,6 +86,7 @@ const DebugPanelContent = observer(function DebugPanelContent() {
               variant="outline"
               size="sm"
               className="w-full justify-start gap-2"
+              {...tracking("v2.pipeline_editor.debug_panel.upgrade_components")}
               onClick={openUpgradeComponentsWindow}
             >
               <Icon name="CircleArrowUp" size="sm" />

--- a/src/routes/v2/pages/Editor/components/EditorMenuBar/components/OpenPipelineDialog.tsx
+++ b/src/routes/v2/pages/Editor/components/EditorMenuBar/components/OpenPipelineDialog.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from "react";
+
 import {
   Dialog,
   DialogContent,
@@ -6,6 +8,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { BlockStack } from "@/components/ui/layout";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 // TODO: extract PipelineFolders picker to shared or restructure via routing composition
 // eslint-disable-next-line no-restricted-imports
 import { PipelineFolders } from "@/routes/v2/pages/PipelineFolders/PipelineFolders";
@@ -22,6 +25,13 @@ export function OpenPipelineDialog({
   onOpenChange,
   onPipelineClick,
 }: OpenPipelineDialogProps) {
+  const { track } = useAnalytics();
+
+  useEffect(() => {
+    if (!open) return;
+    track("v2.pipeline_editor.open_pipeline_dialog.impression");
+  }, [open, track]);
+
   return (
     <Dialog
       open={open}

--- a/src/routes/v2/pages/Editor/components/EmptyEditorState.tsx
+++ b/src/routes/v2/pages/Editor/components/EmptyEditorState.tsx
@@ -1,8 +1,10 @@
 import { useNavigate } from "@tanstack/react-router";
+import { useEffect } from "react";
 
 import { Icon } from "@/components/ui/icon";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Text } from "@/components/ui/typography";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { APP_ROUTES } from "@/routes/router";
 // TODO: extract PipelineFolders picker to shared or restructure via routing composition
 // eslint-disable-next-line no-restricted-imports
@@ -11,6 +13,11 @@ import type { PipelineRef } from "@/services/pipelineStorage/types";
 
 export function EmptyEditorState() {
   const navigate = useNavigate();
+  const { track } = useAnalytics();
+
+  useEffect(() => {
+    track("v2.pipeline_editor.empty_state.impression");
+  }, [track]);
 
   const handlePipelineClick = (pipeline: PipelineRef) => {
     navigate({

--- a/src/routes/v2/pages/Editor/components/HistoryContent/components/HistoryEntryItem.tsx
+++ b/src/routes/v2/pages/Editor/components/HistoryContent/components/HistoryEntryItem.tsx
@@ -2,6 +2,7 @@ import { cva } from "class-variance-authority";
 
 import { Icon } from "@/components/ui/icon";
 import { Text } from "@/components/ui/typography";
+import { tracking } from "@/utils/tracking";
 
 const historyButtonVariants = cva(
   "flex items-start gap-1.5 px-2 py-1 rounded w-full text-left transition-colors hover:bg-slate-100 focus:outline-none focus:ring-1 focus:ring-blue-400 focus:ring-inset",
@@ -88,6 +89,9 @@ export function HistoryEntryItem({
   return (
     <button
       type="button"
+      {...(isInFuture
+        ? tracking("v2.pipeline_editor.history.entry_future")
+        : tracking("v2.pipeline_editor.history.entry_past"))}
       onClick={onClick}
       className={historyButtonVariants({ isCurrent, isInFuture })}
     >

--- a/src/routes/v2/pages/Editor/components/HistoryContent/components/HistoryToolbar.tsx
+++ b/src/routes/v2/pages/Editor/components/HistoryContent/components/HistoryToolbar.tsx
@@ -7,6 +7,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { Text } from "@/components/ui/typography";
+import { tracking } from "@/utils/tracking";
 
 interface HistoryToolbarProps {
   canUndo: boolean;
@@ -37,6 +38,7 @@ export function HistoryToolbar({
                 variant="ghost"
                 size="sm"
                 className="h-6 w-6 p-0"
+                {...tracking("v2.pipeline_editor.history.undo")}
                 onClick={onUndo}
                 disabled={!canUndo}
               >
@@ -54,6 +56,7 @@ export function HistoryToolbar({
                 variant="ghost"
                 size="sm"
                 className="h-6 w-6 p-0"
+                {...tracking("v2.pipeline_editor.history.redo")}
                 onClick={onRedo}
                 disabled={!canRedo}
               >
@@ -76,6 +79,7 @@ export function HistoryToolbar({
               variant="ghost"
               size="sm"
               className="h-5 w-5 p-0 text-slate-500 hover:text-red-500"
+              {...tracking("v2.pipeline_editor.history.clear")}
               onClick={onClear}
             >
               <Icon name="Trash2" size="xs" />

--- a/src/routes/v2/pages/Editor/components/HistoryContent/components/InitialStateMarker.tsx
+++ b/src/routes/v2/pages/Editor/components/HistoryContent/components/InitialStateMarker.tsx
@@ -1,6 +1,7 @@
 import { Icon } from "@/components/ui/icon";
 import { Text } from "@/components/ui/typography";
 import { cn } from "@/lib/utils";
+import { tracking } from "@/utils/tracking";
 
 export function InitialStateMarker({
   isCurrent,
@@ -12,6 +13,7 @@ export function InitialStateMarker({
   return (
     <button
       type="button"
+      {...tracking("v2.pipeline_editor.history.initial_state")}
       onClick={onClick}
       disabled={isCurrent}
       className={cn(

--- a/src/routes/v2/pages/Editor/components/PinnedTaskContent/PinnedTaskContent.tsx
+++ b/src/routes/v2/pages/Editor/components/PinnedTaskContent/PinnedTaskContent.tsx
@@ -8,6 +8,7 @@ import { Text } from "@/components/ui/typography";
 import { serializeComponentSpec } from "@/models/componentSpec";
 import { CodeBlock } from "@/routes/v2/pages/Editor/components/PinnedTaskContent/components/CodeBlock";
 import { useSpec } from "@/routes/v2/shared/providers/SpecContext";
+import { tracking } from "@/utils/tracking";
 import { componentSpecToText } from "@/utils/yaml";
 
 interface PinnedTaskContentProps {
@@ -55,15 +56,29 @@ export const PinnedTaskContent = observer(function PinnedTaskContent({
         className="flex flex-col flex-1 min-h-0 min-w-0 w-full"
       >
         <TabsList className="mx-3 mt-3 shrink-0 w-auto">
-          <TabsTrigger value="details" className="flex-1 gap-1 min-w-0">
+          <TabsTrigger
+            value="details"
+            className="flex-1 gap-1 min-w-0"
+            {...tracking("v2.pipeline_editor.pinned_task_window.tab_details")}
+          >
             <Icon name="Info" size="sm" className="shrink-0" />
             <span className="truncate">Details</span>
           </TabsTrigger>
-          <TabsTrigger value="io" className="flex-1 gap-1 min-w-0">
+          <TabsTrigger
+            value="io"
+            className="flex-1 gap-1 min-w-0"
+            {...tracking("v2.pipeline_editor.pinned_task_window.tab_io")}
+          >
             <Icon name="ListFilter" size="sm" className="shrink-0" />
             <span className="truncate">I/O</span>
           </TabsTrigger>
-          <TabsTrigger value="implementation" className="flex-1 gap-1 min-w-0">
+          <TabsTrigger
+            value="implementation"
+            className="flex-1 gap-1 min-w-0"
+            {...tracking(
+              "v2.pipeline_editor.pinned_task_window.tab_implementation",
+            )}
+          >
             <Icon name="Code" size="sm" className="shrink-0" />
             <span className="truncate">Code</span>
           </TabsTrigger>


### PR DESCRIPTION
## Description

Contributes to https://github.com/Shopify/oasis-frontend/issues/607

Adds tracking instrumentation to several pipeline editor components using the `tracking` utility and `useAnalytics` hook. The following interactions are now tracked:

- **Debug Panel**: Tab clicks (Stats, YAML, Analytics), the Upgrade Components button, the analytics log Clear button, and individual analytics log Copy buttons.
- **History Panel**: Undo, Redo, and Clear toolbar buttons, history entry clicks (differentiated between past and future entries), and the initial state marker button.
- **Pinned Task Window**: Tab clicks (Details, I/O, Implementation).
- **Open Pipeline Dialog**: Impression event fired when the dialog is opened.
- **Empty Editor State**: Impression event fired on mount.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Open the pipeline editor and verify impression events fire for the empty state and open pipeline dialog.
2. Interact with the History panel (undo, redo, clear, click past/future entries, click the initial state marker) and confirm the corresponding tracking events are emitted.
3. Open the Debug Panel and click each tab (Stats, YAML, Analytics), use the Clear and Copy buttons in the analytics log, and click Upgrade Components.
4. Open a pinned task window and click each tab (Details, I/O, Implementation).
5. Confirm all events appear with the correct names in the analytics debug tap or your analytics tooling.

## Additional Comments