### PR TITLE
feat: v2 - minicontent for history window

### DIFF
--- a/src/routes/v2/pages/Editor/components/HistoryContent/HistoryWindowMiniContent.tsx
+++ b/src/routes/v2/pages/Editor/components/HistoryContent/HistoryWindowMiniContent.tsx
@@ -1,0 +1,62 @@
+import { observer } from "mobx-react-lite";
+import type { MouseEvent, PointerEvent } from "react";
+
+import TooltipButton from "@/components/shared/Buttons/TooltipButton";
+import { Icon } from "@/components/ui/icon";
+import { InlineStack } from "@/components/ui/layout";
+import { useEditorSession } from "@/routes/v2/pages/Editor/store/EditorSessionContext";
+import { tracking } from "@/utils/tracking";
+
+const stopPointer = (event: PointerEvent<HTMLButtonElement>) => {
+  event.stopPropagation();
+};
+
+export const HistoryWindowMiniContent = observer(
+  function HistoryWindowMiniContent() {
+    const { undo } = useEditorSession();
+    const { canUndo, canRedo } = undo;
+
+    const handleUndo = (event: MouseEvent<HTMLButtonElement>) => {
+      event.stopPropagation();
+      undo.undo();
+    };
+
+    const handleRedo = (event: MouseEvent<HTMLButtonElement>) => {
+      event.stopPropagation();
+      undo.redo();
+    };
+
+    return (
+      <InlineStack gap="1">
+        <TooltipButton
+          tooltip="Undo"
+          tooltipSide="right"
+          variant="outline"
+          size="icon"
+          aria-label="Undo"
+          title="Undo"
+          disabled={!canUndo}
+          onClick={handleUndo}
+          onPointerDown={stopPointer}
+          {...tracking("v2.pipeline_editor.history.undo")}
+        >
+          <Icon name="Undo2" size="sm" />
+        </TooltipButton>
+        <TooltipButton
+          tooltip="Redo"
+          tooltipSide="right"
+          variant="outline"
+          size="icon"
+          aria-label="Redo"
+          title="Redo"
+          disabled={!canRedo}
+          onClick={handleRedo}
+          onPointerDown={stopPointer}
+          {...tracking("v2.pipeline_editor.history.redo")}
+        >
+          <Icon name="Redo2" size="sm" />
+        </TooltipButton>
+      </InlineStack>
+    );
+  },
+);

--- a/src/routes/v2/pages/Editor/hooks/useHistoryWindow.tsx
+++ b/src/routes/v2/pages/Editor/hooks/useHistoryWindow.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 
 import { HistoryContent } from "@/routes/v2/pages/Editor/components/HistoryContent/HistoryContent";
+import { HistoryWindowMiniContent } from "@/routes/v2/pages/Editor/components/HistoryContent/HistoryWindowMiniContent";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 
 const HISTORY_WINDOW_ID = "history";
@@ -17,6 +18,7 @@ export function useHistoryWindow() {
         disabledActions: ["close"],
         persisted: true,
         defaultDockState: "left",
+        miniContent: <HistoryWindowMiniContent />,
       });
     }
   }, [windows]);


### PR DESCRIPTION
## Description

Adds a mini content component for the History window that displays compact undo/redo buttons. The `HistoryWindowMiniContent` component renders two icon-only buttons (Undo and Redo) that are enabled or disabled based on the current undo/redo state. This mini content is registered with the History window so it can be displayed in a collapsed/mini view of the panel.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## [Screen Recording 2026-05-13 at 5.22.20 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/570d23f9-772f-4eb1-a917-2c013816f250.mov" />](https://app.graphite.com/user-attachments/video/570d23f9-772f-4eb1-a917-2c013816f250.mov)



## Test Instructions

1. Open the pipeline editor.
2. Make a change to trigger an undoable action.
3. Collapse or minimize the History window panel.
4. Verify that the undo and redo buttons appear in the mini view.
5. Confirm that the undo button is enabled after making a change and that clicking it correctly undoes the action.
6. Confirm that the redo button becomes enabled after undoing and correctly redoes the action.

## Additional Comments

Pointer events on the buttons are stopped from propagating to prevent unintended interactions with the surrounding window drag/resize handlers.