### PR TITLE
chore: v2: tidy up Pipeline Structure Window

### DIFF
--- a/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/RootNode.tsx
+++ b/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/RootNode.tsx
@@ -1,6 +1,11 @@
 import { observer } from "mobx-react-lite";
 
 import { Button } from "@/components/ui/button";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
 import { Icon } from "@/components/ui/icon";
 import { BlockStack } from "@/components/ui/layout";
 import { Text } from "@/components/ui/typography";
@@ -46,111 +51,117 @@ export const RootNode = observer(function RootNode({
     navigation.navigateToLevel(0);
   };
 
-  const handleToggle = (e: React.MouseEvent) => {
+  const handleChevronClick = (e: React.MouseEvent) => {
     e.stopPropagation();
     onToggleExpand(nodePath);
   };
 
   return (
     <BlockStack gap="0">
-      <div
-        role="button"
-        tabIndex={0}
-        onClick={handleClick}
-        onKeyDown={(e) => e.key === "Enter" && handleClick()}
-        className={treeNodeRowVariants({
-          isCurrentGraph,
-          hasErrors,
-          fullWidth: true,
-        })}
+      <Collapsible
+        open={isExpanded}
+        onOpenChange={() => onToggleExpand(nodePath)}
+        className="w-full"
       >
-        {hasChildren ? (
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-5 w-5 p-0 shrink-0"
-            onClick={handleToggle}
-          >
-            <Icon
-              name={isExpanded ? "ChevronDown" : "ChevronRight"}
-              size="sm"
-              className="text-slate-500"
-            />
-          </Button>
-        ) : (
-          <div className="w-5 shrink-0" />
-        )}
-
-        <Icon
-          name="Workflow"
-          size="sm"
-          className={treeNodeIconVariants({ isCurrentGraph, hasErrors })}
-        />
-
-        <Text
-          size="xs"
-          weight={isCurrentGraph ? "semibold" : "regular"}
-          className={cn(
-            "wrap-break-word min-w-0 flex-1",
-            isCurrentGraph && "text-blue-900",
-          )}
-        >
-          {spec.name}
-        </Text>
-
-        <IssueBadge issues={graphIssues} />
-
-        {isCurrentGraph && (
-          <Icon
-            name="Eye"
-            size="xs"
-            className="text-blue-600 shrink-0 mt-0.5"
-          />
-        )}
-      </div>
-
-      {graphIssues.length > 0 && (
-        <BlockStack gap="1" className="ml-10 mt-0.5 mb-1">
-          {graphIssues.map((issue, index) => (
-            <IssueRow
-              key={`${issue.type}-${issue.entityId ?? "graph"}-${index}`}
-              issue={issue}
-            />
-          ))}
-        </BlockStack>
-      )}
-
-      {hasChildren && isExpanded && (
-        <BlockStack gap="0" className="ml-4 border-l border-slate-200">
-          <div className="-ml-1.5">
-            {tasks.map((task) => {
-              if (task.subgraphSpec) {
-                return (
-                  <SubgraphNode
-                    key={task.$id}
-                    spec={task.subgraphSpec}
-                    task={task}
-                    navigationPath={[...navigationPath, task.name]}
-                    currentNavPath={currentNavPath}
-                    expandedNodes={expandedNodes}
-                    onToggleExpand={onToggleExpand}
-                    parentSpec={spec}
-                  />
-                );
-              }
-
-              return (
-                <TaskLeafNode
-                  key={task.$id}
-                  task={task}
-                  parentSpec={spec}
-                  parentNavigationPath={navigationPath}
-                />
-              );
+        <CollapsibleTrigger asChild>
+          <div
+            role="button"
+            tabIndex={0}
+            onClick={handleClick}
+            onKeyDown={(e) => e.key === "Enter" && handleClick()}
+            className={treeNodeRowVariants({
+              isCurrentGraph,
+              hasErrors,
+              fullWidth: true,
             })}
+          >
+            {hasChildren ? (
+              <Button
+                variant="ghost"
+                size="sm"
+                aria-label={isExpanded ? "Collapse" : "Expand"}
+                className="h-5 w-5 p-0 shrink-0"
+                onClick={handleChevronClick}
+              >
+                <Icon
+                  name={isExpanded ? "ChevronDown" : "ChevronRight"}
+                  size="sm"
+                  className="text-slate-500"
+                />
+              </Button>
+            ) : (
+              <div className="w-5 shrink-0" />
+            )}
+
+            <Icon
+              name="Network"
+              size="sm"
+              className={cn(
+                "rotate-270",
+                treeNodeIconVariants({ isCurrentGraph, hasErrors }),
+              )}
+            />
+
+            <Text
+              size="xs"
+              weight={isCurrentGraph ? "semibold" : "regular"}
+              className={cn(
+                "wrap-break-word min-w-0 flex-1",
+                isCurrentGraph && "text-blue-900",
+              )}
+            >
+              {spec.name}
+            </Text>
+
+            <IssueBadge issues={graphIssues} />
           </div>
-        </BlockStack>
-      )}
+        </CollapsibleTrigger>
+
+        <CollapsibleContent>
+          {graphIssues.length > 0 && (
+            <BlockStack gap="1" className="ml-10 mt-0.5 mb-1">
+              {graphIssues.map((issue, index) => (
+                <IssueRow
+                  key={`${issue.type}-${issue.entityId ?? "graph"}-${index}`}
+                  issue={issue}
+                />
+              ))}
+            </BlockStack>
+          )}
+
+          {hasChildren && (
+            <BlockStack gap="0" className="ml-4 border-l border-slate-200">
+              <div className="-ml-1.5">
+                {tasks.map((task) => {
+                  if (task.subgraphSpec) {
+                    return (
+                      <SubgraphNode
+                        key={task.$id}
+                        spec={task.subgraphSpec}
+                        task={task}
+                        navigationPath={[...navigationPath, task.name]}
+                        currentNavPath={currentNavPath}
+                        expandedNodes={expandedNodes}
+                        onToggleExpand={onToggleExpand}
+                        parentSpec={spec}
+                      />
+                    );
+                  }
+
+                  return (
+                    <TaskLeafNode
+                      key={task.$id}
+                      task={task}
+                      parentSpec={spec}
+                      parentNavigationPath={navigationPath}
+                    />
+                  );
+                })}
+              </div>
+            </BlockStack>
+          )}
+        </CollapsibleContent>
+      </Collapsible>
     </BlockStack>
   );
 });

--- a/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/SubgraphNode.tsx
+++ b/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/SubgraphNode.tsx
@@ -1,6 +1,11 @@
 import { observer } from "mobx-react-lite";
 
 import { Button } from "@/components/ui/button";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
 import { Icon } from "@/components/ui/icon";
 import { BlockStack } from "@/components/ui/layout";
 import { Text } from "@/components/ui/typography";
@@ -62,7 +67,7 @@ export const SubgraphNode = observer(function SubgraphNode({
     }
   };
 
-  const handleToggle = (e: React.MouseEvent) => {
+  const handleChevronClick = (e: React.MouseEvent) => {
     e.stopPropagation();
     onToggleExpand(nodePath);
   };
@@ -77,99 +82,103 @@ export const SubgraphNode = observer(function SubgraphNode({
 
   return (
     <BlockStack gap="0">
-      <div
-        role="button"
-        tabIndex={0}
-        onClick={handleClick}
-        onKeyDown={(e) => e.key === "Enter" && handleClick()}
-        onMouseEnter={handleMouseEnter}
-        onMouseLeave={handleMouseLeave}
-        className={treeNodeRowVariants({
-          isCurrentGraph,
-          isInCurrentPath,
-          hasErrors,
-        })}
+      <Collapsible
+        open={isExpanded}
+        onOpenChange={() => onToggleExpand(nodePath)}
+        className="w-full"
       >
-        {hasChildren ? (
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-5 w-5 p-0 shrink-0"
-            onClick={handleToggle}
-          >
-            <Icon
-              name={isExpanded ? "ChevronDown" : "ChevronRight"}
-              size="sm"
-              className="text-slate-500"
-            />
-          </Button>
-        ) : (
-          <div className="w-5 shrink-0" />
-        )}
-
-        <Icon
-          name="Layers"
-          size="sm"
-          className={treeNodeIconVariants({
-            isCurrentGraph,
-            isInCurrentPath,
-            hasErrors,
-          })}
-        />
-
-        <Text
-          size="xs"
-          weight={isCurrentGraph ? "semibold" : "regular"}
-          className={cn(
-            "wrap-break-word min-w-0 flex-1",
-            isCurrentGraph && "text-blue-900",
-          )}
-        >
-          {task.name}
-        </Text>
-
-        <IssueBadge issues={allIssues} />
-
-        {isCurrentGraph && (
-          <Icon
-            name="Eye"
-            size="xs"
-            className="text-blue-600 shrink-0 mt-0.5"
-          />
-        )}
-      </div>
-
-      {hasChildren && isExpanded && (
-        <BlockStack gap="0" className="ml-4 border-l border-slate-200 pl-2">
-          <div className="-ml-3.5">
-            {tasks.map((childTask) => {
-              if (childTask.subgraphSpec) {
-                return (
-                  <SubgraphNode
-                    key={childTask.$id}
-                    spec={childTask.subgraphSpec}
-                    task={childTask}
-                    navigationPath={[...navigationPath, childTask.name]}
-                    currentNavPath={currentNavPath}
-                    expandedNodes={expandedNodes}
-                    onToggleExpand={onToggleExpand}
-                    parentSpec={spec}
-                  />
-                );
-              }
-
-              return (
-                <TaskLeafNode
-                  key={childTask.$id}
-                  task={childTask}
-                  parentSpec={spec}
-                  parentNavigationPath={navigationPath}
-                />
-              );
+        <CollapsibleTrigger asChild>
+          <div
+            role="button"
+            tabIndex={0}
+            onClick={handleClick}
+            onKeyDown={(e) => e.key === "Enter" && handleClick()}
+            onMouseEnter={handleMouseEnter}
+            onMouseLeave={handleMouseLeave}
+            className={treeNodeRowVariants({
+              isCurrentGraph,
+              isInCurrentPath,
+              hasErrors,
+              fullWidth: true,
             })}
+          >
+            {hasChildren ? (
+              <Button
+                variant="ghost"
+                size="sm"
+                aria-label={isExpanded ? "Collapse" : "Expand"}
+                className="h-5 w-5 p-0 shrink-0"
+                onClick={handleChevronClick}
+              >
+                <Icon
+                  name={isExpanded ? "ChevronDown" : "ChevronRight"}
+                  size="sm"
+                  className="text-slate-500"
+                />
+              </Button>
+            ) : (
+              <div className="w-5 shrink-0" />
+            )}
+
+            <Icon
+              name="Layers"
+              size="sm"
+              className={treeNodeIconVariants({
+                isCurrentGraph,
+                isInCurrentPath,
+                hasErrors,
+              })}
+            />
+
+            <Text
+              size="xs"
+              weight={isCurrentGraph ? "semibold" : "regular"}
+              className={cn(
+                "wrap-break-word min-w-0 flex-1",
+                isCurrentGraph && "text-blue-900",
+              )}
+            >
+              {task.name}
+            </Text>
+
+            <IssueBadge issues={allIssues} />
           </div>
-        </BlockStack>
-      )}
+        </CollapsibleTrigger>
+
+        <CollapsibleContent>
+          {hasChildren && (
+            <BlockStack gap="0" className="ml-4 border-l border-slate-200 pl-2">
+              <div className="-ml-3.5">
+                {tasks.map((childTask) => {
+                  if (childTask.subgraphSpec) {
+                    return (
+                      <SubgraphNode
+                        key={childTask.$id}
+                        spec={childTask.subgraphSpec}
+                        task={childTask}
+                        navigationPath={[...navigationPath, childTask.name]}
+                        currentNavPath={currentNavPath}
+                        expandedNodes={expandedNodes}
+                        onToggleExpand={onToggleExpand}
+                        parentSpec={spec}
+                      />
+                    );
+                  }
+
+                  return (
+                    <TaskLeafNode
+                      key={childTask.$id}
+                      task={childTask}
+                      parentSpec={spec}
+                      parentNavigationPath={navigationPath}
+                    />
+                  );
+                })}
+              </div>
+            </BlockStack>
+          )}
+        </CollapsibleContent>
+      </Collapsible>
     </BlockStack>
   );
 });

--- a/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/TaskLeafNode.tsx
+++ b/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/TaskLeafNode.tsx
@@ -61,7 +61,7 @@ export const TaskLeafNode = observer(function TaskLeafNode({
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
         className={cn(
-          "flex items-start gap-1 py-1 text-slate-600 rounded-md cursor-pointer transition-colors hover:bg-slate-100",
+          "flex items-start gap-1 py-1 px-2 text-slate-600 rounded-md cursor-pointer transition-colors hover:bg-slate-100",
           hasErrors && "text-red-700",
         )}
       >
@@ -69,7 +69,6 @@ export const TaskLeafNode = observer(function TaskLeafNode({
           name={hasIssues ? "CircleAlert" : "Circle"}
           size="xs"
           className={cn(
-            "bg-white",
             "shrink-0 mt-0.5",
             hasErrors
               ? "text-red-400"


### PR DESCRIPTION
## Description

Tocuh-ups to the Pipeline Structure window



- removed the "eye" icon
- now use a full collapsible, so the entire row/header can be clicked
- can now collapse a parent row without first selecting it
- rows are now full width
- changed the pipeline icon to the correct icon

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

Closes https://github.com/Shopify/oasis-frontend/issues/627

Closes https://github.com/Shopify/oasis-frontend/issues/626

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix
- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

![image.png](https://app.graphite.com/user-attachments/assets/987b65be-555d-4cd6-9bc0-e266f0d6dc3b.png)



<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->