### PR TITLE
chore: v2 - instrument shared window chrome (dock/float/close/snap)

### DIFF
--- a/src/routes/v2/shared/windows/components/DockedWindow.tsx
+++ b/src/routes/v2/shared/windows/components/DockedWindow.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/ui/collapsible";
 import { Icon } from "@/components/ui/icon";
 import { cn } from "@/lib/utils";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { useWindowContext } from "@/routes/v2/shared/windows/ContentWindowStateContext";
 import { useWindowDrag } from "@/routes/v2/shared/windows/hooks/useWindowDrag";
 import { SnapPreview } from "@/routes/v2/shared/windows/SnapPreview";
@@ -22,6 +23,7 @@ const HEADER_HEIGHT = 36;
 
 export const DockedWindow = observer(function DockedWindow() {
   const { model, content, dockIndex = 0 } = useWindowContext();
+  const { track } = useAnalytics();
 
   const {
     isDragging,
@@ -116,7 +118,11 @@ export const DockedWindow = observer(function DockedWindow() {
       open={!model.isMinimized}
       onOpenChange={(shouldExpand) => {
         const isExpanded = !model.isMinimized;
-        if (shouldExpand !== isExpanded) model.toggleMinimize();
+        if (shouldExpand === isExpanded) return;
+        track("v2.shared_window.docked_panel_toggle_completed", {
+          panel_expanded: shouldExpand,
+        });
+        model.toggleMinimize();
       }}
     >
       {/* Sentinel to detect stuck state and serve as scroll target */}

--- a/src/routes/v2/shared/windows/components/WindowActions.tsx
+++ b/src/routes/v2/shared/windows/components/WindowActions.tsx
@@ -3,6 +3,7 @@ import { observer } from "mobx-react-lite";
 import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
 import { useWindowContext } from "@/routes/v2/shared/windows/ContentWindowStateContext";
+import { tracking } from "@/utils/tracking";
 
 const lightButtonClassName =
   "h-5 w-5 text-gray-700 hover:text-gray-900 hover:bg-white/50";
@@ -36,6 +37,9 @@ export const WindowActions = observer(function WindowActions() {
           className={buttonClassName}
           onClick={() => model.toggleMinimize()}
           aria-label={model.isMinimized ? "Expand" : "Minimize"}
+          {...tracking("v2.shared_window.chrome.minimize", {
+            placement: "docked",
+          })}
         >
           <Icon name={model.isMinimized ? "ChevronDown" : "Minus"} size="xs" />
         </Button>
@@ -48,6 +52,9 @@ export const WindowActions = observer(function WindowActions() {
           className={buttonClassName}
           onClick={() => model.toggleMaximize()}
           aria-label={model.isMaximized ? "Restore" : "Maximize"}
+          {...tracking("v2.shared_window.chrome.maximize", {
+            placement: model.isDocked ? "docked" : "floating",
+          })}
         >
           <Icon
             name={model.isMaximized ? "Minimize2" : "Maximize2"}
@@ -63,6 +70,9 @@ export const WindowActions = observer(function WindowActions() {
           className={buttonClassName}
           onClick={() => model.hide()}
           aria-label="Hide"
+          {...tracking("v2.shared_window.chrome.hide", {
+            placement: model.isDocked ? "docked" : "floating",
+          })}
         >
           <Icon name="X" size="xs" />
         </Button>
@@ -73,6 +83,9 @@ export const WindowActions = observer(function WindowActions() {
           className={closeButtonClassName}
           onClick={() => model.close()}
           aria-label="Close"
+          {...tracking("v2.shared_window.chrome.close", {
+            placement: model.isDocked ? "docked" : "floating",
+          })}
         >
           <Icon name="X" size="xs" />
         </Button>

--- a/src/routes/v2/shared/windows/hooks/useWindowDrag.ts
+++ b/src/routes/v2/shared/windows/hooks/useWindowDrag.ts
@@ -1,5 +1,6 @@
 import { useRef, useState } from "react";
 
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 import { useWindowContext } from "@/routes/v2/shared/windows/ContentWindowStateContext";
 import { detectSnapPreview } from "@/routes/v2/shared/windows/snapUtils";
@@ -46,6 +47,7 @@ export function useWindowDrag({
 }: UseWindowDragOptions): UseWindowDragReturn {
   const { model } = useWindowContext();
   const { windows } = useSharedStores();
+  const { track } = useAnalytics();
 
   const [isDragging, setIsDragging] = useState(false);
   const [snapPreview, setSnapPreview] = useState<SnapPreviewType | null>(null);
@@ -59,6 +61,7 @@ export function useWindowDrag({
   const phaseRef = useRef<DragPhase>({ type: "idle" });
   const dragOffset = useRef<Position>({ x: 0, y: 0 });
   const snapPreviewRef = useRef<SnapPreviewType | null>(null);
+  const dragUndockTrackedRef = useRef(false);
   /** Standard DOM ref for the panel element. */
   const panelRef = useRef<HTMLDivElement>(null);
 
@@ -83,6 +86,13 @@ export function useWindowDrag({
 
     raiseZIndex();
     setIsDragging(true);
+    dragUndockTrackedRef.current = false;
+
+    const trackDragUndockOnce = () => {
+      if (dragUndockTrackedRef.current) return;
+      dragUndockTrackedRef.current = true;
+      track("v2.shared_window.drag_undock_completed", {});
+    };
 
     if (docked) {
       const rect = panelRef.current?.getBoundingClientRect();
@@ -120,6 +130,7 @@ export function useWindowDrag({
         if (dx <= UNDOCK_THRESHOLD && dy <= UNDOCK_THRESHOLD) return;
 
         model.undock();
+        trackDragUndockOnce();
         phaseRef.current = { type: "free" };
 
         const halfWidth = model.size.width / 2;
@@ -135,6 +146,7 @@ export function useWindowDrag({
 
       if (model.isDocked) {
         model.undock();
+        trackDragUndockOnce();
       }
 
       const preview = detectSnapPreview({
@@ -153,12 +165,19 @@ export function useWindowDrag({
     const handleMouseUp = () => {
       const currentPreview = snapPreviewRef.current;
 
-      if (currentPreview) {
-        if (currentPreview.type === "edge") {
-          model.dock(currentPreview.side);
-        } else if (currentPreview.type === "dock-insert") {
-          model.dock(currentPreview.side, currentPreview.insertIndex);
-        }
+      if (currentPreview?.type === "edge") {
+        model.dock(currentPreview.side);
+        track("v2.shared_window.snap_dock_completed", {
+          snap_kind: "edge",
+          dock_side: currentPreview.side,
+        });
+      } else if (currentPreview?.type === "dock-insert") {
+        model.dock(currentPreview.side, currentPreview.insertIndex);
+        track("v2.shared_window.snap_dock_completed", {
+          snap_kind: "dock_insert",
+          dock_side: currentPreview.side,
+          insert_index: currentPreview.insertIndex,
+        });
       }
 
       if (!model.isAtFront) {


### PR DESCRIPTION
## Description

Contributes to https://github.com/Shopify/oasis-frontend/issues/607

Adds analytics tracking to window management interactions in the shared windows system. The following user actions are now tracked:

- **Docked panel toggle** — fires `v2.shared_window.docked_panel_toggle_completed` with whether the panel was expanded or collapsed.
- **Drag undock** — fires `v2.shared_window.drag_undock_completed` once per drag gesture when a window is undocked by dragging, using a ref to prevent duplicate events.
- **Snap dock** — fires `v2.shared_window.snap_dock_completed` on mouse up when a window is snapped to an edge or inserted into a dock slot, including the snap kind, dock side, and insert index where applicable.
- **Window chrome actions** (minimize, maximize, hide, close) — each button now spreads a `tracking(...)` attribute with the event name and placement (`docked` or `floating`).

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Open a docked window panel and toggle it open/closed — verify `v2.shared_window.docked_panel_toggle_completed` fires with the correct `panel_expanded` value.
2. Drag a docked window past the undock threshold — verify `v2.shared_window.drag_undock_completed` fires exactly once per drag.
3. Drag a floating window and snap it to an edge or dock slot — verify `v2.shared_window.snap_dock_completed` fires with the correct `snap_kind`, `dock_side`, and `insert_index`.
4. Click the minimize, maximize, hide, and close buttons on both docked and floating windows — verify the corresponding chrome tracking events fire with the correct `placement`.

## Additional Comments