### PR TITLE
fix: v2: order pipeline list by ModifiedAt

### DIFF
--- a/src/routes/v2/pages/PipelineFolders/components/FolderPipelineTable/FolderPipelineTable.tsx
+++ b/src/routes/v2/pages/PipelineFolders/components/FolderPipelineTable/FolderPipelineTable.tsx
@@ -99,9 +99,14 @@ export const FolderPipelineTable = withSuspenseWrapper(
       f.name.toLowerCase().includes(searchQuery.toLowerCase()),
     );
 
-    const filteredPipelines = pipelines.filter((p) =>
-      p.storageKey.toLowerCase().includes(searchQuery.toLowerCase()),
-    );
+    const filteredPipelines = pipelines
+      .filter((p) =>
+        p.storageKey.toLowerCase().includes(searchQuery.toLowerCase()),
+      )
+      .sort(
+        (a, b) =>
+          (b.modifiedAt?.getTime() ?? 0) - (a.modifiedAt?.getTime() ?? 0),
+      );
 
     const pagination = usePagination(filteredPipelines);
 


### PR DESCRIPTION
## Description

The `open pipeline` dialog was ordering pipelines somewhat randomly. now they are order by their last modified date, as per the pipeline dashboard

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

![image.png](https://app.graphite.com/user-attachments/assets/f79b71b5-2b00-4ef7-9a2f-745aae3f894a.png)



<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->