### PR TITLE
chore: v2 - improve autosave spinner ux

### DIFF
--- a/src/routes/v2/pages/Editor/components/EditorMenuBar/components/AutoSaveIndicator.tsx
+++ b/src/routes/v2/pages/Editor/components/EditorMenuBar/components/AutoSaveIndicator.tsx
@@ -1,10 +1,45 @@
 import { observer } from "mobx-react-lite";
+import type { ReactNode } from "react";
 
 import TooltipButton from "@/components/shared/Buttons/TooltipButton";
 import { Icon } from "@/components/ui/icon";
 import { Spinner } from "@/components/ui/spinner";
+import { cn } from "@/lib/utils";
 import { useEditorSession } from "@/routes/v2/pages/Editor/store/EditorSessionContext";
 import { tracking } from "@/utils/tracking";
+
+const LAYER_BASE_CLASS =
+  "absolute inset-0 inline-flex will-change-[opacity] [transform:translateZ(0)]";
+
+function SavingLayer({ children }: { children: ReactNode }) {
+  return (
+    <span
+      className={cn(
+        LAYER_BASE_CLASS,
+        "opacity-0 transition-opacity duration-150 ease-out delay-[600ms]",
+        "group-data-[saving=true]:opacity-100 group-data-[saving=true]:delay-0",
+      )}
+    >
+      {children}
+    </span>
+  );
+}
+
+function IdleLayer({ children }: { children: ReactNode }) {
+  return (
+    <span
+      className={cn(
+        LAYER_BASE_CLASS,
+        "text-stone-400 opacity-100 hover:text-white",
+        "[transition:opacity_150ms_ease-out_600ms,color_1000ms_ease-out_750ms]",
+        "group-data-[saving=true]:text-green-500 group-data-[saving=true]:opacity-0",
+        "group-data-[saving=true]:[transition:opacity_150ms_ease-out,color_0ms]",
+      )}
+    >
+      {children}
+    </span>
+  );
+}
 
 function getTooltipText(isSaving: boolean, lastSavedAt: Date | null): string {
   if (isSaving) return "Saving...";
@@ -27,14 +62,17 @@ export const AutoSaveIndicator = observer(function AutoSaveIndicator() {
       data-testid="auto-save-button"
       {...tracking("v2.pipeline_editor.auto_save_indicator")}
     >
-      {isSaving ? (
-        <Spinner size={16} />
-      ) : (
-        <Icon
-          name="CloudCheck"
-          className="text-stone-400 hover:text-white transition-colors"
-        />
-      )}
+      <div
+        data-saving={isSaving ? "true" : "false"}
+        className="group relative isolate size-4"
+      >
+        <SavingLayer>
+          <Spinner size={16} />
+        </SavingLayer>
+        <IdleLayer>
+          <Icon name="CloudCheck" />
+        </IdleLayer>
+      </div>
     </TooltipButton>
   );
 });

--- a/src/routes/v2/pages/Editor/store/autoSaveStore.ts
+++ b/src/routes/v2/pages/Editor/store/autoSaveStore.ts
@@ -12,18 +12,15 @@ import { debounce } from "@/utils/debounce";
 import type { PipelineFileStore } from "./pipelineFileStore";
 import type { UndoStore } from "./undoStore";
 
