### PR TITLE
chore: v2: Add v1 style undo-redo controls to canvas

### DIFF
--- a/src/routes/v2/pages/Editor/components/FlowCanvas/FlowCanvas.tsx
+++ b/src/routes/v2/pages/Editor/components/FlowCanvas/FlowCanvas.tsx
@@ -26,6 +26,7 @@ import { useNodeRegistry } from "@/routes/v2/shared/nodes/NodeRegistryContext";
 import { CMDALT, SHIFT } from "@/routes/v2/shared/shortcuts/keys";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 
+import { CanvasUndoRedo } from "./components/CanvasUndoRedo";
 import { ConnectionLine } from "./components/ConnectionLine";
 import { FloatingSelectionToolbar } from "./components/FloatingSelectionToolbar";
 import { useClipboardShortcuts } from "./hooks/useClipboardShortcuts";
@@ -141,6 +142,7 @@ export const FlowCanvas = observer(function FlowCanvas({
           onNodeClick={() => track("v2.pipeline_canvas.minimap.node.click")}
         />
       </ReactFlow>
+      <CanvasUndoRedo />
     </BlockStack>
   );
 });

--- a/src/routes/v2/pages/Editor/components/FlowCanvas/components/CanvasUndoRedo.tsx
+++ b/src/routes/v2/pages/Editor/components/FlowCanvas/components/CanvasUndoRedo.tsx
@@ -1,0 +1,71 @@
+import { observer } from "mobx-react-lite";
+
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icon";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
+import { useEditorSession } from "@/routes/v2/pages/Editor/store/EditorSessionContext";
+import { ShortcutBadge } from "@/routes/v2/shared/components/ShortcutBadge";
+
+export const CanvasUndoRedo = observer(function CanvasUndoRedo() {
+  const { track } = useAnalytics();
+  const { undo } = useEditorSession();
+
+  const handleUndo = () => {
+    track("v2.pipeline_canvas.controls.undo.click");
+    undo.undo();
+  };
+
+  const handleRedo = () => {
+    track("v2.pipeline_canvas.controls.redo.click");
+    undo.redo();
+  };
+
+  return (
+    <div className="absolute right-16 bottom-4 z-10 flex gap-1">
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="outline"
+              size="sm"
+              className="p-0"
+              onClick={handleUndo}
+              disabled={!undo.canUndo}
+              aria-label="Undo"
+            >
+              <Icon name="Undo2" size="sm" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="top" className="flex items-center gap-1">
+            Undo
+            <ShortcutBadge id="undo" className="text-primary-foreground z-10" />
+          </TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="outline"
+              size="sm"
+              className="p-0"
+              onClick={handleRedo}
+              disabled={!undo.canRedo}
+              aria-label="Redo"
+            >
+              <Icon name="Redo2" size="sm" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="top" className="flex items-center gap-1">
+            Redo
+            <ShortcutBadge id="redo" className="text-primary-foreground z-10" />
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    </div>
+  );
+});

--- a/src/routes/v2/shared/components/ShortcutBadge.tsx
+++ b/src/routes/v2/shared/components/ShortcutBadge.tsx
@@ -10,15 +10,21 @@ import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 
 export const ShortcutBadge = observer(function ShortcutBadge({
   id,
+  className,
 }: {
   id: string;
+  className?: string;
 }) {
   const { keyboard } = useSharedStores();
   const shortcut = keyboard.getShortcut(id);
 
   if (!shortcut) return null;
 
-  return <Badge variant="outline">{formatShortcut(shortcut.keys)}</Badge>;
+  return (
+    <Badge variant="outline" className={className}>
+      {formatShortcut(shortcut.keys)}
+    </Badge>
+  );
 });
 
 const isMac =


### PR DESCRIPTION
## Description

As per a recent discussion the v1 undo-redo controls have been brought over to the v2 canvas. Behaviour and UI is exactly the same as v1 editor

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

![image.png](https://app.graphite.com/user-attachments/assets/f716987b-e0f5-44b5-9889-1b8e1a2db6b6.png)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->