### PR TITLE
chore: v2: revamp annotation editor

### DIFF
--- a/src/models/componentSpec/annotations.ts
+++ b/src/models/componentSpec/annotations.ts
@@ -167,7 +167,7 @@ export class Annotations extends Model({
   ) {
     const idx = this.items.findIndex((a) => a.key === key);
     if (idx >= 0) {
-      Object.assign(this.items[idx], { value });
+      this.items[idx] = { key, value };
     } else {
       this.items.push({ key, value });
     }
@@ -191,12 +191,19 @@ export class Annotations extends Model({
   @modelAction
   updateAt(index: number, updates: Partial<Annotation>) {
     const ann = this.items[index];
-    if (ann) Object.assign(ann, updates);
+    if (ann) this.items[index] = { ...ann, ...updates };
   }
 
   @modelAction
   removeAt(index: number) {
     this.items.splice(index, 1);
+  }
+
+  @modelAction
+  removeBlanks() {
+    this.items = this.items.filter(
+      (a) => a.key !== "" || String(a.value ?? "") !== "",
+    );
   }
 
   // -- Array-like delegation (backward compat for legacy consumers) --
@@ -222,7 +229,7 @@ export class Annotations extends Model({
     return this.items.map(fn);
   }
 
-  some(fn: (a: Annotation) => boolean) {
+  some(fn: (a: Annotation, i: number) => boolean) {
     return this.items.some(fn);
   }
 

--- a/src/routes/v2/pages/Editor/components/AnnotationsBlock/AnnotationsBlock.tsx
+++ b/src/routes/v2/pages/Editor/components/AnnotationsBlock/AnnotationsBlock.tsx
@@ -1,13 +1,14 @@
 import { observer } from "mobx-react-lite";
-import { type ChangeEvent, useState } from "react";
+import { type FocusEvent, useEffect, useRef, useState } from "react";
 
 import { ContentBlock } from "@/components/shared/ContextPanel/Blocks/ContentBlock";
-import { KeyValueList } from "@/components/shared/ContextPanel/Blocks/KeyValueList";
+import { CopyText } from "@/components/shared/CopyText/CopyText";
 import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
 import { Input } from "@/components/ui/input";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Text } from "@/components/ui/typography";
+import { cn } from "@/lib/utils";
 import type { Annotation } from "@/models/componentSpec";
 import type { Annotations } from "@/models/componentSpec/annotations";
 
@@ -16,153 +17,417 @@ import { useAnnotationActions } from "./useAnnotationActions";
 interface AnnotationsBlockProps {
   annotations: Annotations;
   readonly?: boolean;
-  ignoreAnnotationKeys?: string[];
-  defaultEditing?: boolean;
+  systemAnnotationKeys?: string[];
+}
+
+interface CategorizedAnnotation {
+  annotation: Annotation;
+  index: number;
+}
+
+function formatAnnotationValue(value: unknown): string {
+  if (value === undefined || value === null) return "";
+  if (typeof value === "object") return JSON.stringify(value);
+  return String(value);
 }
 
 export const AnnotationsBlock = observer(function AnnotationsBlock({
   annotations,
   readonly,
-  ignoreAnnotationKeys,
-  defaultEditing = false,
+  systemAnnotationKeys,
 }: AnnotationsBlockProps) {
-  const [isEditing, setIsEditing] = useState(defaultEditing);
+  const { removeBlankAnnotations } = useAnnotationActions();
+  const [editingIndex, setEditingIndex] = useState<number | null>(null);
+  const [isAddingNew, setIsAddingNew] = useState(false);
 
-  const ignoredSet = ignoreAnnotationKeys
-    ? new Set(ignoreAnnotationKeys)
-    : undefined;
+  const systemKeys = new Set(systemAnnotationKeys ?? []);
+  const userAnnotations: CategorizedAnnotation[] = [];
+  const systemAnnotations: CategorizedAnnotation[] = [];
 
-  const displayItems = annotations.filter(
-    (a) => a.key !== "" && String(a.value) !== "",
-  );
-
-  if (isEditing && !readonly) {
-    return (
-      <AnnotationEditMode annotations={annotations} ignoredSet={ignoredSet} />
-    );
+  let index = 0;
+  for (const annotation of annotations) {
+    if (systemKeys.has(annotation.key)) {
+      systemAnnotations.push({ annotation, index });
+    } else {
+      userAnnotations.push({ annotation, index });
+    }
+    index++;
   }
 
-  return (
-    <KeyValueList
-      title="Task annotations"
-      items={displayItems.map((a) => ({
-        label: a.key,
-        value: JSON.stringify(a.value),
-      }))}
-      titleAction={
-        !readonly ? (
-          <Button variant="ghost" size="xs" onClick={() => setIsEditing(true)}>
-            <Icon name="Pencil" size="xs" /> Edit
-          </Button>
-        ) : undefined
-      }
-    />
-  );
-});
+  const handleAddNew = () => {
+    removeBlankAnnotations(annotations);
+    setEditingIndex(null);
+    setIsAddingNew(true);
+  };
 
-function AnnotationEditMode({
-  annotations,
-  ignoredSet,
-}: {
-  annotations: Annotations;
-  ignoredSet?: Set<string>;
-}) {
-  const { addAnnotation } = useAnnotationActions();
+  const handleStartEdit = (index: number) => {
+    removeBlankAnnotations(annotations);
+    setIsAddingNew(false);
+    setEditingIndex(index);
+  };
 
-  const editableItems = ignoredSet
-    ? annotations.filter((a) => !ignoredSet.has(a.key))
-    : [...annotations];
+  const handleStopEdit = () => {
+    setEditingIndex(null);
+  };
 
-  const actions = (
+  const handleCloseDraft = () => {
+    setIsAddingNew(false);
+  };
+
+  const addAction = !readonly ? (
     <Button
       variant="ghost"
       size="xs"
-      onClick={() => addAnnotation(annotations)}
+      onClick={handleAddNew}
+      disabled={isAddingNew}
     >
-      <Icon name="CirclePlus" size="xs" /> New
+      <Icon name="CirclePlus" size="xs" />
+      <Text size="xs">New</Text>
     </Button>
-  );
+  ) : undefined;
+
+  const showEmptyState = userAnnotations.length === 0 && !isAddingNew;
 
   return (
-    <ContentBlock title="Task annotations" titleAction={actions}>
-      {editableItems.length === 0 ? (
-        <Text size="xs" tone="subdued">
-          No annotations
-        </Text>
-      ) : (
-        editableItems.map((annotation, idx) => (
-          <AnnotationRow
-            key={`annotation-${idx}`}
-            annotation={annotation}
-            index={annotations.findIndex((a) => a === annotation)}
-            annotations={annotations}
-          />
-        ))
+    <BlockStack gap="3">
+      <ContentBlock title="Task annotations" titleAction={addAction}>
+        {showEmptyState ? (
+          <Text size="xs" tone="subdued">
+            No annotations
+          </Text>
+        ) : (
+          <BlockStack>
+            {userAnnotations.map(({ annotation, index }) => (
+              <AnnotationRow
+                key={`annotation-${index}`}
+                annotation={annotation}
+                index={index}
+                annotations={annotations}
+                readonly={readonly}
+                isEditing={editingIndex === index}
+                onStartEdit={() => handleStartEdit(index)}
+                onStopEdit={handleStopEdit}
+              />
+            ))}
+            {isAddingNew && (
+              <NewAnnotationRow
+                annotations={annotations}
+                onClose={handleCloseDraft}
+              />
+            )}
+          </BlockStack>
+        )}
+      </ContentBlock>
+      {systemAnnotations.length > 0 && (
+        <SystemAnnotationsSection items={systemAnnotations} />
       )}
-    </ContentBlock>
+    </BlockStack>
   );
-}
+});
 
 interface AnnotationRowProps {
   annotation: Annotation;
   index: number;
   annotations: Annotations;
+  readonly?: boolean;
+  isEditing: boolean;
+  onStartEdit: () => void;
+  onStopEdit: () => void;
 }
 
-function AnnotationRow({ annotation, index, annotations }: AnnotationRowProps) {
+function AnnotationRow({
+  annotation,
+  index,
+  annotations,
+  readonly,
+  isEditing,
+  onStartEdit,
+  onStopEdit,
+}: AnnotationRowProps) {
   const { updateAnnotationKey, updateAnnotationValue, removeAnnotation } =
     useAnnotationActions();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [keyDraft, setKeyDraft] = useState(annotation.key);
+  const [valueDraft, setValueDraft] = useState(() =>
+    formatAnnotationValue(annotation.value),
+  );
+  const [keyError, setKeyError] = useState<string | null>(null);
 
-  const handleUpdateKey = (event: ChangeEvent<HTMLInputElement>) => {
-    const newKey = event.target.value;
-    if (newKey !== annotation.key) {
+  useEffect(() => {
+    setKeyDraft(annotation.key);
+  }, [annotation.key]);
+
+  useEffect(() => {
+    setValueDraft(formatAnnotationValue(annotation.value));
+  }, [annotation.value]);
+
+  const handleCommitKey = () => {
+    const newKey = keyDraft.trim();
+    if (newKey === annotation.key) {
+      setKeyError(null);
+      return;
+    }
+    if (newKey === "") {
       updateAnnotationKey(annotations, index, newKey);
+      setKeyError(null);
+      return;
+    }
+    const collides = annotations.some(
+      (a, i) => i !== index && a.key === newKey,
+    );
+    if (collides) {
+      setKeyError("Key already in use");
+      setKeyDraft(annotation.key);
+      return;
+    }
+    setKeyError(null);
+    updateAnnotationKey(annotations, index, newKey);
+  };
+
+  const handleCommitValue = () => {
+    const currentValue = formatAnnotationValue(annotation.value);
+    if (valueDraft !== currentValue) {
+      updateAnnotationValue(annotations, index, valueDraft);
     }
   };
 
-  const handleUpdateValue = (event: ChangeEvent<HTMLInputElement>) => {
-    const newValue = String(event.target.value);
-    const currentValue =
-      typeof annotation.value === "object"
-        ? JSON.stringify(annotation.value)
-        : String(annotation.value ?? "");
-    if (newValue !== currentValue) {
-      updateAnnotationValue(annotations, index, newValue);
+  const handleContainerBlur = (event: FocusEvent<HTMLDivElement>) => {
+    const next = event.relatedTarget;
+    if (next instanceof Node && containerRef.current?.contains(next)) {
+      return;
     }
+    if (
+      annotation.key === "" &&
+      formatAnnotationValue(annotation.value) === ""
+    ) {
+      removeAnnotation(annotations, index);
+    }
+    onStopEdit();
   };
 
   const handleRemove = () => {
     removeAnnotation(annotations, index);
+    if (isEditing) onStopEdit();
   };
 
+  if (!isEditing) {
+    return (
+      <InlineStack
+        gap="2"
+        wrap="nowrap"
+        blockAlign="center"
+        className="group w-full rounded-xs px-1 py-0.5 hover:bg-gray-50"
+      >
+        <BlockStack align="stretch" className="flex-1 min-w-0">
+          {annotation.key ? (
+            <CopyText
+              size="xs"
+              compact
+              className="font-mono! text-muted-foreground truncate"
+            >
+              {annotation.key}
+            </CopyText>
+          ) : (
+            <Text size="xs" font="mono" tone="subdued">
+              (empty key)
+            </Text>
+          )}
+          {formatAnnotationValue(annotation.value) ? (
+            <CopyText size="xs" compact className="font-mono! truncate">
+              {formatAnnotationValue(annotation.value)}
+            </CopyText>
+          ) : (
+            <Text size="xs" font="mono" tone="subdued">
+              (empty value)
+            </Text>
+          )}
+        </BlockStack>
+        {!readonly && (
+          <InlineStack className="shrink-0 opacity-0 group-hover:opacity-100 focus-within:opacity-100">
+            <Button
+              variant="ghost"
+              size="xs"
+              onClick={onStartEdit}
+              aria-label="Edit annotation"
+            >
+              <Icon name="Pencil" size="xs" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="xs"
+              onClick={handleRemove}
+              aria-label="Remove annotation"
+            >
+              <Icon name="Trash" className="text-destructive" />
+            </Button>
+          </InlineStack>
+        )}
+      </InlineStack>
+    );
+  }
+
   return (
-    <BlockStack gap="1" className="group w-full">
-      <Input
-        className="w-full font-mono text-xs! h-6 border-none px-0 shadow-none text-gray-500"
-        placeholder="Key"
-        defaultValue={annotation.key}
-        onBlur={handleUpdateKey}
-      />
-      <InlineStack gap="1" wrap="nowrap" className="w-full">
-        <Input
-          className="w-full font-mono text-xs!"
-          placeholder="Value"
-          defaultValue={
-            typeof annotation.value === "object"
-              ? JSON.stringify(annotation.value)
-              : String(annotation.value ?? "")
-          }
-          onBlur={handleUpdateValue}
-        />
+    <div ref={containerRef} onBlur={handleContainerBlur} className="w-full">
+      <InlineStack
+        gap="1"
+        wrap="nowrap"
+        className="w-full px-1 py-0.5"
+        blockAlign="start"
+      >
+        <BlockStack gap="1" className="flex-1 min-w-0">
+          <Input
+            autoFocus
+            className={cn(
+              "w-full font-mono text-xs!",
+              keyError && "border-destructive focus-visible:ring-destructive",
+            )}
+            placeholder="Key"
+            value={keyDraft}
+            onChange={(e) => setKeyDraft(e.target.value)}
+            onBlur={handleCommitKey}
+            aria-invalid={keyError !== null}
+          />
+          <Input
+            className="w-full font-mono text-xs!"
+            placeholder="Value"
+            value={valueDraft}
+            onChange={(e) => setValueDraft(e.target.value)}
+            onBlur={handleCommitValue}
+          />
+          {keyError && (
+            <Text size="xs" tone="critical">
+              {keyError}
+            </Text>
+          )}
+        </BlockStack>
         <Button
           variant="ghost"
           size="xs"
-          className="invisible group-hover:visible group-focus-within:visible shrink-0"
+          className="shrink-0"
           onClick={handleRemove}
+          aria-label="Remove annotation"
         >
           <Icon name="Trash" className="text-destructive" />
         </Button>
       </InlineStack>
-    </BlockStack>
+    </div>
+  );
+}
+
+interface NewAnnotationRowProps {
+  annotations: Annotations;
+  onClose: () => void;
+}
+
+function NewAnnotationRow({ annotations, onClose }: NewAnnotationRowProps) {
+  const { addAnnotation } = useAnnotationActions();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [keyDraft, setKeyDraft] = useState("");
+  const [valueDraft, setValueDraft] = useState("");
+  const [keyError, setKeyError] = useState<string | null>(null);
+
+  const validateKey = (key: string): string | null => {
+    if (key === "") return null;
+    const collides = annotations.some((a) => a.key === key);
+    return collides ? "Key already in use" : null;
+  };
+
+  const handleKeyBlur = () => {
+    setKeyError(validateKey(keyDraft.trim()));
+  };
+
+  const handleContainerBlur = (event: FocusEvent<HTMLDivElement>) => {
+    const next = event.relatedTarget;
+    if (next instanceof Node && containerRef.current?.contains(next)) {
+      return;
+    }
+    const key = keyDraft.trim();
+    if (key === "" && valueDraft === "") {
+      onClose();
+      return;
+    }
+    const error = validateKey(key);
+    if (error) {
+      setKeyError(error);
+      return;
+    }
+    addAnnotation(annotations, { key, value: valueDraft });
+    onClose();
+  };
+
+  return (
+    <div ref={containerRef} onBlur={handleContainerBlur} className="w-full">
+      <InlineStack
+        gap="1"
+        wrap="nowrap"
+        className="w-full px-1 py-0.5"
+        blockAlign="start"
+      >
+        <BlockStack align="stretch" gap="1" className="flex-1 min-w-0">
+          <Input
+            autoFocus
+            className={cn(
+              "w-full font-mono text-xs!",
+              keyError && "border-destructive focus-visible:ring-destructive",
+            )}
+            placeholder="Key"
+            value={keyDraft}
+            onChange={(e) => {
+              setKeyDraft(e.target.value);
+              if (keyError) setKeyError(null);
+            }}
+            onBlur={handleKeyBlur}
+            aria-invalid={keyError !== null}
+          />
+          <Input
+            className="w-full font-mono text-xs!"
+            placeholder="Value"
+            value={valueDraft}
+            onChange={(e) => setValueDraft(e.target.value)}
+          />
+          {keyError && (
+            <Text size="xs" tone="critical">
+              {keyError}
+            </Text>
+          )}
+        </BlockStack>
+        <Button
+          variant="ghost"
+          size="xs"
+          className="shrink-0"
+          onClick={onClose}
+          aria-label="Discard new annotation"
+        >
+          <Icon name="Trash" className="text-destructive" />
+        </Button>
+      </InlineStack>
+    </div>
+  );
+}
+
+interface SystemAnnotationsSectionProps {
+  items: CategorizedAnnotation[];
+}
+
+function SystemAnnotationsSection({ items }: SystemAnnotationsSectionProps) {
+  return (
+    <ContentBlock title="System annotations" collapsible defaultOpen={false}>
+      <BlockStack>
+        {items.map(({ annotation, index }) => (
+          <BlockStack key={`system-${index}`} className="py-0.5 w-full">
+            <CopyText
+              size="xs"
+              compact
+              className="font-mono! text-muted-foreground"
+            >
+              {annotation.key}
+            </CopyText>
+            <CopyText size="xs" compact className="font-mono!">
+              {formatAnnotationValue(annotation.value)}
+            </CopyText>
+          </BlockStack>
+        ))}
+      </BlockStack>
+    </ContentBlock>
   );
 }

--- a/src/routes/v2/pages/Editor/components/AnnotationsBlock/annotations.actions.ts
+++ b/src/routes/v2/pages/Editor/components/AnnotationsBlock/annotations.actions.ts
@@ -1,9 +1,14 @@
+import type { Annotation } from "@/models/componentSpec";
 import type { Annotations } from "@/models/componentSpec/annotations";
 import type { UndoGroupable } from "@/routes/v2/shared/nodes/types";
 
-export function addAnnotation(undo: UndoGroupable, annotations: Annotations) {
+export function addAnnotation(
+  undo: UndoGroupable,
+  annotations: Annotations,
+  annotation: Annotation = { key: "", value: "" },
+) {
   undo.withGroup("Add annotation", () => {
-    annotations.add({ key: "", value: "" });
+    annotations.add(annotation);
   });
 }
 
@@ -36,5 +41,18 @@ export function removeAnnotation(
 ) {
   undo.withGroup("Remove annotation", () => {
     annotations.removeAt(index);
+  });
+}
+
+export function removeBlankAnnotations(
+  undo: UndoGroupable,
+  annotations: Annotations,
+) {
+  const hasBlanks = annotations.some(
+    (a) => a.key === "" && String(a.value ?? "") === "",
+  );
+  if (!hasBlanks) return;
+  undo.withGroup("Remove blank annotations", () => {
+    annotations.removeBlanks();
   });
 }

--- a/src/routes/v2/pages/Editor/components/AnnotationsBlock/useAnnotationActions.ts
+++ b/src/routes/v2/pages/Editor/components/AnnotationsBlock/useAnnotationActions.ts
@@ -3,6 +3,7 @@ import { useEditorSession } from "@/routes/v2/pages/Editor/store/EditorSessionCo
 import {
   addAnnotation,
   removeAnnotation,
+  removeBlankAnnotations,
   updateAnnotationKey,
   updateAnnotationValue,
 } from "./annotations.actions";
@@ -15,5 +16,6 @@ export function useAnnotationActions() {
     updateAnnotationKey: updateAnnotationKey.bind(null, undo),
     updateAnnotationValue: updateAnnotationValue.bind(null, undo),
     removeAnnotation: removeAnnotation.bind(null, undo),
+    removeBlankAnnotations: removeBlankAnnotations.bind(null, undo),
   };
 }

--- a/src/routes/v2/pages/Editor/components/PipelineDetailsContent/PipelineDetailsContent.tsx
+++ b/src/routes/v2/pages/Editor/components/PipelineDetailsContent/PipelineDetailsContent.tsx
@@ -25,11 +25,13 @@ import { PipelineDetailsHeader } from "./components/PipelineDetailsHeader";
 import { PipelineDetailsTextField } from "./components/PipelineDetailsTextField";
 import { TagsBlock } from "./components/TagsBlock";
 
-const EXCLUDED_ANNOTATIONS = [
+const SYSTEM_PIPELINE_ANNOTATIONS = [
   "notes",
   PIPELINE_TAGS_ANNOTATION,
   "flex-nodes",
   "tangleml.com/editor/edge-conduits",
+  "sdk",
+  "editor.flow-direction",
 ];
 
 export const PipelineDetailsContent = observer(
@@ -131,7 +133,7 @@ export const PipelineDetailsContent = observer(
               <Separator />
               <AnnotationsBlock
                 annotations={pipelineSpec.annotations}
-                ignoreAnnotationKeys={EXCLUDED_ANNOTATIONS}
+                systemAnnotationKeys={SYSTEM_PIPELINE_ANNOTATIONS}
               />
             </BlockStack>
           </PipelineDetailsCollapsibleSection>

--- a/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/TaskDetails.tsx
+++ b/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/TaskDetails.tsx
@@ -26,7 +26,7 @@ import { TaskActionsBar } from "./components/TaskActionsBar";
 import { TaskArgumentsEditor } from "./components/TaskArgumentsEditor";
 import { useTask } from "./hooks/useTask";
 
-const EDITOR_ANNOTATION_KEYS = [
+const SYSTEM_TASK_ANNOTATIONS = [
   "editor.position",
   "tangleml.com/editor/task-color",
   "tangleml.com/editor/edge-conduits",
@@ -227,8 +227,7 @@ export const TaskDetails = observer(function TaskDetails({
         >
           <AnnotationsBlock
             annotations={task.annotations}
-            defaultEditing
-            ignoreAnnotationKeys={EDITOR_ANNOTATION_KEYS}
+            systemAnnotationKeys={SYSTEM_TASK_ANNOTATIONS}
           />
         </TabsContent>
       </Tabs>


### PR DESCRIPTION
## Description

A quick vibe-coded rework of the v2 annotation editor. this iteration aligns it more closely with existing v1 editor UX, by allowing individual rows to be added and edited separately. This PR also splits out the concept of "system annotations" - protected annotations that users cannot change or overwrite. All annotations key and value are copyable.

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

- [x] New feature
- [x] Improvement
- [x] Cleanup/Refactor

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

before

![image.png](https://app.graphite.com/user-attachments/assets/91c0aad4-f7e4-495f-b6f5-5a6eefa4a7cc.png)

after

![image.png](https://app.graphite.com/user-attachments/assets/708a1b64-e54c-4987-8d80-be53cb3a99b3.png)

![image.png](https://app.graphite.com/user-attachments/assets/ea0c00e6-813b-44b2-bb8d-3b7c6a007dbf.png)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

open v2 editor and confirm:

- pipeline annotations can be added, edited and delete (except system annotations)
- same for run annotations
- same for task annotations

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->