### PR TITLE
fix: add window-global pattern for auth errors

### DIFF
--- a/src/components/shared/RemoteAuthErrorView.tsx
+++ b/src/components/shared/RemoteAuthErrorView.tsx
@@ -1,0 +1,52 @@
+import { InfoBox } from "@/components/shared/InfoBox";
+import { Button } from "@/components/ui/button";
+import { BlockStack } from "@/components/ui/layout";
+import { Paragraph } from "@/components/ui/typography";
+import authPageConfig from "@/config/authPageConfig.json";
+
+interface AuthPageConfig {
+  title: string;
+  body: string;
+  reloadLabel: string;
+  helpLink?: {
+    text: string;
+    url: string;
+  };
+}
+
+const config = authPageConfig as AuthPageConfig;
+
+interface RemoteAuthErrorViewProps {
+  onReload?: () => void;
+}
+
+export const RemoteAuthErrorView = ({
+  onReload = () => window.location.reload(),
+}: RemoteAuthErrorViewProps) => {
+  const { title, body, reloadLabel, helpLink } = config;
+
+  return (
+    <BlockStack fill>
+      <InfoBox title={title} variant="error">
+        <BlockStack gap="3">
+          <Paragraph>{body}</Paragraph>
+          {helpLink && (
+            <Paragraph tone="subdued" size="xs">
+              <a
+                href={helpLink.url}
+                target="_blank"
+                rel="noreferrer"
+                className="underline"
+              >
+                {helpLink.text}
+              </a>
+            </Paragraph>
+          )}
+          <Button onClick={onReload} className="w-fit">
+            {reloadLabel}
+          </Button>
+        </BlockStack>
+      </InfoBox>
+    </BlockStack>
+  );
+};

--- a/src/config/authPageConfig.json
+++ b/src/config/authPageConfig.json
@@ -1,0 +1,5 @@
+{
+  "title": "Couldn't reach the server",
+  "body": "Your session may have expired or the connection was interrupted by an authentication service. Reload the page to reauthenticate and restore the connection.",
+  "reloadLabel": "Reload page"
+}

--- a/src/hooks/usePipelineRunData.ts
+++ b/src/hooks/usePipelineRunData.ts
@@ -11,6 +11,12 @@ import {
   flattenExecutionStatusStats,
   isExecutionComplete,
 } from "@/utils/executionStatus";
