### PR TITLE
chore: v2 - instrument pipeline folders (table, dialogs, connect folder)

### DIFF
--- a/src/components/Home/PipelineSection/PipelineRow.tsx
+++ b/src/components/Home/PipelineSection/PipelineRow.tsx
@@ -29,15 +29,20 @@ import {
 } from "@/components/ui/tooltip";
 import { Paragraph } from "@/components/ui/typography";
 import { cn } from "@/lib/utils";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { EDITOR_PATH } from "@/routes/router";
 import { deletePipeline } from "@/services/pipelineService";
 import { getPipelineTagsFromSpec } from "@/utils/annotations";
 import type { ComponentReferenceWithSpec } from "@/utils/componentStore";
 import { formatDate } from "@/utils/date";
+import { tracking } from "@/utils/tracking";
 
 import type { MatchedField } from "./usePipelineFilters";
 
 const MAX_TITLE_LENGTH = 80;
+
+/** Default `analyticsTrackingPrefix` for the home pipeline list (non-`v2.*` warehouse slice). */
+const DEFAULT_PIPELINE_ROW_ANALYTICS_PREFIX = "pipeline_home.table";
 
 interface PipelineRowProps {
   url?: string;
@@ -57,6 +62,7 @@ interface PipelineRowProps {
   isDragging?: boolean;
   dragItemCount?: number;
   onDragStateChange?: (isDragging: boolean) => void;
+  analyticsTrackingPrefix?: string;
 }
 
 const PipelineRow = withSuspenseWrapper(
@@ -77,8 +83,14 @@ const PipelineRow = withSuspenseWrapper(
     isDragging,
     dragItemCount,
     onDragStateChange,
+    analyticsTrackingPrefix = DEFAULT_PIPELINE_ROW_ANALYTICS_PREFIX,
   }: PipelineRowProps) => {
     const navigate = useNavigate();
+    const { track } = useAnalytics();
+
+    const rowTrack = (suffix: string, metadata?: Record<string, unknown>) => {
+      track(`${analyticsTrackingPrefix}.${suffix}`, metadata);
+    };
 
     const componentSpec = componentRef?.spec;
 
@@ -90,18 +102,27 @@ const PipelineRow = withSuspenseWrapper(
       }
 
       if (onPipelineClick && name) {
+        rowTrack("pipeline_opened", { open_mode: "embedded" });
         onPipelineClick(name);
         return;
       }
 
       if (e.ctrlKey || e.metaKey) {
+        if (name) {
+          rowTrack("pipeline_opened", { open_mode: "editor_new_tab" });
+        }
         window.open(`${EDITOR_PATH}/${name}`, "_blank");
         return;
+      }
+      if (name) {
+        rowTrack("pipeline_opened", { open_mode: "editor_same_tab" });
       }
       navigate({ to: `${EDITOR_PATH}/${name}` });
     };
 
-    const handleCheckboxChange = (checked: boolean) => {
+    const handleCheckboxChange = (checked: boolean | "indeterminate") => {
+      if (checked === "indeterminate") return;
+      rowTrack("pipeline_selection_toggled", { new_value: checked });
       onSelect?.(checked);
     };
 
@@ -216,6 +237,9 @@ const PipelineRow = withSuspenseWrapper(
                   variant="ghost"
                   size="icon"
                   className="opacity-0 group-hover:opacity-100 cursor-pointer text-destructive-foreground hover:text-destructive-foreground"
+                  {...tracking(
+                    `${analyticsTrackingPrefix}.pipeline_delete_confirm_open`,
+                  )}
                 >
                   <Icon name="Trash" />
                 </Button>

--- a/src/components/shared/PaginationControls.tsx
+++ b/src/components/shared/PaginationControls.tsx
@@ -2,6 +2,7 @@ import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
 import { InlineStack } from "@/components/ui/layout";
 import { Text } from "@/components/ui/typography";
+import { tracking } from "@/utils/tracking";
 
 interface PaginationControlsProps {
   currentPage: number;
@@ -11,6 +12,7 @@ interface PaginationControlsProps {
   onNextPage: () => void;
   onPreviousPage: () => void;
   onReset: () => void;
+  analyticsTrackingPrefix?: string;
 }
 
 export function PaginationControls({
@@ -21,8 +23,19 @@ export function PaginationControls({
   onNextPage,
   onPreviousPage,
   onReset,
+  analyticsTrackingPrefix,
 }: PaginationControlsProps) {
   if (totalPages <= 1) return null;
+
+  const firstProps = analyticsTrackingPrefix
+    ? tracking(`${analyticsTrackingPrefix}.pagination_first`)
+    : {};
+  const previousProps = analyticsTrackingPrefix
+    ? tracking(`${analyticsTrackingPrefix}.pagination_previous`)
+    : {};
+  const nextProps = analyticsTrackingPrefix
+    ? tracking(`${analyticsTrackingPrefix}.pagination_next`)
+    : {};
 
   return (
     <InlineStack
@@ -36,6 +49,7 @@ export function PaginationControls({
           variant="outline"
           onClick={onReset}
           disabled={currentPage === 1}
+          {...firstProps}
         >
           <Icon name="ChevronFirst" />
         </Button>
@@ -43,6 +57,7 @@ export function PaginationControls({
           variant="outline"
           onClick={onPreviousPage}
           disabled={!hasPreviousPage}
+          {...previousProps}
         >
           <Icon name="ChevronLeft" />
           Previous
@@ -51,7 +66,12 @@ export function PaginationControls({
       <Text size="sm" tone="subdued">
         Page {currentPage} of {totalPages}
       </Text>
-      <Button variant="outline" onClick={onNextPage} disabled={!hasNextPage}>
+      <Button
+        variant="outline"
+        onClick={onNextPage}
+        disabled={!hasNextPage}
+        {...nextProps}
+      >
         Next
         <Icon name="ChevronRight" />
       </Button>

--- a/src/routes/v2/pages/PipelineFolders/components/ConnectFolderButton.tsx
+++ b/src/routes/v2/pages/PipelineFolders/components/ConnectFolderButton.tsx
@@ -8,6 +8,7 @@ import {
 import { Icon, type IconName } from "@/components/ui/icon";
 import { useConnectFolder } from "@/routes/v2/pages/PipelineFolders/hooks/useFolderMutations";
 import { useConnectGoogleDriveFolder } from "@/services/googleDrive/useConnectGoogleDriveFolder"; // google-drive
+import { tracking } from "@/utils/tracking";
 
 const isLocalFsAvailable = "showDirectoryPicker" in window;
 
@@ -61,6 +62,9 @@ export function ConnectFolderButton() {
         className="gap-2 px-3 py-2 text-sm"
         onClick={primary.action}
         disabled={isPending}
+        {...tracking("v2.pipeline_folders.connect_folder", {
+          driver: primary.id,
+        })}
       >
         <Icon name={primary.icon} size="lg" />
         {primary.label}
@@ -75,6 +79,9 @@ export function ConnectFolderButton() {
         className="gap-2 rounded-r-none border-r-0 px-3 py-2 text-sm"
         onClick={primary.action}
         disabled={isPending}
+        {...tracking("v2.pipeline_folders.connect_folder", {
+          driver: primary.id,
+        })}
       >
         <Icon name={primary.icon} size="lg" />
         {primary.label}
@@ -85,6 +92,7 @@ export function ConnectFolderButton() {
             variant="outline"
             className="rounded-l-none px-1.5 py-2"
             disabled={isPending}
+            {...tracking("v2.pipeline_folders.connect_folder_driver_menu")}
           >
             <Icon name="ChevronDown" size="sm" />
           </Button>
@@ -95,6 +103,9 @@ export function ConnectFolderButton() {
               key={driver.id}
               onClick={driver.action}
               disabled={driver.isPending}
+              {...tracking("v2.pipeline_folders.connect_folder_driver_option", {
+                driver: driver.id,
+              })}
             >
               <Icon name={driver.icon} size="sm" />
               {driver.label}

--- a/src/routes/v2/pages/PipelineFolders/components/CreateFolderDialog.tsx
+++ b/src/routes/v2/pages/PipelineFolders/components/CreateFolderDialog.tsx
@@ -1,4 +1,4 @@
-import { type FormEvent, useState } from "react";
+import { type FormEvent, useEffect, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -13,7 +13,9 @@ import { Icon } from "@/components/ui/icon";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { useCreateFolder } from "@/routes/v2/pages/PipelineFolders/hooks/useFolderMutations";
+import { tracking } from "@/utils/tracking";
 
 interface CreateFolderDialogProps {
   parentId: string | null;
@@ -23,6 +25,15 @@ export function CreateFolderDialog({ parentId }: CreateFolderDialogProps) {
   const [open, setOpen] = useState(false);
   const [name, setName] = useState("");
   const createFolder = useCreateFolder();
+  const { track } = useAnalytics();
+
+  useEffect(() => {
+    if (open) {
+      track("v2.pipeline_folders.create_folder_dialog_impression", {
+        has_parent: parentId !== null,
+      });
+    }
+  }, [open, parentId, track]);
 
   const handleSubmit = (e: FormEvent) => {
     e.preventDefault();
@@ -33,6 +44,9 @@ export function CreateFolderDialog({ parentId }: CreateFolderDialogProps) {
       { name: trimmed, parentId },
       {
         onSuccess: () => {
+          track("v2.pipeline_folders.create_folder_completed", {
+            has_parent: parentId !== null,
+          });
           setName("");
           setOpen(false);
         },
@@ -51,6 +65,7 @@ export function CreateFolderDialog({ parentId }: CreateFolderDialogProps) {
         <Button
           variant="outline"
           className="gap-2 rounded-lg px-3 py-2 text-sm"
+          {...tracking("v2.pipeline_folders.create_folder_open")}
         >
           <Icon name="FolderPlus" size="lg" />
           New Folder
@@ -78,12 +93,14 @@ export function CreateFolderDialog({ parentId }: CreateFolderDialogProps) {
                   type="button"
                   variant="outline"
                   onClick={() => handleOpenChange(false)}
+                  {...tracking("v2.pipeline_folders.create_folder_cancel")}
                 >
                   Cancel
                 </Button>
                 <Button
                   type="submit"
                   disabled={name.trim().length === 0 || createFolder.isPending}
+                  {...tracking("v2.pipeline_folders.create_folder_submit")}
                 >
                   Create
                 </Button>

--- a/src/routes/v2/pages/PipelineFolders/components/FolderPipelineTable/FolderPipelineTable.tsx
+++ b/src/routes/v2/pages/PipelineFolders/components/FolderPipelineTable/FolderPipelineTable.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/components/ui/table";
 import { Text } from "@/components/ui/typography";
 import { usePagination } from "@/hooks/usePagination";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { useBulkDeleteMutation } from "@/routes/v2/pages/PipelineFolders/hooks/useBulkDeleteMutation";
 import { useDropMutation } from "@/routes/v2/pages/PipelineFolders/hooks/useDropMutation";
 import { useFolderBreadcrumbs } from "@/routes/v2/pages/PipelineFolders/hooks/useFolderBreadcrumbs";
@@ -30,6 +31,7 @@ import { type DragItem } from "@/routes/v2/pages/PipelineFolders/types";
 import { MovePipelineDialog } from "@/routes/v2/shared/components/MovePipelineDialog";
 import { usePipelineStorage } from "@/services/pipelineStorage/PipelineStorageProvider";
 import { FoldersQueryKeys } from "@/services/pipelineStorage/types";
+import { tracking } from "@/utils/tracking";
 
 import { FolderList } from "./components/FolderList";
 import { FolderPermissionBanner } from "./components/FolderPermissionBanner";
@@ -68,6 +70,7 @@ export const FolderPipelineTable = withSuspenseWrapper(
     const { data: pipelines, refetch } = useFolderPipelines(folderId);
     const { data: breadcrumbPath } = useFolderBreadcrumbs(folderId);
 
+    const { track } = useAnalytics();
     const selection = useSelection();
     const [searchQuery, setSearchQuery] = useState("");
     const [moveDialogOpen, setMoveDialogOpen] = useState(false);
@@ -107,7 +110,11 @@ export const FolderPipelineTable = withSuspenseWrapper(
       pagination.resetPage();
     };
 
-    const handleSelectAll = (checked: boolean) => {
+    const handleSelectAll = (checked: boolean | "indeterminate") => {
+      if (checked === "indeterminate") return;
+      track("v2.pipeline_folders.table.select_all_toggled", {
+        new_value: checked,
+      });
       if (checked) {
         const pipelineIds = filteredPipelines.map((p) => p.id);
         const folderIds = filteredFolders.map((f) => f.id);
@@ -193,6 +200,9 @@ export const FolderPipelineTable = withSuspenseWrapper(
                         <Button
                           variant="ghost"
                           onClick={() => setSearchQuery("")}
+                          {...tracking(
+                            "v2.pipeline_folders.table.search_clear",
+                          )}
                         >
                           <Icon name="CircleX" />
                         </Button>
@@ -252,6 +262,7 @@ export const FolderPipelineTable = withSuspenseWrapper(
           onNextPage={pagination.goToNextPage}
           onPreviousPage={pagination.goToPreviousPage}
           onReset={pagination.resetPage}
+          analyticsTrackingPrefix="v2.pipeline_folders.table"
         />
 
         <SelectionToolbar

--- a/src/routes/v2/pages/PipelineFolders/components/FolderPipelineTable/components/FolderList.tsx
+++ b/src/routes/v2/pages/PipelineFolders/components/FolderPipelineTable/components/FolderList.tsx
@@ -6,6 +6,7 @@ import { Icon } from "@/components/ui/icon";
 import { FolderRow } from "@/routes/v2/pages/PipelineFolders/components/FolderRow";
 import type { DragItem } from "@/routes/v2/pages/PipelineFolders/types";
 import type { PipelineFolder } from "@/services/pipelineStorage/PipelineFolder";
+import { tracking } from "@/utils/tracking";
 
 interface FolderListProps {
   folders: PipelineFolder[];
@@ -75,6 +76,9 @@ export function FolderList({
                         queryKey: ["pipeline-folders"],
                       })
                     }
+                    {...tracking(
+                      "v2.pipeline_folders.table.permission_gated_folder_refresh",
+                    )}
                   >
                     <Icon name="RefreshCw" className="mr-2 size-4" />
                     Refresh
@@ -83,6 +87,9 @@ export function FolderList({
                     onSelect={() => disconnectFolder(folder.id)}
                     disabled={isDisconnecting}
                     className="text-destructive focus:text-destructive"
+                    {...tracking(
+                      "v2.pipeline_folders.table.permission_gated_folder_disconnect",
+                    )}
                   >
                     <Icon name="Unplug" className="mr-2 size-4" />
                     Disconnect

--- a/src/routes/v2/pages/PipelineFolders/components/FolderPipelineTable/components/FolderPermissionBanner.tsx
+++ b/src/routes/v2/pages/PipelineFolders/components/FolderPipelineTable/components/FolderPermissionBanner.tsx
@@ -7,6 +7,7 @@ import { Text } from "@/components/ui/typography";
 import type { PipelineFolder } from "@/services/pipelineStorage/PipelineFolder";
 import type { PermissionStatus } from "@/services/pipelineStorage/types";
 import { FoldersQueryKeys } from "@/services/pipelineStorage/types";
+import { tracking } from "@/utils/tracking";
 
 interface FolderPermissionBannerProps {
   folder: PipelineFolder;
@@ -46,7 +47,11 @@ export function FolderPermissionBanner({
           <Text tone="subdued">
             Permission required to read files from this folder.
           </Text>
-          <Button variant="outline" onClick={handleRequestPermission}>
+          <Button
+            variant="outline"
+            onClick={handleRequestPermission}
+            {...tracking("v2.pipeline_folders.table.permission_grant_access")}
+          >
             <Icon name="KeyRound" size="sm" />
             Grant Access
           </Button>
@@ -60,6 +65,9 @@ export function FolderPermissionBanner({
             size="sm"
             onClick={onGranted}
             title="Refresh file list"
+            {...tracking(
+              "v2.pipeline_folders.table.permission_granted_refresh",
+            )}
           >
             <Icon name="RefreshCw" size="sm" />
             Refresh

--- a/src/routes/v2/pages/PipelineFolders/components/FolderPipelineTable/components/ParentFolderRow.tsx
+++ b/src/routes/v2/pages/PipelineFolders/components/FolderPipelineTable/components/ParentFolderRow.tsx
@@ -4,6 +4,7 @@ import { Icon } from "@/components/ui/icon";
 import { InlineStack } from "@/components/ui/layout";
 import { TableCell, TableRow } from "@/components/ui/table";
 import { Text } from "@/components/ui/typography";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { APP_ROUTES } from "@/routes/router";
 import { useFolderNavigation } from "@/routes/v2/pages/PipelineFolders/context/FolderNavigationContext";
 import type { PipelineFolder } from "@/services/pipelineStorage/PipelineFolder";
@@ -15,10 +16,14 @@ interface ParentFolderRowProps {
 export function ParentFolderRow({ breadcrumbPath }: ParentFolderRowProps) {
   const navigate = useNavigate();
   const folderNav = useFolderNavigation();
+  const { track } = useAnalytics();
 
   const parentId = breadcrumbPath[breadcrumbPath.length - 1]?.parentId ?? null;
 
   const handleNavigateUp = () => {
+    track("v2.pipeline_folders.table.parent_folder_opened", {
+      navigation_context: folderNav ? "embedded" : "route",
+    });
     if (folderNav) {
       folderNav.navigateToFolder(parentId);
     } else {

--- a/src/routes/v2/pages/PipelineFolders/components/FolderPipelineTable/components/PipelineRows.tsx
+++ b/src/routes/v2/pages/PipelineFolders/components/FolderPipelineTable/components/PipelineRows.tsx
@@ -4,6 +4,8 @@ import { useFolderNavigation } from "@/routes/v2/pages/PipelineFolders/context/F
 import type { DragItem } from "@/routes/v2/pages/PipelineFolders/types";
 import type { PipelineFile } from "@/services/pipelineStorage/PipelineFile";
 
+const PIPELINE_FOLDERS_TABLE_ANALYTICS_PREFIX = "v2.pipeline_folders.table";
+
 interface PipelineRowsProps {
   pipelines: PipelineFile[];
   selectedPipelines: Set<string>;
@@ -49,6 +51,7 @@ export function PipelineRows({
             key={file.id}
             name={name}
             modificationTime={file.modifiedAt}
+            analyticsTrackingPrefix={PIPELINE_FOLDERS_TABLE_ANALYTICS_PREFIX}
             onDelete={onDelete}
             isSelected={selectedPipelines.has(file.id)}
             onSelect={(checked) => onSelectPipeline(file.id, checked)}

--- a/src/routes/v2/pages/PipelineFolders/components/FolderPipelineTable/components/SelectionToolbar.tsx
+++ b/src/routes/v2/pages/PipelineFolders/components/FolderPipelineTable/components/SelectionToolbar.tsx
@@ -4,6 +4,7 @@ import { Icon } from "@/components/ui/icon";
 import { InlineStack } from "@/components/ui/layout";
 import { Text } from "@/components/ui/typography";
 import { pluralize } from "@/utils/string";
+import { tracking } from "@/utils/tracking";
 
 interface SelectionToolbarProps {
   totalSelected: number;
@@ -32,14 +33,26 @@ export function SelectionToolbar({
         </Text>
         <InlineStack gap="2">
           {canMove && (
-            <Button variant="outline" size="sm" onClick={onMove}>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={onMove}
+              {...tracking("v2.pipeline_folders.table.selection_move")}
+            >
               <Icon name="FolderInput" />
               Move
             </Button>
           )}
           <ConfirmationDialog
             trigger={
-              <Button variant="destructive" size="sm" disabled={isDeleting}>
+              <Button
+                variant="destructive"
+                size="sm"
+                disabled={isDeleting}
+                {...tracking(
+                  "v2.pipeline_folders.table.selection_bulk_delete_open",
+                )}
+              >
                 <Icon name="Trash2" />
                 Delete
               </Button>
@@ -48,7 +61,12 @@ export function SelectionToolbar({
             description="Are you sure? Pipelines runs will not be impacted. Deleted folders will have their contents moved to root. This action cannot be undone."
             onConfirm={onDelete}
           />
-          <Button variant="ghost" size="sm" onClick={onClear}>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onClear}
+            {...tracking("v2.pipeline_folders.table.selection_clear")}
+          >
             <Icon name="X" />
           </Button>
         </InlineStack>

--- a/src/routes/v2/pages/PipelineFolders/components/FolderRow.tsx
+++ b/src/routes/v2/pages/PipelineFolders/components/FolderRow.tsx
@@ -7,6 +7,7 @@ import { Icon } from "@/components/ui/icon";
 import { InlineStack } from "@/components/ui/layout";
 import { TableCell, TableRow } from "@/components/ui/table";
 import { Paragraph } from "@/components/ui/typography";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { APP_ROUTES } from "@/routes/router";
 import { useFolderNavigation } from "@/routes/v2/pages/PipelineFolders/context/FolderNavigationContext";
 import type { PipelineFolder } from "@/services/pipelineStorage/PipelineFolder";
@@ -71,6 +72,7 @@ export function FolderRow({
 }: FolderRowProps) {
   const navigate = useNavigate();
   const folderNav = useFolderNavigation();
+  const { track } = useAnalytics();
 
   const {
     isDragOver,
@@ -89,8 +91,14 @@ export function FolderRow({
       return;
     }
     if (folderNav) {
+      track("v2.pipeline_folders.table.folder_opened", {
+        navigation_context: "embedded",
+      });
       folderNav.navigateToFolder(folder.id);
     } else {
+      track("v2.pipeline_folders.table.folder_opened", {
+        navigation_context: "route",
+      });
       navigate({
         to: APP_ROUTES.PIPELINE_FOLDERS,
         search: { folderId: folder.id },
@@ -115,7 +123,13 @@ export function FolderRow({
         <Checkbox
           data-checkbox
           checked={isSelected}
-          onCheckedChange={(checked: boolean) => onSelect?.(checked)}
+          onCheckedChange={(checked: boolean | "indeterminate") => {
+            if (checked === "indeterminate") return;
+            track("v2.pipeline_folders.table.folder_selection_toggled", {
+              new_value: checked,
+            });
+            onSelect?.(checked);
+          }}
           onClick={(e: MouseEvent) => e.stopPropagation()}
         />
       </TableCell>

--- a/src/routes/v2/pages/PipelineFolders/components/FolderRowMenu.tsx
+++ b/src/routes/v2/pages/PipelineFolders/components/FolderRowMenu.tsx
@@ -16,6 +16,7 @@ import {
   useToggleFavorite,
 } from "@/routes/v2/pages/PipelineFolders/hooks/useFolderMutations";
 import type { PipelineFolder } from "@/services/pipelineStorage/PipelineFolder";
+import { tracking } from "@/utils/tracking";
 
 import { RenameFolderDialog } from "./RenameFolderDialog";
 
@@ -56,6 +57,7 @@ export function FolderRowMenu({
             variant="ghost"
             size="icon"
             className="opacity-0 group-hover:opacity-100 cursor-pointer"
+            {...tracking("v2.pipeline_folders.table.folder_row_menu")}
           >
             <Icon name="EllipsisVertical" />
           </Button>
@@ -65,6 +67,12 @@ export function FolderRowMenu({
             <>
               <DropdownMenuItem
                 onSelect={() => toggleFavorite.mutate(folder.id)}
+                {...tracking(
+                  "v2.pipeline_folders.table.folder_toggle_favorite",
+                  {
+                    new_value: !folder.favorite,
+                  },
+                )}
               >
                 <Icon
                   name="Star"
@@ -75,7 +83,10 @@ export function FolderRowMenu({
                 />
                 {folder.favorite ? "Unfavorite" : "Favorite"}
               </DropdownMenuItem>
-              <DropdownMenuItem onSelect={() => setRenameOpen(true)}>
+              <DropdownMenuItem
+                onSelect={() => setRenameOpen(true)}
+                {...tracking("v2.pipeline_folders.table.folder_rename_open")}
+              >
                 <Icon name="Pencil" className="mr-2 size-4" />
                 Rename
               </DropdownMenuItem>
@@ -84,6 +95,9 @@ export function FolderRowMenu({
                   <DropdownMenuItem
                     onSelect={(e) => e.preventDefault()}
                     className="text-destructive focus:text-destructive"
+                    {...tracking(
+                      "v2.pipeline_folders.table.folder_delete_confirm_open",
+                    )}
                   >
                     <Icon name="Trash" className="mr-2 size-4" />
                     Delete

--- a/src/routes/v2/pages/PipelineFolders/components/RenameFolderDialog.tsx
+++ b/src/routes/v2/pages/PipelineFolders/components/RenameFolderDialog.tsx
@@ -11,6 +11,8 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { BlockStack } from "@/components/ui/layout";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
+import { tracking } from "@/utils/tracking";
 
 interface RenameFolderDialogProps {
   open: boolean;
@@ -26,10 +28,17 @@ export function RenameFolderDialog({
   onRename,
 }: RenameFolderDialogProps) {
   const [name, setName] = useState(currentName);
+  const { track } = useAnalytics();
 
   useEffect(() => {
     if (open) setName(currentName);
   }, [open, currentName]);
+
+  useEffect(() => {
+    if (open) {
+      track("v2.pipeline_folders.rename_folder_dialog_impression");
+    }
+  }, [open, track]);
 
   const handleSubmit = (e: FormEvent) => {
     e.preventDefault();
@@ -61,10 +70,15 @@ export function RenameFolderDialog({
                 type="button"
                 variant="outline"
                 onClick={() => onOpenChange(false)}
+                {...tracking("v2.pipeline_folders.rename_folder_cancel")}
               >
                 Cancel
               </Button>
-              <Button type="submit" disabled={name.trim().length === 0}>
+              <Button
+                type="submit"
+                disabled={name.trim().length === 0}
+                {...tracking("v2.pipeline_folders.rename_folder_submit")}
+              >
                 Rename
               </Button>
             </DialogFooter>


### PR DESCRIPTION
## Description

Contributes to https://github.com/Shopify/oasis-frontend/issues/607

Adds analytics tracking across the v2 Pipeline Folders feature and the shared `PipelineRow` / `PaginationControls` components. Tracked interactions include:

- **PipelineRow**: pipeline opened (with `open_mode`: embedded, editor_new_tab, editor_same_tab), pipeline selection toggled, and delete confirmation opened. A new `analyticsTrackingPrefix` prop allows callers to namespace events — the home list uses `pipeline_home.table` and the v2 folder table uses `v2.pipeline_folders.table`.
- **FolderPipelineTable**: select-all toggled, search cleared, and pagination navigation (first/previous/next) via the new `analyticsTrackingPrefix` prop on `PaginationControls`.
- **FolderRow**: folder opened (with `navigation_context`), folder selection toggled.
- **FolderRowMenu**: row menu opened, favorite toggled, rename dialog opened, delete confirmation opened.
- **ParentFolderRow**: parent folder navigation tracked with `navigation_context`.
- **ConnectFolderButton**: connect folder clicked (primary and split-button variants), driver menu opened, driver option selected.
- **CreateFolderDialog**: dialog impression, cancel, submit, and successful folder creation tracked.
- **RenameFolderDialog**: dialog impression, cancel, and submit tracked.
- **SelectionToolbar**: move, bulk delete open, and clear selection tracked.
- **FolderPermissionBanner / FolderList**: grant access, post-grant refresh, permission-gated folder refresh, and disconnect tracked.

`PaginationControls` gains an optional `analyticsTrackingPrefix` prop; when provided, tracking attributes are spread onto each navigation button.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Navigate to the v2 Pipeline Folders page.
2. Perform actions such as opening a folder, opening a pipeline, connecting a folder, creating/renaming/deleting a folder, toggling selection, and paginating.
3. Verify that the corresponding analytics events fire with the correct prefixes and metadata in your analytics tooling.
4. Confirm the home pipeline list still fires events under the `pipeline_home.table` prefix.

## Additional Comments

The `indeterminate` checkbox state is now explicitly guarded against in `handleCheckboxChange` (PipelineRow) and `handleSelectAll` (FolderPipelineTable) to avoid passing a non-boolean value to downstream handlers.