### PR TITLE
fix: Auth Error Retry

### DIFF
--- a/src/components/shared/RemoteAuthErrorView.tsx
+++ b/src/components/shared/RemoteAuthErrorView.tsx
@@ -1,0 +1,29 @@
+import { InfoBox } from "@/components/shared/InfoBox";
+import { Button } from "@/components/ui/button";
+import { BlockStack } from "@/components/ui/layout";
+import { Paragraph } from "@/components/ui/typography";
+
+interface RemoteAuthErrorViewProps {
+  onReload?: () => void;
+}
+
+export const RemoteAuthErrorView = ({
+  onReload = () => window.location.reload(),
+}: RemoteAuthErrorViewProps) => {
+  return (
+    <BlockStack fill>
+      <InfoBox title="Couldn't reach the server" variant="error">
+        <BlockStack gap="3">
+          <Paragraph>
+            Your session may have expired or the connection was interrupted by
+            an authentication service. Reload the page to reauthenticate and
+            restore the connection.
+          </Paragraph>
+          <Button onClick={onReload} className="w-fit">
+            Reload page
+          </Button>
+        </BlockStack>
+      </InfoBox>
+    </BlockStack>
+  );
+};

--- a/src/hooks/usePipelineRunData.ts
+++ b/src/hooks/usePipelineRunData.ts
@@ -11,6 +11,10 @@ import {
   flattenExecutionStatusStats,
   isExecutionComplete,
 } from "@/utils/executionStatus";
