### PR TITLE
fix: Table Visualizer Pagination

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ArtifactVisualizer.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ArtifactVisualizer.tsx
@@ -153,7 +153,6 @@ const ArtifactVisualizer = ({
               name={name}
               value={value}
               type={normalizedType}
-              remoteLink={artifactData?.uri}
               isFullscreen={isFullscreen}
             />
           ) : (
@@ -204,7 +203,6 @@ interface InlineContentProps {
   type: string;
   name: string;
   value: string;
-  remoteLink?: string | null;
   isFullscreen: boolean;
 }
 
@@ -212,19 +210,12 @@ const InlineContent = ({
   type,
   name,
   value,
-  remoteLink,
   isFullscreen,
 }: InlineContentProps) => {
   switch (type) {
     case "csv":
     case "tsv":
-      return (
-        <CsvVisualizerValue
-          value={value}
-          isFullscreen={isFullscreen}
-          remoteLink={remoteLink}
-        />
-      );
+      return <CsvVisualizerValue value={value} isFullscreen={isFullscreen} />;
     case "jsonobject":
     case "jsonarray":
       return <JsonVisualizerValue value={value} name={name} />;

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/CsvVisualizer.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/CsvVisualizer.tsx
@@ -2,11 +2,11 @@ import { Paragraph } from "@/components/ui/typography";
 
 import TableVisualizer from "./TableVisualizer";
 import { useArtifactFetch } from "./useArtifactFetch";
-import { type ArtifactTableData, parseCsv } from "./utils";
+import { useRowCap } from "./useRowCap";
+import { parseCsv, type ParsedArtifact } from "./utils";
 
 interface CsvVisualizerValueProps {
   value: string;
-  remoteLink?: string | null;
   isFullscreen: boolean;
 }
 
@@ -16,15 +16,15 @@ interface CsvVisualizerRemoteProps {
 }
 
 const CsvContent = ({
-  data,
-  remoteLink,
+  parsed,
   isFullscreen,
 }: {
-  data: ArtifactTableData;
-  remoteLink?: string | null;
+  parsed: ParsedArtifact;
   isFullscreen: boolean;
 }) => {
-  if (data.headers.length === 0) {
+  const { data, onLoadMore, onLoadAll } = useRowCap(parsed);
+
+  if (parsed.headers.length === 0) {
     return (
       <Paragraph tone="subdued" size="xs">
         No data
@@ -35,36 +35,29 @@ const CsvContent = ({
   return (
     <TableVisualizer
       data={data}
-      remoteLink={remoteLink}
       isFullscreen={isFullscreen}
+      onLoadMore={onLoadMore}
+      onLoadAll={onLoadAll}
     />
   );
 };
 
 export const CsvVisualizerValue = ({
   value,
-  remoteLink,
   isFullscreen,
 }: CsvVisualizerValueProps) => (
-  <CsvContent
-    data={parseCsv(value)}
-    remoteLink={remoteLink}
-    isFullscreen={isFullscreen}
-  />
+  <CsvContent parsed={parseCsv(value)} isFullscreen={isFullscreen} />
 );
 
 export const CsvVisualizerRemote = ({
   signedUrl,
   isFullscreen,
 }: CsvVisualizerRemoteProps) => {
-  const data = useArtifactFetch("csv", signedUrl, async (r) =>
-    parseCsv(await r.text()),
+  const parsed = useArtifactFetch<ParsedArtifact>(
+    "csv",
+    signedUrl,
+    async (response) => parseCsv(await response.text()),
   );
-  return (
-    <CsvContent
-      data={data}
-      remoteLink={signedUrl}
-      isFullscreen={isFullscreen}
-    />
-  );
+
+  return <CsvContent parsed={parsed} isFullscreen={isFullscreen} />;
 };

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ParquetVisualizer.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ParquetVisualizer.tsx
@@ -4,7 +4,8 @@ import { Paragraph } from "@/components/ui/typography";
 
 import TableVisualizer from "./TableVisualizer";
 import { useArtifactFetch } from "./useArtifactFetch";
-import { MAX_PREVIEW_ROWS } from "./utils";
+import { useRowCap } from "./useRowCap";
+import { MAX_PREVIEW_ROWS, type ParsedArtifact } from "./utils";
 
 interface ParquetVisualizerProps {
   signedUrl: string;
@@ -15,21 +16,33 @@ const ParquetVisualizer = ({
   signedUrl,
   isFullscreen,
 }: ParquetVisualizerProps) => {
-  const data = useArtifactFetch("parquet", signedUrl, async (response) => {
-    const arrayBuffer = await response.arrayBuffer();
-    const objects = await parquetReadObjects({
-      file: arrayBuffer,
-      rowEnd: MAX_PREVIEW_ROWS + 1,
-    });
+  const parsed = useArtifactFetch<ParsedArtifact>(
+    "parquet",
+    signedUrl,
+    async (response) => {
+      const arrayBuffer = await response.arrayBuffer();
+      const objects = await parquetReadObjects({
+        file: arrayBuffer,
+        rowEnd: MAX_PREVIEW_ROWS + 1,
+      });
 
-    if (objects.length === 0) return { headers: [], rows: [] };
-    const headers = Object.keys(objects[0]);
-    const rows = objects.map((obj) => headers.map((h) => obj[String(h)]));
+      if (objects.length === 0) {
+        return { headers: [], rows: [], truncated: false };
+      }
 
-    return { headers, rows };
-  });
+      const headers = Object.keys(objects[0]);
+      const truncated = objects.length > MAX_PREVIEW_ROWS;
+      const rows = objects
+        .slice(0, MAX_PREVIEW_ROWS)
+        .map((obj) => headers.map((h) => obj[String(h)]));
 
-  if (data.headers.length === 0) {
+      return { headers, rows, truncated };
+    },
+  );
+
+  const { data, onLoadMore, onLoadAll } = useRowCap(parsed);
+
+  if (parsed.headers.length === 0) {
     return (
       <Paragraph tone="subdued" size="xs">
         No data
@@ -40,8 +53,9 @@ const ParquetVisualizer = ({
   return (
     <TableVisualizer
       data={data}
-      remoteLink={signedUrl}
       isFullscreen={isFullscreen}
+      onLoadMore={onLoadMore}
+      onLoadAll={onLoadAll}
     />
   );
 };

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/TableVisualizer.test.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/TableVisualizer.test.tsx
@@ -1,19 +1,21 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { userEvent } from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
 
 import TableVisualizer from "./TableVisualizer";
 import type { ArtifactTableData } from "./utils";
 
-const makeData = (rowCount: number): ArtifactTableData => ({
+const makeData = (rowCount: number, hasMore = false): ArtifactTableData => ({
   headers: ["Name", "Score"],
   rows: Array.from({ length: rowCount }, (_, i) => [
     `row-${i}`,
     String(i * 10),
   ]),
+  hasMore,
 });
 
 describe("TableVisualizer", () => {
-  it("renders headers and rows", () => {
+  it("renders headers and all rows it was given", () => {
     const data = makeData(3);
     render(<TableVisualizer data={data} isFullscreen={false} />);
 
@@ -23,66 +25,66 @@ describe("TableVisualizer", () => {
     expect(screen.getByText("row-2")).toBeInTheDocument();
   });
 
-  it("limits rows to DEFAULT_PREVIEW_ROWS (10) when not fullscreen", () => {
-    const data = makeData(20);
-    render(<TableVisualizer data={data} isFullscreen={false} />);
-
-    expect(screen.getByText("row-9")).toBeInTheDocument();
-    expect(screen.queryByText("row-10")).not.toBeInTheDocument();
-    expect(screen.getByText("Showing first 10 rows")).toBeInTheDocument();
-  });
-
-  it("shows up to MAX_PREVIEW_ROWS (30) when fullscreen", () => {
-    const data = makeData(35);
-    render(<TableVisualizer data={data} isFullscreen={true} />);
-
-    expect(screen.getByText("row-29")).toBeInTheDocument();
-    expect(screen.queryByText("row-30")).not.toBeInTheDocument();
-    expect(screen.getByText("Showing first 30 rows")).toBeInTheDocument();
-  });
-
-  it("shows 'Showing all N rows' when all rows fit", () => {
+  it("says 'Showing all N rows' when hasMore is false", () => {
     const data = makeData(5);
     render(<TableVisualizer data={data} isFullscreen={false} />);
 
     expect(screen.getByText("Showing all 5 rows")).toBeInTheDocument();
   });
 
-  it("renders 'See all' link when remoteLink is provided and rows are truncated", () => {
-    const data = makeData(20);
+  it("says 'Showing first N rows' when hasMore is true and load handlers are provided", () => {
+    const data = makeData(100, true);
     render(
       <TableVisualizer
         data={data}
-        remoteLink="https://storage.example.com/file.csv"
         isFullscreen={false}
+        onLoadMore={() => {}}
+        onLoadAll={() => {}}
       />,
     );
 
-    const link = screen.getByRole("link", { name: "See all" });
-    expect(link).toHaveAttribute(
-      "href",
-      "https://storage.example.com/file.csv",
-    );
+    expect(screen.getByText("Showing first 100 rows")).toBeInTheDocument();
   });
 
-  it("does not render 'See all' link when remoteLink is not provided", () => {
-    const data = makeData(20);
+  it("flags the preview limit when hasMore is true but no onLoadMore is provided", () => {
+    const data = makeData(10000, true);
     render(<TableVisualizer data={data} isFullscreen={false} />);
 
-    expect(screen.queryByText("See all")).not.toBeInTheDocument();
+    expect(
+      screen.getByText("Showing first 10000 rows (preview limit reached)"),
+    ).toBeInTheDocument();
   });
 
-  it("does not render 'See all' link when all rows are shown", () => {
-    const data = makeData(3);
+  it("renders Load more / Load all buttons when handlers are provided and fires them on click", async () => {
+    const onLoadMore = vi.fn();
+    const onLoadAll = vi.fn();
+    const data = makeData(100, true);
+
     render(
       <TableVisualizer
         data={data}
-        remoteLink="https://storage.example.com/file.csv"
         isFullscreen={false}
+        onLoadMore={onLoadMore}
+        onLoadAll={onLoadAll}
       />,
     );
 
-    expect(screen.queryByText("See all")).not.toBeInTheDocument();
+    const loadMore = screen.getByRole("button", { name: "Load more" });
+    const loadAll = screen.getByRole("button", { name: "Load all" });
+
+    await userEvent.click(loadMore);
+    expect(onLoadMore).toHaveBeenCalledOnce();
+
+    await userEvent.click(loadAll);
+    expect(onLoadAll).toHaveBeenCalledOnce();
+  });
+
+  it("does not render Load more / Load all when no handlers are provided", () => {
+    const data = makeData(100, true);
+    render(<TableVisualizer data={data} isFullscreen={false} />);
+
+    expect(screen.queryByRole("button", { name: "Load more" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Load all" })).toBeNull();
   });
 
   it("uses the Table container as the scroll element with sticky header cells", () => {

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/TableVisualizer.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/TableVisualizer.tsx
@@ -1,5 +1,5 @@
+import { Button } from "@/components/ui/button";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
-import { Link } from "@/components/ui/link";
 import {
   Table,
   TableBody,
@@ -10,50 +10,53 @@ import {
 } from "@/components/ui/table";
 import { Paragraph } from "@/components/ui/typography";
 
-import {
-  type ArtifactTableData,
-  DEFAULT_PREVIEW_ROWS,
-  MAX_PREVIEW_ROWS,
-} from "./utils";
+import { type ArtifactTableData } from "./utils";
 
 interface TableVisualizerProps {
   data: ArtifactTableData;
-  remoteLink?: string | null;
   isFullscreen: boolean;
+  onLoadMore?: () => void;
+  onLoadAll?: () => void;
 }
+
+const getRowCountMessage = (
+  data: ArtifactTableData,
+  limitReached: boolean,
+): string => {
+  if (!data.hasMore) return `Showing all ${data.rows.length} rows`;
+  if (limitReached)
+    return `Showing first ${data.rows.length} rows (preview limit reached)`;
+  return `Showing first ${data.rows.length} rows`;
+};
 
 const TableVisualizer = ({
   data,
-  remoteLink,
   isFullscreen,
+  onLoadMore,
+  onLoadAll,
 }: TableVisualizerProps) => {
-  const displayedRows = isFullscreen
-    ? data.rows.slice(0, MAX_PREVIEW_ROWS)
-    : data.rows.slice(0, DEFAULT_PREVIEW_ROWS);
-
-  const isShowingAllRows = displayedRows.length >= data.rows.length;
+  const limitReached = data.hasMore && !onLoadMore;
+  const rowCountMessage = getRowCountMessage(data, limitReached);
 
   return (
     <BlockStack
       gap="2"
-      className={isFullscreen ? "min-h-0 flex-1" : "max-h-100"}
+      className={isFullscreen ? "h-full min-h-0" : "max-h-100"}
     >
-      <ArtifactTable headers={data.headers} rows={displayedRows} />
+      <ArtifactTable headers={data.headers} rows={data.rows} />
       <InlineStack gap="4">
         <Paragraph tone="subdued" size="xs">
-          {isShowingAllRows
-            ? `Showing all ${displayedRows.length} rows`
-            : `Showing first ${displayedRows.length} rows`}
+          {rowCountMessage}
         </Paragraph>
-        {!isShowingAllRows && remoteLink && (
-          <Link
-            href={remoteLink}
-            target="_blank"
-            rel="noopener"
-            className="text-xs"
-          >
-            See all
-          </Link>
+        {onLoadMore && (
+          <Button variant="link" size="inline-xs" onClick={onLoadMore}>
+            Load more
+          </Button>
+        )}
+        {onLoadAll && (
+          <Button variant="link" size="inline-xs" onClick={onLoadAll}>
+            Load all
+          </Button>
         )}
       </InlineStack>
     </BlockStack>

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/useRowCap.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/useRowCap.ts
@@ -1,0 +1,33 @@
+import { useState } from "react";
+
+import type { ArtifactTableData, ParsedArtifact } from "./utils";
+import { MAX_PREVIEW_ROWS } from "./utils";
+
+const INITIAL_PREVIEW_ROWS = 100;
+const PREVIEW_BATCH_SIZE = 100;
+
+interface UseRowCapReturn {
+  data: ArtifactTableData;
+  onLoadMore: (() => void) | undefined;
+  onLoadAll: (() => void) | undefined;
+}
+
+export function useRowCap(parsed: ParsedArtifact): UseRowCapReturn {
+  const [rowCap, setRowCap] = useState(INITIAL_PREVIEW_ROWS);
+
+  const handleLoadMore = () =>
+    setRowCap((prev) => Math.min(prev + PREVIEW_BATCH_SIZE, MAX_PREVIEW_ROWS));
+  const handleLoadAll = () => setRowCap(MAX_PREVIEW_ROWS);
+
+  const canLoadMore = rowCap < parsed.rows.length;
+
+  return {
+    data: {
+      headers: parsed.headers,
+      rows: parsed.rows.slice(0, rowCap),
+      hasMore: canLoadMore || parsed.truncated,
+    },
+    onLoadMore: canLoadMore ? handleLoadMore : undefined,
+    onLoadAll: canLoadMore ? handleLoadAll : undefined,
+  };
+}

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/utils.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/utils.ts
@@ -1,20 +1,35 @@
 import Papa from "papaparse";
 
-export type ArtifactTableData = { headers: string[]; rows: string[][] };
+export type ArtifactTableData = {
+  headers: string[];
+  rows: string[][];
+  hasMore: boolean;
+};
 
-export const DEFAULT_PREVIEW_ROWS = 10;
-export const MAX_PREVIEW_ROWS = 30;
+export type ParsedArtifact = {
+  headers: string[];
+  rows: string[][];
+  truncated: boolean;
+};
 
-export function parseCsv(text: string, delimiter?: string): ArtifactTableData {
+export const MAX_PREVIEW_ROWS = 1000;
+
+const HEADER_ROW = 1;
+const TRUNCATION_LOOKAHEAD = 1;
+
+export function parseCsv(text: string, delimiter?: string): ParsedArtifact {
   const result = Papa.parse<string[]>(text, {
     delimiter,
     header: false,
-    preview: MAX_PREVIEW_ROWS + 1,
+    preview: MAX_PREVIEW_ROWS + HEADER_ROW + TRUNCATION_LOOKAHEAD,
     skipEmptyLines: true,
   });
 
-  if (result.data.length === 0) return { headers: [], rows: [] };
+  if (result.data.length === 0) {
+    return { headers: [], rows: [], truncated: false };
+  }
 
   const [headers, ...rows] = result.data;
-  return { headers, rows };
+  const truncated = rows.length > MAX_PREVIEW_ROWS;
+  return { headers, rows: rows.slice(0, MAX_PREVIEW_ROWS), truncated };
 }


### PR DESCRIPTION
## Description

Adds pagination to tabulated data visualizations, instead of redirecting to raw data when clicking "See more."

Table visualizations now load 100 rows of data. The user can now click "load more" to load another 100 rows. They can continue doing this up to a limit of 1,000 rows.

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

Progresses https://github.com/TangleML/tangle-ui/issues/2184

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

![image.png](https://app.graphite.com/user-attachments/assets/3f7ebac4-d0ae-4cb4-a744-c8fae7b35e33.png)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

Open artifac visualization for a large tabulated dataset, e.g. csv or parquet. confirm the load more and laod all buttons work as expected.

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->