### PR TITLE
chore: v2 - integrate update components

### DIFF
--- a/src/components/shared/ManageComponent/hooks/useOutdatedComponents.ts
+++ b/src/components/shared/ManageComponent/hooks/useOutdatedComponents.ts
@@ -14,6 +14,15 @@ import { hasSupersededBy } from "../types";
 import { hydrateAllComponents } from "../utils/hydrateAllComponents";
 import { useAllPublishedComponents } from "./useAllPublishedComponents";
 
+function usedComponentsQueryKeyDigests(
+  usedComponents: ComponentReference[],
+): string[] {
+  return usedComponents
+    .map((c) => c.digest)
+    .filter((d): d is string => Boolean(d))
+    .sort();
+}
+
 /**
  * Hook to get the outdated components in the graph
  *
@@ -25,8 +34,10 @@ export function useOutdatedComponents(usedComponents: ComponentReference[]) {
   const { existingComponentLibraries, getComponentLibrary } =
     useComponentLibrary();
 
+  const usedDigestsKey = usedComponentsQueryKeyDigests(usedComponents);
+
   return useSuspenseQuery({
-    queryKey: ["outdated-components", usedComponents],
+    queryKey: ["outdated-components", usedDigestsKey],
     staleTime: 1000 * 60 * 5,
     queryFn: async () => {
       const mostRecentComponents = await findMostRecentComponents(

--- a/src/components/shared/ReactFlow/FlowSidebar/components/UpgradeAvailableAlertBox.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/components/UpgradeAvailableAlertBox.tsx
@@ -1,3 +1,4 @@
+import { observer } from "mobx-react-lite";
 import { useCallback, useState } from "react";
 
 import { InfoBox } from "@/components/shared/InfoBox";
@@ -9,6 +10,13 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Paragraph } from "@/components/ui/typography";
 import useToastNotification from "@/hooks/useToastNotification";
 import { useComponentLibrary } from "@/providers/ComponentLibraryProvider";
+import { useUpgradeComponentsWindow } from "@/routes/v2/pages/Editor/components/UpgradeComponents/useUpgradeComponentsWindow";
+import {
+  collectUsedComponentReferencesFromV2Spec,
+  EMPTY_USED_COMPONENTS,
+} from "@/routes/v2/pages/Editor/components/UpgradeComponents/utils/collectUsedComponentReferencesFromV2Spec";
+import { useSpec } from "@/routes/v2/shared/providers/SpecContext";
+import { useOptionalWindowContext } from "@/routes/v2/shared/windows/ContentWindowStateContext";
 import { getStorage } from "@/utils/typedStorage";
 
 import { useNodesOverlay } from "../../NodesOverlay/NodesOverlayProvider";
@@ -21,29 +29,66 @@ const UpgradeAvailableAlertBoxSkeleton = () => {
   );
 };
 
-/**
- * Component to display an alert box when there are outdated components in the graph
- *
- * @returns The UpgradeAvailableAlertBox component
- */
-export const UpgradeAvailableAlertBox = withSuspenseWrapper(
-  () => {
-    const notify = useToastNotification();
-    const [dismissed, setDismissed] = useDissmissedStorage();
+interface UpgradeAlertViewProps {
+  onReview: () => void;
+  onDismiss: () => void;
+}
 
+function UpgradeAlertView({ onReview, onDismiss }: UpgradeAlertViewProps) {
+  return (
+    <BlockStack className="px-2">
+      <InfoBox title="Upgrades available" key="outdated-components">
+        <BlockStack gap="2">
+          <Paragraph size="xs">
+            You have outdated components used in your Pipeline.
+          </Paragraph>
+          <InlineStack align="space-between" className="w-full">
+            <Button size="xs" variant="secondary" onClick={onDismiss}>
+              Dismiss
+            </Button>
+            <Button size="xs" onClick={onReview}>
+              Review
+            </Button>
+          </InlineStack>
+        </BlockStack>
+      </InfoBox>
+    </BlockStack>
+  );
+}
+
+/**
+ * Computes alert visibility (outdated > 0 && not dismissed) and a dismiss
+ * callback that persists the dismissal and toasts the user.
+ */
+function useUpgradeAlertVisibility(outdatedCount: number) {
+  const notify = useToastNotification();
+  const [dismissed, setDismissed] = useDissmissedStorage();
+
+  const dismiss = useCallback(() => {
+    setDismissed();
+    notify("Upgrade alert dismissed for next 24 hours", "success");
+  }, [setDismissed, notify]);
+
+  return {
+    visible: outdatedCount > 0 && !dismissed,
+    dismiss,
+  };
+}
+
+const UpgradeAvailableAlertBoxLegacy = withSuspenseWrapper(
+  function UpgradeAvailableAlertBoxLegacyInner() {
     const { usedComponentsFolder } = useComponentLibrary();
 
     const { data: outdatedComponents } = useOutdatedComponents(
       usedComponentsFolder.components ?? [],
     );
 
+    const { visible, dismiss } = useUpgradeAlertVisibility(
+      outdatedComponents.length,
+    );
+
     const { notifyNode, getNodeIdsByDigest, fitNodeIntoView } =
       useNodesOverlay();
-
-    const dismissCallback = useCallback(() => {
-      setDismissed();
-      notify("Upgrade alert dismissed for next 24 hours", "success");
-    }, [setDismissed, notify]);
 
     const upgradeAllComponentsCallback = useCallback(async () => {
       if (outdatedComponents.length === 0) {
@@ -77,36 +122,68 @@ export const UpgradeAvailableAlertBox = withSuspenseWrapper(
       });
     }, [getNodeIdsByDigest, fitNodeIntoView, notifyNode, outdatedComponents]);
 
-    const showOutdatedComponentsAlert =
-      outdatedComponents.length > 0 && !dismissed;
-
-    if (!showOutdatedComponentsAlert) {
+    if (!visible) {
       return null;
     }
 
     return (
-      <BlockStack className="px-2">
-        <InfoBox title="Upgrades available" key="outdated-components">
-          <BlockStack gap="2">
-            <Paragraph size="xs">
-              You have outdated components used in your Pipeline.
-            </Paragraph>
-            <InlineStack align="space-between" className="w-full">
-              <Button size="xs" variant="secondary" onClick={dismissCallback}>
-                Dismiss
-              </Button>
-              <Button size="xs" onClick={upgradeAllComponentsCallback}>
-                Review
-              </Button>
-            </InlineStack>
-          </BlockStack>
-        </InfoBox>
-      </BlockStack>
+      <UpgradeAlertView
+        onDismiss={dismiss}
+        onReview={upgradeAllComponentsCallback}
+      />
     );
   },
   UpgradeAvailableAlertBoxSkeleton,
   () => null,
 );
+
+const UpgradeAvailableAlertBoxV2WindowInner = observer(
+  function UpgradeAvailableAlertBoxV2WindowInner() {
+    const openUpgradeComponentsWindow = useUpgradeComponentsWindow();
+    const spec = useSpec();
+
+    const usedComponents = spec
+      ? collectUsedComponentReferencesFromV2Spec(spec)
+      : EMPTY_USED_COMPONENTS;
+
+    const { data: outdatedComponents } = useOutdatedComponents(usedComponents);
+
+    const { visible, dismiss } = useUpgradeAlertVisibility(
+      outdatedComponents.length,
+    );
+
+    if (!spec || !visible) {
+      return null;
+    }
+
+    return (
+      <UpgradeAlertView
+        onDismiss={dismiss}
+        onReview={() => openUpgradeComponentsWindow()}
+      />
+    );
+  },
+);
+
+const UpgradeAvailableAlertBoxV2Window = withSuspenseWrapper(
+  UpgradeAvailableAlertBoxV2WindowInner,
+  UpgradeAvailableAlertBoxSkeleton,
+  () => null,
+);
+
+/**
+ * When this component is rendered inside the v2 window chrome (e.g. docked
+ * Component Library), `useOptionalWindowContext()` is defined and Review opens
+ * the v2 Upgrade Components window. In the v1 sidebar there is no window
+ * context; Review uses the nodes overlay flow instead.
+ */
+export function UpgradeAvailableAlertBox() {
+  const windowCtx = useOptionalWindowContext();
+  if (windowCtx) {
+    return <UpgradeAvailableAlertBoxV2Window />;
+  }
+  return <UpgradeAvailableAlertBoxLegacy />;
+}
 
 interface DismissedStorage {
   upgradeAvailableAlertDismissed: Date | undefined;

--- a/src/routes/v2/pages/Editor/components/DebugPanel.tsx
+++ b/src/routes/v2/pages/Editor/components/DebugPanel.tsx
@@ -87,7 +87,7 @@ const DebugPanelContent = observer(function DebugPanelContent() {
               size="sm"
               className="w-full justify-start gap-2"
               {...tracking("v2.pipeline_editor.debug_panel.upgrade_components")}
-              onClick={openUpgradeComponentsWindow}
+              onClick={() => openUpgradeComponentsWindow({ useMock: true })}
             >
               <Icon name="CircleArrowUp" size="sm" />
               Upgrade Components

--- a/src/routes/v2/pages/Editor/components/EditorMenuBar/components/WindowsMenu.tsx
+++ b/src/routes/v2/pages/Editor/components/EditorMenuBar/components/WindowsMenu.tsx
@@ -24,9 +24,9 @@ import { tracking } from "@/utils/tracking";
 export const WindowsMenu = observer(function WindowsMenu() {
   const { track } = useAnalytics();
   const { windows } = useSharedStores();
-  const sortedWindows = [...windows.getAllWindows()].sort((a, b) =>
-    a.title.localeCompare(b.title),
-  );
+  const sortedWindows = [...windows.getAllWindows()]
+    .filter((window) => window.persisted)
+    .sort((a, b) => a.title.localeCompare(b.title));
 
   const applyPreset = (preset: ViewPreset) => {
     track("v2.pipeline_editor.windows_menu.view_preset.click", {

--- a/src/routes/v2/pages/Editor/components/UpgradeComponents/UpgradeComponentsContent.tsx
+++ b/src/routes/v2/pages/Editor/components/UpgradeComponents/UpgradeComponentsContent.tsx
@@ -1,3 +1,4 @@
+import { observer } from "mobx-react-lite";
 import { useState } from "react";
 
 import { BlockStack } from "@/components/ui/layout";
@@ -5,7 +6,7 @@ import { VerticalResizeHandle } from "@/components/ui/resize-handle";
 import { Separator } from "@/components/ui/separator";
 import { useTaskActions } from "@/routes/v2/pages/Editor/store/actions/useTaskActions";
 import { useSpec } from "@/routes/v2/shared/providers/SpecContext";
-import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
+import { useOptionalWindowContext } from "@/routes/v2/shared/windows/ContentWindowStateContext";
 
 import { UpgradeCandidateDetail } from "./components/UpgradeCandidateDetail";
 import { UpgradeCandidateRow } from "./components/UpgradeCandidateRow";
@@ -14,16 +15,25 @@ import { UpgradeFooter } from "./components/UpgradeFooter";
 import { UpgradeHeader } from "./components/UpgradeHeader";
 import { useMockUpgradeCandidates } from "./hooks/useMockUpgradeCandidates";
 import { useSelectionSet } from "./hooks/useSelectionSet";
+import { useUpgradeCandidatesFromOutdated } from "./hooks/useUpgradeCandidatesFromOutdated";
 import { useUpgradePreviewOverlay } from "./hooks/useUpgradePreviewOverlay";
-import { candidateHasIssues } from "./types";
+import { candidateHasIssues, type UpgradeCandidate } from "./types";
 
-const WINDOW_ID = "upgrade-components";
 const DEFAULT_LEFT_PANEL_WIDTH = 340;
 
-export function UpgradeComponentsContent() {
+type UpgradeComponentsDataSource = "real" | "mock";
+
+interface UpgradeComponentsContentProps {
+  dataSource?: UpgradeComponentsDataSource;
+}
+
+const UpgradeComponentsInner = observer(function UpgradeComponentsInner({
+  candidates,
+}: {
+  candidates: UpgradeCandidate[];
+}) {
   const spec = useSpec();
-  const { windows } = useSharedStores();
-  const candidates = useMockUpgradeCandidates(true);
+  const windowCtx = useOptionalWindowContext();
   const { upgradeSelectedTasks } = useTaskActions();
 
   const candidateIds = candidates.map((c) => c.taskId);
@@ -40,12 +50,16 @@ export function UpgradeComponentsContent() {
   const focusedCandidate = candidates.find((c) => c.taskId === focusedId);
 
   const handleUpgrade = () => {
-    if (!spec || selectedCandidates.length === 0) return;
+    if (!spec || selectedCandidates.length === 0) {
+      return;
+    }
     upgradeSelectedTasks(spec, selectedCandidates);
-    windows.closeWindow(WINDOW_ID);
+    windowCtx?.model.close();
   };
 
-  if (candidates.length === 0) return <UpgradeEmptyState />;
+  if (candidates.length === 0) {
+    return <UpgradeEmptyState />;
+  }
 
   const issueCount = candidates.filter(candidateHasIssues).length;
 
@@ -94,8 +108,31 @@ export function UpgradeComponentsContent() {
       <UpgradeFooter
         selectedCount={selectedCandidates.length}
         onUpgrade={handleUpgrade}
-        onCancel={() => windows.closeWindow(WINDOW_ID)}
+        onCancel={() => windowCtx?.model.close()}
       />
     </BlockStack>
   );
+});
+
+const UpgradeComponentsContentReal = observer(
+  function UpgradeComponentsContentReal() {
+    const candidates = useUpgradeCandidatesFromOutdated();
+    return <UpgradeComponentsInner candidates={candidates} />;
+  },
+);
+
+const UpgradeComponentsContentMock = observer(
+  function UpgradeComponentsContentMock() {
+    const candidates = useMockUpgradeCandidates(true);
+    return <UpgradeComponentsInner candidates={candidates} />;
+  },
+);
+
+export function UpgradeComponentsContent({
+  dataSource = "real",
+}: UpgradeComponentsContentProps) {
+  if (dataSource === "mock") {
+    return <UpgradeComponentsContentMock />;
+  }
+  return <UpgradeComponentsContentReal />;
 }

--- a/src/routes/v2/pages/Editor/components/UpgradeComponents/hooks/useMockUpgradeCandidates.ts
+++ b/src/routes/v2/pages/Editor/components/UpgradeComponents/hooks/useMockUpgradeCandidates.ts
@@ -1,17 +1,11 @@
-import type { ComponentReference } from "@/models/componentSpec";
+import type { ComponentReference, Task } from "@/models/componentSpec";
 import type { ComponentSpec } from "@/models/componentSpec/entities/componentSpec";
 import type {
   InputSpec,
   OutputSpec,
 } from "@/models/componentSpec/entities/types";
-import type {
-  LostBinding,
-  UpgradeCandidate,
-} from "@/routes/v2/pages/Editor/components/UpgradeComponents/types";
-import {
-  computeDiffComponentSpecs,
-  predictUpgradeIssues,
-} from "@/routes/v2/pages/Editor/store/actions/task.utils";
+import type { UpgradeCandidate } from "@/routes/v2/pages/Editor/components/UpgradeComponents/types";
+import { buildUpgradeCandidateFromResolved } from "@/routes/v2/pages/Editor/components/UpgradeComponents/utils/buildUpgradeCandidateFromResolved";
 import { useSpec } from "@/routes/v2/shared/providers/SpecContext";
 
 /**
@@ -92,70 +86,24 @@ function buildMockComponentRef(
   };
 }
 
-function collectLostBindings(
-  taskId: string,
-  diff: ReturnType<typeof computeDiffComponentSpecs>,
-  spec: ComponentSpec,
-): LostBinding[] {
-  const lostInputNames = new Set(
-    diff.inputDiff.lostEntities.map((i) => i.name),
-  );
-  const lostOutputNames = new Set(
-    diff.outputDiff.lostEntities.map((o) => o.name),
-  );
-
-  const result: LostBinding[] = [];
-
-  for (const b of spec.bindings) {
-    if (b.targetEntityId === taskId && lostInputNames.has(b.targetPortName)) {
-      result.push({
-        bindingId: b.$id,
-        sourceEntityId: b.sourceEntityId,
-        sourcePortName: b.sourcePortName,
-        targetEntityId: b.targetEntityId,
-        targetPortName: b.targetPortName,
-        reason: "lost_input",
-      });
-    }
-    if (b.sourceEntityId === taskId && lostOutputNames.has(b.sourcePortName)) {
-      result.push({
-        bindingId: b.$id,
-        sourceEntityId: b.sourceEntityId,
-        sourcePortName: b.sourcePortName,
-        targetEntityId: b.targetEntityId,
-        targetPortName: b.targetPortName,
-        reason: "lost_output",
-      });
-    }
-  }
-
-  return result;
-}
-
-function buildCandidate(
-  taskId: string,
-  taskName: string,
-  currentRef: ComponentReference,
+function buildMockCandidateForTask(
+  task: Task,
   spec: ComponentSpec,
 ): UpgradeCandidate | null {
-  const currentDigest = currentRef.digest;
-  if (!currentDigest) return null;
+  const currentDigest = task.componentRef.digest;
+  if (!currentDigest) {
+    return null;
+  }
 
-  const newComponentRef = buildMockComponentRef(currentRef, taskName);
-  const diff = computeDiffComponentSpecs(currentRef.spec, newComponentRef.spec);
-  const lostBindings = collectLostBindings(taskId, diff, spec);
-  const predictedIssues = predictUpgradeIssues(taskId, diff, lostBindings);
-
-  return {
-    taskId,
-    taskName,
+  const newComponentRef = buildMockComponentRef(task.componentRef, task.name);
+  return buildUpgradeCandidateFromResolved(
+    task.$id,
+    task.name,
     currentDigest,
+    task.resolvedComponentSpec,
     newComponentRef,
-    inputDiff: diff.inputDiff,
-    outputDiff: diff.outputDiff,
-    lostBindings,
-    predictedIssues,
-  };
+    spec,
+  );
 }
 
 /**
@@ -164,40 +112,44 @@ function buildCandidate(
  */
 export function useMockUpgradeCandidates(enabled = true): UpgradeCandidate[] {
   const spec = useSpec();
-  if (!enabled || !spec) return [];
+  if (!enabled || !spec) {
+    return [];
+  }
 
   const candidates: UpgradeCandidate[] = [];
   let count = 0;
   for (const task of spec.tasks) {
-    const candidate = buildCandidate(
-      task.$id,
-      task.name,
-      task.componentRef,
-      spec,
-    );
-    if (candidate) candidates.push(candidate);
+    const candidate = buildMockCandidateForTask(task, spec);
+    if (candidate) {
+      candidates.push(candidate);
+    }
     count++;
-    if (count > spec.tasks.length / 2) break;
+    if (count > spec.tasks.length / 2) {
+      break;
+    }
   }
 
-  candidates.push({
-    taskId: spec.tasks[count].$id,
-    taskName: spec.tasks[count].name,
-    currentDigest: "clean-digest",
-    newComponentRef: spec.tasks[count].componentRef,
-    inputDiff: {
-      lostEntities: [],
-      newEntities: [],
-      changedEntities: [],
-    },
-    outputDiff: {
-      lostEntities: [],
-      newEntities: [],
-      changedEntities: [],
-    },
-    lostBindings: [],
-    predictedIssues: [],
-  });
+  const tailTask = spec.tasks[count];
+  if (tailTask) {
+    candidates.push({
+      taskId: tailTask.$id,
+      taskName: tailTask.name,
+      currentDigest: "clean-digest",
+      newComponentRef: tailTask.componentRef,
+      inputDiff: {
+        lostEntities: [],
+        newEntities: [],
+        changedEntities: [],
+      },
+      outputDiff: {
+        lostEntities: [],
+        newEntities: [],
+        changedEntities: [],
+      },
+      lostBindings: [],
+      predictedIssues: [],
+    });
+  }
 
   return candidates;
 }

--- a/src/routes/v2/pages/Editor/components/UpgradeComponents/hooks/useUpgradeCandidatesFromOutdated.ts
+++ b/src/routes/v2/pages/Editor/components/UpgradeComponents/hooks/useUpgradeCandidatesFromOutdated.ts
@@ -1,0 +1,61 @@
+import { useOutdatedComponents } from "@/components/shared/ManageComponent/hooks/useOutdatedComponents";
+import type { ComponentReference } from "@/models/componentSpec";
+import type { UpgradeCandidate } from "@/routes/v2/pages/Editor/components/UpgradeComponents/types";
+import { buildUpgradeCandidateFromResolved } from "@/routes/v2/pages/Editor/components/UpgradeComponents/utils/buildUpgradeCandidateFromResolved";
+import {
+  collectUsedComponentReferencesFromV2Spec,
+  EMPTY_USED_COMPONENTS,
+} from "@/routes/v2/pages/Editor/components/UpgradeComponents/utils/collectUsedComponentReferencesFromV2Spec";
+import { useSpec } from "@/routes/v2/shared/providers/SpecContext";
+
+/**
+ * Upgrade candidates derived from {@link useOutdatedComponents} for the
+ * current graph's used components, aligned with {@link replaceTask} previews.
+ *
+ * The window is only opened from the V2 editor, so {@link useSpec} should
+ * always return a non-null spec here; the null branch is defensive and
+ * returns no candidates without iterating the spec.
+ */
+export function useUpgradeCandidatesFromOutdated(): UpgradeCandidate[] {
+  const spec = useSpec();
+
+  const usedComponents = spec
+    ? collectUsedComponentReferencesFromV2Spec(spec)
+    : EMPTY_USED_COMPONENTS;
+
+  const { data: outdatedPairs } = useOutdatedComponents(usedComponents);
+
+  if (!spec) {
+    return [];
+  }
+
+  const digestToMrc = new Map<string, ComponentReference>();
+  for (const [outdated, mrc] of outdatedPairs) {
+    digestToMrc.set(outdated.digest, mrc);
+  }
+
+  const candidates: UpgradeCandidate[] = [];
+  for (const task of spec.tasks) {
+    const digest = task.componentRef.digest;
+    if (!digest) {
+      continue;
+    }
+    const newComponentRef = digestToMrc.get(digest);
+    if (!newComponentRef) {
+      continue;
+    }
+
+    candidates.push(
+      buildUpgradeCandidateFromResolved(
+        task.$id,
+        task.name,
+        digest,
+        task.resolvedComponentSpec,
+        newComponentRef,
+        spec,
+      ),
+    );
+  }
+
+  return candidates;
+}

--- a/src/routes/v2/pages/Editor/components/UpgradeComponents/useUpgradeComponentsWindow.tsx
+++ b/src/routes/v2/pages/Editor/components/UpgradeComponents/useUpgradeComponentsWindow.tsx
@@ -1,3 +1,6 @@
+import { withSuspenseWrapper } from "@/components/shared/SuspenseWrapper";
+import { BlockStack } from "@/components/ui/layout";
+import { Skeleton } from "@/components/ui/skeleton";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 
 import { UpgradeComponentsContent } from "./UpgradeComponentsContent";
@@ -5,25 +8,59 @@ import { UpgradeComponentsContent } from "./UpgradeComponentsContent";
 const WINDOW_ID = "upgrade-components";
 const WINDOW_SIZE = { width: 720, height: 480 };
 
+function UpgradeComponentsWindowFallback() {
+  return (
+    <BlockStack
+      className="h-full gap-3 p-4"
+      data-testid="upgrade-components-window-fallback"
+    >
+      <Skeleton className="h-8 w-64 max-w-full" />
+      <Skeleton className="min-h-32 flex-1 w-full" />
+      <Skeleton className="h-9 w-28" />
+    </BlockStack>
+  );
+}
+
+const UpgradeComponentsContentRealWithBoundary = withSuspenseWrapper(
+  function UpgradeComponentsContentRealBoundary() {
+    return <UpgradeComponentsContent dataSource="real" />;
+  },
+  UpgradeComponentsWindowFallback,
+);
+
+interface OpenUpgradeComponentsWindowOptions {
+  useMock?: boolean;
+}
+
 export function useUpgradeComponentsWindow() {
   const { windows, keyboard } = useSharedStores();
 
-  const openUpgradeWindow = () => {
+  const openUpgradeComponentsWindow = (
+    options?: OpenUpgradeComponentsWindowOptions,
+  ) => {
     const position = { x: globalThis.innerWidth - WINDOW_SIZE.width, y: 60 };
 
     // todo: replace ad-hoc solution with more robust solution
     keyboard.invokeShortcut("focus-mode");
 
-    windows.openWindow(<UpgradeComponentsContent />, {
+    const content =
+      options?.useMock === true ? (
+        <UpgradeComponentsContent dataSource="mock" />
+      ) : (
+        <UpgradeComponentsContentRealWithBoundary />
+      );
+
+    windows.openWindow(content, {
       id: WINDOW_ID,
       title: "Upgrade Components",
       size: WINDOW_SIZE,
       minSize: { width: 600, height: 300 },
       position,
       startVisible: true,
+      disabledActions: ["hide", "minimize", "maximize"],
       onClose: () => keyboard.invokeShortcut("focus-mode"),
     });
   };
 
-  return openUpgradeWindow;
+  return openUpgradeComponentsWindow;
 }

--- a/src/routes/v2/pages/Editor/components/UpgradeComponents/utils/buildUpgradeCandidateFromResolved.ts
+++ b/src/routes/v2/pages/Editor/components/UpgradeComponents/utils/buildUpgradeCandidateFromResolved.ts
@@ -1,0 +1,84 @@
+import type {
+  ComponentReference,
+  ComponentSpec,
+  ComponentSpecJson,
+} from "@/models/componentSpec";
+import type {
+  LostBinding,
+  UpgradeCandidate,
+} from "@/routes/v2/pages/Editor/components/UpgradeComponents/types";
+import {
+  computeDiffComponentSpecs,
+  predictUpgradeIssues,
+} from "@/routes/v2/pages/Editor/store/actions/task.utils";
+
+function collectLostBindings(
+  taskId: string,
+  diff: ReturnType<typeof computeDiffComponentSpecs>,
+  spec: ComponentSpec,
+): LostBinding[] {
+  const lostInputNames = new Set(
+    diff.inputDiff.lostEntities.map((i) => i.name),
+  );
+  const lostOutputNames = new Set(
+    diff.outputDiff.lostEntities.map((o) => o.name),
+  );
+
+  const result: LostBinding[] = [];
+
+  for (const b of spec.bindings) {
+    if (b.targetEntityId === taskId && lostInputNames.has(b.targetPortName)) {
+      result.push({
+        bindingId: b.$id,
+        sourceEntityId: b.sourceEntityId,
+        sourcePortName: b.sourcePortName,
+        targetEntityId: b.targetEntityId,
+        targetPortName: b.targetPortName,
+        reason: "lost_input",
+      });
+    }
+    if (b.sourceEntityId === taskId && lostOutputNames.has(b.sourcePortName)) {
+      result.push({
+        bindingId: b.$id,
+        sourceEntityId: b.sourceEntityId,
+        sourcePortName: b.sourcePortName,
+        targetEntityId: b.targetEntityId,
+        targetPortName: b.targetPortName,
+        reason: "lost_output",
+      });
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Builds an upgrade candidate using the same old/new spec pairing as
+ * {@link replaceTask} (resolved task spec vs target component ref spec).
+ */
+export function buildUpgradeCandidateFromResolved(
+  taskId: string,
+  taskName: string,
+  currentDigest: string,
+  resolvedComponentSpec: ComponentSpecJson | undefined,
+  newComponentRef: ComponentReference,
+  spec: ComponentSpec,
+): UpgradeCandidate {
+  const diff = computeDiffComponentSpecs(
+    resolvedComponentSpec,
+    newComponentRef.spec,
+  );
+  const lostBindings = collectLostBindings(taskId, diff, spec);
+  const predictedIssues = predictUpgradeIssues(taskId, diff, lostBindings);
+
+  return {
+    taskId,
+    taskName,
+    currentDigest,
+    newComponentRef,
+    inputDiff: diff.inputDiff,
+    outputDiff: diff.outputDiff,
+    lostBindings,
+    predictedIssues,
+  };
+}

--- a/src/routes/v2/pages/Editor/components/UpgradeComponents/utils/collectUsedComponentReferencesFromV2Spec.ts
+++ b/src/routes/v2/pages/Editor/components/UpgradeComponents/utils/collectUsedComponentReferencesFromV2Spec.ts
@@ -1,0 +1,22 @@
+import type { ComponentReference, ComponentSpec } from "@/models/componentSpec";
+
+export const EMPTY_USED_COMPONENTS: ComponentReference[] = [];
+
+/**
+ * Unique component references used by tasks in the current V2 editor spec
+ * (deduped by digest). Mirrors {@link fetchUsedComponents} for graph tasks.
+ */
+export function collectUsedComponentReferencesFromV2Spec(
+  spec: ComponentSpec,
+): ComponentReference[] {
+  const usedComponentsMap = new Map<string, ComponentReference>();
+
+  for (const task of spec.tasks) {
+    const key = task.componentRef.digest;
+    if (key && !usedComponentsMap.has(key)) {
+      usedComponentsMap.set(key, { ...task.componentRef });
+    }
+  }
+
+  return Array.from(usedComponentsMap.values());
+}


### PR DESCRIPTION
## Description

Wires the Upgrade Components window in the V2 editor to real outdated-component data instead of always using mock candidates.

Key changes:

- **`collectUsedComponentReferencesFromV2Spec`** – new utility that collects unique component references from V2 spec tasks (deduped by digest), mirroring the existing graph-based `fetchUsedComponents`.
- **`buildUpgradeCandidateFromResolved`** – extracted shared logic for building an `UpgradeCandidate` from a resolved task spec and a target component ref (including lost-binding detection and issue prediction). Previously this logic was duplicated inside `useMockUpgradeCandidates`.
- **`useUpgradeCandidatesFromOutdated`** – new hook that calls `useOutdatedComponents` with the V2 spec's used components and maps the outdated pairs to `UpgradeCandidate` objects using `buildUpgradeCandidateFromResolved`.
- **`UpgradeComponentsContent`** – now accepts a `dataSource` prop (`"real"` | `"mock"`). `"real"` (the default) uses `useUpgradeCandidatesFromOutdated`; `"mock"` uses the existing mock hook. The inner rendering logic is extracted into `UpgradeComponentsInner`.
- **`useUpgradeComponentsWindow`** – accepts an optional `{ useMock?: boolean }` argument. When `useMock` is true (debug panel only), it opens with mock data; otherwise it opens `UpgradeComponentsContent` with `dataSource="real"` wrapped in a suspense boundary with a skeleton fallback.
- **`UpgradeAvailableAlertBox`** – now renders two variants depending on whether a window context is present. Inside the V2 window chrome (e.g. docked Component Library), the Review button opens the Upgrade Components window via `useUpgradeComponentsWindow`. In the V1 sidebar (no window context), the existing nodes-overlay flow is preserved. Alert visibility and dismiss logic are extracted into a shared `useUpgradeAlertVisibility` hook.
- **`useOutdatedComponents`** **query key** – changed from the full `ComponentReference[]` array to a sorted array of digest strings, preventing unnecessary cache misses caused by object reference changes.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Improvement
- [x] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

[Component Update.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/e74ae907-17a2-4b04-9657-9909c92bb278.mov" />](https://app.graphite.com/user-attachments/video/e74ae907-17a2-4b04-9657-9909c92bb278.mov)



## Test Instructions

1. Open the V2 editor with a pipeline that has outdated components.
2. Confirm the "Upgrades available" alert appears in the docked Component Library sidebar.
3. Click **Review** — the Upgrade Components window should open and display the real outdated components with accurate diff previews (lost inputs/outputs highlighted).
4. Open the Debug Panel and click **Upgrade Components** — confirm it opens with mock candidates as before.
5. In the V1 sidebar, confirm the alert's **Review** button still triggers the nodes-overlay highlight flow and does not open the window.
6. Dismiss the alert and confirm it is suppressed for 24 hours with a toast notification.

## Additional Comments

The debug panel intentionally continues to use `useMock: true` so developers can exercise the upgrade UI without needing a pipeline with genuinely outdated components.