### PR TITLE
chore: v2 - optimize task details tabs

### DIFF
--- a/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/TaskDetails.tsx
+++ b/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/TaskDetails.tsx
@@ -192,15 +192,14 @@ export const TaskDetails = observer(function TaskDetails({
             {...tracking("v2.pipeline_editor.task_details.tab_configuration")}
           >
             <Icon name="Settings" size="xs" className="shrink-0" />
-            <span className="truncate">Configuration</span>
+            <span className="truncate">Config</span>
           </TabsTrigger>
           <TabsTrigger
             value="annotations"
-            className="min-w-0 flex-1 gap-1.5"
+            className="flex-none w-8 px-0"
             {...tracking("v2.pipeline_editor.task_details.tab_annotations")}
           >
-            <Icon name="Tag" size="xs" className="shrink-0" />
-            <span className="truncate">Annotations</span>
+            <Icon name="EllipsisVertical" size="xs" className="shrink-0" />
           </TabsTrigger>
         </TabsList>
 


### PR DESCRIPTION
## Description

The "Configuration" tab label in the Task Details panel has been shortened to "Config" to save horizontal space. The "Annotations" tab has been redesigned to display as a compact icon-only button (`EllipsisVertical` icon) instead of a full-width tab with a "Tag" icon and text label, reducing its width to a fixed small size.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

![image.png](https://app.graphite.com/user-attachments/assets/4c98a484-b491-425f-9628-88b21e46696f.png)



## Test Instructions

1. Open the pipeline editor and select a task node.
2. Verify the "Configuration" tab now displays as "Config".
3. Verify the "Annotations" tab now appears as a small icon-only button using the vertical ellipsis icon.
4. Confirm both tabs remain functional and navigable.

## Additional Comments