### PR TITLE
fix: Input Aggregator - Ghost Nodes & V2 Editor

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/utils/createConnectedIONode.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/utils/createConnectedIONode.ts
@@ -1,17 +1,27 @@
 import type { XYPosition } from "@xyflow/react";
 
 import type { TaskType } from "@/types/taskNode";
+import {
+  AGGREGATOR_ADD_INPUT_HANDLE_ID,
+  createAggregatorInput,
+  getNextAggregatorInputName,
+} from "@/utils/aggregatorInputs";
+import { isPipelineAggregator } from "@/utils/annotations";
 import type {
+  ComponentReference,
   ComponentSpec,
   GraphSpec,
+  TaskSpec,
   TypeSpecType,
 } from "@/utils/componentSpec";
 import { isGraphImplementation } from "@/utils/componentSpec";
+import { deepClone } from "@/utils/deepClone";
 import {
   nodeIdToInputName,
   nodeIdToOutputName,
   nodeIdToTaskId,
 } from "@/utils/nodes/nodeIdUtils";
+import { componentSpecToText } from "@/utils/yaml";
 
 import addTask from "./addTask";
 import { setGraphOutputValue } from "./setGraphOutputValue";
@@ -56,14 +66,30 @@ export const createConnectedIONode = ({
   }
 
   const taskId = nodeIdToTaskId(taskNodeId);
+  const taskSpec = componentSpec.implementation.graph.tasks[taskId];
+  const taskComponentSpec = taskSpec?.componentRef?.spec;
+
+  if (
+    ioType === "input" &&
+    handleId === AGGREGATOR_ADD_INPUT_HANDLE_ID &&
+    taskSpec &&
+    taskComponentSpec &&
+    isPipelineAggregator(taskComponentSpec.metadata?.annotations)
+  ) {
+    return createConnectedAggregatorInputNode({
+      componentSpec,
+      taskId,
+      taskSpec,
+      taskComponentSpec,
+      position,
+    });
+  }
+
   const argName =
     ioType === "input"
       ? nodeIdToInputName(handleId)
       : nodeIdToOutputName(handleId);
   const taskType: TaskType = ioType;
-
-  const taskSpec = componentSpec.implementation.graph.tasks[taskId];
-  const taskComponentSpec = taskSpec?.componentRef?.spec;
 
   let ioNodeType: TypeSpecType | undefined;
   let ioNodeDefault: string | undefined;
@@ -134,5 +160,83 @@ export const createConnectedIONode = ({
     implementation: {
       graph: updatedGraph,
     },
+  };
+};
+
+type CreateConnectedAggregatorInputNodeParams = {
+  componentSpec: ComponentSpec;
+  taskId: string;
+  taskSpec: TaskSpec;
+  taskComponentSpec: ComponentSpec;
+  position: XYPosition;
+};
+
+const createConnectedAggregatorInputNode = ({
+  componentSpec,
+  taskId,
+  taskSpec,
+  taskComponentSpec,
+  position,
+}: CreateConnectedAggregatorInputNodeParams): ComponentSpec => {
+  const newAggInputName = getNextAggregatorInputName(
+    taskComponentSpec.inputs ?? [],
+  );
+  const newAggInput = createAggregatorInput(newAggInputName);
+
+  const clonedSpec: ComponentSpec = deepClone(taskComponentSpec);
+  const updatedTaskInputs = [...(clonedSpec.inputs ?? []), newAggInput];
+
+  const orderedTaskSpec: ComponentSpec = {
+    name: clonedSpec.name,
+    ...(clonedSpec.description && { description: clonedSpec.description }),
+    ...(clonedSpec.metadata && { metadata: clonedSpec.metadata }),
+    inputs: updatedTaskInputs,
+    ...(clonedSpec.outputs && { outputs: clonedSpec.outputs }),
+    implementation: clonedSpec.implementation,
+  };
+
+  const updatedComponentRef: ComponentReference = {
+    ...taskSpec.componentRef,
+    spec: orderedTaskSpec,
+    text: componentSpecToText(orderedTaskSpec),
+  };
+
+  const specWithUpdatedTask = componentSpec;
+
+  if (isGraphImplementation(specWithUpdatedTask.implementation)) {
+    specWithUpdatedTask.implementation.graph.tasks[taskId] = {
+      ...taskSpec,
+      componentRef: updatedComponentRef,
+    };
+  }
+
+  const { spec: specWithGraphInput, ioName: createdGraphInputName } = addTask(
+    "input",
+    null,
+    position,
+    specWithUpdatedTask,
+    {
+      name: newAggInputName,
+      type: newAggInput.type,
+    },
+  );
+
+  if (
+    !createdGraphInputName ||
+    !isGraphImplementation(specWithGraphInput.implementation)
+  ) {
+    return specWithGraphInput;
+  }
+
+  const updatedGraph = setTaskArgument(
+    specWithGraphInput.implementation.graph,
+    taskId,
+    newAggInputName,
+    { graphInput: { inputName: createdGraphInputName } },
+  );
+
+  return {
+    ...specWithGraphInput,
+    implementation: { graph: updatedGraph },
   };
 };

--- a/src/hooks/useGhostNode.ts
+++ b/src/hooks/useGhostNode.ts
@@ -4,6 +4,11 @@ import { useMemo } from "react";
 
 import type { GhostNodeData } from "@/components/shared/ReactFlow/FlowCanvas/GhostNode/types";
 import { createGhostNode } from "@/components/shared/ReactFlow/FlowCanvas/GhostNode/utils";
+import {
+  AGGREGATOR_ADD_INPUT_HANDLE_ID,
+  getNextAggregatorInputName,
+} from "@/utils/aggregatorInputs";
+import { isPipelineAggregator } from "@/utils/annotations";
 import type { ComponentSpec } from "@/utils/componentSpec";
 import { isGraphImplementation } from "@/utils/componentSpec";
 import {
@@ -130,9 +135,17 @@ export const useGhostNode = ({
       ? "input"
       : "output";
 
-    const handleName = isInputConnection
-      ? nodeIdToInputName(connectionFromHandle.id ?? "")
-      : nodeIdToOutputName(connectionFromHandle.id ?? "");
+    const rawHandleId = connectionFromHandle.id ?? "";
+    const isAggregatorAddHandle =
+      isInputConnection &&
+      rawHandleId === AGGREGATOR_ADD_INPUT_HANDLE_ID &&
+      isPipelineAggregator(componentRefSpec?.metadata?.annotations);
+
+    const handleName = isAggregatorAddHandle
+      ? getNextAggregatorInputName(componentRefSpec?.inputs ?? [])
+      : isInputConnection
+        ? nodeIdToInputName(rawHandleId)
+        : nodeIdToOutputName(rawHandleId);
 
     const extractedData = isInputConnection
       ? extractInputGhostData(componentRefSpec, handleName, taskSpec?.arguments)

--- a/src/routes/v2/pages/Editor/components/FlowCanvas/hooks/useConnectionBehavior.ts
+++ b/src/routes/v2/pages/Editor/components/FlowCanvas/hooks/useConnectionBehavior.ts
@@ -17,10 +17,16 @@ import {
   connectNodes,
   createConnectedIONode,
 } from "@/routes/v2/pages/Editor/store/actions";
+import {
+  createConnectedAggregatorInputNode,
+  isAggregatorTask,
+  tryConnectAggregatorAddInput,
+} from "@/routes/v2/pages/Editor/store/actions/aggregator.actions";
 import { useEditorSession } from "@/routes/v2/pages/Editor/store/EditorSessionContext";
 import type { UndoGroupable } from "@/routes/v2/shared/nodes/types";
 import { CMDALT } from "@/routes/v2/shared/shortcuts/keys";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
+import { AGGREGATOR_ADD_INPUT_HANDLE_ID } from "@/utils/aggregatorInputs";
 
 type ValidHandle = NonNullable<FinalConnectionState["fromHandle"]> & {
   id: string;
@@ -79,6 +85,15 @@ function handleConnectEnd(
     y: cursorFlowPos.y + GHOST_OFFSET_Y,
   };
 
+  if (
+    ioType === "input" &&
+    fromHandle.id === AGGREGATOR_ADD_INPUT_HANDLE_ID &&
+    isAggregatorTask(spec.tasks.find((t) => t.$id === fromHandle.nodeId))
+  ) {
+    createConnectedAggregatorInputNode(undo, spec, fromHandle.nodeId, position);
+    return;
+  }
+
   createConnectedIONode(
     undo,
     spec,
@@ -107,12 +122,16 @@ export function useConnectionBehavior(
       return;
     if (connection.source === connection.target) return;
 
-    connectNodes(undo, spec, {
+    const connectionInfo = {
       sourceNodeId: connection.source,
       sourceHandleId: connection.sourceHandle,
       targetNodeId: connection.target,
       targetHandleId: connection.targetHandle,
-    });
+    };
+
+    if (tryConnectAggregatorAddInput(undo, spec, connectionInfo)) return;
+
+    connectNodes(undo, spec, connectionInfo);
   };
 
   const onConnectEnd = (

--- a/src/routes/v2/pages/Editor/components/FlowCanvas/hooks/useNodeEdgeChanges.ts
+++ b/src/routes/v2/pages/Editor/components/FlowCanvas/hooks/useNodeEdgeChanges.ts
@@ -3,6 +3,7 @@ import type { EdgeChange, NodeChange, ReactFlowProps } from "@xyflow/react";
 import type { ComponentSpec } from "@/models/componentSpec";
 import { cleanupDeletedBinding } from "@/routes/v2/pages/Editor/nodes/ConduitNode/conduits.actions";
 import { deleteEdge } from "@/routes/v2/pages/Editor/store/actions";
+import { cleanupAggregatorInputForBinding } from "@/routes/v2/pages/Editor/store/actions/aggregator.actions";
 import { useEditorSession } from "@/routes/v2/pages/Editor/store/EditorSessionContext";
 import { useNodeRegistry } from "@/routes/v2/shared/nodes/NodeRegistryContext";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
@@ -66,12 +67,26 @@ export function useNodeEdgeChanges(
     for (const change of removeChanges) {
       if ("id" in change) {
         const edgeId = change.id;
+        const bindingIdMatch = edgeId.match(/^edge_(.+)$/);
+        const binding = bindingIdMatch
+          ? spec.bindings.find((b) => b.$id === bindingIdMatch[1])
+          : undefined;
+        const aggregatorTarget = binding
+          ? {
+              targetEntityId: binding.targetEntityId,
+              targetPortName: binding.targetPortName,
+            }
+          : null;
+
         deleteEdge(undo, spec, edgeId);
 
-        const bindingIdMatch = edgeId.match(/^edge_(.+)$/);
         if (bindingIdMatch) {
           // todo: find out how to decouple
           cleanupDeletedBinding(undo, spec, bindingIdMatch[1]);
+        }
+
+        if (aggregatorTarget) {
+          cleanupAggregatorInputForBinding(undo, spec, aggregatorTarget);
         }
       }
     }

--- a/src/routes/v2/pages/Editor/nodes/GhostNode/hooks/useGhostNode.ts
+++ b/src/routes/v2/pages/Editor/nodes/GhostNode/hooks/useGhostNode.ts
@@ -8,6 +8,11 @@ import {
   GHOST_NODE_ID,
   type GhostNodeData,
 } from "@/routes/v2/pages/Editor/nodes/GhostNode/components/GhostNode";
+import {
+  AGGREGATOR_ADD_INPUT_HANDLE_ID,
+  getNextAggregatorInputName,
+} from "@/utils/aggregatorInputs";
+import { isPipelineAggregator } from "@/utils/annotations";
 
 interface UseGhostNodeParams {
   active: boolean;
@@ -52,11 +57,21 @@ function buildGhostNode(
     : "output";
 
   const handleId = fromHandle.id ?? "";
-  const portName = extractPortName(handleId, ioType);
-
   const task = spec.tasks.find((t) => t.$id === fromHandle.nodeId);
   const taskComponentSpec = task?.resolvedComponentSpec;
-  const dataType = lookupPortType(taskComponentSpec, portName, ioType);
+
+  const isAggregatorAddHandle =
+    isInputConnection &&
+    handleId === AGGREGATOR_ADD_INPUT_HANDLE_ID &&
+    isPipelineAggregator(taskComponentSpec?.metadata?.annotations);
+
+  const portName = isAggregatorAddHandle
+    ? getNextAggregatorInputName(taskComponentSpec?.inputs ?? [])
+    : extractPortName(handleId, ioType);
+
+  const dataType = isAggregatorAddHandle
+    ? undefined
+    : lookupPortType(taskComponentSpec, portName, ioType);
 
   return {
     id: GHOST_NODE_ID,

--- a/src/routes/v2/pages/Editor/nodes/TaskNode/taskNode.manifest.ts
+++ b/src/routes/v2/pages/Editor/nodes/TaskNode/taskNode.manifest.ts
@@ -2,6 +2,7 @@ import type { ComponentReference } from "@/models/componentSpec";
 import { Annotations } from "@/models/componentSpec/annotations";
 import { Task } from "@/models/componentSpec/entities/task";
 import { addTask } from "@/routes/v2/pages/Editor/store/actions";
+import { resetAggregatorOnClone } from "@/routes/v2/pages/Editor/store/actions/aggregator.actions";
 import { generateUniqueTaskName } from "@/routes/v2/pages/Editor/store/nameUtils";
 import {
   isTaskSnapshot,
@@ -53,15 +54,19 @@ export const taskManifest: NodeTypeManifest = {
         { key: "editor.position", value: position },
       ]);
 
+      const clonedComponentRef = deepClone(snapshot.data.componentRef);
+      const clonedArguments = deepClone(snapshot.data.arguments);
+      const reset = resetAggregatorOnClone(clonedComponentRef, clonedArguments);
+
       const task = new Task({
         $id: idGen.next("task"),
         name: uniqueName,
-        componentRef: deepClone(snapshot.data.componentRef),
+        componentRef: reset?.componentRef ?? clonedComponentRef,
         isEnabled: snapshot.data.isEnabled
           ? deepClone(snapshot.data.isEnabled)
           : undefined,
         annotations,
-        arguments: deepClone(snapshot.data.arguments),
+        arguments: reset?.arguments ?? clonedArguments,
         executionOptions: snapshot.data.executionOptions
           ? deepClone(snapshot.data.executionOptions)
           : undefined,

--- a/src/routes/v2/pages/Editor/store/actions/__tests__/aggregator.actions.test.ts
+++ b/src/routes/v2/pages/Editor/store/actions/__tests__/aggregator.actions.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  ComponentSpec,
+  Input,
+  serializeComponentSpec,
+  Task,
+} from "@/models/componentSpec";
+import {
+  createConnectedAggregatorInputNode,
+  resetAggregatorOnClone,
+  tryConnectAggregatorAddInput,
+} from "@/routes/v2/pages/Editor/store/actions/aggregator.actions";
+
+const noopUndo = {
+  withGroup: <T>(_label: string, fn: () => T): T => fn(),
+};
+
+function makeAggregatorTask(taskId: string): Task {
+  return new Task({
+    $id: taskId,
+    name: "Input Aggregator",
+    componentRef: {
+      url: "https://example.com/input_aggregator.component.yaml",
+      digest: "abc123",
+      name: "Input Aggregator",
+      spec: {
+        name: "Input Aggregator",
+        metadata: {
+          annotations: { is_input_aggregator: "true" },
+        },
+        inputs: [
+          {
+            name: "output_type",
+            type: "String",
+            default: "JsonArray",
+            optional: true,
+          },
+        ],
+        outputs: [{ name: "Output", type: "String" }],
+        implementation: {
+          container: {
+            image: "python:3.12-slim",
+            command: ["sh", "-ec", "true"],
+            args: [
+              "--output-type",
+              { inputValue: "output_type" },
+              "----output-paths",
+              { outputPath: "Output" },
+            ],
+          },
+        },
+      },
+    },
+    arguments: [{ name: "output_type", value: "JsonArray" }],
+  });
+}
+
+describe("aggregator.actions integration", () => {
+  it("connect-by-cmd-drop produces a serializable spec with agg_N inputs and bindings", () => {
+    const spec = new ComponentSpec({ $id: "spec_1", name: "Pipeline" });
+    const task = makeAggregatorTask("task_1");
+    spec.addTask(task);
+
+    createConnectedAggregatorInputNode(noopUndo, spec, "task_1", {
+      x: 0,
+      y: 0,
+    });
+    createConnectedAggregatorInputNode(noopUndo, spec, "task_1", {
+      x: 0,
+      y: 100,
+    });
+
+    const json = serializeComponentSpec(spec);
+    const taskJson = (json.implementation as any).graph.tasks[
+      "Input Aggregator"
+    ];
+
+    expect(taskJson.componentRef.spec.inputs.map((i: any) => i.name)).toEqual([
+      "output_type",
+      "agg_1",
+      "agg_2",
+    ]);
+    expect(taskJson.arguments).toEqual({
+      output_type: "JsonArray",
+      agg_1: { graphInput: { inputName: "agg_1" } },
+      agg_2: { graphInput: { inputName: "agg_2" } },
+    });
+    expect(json.inputs?.map((i) => i.name)).toEqual(["agg_1", "agg_2"]);
+  });
+
+  it("connect-from-existing-graph-input creates agg_N input on aggregator", () => {
+    const spec = new ComponentSpec({ $id: "spec_1", name: "Pipeline" });
+    const task = makeAggregatorTask("task_1");
+    spec.addTask(task);
+
+    const existingInput = new Input({ $id: "input_1", name: "user_data" });
+    spec.addInput(existingInput);
+
+    const handled = tryConnectAggregatorAddInput(noopUndo, spec, {
+      sourceNodeId: existingInput.$id,
+      sourceHandleId: `output_${existingInput.$id}`,
+      targetNodeId: task.$id,
+      targetHandleId: "__add_aggregator_input__",
+    });
+
+    expect(handled).toBe(true);
+
+    const json = serializeComponentSpec(spec);
+    const taskJson = (json.implementation as any).graph.tasks[
+      "Input Aggregator"
+    ];
+
+    expect(taskJson.componentRef.spec.inputs.map((i: any) => i.name)).toEqual([
+      "output_type",
+      "agg_1",
+    ]);
+    expect(taskJson.arguments).toEqual({
+      output_type: "JsonArray",
+      agg_1: { graphInput: { inputName: "user_data" } },
+    });
+  });
+
+  it("resetAggregatorOnClone strips agg_* inputs and arguments", () => {
+    const aggRef = {
+      url: "https://example.com/input_aggregator.component.yaml",
+      digest: "abc123",
+      spec: {
+        name: "Input Aggregator",
+        metadata: { annotations: { is_input_aggregator: "true" } },
+        inputs: [
+          {
+            name: "output_type",
+            type: "String",
+            default: "JsonArray",
+            optional: true,
+          },
+          { name: "agg_1", type: "String", optional: true },
+          { name: "agg_2", type: "String", optional: true },
+        ],
+        outputs: [{ name: "Output", type: "String" }],
+        implementation: {
+          container: { image: "x", command: ["sh"], args: [] },
+        },
+      },
+    };
+    const args = [
+      { name: "output_type", value: "JsonArray" },
+      { name: "agg_1", value: { graphInput: { inputName: "agg_1" } } },
+      { name: "agg_2", value: { graphInput: { inputName: "agg_2" } } },
+    ];
+
+    const reset = resetAggregatorOnClone(aggRef, args);
+
+    expect(reset).not.toBeNull();
+    expect(reset!.componentRef.spec!.inputs!.map((i) => i.name)).toEqual([
+      "output_type",
+    ]);
+    expect(reset!.arguments.map((a) => a.name)).toEqual(["output_type"]);
+    // text is regenerated to match the stripped spec
+    expect(reset!.componentRef.text).not.toContain("agg_1");
+  });
+
+  it("resetAggregatorOnClone returns null for non-aggregator tasks", () => {
+    const ref = {
+      spec: {
+        name: "Other",
+        inputs: [{ name: "x", type: "String" }],
+        implementation: { container: { image: "x", command: ["sh"] } },
+      },
+    };
+    expect(resetAggregatorOnClone(ref, [{ name: "x", value: "1" }])).toBeNull();
+  });
+
+  it("non-string metadata annotation values get coerced before submission", async () => {
+    // The backend requires metadata.annotations values to be strings. Legacy/
+    // imported pipelines occasionally have arrays or objects (e.g. comments:
+    // []) — those would 422 the request. submitPipelineRun should sanitize.
+    const { submitPipelineRun } = await import("@/utils/submitPipeline");
+
+    let captured: unknown;
+    const fetchMock = vi.fn(async (_url: string, init: RequestInit) => {
+      captured = JSON.parse(init.body as string);
+      return new Response(JSON.stringify({ id: 1 }), { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const dirtySpec = {
+      name: "Pipeline",
+      metadata: {
+        annotations: {
+          // legacy non-string values
+          comments: [] as unknown,
+          stats: { runs: 3 } as unknown,
+          author: "alice",
+        } as Record<string, unknown>,
+      },
+      implementation: { graph: { tasks: {} } },
+    } as any;
+
+    await submitPipelineRun(dirtySpec, "http://backend");
+
+    vi.unstubAllGlobals();
+    const sentAnnotations = (captured as any)?.root_task?.componentRef?.spec
+      ?.metadata?.annotations;
+    expect(sentAnnotations).toEqual({
+      comments: "[]",
+      stats: '{"runs":3}',
+      author: "alice",
+    });
+  });
+});

--- a/src/routes/v2/pages/Editor/store/actions/aggregator.actions.ts
+++ b/src/routes/v2/pages/Editor/store/actions/aggregator.actions.ts
@@ -1,0 +1,226 @@
+import type { XYPosition } from "@xyflow/react";
+
+import type { ComponentSpec, Task } from "@/models/componentSpec";
+import type { Argument } from "@/models/componentSpec/entities/types";
+import type { UndoGroupable } from "@/routes/v2/shared/nodes/types";
+import {
+  AGGREGATOR_ADD_INPUT_HANDLE_ID,
+  AGGREGATOR_INPUT_PREFIX,
+  createAggregatorInput,
+  getNextAggregatorInputName,
+} from "@/utils/aggregatorInputs";
+import { isPipelineAggregator } from "@/utils/annotations";
+import type {
+  ComponentReference,
+  ComponentSpec as ComponentSpecJson,
+} from "@/utils/componentSpec";
+import { deepClone } from "@/utils/deepClone";
+import { componentSpecToText } from "@/utils/yaml";
+
+import { addInput } from "./io.actions";
+
+interface ConnectionInfo {
+  sourceNodeId: string;
+  sourceHandleId: string;
+  targetNodeId: string;
+  targetHandleId: string;
+}
+
+const AGG_INPUT_PREFIX = AGGREGATOR_INPUT_PREFIX;
+
+export function isAggregatorTask(task: Task | undefined): boolean {
+  if (!task) return false;
+  const annotations = task.resolvedComponentSpec?.metadata?.annotations;
+  return isPipelineAggregator(annotations);
+}
+
+/**
+ * For an aggregator task being cloned (copy/paste, duplicate), return a fresh
+ * componentRef + arguments with the dynamic agg_* inputs/arguments stripped —
+ * a paste should start as a clean aggregator with zero connected inputs.
+ * Returns null when the input isn't an aggregator (caller can keep originals).
+ */
+export function resetAggregatorOnClone(
+  componentRef: ComponentReference,
+  args: Argument[],
+): { componentRef: ComponentReference; arguments: Argument[] } | null {
+  const spec = componentRef.spec;
+  if (!spec || !isPipelineAggregator(spec.metadata?.annotations)) return null;
+
+  const strippedSpec: ComponentSpecJson = {
+    ...spec,
+    inputs: (spec.inputs ?? []).filter(
+      (input) => !input.name.startsWith(AGG_INPUT_PREFIX),
+    ),
+  };
+
+  return {
+    componentRef: {
+      ...componentRef,
+      spec: strippedSpec,
+      text: componentSpecToText(strippedSpec),
+    },
+    arguments: args.filter((a) => !a.name.startsWith(AGG_INPUT_PREFIX)),
+  };
+}
+
+function isAggregatorAddInputHandle(handleId: string): boolean {
+  return handleId === AGGREGATOR_ADD_INPUT_HANDLE_ID;
+}
+
+function appendAggregatorInputToTask(task: Task): string {
+  const taskComponentSpec = task.resolvedComponentSpec;
+  if (!taskComponentSpec) return "";
+
+  const newInputName = getNextAggregatorInputName(
+    taskComponentSpec.inputs ?? [],
+  );
+  const newInput = createAggregatorInput(newInputName);
+
+  const clonedSpec: ComponentSpecJson = deepClone(taskComponentSpec);
+  const updatedInputs = [...(clonedSpec.inputs ?? []), newInput];
+
+  const orderedSpec: ComponentSpecJson = {
+    name: clonedSpec.name,
+    ...(clonedSpec.description && { description: clonedSpec.description }),
+    ...(clonedSpec.metadata && { metadata: clonedSpec.metadata }),
+    inputs: updatedInputs,
+    ...(clonedSpec.outputs && { outputs: clonedSpec.outputs }),
+    implementation: clonedSpec.implementation,
+  };
+
+  task.setComponentRef({
+    ...task.componentRef,
+    spec: orderedSpec,
+    text: componentSpecToText(orderedSpec),
+  });
+
+  return newInputName;
+}
+
+function removeAggregatorInputFromTask(task: Task, inputName: string): void {
+  const taskComponentSpec = task.resolvedComponentSpec;
+  if (!taskComponentSpec) return;
+
+  const clonedSpec: ComponentSpecJson = deepClone(taskComponentSpec);
+  const filteredInputs = (clonedSpec.inputs ?? []).filter(
+    (input) => input.name !== inputName,
+  );
+
+  const orderedSpec: ComponentSpecJson = {
+    name: clonedSpec.name,
+    ...(clonedSpec.description && { description: clonedSpec.description }),
+    ...(clonedSpec.metadata && { metadata: clonedSpec.metadata }),
+    inputs: filteredInputs,
+    ...(clonedSpec.outputs && { outputs: clonedSpec.outputs }),
+    implementation: clonedSpec.implementation,
+  };
+
+  task.removeArgumentByName(inputName);
+  task.setComponentRef({
+    ...task.componentRef,
+    spec: orderedSpec,
+    text: componentSpecToText(orderedSpec),
+  });
+}
+
+function isDuplicateAggregatorSource(
+  spec: ComponentSpec,
+  taskEntityId: string,
+  source: { entityId: string; portName: string },
+): boolean {
+  return spec.bindings.some(
+    (binding) =>
+      binding.targetEntityId === taskEntityId &&
+      binding.targetPortName.startsWith(AGG_INPUT_PREFIX) &&
+      binding.sourceEntityId === source.entityId &&
+      binding.sourcePortName === source.portName,
+  );
+}
+
+/**
+ * If the connection targets an aggregator's special "+ Add Input" handle,
+ * create a new agg_N input on the aggregator task and route the connection
+ * to it. Returns true if the connection was handled here (caller should not
+ * fall through to the regular connect flow).
+ */
+export function tryConnectAggregatorAddInput(
+  undo: UndoGroupable,
+  spec: ComponentSpec,
+  connection: ConnectionInfo,
+): boolean {
+  if (!isAggregatorAddInputHandle(connection.targetHandleId)) return false;
+
+  const targetTask = spec.tasks.find((t) => t.$id === connection.targetNodeId);
+  if (!isAggregatorTask(targetTask) || !targetTask) return false;
+
+  const sourceOutputName = connection.sourceHandleId.replace(/^output_/, "");
+  const source = {
+    entityId: connection.sourceNodeId,
+    portName: sourceOutputName,
+  };
+
+  if (isDuplicateAggregatorSource(spec, targetTask.$id, source)) {
+    return true;
+  }
+
+  undo.withGroup("Connect to aggregator", () => {
+    const newInputName = appendAggregatorInputToTask(targetTask);
+    if (!newInputName) return;
+    spec.connectNodes(source, {
+      entityId: targetTask.$id,
+      portName: newInputName,
+    });
+  });
+
+  return true;
+}
+
+/**
+ * Mirror of v1's handleAggregatorEdgeDeletion: when an edge connected to an
+ * agg_N input is removed, also remove the input itself from the aggregator's
+ * spec so the node UI stays clean.
+ */
+export function cleanupAggregatorInputForBinding(
+  undo: UndoGroupable,
+  spec: ComponentSpec,
+  binding: {
+    targetEntityId: string;
+    targetPortName: string;
+  },
+): void {
+  if (!binding.targetPortName.startsWith(AGG_INPUT_PREFIX)) return;
+
+  const targetTask = spec.tasks.find((t) => t.$id === binding.targetEntityId);
+  if (!isAggregatorTask(targetTask) || !targetTask) return;
+
+  undo.withGroup("Remove aggregator input", () => {
+    removeAggregatorInputFromTask(targetTask, binding.targetPortName);
+  });
+}
+
+/**
+ * Cmd-drop ghost behavior for the aggregator's "+ Add Input" handle: create a
+ * new agg_N input on the task, a new graph Input node at the drop position,
+ * and connect them.
+ */
+export function createConnectedAggregatorInputNode(
+  undo: UndoGroupable,
+  spec: ComponentSpec,
+  taskEntityId: string,
+  position: XYPosition,
+): void {
+  const task = spec.tasks.find((t) => t.$id === taskEntityId);
+  if (!isAggregatorTask(task) || !task) return;
+
+  undo.withGroup("Create aggregator input", () => {
+    const newInputName = appendAggregatorInputToTask(task);
+    if (!newInputName) return;
+
+    const newGraphInput = addInput(undo, spec, position, newInputName);
+    spec.connectNodes(
+      { entityId: newGraphInput.$id, portName: newGraphInput.$id },
+      { entityId: task.$id, portName: newInputName },
+    );
+  });
+}

--- a/src/routes/v2/shared/nodes/TaskNode/InputAggregatorHandle.tsx
+++ b/src/routes/v2/shared/nodes/TaskNode/InputAggregatorHandle.tsx
@@ -1,0 +1,33 @@
+import { Handle, Position } from "@xyflow/react";
+
+import { InlineStack } from "@/components/ui/layout";
+import { AGGREGATOR_ADD_INPUT_HANDLE_ID } from "@/utils/aggregatorInputs";
+
+/**
+ * The aggregator's "+ Add Input" target handle. Connecting to it (or cmd-
+ * dropping from it) mints a fresh `agg_N` input on the aggregator task — see
+ * `aggregator.actions.ts`.
+ */
+export function InputAggregatorHandle() {
+  return (
+    <div
+      className="relative w-full h-fit"
+      data-testid={`input-connection-${AGGREGATOR_ADD_INPUT_HANDLE_ID}`}
+    >
+      <div className="absolute -translate-x-6 flex items-center h-3 w-3">
+        <Handle
+          type="target"
+          id={AGGREGATOR_ADD_INPUT_HANDLE_ID}
+          position={Position.Left}
+          isConnectable
+          className="border-0! h-full! w-full! transform-none! bg-blue-400!"
+        />
+      </div>
+      <InlineStack blockAlign="center" className="rounded-md relative">
+        <div className="text-xs text-blue-600! rounded-md px-2 py-1 bg-blue-50 border border-blue-200 border-dashed">
+          + Add Input
+        </div>
+      </InlineStack>
+    </div>
+  );
+}

--- a/src/routes/v2/shared/nodes/TaskNode/TaskNode.tsx
+++ b/src/routes/v2/shared/nodes/TaskNode/TaskNode.tsx
@@ -2,6 +2,7 @@ import { type Node, type NodeProps, useReactFlow } from "@xyflow/react";
 import { observer } from "mobx-react-lite";
 import type { MouseEvent, ReactElement } from "react";
 
+import { useFlagValue } from "@/components/shared/Settings/useFlags";
 import { Card } from "@/components/ui/card";
 import { Text } from "@/components/ui/typography";
 import { cn } from "@/lib/utils";
@@ -16,7 +17,11 @@ import type { TaskNodeData } from "@/routes/v2/shared/nodes/types";
 import { useSpec } from "@/routes/v2/shared/providers/SpecContext";
 import type { NodeOverlayEffect } from "@/routes/v2/shared/store/canvasOverlay.types";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
-import { EDITOR_COLLAPSED_ANNOTATION } from "@/utils/annotations";
+import { AggregatorOutputType } from "@/types/aggregator";
+import {
+  EDITOR_COLLAPSED_ANNOTATION,
+  isPipelineAggregator,
+} from "@/utils/annotations";
 import { ISO8601_DURATION_ZERO_DAYS } from "@/utils/constants";
 
 import { TaskNodeCard } from "./TaskNodeCard";
@@ -55,6 +60,9 @@ export interface TaskNodeViewProps {
   cacheDisabled: boolean;
   digest?: string;
   inputDisplayValues: Record<string, string | undefined>;
+  isAggregator: boolean;
+  outputType: AggregatorOutputType;
+  onOutputTypeChange: (value: AggregatorOutputType) => void;
   onNodeClick: (event: React.MouseEvent) => void;
   onInputClick: (inputName: string, event: React.MouseEvent) => void;
   onOutputClick: (outputName: string, event: React.MouseEvent) => void;
@@ -186,6 +194,14 @@ function TaskNodeNotFound({ entityId }: { entityId: string }) {
   );
 }
 
+function resolveAggregatorOutputType(task: Task): AggregatorOutputType {
+  const value = task.arguments.find((a) => a.name === "output_type")?.value;
+  const allowed = Object.values(AggregatorOutputType) as string[];
+  return typeof value === "string" && allowed.includes(value)
+    ? (value as AggregatorOutputType)
+    : AggregatorOutputType.JsonArray;
+}
+
 export const TaskNode = observer(function TaskNode({
   id,
   data,
@@ -195,6 +211,7 @@ export const TaskNode = observer(function TaskNode({
   const { editor, canvasOverlay } = useSharedStores();
   const { getEdges, setEdges } = useReactFlow();
   const showContent = useIsDetailedView();
+  const inputAggregatorEnabled = useFlagValue("input-aggregator");
 
   const spec = useSpec();
   const task = spec?.tasks.find((t) => t.$id === entityId);
@@ -208,6 +225,9 @@ export const TaskNode = observer(function TaskNode({
     getComponentSpecDefaults(componentSpec);
   const isManuallyCollapsed =
     task.annotations.get(EDITOR_COLLAPSED_ANNOTATION) === "true";
+  const isAggregator =
+    inputAggregatorEnabled &&
+    isPipelineAggregator(componentSpec?.metadata?.annotations);
 
   const handleClick = (event: MouseEvent) => {
     editor.selectNode(id, "task", { shiftKey: event.shiftKey, entityId });
@@ -242,6 +262,10 @@ export const TaskNode = observer(function TaskNode({
 
   const connectedPorts = resolveConnectedPortNames(entityId, spec);
 
+  const handleOutputTypeChange = (value: AggregatorOutputType) => {
+    task.setArgument("output_type", value);
+  };
+
   const viewProps: TaskNodeViewProps = {
     id,
     entityId,
@@ -260,6 +284,9 @@ export const TaskNode = observer(function TaskNode({
     cacheDisabled:
       task.executionOptions?.cachingStrategy?.maxCacheStaleness ===
       ISO8601_DURATION_ZERO_DAYS,
+    isAggregator,
+    outputType: resolveAggregatorOutputType(task),
+    onOutputTypeChange: handleOutputTypeChange,
     digest: task.componentRef.digest,
     inputDisplayValues: resolveInputDisplayValues(task, entityId, spec),
     onNodeClick: handleClick,

--- a/src/routes/v2/shared/nodes/TaskNode/TaskNodeCard.tsx
+++ b/src/routes/v2/shared/nodes/TaskNode/TaskNodeCard.tsx
@@ -4,6 +4,7 @@ import { observer } from "mobx-react-lite";
 import { type MouseEvent as ReactMouseEvent, useEffect, useState } from "react";
 
 import { trimDigest } from "@/components/shared/ManageComponent/utils/digest";
+import { OutputTypeSelector } from "@/components/shared/ReactFlow/FlowCanvas/TaskNode/OutputTypeSelector/OutputTypeSelector";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Icon } from "@/components/ui/icon";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
@@ -14,10 +15,17 @@ import {
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { useSpec } from "@/routes/v2/shared/providers/SpecContext";
+import { AGGREGATOR_ADD_INPUT_HANDLE_ID } from "@/utils/aggregatorInputs";
 import { pluralize } from "@/utils/string";
 
 import { deriveColorPalette } from "./color.utils";
+import { InputAggregatorHandle } from "./InputAggregatorHandle";
 import type { TaskNodeInput, TaskNodeViewProps } from "./TaskNode";
+
+const AGGREGATOR_INTERNAL_INPUTS = new Set([
+  AGGREGATOR_ADD_INPUT_HANDLE_ID,
+  "output_type",
+]);
 
 const cardVariants = cva(
   "min-w-[300px] max-w-[350px] rounded-2xl border-2 p-0 drop-shadow-none cursor-pointer select-none gap-2 transition-shadow",
@@ -185,6 +193,9 @@ export const TaskNodeCard = observer(function TaskNodeCard({
   taskColor,
   cacheDisabled,
   digest,
+  isAggregator,
+  outputType,
+  onOutputTypeChange,
 }: TaskNodeViewProps) {
   const palette = taskColor ? deriveColorPalette(taskColor) : undefined;
   const cardStyle = palette
@@ -204,14 +215,19 @@ export const TaskNodeCard = observer(function TaskNodeCard({
     }
   }, [collapsed]);
 
+  const filteredInputs = isAggregator
+    ? inputs.filter((input) => !AGGREGATOR_INTERNAL_INPUTS.has(input.name))
+    : inputs;
+
   const condensedInputs =
-    inputs.length > 0 && connectedInputNames.size > 0
-      ? inputs.filter((input) => connectedInputNames.has(input.name))
-      : inputs.slice(0, 1);
-  const hiddenInputCount = inputs.length - condensedInputs.length;
+    filteredInputs.length > 0 && connectedInputNames.size > 0
+      ? filteredInputs.filter((input) => connectedInputNames.has(input.name))
+      : filteredInputs.slice(0, 1);
+  const hiddenInputCount = filteredInputs.length - condensedInputs.length;
   const showCondensedInputs =
-    collapsed && !inputsExpanded && hiddenInputCount > 0;
-  const visibleInputs = showCondensedInputs ? condensedInputs : inputs;
+    !isAggregator && collapsed && !inputsExpanded && hiddenInputCount > 0;
+  const visibleInputs = showCondensedInputs ? condensedInputs : filteredInputs;
+  const showInputsSection = filteredInputs.length > 0 || isAggregator;
 
   const condensedOutputs =
     outputs.length > 0 && connectedOutputNames.size > 0
@@ -302,18 +318,19 @@ export const TaskNodeCard = observer(function TaskNodeCard({
       </CardHeader>
 
       <CardContent className="p-2 flex flex-col gap-2">
-        {inputs.length > 0 && (
+        {showInputsSection && (
           <div
             className={cn(
               "p-2 rounded-lg",
               !palette && "bg-gray-200/50",
-              collapsed &&
+              !isAggregator &&
+                collapsed &&
                 hiddenInputCount > 0 &&
                 "cursor-pointer hover:bg-gray-200/80",
             )}
             style={palette ? { backgroundColor: palette.sectionBg } : undefined}
             onClickCapture={
-              collapsed && hiddenInputCount > 0
+              !isAggregator && collapsed && hiddenInputCount > 0
                 ? (e) => {
                     e.stopPropagation();
                     setInputsExpanded((prev) => !prev);
@@ -322,6 +339,7 @@ export const TaskNodeCard = observer(function TaskNodeCard({
             }
           >
             <BlockStack gap="3">
+              {isAggregator && <InputAggregatorHandle />}
               {visibleInputs.map((input, index) => (
                 <ClassicInputHandle
                   key={input.name}
@@ -348,7 +366,7 @@ export const TaskNodeCard = observer(function TaskNodeCard({
           </div>
         )}
 
-        {outputs.length > 0 && (
+        {(outputs.length > 0 || isAggregator) && (
           <div
             className={cn(
               "p-2 rounded-lg",
@@ -368,6 +386,14 @@ export const TaskNodeCard = observer(function TaskNodeCard({
             }
           >
             <BlockStack gap="3">
+              {isAggregator && (
+                <div className="w-full">
+                  <OutputTypeSelector
+                    value={outputType}
+                    onChange={onOutputTypeChange}
+                  />
+                </div>
+              )}
               {visibleOutputs.map((output, index) => (
                 <div
                   key={output.name}

--- a/src/routes/v2/shared/nodes/TaskNode/TaskNodeSimplified.tsx
+++ b/src/routes/v2/shared/nodes/TaskNode/TaskNodeSimplified.tsx
@@ -12,9 +12,15 @@ import {
   deriveColorPalette,
   getContrastTextColor,
 } from "@/routes/v2/shared/nodes/TaskNode/color.utils";
+import { AGGREGATOR_ADD_INPUT_HANDLE_ID } from "@/utils/aggregatorInputs";
 
 import type { TaskNodeViewProps } from "./TaskNode";
 import { createTaskNodeCardVariants } from "./taskNode.variants";
+
+const AGGREGATOR_INTERNAL_INPUTS = new Set([
+  AGGREGATOR_ADD_INPUT_HANDLE_ID,
+  "output_type",
+]);
 
 const PERCEIVED_FONT_SIZE = "28px";
 const s = "var(--simplified-scale, 1)";
@@ -31,12 +37,17 @@ export function TaskNodeSimplified({
   selected,
   isHovered,
   taskColor,
+  isAggregator,
   onNodeClick,
 }: TaskNodeViewProps) {
   const palette = taskColor ? deriveColorPalette(taskColor) : undefined;
   const headerTextColor = taskColor
     ? getContrastTextColor(taskColor)
     : undefined;
+
+  const visibleInputs = isAggregator
+    ? inputs.filter((input) => !AGGREGATOR_INTERNAL_INPUTS.has(input.name))
+    : inputs;
 
   return (
     <Card
@@ -58,7 +69,7 @@ export function TaskNodeSimplified({
       }}
       onClick={onNodeClick}
     >
-      {inputs.map((input) => (
+      {visibleInputs.map((input) => (
         <Handle
           key={input.name}
           type="target"
@@ -73,6 +84,20 @@ export function TaskNodeSimplified({
           className="bg-gray-500! border-0!"
         />
       ))}
+      {isAggregator && (
+        <Handle
+          type="target"
+          position={Position.Left}
+          id={AGGREGATOR_ADD_INPUT_HANDLE_ID}
+          style={{
+            top: "50%",
+            width: `calc(${s} * 12px)`,
+            height: `calc(${s} * 12px)`,
+            left: `calc(${s} * -4px)`,
+          }}
+          className="bg-blue-400! border-0!"
+        />
+      )}
 
       <div
         className="flex items-center w-full h-full"

--- a/src/utils/submitPipeline.ts
+++ b/src/utils/submitPipeline.ts
@@ -47,6 +47,7 @@ export async function submitPipelineRun(
       },
     );
     const transformedSpec = transformAggregatorComponentSpec(fullyLoadedSpec);
+    coerceMetadataAnnotations(transformedSpec);
     const argumentsFromInputs = getArgumentsFromInputs(transformedSpec);
     // Merge default arguments with provided task arguments
     // Task arguments (including SecretArguments) are preserved as-is
@@ -211,6 +212,38 @@ const parseComponentYaml = (text: string): ComponentSpec => {
   }
 
   return componentSpecFromYaml(text);
+};
+
+/**
+ * Coerce every `metadata.annotations` value (root spec + every nested task
+ * componentRef.spec) to a string, since the backend's MetadataSpec strictly
+ * requires `Record<string, string>`. Strings pass through unchanged; arrays
+ * and objects are JSON-stringified; primitives are stringified; null/undefined
+ * values are dropped. Mutates in place.
+ */
+const coerceMetadataAnnotations = (spec: ComponentSpec): void => {
+  const annotations = spec.metadata?.annotations;
+  if (annotations) {
+    for (const key of Object.keys(annotations)) {
+      const value = annotations[key];
+      if (typeof value === "string") continue;
+      if (value === null || value === undefined) {
+        delete annotations[key];
+        continue;
+      }
+      annotations[key] =
+        typeof value === "object" ? JSON.stringify(value) : String(value);
+    }
+  }
+
+  if (!spec.implementation || !("graph" in spec.implementation)) return;
+  const tasks = spec.implementation.graph?.tasks;
+  if (!tasks) return;
+  for (const task of Object.values(tasks)) {
+    const nestedSpec = (task as { componentRef?: { spec?: ComponentSpec } })
+      ?.componentRef?.spec;
+    if (nestedSpec) coerceMetadataAnnotations(nestedSpec);
+  }
 };
 
 // Fetch component with timeout to avoid hanging on unresponsive URLs


### PR DESCRIPTION
## Description

This PR does two things:

1. fixes a bug in the v1 Input Aggregator component where it was not compatible with ghost node (cmd + drop) functionality
2. migrates full capability input aggregator into the v2 editor (previously non-functional)

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

Closes https://github.com/TangleML/tangle-ui/issues/2071

Closes https://github.com/Shopify/oasis-frontend/issues/592

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix
- [x] New feature
- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

![image.png](https://app.graphite.com/user-attachments/assets/d7e002d2-c4f7-4a61-aec1-bd8fd971547e.png)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

Ghost Nodes:

1. turn on input aggregator beta flag
2. open v1 editor
3. under Inputs & Outputs add the aggregator component to the canvas
4. draw an edge from the input handle, hold down CMD to create a ghost node and drop it on the canvas
5. confirm that the ghost node is converted into an input node and is fully connected up to a new input on the aggregator component

V2 Editor

1. turn on input aggregator beta flag
2. open v2 editor
3. under Inputs & Outputs confirm the aggregator component is available and can be added to the canvas
4. Add the component to canvas and confirm it behaves the same as v1 (including ghost node functionality)
5. confirm runs can be successfully submitted<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->