### PR TITLE
feat: v2 - resolution for missing input value

### DIFF
--- a/src/routes/v2/pages/Editor/components/IssueResolution/ValidationIssueResolutionCard.tsx
+++ b/src/routes/v2/pages/Editor/components/IssueResolution/ValidationIssueResolutionCard.tsx
@@ -15,6 +15,7 @@ import { BadReferenceResolution } from "./resolutions/BadReferenceResolution";
 import { DeleteEntityResolution } from "./resolutions/DeleteEntityResolution";
 import { DuplicateNameResolution } from "./resolutions/DuplicateNameResolution";
 import { InfoOnlyResolution } from "./resolutions/InfoOnlyResolution";
+import { MissingPipelineInputValueResolution } from "./resolutions/MissingPipelineInputValueResolution";
 import { MissingRequiredInputResolution } from "./resolutions/MissingRequiredInputResolution";
 import { RenameEntityResolution } from "./resolutions/RenameEntityResolution";
 import { useValidationResolutionActions } from "./useValidationResolutionActions";
@@ -152,10 +153,9 @@ function renderInfoResolution(message: string): ReactNode {
 }
 
 const RESOLUTION_MAP: Record<ValidationIssueCode, ResolutionResolver> = {
-  MISSING_PIPELINE_INPUT_VALUE: () =>
-    renderInfoResolution(
-      "Set a default or pipeline value on this input in pipeline details, or mark the input as optional.",
-    ),
+  MISSING_PIPELINE_INPUT_VALUE: (p) => (
+    <MissingPipelineInputValueResolution issue={p.issue} spec={p.spec} />
+  ),
   MISSING_REQUIRED_ANNOTATION: () =>
     renderInfoResolution(
       "Open the task and fill in the required launcher annotation in the task settings.",

--- a/src/routes/v2/pages/Editor/components/IssueResolution/resolutions/MissingPipelineInputValueResolution.tsx
+++ b/src/routes/v2/pages/Editor/components/IssueResolution/resolutions/MissingPipelineInputValueResolution.tsx
@@ -1,0 +1,74 @@
+import { observer } from "mobx-react-lite";
+
+import { BlockStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
+import type { ComponentSpec, ValidationIssue } from "@/models/componentSpec";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
+import { AutoGrowTextarea } from "@/routes/v2/pages/Editor/components/AutoGrowTextArea";
+import { InputLabel } from "@/routes/v2/pages/Editor/components/InputLabel/InputLabel";
+import { useIOActions } from "@/routes/v2/pages/Editor/store/actions/useIOActions";
+
+import { InfoOnlyResolution } from "./InfoOnlyResolution";
+
+export const MissingPipelineInputValueResolution = observer(
+  function MissingPipelineInputValueResolution({
+    issue,
+    spec,
+  }: {
+    issue: ValidationIssue;
+    spec: ComponentSpec;
+  }) {
+    const { track } = useAnalytics();
+    const ioActions = useIOActions();
+
+    if (!issue.entityId) {
+      return (
+        <InfoOnlyResolution message="Cannot resolve: missing pipeline input id." />
+      );
+    }
+
+    const input = spec.inputs.find((i) => i.$id === issue.entityId);
+    if (!input) {
+      return (
+        <InfoOnlyResolution message="Pipeline input not found in the current graph." />
+      );
+    }
+
+    const entityId = issue.entityId;
+
+    const handleDefaultValueChange = (value: string) => {
+      const newDefault = value || undefined;
+      if (newDefault !== input.defaultValue) {
+        ioActions.setInputDefaultValue(spec, entityId, newDefault);
+        track("v2.pipeline_editor.input_details.default_value.updated");
+      }
+    };
+
+    return (
+      <BlockStack gap="2">
+        <Text size="xs" weight="semibold" className="text-gray-700">
+          Set a default value for pipeline input &ldquo;{input.name}&rdquo;
+        </Text>
+        <BlockStack gap="2">
+          <InputLabel
+            htmlFor="resolution-input-default-value"
+            onCopy={() => input.defaultValue}
+          >
+            Default value
+          </InputLabel>
+          <AutoGrowTextarea
+            id="resolution-input-default-value"
+            key={`${entityId}-default-value`}
+            expandDialogTitle="Default Value"
+            highlightSyntax={true}
+            defaultValue={input.defaultValue}
+            onChangeComplete={handleDefaultValueChange}
+            placeholder="Default value"
+            className="h-4 min-h-4 text-xs font-mono"
+            data-testid="resolution-pipeline-input-default-value"
+          />
+        </BlockStack>
+      </BlockStack>
+    );
+  },
+);


### PR DESCRIPTION
## Description

Replaces the static info-only message for `MISSING_PIPELINE_INPUT_VALUE` validation issues with an interactive resolution component. Users can now set a default value directly from the issue resolution card, rather than being directed to navigate elsewhere in the UI.

The new `MissingPipelineInputValueResolution` component looks up the relevant pipeline input by ID, renders a labeled text area pre-populated with the current default value, and calls `setInputDefaultValue` when the value changes. If the input ID is missing or the input cannot be found in the current graph, a fallback info message is shown.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

![image.png](https://app.graphite.com/user-attachments/assets/35691759-cd6e-41df-bc78-a9dc52d8f884.png)



## Test Instructions

1. Open a pipeline that has a `MISSING_PIPELINE_INPUT_VALUE` validation issue.
2. Open the issue resolution card for the affected input.
3. Verify that a default value text area is rendered, pre-populated with any existing default.
4. Enter a new default value and confirm it is saved to the pipeline input.
5. Verify that removing the value clears the default (sets it to `undefined`).
6. Verify that inputs with a missing or unresolvable entity ID display the appropriate fallback message.

## Additional Comments

Analytics are tracked via `v2.pipeline_editor.input_details.default_value.updated` when a default value is changed through this resolution card.