### PR TITLE
chore: v2 - set editorv2 beta flag to default true

### DIFF
--- a/src/flags.ts
+++ b/src/flags.ts
@@ -51,7 +51,7 @@ export const ExistingFlags: ConfigFlags = {
     name: "V2 Editor",
     description:
       "Enable the V2 Editor. You can switch back and forth between the V1 and V2 editors.",
-    default: false,
+    default: true,
     category: "beta",
   },
 };


### PR DESCRIPTION
## Description

The V2 Editor feature flag has been enabled by default. Users will now land on the V2 Editor experience without needing to manually opt in, while still retaining the ability to switch back to the V1 Editor.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Log in and navigate to the editor.
2. Confirm that the V2 Editor loads by default.
3. Verify that switching back to the V1 Editor still works as expected.

## Additional Comments

This change promotes the V2 Editor to the default experience for all users. The flag remains in the `beta` category, so it can still be toggled if needed.