### PR TITLE
fix: v2: copy+paste issues

### DIFF
--- a/src/routes/v2/pages/Editor/components/FlowCanvas/components/FloatingSelectionToolbar.tsx
+++ b/src/routes/v2/pages/Editor/components/FlowCanvas/components/FloatingSelectionToolbar.tsx
@@ -12,8 +12,7 @@ import { SelectionToolbar } from "./SelectionToolbar";
 export const FloatingSelectionToolbar = observer(
   function FloatingSelectionToolbar({ spec }: { spec: ComponentSpec | null }) {
     const { editor } = useSharedStores();
-    const { duplicateSelectedNodes, copySelectedNodes, pasteNodes } =
-      useTaskActions();
+    const { duplicateSelectedNodes, copySelectedNodes } = useTaskActions();
     const { createSubgraph } = usePipelineActions();
     const { multiSelection } = editor;
     const reactFlow = useReactFlow();
@@ -30,14 +29,6 @@ export const FloatingSelectionToolbar = observer(
     const handleCopy = () => {
       if (!spec) return;
       copySelectedNodes(spec, multiSelection);
-    };
-
-    const handlePaste = () => {
-      if (!spec) return;
-      const viewport = reactFlow.getViewport();
-      const centerX = (window.innerWidth / 2 - viewport.x) / viewport.zoom;
-      const centerY = (window.innerHeight / 2 - viewport.y) / viewport.zoom;
-      void pasteNodes(spec, { x: centerX, y: centerY });
     };
 
     const handleDelete = () => {
@@ -74,7 +65,6 @@ export const FloatingSelectionToolbar = observer(
         <SelectionToolbar
           onDuplicate={handleDuplicate}
           onCopy={handleCopy}
-          onPaste={handlePaste}
           onDelete={handleDelete}
           onCreateSubgraph={handleCreateSubgraph}
           selectedTaskCount={selectedTasks.length}

--- a/src/routes/v2/pages/Editor/components/FlowCanvas/components/SelectionToolbar.tsx
+++ b/src/routes/v2/pages/Editor/components/FlowCanvas/components/SelectionToolbar.tsx
@@ -14,13 +14,11 @@ import { Separator } from "@/components/ui/separator";
 import { Text } from "@/components/ui/typography";
 import { cn } from "@/lib/utils";
 import { CreateSubgraphForm } from "@/routes/v2/pages/Editor/components/CreateSubgraphForm";
-import { useEditorSession } from "@/routes/v2/pages/Editor/store/EditorSessionContext";
 import { tracking } from "@/utils/tracking";
 
 interface SelectionToolbarProps {
   onDuplicate: () => void;
   onCopy: () => void;
-  onPaste?: () => void;
   onDelete: () => void;
   onCreateSubgraph?: (name: string) => void;
   selectedTaskCount?: number;
@@ -29,12 +27,10 @@ interface SelectionToolbarProps {
 export const SelectionToolbar = observer(function SelectionToolbar({
   onDuplicate,
   onCopy,
-  onPaste,
   onDelete,
   onCreateSubgraph,
   selectedTaskCount = 0,
 }: SelectionToolbarProps) {
-  const { clipboard } = useEditorSession();
   const [popoverOpen, setPopoverOpen] = useState(false);
 
   const handleCreate = (name: string) => {
@@ -63,15 +59,6 @@ export const SelectionToolbar = observer(function SelectionToolbar({
         testId="selection-copy"
         trackingAction="v2.pipeline_canvas.selection_toolbar.copy"
       />
-      {clipboard.hasContent && onPaste && (
-        <ToolbarButton
-          label="Paste"
-          icon="ClipboardPaste"
-          onClick={onPaste}
-          testId="selection-paste"
-          trackingAction="v2.pipeline_canvas.selection_toolbar.paste"
-        />
-      )}
       {onCreateSubgraph && selectedTaskCount >= 2 && (
         <>
           <Separator orientation="vertical" className="mx-0.5 self-stretch" />

--- a/src/routes/v2/pages/Editor/components/FlowCanvas/hooks/useClipboardShortcuts.ts
+++ b/src/routes/v2/pages/Editor/components/FlowCanvas/hooks/useClipboardShortcuts.ts
@@ -42,6 +42,14 @@ export function useClipboardShortcuts(
       keys: [CMDALT, "C"],
       label: "Copy",
       action: (e) => {
+        const textSelection = window.getSelection();
+        if (
+          textSelection &&
+          !textSelection.isCollapsed &&
+          textSelection.toString().length > 0
+        ) {
+          return false;
+        }
         e.preventDefault();
         if (!spec) return;
         const selection = getEffectiveSelection(registry, spec, editor);

--- a/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/TaskDetails.tsx
+++ b/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/TaskDetails.tsx
@@ -140,7 +140,11 @@ export const TaskDetails = observer(function TaskDetails({
               />
             ) : (
               <div className="group min-w-0 flex items-baseline gap-1">
-                <Text size="md" weight="semibold" className="wrap-anywhere">
+                <Text
+                  size="md"
+                  weight="semibold"
+                  className="wrap-anywhere select-text"
+                >
                   {task.name}
                 </Text>
                 <Button

--- a/src/routes/v2/pages/Editor/store/clipboardStore.ts
+++ b/src/routes/v2/pages/Editor/store/clipboardStore.ts
@@ -1,5 +1,11 @@
 import type { XYPosition } from "@xyflow/react";
-import { action, computed, makeObservable, observable } from "mobx";
+import {
+  action,
+  computed,
+  makeObservable,
+  observable,
+  runInAction,
+} from "mobx";
 
 import type { ComponentSpec } from "@/models/componentSpec";
 import { IncrementingIdGenerator } from "@/models/componentSpec/factories/idGenerator";
@@ -26,6 +32,7 @@ const idGen = new IncrementingIdGenerator();
 export class ClipboardStore {
   @observable.shallow accessor snapshots: NodeSnapshot[] = [];
   @observable.shallow accessor bindingSnapshots: BindingSnapshot[] = [];
+  @observable accessor pasteOffsetIndex: number = 0;
 
   constructor(private undoStore: UndoGroupable) {
     makeObservable(this);
@@ -50,6 +57,7 @@ export class ClipboardStore {
 
     this.snapshots = snapshots;
     this.bindingSnapshots = bindings;
+    this.pasteOffsetIndex = 0;
 
     writeToSystemClipboard(snapshots, bindings);
   }
@@ -64,11 +72,20 @@ export class ClipboardStore {
 
     if (snapshots.length === 0) return [];
 
+    const offset = this.pasteOffsetIndex * PASTE_OFFSET;
+    const offsetCenter = {
+      x: centerPosition.x + offset,
+      y: centerPosition.y + offset,
+    };
+    runInAction(() => {
+      this.pasteOffsetIndex += 1;
+    });
+
     return this.cloneSnapshotsAtPosition(
       spec,
       snapshots,
       bindings,
-      centerPosition,
+      offsetCenter,
     );
   }
 
@@ -104,6 +121,7 @@ export class ClipboardStore {
   @action clear() {
     this.snapshots = [];
     this.bindingSnapshots = [];
+    this.pasteOffsetIndex = 0;
   }
 
   private cloneSnapshotsAtPosition(


### PR DESCRIPTION
## Description

Fixes 3 issues relating to copy+paste:

1. pasting multiple of the same task will now offset each paste diagonally (same as v1 editor) rather than stacking directly on top.
2. the unneeded "paste" button has been removed from the multiselection toolbar - it made no sense to select multiple nodes and then paste from clipboard
3. task name in the properties window is now selectable & copyable. in fact, any selected text is now copyable

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

![image.png](https://app.graphite.com/user-attachments/assets/6b5c6903-3063-436e-b63d-bcd0b2dce7c7.png)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

1. open v2 editor. add a task
2. select a task. ctrl + c to copy
3. ctrl + v multiple times to paste the task on the canvas, each paste should offset from the previous
4. shift + drag to select the group of pasted tasks - there should be no option "paste"
5. select one of the tasks. in the properties window select the task name and ctrl + c to copy. confirm the text was correctly copied by pasting somewhere else

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->