### PR TITLE
chore: v2 - pipelinedigestbar improvement

### DIFF
--- a/src/routes/v2/pages/Editor/components/PipelineDetailsContent/components/PipelineDigestBar.tsx
+++ b/src/routes/v2/pages/Editor/components/PipelineDetailsContent/components/PipelineDigestBar.tsx
@@ -1,8 +1,9 @@
 import { useQuery } from "@tanstack/react-query";
 import { useState } from "react";
 
+import TooltipButton from "@/components/shared/Buttons/TooltipButton";
 import { CodeViewer } from "@/components/shared/CodeViewer";
-import { TrimmedDigest } from "@/components/shared/ManageComponent/TrimmedDigest";
+import { trimDigest } from "@/components/shared/ManageComponent/utils/digest";
 import { withSuspenseWrapper } from "@/components/shared/SuspenseWrapper";
 import { Button } from "@/components/ui/button";
 import {
@@ -13,6 +14,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Icon } from "@/components/ui/icon";
 import { InlineStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
 import useToastNotification from "@/hooks/useToastNotification";
 import { generateDigest } from "@/utils/componentStore";
 import { downloadYamlFromComponentText } from "@/utils/URL";
@@ -79,23 +81,31 @@ export const PipelineDigestBar = withSuspenseWrapper(
             variant="ghost"
             aria-label="View pipeline YAML"
             className="h-auto min-h-0 min-w-0 flex-1 justify-start gap-1.5 px-1 py-0.5 font-normal"
-            onClick={() => setShowCodeViewer(true)}
+            onClick={() => handleCopyDigest()}
           >
             <Icon
               name={isNestedSubgraph ? "Workflow" : "GitBranch"}
               size="sm"
               className="shrink-0 text-muted-foreground"
             />
-            <TrimmedDigest
-              digest={digest}
+            <Text
+              size="xs"
+              font="mono"
               className="min-w-0 shrink truncate text-muted-foreground"
-            />
+            >
+              {trimDigest(digest)}
+            </Text>
           </Button>
 
           <InlineStack blockAlign="center" className="shrink-0">
-            <Button variant="ghost" size="min" onClick={handleCopyDigest}>
-              <Icon name="Copy" size="sm" />
-            </Button>
+            <TooltipButton
+              variant="ghost"
+              size="min"
+              onClick={() => setShowCodeViewer(true)}
+              tooltip="View pipeline YAML"
+            >
+              <Icon name="FileCode" size="sm" />
+            </TooltipButton>
 
             <DropdownMenu>
               <DropdownMenuTrigger asChild>


### PR DESCRIPTION
## Description

The `PipelineDigestBar` component has been updated to swap the actions of the digest button and the copy button. Clicking the digest text now copies the digest to the clipboard, while viewing the pipeline YAML has been moved to a dedicated `TooltipButton` with a `FileCode` icon. The `TrimmedDigest` component has been replaced with a `Text` component using the `trimDigest` utility directly, and a tooltip label ("View pipeline YAML") has been added to the YAML viewer button for improved clarity.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [x] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

| Before | After |
| --- | --- |
| ![image.png](https://app.graphite.com/user-attachments/assets/6984522f-3d66-4609-8f40-5d503528d284.png)<br> | ![image.png](https://app.graphite.com/user-attachments/assets/497ebb27-92f0-4141-833e-07e422e25ceb.png)<br> |

## Test Instructions

1. Open a pipeline in the Editor view.
2. Verify that clicking the digest text copies the digest to the clipboard.
3. Verify that clicking the `FileCode` icon opens the pipeline YAML viewer.
4. Hover over the `FileCode` icon and confirm the tooltip displays "View pipeline YAML".

## Additional Comments