+import { RemoteAuthError } from "@/utils/fetchWithErrorHandling";
+
+const retryUnlessAuth = (failureCount: number, error: Error) =>
+  !(error instanceof RemoteAuthError) && failureCount < 3;
 
 const useRootExecutionId = (id: string) => {
   const { backendUrl } = useBackend();
@@ -41,7 +45,7 @@ export const usePipelineRunData = (id: string) => {
 
   const rootExecutionId = useRootExecutionId(id);
 
-  const { data: executionDetails } = useQuery({
+  const { data: executionDetails, error: executionDetailsError } = useQuery({
     enabled: !!rootExecutionId,
     queryKey: ["execution-details", rootExecutionId],
     queryFn: async () => {
@@ -52,11 +56,12 @@ export const usePipelineRunData = (id: string) => {
       return fetchExecutionDetails(rootExecutionId, backendUrl);
     },
     staleTime: 1 * HOURS,
+    retry: retryUnlessAuth,
   });
 
   const {
     data: executionData,
-    error,
+    error: executionDataError,
     isLoading,
   } = useQuery({
     enabled: !!rootExecutionId && !!executionDetails,
@@ -87,12 +92,13 @@ export const usePipelineRunData = (id: string) => {
       return false;
     },
     staleTime: 5000,
+    retry: retryUnlessAuth,
   });
 
   return {
     executionData,
     rootExecutionId,
     isLoading,
-    error,
+    error: executionDetailsError ?? executionDataError,
   };
 };

--- a/src/routes/PipelineRun/PipelineRun.tsx
+++ b/src/routes/PipelineRun/PipelineRun.tsx
@@ -7,6 +7,7 @@ import PipelineRunPage from "@/components/PipelineRun";
 import { InfoBox } from "@/components/shared/InfoBox";
 import { LoadingScreen } from "@/components/shared/LoadingScreen";
 import { NodesOverlayProvider } from "@/components/shared/ReactFlow/NodesOverlay/NodesOverlayProvider";
+import { RemoteAuthErrorView } from "@/components/shared/RemoteAuthErrorView";
 import { BlockStack } from "@/components/ui/layout";
 import { Paragraph } from "@/components/ui/typography";
 import { faviconManager } from "@/favicon";
@@ -24,6 +25,7 @@ import {
   flattenExecutionStatusStats,
   getOverallExecutionStatusFromStats,
 } from "@/utils/executionStatus";
+import { RemoteAuthError } from "@/utils/fetchWithErrorHandling";
 
 const PipelineRunContent = () => {
   const { setComponentSpec, clearComponentSpec, componentSpec } =
@@ -109,17 +111,10 @@ const PipelineRunContent = () => {
     );
   }
 
-  if (!componentSpec) {
-    return (
-      <BlockStack fill>
-        <InfoBox title="Error loading pipeline run" variant="error">
-          No pipeline data available.
-        </InfoBox>
-      </BlockStack>
-    );
-  }
-
-  if (error) {
+  if (error && !rootDetails) {
+    if (error instanceof RemoteAuthError) {
+      return <RemoteAuthErrorView />;
+    }
     const backendStatusString = getBackendStatusString(configured, available);
     return (
       <BlockStack fill>

--- a/src/routes/v2/pages/RunView/RunViewV2.tsx
+++ b/src/routes/v2/pages/RunView/RunViewV2.tsx
@@ -8,6 +8,7 @@ import { useEffect, useRef } from "react";
 
 import { InfoBox } from "@/components/shared/InfoBox";
 import { LoadingScreen } from "@/components/shared/LoadingScreen";
+import { RemoteAuthErrorView } from "@/components/shared/RemoteAuthErrorView";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Paragraph } from "@/components/ui/typography";
 import type { ComponentSpec } from "@/models/componentSpec";
@@ -35,6 +36,7 @@ import { WindowContainer } from "@/routes/v2/shared/windows/WindowContainer";
 import { useWindowPersistence } from "@/routes/v2/shared/windows/windowPersistence";
 import { getBackendStatusString } from "@/utils/backend";
 import type { ComponentSpec as DomainComponentSpec } from "@/utils/componentSpec";
+import { RemoteAuthError } from "@/utils/fetchWithErrorHandling";
 
 import { RunViewFlowCanvas } from "./components/RunViewFlowCanvas";
 import { RunViewMenuBar } from "./components/RunViewMenuBar/RunViewMenuBar";
@@ -114,6 +116,9 @@ const RunViewContent = observer(function RunViewContent() {
   }
 
   if (error) {
+    if (error instanceof RemoteAuthError) {
+      return <RemoteAuthErrorView />;
+    }
     const backendStatusString = getBackendStatusString(configured, available);
     return (
       <BlockStack fill>

--- a/src/services/executionService.ts
+++ b/src/services/executionService.ts
@@ -18,8 +18,14 @@ import {
   flattenExecutionStatusStats,
   getOverallExecutionStatusFromStats,
 } from "@/utils/executionStatus";
-import { fetchWithErrorHandling } from "@/utils/fetchWithErrorHandling";
+import {
+  fetchWithErrorHandling,
+  RemoteAuthError,
+} from "@/utils/fetchWithErrorHandling";
 import { rateLimit } from "@/utils/rateLimit";
+
+const retryUnlessAuth = (failureCount: number, error: Error) =>
+  !(error instanceof RemoteAuthError) && failureCount < 3;
 
 export const fetchExecutionState = async (
   executionId: string,
@@ -41,11 +47,8 @@ export const fetchPipelineRun = async (
   runId: string,
   backendUrl: string,
 ): Promise<PipelineRunResponse> => {
-  const response = await fetch(`${backendUrl}/api/pipeline_runs/${runId}`);
-  if (!response.ok) {
-    throw new Error(`Failed to fetch pipeline run: ${response.statusText}`);
-  }
-  return response.json();
+  const url = `${backendUrl}/api/pipeline_runs/${runId}`;
+  return fetchWithErrorHandling(url);
 };
 
 export const useFetchPipelineRunMetadata = (runId: string | undefined) => {
@@ -57,6 +60,7 @@ export const useFetchPipelineRunMetadata = (runId: string | undefined) => {
     enabled: !!runId,
     refetchOnWindowFocus: false,
     staleTime: TWENTY_FOUR_HOURS_IN_MS,
+    retry: retryUnlessAuth,
   });
 };
 
@@ -81,6 +85,7 @@ export const useFetchContainerExecutionState = (
     queryFn: () => fetchContainerExecutionState(executionId!, backendUrl),
     enabled: shouldFetch,
     refetchOnWindowFocus: false,
+    retry: retryUnlessAuth,
   });
 };
 

--- a/src/utils/fetchWithErrorHandling.test.ts
+++ b/src/utils/fetchWithErrorHandling.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  fetchWithErrorHandling,
+  RemoteAuthError,
+} from "./fetchWithErrorHandling";
+
+const buildResponse = (overrides: Partial<Response> = {}): Response => {
+  const headers = new Headers();
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    type: "basic",
+    redirected: false,
+    url: "https://example.com/api/foo",
+    headers,
+    json: async () => ({}),
+    text: async () => "",
+    ...overrides,
+  } as Response;
+};
+
+describe("fetchWithErrorHandling", () => {
+  const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+  beforeEach(() => {
+    fetchSpy.mockReset();
+  });
+
+  afterEach(() => {
+    fetchSpy.mockReset();
+  });
+
+  it("requests with redirect: 'manual' by default", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      buildResponse({
+        headers: new Headers({ "content-type": "application/json" }),
+        json: async () => ({ ok: true }),
+      }),
+    );
+
+    await fetchWithErrorHandling("https://example.com/api/foo");
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://example.com/api/foo",
+      expect.objectContaining({ redirect: "manual" }),
+    );
+  });
+
+  it("throws RemoteAuthError when the response is an opaque redirect", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      buildResponse({
+        type: "opaqueredirect",
+        ok: false,
+        status: 0,
+      }),
+    );
+
+    await expect(
+      fetchWithErrorHandling("https://example.com/api/foo"),
+    ).rejects.toBeInstanceOf(RemoteAuthError);
+  });
+
+  it("preserves the request URL on RemoteAuthError", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      buildResponse({
+        type: "opaqueredirect",
+        ok: false,
+        status: 0,
+      }),
+    );
+
+    await expect(
+      fetchWithErrorHandling("https://example.com/api/bar"),
+    ).rejects.toMatchObject({ url: "https://example.com/api/bar" });
+  });
+
+  it("returns parsed JSON on success", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      buildResponse({
+        headers: new Headers({ "content-type": "application/json" }),
+        json: async () => ({ value: 42 }),
+      }),
+    );
+
+    const result = await fetchWithErrorHandling("https://example.com/api/foo");
+
+    expect(result).toEqual({ value: 42 });
+  });
+
+  it("wraps network failures with the request URL", async () => {
+    fetchSpy.mockRejectedValueOnce(new TypeError("Failed to fetch"));
+
+    await expect(
+      fetchWithErrorHandling("https://example.com/api/foo"),
+    ).rejects.toThrow(/Network error.*example.com\/api\/foo/);
+  });
+
+  it("allows callers to override the redirect option", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      buildResponse({
+        headers: new Headers({ "content-type": "application/json" }),
+        json: async () => ({}),
+      }),
+    );
+
+    await fetchWithErrorHandling("https://example.com/api/foo", {
+      redirect: "follow",
+    });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://example.com/api/foo",
+      expect.objectContaining({ redirect: "follow" }),
+    );
+  });
+});

