### PR TITLE
chore: v2 - task details - add annotations tab

### DIFF
--- a/src/routes/v2/pages/Editor/components/AnnotationsBlock/AnnotationsBlock.tsx
+++ b/src/routes/v2/pages/Editor/components/AnnotationsBlock/AnnotationsBlock.tsx
@@ -44,7 +44,7 @@ export const AnnotationsBlock = observer(function AnnotationsBlock({
 
   return (
     <KeyValueList
-      title="Annotations"
+      title="Task annotations"
       items={displayItems.map((a) => ({
         label: a.key,
         value: JSON.stringify(a.value),
@@ -84,7 +84,7 @@ function AnnotationEditMode({
   );
 
   return (
-    <ContentBlock title="Annotations" titleAction={actions}>
+    <ContentBlock title="Task annotations" titleAction={actions}>
       {editableItems.length === 0 ? (
         <Text size="xs" tone="subdued">
           No annotations

--- a/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/TaskDetails.tsx
+++ b/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/TaskDetails.tsx
@@ -37,7 +37,7 @@ interface TaskDetailsProps {
   entityId: string;
 }
 
-type DetailsTab = "arguments" | "configuration";
+type DetailsTab = "arguments" | "configuration" | "annotations";
 
 export const TaskDetails = observer(function TaskDetails({
   entityId,
@@ -62,7 +62,11 @@ export const TaskDetails = observer(function TaskDetails({
   }, [focusedArgumentName]);
 
   const handleDetailsTabChange = (value: string) => {
-    if (value === "arguments" || value === "configuration") {
+    if (
+      value === "arguments" ||
+      value === "configuration" ||
+      value === "annotations"
+    ) {
       setDetailsTab(value);
     }
   };
@@ -190,6 +194,14 @@ export const TaskDetails = observer(function TaskDetails({
             <Icon name="Settings" size="xs" className="shrink-0" />
             <span className="truncate">Configuration</span>
           </TabsTrigger>
+          <TabsTrigger
+            value="annotations"
+            className="min-w-0 flex-1 gap-1.5"
+            {...tracking("v2.pipeline_editor.task_details.tab_annotations")}
+          >
+            <Icon name="Tag" size="xs" className="shrink-0" />
+            <span className="truncate">Annotations</span>
+          </TabsTrigger>
         </TabsList>
 
         <TabsContent
@@ -203,17 +215,18 @@ export const TaskDetails = observer(function TaskDetails({
           value="configuration"
           className="mt-0 min-h-0 min-w-0 flex-1 overflow-y-auto py-3"
         >
-          <BlockStack gap="4">
-            <ConfigurationSection task={task} />
+          <ConfigurationSection task={task} />
+        </TabsContent>
 
-            <Separator />
-
-            <AnnotationsBlock
-              annotations={task.annotations}
-              defaultEditing
-              ignoreAnnotationKeys={EDITOR_ANNOTATION_KEYS}
-            />
-          </BlockStack>
+        <TabsContent
+          value="annotations"
+          className="mt-0 min-h-0 min-w-0 flex-1 overflow-y-auto py-3"
+        >
+          <AnnotationsBlock
+            annotations={task.annotations}
+            defaultEditing
+            ignoreAnnotationKeys={EDITOR_ANNOTATION_KEYS}
+          />
         </TabsContent>
       </Tabs>
       <Separator />

--- a/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/components/ConfigurationSection.tsx
+++ b/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/components/ConfigurationSection.tsx
@@ -12,7 +12,7 @@ import { ColorPicker } from "@/components/ui/color";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Separator } from "@/components/ui/separator";
 import { Switch } from "@/components/ui/switch";
-import { Paragraph, Text } from "@/components/ui/typography";
+import { Heading, Paragraph } from "@/components/ui/typography";
 import type { Task } from "@/models/componentSpec";
 import { useAnalytics } from "@/providers/AnalyticsProvider";
 import type { AnnotationConfig, Annotations } from "@/types/annotations";
@@ -136,16 +136,7 @@ export const ConfigurationSection = observer(function ConfigurationSection({
 
   return (
     <BlockStack gap="3">
-      <Text
-        as="h3"
-        size="xs"
-        weight="semibold"
-        tone="subdued"
-        role="heading"
-        aria-level={3}
-      >
-        Configuration
-      </Text>
+      <Heading level={3}>General configuration</Heading>
 
       <InlineStack align="space-between" gap="2" className="w-full">
         <Paragraph size="xs" tone="subdued">


### PR DESCRIPTION
## Description

Moves the "Annotations" section out of the Configuration tab in the Task Details panel and into its own dedicated "Annotations" tab. The Configuration tab now only contains the general configuration settings, while the new Annotations tab houses the `AnnotationsBlock` component. The annotations block title has been updated to "Task annotations" to better reflect its context, and the configuration section heading has been updated to "General configuration".

## Related Issue and Pull requests

Closes https://github.com/TangleML/tangle-ui/issues/2116

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## [Screen Recording 2026-05-12 at 3.53.40 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/adcd3f9c-72c9-4586-a81b-b540aaa5ff61.mov" />](https://app.graphite.com/user-attachments/video/adcd3f9c-72c9-4586-a81b-b540aaa5ff61.mov)

## Test Instructions

1. Open the pipeline editor and select a task node.
2. Verify the Task Details panel now shows three tabs: **Arguments**, **Configuration**, and **Annotations**.
3. Confirm the **Configuration** tab only displays general configuration settings (no annotations).
4. Confirm the **Annotations** tab displays the task annotations block with the title "Task annotations".

## Additional Comments