### PR TITLE
chore: v2 - instrument run view shell, menu bar, toolbars, and run-scoped actions

### DIFF
--- a/src/components/PipelineRun/components/CancelPipelineRunButton.tsx
+++ b/src/components/PipelineRun/components/CancelPipelineRunButton.tsx
@@ -1,5 +1,5 @@
 import { useMutation } from "@tanstack/react-query";
-import { useCallback, useState } from "react";
+import { type ComponentPropsWithoutRef, useCallback, useState } from "react";
 
 import TooltipButton from "@/components/shared/Buttons/TooltipButton";
 import ConfirmationDialog from "@/components/shared/Dialogs/ConfirmationDialog";
@@ -9,14 +9,18 @@ import useToastNotification from "@/hooks/useToastNotification";
 import { useBackend } from "@/providers/BackendProvider";
 import { cancelPipelineRun } from "@/services/pipelineRunService";
 
-interface CancelPipelineRunButtonProps {
+type CancelPipelineRunButtonProps = {
   runId: string | null | undefined;
   showLabel?: boolean;
-}
+} & Omit<
+  ComponentPropsWithoutRef<typeof TooltipButton>,
+  "onClick" | "tooltip" | "variant" | "children"
+>;
 
 export const CancelPipelineRunButton = ({
   runId,
   showLabel,
+  ...rest
 }: CancelPipelineRunButtonProps) => {
   const { backendUrl, available } = useBackend();
   const notify = useToastNotification();
@@ -67,7 +71,7 @@ export const CancelPipelineRunButton = ({
 
   if (isSuccess) {
     return (
-      <TooltipButton disabled tooltip="Run cancelled">
+      <TooltipButton disabled tooltip="Run cancelled" {...rest}>
         <Icon name="CircleSlash" />
         {showLabel && "Cancelled"}
       </TooltipButton>
@@ -82,6 +86,7 @@ export const CancelPipelineRunButton = ({
         tooltip="Cancel run"
         disabled={isPending || !available}
         data-testid="cancel-pipeline-run-button"
+        {...rest}
       >
         {isPending ? (
           <Spinner className="mr-2" />

--- a/src/components/PipelineRun/components/ClonePipelineButton.tsx
+++ b/src/components/PipelineRun/components/ClonePipelineButton.tsx
@@ -1,6 +1,11 @@
 import { useMutation } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
-import { type MouseEvent, useCallback, useRef } from "react";
+import {
+  type ComponentPropsWithoutRef,
+  type MouseEvent,
+  useCallback,
+  useRef,
+} from "react";
 
 import TooltipButton from "@/components/shared/Buttons/TooltipButton";
 import { buildTaskSpecShape } from "@/components/shared/PipelineRunNameTemplate/types";
@@ -21,12 +26,16 @@ type ClonePipelineButtonProps = {
   componentSpec: ComponentSpec;
   runId?: string | null;
   showLabel?: boolean;
-};
+} & Omit<
+  ComponentPropsWithoutRef<typeof TooltipButton>,
+  "onClick" | "tooltip" | "variant" | "children"
+>;
 
 export const ClonePipelineButton = ({
   componentSpec,
   runId,
   showLabel,
+  ...rest
 }: ClonePipelineButtonProps) => {
   const navigate = useNavigate();
   const notify = useToastNotification();
@@ -96,6 +105,7 @@ export const ClonePipelineButton = ({
       tooltip="Clone pipeline"
       disabled={isPending}
       data-testid="clone-pipeline-run-button"
+      {...rest}
     >
       <Icon name="CopyPlus" />
       {showLabel && "Clone"}

--- a/src/components/PipelineRun/components/InspectPipelineButton.tsx
+++ b/src/components/PipelineRun/components/InspectPipelineButton.tsx
@@ -1,5 +1,9 @@
 import { useNavigate } from "@tanstack/react-router";
-import { type MouseEvent, useCallback } from "react";
+import {
+  type ComponentPropsWithoutRef,
+  type MouseEvent,
+  useCallback,
+} from "react";
 
 import TooltipButton from "@/components/shared/Buttons/TooltipButton";
 import { Icon } from "@/components/ui/icon";
@@ -7,11 +11,15 @@ import { Icon } from "@/components/ui/icon";
 type InspectPipelineButtonProps = {
   pipelineName: string;
   showLabel?: boolean;
-};
+} & Omit<
+  ComponentPropsWithoutRef<typeof TooltipButton>,
+  "onClick" | "tooltip" | "variant" | "children"
+>;
 
 export const InspectPipelineButton = ({
   pipelineName,
   showLabel,
+  ...rest
 }: InspectPipelineButtonProps) => {
   const navigate = useNavigate();
 
@@ -35,6 +43,7 @@ export const InspectPipelineButton = ({
       onClick={handleInspect}
       tooltip="Inspect pipeline"
       data-testid="inspect-pipeline-button"
+      {...rest}
     >
       <Icon name="Network" className="rotate-270" />
       {showLabel && "Inspect"}

--- a/src/components/PipelineRun/components/RerunPipelineButton.tsx
+++ b/src/components/PipelineRun/components/RerunPipelineButton.tsx
@@ -1,6 +1,6 @@
 import { useMutation } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
-import { useCallback } from "react";
+import { type ComponentPropsWithoutRef, useCallback } from "react";
 
 import { isAuthorizationRequired } from "@/components/shared/Authentication/helpers";
 import { useAuthLocalStorage } from "@/components/shared/Authentication/useAuthLocalStorage";
@@ -21,11 +21,15 @@ import { submitPipelineRun } from "@/utils/submitPipeline";
 type RerunPipelineButtonProps = {
   componentSpec: ComponentSpec;
   showLabel?: boolean;
-};
+} & Omit<
+  ComponentPropsWithoutRef<typeof TooltipButton>,
+  "onClick" | "tooltip" | "variant" | "children"
+>;
 
 export const RerunPipelineButton = ({
   componentSpec,
   showLabel,
+  ...rest
 }: RerunPipelineButtonProps) => {
   const runNameOverride = useFlagValue("templatized-pipeline-run-name");
   const { backendUrl } = useBackend();
@@ -94,6 +98,7 @@ export const RerunPipelineButton = ({
       tooltip="Rerun pipeline"
       disabled={isPending}
       data-testid="rerun-pipeline-button"
+      {...rest}
     >
       <Icon name="RefreshCcw" />
       {showLabel && "Rerun"}

--- a/src/components/shared/Buttons/LinkNodeButton.tsx
+++ b/src/components/shared/Buttons/LinkNodeButton.tsx
@@ -1,12 +1,17 @@
+import { type ComponentPropsWithoutRef } from "react";
+
 import useToastNotification from "@/hooks/useToastNotification";
 
 import { ActionButton } from "./ActionButton";
 
-interface LinkNodeButtonProps {
+type LinkNodeButtonProps = {
   nodeId: string;
-}
+} & Omit<
+  ComponentPropsWithoutRef<typeof ActionButton>,
+  "onClick" | "tooltip" | "icon" | "children"
+>;
 
-export const LinkNodeButton = ({ nodeId }: LinkNodeButtonProps) => {
+export const LinkNodeButton = ({ nodeId, ...rest }: LinkNodeButtonProps) => {
   const notify = useToastNotification();
 
   const handleLink = () => {
@@ -18,6 +23,11 @@ export const LinkNodeButton = ({ nodeId }: LinkNodeButtonProps) => {
   };
 
   return (
-    <ActionButton tooltip="Shareable Link" icon="Link" onClick={handleLink} />
+    <ActionButton
+      tooltip="Shareable Link"
+      icon="Link"
+      onClick={handleLink}
+      {...rest}
+    />
   );
 };

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/logs.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/logs.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { useEffect, useState } from "react";
+import { type ComponentPropsWithoutRef, useEffect, useState } from "react";
 
 import { CodeViewer } from "@/components/shared/CodeViewer";
 import { InfoBox } from "@/components/shared/InfoBox";
@@ -171,13 +171,19 @@ const Logs = ({
   );
 };
 
+type OpenLogsInNewWindowLinkProps = {
+  executionId: string;
+  status?: string;
+} & Omit<
+  ComponentPropsWithoutRef<typeof Link>,
+  "href" | "children" | "external" | "variant" | "size" | "aria-label"
+>;
+
 export const OpenLogsInNewWindowLink = ({
   executionId,
   status,
-}: {
-  executionId: string;
-  status?: string;
-}) => {
+  ...linkRest
+}: OpenLogsInNewWindowLinkProps) => {
   const { backendUrl, available } = useBackend();
   const logsUrl = `${backendUrl}/api/executions/${executionId}/stream_container_log`;
 
@@ -196,6 +202,7 @@ export const OpenLogsInNewWindowLink = ({
           ? "Open logs in a new tab"
           : "Cant open logs: Backend not available"
       }
+      {...linkRest}
     >
       Open in new tab
     </Link>

--- a/src/components/shared/SubgraphBreadcrumbsView.tsx
+++ b/src/components/shared/SubgraphBreadcrumbsView.tsx
@@ -12,14 +12,21 @@ import {
 import { Button } from "@/components/ui/button";
 import { InlineStack } from "@/components/ui/layout";
 
+type CrumbTrackingAttrs = {
+  "data-tracking-id": string;
+  "data-tracking-metadata"?: string;
+};
+
 interface SubgraphBreadcrumbsViewProps {
   path: string[];
   onNavigate: (index: number) => void;
+  getCrumbTracking?: (index: number) => CrumbTrackingAttrs;
 }
 
 export const SubgraphBreadcrumbsView = ({
   path,
   onNavigate,
+  getCrumbTracking,
 }: SubgraphBreadcrumbsViewProps) => {
   if (path.length <= 1) {
     return null;
@@ -47,6 +54,7 @@ export const SubgraphBreadcrumbsView = ({
                         size="sm"
                         onClick={() => onNavigate(index)}
                         className="h-6 px-2"
+                        {...(getCrumbTracking?.(index) ?? {})}
                       >
                         {isRoot ? (
                           <InlineStack align="start" gap="1">

--- a/src/routes/v2/pages/RunView/components/RunDetailsContent.tsx
+++ b/src/routes/v2/pages/RunView/components/RunDetailsContent.tsx
@@ -120,7 +120,10 @@ function RunDetailsContentLoaded({
 
   return (
     <BlockStack gap="6" className="p-2 h-full">
-      <CopyText className="text-lg font-semibold">
+      <CopyText
+        className="text-lg font-semibold"
+        copyTrackingAction="v2.run_view.context_panel.run_details_pipeline_title_copy"
+      >
         {spec.name ?? "Unnamed Pipeline"}
       </CopyText>
 

--- a/src/routes/v2/pages/RunView/components/RunToolsContent.tsx
+++ b/src/routes/v2/pages/RunView/components/RunToolsContent.tsx
@@ -5,6 +5,7 @@ import { RerunPipelineButton } from "@/components/PipelineRun/components/RerunPi
 import { ViewYamlButton } from "@/components/shared/Buttons/ViewYamlButton";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { useRunViewActions } from "@/routes/v2/pages/RunView/hooks/useRunViewActions";
+import { tracking } from "@/utils/tracking";
 
 export function RunToolsContent() {
   const actions = useRunViewActions();
@@ -24,24 +25,41 @@ export function RunToolsContent() {
   return (
     <BlockStack gap="2" className="p-2">
       <InlineStack gap="2">
-        <ViewYamlButton componentSpec={componentSpec} displayLabel="View" />
+        <ViewYamlButton
+          componentSpec={componentSpec}
+          displayLabel="View"
+          {...tracking("v2.run_view.tools.view_yaml")}
+        />
 
         {canAccessEditorSpec && pipelineName && (
-          <InspectPipelineButton pipelineName={pipelineName} showLabel />
+          <InspectPipelineButton
+            pipelineName={pipelineName}
+            showLabel
+            {...tracking("v2.run_view.tools.inspect_pipeline")}
+          />
         )}
 
         <ClonePipelineButton
           componentSpec={componentSpec}
           runId={runId}
           showLabel
+          {...tracking("v2.run_view.tools.clone_pipeline")}
         />
 
         {isInProgress && isRunCreator && (
-          <CancelPipelineRunButton runId={runId} showLabel />
+          <CancelPipelineRunButton
+            runId={runId}
+            showLabel
+            {...tracking("v2.run_view.tools.cancel_run")}
+          />
         )}
 
         {isComplete && (
-          <RerunPipelineButton componentSpec={componentSpec} showLabel />
+          <RerunPipelineButton
+            componentSpec={componentSpec}
+            showLabel
+            {...tracking("v2.run_view.tools.rerun_pipeline")}
+          />
         )}
       </InlineStack>
     </BlockStack>

--- a/src/routes/v2/pages/RunView/components/RunViewFlowCanvas.tsx
+++ b/src/routes/v2/pages/RunView/components/RunViewFlowCanvas.tsx
@@ -11,6 +11,7 @@ import { observer } from "mobx-react-lite";
 import { BlockStack } from "@/components/ui/layout";
 import { cn } from "@/lib/utils";
 import type { ComponentSpec } from "@/models/componentSpec";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { useCopyShortcut } from "@/routes/v2/pages/RunView/hooks/useCopyShortcut";
 import { SubgraphBreadcrumbs } from "@/routes/v2/shared/components/SubgraphBreadcrumbs";
 import {
@@ -36,6 +37,7 @@ export const RunViewFlowCanvas = observer(function RunViewFlowCanvas({
   spec,
   className,
 }: RunViewFlowCanvasProps) {
+  const { track } = useAnalytics();
   const registry = useNodeRegistry();
   const nodeTypes = registry.getNodeTypes();
   const edgeTypes = registry.getEdgeTypes();
@@ -97,8 +99,24 @@ export const RunViewFlowCanvas = observer(function RunViewFlowCanvas({
       >
         <RunViewSelectionToolbar spec={spec} />
         <Background gap={GRID_SIZE} className="!bg-slate-50" />
-        <Controls position="bottom-right" />
-        <MiniMap position="bottom-left" pannable zoomable />
+        <Controls
+          position="bottom-right"
+          onZoomIn={() => track("v2.run_view.canvas.controls.zoom_in.click")}
+          onZoomOut={() => track("v2.run_view.canvas.controls.zoom_out.click")}
+          onFitView={() => track("v2.run_view.canvas.controls.fit_view.click")}
+          onInteractiveChange={(interactive) =>
+            track("v2.run_view.canvas.controls.interactive.toggle", {
+              interactive,
+            })
+          }
+        />
+        <MiniMap
+          position="bottom-left"
+          pannable
+          zoomable
+          onClick={() => track("v2.run_view.canvas.minimap.click")}
+          onNodeClick={() => track("v2.run_view.canvas.minimap.node.click")}
+        />
       </ReactFlow>
     </BlockStack>
   );

--- a/src/routes/v2/pages/RunView/components/RunViewMenuBar/RunViewMenuBar.tsx
+++ b/src/routes/v2/pages/RunView/components/RunViewMenuBar/RunViewMenuBar.tsx
@@ -7,6 +7,7 @@ import { Text } from "@/components/ui/typography";
 import { AppMenuActions } from "@/routes/v2/shared/components/AppMenuActions";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 import { TOP_NAV_HEIGHT } from "@/utils/constants";
+import { tracking } from "@/utils/tracking";
 
 import { RunMenu } from "./components/RunMenu";
 import { RunViewViewMenu } from "./components/RunViewViewMenu";
@@ -34,7 +35,13 @@ export const RunViewMenuBar = observer(function RunViewMenuBar() {
           blockAlign="center"
           className="min-w-0"
         >
-          <Link href="/" aria-label="Home" variant="block" className="shrink-0">
+          <Link
+            href="/"
+            aria-label="Home"
+            variant="block"
+            className="shrink-0"
+            {...tracking("v2.run_view.menu_bar.home")}
+          >
             <img
               src={logo}
               alt="logo"

--- a/src/routes/v2/pages/RunView/components/RunViewMenuBar/components/RunMenu.tsx
+++ b/src/routes/v2/pages/RunView/components/RunViewMenuBar/components/RunMenu.tsx
@@ -10,6 +10,7 @@ import {
 import { Icon } from "@/components/ui/icon";
 import { useRunViewActions } from "@/routes/v2/pages/RunView/hooks/useRunViewActions";
 import { MenuTriggerButton } from "@/routes/v2/shared/components/MenuTriggerButton";
+import { tracking } from "@/utils/tracking";
 
 export function RunMenu() {
   const navigate = useNavigate();
@@ -19,7 +20,12 @@ export function RunMenu() {
     return (
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
-          <MenuTriggerButton disabled>Run</MenuTriggerButton>
+          <MenuTriggerButton
+            disabled
+            {...tracking("v2.run_view.menu_bar.run_menu")}
+          >
+            Run
+          </MenuTriggerButton>
         </DropdownMenuTrigger>
       </DropdownMenu>
     );
@@ -42,11 +48,16 @@ export function RunMenu() {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <MenuTriggerButton>Run</MenuTriggerButton>
+        <MenuTriggerButton {...tracking("v2.run_view.menu_bar.run_menu")}>
+          Run
+        </MenuTriggerButton>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" sideOffset={2}>
         {canAccessEditorSpec && pipelineName && (
-          <DropdownMenuItem onSelect={handleInspect}>
+          <DropdownMenuItem
+            onSelect={handleInspect}
+            {...tracking("v2.run_view.menu_bar.inspect_pipeline")}
+          >
             <Icon name="ExternalLink" size="sm" />
             Inspect Pipeline
           </DropdownMenuItem>

--- a/src/routes/v2/pages/RunView/components/RunViewMenuBar/components/RunViewViewMenu.tsx
+++ b/src/routes/v2/pages/RunView/components/RunViewMenuBar/components/RunViewViewMenu.tsx
@@ -15,6 +15,7 @@ import { Icon } from "@/components/ui/icon";
 import { MenuTriggerButton } from "@/routes/v2/shared/components/MenuTriggerButton";
 import { ShortcutBadge } from "@/routes/v2/shared/components/ShortcutBadge";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
+import { tracking } from "@/utils/tracking";
 
 const LAYOUT_ALGORITHMS: { key: LayoutAlgorithm; label: string }[] = [
   { key: "sugiyama", label: "Sugiyama" },
@@ -30,11 +31,16 @@ export const RunViewViewMenu = observer(function RunViewViewMenu() {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <MenuTriggerButton>View</MenuTriggerButton>
+        <MenuTriggerButton {...tracking("v2.run_view.menu_bar.view_menu")}>
+          View
+        </MenuTriggerButton>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" sideOffset={2}>
         <DropdownMenuSub>
-          <DropdownMenuSubTrigger disabled={!autoLayoutShortcut}>
+          <DropdownMenuSubTrigger
+            disabled={!autoLayoutShortcut}
+            {...tracking("v2.run_view.menu_bar.auto_layout_submenu")}
+          >
             <Icon name="LayoutDashboard" size="sm" />
             Auto-layout
           </DropdownMenuSubTrigger>
@@ -47,6 +53,9 @@ export const RunViewViewMenu = observer(function RunViewViewMenu() {
                     algorithm: algo.key,
                   })
                 }
+                {...tracking("v2.run_view.menu_bar.auto_layout", {
+                  selected_layout: algo.key,
+                })}
               >
                 {algo.label}
                 {algo.key === "sugiyama" && (

--- a/src/routes/v2/pages/RunView/components/RunViewSelectionToolbar.tsx
+++ b/src/routes/v2/pages/RunView/components/RunViewSelectionToolbar.tsx
@@ -9,6 +9,7 @@ import type { ComponentSpec } from "@/models/componentSpec";
 import { copyNodesToClipboard } from "@/routes/v2/shared/clipboard/copyNodesToClipboard";
 import { useNodeRegistry } from "@/routes/v2/shared/nodes/NodeRegistryContext";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
+import { tracking } from "@/utils/tracking";
 
 export const RunViewSelectionToolbar = observer(
   function RunViewSelectionToolbar({ spec }: { spec: ComponentSpec | null }) {
@@ -45,6 +46,7 @@ export const RunViewSelectionToolbar = observer(
             className="gap-1.5 px-2"
             onClick={handleCopy}
             data-testid="runview-selection-copy"
+            {...tracking("v2.run_view.toolbar.selection_copy")}
           >
             <Icon name="ClipboardCopy" size="sm" />
             <Text size="xs" weight="semibold">

--- a/src/routes/v2/pages/RunView/nodes/IONode/context/RunViewInputDetails.tsx
+++ b/src/routes/v2/pages/RunView/nodes/IONode/context/RunViewInputDetails.tsx
@@ -7,6 +7,7 @@ import { Icon } from "@/components/ui/icon";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Text } from "@/components/ui/typography";
 import { useSpec } from "@/routes/v2/shared/providers/SpecContext";
+import { tracking } from "@/utils/tracking";
 
 interface RunViewInputDetailsProps {
   entityId: string;
@@ -44,7 +45,13 @@ export const RunViewInputDetails = observer(function RunViewInputDetails({
       </InlineStack>
 
       <ActionBlock
-        actions={[<LinkNodeButton key="link" nodeId={input.name} />]}
+        actions={[
+          <LinkNodeButton
+            key="link"
+            nodeId={input.name}
+            {...tracking("v2.run_view.context_panel.input_link_share")}
+          />,
+        ]}
       />
 
       <BlockStack gap="4" className="p-1">

--- a/src/routes/v2/pages/RunView/nodes/IONode/context/RunViewOutputDetails.tsx
+++ b/src/routes/v2/pages/RunView/nodes/IONode/context/RunViewOutputDetails.tsx
@@ -7,6 +7,7 @@ import { Icon } from "@/components/ui/icon";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Text } from "@/components/ui/typography";
 import { useSpec } from "@/routes/v2/shared/providers/SpecContext";
+import { tracking } from "@/utils/tracking";
 
 interface RunViewOutputDetailsProps {
   entityId: string;
@@ -44,7 +45,13 @@ export const RunViewOutputDetails = observer(function RunViewOutputDetails({
       </InlineStack>
 
       <ActionBlock
-        actions={[<LinkNodeButton key="link" nodeId={output.name} />]}
+        actions={[
+          <LinkNodeButton
+            key="link"
+            nodeId={output.name}
+            {...tracking("v2.run_view.context_panel.output_link_share")}
+          />,
+        ]}
       />
 
       <BlockStack gap="4" className="p-1">

--- a/src/routes/v2/pages/RunView/nodes/TaskNode/RunViewTaskNode.tsx
+++ b/src/routes/v2/pages/RunView/nodes/TaskNode/RunViewTaskNode.tsx
@@ -8,6 +8,7 @@ import { Icon } from "@/components/ui/icon";
 import { TaskNode } from "@/routes/v2/shared/nodes/TaskNode/TaskNode";
 import type { TaskNodeData } from "@/routes/v2/shared/nodes/types";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
+import { tracking } from "@/utils/tracking";
 
 import { useTaskRunStatus } from "./useTaskRunStatus";
 
@@ -41,6 +42,7 @@ export const RunViewTaskNode = observer(function RunViewTaskNode(
           variant="outline"
           size="sm"
           className="absolute -z-1 -top-8 right-0"
+          {...tracking("v2.run_view.canvas.task_node_open_logs")}
         >
           <Icon name="ScrollText" size="xs" />
           Open Logs

--- a/src/routes/v2/pages/RunView/nodes/TaskNode/context/RunViewTaskDetails.tsx
+++ b/src/routes/v2/pages/RunView/nodes/TaskNode/context/RunViewTaskDetails.tsx
@@ -13,9 +13,11 @@ import { Icon } from "@/components/ui/icon";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Text } from "@/components/ui/typography";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { useExecutionDataOptional } from "@/providers/ExecutionDataProvider";
 import { useSpec } from "@/routes/v2/shared/providers/SpecContext";
 import type { TaskSpec } from "@/utils/componentSpec";
+import { tracking } from "@/utils/tracking";
 
 import { RunViewTaskActions } from "./RunViewTaskActions";
 
@@ -26,6 +28,7 @@ interface RunViewTaskDetailsProps {
 export const RunViewTaskDetails = observer(function RunViewTaskDetails({
   entityId,
 }: RunViewTaskDetailsProps) {
+  const { track } = useAnalytics();
   const spec = useSpec();
   const executionData = useExecutionDataOptional();
 
@@ -67,7 +70,15 @@ export const RunViewTaskDetails = observer(function RunViewTaskDetails({
       <RunViewTaskActions componentRef={componentRef} taskName={task.name} />
 
       <div className="overflow-y-auto pb-4 h-full w-full">
-        <Tabs defaultValue="artifacts" className="h-full">
+        <Tabs
+          defaultValue="artifacts"
+          className="h-full"
+          onValueChange={(activeTab) =>
+            track("v2.run_view.context_panel.task_detail_tab.select", {
+              active_tab: activeTab,
+            })
+          }
+        >
           <TabsList className="mb-2">
             <TabsTrigger value="artifacts" className="flex-1">
               <AmphoraIcon className="w-4 h-4" />
@@ -110,6 +121,7 @@ export const RunViewTaskDetails = observer(function RunViewTaskDetails({
                   <OpenLogsInNewWindowLink
                     executionId={executionId}
                     status={status}
+                    {...tracking("v2.run_view.context_panel.open_logs_new_tab")}
                   />
                 </div>
               )}

--- a/src/routes/v2/shared/components/SubgraphBreadcrumbs.tsx
+++ b/src/routes/v2/shared/components/SubgraphBreadcrumbs.tsx
@@ -1,10 +1,16 @@
+import { useRouterState } from "@tanstack/react-router";
 import { observer } from "mobx-react-lite";
 
 import { SubgraphBreadcrumbsView } from "@/components/shared/SubgraphBreadcrumbsView";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
+import { tracking } from "@/utils/tracking";
+
+const RUNS_V2_PATH_PREFIX = "/runs-v2";
 
 export const SubgraphBreadcrumbs = observer(function SubgraphBreadcrumbs() {
   const { navigation } = useSharedStores();
+  const pathname = useRouterState({ select: (s) => s.location.pathname });
+  const isRunView = pathname.startsWith(RUNS_V2_PATH_PREFIX);
 
   const path = navigation.navigationPath.map((entry, i) =>
     i === 0 ? "Root" : entry.displayName,
@@ -14,5 +20,16 @@ export const SubgraphBreadcrumbs = observer(function SubgraphBreadcrumbs() {
     navigation.navigateToLevel(index);
   };
 
-  return <SubgraphBreadcrumbsView path={path} onNavigate={handleNavigate} />;
+  const getCrumbTracking = isRunView
+    ? (index: number) =>
+        tracking("v2.run_view.breadcrumb.navigate", { crumb_index: index })
+    : undefined;
+
+  return (
+    <SubgraphBreadcrumbsView
+      path={path}
+      onNavigate={handleNavigate}
+      getCrumbTracking={getCrumbTracking}
+    />
+  );
 });


### PR DESCRIPTION
## Description

Contributes to https://github.com/Shopify/oasis-frontend/issues/607

Adds analytics tracking to the Run View page across a wide range of user interactions, including:

- Toolbar buttons (View YAML, Inspect Pipeline, Clone, Cancel, Rerun)
- Menu bar items (Home link, Run menu, View menu, auto-layout selection)
- Canvas controls (zoom in/out, fit view, interactive toggle, minimap clicks)
- Context panel actions (task detail tab switching, open logs in new tab, input/output link sharing, pipeline title copy)
- Subgraph breadcrumb navigation (run view only)
- Task node "Open Logs" button

To support passing tracking attributes through to underlying elements, several button and link components (`CancelPipelineRunButton`, `ClonePipelineButton`, `InspectPipelineButton`, `RerunPipelineButton`, `LinkNodeButton`, `OpenLogsInNewWindowLink`) have been updated to accept and forward additional props via `ComponentPropsWithoutRef` intersection types, excluding controlled props like `onClick`, `tooltip`, `variant`, and `children`.

`SubgraphBreadcrumbsView` now accepts an optional `getCrumbTracking` callback to attach per-crumb tracking attributes, and `SubgraphBreadcrumbs` uses the current route to conditionally provide this callback only in the run view context.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

Navigate to the Run View and exercise the following interactions to verify tracking events are fired:

1. Click the Home link in the menu bar
2. Open the Run and View menus and select items
3. Use the canvas controls (zoom in/out, fit view, interactive toggle) and click the minimap
4. Open a task node's context panel and switch between tabs
5. Use the toolbar buttons (View YAML, Clone, Cancel, Rerun, Inspect)
6. Click the "Open in new tab" logs link
7. Click the shareable link button on input/output nodes
8. Navigate subgraph breadcrumbs

## Additional Comments