### PR TITLE
fix: v2: debug panel yaml viewer has no height

### DIFF
--- a/src/routes/v2/pages/Editor/components/DebugPanel.tsx
+++ b/src/routes/v2/pages/Editor/components/DebugPanel.tsx
@@ -119,8 +119,10 @@ const DebugPanelContent = observer(function DebugPanelContent() {
       </TabsContent>
 
       <TabsContent value="yaml" className="flex-1 min-h-0">
-        <div className="m-2 h-full rounded-md overflow-hidden bg-gray-50 border border-gray-200">
-          <CodeSyntaxHighlighter code={specYaml} language="yaml" />
+        <div className="m-2 h-full min-h-75 rounded-md overflow-hidden bg-gray-50 border border-gray-200 relative">
+          <div className="absolute inset-0">
+            <CodeSyntaxHighlighter code={specYaml} language="yaml" />
+          </div>
         </div>
       </TabsContent>
     </Tabs>


### PR DESCRIPTION
## Description

minor ui issue i noticed.

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

before

![image.png](https://app.graphite.com/user-attachments/assets/c8dcf102-4319-4f1f-a8c6-88b57d7d2f9b.png)





after

![image.png](https://app.graphite.com/user-attachments/assets/d702966d-c8b5-43de-8ebf-e43f2e7f0bd1.png)



<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

open debug panel -> view yaml



it should now have a bit of height to it.

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->