### PR TITLE
fix: Parquet Schema

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/CsvVisualizer.test.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/CsvVisualizer.test.tsx
@@ -11,13 +11,13 @@ vi.mock("./TableVisualizer", () => ({
     data,
     isFullscreen,
   }: {
-    data: { headers: string[]; rows: string[][] };
+    data: { columns: { name: string }[]; rows: string[][] };
     isFullscreen: boolean;
   }) => (
     <div
       data-testid="table-visualizer"
       data-fullscreen={isFullscreen}
-      data-headers={data.headers.join(",")}
+      data-headers={data.columns.map((c) => c.name).join(",")}
       data-row-count={data.rows.length}
     />
   ),

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/CsvVisualizer.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/CsvVisualizer.tsx
@@ -24,7 +24,7 @@ const CsvContent = ({
 }) => {
   const { data, onLoadMore, onLoadAll } = useRowCap(parsed);
 
-  if (parsed.headers.length === 0) {
+  if (data.columns.length === 0) {
     return (
       <Paragraph tone="subdued" size="xs">
         No data

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ParquetVisualizer.test.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ParquetVisualizer.test.tsx
@@ -5,9 +5,11 @@ import { ErrorBoundary } from "react-error-boundary";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import ParquetVisualizer from "./ParquetVisualizer";
+import type { ArtifactColumn } from "./utils";
 
 vi.mock("hyparquet", () => ({
   parquetReadObjects: vi.fn(),
+  parquetMetadata: vi.fn(),
 }));
 
 vi.mock("./TableVisualizer", () => ({
@@ -15,19 +17,20 @@ vi.mock("./TableVisualizer", () => ({
     data,
     isFullscreen,
   }: {
-    data: { headers: string[]; rows: string[][] };
+    data: { columns: ArtifactColumn[]; rows: string[][] };
     isFullscreen: boolean;
   }) => (
     <div
       data-testid="table-visualizer"
       data-fullscreen={isFullscreen}
-      data-headers={data.headers.join(",")}
+      data-headers={data.columns.map((c) => c.name).join(",")}
       data-row-count={data.rows.length}
+      data-columns={JSON.stringify(data.columns)}
     />
   ),
 }));
 
-const { parquetReadObjects } = await import("hyparquet");
+const { parquetReadObjects, parquetMetadata } = await import("hyparquet");
 
 const queryClient = new QueryClient({
   defaultOptions: { queries: { retry: false } },
@@ -50,8 +53,15 @@ const renderWithSuspense = (ui: ReactElement) =>
     </QueryClientProvider>,
   );
 
+const mockMetadata = (schema: unknown[] = []) =>
+  vi.mocked(parquetMetadata).mockReturnValue({
+    schema,
+  } as unknown as ReturnType<typeof parquetMetadata>);
+
 beforeEach(() => {
   queryClient.clear();
+  vi.mocked(parquetMetadata).mockReset();
+  vi.mocked(parquetReadObjects).mockReset();
 });
 
 describe("ParquetVisualizer", () => {
@@ -62,6 +72,11 @@ describe("ParquetVisualizer", () => {
       arrayBuffer: () => Promise.resolve(buffer),
     } as Response);
 
+    mockMetadata([
+      { name: "root" },
+      { name: "name", type: "BYTE_ARRAY", repetition_type: "OPTIONAL" },
+      { name: "score", type: "INT64", repetition_type: "REQUIRED" },
+    ]);
     vi.mocked(parquetReadObjects).mockResolvedValue([
       { name: "Alice", score: 100 },
       { name: "Bob", score: 90 },
@@ -110,6 +125,7 @@ describe("ParquetVisualizer", () => {
       arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
     } as Response);
 
+    mockMetadata([]);
     vi.mocked(parquetReadObjects).mockResolvedValue([]);
 
     renderWithSuspense(
@@ -132,6 +148,10 @@ describe("ParquetVisualizer", () => {
       arrayBuffer: () => Promise.resolve(new ArrayBuffer(8)),
     } as Response);
 
+    mockMetadata([
+      { name: "root" },
+      { name: "col", type: "BYTE_ARRAY", repetition_type: "OPTIONAL" },
+    ]);
     vi.mocked(parquetReadObjects).mockResolvedValue([{ col: "val" }]);
 
     renderWithSuspense(
@@ -146,6 +166,43 @@ describe("ParquetVisualizer", () => {
         "data-fullscreen",
         "true",
       );
+    });
+
+    vi.restoreAllMocks();
+  });
+
+  it("attaches schema-derived type and nullable flags to each column", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      arrayBuffer: () => Promise.resolve(new ArrayBuffer(8)),
+    } as Response);
+
+    mockMetadata([
+      { name: "root" },
+      { name: "id", type: "INT64", repetition_type: "REQUIRED" },
+      {
+        name: "label",
+        type: "BYTE_ARRAY",
+        repetition_type: "OPTIONAL",
+        logical_type: { type: "STRING" },
+      },
+    ]);
+    vi.mocked(parquetReadObjects).mockResolvedValue([{ id: 1, label: "a" }]);
+
+    renderWithSuspense(
+      <ParquetVisualizer
+        signedUrl="https://storage.example.com/data.parquet"
+        isFullscreen={false}
+      />,
+    );
+
+    await waitFor(() => {
+      const table = screen.getByTestId("table-visualizer");
+      const columns = JSON.parse(table.getAttribute("data-columns") ?? "[]");
+      expect(columns).toEqual([
+        { name: "id", type: "INT64", nullable: false },
+        { name: "label", type: "STRING", nullable: true },
+      ]);
     });
 
     vi.restoreAllMocks();

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ParquetVisualizer.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ParquetVisualizer.tsx
@@ -1,11 +1,19 @@
-import { parquetReadObjects } from "hyparquet";
+import {
+  parquetMetadata,
+  parquetReadObjects,
+  type SchemaElement,
+} from "hyparquet";
 
 import { Paragraph } from "@/components/ui/typography";
 
 import TableVisualizer from "./TableVisualizer";
 import { useArtifactFetch } from "./useArtifactFetch";
 import { useRowCap } from "./useRowCap";
-import { MAX_PREVIEW_ROWS, type ParsedArtifact } from "./utils";
+import {
+  type ArtifactColumn,
+  MAX_PREVIEW_ROWS,
+  type ParsedArtifact,
+} from "./utils";
 
 interface ParquetVisualizerProps {
   signedUrl: string;
@@ -21,28 +29,29 @@ const ParquetVisualizer = ({
     signedUrl,
     async (response) => {
       const arrayBuffer = await response.arrayBuffer();
+      const metadata = parquetMetadata(arrayBuffer);
       const objects = await parquetReadObjects({
         file: arrayBuffer,
         rowEnd: MAX_PREVIEW_ROWS + 1,
       });
 
       if (objects.length === 0) {
-        return { headers: [], rows: [], truncated: false };
+        return { columns: [], rows: [], truncated: false };
       }
 
-      const headers = Object.keys(objects[0]);
+      const columns = buildColumns(metadata.schema, objects[0]);
       const truncated = objects.length > MAX_PREVIEW_ROWS;
       const rows = objects
         .slice(0, MAX_PREVIEW_ROWS)
-        .map((obj) => headers.map((h) => obj[String(h)]));
+        .map((obj) => columns.map((col) => obj[col.name])) as string[][];
 
-      return { headers, rows, truncated };
+      return { columns, rows, truncated };
     },
   );
 
   const { data, onLoadMore, onLoadAll } = useRowCap(parsed);
 
-  if (parsed.headers.length === 0) {
+  if (data.columns.length === 0) {
     return (
       <Paragraph tone="subdued" size="xs">
         No data
@@ -61,3 +70,25 @@ const ParquetVisualizer = ({
 };
 
 export default ParquetVisualizer;
+
+function buildColumns(
+  schema: SchemaElement[],
+  firstRow: Record<string, unknown>,
+): ArtifactColumn[] {
+  const schemaByName = new Map(
+    schema.filter((el) => el.type !== undefined).map((el) => [el.name, el]),
+  );
+  return Object.keys(firstRow).map((name) => {
+    const el = schemaByName.get(name);
+    return {
+      name,
+      type: el ? formatParquetType(el) : undefined,
+      nullable: el?.repetition_type === "OPTIONAL",
+    };
+  });
+}
+
+function formatParquetType(el: SchemaElement): string {
+  if (el.logical_type) return el.logical_type.type;
+  return el.type ?? "";
+}

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/TableVisualizer.test.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/TableVisualizer.test.tsx
@@ -6,7 +6,7 @@ import TableVisualizer from "./TableVisualizer";
 import type { ArtifactTableData } from "./utils";
 
 const makeData = (rowCount: number, hasMore = false): ArtifactTableData => ({
-  headers: ["Name", "Score"],
+  columns: [{ name: "Name" }, { name: "Score" }],
   rows: Array.from({ length: rowCount }, (_, i) => [
     `row-${i}`,
     String(i * 10),

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/TableVisualizer.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/TableVisualizer.tsx
@@ -8,9 +8,9 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { Paragraph } from "@/components/ui/typography";
+import { Paragraph, Text } from "@/components/ui/typography";
 
-import { type ArtifactTableData } from "./utils";
+import { type ArtifactColumn, type ArtifactTableData } from "./utils";
 
 interface TableVisualizerProps {
   data: ArtifactTableData;
@@ -43,7 +43,7 @@ const TableVisualizer = ({
       gap="2"
       className={isFullscreen ? "h-full min-h-0" : "max-h-100"}
     >
-      <ArtifactTable headers={data.headers} rows={data.rows} />
+      <ArtifactTable columns={data.columns} rows={data.rows} />
       <InlineStack gap="4">
         <Paragraph tone="subdued" size="xs">
           {rowCountMessage}
@@ -66,20 +66,28 @@ const TableVisualizer = ({
 export default TableVisualizer;
 
 interface ArtifactTableProps {
-  headers: string[];
+  columns: ArtifactColumn[];
   rows: string[][];
 }
 
-const ArtifactTable = ({ headers, rows }: ArtifactTableProps) => (
+const ArtifactTable = ({ columns, rows }: ArtifactTableProps) => (
   <Table containerClassName="flex-1 overflow-auto">
     <TableHeader>
       <TableRow>
-        {headers.map((h) => (
+        {columns.map((col) => (
           <TableHead
-            key={h}
-            className="bg-background sticky top-0 z-10 text-xs"
+            key={col.name}
+            className="bg-background sticky top-0 z-10 h-auto py-2 align-bottom text-xs"
           >
-            {h}
+            <BlockStack>
+              <Text>{col.name}</Text>
+              {col.type && (
+                <Text tone="subdued" className="text-[10px]">
+                  {col.type}
+                  {col.nullable ? "?" : ""}
+                </Text>
+              )}
+            </BlockStack>
           </TableHead>
         ))}
       </TableRow>

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/useRowCap.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/useRowCap.ts
@@ -23,7 +23,7 @@ export function useRowCap(parsed: ParsedArtifact): UseRowCapReturn {
 
   return {
     data: {
-      headers: parsed.headers,
+      columns: parsed.columns,
       rows: parsed.rows.slice(0, rowCap),
       hasMore: canLoadMore || parsed.truncated,
     },

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/utils.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/utils.ts
@@ -1,13 +1,19 @@
 import Papa from "papaparse";
 
+export type ArtifactColumn = {
+  name: string;
+  type?: string;
+  nullable?: boolean;
+};
+
 export type ArtifactTableData = {
-  headers: string[];
+  columns: ArtifactColumn[];
   rows: string[][];
   hasMore: boolean;
 };
 
 export type ParsedArtifact = {
-  headers: string[];
+  columns: ArtifactColumn[];
   rows: string[][];
   truncated: boolean;
 };
@@ -26,10 +32,11 @@ export function parseCsv(text: string, delimiter?: string): ParsedArtifact {
   });
 
   if (result.data.length === 0) {
-    return { headers: [], rows: [], truncated: false };
+    return { columns: [], rows: [], truncated: false };
   }
 
   const [headers, ...rows] = result.data;
+  const columns = headers.map((name) => ({ name }));
   const truncated = rows.length > MAX_PREVIEW_ROWS;
-  return { headers, rows: rows.slice(0, MAX_PREVIEW_ROWS), truncated };
+  return { columns, rows: rows.slice(0, MAX_PREVIEW_ROWS), truncated };
 }


### PR DESCRIPTION
## Description

Adds column types to table header in Parquet Viewer (or where a data schema exists). Optional types will have a `?` appended



This is achieved by remapping the data headers into typed columns.

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

Progresses https://github.com/TangleML/tangle-ui/issues/2184

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

![image.png](https://app.graphite.com/user-attachments/assets/76459824-7d67-4a0d-b9c7-9c28d6235e4b.png)



<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

Open an artifact visualization for a Parquet. confirm the column data type is shown in the column header

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->