### PR TITLE
fix: v2 - fitToView when navigating to subgraph

### DIFF
--- a/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/IssueRow.tsx
+++ b/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/IssueRow.tsx
@@ -17,17 +17,21 @@ import {
 
 interface IssueRowProps {
   issue: ValidationIssue;
+  issueNavigationPath: string[];
 }
 
-export const IssueRow = observer(function IssueRow({ issue }: IssueRowProps) {
+export const IssueRow = observer(function IssueRow({
+  issue,
+  issueNavigationPath,
+}: IssueRowProps) {
   const { editor } = useSharedStores();
-  const { focusValidationIssue } = useFocusActions();
+  const { focusIssueAtNavigationPath } = useFocusActions();
   const isSelected = editor.selectedValidationIssue === issue;
   const severity: IssueRowSeverity =
     issue.severity === "error" ? "error" : "warning";
 
   const handleSelectIssue = () => {
-    focusValidationIssue(issue);
+    focusIssueAtNavigationPath(issueNavigationPath, issue);
   };
 
   const handleClick = (e: MouseEvent) => {

--- a/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/RootNode.tsx
+++ b/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/RootNode.tsx
@@ -75,6 +75,7 @@ export const RootNode = observer(function RootNode({
               <IssueRow
                 key={`${issue.type}-${issue.entityId ?? "graph"}-${index}`}
                 issue={issue}
+                issueNavigationPath={navigationPath}
               />
             ))}
           </BlockStack>

--- a/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/SubgraphNode.tsx
+++ b/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/SubgraphNode.tsx
@@ -64,6 +64,7 @@ export const SubgraphNode = observer(function SubgraphNode({
     (issue) => !issue.entityId || !childTaskIds.has(issue.entityId),
   );
   const ownIssues = [...taskIssues, ...specIssuesWithoutChildTaskRow];
+  const parentNavPath = navigationPath.slice(0, -1);
   const allIssues = [...taskIssues, ...spec.allValidationIssues];
   const hasErrors = countErrors(allIssues) > 0;
 
@@ -162,6 +163,9 @@ export const SubgraphNode = observer(function SubgraphNode({
                 <IssueRow
                   key={`${issue.type}-${issue.entityId ?? "graph"}-${index}`}
                   issue={issue}
+                  issueNavigationPath={
+                    taskIssues.includes(issue) ? parentNavPath : navigationPath
+                  }
                 />
               ))}
             </BlockStack>

--- a/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/TaskLeafNode.tsx
+++ b/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/TaskLeafNode.tsx
@@ -33,15 +33,16 @@ export const TaskLeafNode = observer(function TaskLeafNode({
   parentNavigationPath,
 }: TaskLeafNodeProps) {
   const { editor } = useSharedStores();
-  const { navigateToEntity, focusValidationIssue } = useFocusActions();
+  const { navigateToEntity, focusIssueAtNavigationPath } = useFocusActions();
   const issues = getEntityIssues(parentSpec, task.$id);
   const hasErrors = countErrors(issues) > 0;
   const isSelected = editor.isTaskSelected(task.$id);
 
   const handleClick = () => {
-    navigateToEntity(parentNavigationPath, task.$id, "task");
     if (issues.length > 0) {
-      focusValidationIssue(issues[0]);
+      focusIssueAtNavigationPath(parentNavigationPath, issues[0]);
+    } else {
+      navigateToEntity(parentNavigationPath, task.$id, "task");
     }
   };
 
@@ -83,6 +84,7 @@ export const TaskLeafNode = observer(function TaskLeafNode({
             <IssueRow
               key={`${issue.type}-${issue.entityId ?? "graph"}-${index}`}
               issue={issue}
+              issueNavigationPath={parentNavigationPath}
             />
           ))}
         </BlockStack>

--- a/src/routes/v2/shared/hooks/useFitViewOnFocus.ts
+++ b/src/routes/v2/shared/hooks/useFitViewOnFocus.ts
@@ -8,6 +8,11 @@ import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
  * Uses a MobX reaction instead of render-time observable read + useEffect
  * so that fitView fires reliably even when navigateToPath triggers
  * intermediate clearSelection reactions before setPendingFocusNode is called.
+ *
+ * `fireImmediately` is required: `FlowCanvas` remounts when `activeSpec.$id`
+ * changes (subgraph navigation), so this hook often subscribes after
+ * `pendingFocusNodeId` is already set—without an immediate run the effect
+ * would never fire until a later change.
  */
 export function useFitViewOnFocus(): void {
   const { editor } = useSharedStores();
@@ -35,6 +40,7 @@ export function useFitViewOnFocus(): void {
           editor.setPendingFocusNode(null);
         }, 50);
       },
+      { fireImmediately: true },
     );
 
     return () => {

--- a/src/routes/v2/shared/store/focus.actions.ts
+++ b/src/routes/v2/shared/store/focus.actions.ts
@@ -1,4 +1,5 @@
 import type {
+  ComponentSpec,
   ComponentValidationIssue,
   ValidationIssue,
 } from "@/models/componentSpec";
@@ -6,10 +7,60 @@ import type {
 import type { EditorStore, NodeEntityType } from "./editorStore";
 import type { NavigationStore } from "./navigationStore";
 
+interface ResolvedValidationEntity {
+  id: string;
+  type: NodeEntityType;
+}
+
 function isComponentValidationIssue(
   issue: ValidationIssue,
 ): issue is ComponentValidationIssue {
   return "subgraphPath" in issue && Array.isArray(issue.subgraphPath);
+}
+
+function resolveValidationEntityFromSpec(
+  spec: ComponentSpec,
+  key: string,
+  matchBy: "name" | "id",
+): ResolvedValidationEntity | undefined {
+  const findIn = <T extends { name: string; $id: string }>(
+    items: readonly T[],
+  ): T | undefined =>
+    matchBy === "name"
+      ? items.find((x) => x.name === key)
+      : items.find((x) => x.$id === key);
+
+  const task = findIn(spec.tasks);
+  const input = findIn(spec.inputs);
+  const output = findIn(spec.outputs);
+  const id = task?.$id ?? input?.$id ?? output?.$id;
+  if (!id) {
+    return undefined;
+  }
+  const type: NodeEntityType = task ? "task" : input ? "input" : "output";
+  return { id, type };
+}
+
+function applyValidationIssueEditorFocus(
+  editor: EditorStore,
+  issue: ValidationIssue,
+  resolved: ResolvedValidationEntity | undefined,
+  options?: { skipHoveredEntity?: boolean },
+): void {
+  if (resolved) {
+    editor.setPendingFocusNode(resolved.id);
+    editor.selectNode(resolved.id, resolved.type, {
+      entityId: resolved.id,
+    });
+    if (!options?.skipHoveredEntity) {
+      editor.setHoveredEntity(resolved.id);
+    }
+  }
+
+  if (issue.argumentName) {
+    editor.setFocusedArgument(issue.argumentName);
+  }
+  editor.setSelectedValidationIssue(issue);
 }
 
 export function sameValidationIssue(
@@ -55,37 +106,40 @@ export function navigateAndSelectIssue(
   // The issue's entityId comes from validation's own deserialization,
   // so it won't match the navigation spec's IDs. Look up by name instead.
   const activeSpec = navigation.activeSpec;
-  if (activeSpec && issue.entityName) {
-    const task = activeSpec.tasks.find((t) => t.name === issue.entityName);
-    const input = activeSpec.inputs.find((i) => i.name === issue.entityName);
-    const output = activeSpec.outputs.find((o) => o.name === issue.entityName);
-    const resolvedId = task?.$id ?? input?.$id ?? output?.$id;
-    if (resolvedId) {
-      const resolvedType = task ? "task" : input ? "input" : "output";
-      editor.setPendingFocusNode(resolvedId);
-      editor.selectNode(resolvedId, resolvedType, {
-        entityId: resolvedId,
-      });
-      editor.setHoveredEntity(resolvedId);
-    }
-  }
+  const resolved =
+    activeSpec && issue.entityName
+      ? resolveValidationEntityFromSpec(activeSpec, issue.entityName, "name")
+      : undefined;
 
-  if (issue.argumentName) {
-    editor.setFocusedArgument(issue.argumentName);
-  }
-  editor.setSelectedValidationIssue(issue);
+  applyValidationIssueEditorFocus(editor, issue, resolved);
+}
+
+export function focusIssueAtNavigationPath(
+  editor: EditorStore,
+  navigation: NavigationStore,
+  pathFromRoot: string[],
+  issue: ValidationIssue,
+): void {
+  navigation.navigateToPath(pathFromRoot);
+
+  const activeSpec = navigation.activeSpec;
+  const resolved =
+    activeSpec && issue.entityId
+      ? resolveValidationEntityFromSpec(activeSpec, issue.entityId, "id")
+      : undefined;
+
+  applyValidationIssueEditorFocus(editor, issue, resolved);
 }
 
 export function focusValidationIssue(
   editor: EditorStore,
   issue: ValidationIssue,
 ): void {
-  if (issue.entityId) {
-    editor.setPendingFocusNode(issue.entityId);
-    editor.selectNode(issue.entityId, "task", { entityId: issue.entityId });
-  }
-  if (issue.argumentName) {
-    editor.setFocusedArgument(issue.argumentName);
-  }
-  editor.setSelectedValidationIssue(issue);
+  const resolved: ResolvedValidationEntity | undefined = issue.entityId
+    ? { id: issue.entityId, type: "task" }
+    : undefined;
+
+  applyValidationIssueEditorFocus(editor, issue, resolved, {
+    skipHoveredEntity: true,
+  });
 }

--- a/src/routes/v2/shared/store/useFocusActions.ts
+++ b/src/routes/v2/shared/store/useFocusActions.ts
@@ -1,4 +1,8 @@
-import { focusValidationIssue, navigateToEntity } from "./focus.actions";
+import {
+  focusIssueAtNavigationPath,
+  focusValidationIssue,
+  navigateToEntity,
+} from "./focus.actions";
 import { useSharedStores } from "./SharedStoreContext";
 
 export function useFocusActions() {
@@ -7,5 +11,10 @@ export function useFocusActions() {
   return {
     navigateToEntity: navigateToEntity.bind(null, editor, navigation),
     focusValidationIssue: focusValidationIssue.bind(null, editor),
+    focusIssueAtNavigationPath: focusIssueAtNavigationPath.bind(
+      null,
+      editor,
+      navigation,
+    ),
   };
 }


### PR DESCRIPTION
## Description

Fixes validation issue navigation so that clicking an issue in the pipeline tree correctly navigates to the subgraph canvas where the issue lives, rather than staying on the current canvas.

A new `focusIssueAtNavigationPath` action is introduced that accepts an explicit navigation path alongside the issue. This replaces the previous `focusValidationIssue` call in `IssueRow`, `TaskLeafNode`, and related components, which had no awareness of which subgraph the issue belonged to. Each node now passes its `navigationPath` (or `parentNavigationPath`) when rendering `IssueRow`, so the correct canvas is activated before the node is selected and focused.

In `SubgraphNode`, issues that belong to child tasks use the parent navigation path (`navigationPath.slice(0, -1)`) rather than the subgraph's own path, ensuring they open on the correct level.

The `TaskLeafNode` click handler is also corrected: when a task has issues, it now focuses the first issue at the correct path instead of navigating to the entity and then separately focusing the issue. Navigation to the entity only happens when there are no issues.

Additionally, `useFitViewOnFocus` now runs its MobX reaction with `fireImmediately: true`. Because `FlowCanvas` remounts on subgraph navigation (when `activeSpec.$id` changes), the hook frequently subscribes after `pendingFocusNodeId` is already set, meaning the fit-view effect would never fire without an immediate execution.

## Related Issue and Pull requests

## Type of Change

- [x] Bug fix

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

[Screen Recording 2026-05-07 at 9.39.11 AM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/0b114e37-466d-42b4-987c-1ba5a03abd83.mov" />](https://app.graphite.com/user-attachments/video/0b114e37-466d-42b4-987c-1ba5a03abd83.mov)



## Test Instructions

1. Open a pipeline that contains subgraphs with validation errors or warnings.
2. Expand the pipeline tree and click an issue row that belongs to a node inside a subgraph.
3. Verify the canvas navigates into the correct subgraph and the relevant node is selected and centered in view.
4. Click an issue row for a task leaf node and confirm the canvas navigates to the correct level and focuses the task.
5. Verify that clicking a task leaf node with no issues still navigates to the entity as before.

## Additional Comments