### PR TITLE
chore: v2 - restore focus mode

### DIFF
--- a/src/routes/v2/pages/Editor/components/EditorMenuBar/components/ViewMenu.tsx
+++ b/src/routes/v2/pages/Editor/components/EditorMenuBar/components/ViewMenu.tsx
@@ -5,6 +5,7 @@ import { CodeViewer } from "@/components/shared/CodeViewer";
 import type { LayoutAlgorithm } from "@/components/shared/ReactFlow/FlowCanvas/utils/autolayout";
 import {
   DropdownMenu,
+  DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator,
@@ -19,6 +20,7 @@ import { serializeComponentSpecToText } from "@/models/componentSpec";
 import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { MenuTriggerButton } from "@/routes/v2/shared/components/MenuTriggerButton";
 import { ShortcutBadge } from "@/routes/v2/shared/components/ShortcutBadge";
+import { focusModeStore } from "@/routes/v2/shared/hooks/useFocusMode";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 import { tracking } from "@/utils/tracking";
 
@@ -74,7 +76,7 @@ export const ViewMenu = observer(function ViewMenu() {
               ))}
             </DropdownMenuSubContent>
           </DropdownMenuSub>
-          <DropdownMenuSeparator />
+
           <DropdownMenuItem
             disabled={!spec}
             onSelect={() => {
@@ -85,6 +87,22 @@ export const ViewMenu = observer(function ViewMenu() {
             <Icon name="FileCode" size="sm" />
             View YAML
           </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuCheckboxItem
+            checked={focusModeStore.active}
+            onSelect={(e) => e.preventDefault()}
+            onCheckedChange={(checked) => {
+              track("v2.pipeline_editor.view_menu.focus_mode.toggle", {
+                enabled: checked,
+              });
+              focusModeStore.toggle();
+            }}
+          >
+            Focus mode
+            <DropdownMenuShortcut>
+              <ShortcutBadge id="focus-mode" />
+            </DropdownMenuShortcut>
+          </DropdownMenuCheckboxItem>
         </DropdownMenuContent>
       </DropdownMenu>
 

--- a/src/routes/v2/pages/Editor/components/FlowCanvas/FlowCanvas.tsx
+++ b/src/routes/v2/pages/Editor/components/FlowCanvas/FlowCanvas.tsx
@@ -90,7 +90,7 @@ export const FlowCanvas = observer(function FlowCanvas({
       fill
       className={cn(
         "relative select-none",
-        focusModeActive && "border-2 border-red-500",
+        focusModeActive && "ring-2 ring-blue-500",
         className,
       )}
     >

--- a/src/routes/v2/shared/hooks/useFocusMode.ts
+++ b/src/routes/v2/shared/hooks/useFocusMode.ts
@@ -28,41 +28,35 @@ class FocusModeStore {
 export const focusModeStore = new FocusModeStore();
 
 /**
- * Registers keyboard shortcuts for view presets:
- * - Cmd+Alt+/ : Toggle Minimal layout (hide all panels)
- * - Cmd+Alt+D : Default layout
+ * Registers keyboard shortcuts:
+ * - Cmd+Alt+/ : Toggle Focus mode (temporarily hide dock panels without
+ *               mutating window layout state)
+ * - Cmd+Alt+D : Default layout (apply the Default view preset)
  */
 export function useFocusMode(): void {
   const { keyboard, windows } = useSharedStores();
 
-  const applyPreset = (presetLabel: string) => {
-    const preset = VIEW_PRESETS.find((p) => p.label === presetLabel);
-    if (!preset) return;
-    windows.applyViewPreset(preset);
-  };
-
   useEffect(() => {
-    const unregisterMinimal = keyboard.registerShortcut({
+    const unregisterFocusMode = keyboard.registerShortcut({
       id: "focus-mode",
       keys: [CMDALT, "/"],
-      label: "Minimal layout",
-      action: () => {
-        const allHidden = windows
-          .getAllWindows()
-          .every((w) => w.state === "hidden");
-        applyPreset(allHidden ? "Default" : "Minimal");
-      },
+      label: "Focus mode",
+      action: () => focusModeStore.toggle(),
     });
 
     const unregisterDefault = keyboard.registerShortcut({
       id: "default-layout",
       keys: [CMDALT, "D"],
       label: "Default layout",
-      action: () => applyPreset("Default"),
+      action: () => {
+        const preset = VIEW_PRESETS.find((p) => p.label === "Default");
+        if (!preset) return;
+        windows.applyViewPreset(preset);
+      },
     });
 
     return () => {
-      unregisterMinimal();
+      unregisterFocusMode();
       unregisterDefault();
     };
   }, [keyboard, windows]);

--- a/src/routes/v2/shared/windows/DockArea.tsx
+++ b/src/routes/v2/shared/windows/DockArea.tsx
@@ -19,6 +19,11 @@ interface DockAreaProps {
   side: "left" | "right";
 }
 
+// Context panel ("Properties") is selection-driven and stays visible in
+// focus mode so users can still inspect a selected task or multi-selection
+// without leaving focus mode.
+const FOCUS_MODE_ALLOWED_WINDOW_IDS = new Set(["context-panel"]);
+
 export const DockArea = observer(function DockArea({ side }: DockAreaProps) {
   const { windows } = useSharedStores();
   const dockArea = windows.getDockAreaConfig(side);
@@ -27,7 +32,11 @@ export const DockArea = observer(function DockArea({ side }: DockAreaProps) {
 
   const visibleWindows = windowOrder.filter((id) => {
     const win = windows.getWindowById(id);
-    return win && win.state !== "hidden";
+    if (!win || win.state === "hidden") return false;
+    if (focusModeStore.active && !FOCUS_MODE_ALLOWED_WINDOW_IDS.has(id)) {
+      return false;
+    }
+    return true;
   });
   const isEmpty = visibleWindows.length === 0;
 
@@ -58,7 +67,7 @@ export const DockArea = observer(function DockArea({ side }: DockAreaProps) {
     return () => observer.disconnect();
   }, [side, collapsed, isEmpty]);
 
-  if (isEmpty || focusModeStore.active) return null;
+  if (isEmpty) return null;
 
   const setRef = (element: HTMLDivElement | null) => {
     containerRef.current = element;


### PR DESCRIPTION
## Description

Focus mode now hides dock panels without mutating the underlying window layout state, meaning toggling it off restores panels exactly as they were before. Previously, focus mode applied the "Minimal" view preset, which permanently altered the layout.

The context panel ("Properties") is intentionally kept visible during focus mode so users can still inspect selected tasks or multi-selections without leaving focus mode.

Focus mode can now also be toggled directly from the View menu via a new checkbox item, in addition to the existing `Cmd+Alt+/` keyboard shortcut.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

[Screen Recording 2026-05-11 at 1.06.51 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/8efe1223-a811-4f34-b2ba-3279313bc105.mov" />](https://app.graphite.com/user-attachments/video/8efe1223-a811-4f34-b2ba-3279313bc105.mov)



## Test Instructions

1. Open the pipeline editor.
2. Toggle focus mode via `Cmd+Alt+/` or via **View → Focus mode** in the menu bar.
3. Verify that dock panels (except the context/Properties panel) are hidden.
4. Select a task and confirm the Properties panel remains visible in focus mode.
5. Toggle focus mode off and confirm all previously visible panels are restored to their original state.
6. Use `Cmd+Alt+D` to apply the Default layout and confirm it still works independently of focus mode.

## Additional Comments

The `Cmd+Alt+/` shortcut label has been updated from "Minimal layout" to "Focus mode" to reflect the new behavior.