### PR TITLE
Adds component marketplace analytics telemetry baseline

### DIFF
--- a/.claude/skills/analytics-tracking/SKILL.md
+++ b/.claude/skills/analytics-tracking/SKILL.md
@@ -197,3 +197,50 @@ tracking("pipeline_canvas.tool_bar.auto_layout_select", {
 
 track("settings.secrets.secret_mutated", { action: "created" });
 ```
+
+## Component events
+
+Two namespaces are reserved for the Component Marketplace telemetry baseline:
+
+- `pipeline_editor.component.*` — canvas interactions for a specific component instance (drop, replace, remove, upgrade, duplicate).
+- `component_library.*` — discovery and library CRUD (search, row click, add, remove, future publish/deprecate).
+
+### Standard metadata for component events
+
+Spread `componentMetadata(ref, source)` from `@/utils/componentTracking` so every event carries the same identity fields:
+
+```ts
+import { componentMetadata } from "@/utils/componentTracking";
+
+track("pipeline_editor.component.dropped", {
+  ...componentMetadata(componentRef, "library"),
+  drop_kind: "new_node",
+  pipeline_id: pipelineId,
+});
+```
+
+| Key                | Type                                                                 | Notes                                            |
+| ------------------ | -------------------------------------------------------------------- | ------------------------------------------------ |
+| `component_id`     | `string \| undefined`                                                | Content-addressed digest. Stable across renames. |
+| `component_name`   | `string \| undefined`                                                | Human-readable name.                             |
+| `component_source` | `"user" \| "library" \| "published" \| "url" \| "file" \| "unknown"` | Where the component came from.                   |
+
+### Library mutation events fire from the provider
+
+`component_library.added` and `component_library.removed` are emitted from inside `ComponentLibraryProvider` — callers do **not** call `track()` for them. Instead, pass an `entryPoint` string so the provider can attribute which UI surface triggered the mutation:
+
+```ts
+await addToComponentLibrary(hydratedComponent, "favorite_button");
+await removeFromComponentLibrary(component, "favorite_button");
+```
+
+Valid `entryPoint` values: `"favorite_button"`, `"canvas_file_drop"`, `"canvas_file_drop_v2"`, `"import_dialog"`, `"editor_save"`, `"unknown"`.
+
+### Reserved names (do not use yet)
+
+These are documented so future PRs don't collide with the marketplace taxonomy:
+
+- `component_library.published`, `component_library.deprecated`, `component_library.superseded`
+- `component_library.shared_link.copied`
+- `component_collection.created`, `component_collection.viewed`, `component_collection.member_added`
+- `component_library.search.result.semantic_match`

--- a/src/components/shared/ComponentEditor/ComponentEditorDialog.test.tsx
+++ b/src/components/shared/ComponentEditor/ComponentEditorDialog.test.tsx
@@ -324,6 +324,7 @@ describe("<ComponentEditorDialog />", () => {
         // Verify addToComponentLibrary was called
         expect(mockAddToComponentLibrary).toHaveBeenCalledWith(
           mockHydratedComponent,
+          "editor_save",
         );
 
         // Verify success toast notification was shown

--- a/src/components/shared/ComponentEditor/ComponentEditorDialog.tsx
+++ b/src/components/shared/ComponentEditor/ComponentEditorDialog.tsx
@@ -1,5 +1,5 @@
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
@@ -88,12 +88,15 @@ export const ComponentEditorDialog = withSuspenseWrapper(
 
     const mode = text ? "edit" : "create";
 
+    const hasTrackedOpen = useRef(false);
     useEffect(() => {
+      if (hasTrackedOpen.current) return;
+      hasTrackedOpen.current = true;
       track("component_editor.opened", {
         mode,
         selected_template: templateName,
       });
-    }, []);
+    }, [mode, templateName, track]);
 
     const { data: pythonCodeDetection } = useSuspenseQuery({
       queryKey: ["isPython", `${templateName}-${JSON.stringify(text)}`],

--- a/src/components/shared/ComponentEditor/ComponentEditorDialog.tsx
+++ b/src/components/shared/ComponentEditor/ComponentEditorDialog.tsx
@@ -1,5 +1,5 @@
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
@@ -82,8 +82,18 @@ export const ComponentEditorDialog = withSuspenseWrapper(
     const { addToComponentLibrary } = useComponentLibrary();
 
     const { data: templateCode } = useTemplateCodeByName(templateName);
-    const [componentText, setComponentText] = useState(text ?? templateCode);
+    const initialText = text ?? templateCode;
+    const [componentText, setComponentText] = useState(initialText);
     const [errors, setErrors] = useState<string[]>([]);
+
+    const mode = text ? "edit" : "create";
+
+    useEffect(() => {
+      track("component_editor.opened", {
+        mode,
+        selected_template: templateName,
+      });
+    }, []);
 
     const { data: pythonCodeDetection } = useSuspenseQuery({
       queryKey: ["isPython", `${templateName}-${JSON.stringify(text)}`],
@@ -158,30 +168,43 @@ export const ComponentEditorDialog = withSuspenseWrapper(
         text: componentText,
       });
 
-      if (hydratedComponent) {
-        await saveComponent({
-          id: `component-${hydratedComponent.digest}`,
-          url: "",
-          data: componentText,
-          createdAt: Date.now(),
-          updatedAt: Date.now(),
-        });
-
-        onClose();
-
-        await addToComponentLibrary(hydratedComponent);
-
-        track("component_editor.component_created", {
+      if (!hydratedComponent) {
+        track("component_editor.save.failed", {
+          mode,
           selected_template: templateName,
+          reason: "hydration_failed",
         });
-        notify(
-          `Component ${hydratedComponent.name} imported successfully`,
-          "success",
-        );
+        return;
       }
+
+      await saveComponent({
+        id: `component-${hydratedComponent.digest}`,
+        url: "",
+        data: componentText,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+
+      onClose();
+
+      await addToComponentLibrary(hydratedComponent, "editor_save");
+
+      track("component_editor.save.completed", {
+        mode,
+        selected_template: templateName,
+      });
+      notify(
+        `Component ${hydratedComponent.name} imported successfully`,
+        "success",
+      );
     };
 
     const handleClose = () => {
+      track("component_editor.dismissed", {
+        mode,
+        selected_template: templateName,
+        had_changes: componentText !== initialText,
+      });
       onClose();
     };
 

--- a/src/components/shared/FavoriteComponentToggle.tsx
+++ b/src/components/shared/FavoriteComponentToggle.tsx
@@ -221,9 +221,9 @@ const ComponentFavoriteToggleInternal = ({
         return;
       }
 
-      await addToComponentLibrary(hydratedComponent);
+      await addToComponentLibrary(hydratedComponent, "favorite_button");
     } else {
-      await removeFromComponentLibrary(component);
+      await removeFromComponentLibrary(component, "favorite_button");
     }
   }, [
     component,

--- a/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
@@ -40,6 +40,7 @@ import { useSubgraphKeyboardNavigation } from "@/hooks/useSubgraphKeyboardNaviga
 import useToastNotification from "@/hooks/useToastNotification";
 import { useUserDetails } from "@/hooks/useUserDetails";
 import { cn } from "@/lib/utils";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { useComponentLibrary } from "@/providers/ComponentLibraryProvider";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 import { useContextPanel } from "@/providers/ContextPanelProvider";
@@ -50,6 +51,7 @@ import {
   isNotMaterializedComponentReference,
   type TaskSpec,
 } from "@/utils/componentSpec";
+import { componentMetadata } from "@/utils/componentTracking";
 import { readTextFromFile } from "@/utils/dom";
 import { deselectAllNodes } from "@/utils/flowUtils";
 import createNodesFromComponentSpec from "@/utils/nodes/createNodesFromComponentSpec";
@@ -215,6 +217,7 @@ const FlowCanvasContent = ({
   const [metaKeyPressed, setMetaKeyPressed] = useState(false);
 
   const { addToComponentLibrary } = useComponentLibrary();
+  const { track } = useAnalytics();
 
   const handleKeyDown = (event: KeyboardEvent) => {
     const target = event.target as HTMLElement;
@@ -663,7 +666,10 @@ const FlowCanvasContent = ({
           return;
         }
 
-        const result = await addToComponentLibrary(hydratedComponentRef);
+        const result = await addToComponentLibrary(
+          hydratedComponentRef,
+          "canvas_file_drop",
+        );
 
         if (result && reactFlowInstance) {
           // Use the drop position if available
@@ -689,6 +695,12 @@ const FlowCanvasContent = ({
               name: ref.spec.name,
             });
           }
+
+          track("pipeline_editor.component.dropped", {
+            ...componentMetadata(hydratedComponentRef, "file"),
+            drop_kind: "file_import",
+            pipeline_id: componentSpec.name,
+          });
         }
       } catch (error) {
         console.error("Failed to add imported component to canvas:", error);
@@ -760,8 +772,10 @@ const FlowCanvasContent = ({
         return;
       }
 
+      const targetTaskId = replaceTarget.data.taskId as string;
+
       const { updatedGraphSpec, lostInputs, newTaskId } = replaceTaskNode(
-        replaceTarget.data.taskId as string,
+        targetTaskId,
         droppedTask.componentRef,
         currentGraphSpec,
       );
@@ -774,10 +788,26 @@ const FlowCanvasContent = ({
 
       const confirmed = await triggerConfirmation(dialogData);
 
+      const fromComponentRef =
+        currentGraphSpec.tasks[targetTaskId]?.componentRef;
+
       setReplaceTarget(null);
 
       if (confirmed) {
         updateGraphSpec(updatedGraphSpec);
+
+        track("pipeline_editor.component.replaced", {
+          from_component_id: fromComponentRef?.digest,
+          from_component_name: fromComponentRef
+            ? componentMetadata(fromComponentRef).component_name
+            : undefined,
+          to_component_id: droppedTask.componentRef?.digest,
+          to_component_name: droppedTask.componentRef
+            ? componentMetadata(droppedTask.componentRef).component_name
+            : undefined,
+          lost_inputs_count: lostInputs.length,
+          pipeline_id: componentSpec.name,
+        });
       }
 
       return;
@@ -807,6 +837,14 @@ const FlowCanvasContent = ({
           type: "component",
           id: ref.digest,
           name: ref.spec.name,
+        });
+      }
+
+      if (ref) {
+        track("pipeline_editor.component.dropped", {
+          ...componentMetadata(ref, "library"),
+          drop_kind: "new_node",
+          pipeline_id: componentSpec.name,
         });
       }
     }

--- a/src/components/shared/ReactFlow/FlowSidebar/components/ImportComponent.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/components/ImportComponent.tsx
@@ -124,7 +124,7 @@ const ImportComponent = ({
         throw new Error("Failed to hydrate component");
       }
 
-      return await addToComponentLibrary(hydratedComponent);
+      return await addToComponentLibrary(hydratedComponent, "import_dialog");
     },
     onSuccess: async (result) => {
       setIsOpen(false);

--- a/src/components/shared/ReactFlow/FlowSidebar/components/PublishedComponentsSearch.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/components/PublishedComponentsSearch.tsx
@@ -26,6 +26,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { Text } from "@/components/ui/typography";
 import { cn } from "@/lib/utils";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { useBackend } from "@/providers/BackendProvider";
 import { useComponentLibrary } from "@/providers/ComponentLibraryProvider/ComponentLibraryProvider";
 import {
@@ -356,6 +357,27 @@ const Search = withSuspenseWrapper(
         return result;
       },
     });
+
+    const { track } = useAnalytics();
+    const queryLength = searchRequest.searchTerm?.length ?? 0;
+    const resultCount = (data ?? []).reduce(
+      (acc, folder) => acc + (folder.components?.length ?? 0),
+      0,
+    );
+
+    // The parent only renders <Search> when isSearchRequestValid (≥ MIN_SEARCH_TERM_LENGTH),
+    // so queryLength is guaranteed to be > 0 here.
+    useEffect(() => {
+      const timeoutId = setTimeout(() => {
+        track("component_library.search.query", {
+          query_length: queryLength,
+          result_count: resultCount,
+          surface: "editor_sidebar",
+          search_backend: "frontend_title",
+        });
+      }, 400);
+      return () => clearTimeout(timeoutId);
+    }, [queryLength, resultCount, track]);
 
     if (data) {
       return (

--- a/src/components/shared/TaskDetails/Actions.tsx
+++ b/src/components/shared/TaskDetails/Actions.tsx
@@ -1,5 +1,7 @@
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { type TaskNodeContextType } from "@/providers/TaskNodeProvider";
 import type { HydratedComponentReference } from "@/utils/componentSpec";
+import { componentMetadata } from "@/utils/componentTracking";
 import { isSubgraph } from "@/utils/subgraphUtils";
 import { tracking } from "@/utils/tracking";
 
@@ -32,6 +34,7 @@ const TaskActions = ({
   const { taskId, nodeId, taskSpec, state, callbacks } = taskNode || {};
   const { onDuplicate, onUpgrade, onDelete } = callbacks || {};
   const isCustomComponent = state?.isCustomComponent;
+  const { track } = useAnalytics();
 
   const isSubgraphNode = taskSpec ? isSubgraph(taskSpec) : false;
 
@@ -59,10 +62,24 @@ const TaskActions = ({
   // Canvas Actions
   const linkTask = readOnly && nodeId && <LinkNodeButton nodeId={nodeId} />;
   const duplicateTask = onDuplicate && !readOnly && (
-    <DuplicateTaskButton onDuplicate={onDuplicate} />
+    <DuplicateTaskButton
+      onDuplicate={() => {
+        onDuplicate();
+        track("pipeline_editor.component.duplicated", {
+          ...componentMetadata(componentRef),
+        });
+      }}
+    />
   );
   const upgradeTask = onUpgrade && !isCustomComponent && !readOnly && (
-    <UpgradeTaskButton onUpgrade={onUpgrade} />
+    <UpgradeTaskButton
+      onUpgrade={() => {
+        onUpgrade();
+        track("pipeline_editor.component.upgraded", {
+          ...componentMetadata(componentRef),
+        });
+      }}
+    />
   );
   const navigateToSubgraph = isSubgraphNode && taskId && !readOnly && (
     <NavigateToSubgraphButton taskId={taskId} />
@@ -71,7 +88,14 @@ const TaskActions = ({
     <UnpackSubgraphButton taskId={taskId} />
   );
   const deleteComponent = onDelete && !readOnly && (
-    <DeleteComponentButton onDelete={onDelete} />
+    <DeleteComponentButton
+      onDelete={() => {
+        onDelete();
+        track("pipeline_editor.component.removed", {
+          ...componentMetadata(componentRef),
+        });
+      }}
+    />
   );
 
   const actions = [

--- a/src/providers/ComponentLibraryProvider/ComponentLibraryProvider.test.tsx
+++ b/src/providers/ComponentLibraryProvider/ComponentLibraryProvider.test.tsx
@@ -36,6 +36,11 @@ vi.mock("@/providers/BackendProvider", () => ({
   useBackend: () => ({ backendUrl: "" }),
 }));
 
+const mockTrack = vi.fn();
+vi.mock("@/providers/AnalyticsProvider", () => ({
+  useAnalytics: () => ({ track: mockTrack }),
+}));
+
 // Mock all dependencies
 vi.mock("@/services/componentService");
 vi.mock("@/utils/componentStore");
@@ -617,6 +622,150 @@ describe("ComponentLibraryProvider - Component Management", () => {
         ...mockStoredComponent,
         favorited: true,
       });
+    });
+  });
+
+  describe("Analytics tracking", () => {
+    it("emits component_library.added on successful add with entry_point", async () => {
+      const newComponent: HydratedComponentReference = {
+        name: "tracked-component",
+        digest: "tracked-digest",
+        spec: mockComponentSpec,
+        text: "tracked yaml",
+      };
+
+      mockImportComponent.mockResolvedValue(undefined);
+      mockFlattenFolders.mockReturnValue([]);
+
+      const { result } = renderHook(() => useComponentLibrary(), {
+        wrapper: createWrapper,
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      await act(async () => {
+        await result.current.addToComponentLibrary(
+          newComponent,
+          "favorite_button",
+        );
+      });
+
+      expect(mockTrack).toHaveBeenCalledWith("component_library.added", {
+        component_id: "tracked-digest",
+        component_name: "tracked-component",
+        entry_point: "favorite_button",
+      });
+    });
+
+    it("does not emit component_library.added when duplicate dialog opens", async () => {
+      const newComponent: HydratedComponentReference = {
+        name: "duplicate-name",
+        digest: "new-digest",
+        spec: mockComponentSpec,
+        text: "yaml",
+      };
+
+      const existingComponent: ComponentReference = {
+        name: "duplicate-name",
+        digest: "existing-digest",
+        spec: mockComponentSpec,
+      };
+
+      mockFlattenFolders.mockReturnValue([existingComponent]);
+      mockGetUserComponentByName.mockResolvedValue({
+        componentRef: existingComponent,
+        name: "duplicate-name",
+        data: new ArrayBuffer(0),
+        creationTime: new Date(),
+        modificationTime: new Date(),
+      });
+
+      const { result } = renderHook(() => useComponentLibrary(), {
+        wrapper: createWrapper,
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      await act(async () => {
+        const pending = result.current.addToComponentLibrary(newComponent);
+        // Simulate user dismissing the duplicate dialog
+        window.dispatchEvent(
+          new CustomEvent("tangle.library.duplicateDialogClosed"),
+        );
+        await pending;
+      });
+
+      expect(mockTrack).not.toHaveBeenCalledWith(
+        "component_library.added",
+        expect.anything(),
+      );
+    });
+
+    it("emits component_library.removed on successful remove", async () => {
+      const componentToRemove: ComponentReference = {
+        name: "removed-component",
+        digest: "removed-digest",
+        spec: mockComponentSpec,
+      };
+
+      mockDeleteComponentFileFromList.mockResolvedValue();
+
+      const { result } = renderHook(() => useComponentLibrary(), {
+        wrapper: createWrapper,
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      await act(async () => {
+        await result.current.removeFromComponentLibrary(
+          componentToRemove,
+          "favorite_button",
+        );
+      });
+
+      expect(mockTrack).toHaveBeenCalledWith("component_library.removed", {
+        component_id: "removed-digest",
+        component_name: "removed-component",
+        entry_point: "favorite_button",
+      });
+    });
+
+    it("does not emit component_library.removed when delete fails", async () => {
+      const componentToRemove: ComponentReference = {
+        name: "error-component",
+        digest: "error-digest",
+        spec: mockComponentSpec,
+      };
+
+      mockDeleteComponentFileFromList.mockRejectedValue(new Error("boom"));
+      const consoleSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+
+      const { result } = renderHook(() => useComponentLibrary(), {
+        wrapper: createWrapper,
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      await act(async () => {
+        await result.current.removeFromComponentLibrary(componentToRemove);
+      });
+
+      expect(mockTrack).not.toHaveBeenCalledWith(
+        "component_library.removed",
+        expect.anything(),
+      );
+
+      consoleSpy.mockRestore();
     });
   });
 });

--- a/src/providers/ComponentLibraryProvider/ComponentLibraryProvider.tsx
+++ b/src/providers/ComponentLibraryProvider/ComponentLibraryProvider.tsx
@@ -12,6 +12,7 @@ import ComponentDuplicateDialog from "@/components/shared/Dialogs/ComponentDupli
 import { GitHubFlatComponentLibrary } from "@/components/shared/GitHubLibrary/githubFlatComponentLibrary";
 import { isGitHubLibraryConfiguration } from "@/components/shared/GitHubLibrary/types";
 import { getComponentQueryKey } from "@/hooks/useHydrateComponentReference";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { useBackend } from "@/providers/BackendProvider";
 import {
   fetchAndStoreComponentLibrary,
@@ -33,6 +34,7 @@ import {
   updateComponentInListByText,
   updateComponentRefInList,
 } from "@/utils/componentStore";
+import { type ComponentLibraryEntryPoint } from "@/utils/componentTracking";
 import {
   ComponentSearchFilter,
   MINUTES,
@@ -91,8 +93,12 @@ type ComponentLibraryContextType = {
   ) => Promise<SearchResult | null>;
   addToComponentLibrary: (
     component: HydratedComponentReference,
+    entryPoint?: ComponentLibraryEntryPoint,
   ) => Promise<HydratedComponentReference | undefined>;
-  removeFromComponentLibrary: (component: ComponentReference) => void;
+  removeFromComponentLibrary: (
+    component: ComponentReference,
+    entryPoint?: ComponentLibraryEntryPoint,
+  ) => Promise<void>;
   setComponentFavorite: (
     component: ComponentReference,
     favorited: boolean,
@@ -178,6 +184,7 @@ export const ComponentLibraryProvider = ({
   const { graphSpec } = useComponentSpec();
   const { currentSearchFilter } = useForcedSearchContext();
   const queryClient = useQueryClient();
+  const { track } = useAnalytics();
 
   const { getComponentLibraryObject, existingComponentLibraries } =
     useComponentLibraryRegistry();
@@ -523,6 +530,7 @@ export const ComponentLibraryProvider = ({
   const addToComponentLibrary = useCallback(
     async (
       hydratedComponentRef: HydratedComponentReference,
+      entryPoint: ComponentLibraryEntryPoint = "unknown",
     ): Promise<HydratedComponentReference | undefined> => {
       const abortController = new AbortController();
       const [result, _] = await Promise.all([
@@ -543,13 +551,27 @@ export const ComponentLibraryProvider = ({
         abortController.abort();
       });
 
-      return result instanceof CustomEvent ? hydratedComponentRef : undefined;
+      const succeeded =
+        result instanceof CustomEvent &&
+        result.type === "tangle.library.componentAdded";
+      if (succeeded) {
+        track("component_library.added", {
+          component_id: hydratedComponentRef.digest,
+          component_name: getComponentName(hydratedComponentRef),
+          entry_point: entryPoint,
+        });
+      }
+
+      return succeeded ? hydratedComponentRef : undefined;
     },
-    [addToComponentLibraryWithDuplicateCheck],
+    [addToComponentLibraryWithDuplicateCheck, track],
   );
 
   const removeFromComponentLibrary = useCallback(
-    async (component: ComponentReference) => {
+    async (
+      component: ComponentReference,
+      entryPoint: ComponentLibraryEntryPoint = "unknown",
+    ) => {
       try {
         if (component.name) {
           await deleteComponentFileFromList(
@@ -558,6 +580,11 @@ export const ComponentLibraryProvider = ({
           ).then(async () => {
             await refreshComponentLibrary();
             await refreshUserComponents();
+          });
+          track("component_library.removed", {
+            component_id: component.digest,
+            component_name: getComponentName(component),
+            entry_point: entryPoint,
           });
         } else {
           console.error(
@@ -568,7 +595,7 @@ export const ComponentLibraryProvider = ({
         console.error("Error deleting component:", error);
       }
     },
-    [refreshComponentLibrary, refreshUserComponents],
+    [refreshComponentLibrary, refreshUserComponents, track],
   );
 
   const handleCloseDuplicationDialog = useCallback(() => {

--- a/src/routes/Dashboard/DashboardComponentsView.tsx
+++ b/src/routes/Dashboard/DashboardComponentsView.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { useNavigate, useSearch } from "@tanstack/react-router";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import type { ListPublishedComponentsResponse } from "@/api/types.gen";
 import { CodeViewer } from "@/components/shared/CodeViewer";
@@ -20,6 +20,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Heading, Paragraph, Text } from "@/components/ui/typography";
 import { useHydrateComponentReference } from "@/hooks/useHydrateComponentReference";
 import { cn } from "@/lib/utils";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { useBackend } from "@/providers/BackendProvider";
 import {
   fetchUserComponents,
@@ -33,9 +34,13 @@ import type {
   InputSpec,
   OutputSpec,
 } from "@/utils/componentSpec";
+import { componentMetadata } from "@/utils/componentTracking";
 import { TOP_NAV_HEIGHT } from "@/utils/constants";
 import { fetchWithErrorHandling } from "@/utils/fetchWithErrorHandling";
 import { getComponentName } from "@/utils/getComponentName";
+import { tracking } from "@/utils/tracking";
+
+type ComponentRowSection = "user" | "library" | "published";
 
 const PUBLISHED_COMPONENTS_URL = "/api/published_components/";
 
@@ -80,11 +85,17 @@ const ComponentRow = ({
   selectedDigest,
   onSelect,
   depth = 0,
+  section,
+  position,
+  hadQuery,
 }: {
   component: ComponentReference;
   selectedDigest?: string;
   onSelect: (c: ComponentReference) => void;
   depth?: number;
+  section: ComponentRowSection;
+  position: number;
+  hadQuery: boolean;
 }) => (
   <button
     onClick={() => onSelect(component)}
@@ -93,6 +104,13 @@ const ComponentRow = ({
       "w-full text-left pr-3 py-1.5 border-b border-border/50 hover:bg-muted/50 flex flex-col gap-0 cursor-pointer",
       selectedDigest === component.digest && "bg-muted",
     )}
+    {...tracking("component_library.row", {
+      ...componentMetadata(component, section),
+      surface: "dashboard",
+      section,
+      result_position: position,
+      had_query: hadQuery,
+    })}
   >
     <Text size="xs" className="truncate">
       {component.name ?? getComponentName(component)}
@@ -115,11 +133,13 @@ const FolderNode = ({
   depth,
   selectedDigest,
   onSelect,
+  hadQuery,
 }: {
   folder: ComponentFolder;
   depth: number;
   selectedDigest?: string;
   onSelect: (c: ComponentReference) => void;
+  hadQuery: boolean;
 }) => (
   <Collapsible defaultOpen>
     <CollapsibleTrigger
@@ -137,13 +157,16 @@ const FolderNode = ({
       </Text>
     </CollapsibleTrigger>
     <CollapsibleContent>
-      {folder.components?.map((c) => (
+      {folder.components?.map((c, i) => (
         <ComponentRow
           key={c.digest ?? c.url ?? c.name}
           component={c}
           selectedDigest={selectedDigest}
           onSelect={onSelect}
           depth={depth + 1}
+          section="library"
+          position={i}
+          hadQuery={hadQuery}
         />
       ))}
       {folder.folders?.map((sub) => (
@@ -153,6 +176,7 @@ const FolderNode = ({
           depth={depth + 1}
           selectedDigest={selectedDigest}
           onSelect={onSelect}
+          hadQuery={hadQuery}
         />
       ))}
     </CollapsibleContent>
@@ -171,6 +195,7 @@ const ComponentList = ({
   onSelect: (component: ComponentReference) => void;
 }) => {
   const { backendUrl, configured, available, ready } = useBackend();
+  const { track } = useAnalytics();
 
   // User components — IndexedDB, no backend needed
   const { data: userFolder } = useQuery({
@@ -199,17 +224,8 @@ const ComponentList = ({
       },
     });
 
-  if (!ready || publishedLoading) {
-    return (
-      <BlockStack gap="2" className="p-3">
-        {Array.from({ length: 5 }).map((_, i) => (
-          <Skeleton key={i} className="h-9 w-full" />
-        ))}
-      </BlockStack>
-    );
-  }
-
   const q = query.trim().toLowerCase();
+  const hadQuery = q.length > 0;
 
   const matches = (name?: string | null, author?: string | null) =>
     !q || name?.toLowerCase().includes(q) || author?.toLowerCase().includes(q);
@@ -241,6 +257,29 @@ const ComponentList = ({
     filteredLibraryComponents.length +
     publishedComponents.length;
 
+  useEffect(() => {
+    if (!ready || publishedLoading || q.length === 0) return;
+    const timeoutId = setTimeout(() => {
+      track("component_library.search.query", {
+        query_length: q.length,
+        result_count: total,
+        surface: "dashboard",
+        search_backend: "frontend_title",
+      });
+    }, 400);
+    return () => clearTimeout(timeoutId);
+  }, [q, total, ready, publishedLoading, track]);
+
+  if (!ready || publishedLoading) {
+    return (
+      <BlockStack gap="2" className="p-3">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <Skeleton key={i} className="h-9 w-full" />
+        ))}
+      </BlockStack>
+    );
+  }
+
   if (total === 0) {
     return (
       <div className="px-4 py-3">
@@ -258,12 +297,15 @@ const ComponentList = ({
           label="User Components"
           count={userComponents.length}
         >
-          {userComponents.map((c) => (
+          {userComponents.map((c, i) => (
             <ComponentRow
               key={c.digest ?? c.url ?? c.name}
               component={c}
               selectedDigest={selectedDigest}
               onSelect={onSelect}
+              section="user"
+              position={i}
+              hadQuery={hadQuery}
             />
           ))}
         </CollapsibleSection>
@@ -276,12 +318,15 @@ const ComponentList = ({
         >
           {q
             ? // When searching, show a flat filtered list
-              filteredLibraryComponents.map((c) => (
+              filteredLibraryComponents.map((c, i) => (
                 <ComponentRow
                   key={c.digest ?? c.url ?? c.name}
                   component={c}
                   selectedDigest={selectedDigest}
                   onSelect={onSelect}
+                  section="library"
+                  position={i}
+                  hadQuery={hadQuery}
                 />
               ))
             : // When not searching, show the folder tree
@@ -292,6 +337,7 @@ const ComponentList = ({
                   depth={0}
                   selectedDigest={selectedDigest}
                   onSelect={onSelect}
+                  hadQuery={hadQuery}
                 />
               ))}
         </CollapsibleSection>
@@ -302,12 +348,15 @@ const ComponentList = ({
           label="Published Components"
           count={publishedComponents.length}
         >
-          {publishedComponents.map((c) => (
+          {publishedComponents.map((c, i) => (
             <ComponentRow
               key={c.digest}
               component={c}
               selectedDigest={selectedDigest}
               onSelect={onSelect}
+              section="published"
+              position={i}
+              hadQuery={hadQuery}
             />
           ))}
         </CollapsibleSection>

--- a/src/routes/Dashboard/DashboardHomeView.tsx
+++ b/src/routes/Dashboard/DashboardHomeView.tsx
@@ -13,6 +13,7 @@ import {
   type RecentlyViewedItem,
   useRecentlyViewed,
 } from "@/hooks/useRecentlyViewed";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { APP_ROUTES } from "@/routes/router";
 import { formatRelativeTime } from "@/utils/date";
 import { tracking } from "@/utils/tracking";
@@ -99,29 +100,40 @@ const RecentlyViewedPreview = () => {
   );
 };
 
-const RecentComponentPreviewRow = ({ item }: { item: RecentlyViewedItem }) => (
-  <InlineStack gap="2" className="min-w-0 overflow-hidden">
-    <Link
-      to={APP_ROUTES.DASHBOARD_COMPONENTS}
-      search={{ component: item.id }}
-      {...tracking("homepage.recently_used_components.item")}
-      className="flex w-full items-center gap-3 px-4 py-3 hover:bg-muted/50 no-underline"
-    >
-      <TypePill type="component" />
-      <Tooltip>
-        <TooltipTrigger className="flex-1 min-w-0 overflow-hidden text-left">
-          <Text size="sm" className="truncate block">
-            {item.name}
-          </Text>
-        </TooltipTrigger>
-        <TooltipContent>{item.name}</TooltipContent>
-      </Tooltip>
-      <Text size="xs" className="text-muted-foreground shrink-0">
-        {formatRelativeTime(new Date(item.viewedAt))}
-      </Text>
-    </Link>
-  </InlineStack>
-);
+const RecentComponentPreviewRow = ({ item }: { item: RecentlyViewedItem }) => {
+  const { track } = useAnalytics();
+  return (
+    <InlineStack gap="2" className="min-w-0 overflow-hidden">
+      <Link
+        to={APP_ROUTES.DASHBOARD_COMPONENTS}
+        search={{ component: item.id }}
+        {...tracking("homepage.recently_used_components.item")}
+        onClick={() => {
+          track("component_library.row.click", {
+            component_id: item.id,
+            component_name: item.name,
+            component_source: "unknown",
+            surface: "homepage_recent",
+          });
+        }}
+        className="flex w-full items-center gap-3 px-4 py-3 hover:bg-muted/50 no-underline"
+      >
+        <TypePill type="component" />
+        <Tooltip>
+          <TooltipTrigger className="flex-1 min-w-0 overflow-hidden text-left">
+            <Text size="sm" className="truncate block">
+              {item.name}
+            </Text>
+          </TooltipTrigger>
+          <TooltipContent>{item.name}</TooltipContent>
+        </Tooltip>
+        <Text size="xs" className="text-muted-foreground shrink-0">
+          {formatRelativeTime(new Date(item.viewedAt))}
+        </Text>
+      </Link>
+    </InlineStack>
+  );
+};
 
 const RecentComponentsPreview = () => {
   const { recentlyViewed } = useRecentlyViewed();

--- a/src/routes/v2/pages/Editor/components/EditorMenuBar/components/NodeMenu.tsx
+++ b/src/routes/v2/pages/Editor/components/EditorMenuBar/components/NodeMenu.tsx
@@ -25,6 +25,7 @@ import { useTaskActions } from "@/routes/v2/pages/Editor/store/actions/useTaskAc
 import { useEditorSession } from "@/routes/v2/pages/Editor/store/EditorSessionContext";
 import { MenuTriggerButton } from "@/routes/v2/shared/components/MenuTriggerButton";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
+import { componentMetadata } from "@/utils/componentTracking";
 import { getErrorMessage } from "@/utils/string";
 import { tracking } from "@/utils/tracking";
 
@@ -36,13 +37,13 @@ function findEntityAnnotations(spec: ComponentSpec, entityId: string) {
 }
 
 export const NodeMenu = observer(function NodeMenu() {
-  const { track } = useAnalytics();
   const { editor, navigation } = useSharedStores();
   const { undo } = useEditorSession();
   const spec = navigation.activeSpec;
   const { deleteTask, duplicateSelectedNodes, unpackSubgraphTask } =
     useTaskActions();
   const notify = useToastNotification();
+  const { track } = useAnalytics();
   const { getNodes } = useReactFlow();
 
   const entityId = editor.selectedNodeId;
@@ -68,6 +69,9 @@ export const NodeMenu = observer(function NodeMenu() {
     try {
       duplicateSelectedNodes(spec, [{ id: entityId, type: "task", position }]);
       notify("Task duplicated", "success");
+      track("pipeline_editor.component.duplicated", {
+        ...componentMetadata(task.componentRef),
+      });
     } catch (error) {
       notify("Failed to duplicate task: " + getErrorMessage(error), "error");
     }
@@ -76,9 +80,13 @@ export const NodeMenu = observer(function NodeMenu() {
   const handleDelete = () => {
     track("v2.pipeline_editor.node_menu.delete_task.click");
     try {
+      const removedComponentRef = task?.componentRef;
       deleteTask(spec, entityId);
       editor.clearSelection();
       editor.clearMultiSelection();
+      track("pipeline_editor.component.removed", {
+        ...componentMetadata(removedComponentRef),
+      });
     } catch (error) {
       notify("Failed to delete task: " + getErrorMessage(error), "error");
     }

--- a/src/routes/v2/pages/Editor/components/FlowCanvas/hooks/useDropBehavior.ts
+++ b/src/routes/v2/pages/Editor/components/FlowCanvas/hooks/useDropBehavior.ts
@@ -6,6 +6,7 @@ import type {
 import type { DragEvent } from "react";
 
 import type { ComponentSpec } from "@/models/componentSpec";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { useEditorSession } from "@/routes/v2/pages/Editor/store/EditorSessionContext";
 import { useNodeRegistry } from "@/routes/v2/shared/nodes/NodeRegistryContext";
 import type { NodeTypeRegistry } from "@/routes/v2/shared/nodes/registry";
@@ -14,6 +15,7 @@ import type {
   UndoGroupable,
 } from "@/routes/v2/shared/nodes/types";
 import type { TaskSpec } from "@/utils/componentSpec";
+import { componentMetadata } from "@/utils/componentTracking";
 
 import { useFileDropHandler } from "./useFileDropHandler";
 import { useReplaceDropHandler } from "./useReplaceDropHandler";
@@ -64,6 +66,7 @@ export function useDropBehavior(
 ): DropBehaviorResult {
   const registry = useNodeRegistry();
   const { undo } = useEditorSession();
+  const { track } = useAnalytics();
   const handleFileDrop = useFileDropHandler();
   const { detectReplaceTarget, flushReplaceState, performReplaceDrop } =
     useReplaceDropHandler(spec, reactFlowInstance);
@@ -94,19 +97,28 @@ export function useDropBehavior(
 
     const replaceTarget = flushReplaceState();
     const payload = parseDropPayload(event);
+    const droppedTaskComponentRef = payload?.task?.componentRef;
 
-    switch (true) {
-      case isFileDrop(event):
-        await handleFileDrop(event.dataTransfer.files[0], spec, position);
-        break;
+    if (isFileDrop(event)) {
+      await handleFileDrop(event.dataTransfer.files[0], spec, position);
+      return;
+    }
 
-      case isReplaceTargetDrop(replaceTarget, payload):
-        await performReplaceDrop(replaceTarget, payload?.task);
-        break;
+    if (isReplaceTargetDrop(replaceTarget, payload)) {
+      await performReplaceDrop(replaceTarget, payload?.task);
+      return;
+    }
 
-      case isDropPayload(payload):
-        await resolveDropHandler(registry, payload)?.(spec, position, undo);
-        break;
+    if (!isDropPayload(payload)) return;
+
+    await resolveDropHandler(registry, payload)?.(spec, position, undo);
+
+    if (droppedTaskComponentRef) {
+      track("pipeline_editor.component.dropped", {
+        ...componentMetadata(droppedTaskComponentRef, "library"),
+        drop_kind: "new_node",
+        pipeline_id: spec.name,
+      });
     }
   };
 

--- a/src/routes/v2/pages/Editor/components/FlowCanvas/hooks/useDropBehavior.ts
+++ b/src/routes/v2/pages/Editor/components/FlowCanvas/hooks/useDropBehavior.ts
@@ -111,7 +111,10 @@ export function useDropBehavior(
 
     if (!isDropPayload(payload)) return;
 
-    await resolveDropHandler(registry, payload)?.(spec, position, undo);
+    const handler = resolveDropHandler(registry, payload);
+    if (!handler) return;
+
+    await handler(spec, position, undo);
 
     if (droppedTaskComponentRef) {
       track("pipeline_editor.component.dropped", {

--- a/src/routes/v2/pages/Editor/components/FlowCanvas/hooks/useFileDropHandler.ts
+++ b/src/routes/v2/pages/Editor/components/FlowCanvas/hooks/useFileDropHandler.ts
@@ -2,10 +2,12 @@ import type { XYPosition } from "@xyflow/react";
 
 import useToastNotification from "@/hooks/useToastNotification";
 import type { ComponentReference, ComponentSpec } from "@/models/componentSpec";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { useComponentLibrary } from "@/providers/ComponentLibraryProvider";
 import { useTaskActions } from "@/routes/v2/pages/Editor/store/actions/useTaskActions";
 import { hydrateComponentReference } from "@/services/componentService";
 import type { HydratedComponentReference } from "@/utils/componentSpec";
+import { componentMetadata } from "@/utils/componentTracking";
 import { readTextFromFile } from "@/utils/dom";
 
 /**
@@ -22,6 +24,7 @@ function toModelComponentRef(
 export function useFileDropHandler() {
   const { addTask } = useTaskActions();
   const { addToComponentLibrary } = useComponentLibrary();
+  const { track } = useAnalytics();
   const notify = useToastNotification();
 
   return async (file: File, spec: ComponentSpec, position: XYPosition) => {
@@ -34,10 +37,19 @@ export function useFileDropHandler() {
         return;
       }
 
-      const result = await addToComponentLibrary(hydrated);
+      const result = await addToComponentLibrary(
+        hydrated,
+        "canvas_file_drop_v2",
+      );
       if (!result) return;
 
       addTask(spec, toModelComponentRef(result), position);
+
+      track("pipeline_editor.component.dropped", {
+        ...componentMetadata(result, "file"),
+        drop_kind: "file_import",
+        pipeline_id: spec.name,
+      });
     } catch (error) {
       console.error("Failed to add imported component to canvas:", error);
       notify("Failed to add component to canvas", "error");

--- a/src/routes/v2/pages/Editor/components/FlowCanvas/hooks/useReplaceDropHandler.tsx
+++ b/src/routes/v2/pages/Editor/components/FlowCanvas/hooks/useReplaceDropHandler.tsx
@@ -13,6 +13,7 @@ import type { CanvasOverlayConfig } from "@/routes/v2/shared/store/canvasOverlay
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 import { hydrateComponentReference } from "@/services/componentService";
 import type { TaskSpec } from "@/utils/componentSpec";
+import { componentMetadata } from "@/utils/componentTracking";
 
 const OVERLAY_ID = "replace-drop-target";
 const REPLACEABLE_NODE_TYPE = "task";
@@ -51,10 +52,10 @@ export function useReplaceDropHandler(
   spec: ComponentSpec | null,
   reactFlowInstance: ReactFlowInstance | null,
 ) {
-  const { track } = useAnalytics();
   const { canvasOverlay } = useSharedStores();
   const { replaceTask } = useTaskActions();
   const { open: openDialog } = useDialog();
+  const { track } = useAnalytics();
 
   const replaceTargetRef = useRef<string | null>(null);
 
@@ -147,9 +148,23 @@ export function useReplaceDropHandler(
 
     if (!canReplace) return;
 
+    const fromComponentRef = task.componentRef;
+
     replaceTask(spec, targetEntityId, newComponentRef);
+
     track("v2.pipeline_canvas.replace_drop.completed", {
       had_breaking_change_prompt: hasBreakingChanges,
+    });
+
+    track("pipeline_editor.component.replaced", {
+      from_component_id: fromComponentRef?.digest,
+      from_component_name: fromComponentRef
+        ? componentMetadata(fromComponentRef).component_name
+        : undefined,
+      to_component_id: newComponentRef.digest,
+      to_component_name: componentMetadata(newComponentRef).component_name,
+      lost_inputs_count: inputDiff.lostEntities.length,
+      pipeline_id: spec.name,
     });
   };
 

--- a/src/utils/componentTracking.test.ts
+++ b/src/utils/componentTracking.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { ComponentReference } from "./componentSpec";
+import { componentMetadata } from "./componentTracking";
+
+vi.mock("./getComponentName", () => ({
+  getComponentName: (c: ComponentReference) => c.name ?? "fallback-name",
+}));
+
+describe("componentMetadata", () => {
+  it("includes digest, name, and source", () => {
+    const ref = { digest: "sha:abc", name: "foo" } as ComponentReference;
+    expect(componentMetadata(ref, "library")).toEqual({
+      component_id: "sha:abc",
+      component_name: "foo",
+      component_source: "library",
+    });
+  });
+
+  it("defaults source to unknown", () => {
+    const ref = { digest: "sha:abc", name: "foo" } as ComponentReference;
+    expect(componentMetadata(ref).component_source).toBe("unknown");
+  });
+
+  it("handles missing digest", () => {
+    const ref = { name: "foo" } as ComponentReference;
+    expect(componentMetadata(ref, "user")).toEqual({
+      component_id: undefined,
+      component_name: "foo",
+      component_source: "user",
+    });
+  });
+
+  it("falls back to getComponentName when name is missing", () => {
+    const ref = { digest: "sha:abc" } as ComponentReference;
+    expect(componentMetadata(ref).component_name).toBe("fallback-name");
+  });
+
+  it("handles undefined ref", () => {
+    expect(componentMetadata(undefined, "file")).toEqual({
+      component_id: undefined,
+      component_name: undefined,
+      component_source: "file",
+    });
+  });
+});

--- a/src/utils/componentTracking.ts
+++ b/src/utils/componentTracking.ts
@@ -1,0 +1,42 @@
+import type { ComponentReference } from "./componentSpec";
+import { getComponentName } from "./getComponentName";
+
+type ComponentSource =
+  | "user"
+  | "library"
+  | "published"
+  | "url"
+  | "file"
+  | "unknown";
+
+export type ComponentLibraryEntryPoint =
+  | "favorite_button"
+  | "canvas_file_drop"
+  | "canvas_file_drop_v2"
+  | "import_dialog"
+  | "editor_save"
+  | "unknown";
+
+interface ComponentTrackingMetadata {
+  component_id: string | undefined;
+  component_name: string | undefined;
+  component_source: ComponentSource;
+}
+
+/**
+ * Standard metadata shape for component-scoped analytics events.
+ *
+ * Identity is anchored on `digest` (content-addressed) so events are stable
+ * across renames and dedupable across versions. `component_name` is included
+ * for human-readable dashboards. Both are non-PII.
+ */
+export function componentMetadata(
+  ref: ComponentReference | undefined,
+  source: ComponentSource = "unknown",
+): ComponentTrackingMetadata {
+  return {
+    component_id: ref?.digest,
+    component_name: ref ? getComponentName(ref) : undefined,
+    component_source: source,
+  };
+}


### PR DESCRIPTION
## Summary

Establishes the analytics baseline for the upcoming Component Marketplace
project. Replaces today's title-only frontend search measurement with
end-to-end instrumentation of every component lifecycle event in both v1
and v2 editors, so we can measure the marketplace's success metrics
(search adoption, duplication reduction, library-add attribution) against
the pre-marketplace baseline.

This is **frontend-only**. No backend changes, no UI changes, no new analytics
infrastructure — events flow through the existing `AnalyticsProvider` →
`tangle.analytics.track` window event → oasis-frontend's monorail bridge
→ `sdp-ingest.monorail.monorail_tangle_ui_events_1`.

## Events emitted

All events identify components by content digest (`component_id`) and human-readable
name (`component_name`). No PII anywhere — query lengths, result counts, and
content-addressed digests only.

### Library mutations — fire from `ComponentLibraryProvider`

Centralized so every caller is covered automatically.

| Event | Fires when | Key metadata |
|---|---|---|
| `component_library.added` | A component is successfully added to the user's library | `entry_point` (`favorite_button` / `canvas_file_drop` / `canvas_file_drop_v2` / `import_dialog` / `editor_save` / `unknown`) |
| `component_library.removed` | A user component is successfully removed | `entry_point` |

### Component editor lifecycle — fire from `ComponentEditorDialog`

| Event | Fires when | Key metadata |
|---|---|---|
| `component_editor.opened` | Editor mounts (impression) | `mode` (`create` / `edit`), `selected_template` |
| `component_editor.dismissed` | Editor closed without saving | `mode`, `had_changes` |
| `component_editor.save.completed` | Save succeeded | `mode` |
| `component_editor.save.failed` | Hydration returned null | `mode`, `reason` |

### Discovery — fire from `DashboardComponentsView`, `PublishedComponentsSearch`, `DashboardHomeView`

| Event | Fires when | Key metadata |
|---|---|---|
| `component_library.search.query` | User types in dashboard or editor sidebar (debounced 400 ms) | `query_length`, `result_count`, `surface` (`dashboard` / `editor_sidebar`), `search_backend` (`frontend_title` today; flips when the marketplace API ships) |
| `component_library.row.click` | A component row is clicked in the dashboard or homepage | `surface`, `section`, `result_position`, `had_query` |

### Canvas — v1/v2 parity

Both editors emit the same events at the same lifecycle points so cross-editor
analytics joins work without app-version filtering.

| Event | Fires when | Key metadata |
|---|---|---|
| `pipeline_editor.component.dropped` | Component dropped onto canvas (file or sidebar) | `drop_kind` (`file_import` / `new_node`), `pipeline_id` |
| `pipeline_editor.component.replaced` | Existing task swapped via drag-drop or upgrade flow | `from_component_id`, `from_component_name`, `to_component_id`, `to_component_name`, `lost_inputs_count` |
| `pipeline_editor.component.removed` | Task deleted from canvas | (standard identity) |
| `pipeline_editor.component.duplicated` | Task duplicated | (standard identity) |
| `pipeline_editor.component.upgraded` | Task upgraded to a new version | (standard identity) |

### Pre-existing click events — left intact

The existing `pipeline_editor.task_node.*` click events (delete / duplicate / upgrade /
edit / yaml / info) and `pipeline_editor.add_component.*` events stay where they are.
They capture user *intent* (the click); the new events above capture the *outcome*.

## Implementation notes

- **`componentMetadata()` helper** (`src/utils/componentTracking.ts`) — every event uses this so the `component_id` / `component_name` / `component_source` shape stays consistent.
- **Library mutations centralized in the provider** — `addToComponentLibrary` / `removeFromComponentLibrary` accept an `entryPoint` arg so all five call sites are covered by one tracking site.
- **No PII**: digests, names, query lengths, counts only. No raw search text, no user-typed YAML.
- **Reserved namespaces** documented in `.claude/skills/analytics-tracking/SKILL.md` for Phase 2/3 (publish / deprecate / shared links / collections / semantic search).

## How to query

```sql
SELECT event_timestamp, payload.action_type, payload.action_metadata
FROM `sdp-ingest.monorail.monorail_tangle_ui_events_1`
WHERE event_timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 24 HOUR)
  AND (
       STARTS_WITH(payload.action_type, 'component_library.')
    OR STARTS_WITH(payload.action_type, 'component_editor.')
    OR STARTS_WITH(payload.action_type, 'pipeline_editor.component.')
  )
ORDER BY event_timestamp DESC;
```

## Test plan

- [x] Unit tests for `componentMetadata()` helper (5 cases)
- [x] Provider tests asserting `component_library.added` / `.removed` fire on success and skip on dialog-cancel / delete-failure
- [x] Existing `ComponentEditorDialog` test updated for new `addToComponentLibrary` signature
- [x] Manual smoke: drag, drop, replace, delete, duplicate, upgrade, save, search — all produce the expected events on both v1 and v2 editors
- [x] PII audit: no raw query text or user input in any payload