-const SAVED_MESSAGE_DURATION_MS = 2000;
-const MIN_SAVING_DISPLAY_MS = 1000;
+const AUTOSAVE_MIN_SAVING_INDICATOR_MS = 600;
 
 export class AutoSaveStore {
   @observable accessor isSaving = false;
   @observable accessor lastSavedAt: Date | null = null;
-  @observable accessor showSavedMessage = false;
 
   private spec: ComponentSpec | null = null;
   private pipelineName: string | null = null;
   private disposeReaction: (() => void) | null = null;
-  private savedMessageTimeout: ReturnType<typeof setTimeout> | null = null;
 
   private debouncedSave = debounce((yamlText: string) => {
     void this.performSave(yamlText);
@@ -42,7 +39,6 @@ export class AutoSaveStore {
     this.pipelineName = pipelineName;
     this.isSaving = false;
     this.lastSavedAt = null;
-    this.showSavedMessage = false;
 
     this.disposeReaction = reaction(
       () => this.serializeSpec(),
@@ -55,7 +51,6 @@ export class AutoSaveStore {
     this.disposeReaction?.();
     this.disposeReaction = null;
     this.debouncedSave.cancel();
-    this.clearSavedMessageTimeout();
     this.spec = null;
     this.pipelineName = null;
   }
@@ -74,10 +69,6 @@ export class AutoSaveStore {
   @action setSaved(date: Date) {
     this.lastSavedAt = date;
     this.isSaving = false;
-  }
-
-  @action setShowSavedMessage(value: boolean) {
-    this.showSavedMessage = value;
   }
 
   private serializeSpec(): string | null {
@@ -107,19 +98,24 @@ export class AutoSaveStore {
       try {
         await this.pipelineFileStore.activePipelineFile?.write(yamlText);
         await this.persistUndoHistory();
-        this.setSaved(new Date());
-        this.flashSavedMessage();
+        return new Date();
       } catch (error) {
         console.error("Auto-save failed:", error);
-        this.setSaving(false);
+        return null;
       }
     })();
 
     const minDisplayPromise = new Promise((resolve) =>
-      setTimeout(resolve, MIN_SAVING_DISPLAY_MS),
+      setTimeout(resolve, AUTOSAVE_MIN_SAVING_INDICATOR_MS),
     );
 
-    await Promise.all([savePromise, minDisplayPromise]);
+    const [savedAt] = await Promise.all([savePromise, minDisplayPromise]);
+
+    if (savedAt) {
+      this.setSaved(savedAt);
+    } else {
+      this.setSaving(false);
+    }
   }
 
   private async persistUndoHistory() {
@@ -132,21 +128,6 @@ export class AutoSaveStore {
       await saveUndoHistory(this.pipelineName, idStack, manager);
     } catch (error) {
       console.error("Failed to persist undo history:", error);
-    }
-  }
-
-  private flashSavedMessage() {
-    this.clearSavedMessageTimeout();
-    this.setShowSavedMessage(true);
-    this.savedMessageTimeout = setTimeout(() => {
-      this.setShowSavedMessage(false);
-    }, SAVED_MESSAGE_DURATION_MS);
-  }
-
-  private clearSavedMessageTimeout() {
-    if (this.savedMessageTimeout) {
-      clearTimeout(this.savedMessageTimeout);
-      this.savedMessageTimeout = null;
     }
   }
 }


### PR DESCRIPTION
## Description

Replaces the hard-cut swap between the spinner and `CloudCheck` icon in the auto-save indicator with a smooth cross-fade animation. Both icons are now rendered simultaneously in a stacked layout, with CSS transitions controlling their opacity based on a `data-saving` attribute on the parent element. The spinner fades out with a 600ms delay after saving ends, while the `CloudCheck` fades in starting green and eases to `stone-400` over 1 second.

## Screenshots (if applicable)

## [Screen Recording 2026-05-12 at 5.17.18 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/2cc33fee-b03d-47ee-a471-ae0c474f7379.mov" />](https://app.graphite.com/user-attachments/video/2cc33fee-b03d-47ee-a471-ae0c474f7379.mov)

## Test Instructions

1. Open the pipeline editor and make a change to trigger an auto-save.
2. Observe that the spinner fades out smoothly rather than cutting away instantly.
3. Confirm the `CloudCheck` icon fades in green and transitions to `stone-400` over ~1 second.
4. Verify that hovering over the `CloudCheck` still transitions it to white.
5. Confirm that save errors correctly reset the saving state without flashing the saved indicator.

## Additional Comments

The asymmetric CSS transitions (different durations and delays for the saving vs. saved states) are intentional — the spinner lingers briefly after the save completes to avoid a jarring flash, while the green-to-grey color fade gives subtle feedback that the save succeeded.