### PR TITLE
fix: v2: closing task properties does not deselect the task

### DIFF
--- a/src/routes/v2/pages/Editor/hooks/useEditorEscapeShortcut.ts
+++ b/src/routes/v2/pages/Editor/hooks/useEditorEscapeShortcut.ts
@@ -2,6 +2,7 @@ import { useReactFlow } from "@xyflow/react";
 import { useEffect } from "react";
 
 import { useDialog } from "@/providers/DialogProvider/hooks/useDialog";
+import { useDeselectAll } from "@/routes/v2/shared/hooks/useDeselectAll";
 import { ESCAPE } from "@/routes/v2/shared/shortcuts/keys";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 
@@ -25,6 +26,7 @@ export function useEditorEscapeShortcut(): void {
   const { stack } = useDialog();
   const { editor, keyboard, windows } = useSharedStores();
   const reactFlow = useReactFlow();
+  const deselectAll = useDeselectAll();
 
   useEffect(() => {
     const unregister = keyboard.registerShortcut({
@@ -41,21 +43,13 @@ export function useEditorEscapeShortcut(): void {
           return;
         }
 
-        const rfSelected = hasReactFlowSelection(reactFlow);
-        const editorSelected = editor.hasAnySelection;
-        if (!rfSelected && !editorSelected) return false;
-
-        editor.clearSelection();
-        if (rfSelected) {
-          reactFlow.setNodes((ns) =>
-            ns.map((n) => (n.selected ? { ...n, selected: false } : n)),
-          );
-          reactFlow.setEdges((es) =>
-            es.map((e) => (e.selected ? { ...e, selected: false } : e)),
-          );
+        if (!hasReactFlowSelection(reactFlow) && !editor.hasAnySelection) {
+          return false;
         }
+
+        deselectAll();
       },
     });
     return unregister;
-  }, [editor, keyboard, reactFlow, stack, windows]);
+  }, [editor, keyboard, reactFlow, stack, windows, deselectAll]);
 }

--- a/src/routes/v2/pages/Editor/hooks/useSelectionWindowSync.tsx
+++ b/src/routes/v2/pages/Editor/hooks/useSelectionWindowSync.tsx
@@ -3,6 +3,7 @@ import { useEffect } from "react";
 
 import { ContextPanelContent } from "@/routes/v2/pages/Editor/components/ContextPanel/ContextPanel";
 import { PinnedTaskContent } from "@/routes/v2/pages/Editor/components/PinnedTaskContent/PinnedTaskContent";
+import { useDeselectAll } from "@/routes/v2/shared/hooks/useDeselectAll";
 import type { EditorStore } from "@/routes/v2/shared/store/editorStore";
 import type { NavigationStore } from "@/routes/v2/shared/store/navigationStore";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
@@ -76,7 +77,10 @@ function scrollWindowIntoView() {
   }, 100);
 }
 
-function ensureContextPanelVisible(windows: WindowStoreImpl) {
+function ensureContextPanelVisible(
+  windows: WindowStoreImpl,
+  deselectAll: () => void,
+) {
   const existing = windows.getWindowById(CONTEXT_PANEL_WINDOW_ID);
 
   if (existing) {
@@ -96,6 +100,8 @@ function ensureContextPanelVisible(windows: WindowStoreImpl) {
     startVisible: true,
     persisted: true,
     defaultDockState: "right",
+    disabledActions: ["hide"],
+    onClose: deselectAll,
   });
   scrollWindowIntoView();
 }
@@ -107,6 +113,7 @@ function closeContextPanel(windows: WindowStoreImpl) {
 
 export function useSelectionWindowSync() {
   const { editor, navigation, windows } = useSharedStores();
+  const deselectAll = useDeselectAll();
 
   useEffect(() => {
     const disposeSelectionWatcher = reaction(
@@ -138,7 +145,7 @@ export function useSelectionWindowSync() {
           multiSelectionLength > 1 || (selectedNodeId && selectedNodeType);
 
         if (shouldShowPanel) {
-          ensureContextPanelVisible(windows);
+          ensureContextPanelVisible(windows, deselectAll);
         } else {
           closeContextPanel(windows);
         }
@@ -146,5 +153,5 @@ export function useSelectionWindowSync() {
     );
 
     return disposeSelectionWatcher;
-  }, [editor, navigation, windows]);
+  }, [editor, navigation, windows, deselectAll]);
 }

--- a/src/routes/v2/shared/hooks/useDeselectAll.ts
+++ b/src/routes/v2/shared/hooks/useDeselectAll.ts
@@ -1,0 +1,22 @@
+import { useReactFlow } from "@xyflow/react";
+
+import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
+
+/**
+ * Returns a function that clears all selection state: the editor store and
+ * ReactFlow's internal node/edge `selected` flags.
+ */
+export function useDeselectAll(): () => void {
+  const { editor } = useSharedStores();
+  const reactFlow = useReactFlow();
+
+  return () => {
+    editor.clearSelection();
+    reactFlow.setNodes((ns) =>
+      ns.map((n) => (n.selected ? { ...n, selected: false } : n)),
+    );
+    reactFlow.setEdges((es) =>
+      es.map((e) => (e.selected ? { ...e, selected: false } : e)),
+    );
+  };
+}


### PR DESCRIPTION
## Description

Closing a task properties window does not deselect the task, making it impossible to reopen the window without first manually deselecting and reselecting the task. This PR fixes that by extracting the (now shared) deselection logic into a hook and attaching it to the task properties close handler.

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix
- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

Select a task in v2 editor

Close the properties window that opened up -> task should deselect

Click the task again and window should open again

confirm the esc handlers still work as expected.

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->