### PR TITLE
chore: v2 - beta flag for v2 editor

### DIFF
--- a/src/components/shared/EditorVersionToggle.tsx
+++ b/src/components/shared/EditorVersionToggle.tsx
@@ -4,7 +4,7 @@ import TooltipButton from "@/components/shared/Buttons/TooltipButton";
 import { Icon } from "@/components/ui/icon";
 import { APP_ROUTES, EDITOR_PATH } from "@/routes/router";
 
-const isEnabled = import.meta.env.VITE_ENABLE_V2_EDITOR_TOGGLE === "true";
+import { useFlagValue } from "./Settings/useFlags";
 
 type EditorVersion = "v1" | "v2";
 
@@ -17,6 +17,7 @@ const detectEditorVersion = (pathname: string): EditorVersion | null => {
 export const EditorVersionToggle = () => {
   const location = useLocation();
   const navigate = useNavigate();
+  const isEnabled = useFlagValue("v2_editor");
 
   if (!isEnabled) return null;
 

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -46,4 +46,12 @@ export const ExistingFlags: ConfigFlags = {
     default: false,
     category: "beta",
   },
+
+  ["v2_editor"]: {
+    name: "V2 Editor",
+    description:
+      "Enable the V2 Editor. You can switch back and forth between the V1 and V2 editors.",
+    default: false,
+    category: "beta",
+  },
 };


### PR DESCRIPTION
## Description

The V2 Editor toggle has been migrated from an environment variable (`VITE_ENABLE_V2_EDITOR_TOGGLE`) to a feature flag (`v2_editor`). This allows the V2 Editor to be toggled at runtime through the flags/settings system rather than requiring a build-time environment variable. The new flag is categorized under `beta` and defaults to `false`.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

[Screen Recording 2026-05-08 at 9.20.22 AM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/eb2a2c6b-9b55-48c0-959b-54d451cc9461.mov" />](https://app.graphite.com/user-attachments/video/eb2a2c6b-9b55-48c0-959b-54d451cc9461.mov)

## Test Instructions

1. Navigate to the Settings/Flags panel and enable the `V2 Editor` beta flag.
2. Verify the editor version toggle appears in the UI.
3. Disable the flag and confirm the toggle is hidden.
4. Confirm that the `VITE_ENABLE_V2_EDITOR_TOGGLE` environment variable no longer has any effect on the toggle visibility.

## Additional Comments

Any existing deployments relying on the `VITE_ENABLE_V2_EDITOR_TOGGLE` environment variable to enable the V2 editor toggle will need to switch to enabling the `v2_editor` feature flag instead.