### PR TITLE
feat: v2 - minimap in separate window

### DIFF
--- a/src/routes/v2/pages/Editor/EditorV2.tsx
+++ b/src/routes/v2/pages/Editor/EditorV2.tsx
@@ -18,6 +18,7 @@ import { useTourMode } from "@/providers/TourProvider/TourModeContext";
 import { TourSaveExploreDialog } from "@/providers/TourProvider/TourSaveExploreDialog";
 import { TourSecretsDialog } from "@/providers/TourProvider/TourSecretsDialog";
 import { AiChatStoreProvider } from "@/routes/v2/shared/components/AiChat/AiChatStoreContext";
+import { useCanvasControlsWindow } from "@/routes/v2/shared/components/MiniMap/useCanvasControlsWindow";
 import { useDockAreaAccordion } from "@/routes/v2/shared/hooks/useDockAreaAccordion";
 import { useFocusMode } from "@/routes/v2/shared/hooks/useFocusMode";
 import { NodeRegistryProvider } from "@/routes/v2/shared/nodes/NodeRegistryContext";
@@ -97,6 +98,7 @@ const PipelineEditor = withSuspenseWrapper(
     usePipelineDetailsWindow();
     usePipelineTreeWindow();
     useHistoryWindow();
+    useCanvasControlsWindow("v2.pipeline_canvas");
     useRecentRunsWindow();
     useRunsAndSubmissionWindow();
     useUndoRedoKeyboard();

--- a/src/routes/v2/pages/Editor/components/FlowCanvas/FlowCanvas.tsx
+++ b/src/routes/v2/pages/Editor/components/FlowCanvas/FlowCanvas.tsx
@@ -1,7 +1,5 @@
 import {
   Background,
-  Controls,
-  MiniMap,
   ReactFlow,
   type ReactFlowInstance,
   useConnection,
@@ -12,7 +10,6 @@ import { useState } from "react";
 import { BlockStack } from "@/components/ui/layout";
 import { cn } from "@/lib/utils";
 import type { ComponentSpec } from "@/models/componentSpec";
-import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { useAutoLayout } from "@/routes/v2/pages/Editor/hooks/useAutoLayout";
 import { SubgraphBreadcrumbs } from "@/routes/v2/shared/components/SubgraphBreadcrumbs";
 import { FLOW_CANVAS_DEFAULT_PROPS } from "@/routes/v2/shared/flowCanvasDefaults";
@@ -45,7 +42,6 @@ export const FlowCanvas = observer(function FlowCanvas({
   spec,
   className,
 }: FlowCanvasProps) {
-  const { track } = useAnalytics();
   const registry = useNodeRegistry();
   const nodeTypes = registry.getNodeTypes();
   const edgeTypes = registry.getEdgeTypes();
@@ -123,25 +119,6 @@ export const FlowCanvas = observer(function FlowCanvas({
       >
         <FloatingSelectionToolbar spec={spec} />
         <Background gap={10} className="bg-canvas!" />
-        <Controls
-          position="bottom-right"
-          onZoomIn={() => track("v2.pipeline_canvas.controls.zoom_in.click")}
-          onZoomOut={() => track("v2.pipeline_canvas.controls.zoom_out.click")}
-          onFitView={() => track("v2.pipeline_canvas.controls.fit_view.click")}
-          onInteractiveChange={(interactive) =>
-            track("v2.pipeline_canvas.controls.interactive.toggle", {
-              interactive,
-            })
-          }
-        />
-        <MiniMap
-          position="bottom-left"
-          className="dark:rounded-md dark:border dark:border-border"
-          pannable
-          zoomable
-          onClick={() => track("v2.pipeline_canvas.minimap.click")}
-          onNodeClick={() => track("v2.pipeline_canvas.minimap.node.click")}
-        />
       </ReactFlow>
       <CanvasUndoRedo />
     </BlockStack>

--- a/src/routes/v2/pages/RunView/RunViewV2.tsx
+++ b/src/routes/v2/pages/RunView/RunViewV2.tsx
@@ -26,6 +26,7 @@ import {
   useExecutionData,
 } from "@/providers/ExecutionDataProvider";
 import { AiChatStoreProvider } from "@/routes/v2/shared/components/AiChat/AiChatStoreContext";
+import { useCanvasControlsWindow } from "@/routes/v2/shared/components/MiniMap/useCanvasControlsWindow";
 import { useDockAreaAccordion } from "@/routes/v2/shared/hooks/useDockAreaAccordion";
 import { NodeRegistryProvider } from "@/routes/v2/shared/nodes/NodeRegistryContext";
 import { SpecProvider } from "@/routes/v2/shared/providers/SpecContext";
@@ -168,6 +169,7 @@ const RunViewLayout = observer(function RunViewLayout({
   useRunViewSelectionSync();
   useRunViewSubgraphUrlSync();
   useFocusTaskFromUrl(spec);
+  useCanvasControlsWindow("v2.run_view");
 
   const aiEnabled = useFlagValue("ai-assistant");
   useAiChatWindow(aiEnabled);

--- a/src/routes/v2/pages/RunView/components/RunViewFlowCanvas.tsx
+++ b/src/routes/v2/pages/RunView/components/RunViewFlowCanvas.tsx
@@ -1,7 +1,5 @@
 import {
   Background,
-  Controls,
-  MiniMap,
   type NodeChange,
   ReactFlow,
   useReactFlow,
@@ -11,7 +9,6 @@ import { observer } from "mobx-react-lite";
 import { BlockStack } from "@/components/ui/layout";
 import { cn } from "@/lib/utils";
 import type { ComponentSpec } from "@/models/componentSpec";
-import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { useCopyShortcut } from "@/routes/v2/pages/RunView/hooks/useCopyShortcut";
 import { SubgraphBreadcrumbs } from "@/routes/v2/shared/components/SubgraphBreadcrumbs";
 import {
@@ -37,7 +34,6 @@ export const RunViewFlowCanvas = observer(function RunViewFlowCanvas({
   spec,
   className,
 }: RunViewFlowCanvasProps) {
-  const { track } = useAnalytics();
   const registry = useNodeRegistry();
   const nodeTypes = registry.getNodeTypes();
   const edgeTypes = registry.getEdgeTypes();
@@ -99,25 +95,6 @@ export const RunViewFlowCanvas = observer(function RunViewFlowCanvas({
       >
         <RunViewSelectionToolbar spec={spec} />
         <Background gap={GRID_SIZE} className="bg-canvas!" />
-        <Controls
-          position="bottom-right"
-          onZoomIn={() => track("v2.run_view.canvas.controls.zoom_in.click")}
-          onZoomOut={() => track("v2.run_view.canvas.controls.zoom_out.click")}
-          onFitView={() => track("v2.run_view.canvas.controls.fit_view.click")}
-          onInteractiveChange={(interactive) =>
-            track("v2.run_view.canvas.controls.interactive.toggle", {
-              interactive,
-            })
-          }
-        />
-        <MiniMap
-          position="bottom-left"
-          className="dark:rounded-md dark:border dark:border-border"
-          pannable
-          zoomable
-          onClick={() => track("v2.run_view.canvas.minimap.click")}
-          onNodeClick={() => track("v2.run_view.canvas.minimap.node.click")}
-        />
       </ReactFlow>
     </BlockStack>
   );

--- a/src/routes/v2/shared/components/MiniMap/CanvasControlsContent.tsx
+++ b/src/routes/v2/shared/components/MiniMap/CanvasControlsContent.tsx
@@ -1,0 +1,44 @@
+import { Controls, MiniMap } from "@xyflow/react";
+
+import { BlockStack } from "@/components/ui/layout";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
+
+export function CanvasControlsContent({
+  trackingSpace = "v2.pipeline_canvas",
+}: {
+  trackingSpace: string;
+}) {
+  const { track } = useAnalytics();
+
+  return (
+    <BlockStack
+      fill
+      className="@container relative bg-background [--xy-minimap-mask-background-color-props:#f0f0f0] [--xy-minimap-node-background-color-props:grey] dark:[--xy-minimap-mask-background-color-props:black]"
+      data-testid="canvas-controls-window"
+    >
+      <BlockStack fill align="stretch" className="relative @[220px]:flex-row">
+        <MiniMap
+          pannable
+          zoomable
+          onClick={() => track(`${trackingSpace}.minimap.click`)}
+          onNodeClick={() => track(`${trackingSpace}.minimap.node.click`)}
+          className="dark:rounded-md dark:border dark:border-border flex-1 !relative !inset-auto !m-0 !w-full !h-full [&_.react-flow__minimap-svg]:!w-full [&_.react-flow__minimap-svg]:!h-full [&_.react-flow__minimap-svg]:!block"
+        />
+        <Controls
+          showZoom
+          showFitView
+          showInteractive
+          onZoomIn={() => track(`${trackingSpace}.controls.zoom_in.click`)}
+          onZoomOut={() => track(`${trackingSpace}.controls.zoom_out.click`)}
+          onFitView={() => track(`${trackingSpace}.controls.fit_view.click`)}
+          onInteractiveChange={(interactive) =>
+            track(`${trackingSpace}.controls.interactive.toggle`, {
+              interactive,
+            })
+          }
+          className="!relative !inset-auto !m-0 !shadow-none flex !flex-row justify-around @[220px]:h-full @[220px]:!flex-col"
+        />
+      </BlockStack>
+    </BlockStack>
+  );
+}

--- a/src/routes/v2/shared/components/MiniMap/useCanvasControlsWindow.tsx
+++ b/src/routes/v2/shared/components/MiniMap/useCanvasControlsWindow.tsx
@@ -1,0 +1,36 @@
+import { useEffect } from "react";
+
+import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
+
+import { CanvasControlsContent } from "./CanvasControlsContent";
+
+const CANVAS_CONTROLS_WINDOW_ID = "canvas-controls";
+const CANVAS_CONTROLS_WINDOW_HEIGHT = 150;
+const WINDOW_CHROME_HEIGHT = 30;
+
+export function useCanvasControlsWindow(trackingSpace: string) {
+  const { windows } = useSharedStores();
+  useEffect(() => {
+    if (!windows.getWindowById(CANVAS_CONTROLS_WINDOW_ID)) {
+      windows.openWindow(
+        <CanvasControlsContent trackingSpace={trackingSpace} />,
+        {
+          id: CANVAS_CONTROLS_WINDOW_ID,
+          title: "Minimap",
+          position: {
+            x: 320,
+            y:
+              window.innerHeight -
+              CANVAS_CONTROLS_WINDOW_HEIGHT -
+              WINDOW_CHROME_HEIGHT,
+          },
+          size: { width: 226, height: CANVAS_CONTROLS_WINDOW_HEIGHT },
+          minSize: { width: 226, height: CANVAS_CONTROLS_WINDOW_HEIGHT },
+          disabledActions: ["close", "maximize"],
+          variant: "panel",
+          persisted: true,
+        },
+      );
+    }
+  }, [windows]);
+}

--- a/src/routes/v2/shared/windows/viewPresets.ts
+++ b/src/routes/v2/shared/windows/viewPresets.ts
@@ -27,6 +27,7 @@ export const DEFAULT_DOCK_AREAS: PresetDockAreas = {
     "history",
     "debug-panel",
     "recent-runs",
+    "canvas-controls",
   ],
   right: ["pipeline-details", "context-panel"],
 };
@@ -56,6 +57,7 @@ export const DEFAULT_VIEW_PRESET: ViewPreset = {
     "component-library",
     AI_ASSISTANT_WINDOW_ID,
     "pipeline-details",
+    "canvas-controls",
     "tip-of-the-day",
   ]),
   dockAreas: DEFAULT_DOCK_AREAS,
@@ -77,6 +79,7 @@ export const VIEW_PRESETS: ViewPreset[] = [
       "pipeline-details",
       "debug-panel",
       "recent-runs",
+      "canvas-controls",
       "tip-of-the-day",
     ]),
     dockAreas: DEFAULT_DOCK_AREAS,


### PR DESCRIPTION
## Description

The `MiniMap` and `Controls` components have been extracted from `FlowCanvas` and moved into a dedicated `CanvasControlsContent` component, which is now rendered inside its own managed window via a new `useCanvasControlsWindow` hook. This window is registered as a persisted, non-closeable, non-maximizable panel positioned at the bottom of the editor, and is included in the default dock areas and view presets alongside the other editor windows.

## Screenshots (if applicable)

## [Screen Recording 2026-07-16 at 1.17.22 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/a3f9aef2-e6d4-45b6-b34d-9c98d115e415.mov" />](https://app.graphite.com/user-attachments/video/a3f9aef2-e6d4-45b6-b34d-9c98d115e415.mov)

## Test Instructions

1. Open the pipeline editor.
2. Verify that the minimap and canvas controls (zoom in/out, fit view, interactive toggle) appear in the Canvas Controls window panel at the bottom of the editor rather than overlaid on the flow canvas.
3. Confirm the Canvas Controls window cannot be closed or maximized.
4. Confirm that analytics events are still fired correctly when interacting with the minimap and controls.
5. Verify the window appears correctly across all view presets.

## Additional Comments

Analytics tracking for the minimap and controls has been preserved in `CanvasControlsContent`, maintaining the same event names as before.