### PR TITLE
chore: v2 - pipeline structure - make rootnode always expanded

### DIFF
--- a/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/RootNode.tsx
+++ b/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/RootNode.tsx
@@ -1,12 +1,5 @@
 import { observer } from "mobx-react-lite";
 
-import { Button } from "@/components/ui/button";
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from "@/components/ui/collapsible";
-import { Icon } from "@/components/ui/icon";
 import { BlockStack } from "@/components/ui/layout";
 import { Text } from "@/components/ui/typography";
 import type { ComponentSpec } from "@/models/componentSpec";
@@ -18,7 +11,6 @@ import { IssueRow } from "./IssueRow";
 import { SubgraphNode } from "./SubgraphNode";
 import { TaskLeafNode } from "./TaskLeafNode";
 import {
-  treeNodeChevronIconVariants,
   treeNodeLabelToneVariants,
   treeNodeRowVariants,
 } from "./treeNode.variants";
@@ -39,8 +31,6 @@ export const RootNode = observer(function RootNode({
 }: RootNodeProps) {
   const { navigation } = useSharedStores();
   const navigationPath = [spec.name];
-  const nodePath = navigationPath.join("/");
-  const isExpanded = expandedNodes.has(nodePath);
 
   const tasks = spec.tasks;
   const hasChildren = tasks.length > 0;
@@ -55,98 +45,73 @@ export const RootNode = observer(function RootNode({
 
   return (
     <BlockStack gap="0" align="stretch" className="min-w-0 w-full">
-      <Collapsible
-        open={isExpanded}
-        onOpenChange={() => onToggleExpand(nodePath)}
-        className="w-full"
+      <div
+        className={treeNodeRowVariants({
+          hasErrors,
+          fullWidth: true,
+        })}
       >
-        <div
-          className={treeNodeRowVariants({
-            hasErrors,
-            fullWidth: true,
-          })}
-        >
-          <TreeRowActivate layout="rootStrip" onActivate={handleRowNavigate}>
-            <Text
-              size="xs"
-              weight="semibold"
-              className={treeNodeLabelToneVariants({ tone: "none" })}
-            >
-              {spec.name}
-            </Text>
+        <TreeRowActivate layout="rootStrip" onActivate={handleRowNavigate}>
+          <Text
+            size="xs"
+            weight="semibold"
+            className={treeNodeLabelToneVariants({ tone: "none" })}
+          >
+            {spec.name}
+          </Text>
 
-            <IssueBadge issues={graphIssues} />
-          </TreeRowActivate>
+          <IssueBadge issues={graphIssues} />
+        </TreeRowActivate>
+      </div>
 
-          {hasChildren && (
-            <CollapsibleTrigger asChild>
-              <Button
-                variant="ghost"
-                size="sm"
-                className="shrink-0 p-0"
-                aria-label={
-                  isExpanded ? "Collapse pipeline" : "Expand pipeline"
-                }
-              >
-                <Icon
-                  name={isExpanded ? "ChevronDown" : "ChevronRight"}
-                  size="sm"
-                  className={treeNodeChevronIconVariants({ hasErrors })}
-                />
-              </Button>
-            </CollapsibleTrigger>
-          )}
-        </div>
+      <div className="w-full">
+        {graphIssues.length > 0 && (
+          <BlockStack gap="1" className="ml-2 mt-0.5 mb-1">
+            {graphIssues.map((issue, index) => (
+              <IssueRow
+                key={`${issue.type}-${issue.entityId ?? "graph"}-${index}`}
+                issue={issue}
+              />
+            ))}
+          </BlockStack>
+        )}
 
-        <CollapsibleContent className="w-full">
-          {graphIssues.length > 0 && (
-            <BlockStack gap="1" className="ml-2 mt-0.5 mb-1">
-              {graphIssues.map((issue, index) => (
-                <IssueRow
-                  key={`${issue.type}-${issue.entityId ?? "graph"}-${index}`}
-                  issue={issue}
-                />
-              ))}
-            </BlockStack>
-          )}
-
-          {hasChildren && (
-            <BlockStack
-              gap="0"
-              align="stretch"
-              className="ml-2 min-w-0 w-full border-l border-slate-200"
-            >
-              <div className="-ml-1.5 min-w-0 w-full">
-                {tasks.map((task) => {
-                  if (task.subgraphSpec) {
-                    return (
-                      <SubgraphNode
-                        key={task.$id}
-                        spec={task.subgraphSpec}
-                        task={task}
-                        navigationPath={[...navigationPath, task.name]}
-                        currentNavPath={currentNavPath}
-                        expandedNodes={expandedNodes}
-                        onToggleExpand={onToggleExpand}
-                        parentSpec={spec}
-                      />
-                    );
-                  }
-
+        {hasChildren && (
+          <BlockStack
+            gap="0"
+            align="stretch"
+            className="ml-2 min-w-0 w-full border-l border-slate-200"
+          >
+            <div className="-ml-1.5 min-w-0 w-full">
+              {tasks.map((task) => {
+                if (task.subgraphSpec) {
                   return (
-                    <TaskLeafNode
+                    <SubgraphNode
                       key={task.$id}
+                      spec={task.subgraphSpec}
                       task={task}
+                      navigationPath={[...navigationPath, task.name]}
+                      currentNavPath={currentNavPath}
+                      expandedNodes={expandedNodes}
+                      onToggleExpand={onToggleExpand}
                       parentSpec={spec}
-                      parentNavigationPath={navigationPath}
                     />
                   );
-                })}
-              </div>
-            </BlockStack>
-          )}
-        </CollapsibleContent>
-      </Collapsible>
+                }
+
+                return (
+                  <TaskLeafNode
+                    key={task.$id}
+                    task={task}
+                    parentSpec={spec}
+                    parentNavigationPath={navigationPath}
+                  />
+                );
+              })}
+            </div>
+          </BlockStack>
+        )}
+      </div>
     </BlockStack>
   );
 });


### PR DESCRIPTION
## Description

Rationale: unless we work with multiple Root Pipelines, collapsing root node is redundant - it can be achieved via collapsing the window itself.

The `RootNode` component in the Pipeline Tree has been refactored to remove the collapsible expand/collapse behavior. The root node is now always expanded, showing its children (tasks, subgraph nodes, and issue rows) unconditionally. The `Collapsible`, `CollapsibleContent`, `CollapsibleTrigger`, `Button`, and `Icon` components have been removed, along with the associated `nodePath`, `isExpanded`, and chevron icon logic.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [x] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Open the pipeline editor and navigate to the Pipeline Tree panel.
2. Verify that the root node is always expanded and its child tasks and subgraph nodes are visible without needing to toggle.
3. Confirm that issue badges and issue rows still render correctly under the root node.
4. Verify that clicking the root node label still navigates correctly.

## Additional Comments

The `expandedNodes` and `onToggleExpand` props are still passed through to child `SubgraphNode` components, so expand/collapse behavior is preserved at the subgraph level.