+import { RemoteAuthError } from "@/utils/fetchWithErrorHandling";
+
+const NUM_RETRIES = 3;
+
+const retryUnlessAuth = (failureCount: number, error: Error) =>
+  !(error instanceof RemoteAuthError) && failureCount < NUM_RETRIES;
 
 const useRootExecutionId = (id: string) => {
   const { backendUrl } = useBackend();
@@ -41,7 +47,7 @@ export const usePipelineRunData = (id: string) => {
 
   const rootExecutionId = useRootExecutionId(id);
 
-  const { data: executionDetails } = useQuery({
+  const { data: executionDetails, error: executionDetailsError } = useQuery({
     enabled: !!rootExecutionId,
     queryKey: ["execution-details", rootExecutionId],
     queryFn: async () => {
@@ -52,11 +58,12 @@ export const usePipelineRunData = (id: string) => {
       return fetchExecutionDetails(rootExecutionId, backendUrl);
     },
     staleTime: 1 * HOURS,
+    retry: retryUnlessAuth,
   });
 
   const {
     data: executionData,
-    error,
+    error: executionDataError,
     isLoading,
   } = useQuery({
     enabled: !!rootExecutionId && !!executionDetails,
@@ -87,12 +94,13 @@ export const usePipelineRunData = (id: string) => {
       return false;
     },
     staleTime: 5000,
+    retry: retryUnlessAuth,
   });
 
   return {
     executionData,
     rootExecutionId,
     isLoading,
-    error,
+    error: executionDetailsError ?? executionDataError,
   };
 };

--- a/src/routes/PipelineRun/PipelineRun.tsx
+++ b/src/routes/PipelineRun/PipelineRun.tsx
@@ -7,6 +7,7 @@ import PipelineRunPage from "@/components/PipelineRun";
 import { InfoBox } from "@/components/shared/InfoBox";
 import { LoadingScreen } from "@/components/shared/LoadingScreen";
 import { NodesOverlayProvider } from "@/components/shared/ReactFlow/NodesOverlay/NodesOverlayProvider";
+import { RemoteAuthErrorView } from "@/components/shared/RemoteAuthErrorView";
 import { BlockStack } from "@/components/ui/layout";
 import { Paragraph } from "@/components/ui/typography";
 import { faviconManager } from "@/favicon";
@@ -24,6 +25,7 @@ import {
   flattenExecutionStatusStats,
   getOverallExecutionStatusFromStats,
 } from "@/utils/executionStatus";
+import { RemoteAuthError } from "@/utils/fetchWithErrorHandling";
 
 const PipelineRunContent = () => {
   const { setComponentSpec, clearComponentSpec, componentSpec } =
@@ -109,17 +111,10 @@ const PipelineRunContent = () => {
     );
   }
 
-  if (!componentSpec) {
-    return (
-      <BlockStack fill>
-        <InfoBox title="Error loading pipeline run" variant="error">
-          No pipeline data available.
-        </InfoBox>
-      </BlockStack>
-    );
-  }
-
-  if (error) {
+  if (error && !rootDetails) {
+    if (error instanceof RemoteAuthError) {
+      return <RemoteAuthErrorView />;
+    }
     const backendStatusString = getBackendStatusString(configured, available);
     return (
       <BlockStack fill>

--- a/src/routes/v2/pages/RunView/RunViewV2.tsx
+++ b/src/routes/v2/pages/RunView/RunViewV2.tsx
@@ -8,6 +8,7 @@ import { useEffect, useRef } from "react";
 
 import { InfoBox } from "@/components/shared/InfoBox";
 import { LoadingScreen } from "@/components/shared/LoadingScreen";
+import { RemoteAuthErrorView } from "@/components/shared/RemoteAuthErrorView";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Paragraph } from "@/components/ui/typography";
 import type { ComponentSpec } from "@/models/componentSpec";
@@ -35,6 +36,7 @@ import { WindowContainer } from "@/routes/v2/shared/windows/WindowContainer";
 import { useWindowPersistence } from "@/routes/v2/shared/windows/windowPersistence";
 import { getBackendStatusString } from "@/utils/backend";
 import type { ComponentSpec as DomainComponentSpec } from "@/utils/componentSpec";
+import { RemoteAuthError } from "@/utils/fetchWithErrorHandling";
 
 import { RunViewFlowCanvas } from "./components/RunViewFlowCanvas";
 import { RunViewMenuBar } from "./components/RunViewMenuBar/RunViewMenuBar";
@@ -114,6 +116,9 @@ const RunViewContent = observer(function RunViewContent() {
   }
 
   if (error) {
+    if (error instanceof RemoteAuthError) {
+      return <RemoteAuthErrorView />;
+    }
     const backendStatusString = getBackendStatusString(configured, available);
     return (
       <BlockStack fill>

--- a/src/services/executionService.ts
+++ b/src/services/executionService.ts
@@ -18,8 +18,14 @@ import {
   flattenExecutionStatusStats,
   getOverallExecutionStatusFromStats,
 } from "@/utils/executionStatus";
-import { fetchWithErrorHandling } from "@/utils/fetchWithErrorHandling";
+import {
+  fetchWithErrorHandling,
+  RemoteAuthError,
+} from "@/utils/fetchWithErrorHandling";
 import { rateLimit } from "@/utils/rateLimit";
+
+const retryUnlessAuth = (failureCount: number, error: Error) =>
+  !(error instanceof RemoteAuthError) && failureCount < 3;
 
 export const fetchExecutionState = async (
   executionId: string,
@@ -41,11 +47,8 @@ export const fetchPipelineRun = async (
   runId: string,
   backendUrl: string,
 ): Promise<PipelineRunResponse> => {
-  const response = await fetch(`${backendUrl}/api/pipeline_runs/${runId}`);
-  if (!response.ok) {
-    throw new Error(`Failed to fetch pipeline run: ${response.statusText}`);
-  }
-  return response.json();
+  const url = `${backendUrl}/api/pipeline_runs/${runId}`;
+  return fetchWithErrorHandling(url);
 };
 
 export const useFetchPipelineRunMetadata = (runId: string | undefined) => {
@@ -57,6 +60,7 @@ export const useFetchPipelineRunMetadata = (runId: string | undefined) => {
     enabled: !!runId,
     refetchOnWindowFocus: false,
     staleTime: TWENTY_FOUR_HOURS_IN_MS,
+    retry: retryUnlessAuth,
   });
 };
 
@@ -81,6 +85,7 @@ export const useFetchContainerExecutionState = (
     queryFn: () => fetchContainerExecutionState(executionId!, backendUrl),
     enabled: shouldFetch,
     refetchOnWindowFocus: false,
+    retry: retryUnlessAuth,
   });
 };
 

--- a/src/utils/fetchWithErrorHandling.test.ts
+++ b/src/utils/fetchWithErrorHandling.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  fetchWithErrorHandling,
+  RemoteAuthError,
+} from "./fetchWithErrorHandling";
+
+const buildResponse = (overrides: Partial<Response> = {}): Response => {
+  const headers = new Headers();
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    type: "basic",
+    redirected: false,
+    url: "https://example.com/api/foo",
+    headers,
+    json: async () => ({}),
+    text: async () => "",
+    ...overrides,
+  } as Response;
+};
+
+describe("fetchWithErrorHandling", () => {
+  const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+  beforeEach(() => {
+    fetchSpy.mockReset();
+  });
+
+  afterEach(() => {
+    fetchSpy.mockReset();
+  });
+
+  it("requests with redirect: 'manual' by default", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      buildResponse({
+        headers: new Headers({ "content-type": "application/json" }),
+        json: async () => ({ ok: true }),
+      }),
+    );
+
+    await fetchWithErrorHandling("https://example.com/api/foo");
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://example.com/api/foo",
+      expect.objectContaining({ redirect: "manual" }),
+    );
+  });
+
+  it("throws RemoteAuthError when the response is an opaque redirect", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      buildResponse({
+        type: "opaqueredirect",
+        ok: false,
+        status: 0,
+      }),
+    );
+
+    await expect(
+      fetchWithErrorHandling("https://example.com/api/foo"),
+    ).rejects.toBeInstanceOf(RemoteAuthError);
+  });
+
+  it("preserves the request URL on RemoteAuthError", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      buildResponse({
+        type: "opaqueredirect",
+        ok: false,
+        status: 0,
+      }),
+    );
+
+    await expect(
+      fetchWithErrorHandling("https://example.com/api/bar"),
+    ).rejects.toMatchObject({ url: "https://example.com/api/bar" });
+  });
+
+  it("returns parsed JSON on success", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      buildResponse({
+        headers: new Headers({ "content-type": "application/json" }),
+        json: async () => ({ value: 42 }),
+      }),
+    );
+
+    const result = await fetchWithErrorHandling("https://example.com/api/foo");
+
+    expect(result).toEqual({ value: 42 });
+  });
+
+  it("wraps network failures with the request URL", async () => {
+    fetchSpy.mockRejectedValueOnce(new TypeError("Failed to fetch"));
+
+    await expect(
+      fetchWithErrorHandling("https://example.com/api/foo"),
+    ).rejects.toThrow(/Network error.*example.com\/api\/foo/);
+  });
+
+  it("allows callers to override the redirect option", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      buildResponse({
+        headers: new Headers({ "content-type": "application/json" }),
+        json: async () => ({}),
+      }),
+    );
+
+    await fetchWithErrorHandling("https://example.com/api/foo", {
+      redirect: "follow",
+    });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://example.com/api/foo",
+      expect.objectContaining({ redirect: "follow" }),
+    );
+  });
+});

