### PR TITLE
chore: v2 - autosaveindicator click triggers save

### DIFF
--- a/src/routes/v2/pages/Editor/components/EditorMenuBar/components/AutoSaveIndicator.tsx
+++ b/src/routes/v2/pages/Editor/components/EditorMenuBar/components/AutoSaveIndicator.tsx
@@ -30,7 +30,7 @@ function IdleLayer({ children }: { children: ReactNode }) {
     <span
       className={cn(
         LAYER_BASE_CLASS,
-        "text-stone-400 opacity-100 hover:text-white",
+        "opacity-100 hover:text-white",
         "[transition:opacity_150ms_ease-out_600ms,color_1000ms_ease-out_750ms]",
         "group-data-[saving=true]:text-green-500 group-data-[saving=true]:opacity-0",
         "group-data-[saving=true]:[transition:opacity_150ms_ease-out,color_0ms]",
@@ -54,11 +54,16 @@ export const AutoSaveIndicator = observer(function AutoSaveIndicator() {
   const { isSaving, lastSavedAt } = autoSave;
   const tooltipText = getTooltipText(isSaving, lastSavedAt);
 
+  const handleClick = () => {
+    void autoSave.save();
+  };
+
   return (
     <TooltipButton
       tooltip={tooltipText}
       className="hover:bg-transparent"
       disabled={isSaving}
+      onClick={handleClick}
       data-testid="auto-save-button"
       {...tracking("v2.pipeline_editor.auto_save_indicator")}
     >


### PR DESCRIPTION
## Description

Clicking the auto-save indicator button now triggers a manual save. Previously, the button was purely informational and clicking it had no effect. Additionally, the default `text-stone-400` color class has been removed from the idle layer, allowing the button's text color to be inherited from its context rather than being hardcoded.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## [Screen Recording 2026-05-13 at 11.24.03 AM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/ccbe8140-089a-4642-b2ed-f4fcdeff1718.mov" />](https://app.graphite.com/user-attachments/video/ccbe8140-089a-4642-b2ed-f4fcdeff1718.mov)



## Test Instructions

1. Open the pipeline editor.
2. Make a change to a pipeline.
3. Click the auto-save indicator button in the menu bar before the auto-save triggers.
4. Verify that the save is triggered immediately and the indicator reflects the saving state.

## Additional Comments