### PR TITLE
feat: v2 - quick run differntiate by state by color

### DIFF
--- a/src/routes/v2/pages/Editor/components/EditorMenuBar/components/QuickRunButton.tsx
+++ b/src/routes/v2/pages/Editor/components/EditorMenuBar/components/QuickRunButton.tsx
@@ -1,3 +1,4 @@
+import { cva } from "class-variance-authority";
 import { observer } from "mobx-react-lite";
 
 import { useAwaitAuthorization } from "@/components/shared/Authentication/useAwaitAuthorization";
@@ -8,6 +9,39 @@ import { serializeComponentSpec } from "@/models/componentSpec";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 import { deepClone } from "@/utils/deepClone";
 
+const quickRunIconVariants = cva("transition-colors", {
+  variants: {
+    hasErrors: { true: "", false: "" },
+    onlyWarnings: { true: "", false: "" },
+  },
+  compoundVariants: [
+    {
+      hasErrors: false,
+      onlyWarnings: false,
+      className: "text-green-400 hover:text-green-300",
+    },
+    {
+      hasErrors: false,
+      onlyWarnings: true,
+      className: "text-amber-400 hover:text-amber-300",
+    },
+    {
+      hasErrors: true,
+      className: "text-red-400 hover:text-red-300",
+    },
+  ],
+  defaultVariants: {
+    hasErrors: false,
+    onlyWarnings: false,
+  },
+});
+
+function tooltipLabel(hasErrors: boolean, onlyWarnings: boolean) {
+  if (hasErrors) return "Pipeline has validation errors";
+  if (onlyWarnings) return "Pipeline has validation warnings";
+  return "Submit Run";
+}
+
 export const QuickRunButton = observer(function QuickRunButton() {
   const { navigation } = useSharedStores();
   const { isAuthorized } = useAwaitAuthorization();
@@ -15,6 +49,7 @@ export const QuickRunButton = observer(function QuickRunButton() {
   const allIssues = rootSpec?.allValidationIssues ?? [];
   const errorCount = allIssues.filter((i) => i.severity === "error").length;
   const hasErrors = errorCount > 0;
+  const onlyWarnings = allIssues.length > 0 && errorCount === 0;
 
   let legacySpec: ReturnType<typeof serializeComponentSpec> | undefined;
   try {
@@ -25,11 +60,7 @@ export const QuickRunButton = observer(function QuickRunButton() {
     legacySpec = undefined;
   }
 
-  const iconColor = hasErrors
-    ? "text-red-400 hover:text-red-300"
-    : "text-green-400 hover:text-green-300";
-
-  const tooltip = hasErrors ? "Pipeline has validation errors" : "Submit Run";
+  const tooltip = tooltipLabel(hasErrors, onlyWarnings);
 
   return (
     <>
@@ -39,7 +70,10 @@ export const QuickRunButton = observer(function QuickRunButton() {
         disabled={hasErrors}
         onClick={triggerSubmitRun}
       >
-        <Icon name="Play" className={`${iconColor} transition-colors`} />
+        <Icon
+          name="Play"
+          className={quickRunIconVariants({ hasErrors, onlyWarnings })}
+        />
       </TooltipButton>
       {legacySpec && isAuthorized && (
         <div data-quick-run className="sr-only">


### PR DESCRIPTION
## Description

The `QuickRunButton` now distinguishes between pipelines that have validation **errors** versus only **warnings**. Previously, the button only differentiated between "has errors" (red) and "no issues" (green). A new `onlyWarnings` state has been added that renders the icon in amber when there are warnings but no errors, and updates the tooltip text accordingly to "Pipeline has validation warnings".

Icon color logic has been refactored using `cva` (class-variance-authority) compound variants to cleanly handle the three states: errors (red), warnings only (amber), and no issues (green).

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)



| State | Icon Color | Tooltip |
| --- | --- | --- |
| No issues | Green | Submit Run |
| Warnings only | Amber | Pipeline has validation warnings |
| Errors | Red | Pipeline has validation errors |

## [Screen Recording 2026-05-07 at 6.02.09 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/11ed2872-271e-42d2-9a00-7bc5bc201ab3.mov" />](https://app.graphite.com/user-attachments/video/11ed2872-271e-42d2-9a00-7bc5bc201ab3.mov)



##   
  
Test Instructions

1. Open a pipeline with no validation issues — confirm the Play icon is green and tooltip reads "Submit Run".
2. Open a pipeline with only validation warnings — confirm the Play icon is amber and tooltip reads "Pipeline has validation warnings".
3. Open a pipeline with validation errors — confirm the Play icon is red, tooltip reads "Pipeline has validation errors", and the button is disabled.

## Additional Comments