--- a/src/utils/fetchWithErrorHandling.ts
+++ b/src/utils/fetchWithErrorHandling.ts
@@ -1,3 +1,13 @@
+export class RemoteAuthError extends Error {
+  constructor(public readonly url: string) {
+    super(
+      `Request to ${url} was intercepted by a remote authentication service.`,
+    );
+    this.name = "RemoteAuthError";
+    Object.setPrototypeOf(this, RemoteAuthError.prototype);
+  }
+}
+
 export const fetchWithErrorHandling = async (
   url: string,
   options?: RequestInit,
@@ -5,11 +15,15 @@ export const fetchWithErrorHandling = async (
   let response: Response;
 
   try {
-    response = await fetch(url, options);
+    response = await fetch(url, { redirect: "manual", ...options });
   } catch (fetchError) {
     const message =
       fetchError instanceof Error ? fetchError.message : String(fetchError);
     throw new Error(`Network error: ${message} (URL: ${url})`);
+  }
+
+  if (response.type === "opaqueredirect") {
+    throw new RemoteAuthError(url);
   }
 
   if (!response.ok) {


### PR DESCRIPTION
## Description

Fixes the blank/confusing UX when a run page can't load because an authentication service is intercepting the backend API calls with a CORS-blocked 302.

- Detects auth-bounce responses generically by setting `redirect: 'manual'` in `fetchWithErrorHandling` and throwing a typed `RemoteAuthError` on `response.type === 'opaqueredirect'` — no provider-specific references needed.
- Adds `RemoteAuthErrorView` on the v1 and v2 run pages, replacing the previous generic "Error loading pipeline run" full-page state with a focused "Couldn't reach the server" + Reload button. Copy is provider-agnostic for OSS.
- Skips TanStack Query retries on `RemoteAuthError` for the run/execution queries so users see the prompt immediately instead of burning through three failed requests.
- Surfaces the `executionDetails` query error (previously dropped on the floor) so the auth UI also fires when that fetch is the one being intercepted, not just `state`.
- Fixes a dead-code bug in v1's `PipelineRunContent`: the error UI was gated on `!componentSpec`, but `ComponentSpecProvider` defaults to `EMPTY_GRAPH_COMPONENT_SPEC` so it's never falsy. Replaced with `!rootDetails`, which actually reflects whether data has loaded.
- Keeps already-loaded pages intact when the 5s poll later fails — no full-screen error replaces a successfully-rendered run. v2 already handled this via `specRef`; v1 now matches by gating on `rootDetails`.

`RemoteAuthErrorView` reads optional overrides from `window.__TANGLE_AUTH_ERROR_VIEW__` (title, body, reloadLabel, helpLink) — matches the existing `window.__TANGLE_ANNOUNCEMENTS__` precedent. OSS users get the generic copy; downstream consumers like can set the global from their overlay's `index.html` to customize the copy without forking any React source.

## Related Issue and Pull requests

Closes https://github.com/Shopify/oasis-frontend/issues/167
Hopefully closes https://github.com/Shopify/oasis-frontend/issues/631

## Type of Change

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

![image.png](https://app.graphite.com/user-attachments/assets/182ec54c-7fb4-49b9-8baf-891ebb0f8732.png)

## Test Instructions

The auth-bounce condition can't be reproduced directly against a healthy backend, so test by temporarily forcing it locally:

1. At the top of `fetchWithErrorHandling`, add:
2. (Optional, to preview the override) At the top of `src/index.tsx` before `ReactDOM.createRoot`:
3. Open a run URL **in an Incognito window** (required — TanStack Query cache + the v2 `specRef` persist across reloads and will mask the cold-load behavior otherwise).
4. Verify the focused error UI renders (custom copy if the global is set, generic copy if not).
5. Click "Reload page" — confirms a full document reload.
6. Revert both temporary blocks before requesting review.

To verify the "don't tear down loaded page" behavior, change the throw to fire only after arming:

```ts
if (import.meta.env.DEV && url.includes("/api/executions/") && (window as any).__authBounceArmed) {
  throw new RemoteAuthError(url);
}
```

Load the run normally → in console: `window.__authBounceArmed = true` → wait ~5s for the next poll → the page should stay rendered, no full-screen takeover.

## Additional Comments

- **Why** **`redirect: 'manual'`** **is safe here:** every call site of `fetchWithErrorHandling` hits a Tangle API endpoint, none of which legitimately return 30x responses. With manual redirect, any 3xx surfaces as `opaqueredirect`, which is what we want. Callers can still override the redirect option via `RequestInit`.
- **Reload, not retry:** the button does a top-level `window.location.reload()` (not a programmatic retry) because the auth cookie can only be set by a fresh document navigation through the SSO redirect chain. An in-place refetch would hit the same wall.
- **Cache busting note:** the modern browser API for forcing a hard refresh from JS no longer exists (`window.location.reload(true)` is deprecated and ignored). The plain reload is sufficient for the auth-recovery case because the redirect chain runs at the navigation layer regardless of cache state.
- **Not in scope:** no global "connection status" banner, no inline "updates paused" pill for failing 5s polls on already-loaded pages, no auto-reload (the Slack thread on the linked issue explicitly called out the risk of reload loops, so all reloads stay user-initiated).