### PR TITLE
feat: v2 - facelift for pipeline structure window

### DIFF
--- a/src/routes/v2/pages/Editor/components/PipelineTreeContent/PipelineTreeContent.tsx
+++ b/src/routes/v2/pages/Editor/components/PipelineTreeContent/PipelineTreeContent.tsx
@@ -4,7 +4,7 @@
  * Shows the hierarchical structure of the pipeline including all tasks.
  * Subgraph tasks are clickable and can be navigated into.
  * Regular tasks are displayed but not clickable.
- * Highlights the currently displayed graph in the tree.
+ * Highlights the navigation path via label weight on root and subgraph rows; expansion follows the navigation path.
  * Displays validation error badges per entity.
  */
 
@@ -82,17 +82,18 @@ export const PipelineTreeContent = observer(function PipelineTreeContent() {
 
   return (
     <BlockStack
-      className="@container h-full"
+      className="@container min-w-0 h-full"
       data-testid="pipeline-tree-content"
     >
       <InlineStack
-        className="flex-col @[600px]:grid @[600px]:grid-cols-[40%_60%] @[600px]:items-start h-full"
+        className="h-full min-w-0 flex-col @[600px]:grid @[600px]:grid-cols-[minmax(0,40%)_minmax(0,60%)] @[600px]:items-start"
         fill
         data-testid="pipeline-tree-content-container"
       >
         <BlockStack
           gap="2"
-          className="p-2 overflow-y-auto overflow-x-hidden hide-scrollbar flex-1 min-h-0 @[600px]:border-r @[600px]:border-border"
+          align="stretch"
+          className="min-h-0 min-w-0 flex-1 overflow-x-hidden overflow-y-auto p-2 hide-scrollbar @[600px]:border-r @[600px]:border-border"
         >
           <RootNode
             spec={rootSpec}
@@ -101,7 +102,7 @@ export const PipelineTreeContent = observer(function PipelineTreeContent() {
             onToggleExpand={handleToggleExpand}
           />
         </BlockStack>
-        <BlockStack className="hidden @[600px]:flex overflow-y-auto min-h-0 max-w-md">
+        <BlockStack className="hidden min-h-0 min-w-0 max-w-md overflow-y-auto @[600px]:flex">
           {activeIssue ? (
             <ValidationIssueResolutionCard issue={activeIssue} />
           ) : (

--- a/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/IssueRow.tsx
+++ b/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/IssueRow.tsx
@@ -1,11 +1,17 @@
 import { observer } from "mobx-react-lite";
 
 import { Text } from "@/components/ui/typography";
-import { cn } from "@/lib/utils";
 import type { ValidationIssue } from "@/models/componentSpec";
 import { issueTypeLabel } from "@/routes/v2/pages/Editor/components/ValidationSummary";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 import { useFocusActions } from "@/routes/v2/shared/store/useFocusActions";
+
+import {
+  issueRowMessageVariants,
+  type IssueRowSeverity,
+  issueRowTypeLabelVariants,
+  issueRowVariants,
+} from "./issueRow.variants";
 
 interface IssueRowProps {
   issue: ValidationIssue;
@@ -15,6 +21,8 @@ export const IssueRow = observer(function IssueRow({ issue }: IssueRowProps) {
   const { editor } = useSharedStores();
   const { focusValidationIssue } = useFocusActions();
   const isSelected = editor.selectedValidationIssue === issue;
+  const severity: IssueRowSeverity =
+    issue.severity === "error" ? "error" : "warning";
 
   const handleClick = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -29,30 +37,19 @@ export const IssueRow = observer(function IssueRow({ issue }: IssueRowProps) {
       onKeyDown={(e) =>
         e.key === "Enter" && handleClick(e as unknown as React.MouseEvent)
       }
-      className={cn(
-        "flex items-baseline gap-1 py-0.5 px-2 rounded text-xs cursor-pointer transition-colors",
-        isSelected ? "ring-1 ring-blue-400" : "",
-        issue.severity === "error"
-          ? "bg-red-50 text-red-800 hover:bg-red-100"
-          : "bg-amber-50 text-amber-800 hover:bg-amber-100",
-      )}
+      className={issueRowVariants({
+        selected: isSelected,
+        severity,
+      })}
     >
       <Text
         size="xs"
         weight="semibold"
-        className={cn(
-          "shrink-0 uppercase tracking-wide",
-          issue.severity === "error" ? "text-red-600" : "text-amber-600",
-        )}
+        className={issueRowTypeLabelVariants({ severity })}
       >
         {issueTypeLabel(issue.type)}
       </Text>
-      <Text
-        size="xs"
-        className={
-          issue.severity === "error" ? "text-red-700" : "text-amber-700"
-        }
-      >
+      <Text size="xs" className={issueRowMessageVariants({ severity })}>
         {issue.message}
       </Text>
     </div>

--- a/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/RootNode.tsx
+++ b/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/RootNode.tsx
@@ -9,7 +9,6 @@ import {
 import { Icon } from "@/components/ui/icon";
 import { BlockStack } from "@/components/ui/layout";
 import { Text } from "@/components/ui/typography";
-import { cn } from "@/lib/utils";
 import type { ComponentSpec } from "@/models/componentSpec";
 import { countErrors } from "@/routes/v2/pages/Editor/components/ValidationSummary";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
@@ -18,7 +17,12 @@ import { IssueBadge } from "./IssueBadge";
 import { IssueRow } from "./IssueRow";
 import { SubgraphNode } from "./SubgraphNode";
 import { TaskLeafNode } from "./TaskLeafNode";
-import { treeNodeIconVariants, treeNodeRowVariants } from "./treeNode.variants";
+import {
+  treeNodeChevronIconVariants,
+  treeNodeLabelToneVariants,
+  treeNodeRowVariants,
+} from "./treeNode.variants";
+import { TreeRowActivate } from "./TreeRowActivate";
 
 interface RootNodeProps {
   spec: ComponentSpec;
@@ -38,8 +42,6 @@ export const RootNode = observer(function RootNode({
   const nodePath = navigationPath.join("/");
   const isExpanded = expandedNodes.has(nodePath);
 
-  const isCurrentGraph = currentNavPath.join("/") === nodePath;
-
   const tasks = spec.tasks;
   const hasChildren = tasks.length > 0;
 
@@ -47,79 +49,58 @@ export const RootNode = observer(function RootNode({
   const graphIssues = spec.graphLevelIssues;
   const hasErrors = countErrors(specIssues) > 0;
 
-  const handleClick = () => {
+  const handleRowNavigate = () => {
     navigation.navigateToLevel(0);
   };
 
-  const handleChevronClick = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    onToggleExpand(nodePath);
-  };
-
   return (
-    <BlockStack gap="0">
+    <BlockStack gap="0" align="stretch" className="min-w-0 w-full">
       <Collapsible
         open={isExpanded}
         onOpenChange={() => onToggleExpand(nodePath)}
         className="w-full"
       >
-        <CollapsibleTrigger asChild>
-          <div
-            role="button"
-            tabIndex={0}
-            onClick={handleClick}
-            onKeyDown={(e) => e.key === "Enter" && handleClick()}
-            className={treeNodeRowVariants({
-              isCurrentGraph,
-              hasErrors,
-              fullWidth: true,
-            })}
-          >
-            {hasChildren ? (
-              <Button
-                variant="ghost"
-                size="sm"
-                aria-label={isExpanded ? "Collapse" : "Expand"}
-                className="h-5 w-5 p-0 shrink-0"
-                onClick={handleChevronClick}
-              >
-                <Icon
-                  name={isExpanded ? "ChevronDown" : "ChevronRight"}
-                  size="sm"
-                  className="text-slate-500"
-                />
-              </Button>
-            ) : (
-              <div className="w-5 shrink-0" />
-            )}
-
-            <Icon
-              name="Network"
-              size="sm"
-              className={cn(
-                "rotate-270",
-                treeNodeIconVariants({ isCurrentGraph, hasErrors }),
-              )}
-            />
-
+        <div
+          className={treeNodeRowVariants({
+            hasErrors,
+            fullWidth: true,
+          })}
+        >
+          <TreeRowActivate layout="rootStrip" onActivate={handleRowNavigate}>
             <Text
               size="xs"
-              weight={isCurrentGraph ? "semibold" : "regular"}
-              className={cn(
-                "wrap-break-word min-w-0 flex-1",
-                isCurrentGraph && "text-blue-900",
-              )}
+              weight="semibold"
+              className={treeNodeLabelToneVariants({ tone: "none" })}
             >
               {spec.name}
             </Text>
 
             <IssueBadge issues={graphIssues} />
-          </div>
-        </CollapsibleTrigger>
+          </TreeRowActivate>
 
-        <CollapsibleContent>
+          {hasChildren && (
+            <CollapsibleTrigger asChild>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="shrink-0 p-0"
+                aria-label={
+                  isExpanded ? "Collapse pipeline" : "Expand pipeline"
+                }
+              >
+                <Icon
+                  name={isExpanded ? "ChevronDown" : "ChevronRight"}
+                  size="sm"
+                  className={treeNodeChevronIconVariants({ hasErrors })}
+                />
+              </Button>
+            </CollapsibleTrigger>
+          )}
+        </div>
+
+        <CollapsibleContent className="w-full">
           {graphIssues.length > 0 && (
-            <BlockStack gap="1" className="ml-10 mt-0.5 mb-1">
+            <BlockStack gap="1" className="ml-2 mt-0.5 mb-1">
               {graphIssues.map((issue, index) => (
                 <IssueRow
                   key={`${issue.type}-${issue.entityId ?? "graph"}-${index}`}
@@ -130,8 +111,12 @@ export const RootNode = observer(function RootNode({
           )}
 
           {hasChildren && (
-            <BlockStack gap="0" className="ml-4 border-l border-slate-200">
-              <div className="-ml-1.5">
+            <BlockStack
+              gap="0"
+              align="stretch"
+              className="ml-2 min-w-0 w-full border-l border-slate-200"
+            >
+              <div className="-ml-1.5 min-w-0 w-full">
                 {tasks.map((task) => {
                   if (task.subgraphSpec) {
                     return (

--- a/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/SubgraphNode.tsx
+++ b/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/SubgraphNode.tsx
@@ -7,7 +7,7 @@ import {
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
 import { Icon } from "@/components/ui/icon";
-import { BlockStack } from "@/components/ui/layout";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Text } from "@/components/ui/typography";
 import { cn } from "@/lib/utils";
 import type { ComponentSpec, Task } from "@/models/componentSpec";
@@ -16,8 +16,15 @@ import { countErrors } from "@/routes/v2/pages/Editor/components/ValidationSumma
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 
 import { IssueBadge } from "./IssueBadge";
+import { IssueRow } from "./IssueRow";
 import { TaskLeafNode } from "./TaskLeafNode";
-import { treeNodeIconVariants, treeNodeRowVariants } from "./treeNode.variants";
+import {
+  treeNodeChevronIconVariants,
+  treeNodeIconVariants,
+  treeNodeLabelToneVariants,
+  treeNodeRowVariants,
+} from "./treeNode.variants";
+import { TreeRowActivate } from "./TreeRowActivate";
 
 interface SubgraphNodeProps {
   spec: ComponentSpec;
@@ -47,17 +54,19 @@ export const SubgraphNode = observer(function SubgraphNode({
     currentNavPath.length > depth &&
     currentNavPath.slice(0, depth + 1).join("/") === nodePath;
 
-  const isCurrentGraph = currentNavPath.join("/") === nodePath;
-
   const tasks = spec.tasks;
   const hasChildren = tasks.length > 0;
+  const childTaskIds = new Set(tasks.map((t) => t.$id));
 
   const taskIssues = getEntityIssues(parentSpec, task.$id);
-  const specIssues = spec.validationIssues;
-  const allIssues = [...taskIssues, ...specIssues];
+  const specIssuesWithoutChildTaskRow = spec.validationIssues.filter(
+    (issue) => !issue.entityId || !childTaskIds.has(issue.entityId),
+  );
+  const ownIssues = [...taskIssues, ...specIssuesWithoutChildTaskRow];
+  const allIssues = [...taskIssues, ...spec.allValidationIssues];
   const hasErrors = countErrors(allIssues) > 0;
 
-  const isParentOnActiveCanvas = parentSpec === navigation.activeSpec;
+  const isSelected = editor.isTaskSelected(task.$id);
 
   const handleClick = () => {
     const pathResult = navigation.navigateToPath(navigationPath);
@@ -67,88 +76,99 @@ export const SubgraphNode = observer(function SubgraphNode({
     }
   };
 
-  const handleChevronClick = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    onToggleExpand(nodePath);
-  };
-
-  const handleMouseEnter = () => {
-    if (isParentOnActiveCanvas) editor.setHoveredEntity(task.$id);
-  };
-
-  const handleMouseLeave = () => {
-    editor.setHoveredEntity(null);
-  };
+  const collapsibleOpen = hasChildren ? isExpanded : true;
 
   return (
-    <BlockStack gap="0">
+    <BlockStack gap="0" align="stretch" className="min-w-0 w-full">
       <Collapsible
-        open={isExpanded}
+        open={collapsibleOpen}
         onOpenChange={() => onToggleExpand(nodePath)}
         className="w-full"
       >
-        <CollapsibleTrigger asChild>
-          <div
-            role="button"
-            tabIndex={0}
-            onClick={handleClick}
-            onKeyDown={(e) => e.key === "Enter" && handleClick()}
-            onMouseEnter={handleMouseEnter}
-            onMouseLeave={handleMouseLeave}
-            className={treeNodeRowVariants({
-              isCurrentGraph,
-              isInCurrentPath,
-              hasErrors,
-              fullWidth: true,
-            })}
+        <div
+          className={treeNodeRowVariants({
+            hasErrors,
+            fullWidth: true,
+          })}
+        >
+          <TreeRowActivate
+            layout="subgraphStrip"
+            selected={isSelected}
+            taskId={task.$id}
+            onActivate={handleClick}
           >
-            {hasChildren ? (
-              <Button
-                variant="ghost"
-                size="sm"
-                aria-label={isExpanded ? "Collapse" : "Expand"}
-                className="h-5 w-5 p-0 shrink-0"
-                onClick={handleChevronClick}
-              >
-                <Icon
-                  name={isExpanded ? "ChevronDown" : "ChevronRight"}
-                  size="sm"
-                  className="text-slate-500"
-                />
-              </Button>
-            ) : (
-              <div className="w-5 shrink-0" />
-            )}
-
-            <Icon
-              name="Layers"
-              size="sm"
-              className={treeNodeIconVariants({
-                isCurrentGraph,
-                isInCurrentPath,
-                hasErrors,
-              })}
-            />
+            <InlineStack
+              className="shrink-0 rounded-sm bg-white"
+              gap="0"
+              align="center"
+              blockAlign="center"
+            >
+              <Icon
+                name="Workflow"
+                size="xs"
+                className={cn(
+                  treeNodeIconVariants({
+                    hasErrors,
+                    selected: isSelected,
+                  }),
+                )}
+              />
+            </InlineStack>
 
             <Text
               size="xs"
-              weight={isCurrentGraph ? "semibold" : "regular"}
-              className={cn(
-                "wrap-break-word min-w-0 flex-1",
-                isCurrentGraph && "text-blue-900",
-              )}
+              weight={isInCurrentPath ? "semibold" : "regular"}
+              title={task.name}
+              className={treeNodeLabelToneVariants({
+                tone: "none",
+                line: "ellipsis",
+              })}
             >
               {task.name}
             </Text>
 
             <IssueBadge issues={allIssues} />
-          </div>
-        </CollapsibleTrigger>
+          </TreeRowActivate>
 
-        <CollapsibleContent>
           {hasChildren && (
-            <BlockStack gap="0" className="ml-4 border-l border-slate-200 pl-2">
-              <div className="-ml-3.5">
+            <CollapsibleTrigger asChild>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-5 w-5 shrink-0 p-0"
+                aria-label={
+                  isExpanded ? "Collapse subgraph" : "Expand subgraph"
+                }
+              >
+                <Icon
+                  name={isExpanded ? "ChevronDown" : "ChevronRight"}
+                  size="sm"
+                  className={treeNodeChevronIconVariants({ hasErrors })}
+                />
+              </Button>
+            </CollapsibleTrigger>
+          )}
+        </div>
+
+        <CollapsibleContent className="w-full">
+          {ownIssues.length > 0 && (
+            <BlockStack gap="1" className="ml-7 mt-0.5 mb-1">
+              {ownIssues.map((issue, index) => (
+                <IssueRow
+                  key={`${issue.type}-${issue.entityId ?? "graph"}-${index}`}
+                  issue={issue}
+                />
+              ))}
+            </BlockStack>
+          )}
+
+          {hasChildren && (
+            <BlockStack
+              gap="0"
+              align="stretch"
+              className="ml-4 min-w-0 w-full border-l border-slate-200 pl-2"
+            >
+              <div className="-ml-3.5 min-w-0 w-full">
                 {tasks.map((childTask) => {
                   if (childTask.subgraphSpec) {
                     return (

--- a/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/TaskLeafNode.tsx
+++ b/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/TaskLeafNode.tsx
@@ -3,7 +3,6 @@ import { observer } from "mobx-react-lite";
 import { Icon } from "@/components/ui/icon";
 import { BlockStack } from "@/components/ui/layout";
 import { Text } from "@/components/ui/typography";
-import { cn } from "@/lib/utils";
 import type { ComponentSpec, Task } from "@/models/componentSpec";
 import { getEntityIssues } from "@/routes/v2/pages/Editor/components/PipelineTreeContent/utils";
 import {
@@ -15,6 +14,12 @@ import { useFocusActions } from "@/routes/v2/shared/store/useFocusActions";
 
 import { IssueBadge } from "./IssueBadge";
 import { IssueRow } from "./IssueRow";
+import {
+  type TreeNodeLabelTone,
+  treeNodeLabelToneVariants,
+  treeNodeLeafIconToneVariants,
+} from "./treeNode.variants";
+import { TreeRowActivate } from "./TreeRowActivate";
 
 interface TaskLeafNodeProps {
   task: Task;
@@ -27,11 +32,11 @@ export const TaskLeafNode = observer(function TaskLeafNode({
   parentSpec,
   parentNavigationPath,
 }: TaskLeafNodeProps) {
-  const { editor, navigation } = useSharedStores();
+  const { editor } = useSharedStores();
   const { navigateToEntity, focusValidationIssue } = useFocusActions();
   const issues = getEntityIssues(parentSpec, task.$id);
   const hasErrors = countErrors(issues) > 0;
-  const isOnActiveCanvas = parentSpec === navigation.activeSpec;
+  const isSelected = editor.isTaskSelected(task.$id);
 
   const handleClick = () => {
     navigateToEntity(parentNavigationPath, task.$id, "task");
@@ -40,50 +45,39 @@ export const TaskLeafNode = observer(function TaskLeafNode({
     }
   };
 
-  const handleMouseEnter = () => {
-    if (isOnActiveCanvas) editor.setHoveredEntity(task.$id);
-  };
-
-  const handleMouseLeave = () => {
-    editor.setHoveredEntity(null);
-  };
-
   const hasIssues = issues.length > 0;
   const hasWarnings = countWarnings(issues) > 0;
 
+  let iconTone: TreeNodeLabelTone = "none";
+  if (hasErrors) {
+    iconTone = "error";
+  } else if (hasWarnings) {
+    iconTone = "warning";
+  }
+
   return (
-    <BlockStack gap="0">
-      <div
-        role="button"
-        tabIndex={0}
-        onClick={handleClick}
-        onKeyDown={(e) => e.key === "Enter" && handleClick()}
-        onMouseEnter={handleMouseEnter}
-        onMouseLeave={handleMouseLeave}
-        className={cn(
-          "flex items-start gap-1 py-1 px-2 text-slate-600 rounded-md cursor-pointer transition-colors hover:bg-slate-100",
-          hasErrors && "text-red-700",
-        )}
+    <BlockStack gap="0" align="stretch" className="min-w-0 w-full">
+      <TreeRowActivate
+        layout="leafRow"
+        selected={isSelected}
+        taskId={task.$id}
+        onActivate={handleClick}
       >
         <Icon
           name={hasIssues ? "CircleAlert" : "Circle"}
           size="xs"
-          className={cn(
-            "shrink-0 mt-0.5",
-            hasErrors
-              ? "text-red-400"
-              : hasWarnings
-                ? "text-amber-400"
-                : "text-slate-400",
-          )}
+          className={treeNodeLeafIconToneVariants({
+            tone: iconTone,
+            selected: isSelected,
+          })}
         />
-        <Text size="xs" className="wrap-break-word min-w-0 flex-1">
+        <Text size="xs" className={treeNodeLabelToneVariants({ tone: "none" })}>
           {task.name}
         </Text>
         <IssueBadge issues={issues} />
-      </div>
+      </TreeRowActivate>
       {hasIssues && (
-        <BlockStack gap="1" className="ml-10 mb-1">
+        <BlockStack gap="1" className="ml-3 mb-1">
           {issues.map((issue, index) => (
             <IssueRow
               key={`${issue.type}-${issue.entityId ?? "graph"}-${index}`}

--- a/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/TreeRowActivate.tsx
+++ b/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/TreeRowActivate.tsx
@@ -1,0 +1,70 @@
+import { cva } from "class-variance-authority";
+import type { KeyboardEvent, ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
+
+type TreeRowActivateLayout = "rootStrip" | "subgraphStrip" | "leafRow";
+
+const treeRowActivateVariants = cva(
+  "flex items-start gap-1 outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50",
+  {
+    variants: {
+      layout: {
+        rootStrip: "min-w-0 flex-1 px-2",
+        subgraphStrip: "min-w-0 flex-1 ",
+        leafRow: "group min-w-0 py-1.5 rounded-md cursor-pointer w-full",
+      },
+    },
+  },
+);
+
+interface TreeRowActivateProps {
+  children: ReactNode;
+  layout: TreeRowActivateLayout;
+  selected?: boolean;
+  taskId?: string;
+  className?: string;
+
+  onActivate: () => void;
+}
+
+export function TreeRowActivate({
+  children,
+  layout,
+  onActivate,
+  selected,
+  taskId,
+  className,
+}: TreeRowActivateProps) {
+  const { editor } = useSharedStores();
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    if (e.key !== "Enter" && e.key !== " ") return;
+    e.preventDefault();
+    onActivate();
+  };
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      aria-selected={selected}
+      onClick={onActivate}
+      onKeyDown={handleKeyDown}
+      {...(taskId !== undefined
+        ? {
+            onMouseEnter: () => {
+              editor.setHoveredEntity(taskId);
+            },
+            onMouseLeave: () => {
+              editor.setHoveredEntity(null);
+            },
+          }
+        : {})}
+      className={cn(treeRowActivateVariants({ layout }), className)}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/ValidationIssueResolutionCard.tsx
+++ b/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/ValidationIssueResolutionCard.tsx
@@ -4,7 +4,6 @@ import type { ReactNode } from "react";
 import { Icon } from "@/components/ui/icon";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Text } from "@/components/ui/typography";
-import { cn } from "@/lib/utils";
 import type {
   ComponentSpec,
   ValidationIssue,
@@ -19,6 +18,11 @@ import { InfoOnlyResolution } from "./resolutions/InfoOnlyResolution";
 import { MissingRequiredInputResolution } from "./resolutions/MissingRequiredInputResolution";
 import { RenameEntityResolution } from "./resolutions/RenameEntityResolution";
 import { useValidationResolutionActions } from "./useValidationResolutionActions";
+import {
+  validationIssueHeaderAccentVariants,
+  validationIssueHeaderMessageBoxVariants,
+  type ValidationIssueHeaderSeverity,
+} from "./validationIssueHeader.variants";
 
 interface ValidationIssueResolutionCardProps {
   issue: ValidationIssue;
@@ -45,22 +49,32 @@ export const ValidationIssueResolutionCard = observer(
 );
 
 function IssueHeader({ issue }: { issue: ValidationIssue }) {
-  const severityColor =
-    issue.severity === "error" ? "text-red-600" : "text-amber-600";
-  const severityBg = issue.severity === "error" ? "bg-red-50" : "bg-amber-50";
+  const severity: ValidationIssueHeaderSeverity =
+    issue.severity === "error" ? "error" : "warning";
   const severityIcon =
     issue.severity === "error" ? "CircleAlert" : "TriangleAlert";
 
   return (
     <BlockStack gap="2">
       <InlineStack gap="2" blockAlign="center">
-        <Icon name={severityIcon} size="sm" className={severityColor} />
-        <Text size="xs" weight="semibold" className={severityColor}>
+        <Icon
+          name={severityIcon}
+          size="sm"
+          className={validationIssueHeaderAccentVariants({ severity })}
+        />
+        <Text
+          size="xs"
+          weight="semibold"
+          className={validationIssueHeaderAccentVariants({ severity })}
+        >
           {issue.severity === "error" ? "Error" : "Warning"}
         </Text>
       </InlineStack>
-      <div className={cn("rounded-md p-2", severityBg)}>
-        <Text size="xs" className={severityColor}>
+      <div className={validationIssueHeaderMessageBoxVariants({ severity })}>
+        <Text
+          size="xs"
+          className={validationIssueHeaderAccentVariants({ severity })}
+        >
           {issue.message}
         </Text>
       </div>

--- a/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/issueRow.variants.ts
+++ b/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/issueRow.variants.ts
@@ -1,0 +1,68 @@
+import { cva } from "class-variance-authority";
+
+export type IssueRowSeverity = "error" | "warning";
+
+export const issueRowVariants = cva(
+  "flex items-baseline gap-1 py-0.5 px-2 rounded text-xs cursor-pointer transition-colors",
+  {
+    variants: {
+      selected: { true: "", false: "" },
+      severity: { error: "", warning: "" },
+    },
+    compoundVariants: [
+      {
+        selected: false,
+        severity: "error",
+        className: "bg-red-50 text-red-800 hover:bg-red-100",
+      },
+      {
+        selected: false,
+        severity: "warning",
+        className: "bg-amber-50 text-amber-800 hover:bg-amber-100",
+      },
+      {
+        selected: true,
+        severity: "error",
+        className:
+          "ring-1 ring-blue-400 bg-red-50 text-red-800 hover:bg-red-100",
+      },
+      {
+        selected: true,
+        severity: "warning",
+        className:
+          "ring-1 ring-blue-400 bg-amber-50 text-amber-800 hover:bg-amber-100",
+      },
+    ],
+    defaultVariants: {
+      selected: false,
+      severity: "warning",
+    },
+  },
+);
+
+export const issueRowTypeLabelVariants = cva(
+  "shrink-0 uppercase tracking-wide",
+  {
+    variants: {
+      severity: {
+        error: "text-red-600",
+        warning: "text-amber-600",
+      },
+    },
+    defaultVariants: {
+      severity: "warning",
+    },
+  },
+);
+
+export const issueRowMessageVariants = cva("", {
+  variants: {
+    severity: {
+      error: "text-red-700",
+      warning: "text-amber-700",
+    },
+  },
+  defaultVariants: {
+    severity: "warning",
+  },
+});

--- a/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/treeNode.variants.ts
+++ b/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/treeNode.variants.ts
@@ -1,78 +1,125 @@
 import { cva } from "class-variance-authority";
 
+export type TreeNodeLabelTone = "error" | "warning" | "none";
+
 export const treeNodeRowVariants = cva(
-  "flex items-start gap-1 py-1.5 px-2 rounded-md cursor-pointer transition-colors",
+  "group flex min-w-0 items-center gap-1 py-1.5 rounded-md cursor-pointer",
   {
     variants: {
-      isCurrentGraph: { true: "", false: "" },
-      isInCurrentPath: { true: "", false: "" },
       hasErrors: { true: "", false: "" },
       fullWidth: { true: "w-full", false: "" },
     },
-    compoundVariants: [
-      {
-        isCurrentGraph: false,
-        isInCurrentPath: false,
-        hasErrors: false,
-        className: "hover:bg-slate-100",
-      },
-      {
-        isCurrentGraph: false,
-        isInCurrentPath: false,
-        hasErrors: true,
-        className: "bg-red-50/50",
-      },
-      {
-        isCurrentGraph: false,
-        isInCurrentPath: true,
-        className: "bg-blue-50 text-blue-800",
-      },
-      {
-        isCurrentGraph: true,
-        className: "bg-blue-100 text-blue-900",
-      },
-    ],
     defaultVariants: {
-      isCurrentGraph: false,
-      isInCurrentPath: false,
       hasErrors: false,
       fullWidth: false,
     },
   },
 );
 
-export const treeNodeIconVariants = cva("shrink-0 mt-0.5", {
-  variants: {
-    isCurrentGraph: { true: "", false: "" },
-    isInCurrentPath: { true: "", false: "" },
-    hasErrors: { true: "", false: "" },
-  },
-  compoundVariants: [
-    {
-      isCurrentGraph: false,
-      isInCurrentPath: false,
+export const treeNodeIconVariants = cva(
+  "shrink-0 mt-0.5 rounded-sm transition-colors",
+  {
+    variants: {
+      hasErrors: {
+        true: "text-destructive group-hover:text-destructive/90",
+        false: "text-slate-600 group-hover:text-slate-950",
+      },
+      selected: {
+        true: "",
+        false: "",
+      },
+    },
+    compoundVariants: [
+      {
+        hasErrors: false,
+        selected: true,
+        className:
+          "text-primary ring-2 ring-primary/35 ring-offset-1 ring-offset-background group-hover:text-primary",
+      },
+      {
+        hasErrors: true,
+        selected: true,
+        className:
+          "ring-2 ring-primary/40 ring-offset-1 ring-offset-background",
+      },
+    ],
+    defaultVariants: {
       hasErrors: false,
-      className: "text-slate-500",
+      selected: false,
     },
-    {
-      isCurrentGraph: false,
-      isInCurrentPath: false,
-      hasErrors: true,
-      className: "text-red-500",
+  },
+);
+
+/** Primary label on tree rows (root, subgraph, leaf).
+ * Subgraph rows use `line: "ellipsis"` (single-line). Root/leaf use `wrap` (default). Parent stacks use `align="stretch"` so labels get a bounded width. */
+export const treeNodeLabelToneVariants = cva("transition-colors truncate", {
+  variants: {
+    tone: {
+      error: "text-destructive group-hover:text-destructive/90",
+      warning:
+        "text-amber-800 group-hover:text-amber-950 dark:text-amber-200 dark:group-hover:text-amber-100",
+      none: "text-slate-700 group-hover:text-slate-950",
     },
-    {
-      isCurrentGraph: false,
-      isInCurrentPath: true,
-      className: "text-blue-500",
+    line: {
+      wrap: "min-w-0 flex-1 wrap-break-word",
+      ellipsis: "min-w-0 flex-1 truncate",
     },
-    {
-      isCurrentGraph: true,
-      className: "text-blue-600",
-    },
-  ],
+  },
   defaultVariants: {
-    isCurrentGraph: false,
-    isInCurrentPath: false,
+    tone: "none",
+    line: "wrap",
+  },
+});
+
+/** Leaf task status icon (Circle / CircleAlert) — includes bg-white ring. */
+export const treeNodeLeafIconToneVariants = cva(
+  "shrink-0 mt-0.5 rounded-full transition-colors bg-white",
+  {
+    variants: {
+      tone: {
+        error: "text-destructive group-hover:text-destructive/90",
+        warning: "text-amber-500 group-hover:text-amber-600",
+        none: "text-slate-600 group-hover:text-slate-950",
+      },
+      selected: {
+        true: "",
+        false: "",
+      },
+    },
+    compoundVariants: [
+      {
+        tone: "none",
+        selected: true,
+        className:
+          "text-primary ring-2 ring-primary/35 ring-offset-1 ring-offset-white group-hover:text-primary",
+      },
+      {
+        tone: "warning",
+        selected: true,
+        className: "ring-2 ring-primary/40 ring-offset-1 ring-offset-white",
+      },
+      {
+        tone: "error",
+        selected: true,
+        className: "ring-2 ring-primary/40 ring-offset-1 ring-offset-white",
+      },
+    ],
+    defaultVariants: {
+      tone: "none",
+      selected: false,
+    },
+  },
+);
+
+/** Expand/chevron icon inside ghost button (size sm, no mt offset). */
+export const treeNodeChevronIconVariants = cva("", {
+  variants: {
+    hasErrors: {
+      true: "text-destructive",
+      false: "text-slate-600 group-hover:text-slate-950",
+    },
+  },
+  defaultVariants: {
     hasErrors: false,
   },
 });

--- a/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/validationIssueHeader.variants.ts
+++ b/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/validationIssueHeader.variants.ts
@@ -1,0 +1,27 @@
+import { cva } from "class-variance-authority";
+
+export type ValidationIssueHeaderSeverity = "error" | "warning";
+
+export const validationIssueHeaderAccentVariants = cva("", {
+  variants: {
+    severity: {
+      error: "text-red-600",
+      warning: "text-amber-600",
+    },
+  },
+  defaultVariants: {
+    severity: "warning",
+  },
+});
+
+export const validationIssueHeaderMessageBoxVariants = cva("rounded-md p-2", {
+  variants: {
+    severity: {
+      error: "bg-red-50",
+      warning: "bg-amber-50",
+    },
+  },
+  defaultVariants: {
+    severity: "warning",
+  },
+});

--- a/src/routes/v2/shared/store/editorStore.ts
+++ b/src/routes/v2/shared/store/editorStore.ts
@@ -106,4 +106,14 @@ export class EditorStore {
   @action setSelectedValidationIssue(issue: ValidationIssue | null) {
     this.selectedValidationIssue = issue;
   }
+
+  /** True when this task is the sole selection or part of a canvas multi-selection. */
+  isTaskSelected(taskId: string): boolean {
+    if (this.selectedNodeType === "task" && this.selectedNodeId === taskId) {
+      return true;
+    }
+    return this.multiSelection.some(
+      (n) => n.type === "task" && n.id === taskId,
+    );
+  }
 }


### PR DESCRIPTION
## Description

Refactors the Pipeline Tree UI to improve visual clarity, layout stability, and selection feedback across `RootNode`, `SubgraphNode`, and `TaskLeafNode` components.

**Navigation path highlighting** is now conveyed via label font weight on root and subgraph rows (bold when in the active navigation path) rather than background color changes tied to `isCurrentGraph`. The `isCurrentGraph` prop has been removed from tree node variants entirely.

**Selected task state** is now reflected in the tree. `EditorStore` gains an `isTaskSelected` helper that checks both single and multi-selection, and both `SubgraphNode` and `TaskLeafNode` use it to apply a ring highlight on their icons.

**Layout fixes** address text overflow and truncation in narrow containers. Grid columns use `minmax(0, ...)` to prevent overflow, and `min-w-0` is applied throughout the tree hierarchy so long task names truncate correctly instead of pushing the layout.

**Subgraph issue rows** are now shown inline beneath the subgraph row itself, filtered to exclude issues that belong to child task rows (which already render their own `IssueRow` entries). The chevron expand/collapse control is moved outside the `CollapsibleTrigger` wrapper so clicking the row label navigates without toggling expansion.

**CVA variant files** are extracted for `IssueRow`, `ValidationIssueResolutionCard` header, and tree node elements (`treeNode.variants.ts` is updated), replacing inline `cn()` calls with typed, composable variant functions.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] Improvement
- [x] Cleanup/Refactor

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)



| Before | After |
| --- | --- |
| ![image.png](https://app.graphite.com/user-attachments/assets/d01b5b4c-a4cb-49dc-a48d-b3c81b012012.png)<br> | ![image.png](https://app.graphite.com/user-attachments/assets/d15fdfe9-51f3-429a-a7c7-2b24d0c76c8d.png)<br> |

[Screen Recording 2026-05-07 at 9.20.28 AM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/6d146b42-58be-4fa2-99c6-b739a86cb518.mov" />](https://app.graphite.com/user-attachments/video/6d146b42-58be-4fa2-99c6-b739a86cb518.mov)



## Test Instructions

1. Open a pipeline with nested subgraphs in the editor.
2. Navigate into a subgraph and verify the path from root to the active level is shown in bold.
3. Select a task on the canvas and confirm the corresponding tree row icon shows a ring highlight.
4. Resize the tree panel to a narrow width and confirm task names truncate without breaking the layout.
5. Expand a subgraph node that has graph-level validation issues and confirm issue rows appear beneath the subgraph row, not duplicated under child tasks.

## Additional Comments

The `isCurrentGraph` variant has been fully removed from `treeNodeRowVariants` and `treeNodeIconVariants`. Any future code referencing that prop will need to use the new `isInCurrentPath` / `selected` / `tone` variants instead.