### PR TITLE
fix: v2: UI fixes to Open Pipeline Dialog

### DIFF
--- a/src/components/Home/PipelineSection/PipelineRow.tsx
+++ b/src/components/Home/PipelineSection/PipelineRow.tsx
@@ -157,7 +157,6 @@ const PipelineRow = withSuspenseWrapper(
               onDragStateChange?.(true);
             }}
             onDragEnd={() => onDragStateChange?.(false)}
-            className={dragData ? "cursor-grab" : undefined}
           >
             <InlineStack
               gap="2"

--- a/src/routes/v2/pages/Editor/components/EditorMenuBar/components/OpenPipelineDialog.tsx
+++ b/src/routes/v2/pages/Editor/components/EditorMenuBar/components/OpenPipelineDialog.tsx
@@ -1,6 +1,7 @@
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
@@ -30,6 +31,9 @@ export function OpenPipelineDialog({
       <DialogContent className="max-w-[95vw] sm:max-w-[95vw] w-full">
         <DialogHeader>
           <DialogTitle>Open Pipeline</DialogTitle>
+          <DialogDescription className="hidden">
+            Select a pipeline to open
+          </DialogDescription>
         </DialogHeader>
         <BlockStack gap="4" className="w-full h-[80vh] overflow-y-auto">
           <PipelineFolders onPipelineClick={onPipelineClick} />

--- a/src/routes/v2/pages/PipelineFolders/components/FolderBreadcrumb.tsx
+++ b/src/routes/v2/pages/PipelineFolders/components/FolderBreadcrumb.tsx
@@ -1,4 +1,5 @@
 import { Link } from "@tanstack/react-router";
+import { Fragment } from "react";
 
 import { withSuspenseWrapper } from "@/components/shared/SuspenseWrapper";
 import {
@@ -74,34 +75,36 @@ export const FolderBreadcrumb = withSuspenseWrapper(
           {path.map((folder, index) => {
             const isLast = index === path.length - 1;
             return (
-              <BreadcrumbItem key={folder.id}>
+              <Fragment key={folder.id}>
                 <BreadcrumbSeparator />
-                {isLast ? (
-                  <BreadcrumbPage>
-                    <InlineStack gap="1" blockAlign="center">
-                      {folder.name}
-                      <Button
-                        variant="ghost"
-                        size="min"
-                        disabled={isPending}
-                        onClick={() => toggleFavorite(folder.id)}
-                      >
-                        <Icon
-                          name="Heart"
-                          className={cn(
-                            "size-4",
-                            folder.favorite
-                              ? "fill-yellow-400 text-yellow-400"
-                              : "text-muted-foreground",
-                          )}
-                        />
-                      </Button>
-                    </InlineStack>
-                  </BreadcrumbPage>
-                ) : (
-                  <FolderLink folderId={folder.id}>{folder.name}</FolderLink>
-                )}
-              </BreadcrumbItem>
+                <BreadcrumbItem>
+                  {isLast ? (
+                    <BreadcrumbPage>
+                      <InlineStack gap="1" blockAlign="center">
+                        {folder.name}
+                        <Button
+                          variant="ghost"
+                          size="min"
+                          disabled={isPending}
+                          onClick={() => toggleFavorite(folder.id)}
+                        >
+                          <Icon
+                            name="Heart"
+                            className={cn(
+                              "size-4",
+                              folder.favorite
+                                ? "fill-yellow-400 text-yellow-400"
+                                : "text-muted-foreground",
+                            )}
+                          />
+                        </Button>
+                      </InlineStack>
+                    </BreadcrumbPage>
+                  ) : (
+                    <FolderLink folderId={folder.id}>{folder.name}</FolderLink>
+                  )}
+                </BreadcrumbItem>
+              </Fragment>
             );
           })}
         </BreadcrumbList>

--- a/src/routes/v2/pages/PipelineFolders/components/FolderPipelineTable/FolderPipelineTable.tsx
+++ b/src/routes/v2/pages/PipelineFolders/components/FolderPipelineTable/FolderPipelineTable.tsx
@@ -90,6 +90,7 @@ export const FolderPipelineTable = withSuspenseWrapper(
 
     const requiresPermission = currentFolder.requiresPermission;
     const canMoveOut = currentFolder.canMoveFilesOut;
+    const canDrag = canMoveOut && folders.length > 0;
 
     const filteredFolders = folders.filter((f) =>
       f.name.toLowerCase().includes(searchQuery.toLowerCase()),
@@ -173,7 +174,7 @@ export const FolderPipelineTable = withSuspenseWrapper(
                 <TableHead className="w-36">Tags</TableHead>
                 <TableHead className="w-36">Last run</TableHead>
                 <TableHead className="w-16">Runs</TableHead>
-                <TableHead className="w-12"></TableHead>
+                <TableHead className="w-20"></TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -209,7 +210,7 @@ export const FolderPipelineTable = withSuspenseWrapper(
                 folders={filteredFolders}
                 selectedFolders={selection.selectedFolders}
                 draggingIds={draggingIds}
-                canDrag={canMoveOut}
+                canDrag={canDrag && folders.length > 1}
                 getDragItems={getDragItems}
                 onSelectFolder={selection.selectFolder}
                 onDrop={(targetFolderId, data) =>
@@ -224,7 +225,7 @@ export const FolderPipelineTable = withSuspenseWrapper(
                 pipelines={pagination.paginatedItems}
                 selectedPipelines={selection.selectedPipelines}
                 draggingIds={draggingIds}
-                canDrag={canMoveOut}
+                canDrag={canDrag}
                 getDragItems={getDragItems}
                 onSelectPipeline={selection.selectPipeline}
                 onDragStateChange={handleDragStateChange}

--- a/src/routes/v2/pages/PipelineFolders/components/FolderRow.tsx
+++ b/src/routes/v2/pages/PipelineFolders/components/FolderRow.tsx
@@ -126,7 +126,6 @@ export function FolderRow({
             handleDragStart(e, dragData, dragItemCount, onDragStateChange)
           }
           onDragEnd={() => onDragStateChange?.(false)}
-          className={dragData ? "cursor-grab" : undefined}
         >
           <InlineStack gap="2" blockAlign="center">
             {icon ?? (


### PR DESCRIPTION
## Description

Fixes a couple of UI issues with the v2 editor's "Open Pipeline" dialog.

1. Fix row width so there is no horizontal scroll
2. Fix delete button hanging off the end of the row
3. Changed cursor to a pointer, showing that the row can be clicked and opened 
4. Disable dragging when there is no folder to drag into
5. Add a hidden description to satisfy aria requirements
6. Fix a hydration error where lists were trying to render inside of lists

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

Closes https://github.com/Shopify/oasis-frontend/issues/624

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix
- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

![image.png](https://app.graphite.com/user-attachments/assets/6669fb5a-4c6b-44c1-b71b-311edd1e4a70.png)



<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

1. go to v2 editor
2. top menu -> file -> open
3. confirm that that rows no longer scroll horizontally and instead fit on the page
4. confirm the delete button appears within the row
5. confirm there is no aria warning in console when the dialog is opened
6. confirm that the cursor shows a pointer when a row is hovered
7. confirm that rows cannot be dragged when there are no folders, and can be dragged when there are folders
8. confirm that no hydration error appears in console when opening a folder with stuff in it

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->