--- a/src/utils/fetchWithErrorHandling.ts
+++ b/src/utils/fetchWithErrorHandling.ts
@@ -1,15 +1,33 @@
+export class RemoteAuthError extends Error {
+  constructor(public readonly url: string) {
+    super(
+      `Request to ${url} was intercepted by a remote authentication service.`,
+    );
+    this.name = "RemoteAuthError";
+    Object.setPrototypeOf(this, RemoteAuthError.prototype);
+  }
+}
+
 export const fetchWithErrorHandling = async (
   url: string,
   options?: RequestInit,
 ): Promise<any> => {
   let response: Response;
 
+  if (import.meta.env.DEV && url.includes("/api/executions/")) {
+    throw new RemoteAuthError(url);
+  }
+
   try {
-    response = await fetch(url, options);
+    response = await fetch(url, { redirect: "manual", ...options });
   } catch (fetchError) {
     const message =
       fetchError instanceof Error ? fetchError.message : String(fetchError);
     throw new Error(`Network error: ${message} (URL: ${url})`);
+  }
+
+  if (response.type === "opaqueredirect") {
+    throw new RemoteAuthError(url);
   }
 
   if (!response.ok) {


### PR DESCRIPTION
## Description

Updates fetching/error messaging to specifically surface authentication errors that block fetch data from the backend. Adds a reload button, which may help refresh auth tokens.



Given this is an open source repo the scope of this PR is generic and not targeted at any particular auth provided or system.

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

Closes https://github.com/Shopify/oasis-frontend/issues/167

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

![image.png](https://app.graphite.com/user-attachments/assets/25011545-9aed-4914-95e3-5100ae53b4e5.png)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->