### PR TITLE
chore: v2 - increase font for zoomed out mode

### DIFF
--- a/src/routes/v2/shared/nodes/TaskNode/TaskNodeSimplified.tsx
+++ b/src/routes/v2/shared/nodes/TaskNode/TaskNodeSimplified.tsx
@@ -22,7 +22,7 @@ const AGGREGATOR_INTERNAL_INPUTS = new Set([
   "output_type",
 ]);
 
-const PERCEIVED_FONT_SIZE = "28px";
+const PERCEIVED_FONT_SIZE = "32px";
 const s = "var(--simplified-scale, 1)";
 
 const simplifiedCardVariants = createTaskNodeCardVariants(


### PR DESCRIPTION
## Description

Increases the perceived font size in the simplified Task Node from `28px` to `32px` to improve text visibility and readability in the simplified node view.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

![image.png](https://app.graphite.com/user-attachments/assets/6727c874-3423-4c58-b8b0-16243c94dc72.png)



## Test Instructions

1. Open the workflow editor and view a pipeline containing Task Nodes in simplified view.
2. Verify that the text within the simplified Task Node appears larger and more legible compared to before.

## Additional Comments