### PR TITLE
feat: Learning Hub Dashboard

### DIFF
--- a/react-compiler.config.js
+++ b/react-compiler.config.js
@@ -5,6 +5,7 @@ export const REACT_COMPILER_ENABLED_DIRS = [
   // ✅ Enabled
   "src/components/Home",
   "src/components/Editor",
+  "src/components/Learn",
 
   // 0 useCallback/useMemo - ready to enable
   "src/components/layout",

--- a/src/components/Learn/DocumentationPanel.tsx
+++ b/src/components/Learn/DocumentationPanel.tsx
@@ -1,0 +1,198 @@
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { Icon, type IconName } from "@/components/ui/icon";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Heading, Paragraph, Text } from "@/components/ui/typography";
+import { DOCUMENTATION_URL } from "@/utils/constants";
+import { tracking } from "@/utils/tracking";
+
+interface QuickLink {
+  id: string;
+  label: string;
+  href: string;
+  icon: IconName;
+}
+
+const QUICK_LINKS: QuickLink[] = [
+  {
+    id: "getting-started",
+    label: "Getting started",
+    href: `${DOCUMENTATION_URL}getting-started/first-pipeline/`,
+    icon: "Rocket",
+  },
+  {
+    id: "components",
+    label: "Components",
+    href: `${DOCUMENTATION_URL}core-concepts/what-are-components/`,
+    icon: "Package",
+  },
+  {
+    id: "pipelines",
+    label: "Pipelines",
+    href: `${DOCUMENTATION_URL}core-concepts/understanding-inputs-outputs/`,
+    icon: "GitBranch",
+  },
+  {
+    id: "secrets",
+    label: "Secrets & auth",
+    href: `${DOCUMENTATION_URL}core-concepts/secrets/`,
+    icon: "Lock",
+  },
+  {
+    id: "runs",
+    label: "Running pipelines",
+    href: `${DOCUMENTATION_URL}core-concepts/tasks-and-executions/`,
+    icon: "Play",
+  },
+  {
+    id: "schema",
+    label: "Schema reference",
+    href: `${DOCUMENTATION_URL}reference/schema/`,
+    icon: "Code",
+  },
+];
+
+interface FaqItem {
+  id: string;
+  question: string;
+  answer: string;
+}
+
+const FAQ_ITEMS: FaqItem[] = [
+  {
+    id: "create-pipeline",
+    question: "How do I create my first pipeline?",
+    answer:
+      "Open the Pipelines tab and click 'New pipeline', or import one of the example pipelines from the Learning Hub to get started quickly.",
+  },
+  {
+    id: "share-pipeline",
+    question: "Can I share a pipeline with someone else?",
+    answer:
+      "Yes — export the pipeline as YAML from the editor and share the file. The recipient can import it from the home dashboard.",
+  },
+  {
+    id: "secrets",
+    question: "Where are secrets stored?",
+    answer:
+      "Secrets are managed under Settings → Secrets and are encrypted at rest. Components reference secrets by name at runtime.",
+  },
+  {
+    id: "self-host",
+    question: "Can I run Tangle against my own backend?",
+    answer:
+      "Yes. Under Settings → Backend you can point Tangle at any compatible backend URL — see the docs for self-hosting instructions.",
+  },
+];
+
+function QuickLinkTile({ link }: { link: QuickLink }) {
+  return (
+    <a
+      href={link.href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="no-underline"
+      {...tracking("learning_hub.documentation.quick_link", {
+        link_id: link.id,
+      })}
+    >
+      <InlineStack
+        gap="2"
+        blockAlign="center"
+        className="px-3 py-2 rounded-md border border-border hover:border-primary/40 hover:bg-muted/40 transition-all"
+      >
+        <Icon
+          name={link.icon}
+          size="sm"
+          className="text-muted-foreground shrink-0"
+          aria-hidden="true"
+        />
+        <Text size="sm" weight="semibold" className="truncate">
+          {link.label}
+        </Text>
+        <div className="flex-1" />
+        <Icon
+          name="ExternalLink"
+          size="xs"
+          className="text-muted-foreground shrink-0"
+          aria-hidden="true"
+        />
+      </InlineStack>
+    </a>
+  );
+}
+
+function FaqRow({ item }: { item: FaqItem }) {
+  return (
+    <Collapsible>
+      <CollapsibleTrigger
+        className="group w-full flex items-center justify-between gap-3 py-3 text-left cursor-pointer"
+        {...tracking("learning_hub.documentation.faq_toggle", {
+          faq_id: item.id,
+        })}
+      >
+        <Text size="sm" weight="semibold">
+          {item.question}
+        </Text>
+        <Icon
+          name="ChevronDown"
+          size="sm"
+          className="text-muted-foreground transition-transform duration-200 group-data-[state=open]:rotate-180"
+          aria-hidden="true"
+        />
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        <Paragraph size="sm" tone="subdued" className="pb-3">
+          {item.answer}
+        </Paragraph>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+export function DocumentationPanel() {
+  return (
+    <BlockStack gap="4">
+      <InlineStack gap="2" blockAlign="center" align="space-between">
+        <InlineStack gap="2" blockAlign="center">
+          <Icon
+            name="BookOpen"
+            size="md"
+            className="text-primary"
+            aria-hidden="true"
+          />
+          <Heading level={2}>Documentation</Heading>
+        </InlineStack>
+        <a
+          href={DOCUMENTATION_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-sm text-primary hover:underline"
+          {...tracking("learning_hub.documentation.full_docs")}
+        >
+          Full docs ↗
+        </a>
+      </InlineStack>
+
+      <div className="grid grid-cols-2 md:grid-cols-3 gap-2">
+        {QUICK_LINKS.map((link) => (
+          <QuickLinkTile key={link.id} link={link} />
+        ))}
+      </div>
+
+      <BlockStack gap="0" className="border-t border-border pt-2">
+        <Text size="xs" tone="subdued" weight="semibold" className="pb-1">
+          Frequently asked
+        </Text>
+        <BlockStack className="divide-y divide-border">
+          {FAQ_ITEMS.map((item) => (
+            <FaqRow key={item.id} item={item} />
+          ))}
+        </BlockStack>
+      </BlockStack>
+    </BlockStack>
+  );
+}

--- a/src/components/Learn/FeaturedExamples.tsx
+++ b/src/components/Learn/FeaturedExamples.tsx
@@ -1,0 +1,103 @@
+import { Link } from "@tanstack/react-router";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Icon } from "@/components/ui/icon";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Heading } from "@/components/ui/typography";
+import { tracking } from "@/utils/tracking";
+
+interface FeaturedExample {
+  id: string;
+  name: string;
+  description: string;
+  tags: string[];
+}
+
+const STUB_EXAMPLES: FeaturedExample[] = [
+  {
+    id: "xgboost",
+    name: "XGBoost classification",
+    description:
+      "Train and evaluate an XGBoost model end-to-end with preprocessing and hyperparameter tuning.",
+    tags: ["XGBoost", "Tabular"],
+  },
+  {
+    id: "pytorch",
+    name: "PyTorch neural network",
+    description:
+      "Build, train and evaluate a fully-connected network in PyTorch — data loading through metrics.",
+    tags: ["PyTorch", "Deep Learning"],
+  },
+  {
+    id: "vertex-automl",
+    name: "Vertex AI AutoML",
+    description:
+      "Use Google Vertex AI AutoML to train tabular models without writing model code.",
+    tags: ["AutoML", "Vertex AI"],
+  },
+];
+
+export function FeaturedExamples() {
+  return (
+    <BlockStack gap="3">
+      <InlineStack gap="3" align="space-between" blockAlign="center">
+        <InlineStack gap="2" blockAlign="center">
+          <Icon
+            name="Sparkles"
+            size="md"
+            className="text-primary"
+            aria-hidden="true"
+          />
+          <Heading level={2}>Example pipelines</Heading>
+        </InlineStack>
+        <Button
+          asChild
+          size="sm"
+          variant="link"
+          className="px-0"
+          {...tracking("learning_hub.examples.browse_all")}
+        >
+          <Link to="/learn/examples">Browse all examples →</Link>
+        </Button>
+      </InlineStack>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        {STUB_EXAMPLES.map((example) => (
+          <Link
+            key={example.id}
+            to="/learn/examples"
+            className="no-underline"
+            {...tracking("learning_hub.examples.item", {
+              example_id: example.id,
+            })}
+          >
+            <Card className="h-full hover:shadow-md hover:border-primary/40 transition-all duration-200 cursor-pointer">
+              <CardHeader>
+                <BlockStack gap="2">
+                  <CardTitle className="text-base">{example.name}</CardTitle>
+                  <CardDescription className="line-clamp-2">
+                    {example.description}
+                  </CardDescription>
+                  <InlineStack gap="1" wrap="wrap">
+                    {example.tags.map((tag) => (
+                      <Badge key={tag} size="sm" variant="secondary">
+                        {tag}
+                      </Badge>
+                    ))}
+                  </InlineStack>
+                </BlockStack>
+              </CardHeader>
+            </Card>
+          </Link>
+        ))}
+      </div>
+    </BlockStack>
+  );
+}

--- a/src/components/Learn/FeaturedTours.tsx
+++ b/src/components/Learn/FeaturedTours.tsx
@@ -1,0 +1,103 @@
+import { Link } from "@tanstack/react-router";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icon";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Heading, Paragraph, Text } from "@/components/ui/typography";
+import { tracking } from "@/utils/tracking";
+
+interface FeaturedTour {
+  id: string;
+  title: string;
+  duration: string;
+  tag?: "new" | "popular";
+}
+
+const STUB_TOURS: FeaturedTour[] = [
+  {
+    id: "first-pipeline",
+    title: "Build your first pipeline",
+    duration: "4 min",
+    tag: "popular",
+  },
+  { id: "using-secrets", title: "Using secrets safely", duration: "2 min" },
+  {
+    id: "multinode-tasks",
+    title: "Run multinode tasks",
+    duration: "3 min",
+    tag: "new",
+  },
+  {
+    id: "custom-components",
+    title: "Create a custom component",
+    duration: "5 min",
+  },
+];
+
+export function FeaturedTours() {
+  return (
+    <div className="h-full rounded-xl border border-border bg-card p-5">
+      <BlockStack gap="3" className="h-full">
+        <InlineStack gap="2" blockAlign="center" align="space-between">
+          <InlineStack gap="2" blockAlign="center">
+            <Icon
+              name="Compass"
+              size="md"
+              className="text-primary"
+              aria-hidden="true"
+            />
+            <Heading level={3}>Featured tours</Heading>
+          </InlineStack>
+          <Button
+            asChild
+            size="sm"
+            variant="link"
+            className="px-0"
+            {...tracking("learning_hub.tours.browse_all")}
+          >
+            <Link to="/learn/tours">All tours →</Link>
+          </Button>
+        </InlineStack>
+
+        <ul className="list-none p-0 m-0 flex flex-col gap-1 flex-1">
+          {STUB_TOURS.map((tour) => (
+            <li key={tour.id}>
+              <button
+                type="button"
+                className="w-full flex items-center justify-between gap-3 px-3 py-2 rounded-md hover:bg-muted/60 text-left"
+                {...tracking("learning_hub.tours.start", { tour_id: tour.id })}
+              >
+                <BlockStack gap="0" className="min-w-0">
+                  <InlineStack gap="2" blockAlign="center">
+                    <Paragraph size="sm" weight="semibold" className="truncate">
+                      {tour.title}
+                    </Paragraph>
+                    {tour.tag && (
+                      <Badge
+                        size="sm"
+                        variant={tour.tag === "new" ? "default" : "secondary"}
+                        className="capitalize"
+                      >
+                        {tour.tag}
+                      </Badge>
+                    )}
+                  </InlineStack>
+                  <Text size="xs" tone="subdued">
+                    {tour.duration}
+                  </Text>
+                </BlockStack>
+                <Icon
+                  name="Play"
+                  size="sm"
+                  className="text-muted-foreground shrink-0"
+                  aria-hidden="true"
+                />
+              </button>
+            </li>
+          ))}
+        </ul>
+      </BlockStack>
+    </div>
+  );
+}

--- a/src/components/Learn/LearnComingSoon.tsx
+++ b/src/components/Learn/LearnComingSoon.tsx
@@ -1,0 +1,40 @@
+import { Link } from "@tanstack/react-router";
+
+import { Icon, type IconName } from "@/components/ui/icon";
+import { BlockStack } from "@/components/ui/layout";
+import { Heading, Paragraph } from "@/components/ui/typography";
+
+interface LearnComingSoonProps {
+  title: string;
+  description: string;
+  icon: IconName;
+}
+
+export function LearnComingSoon({
+  title,
+  description,
+  icon,
+}: LearnComingSoonProps) {
+  return (
+    <BlockStack
+      gap="4"
+      align="center"
+      className="border border-dashed border-border rounded-xl py-16 px-6 text-center"
+    >
+      <div className="flex items-center justify-center w-14 h-14 rounded-full bg-muted">
+        <Icon name={icon} size="xl" aria-hidden="true" />
+      </div>
+      <BlockStack gap="2" align="center">
+        <Heading level={2}>{title}</Heading>
+        <Paragraph size="md" tone="subdued" className="max-w-md">
+          {description}
+        </Paragraph>
+      </BlockStack>
+      <BlockStack align="center">
+        <Link to="/learn" className="text-sm text-primary hover:underline">
+          ← Back to Learning Hub
+        </Link>
+      </BlockStack>
+    </BlockStack>
+  );
+}

--- a/src/components/Learn/LearnPageHeader.tsx
+++ b/src/components/Learn/LearnPageHeader.tsx
@@ -1,0 +1,53 @@
+import { Link } from "@tanstack/react-router";
+
+import { Icon, type IconName } from "@/components/ui/icon";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Heading, Paragraph } from "@/components/ui/typography";
+import { tracking } from "@/utils/tracking";
+
+interface LearnPageHeaderProps {
+  title: string;
+  description?: string;
+  icon?: IconName;
+  backTo?: string;
+  backLabel?: string;
+}
+
+export function LearnPageHeader({
+  title,
+  description,
+  icon,
+  backTo,
+  backLabel = "Back to Learning Hub",
+}: LearnPageHeaderProps) {
+  return (
+    <BlockStack gap="2">
+      {backTo && (
+        <Link
+          to={backTo}
+          className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground w-fit"
+          {...tracking("learning_hub.back", { from: title })}
+        >
+          <Icon name="ArrowLeft" size="sm" aria-hidden="true" />
+          {backLabel}
+        </Link>
+      )}
+      <InlineStack gap="3" blockAlign="center">
+        {icon && (
+          <Icon
+            name={icon}
+            size="xl"
+            className="text-primary"
+            aria-hidden="true"
+          />
+        )}
+        <Heading level={1}>{title}</Heading>
+      </InlineStack>
+      {description && (
+        <Paragraph size="md" tone="subdued">
+          {description}
+        </Paragraph>
+      )}
+    </BlockStack>
+  );
+}

--- a/src/components/Learn/LearnSearchBar.tsx
+++ b/src/components/Learn/LearnSearchBar.tsx
@@ -1,0 +1,43 @@
+import { useState } from "react";
+
+import { Icon } from "@/components/ui/icon";
+import { Input, InputGroup } from "@/components/ui/input";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
+import { TANGLE_WEBSITE_URL } from "@/utils/constants";
+
+export function LearnSearchBar() {
+  const [value, setValue] = useState("");
+  const { track } = useAnalytics();
+
+  const handleSubmit = () => {
+    const query = value.trim();
+    if (!query) return;
+    track("learning_hub.search.submitted");
+    const url = `${TANGLE_WEBSITE_URL}search/?q=${encodeURIComponent(query)}`;
+    window.open(url, "_blank", "noopener,noreferrer");
+  };
+
+  return (
+    <InputGroup
+      className="h-11"
+      prefixElement={
+        <Icon
+          name="Search"
+          size="md"
+          className="ml-3 text-muted-foreground"
+          aria-hidden="true"
+        />
+      }
+    >
+      <Input
+        variant="noBorder"
+        placeholder="Search docs, tips and examples…"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onEnter={handleSubmit}
+        aria-label="Search the Learning Hub"
+        className="h-11 text-sm w-80"
+      />
+    </InputGroup>
+  );
+}

--- a/src/components/Learn/OnboardingHero.tsx
+++ b/src/components/Learn/OnboardingHero.tsx
@@ -1,0 +1,117 @@
+import { Link } from "@tanstack/react-router";
+
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icon";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Heading, Paragraph, Text } from "@/components/ui/typography";
+import { cn } from "@/lib/utils";
+import { tracking } from "@/utils/tracking";
+
+interface OnboardingStep {
+  id: string;
+  label: string;
+  completed: boolean;
+}
+
+const STUB_STEPS: OnboardingStep[] = [
+  { id: "configure-backend", label: "Connect a backend", completed: true },
+  { id: "import-sample", label: "Import a sample pipeline", completed: true },
+  { id: "run-pipeline", label: "Run your first pipeline", completed: false },
+  { id: "edit-component", label: "Edit a component", completed: false },
+  {
+    id: "create-pipeline",
+    label: "Build a pipeline from scratch",
+    completed: false,
+  },
+];
+
+export function OnboardingHero() {
+  const completed = STUB_STEPS.filter((s) => s.completed).length;
+  const total = STUB_STEPS.length;
+  const isComplete = completed === total;
+  const nextStep = STUB_STEPS.find((s) => !s.completed);
+
+  return (
+    <div className="rounded-xl border border-border bg-linear-to-br from-primary/5 to-transparent p-6">
+      <BlockStack gap="4">
+        <InlineStack gap="4" align="space-between" blockAlign="start">
+          <BlockStack gap="2">
+            <InlineStack gap="2" blockAlign="center">
+              <Icon
+                name="Rocket"
+                size="lg"
+                className="text-primary"
+                aria-hidden="true"
+              />
+              <Heading level={2}>
+                {isComplete ? "You're all set up!" : "Welcome to Tangle"}
+              </Heading>
+            </InlineStack>
+            <Paragraph tone="subdued" size="sm">
+              {isComplete
+                ? "Onboarding complete — explore tours and tips below to keep going."
+                : "Follow a few quick steps to get from zero to your first pipeline run."}
+            </Paragraph>
+          </BlockStack>
+          {!isComplete && nextStep && (
+            <Button
+              asChild
+              size="sm"
+              {...tracking("learning_hub.onboarding.resume")}
+            >
+              <Link to="/learn">
+                Resume
+                <Icon name="ArrowRight" size="sm" aria-hidden="true" />
+              </Link>
+            </Button>
+          )}
+        </InlineStack>
+
+        <BlockStack gap="2">
+          <InlineStack gap="3" blockAlign="center">
+            <Text size="xs" tone="subdued" weight="semibold">
+              {completed} of {total} steps
+            </Text>
+            <div
+              className="flex-1 h-2 rounded-full bg-muted overflow-hidden"
+              role="progressbar"
+              aria-valuenow={completed}
+              aria-valuemin={0}
+              aria-valuemax={total}
+              aria-label="Onboarding progress"
+            >
+              <div
+                className="h-full bg-primary transition-all duration-300"
+                style={{ width: `${(completed / total) * 100}%` }}
+              />
+            </div>
+          </InlineStack>
+
+          <ul className="flex flex-wrap gap-x-4 gap-y-1.5 list-none p-0 m-0">
+            {STUB_STEPS.map((step) => (
+              <li key={step.id} className="flex items-center gap-1.5 text-xs">
+                <Icon
+                  name={step.completed ? "CircleCheck" : "Circle"}
+                  size="sm"
+                  className={cn(
+                    step.completed
+                      ? "text-primary"
+                      : "text-muted-foreground/60",
+                  )}
+                  aria-hidden="true"
+                />
+                <Text
+                  size="xs"
+                  tone={step.completed ? "subdued" : "inherit"}
+                  className={cn(step.completed && "line-through")}
+                >
+                  {step.label}
+                </Text>
+              </li>
+            ))}
+          </ul>
+        </BlockStack>
+      </BlockStack>
+    </div>
+  );
+}

--- a/src/components/Learn/TipOfTheDay.tsx
+++ b/src/components/Learn/TipOfTheDay.tsx
@@ -1,0 +1,62 @@
+import { Link } from "@tanstack/react-router";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icon";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Heading, Paragraph } from "@/components/ui/typography";
+import { tracking } from "@/utils/tracking";
+
+const STUB_TIP = {
+  id: "subgraph-navigation",
+  category: "Editor",
+  title: "Use subgraphs to keep complex pipelines readable",
+  body: "Double-click any task to dive into its subgraph. Use the breadcrumbs at the top of the editor to navigate back up — perfect for organising large pipelines without clutter.",
+};
+
+export function TipOfTheDay() {
+  return (
+    <div className="h-full rounded-xl border border-border bg-card p-5">
+      <BlockStack gap="3" className="h-full">
+        <InlineStack gap="2" blockAlign="center" align="space-between">
+          <InlineStack gap="2" blockAlign="center">
+            <Icon
+              name="Lightbulb"
+              size="md"
+              className="text-amber-500"
+              aria-hidden="true"
+            />
+            <Heading level={3}>Tip of the day</Heading>
+          </InlineStack>
+          <Badge size="sm" variant="secondary">
+            {STUB_TIP.category}
+          </Badge>
+        </InlineStack>
+
+        <BlockStack gap="1" className="flex-1">
+          <Paragraph size="sm" weight="semibold">
+            {STUB_TIP.title}
+          </Paragraph>
+          <Paragraph size="sm" tone="subdued">
+            {STUB_TIP.body}
+          </Paragraph>
+        </BlockStack>
+
+        <InlineStack gap="2" align="space-between" blockAlign="center">
+          <Button
+            asChild
+            size="sm"
+            variant="link"
+            className="px-0"
+            {...tracking("learning_hub.tip.browse_all")}
+          >
+            <Link to="/learn/tips">
+              Browse all tips
+              <Icon name="ArrowRight" size="sm" aria-hidden="true" />
+            </Link>
+          </Button>
+        </InlineStack>
+      </BlockStack>
+    </div>
+  );
+}

--- a/src/routes/Dashboard/DashboardLayout.tsx
+++ b/src/routes/Dashboard/DashboardLayout.tsx
@@ -31,6 +31,7 @@ const SIDEBAR_ITEMS: SidebarItem[] = [
   { to: "/components", label: "Components", icon: "Package" },
   { to: "/favorites", label: "Favorites", icon: "Star" },
   { to: "/recently-viewed", label: "Recently Viewed", icon: "Clock" },
+  { to: "/learn", label: "Learning Hub", icon: "GraduationCap" },
 ];
 
 const navItemClass = (isActive: boolean) =>

--- a/src/routes/Dashboard/Learn/LearnExamplesView.tsx
+++ b/src/routes/Dashboard/Learn/LearnExamplesView.tsx
@@ -1,0 +1,21 @@
+import { LearnComingSoon } from "@/components/Learn/LearnComingSoon";
+import { LearnPageHeader } from "@/components/Learn/LearnPageHeader";
+import { BlockStack } from "@/components/ui/layout";
+
+export function LearnExamplesView() {
+  return (
+    <BlockStack gap="8">
+      <LearnPageHeader
+        title="Example Pipelines"
+        description="Ready-made pipelines you can import and run to learn by example."
+        icon="Sparkles"
+        backTo="/learn"
+      />
+      <LearnComingSoon
+        title="Example pipelines are on the way"
+        description="A gallery of importable example pipelines, organised by topic and difficulty."
+        icon="Sparkles"
+      />
+    </BlockStack>
+  );
+}

--- a/src/routes/Dashboard/Learn/LearnHomeView.test.tsx
+++ b/src/routes/Dashboard/Learn/LearnHomeView.test.tsx
@@ -1,0 +1,71 @@
+import { screen } from "@testing-library/dom";
+import { cleanup, render } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { LearnHomeView } from "./LearnHomeView";
+
+vi.mock("@tanstack/react-router", async (importOriginal) => ({
+  ...(await importOriginal()),
+  Link: ({
+    to,
+    children,
+    ...rest
+  }: {
+    to: string;
+    children: ReactNode;
+    [key: string]: unknown;
+  }) => (
+    <a href={to} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@/providers/AnalyticsProvider", () => ({
+  useAnalytics: vi.fn().mockReturnValue({ track: vi.fn() }),
+}));
+
+describe("<LearnHomeView/>", () => {
+  afterEach(cleanup);
+
+  test("renders the page header", () => {
+    render(<LearnHomeView />);
+    expect(
+      screen.getByRole("heading", { level: 1, name: "Learning Hub" }),
+    ).toBeInTheDocument();
+  });
+
+  test("renders the search bar", () => {
+    render(<LearnHomeView />);
+    expect(
+      screen.getByRole("textbox", { name: /search the learning hub/i }),
+    ).toBeInTheDocument();
+  });
+
+  test("renders the onboarding hero with progress", () => {
+    render(<LearnHomeView />);
+    expect(
+      screen.getByRole("heading", { level: 2, name: /welcome to tangle/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("progressbar", { name: /onboarding progress/i }),
+    ).toBeInTheDocument();
+  });
+
+  test("renders the tip of the day, tours, examples and documentation sections", () => {
+    render(<LearnHomeView />);
+    expect(
+      screen.getByRole("heading", { level: 3, name: /tip of the day/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { level: 3, name: /featured tours/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { level: 2, name: /example pipelines/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { level: 2, name: /documentation/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/routes/Dashboard/Learn/LearnHomeView.tsx
+++ b/src/routes/Dashboard/Learn/LearnHomeView.tsx
@@ -1,0 +1,34 @@
+import { DocumentationPanel } from "@/components/Learn/DocumentationPanel";
+import { FeaturedExamples } from "@/components/Learn/FeaturedExamples";
+import { FeaturedTours } from "@/components/Learn/FeaturedTours";
+import { LearnPageHeader } from "@/components/Learn/LearnPageHeader";
+import { LearnSearchBar } from "@/components/Learn/LearnSearchBar";
+import { OnboardingHero } from "@/components/Learn/OnboardingHero";
+import { TipOfTheDay } from "@/components/Learn/TipOfTheDay";
+import { BlockStack } from "@/components/ui/layout";
+
+export function LearnHomeView() {
+  return (
+    <BlockStack gap="6">
+      <BlockStack gap="4">
+        <LearnPageHeader
+          title="Learning Hub"
+          description="Everything you need to get the most out of Tangle, all in one place."
+          icon="GraduationCap"
+        />
+        <LearnSearchBar />
+      </BlockStack>
+
+      <OnboardingHero />
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <TipOfTheDay />
+        <FeaturedTours />
+      </div>
+
+      <FeaturedExamples />
+
+      <DocumentationPanel />
+    </BlockStack>
+  );
+}

--- a/src/routes/Dashboard/Learn/LearnTipsView.tsx
+++ b/src/routes/Dashboard/Learn/LearnTipsView.tsx
@@ -1,0 +1,21 @@
+import { LearnComingSoon } from "@/components/Learn/LearnComingSoon";
+import { LearnPageHeader } from "@/components/Learn/LearnPageHeader";
+import { BlockStack } from "@/components/ui/layout";
+
+export function LearnTipsView() {
+  return (
+    <BlockStack gap="8">
+      <LearnPageHeader
+        title="Tips & Tricks"
+        description="Bite-sized tips covering shortcuts, hidden features and best practices."
+        icon="Lightbulb"
+        backTo="/learn"
+      />
+      <LearnComingSoon
+        title="Tips library is on the way"
+        description="A browsable library of in-app tips — searchable, filterable and shareable by link."
+        icon="Lightbulb"
+      />
+    </BlockStack>
+  );
+}

--- a/src/routes/Dashboard/Learn/LearnToursView.tsx
+++ b/src/routes/Dashboard/Learn/LearnToursView.tsx
@@ -1,0 +1,21 @@
+import { LearnComingSoon } from "@/components/Learn/LearnComingSoon";
+import { LearnPageHeader } from "@/components/Learn/LearnPageHeader";
+import { BlockStack } from "@/components/ui/layout";
+
+export function LearnToursView() {
+  return (
+    <BlockStack gap="8">
+      <LearnPageHeader
+        title="Guided Tours"
+        description="Interactive step-by-step walkthroughs of features across the app."
+        icon="Compass"
+        backTo="/learn"
+      />
+      <LearnComingSoon
+        title="Tours are on the way"
+        description="Launch interactive tours that highlight UI elements and walk you through real workflows."
+        icon="Compass"
+      />
+    </BlockStack>
+  );
+}

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -23,6 +23,10 @@ import { DashboardLayout } from "./Dashboard/DashboardLayout";
 import { DashboardPipelinesView } from "./Dashboard/DashboardPipelinesView";
 import { DashboardRecentlyViewedView } from "./Dashboard/DashboardRecentlyViewedView";
 import { DashboardRunsView } from "./Dashboard/DashboardRunsView";
+import { LearnExamplesView } from "./Dashboard/Learn/LearnExamplesView";
+import { LearnHomeView } from "./Dashboard/Learn/LearnHomeView";
+import { LearnTipsView } from "./Dashboard/Learn/LearnTipsView";
+import { LearnToursView } from "./Dashboard/Learn/LearnToursView";
 import Editor from "./Editor";
 import { ImportPage } from "./Import";
 import NotFoundPage from "./NotFoundPage";
@@ -47,6 +51,7 @@ declare module "@tanstack/react-router" {
 export const EDITOR_PATH = "/editor";
 export const RUNS_BASE_PATH = "/runs";
 export const QUICK_START_PATH = "/quick-start";
+const LEARN_BASE_PATH = "/learn";
 const EDITOR_V2_BASE_PATH = "/editor-v2";
 const RUNS_V2_BASE_PATH = "/runs-v2";
 const SETTINGS_PATH = "/settings";
@@ -59,6 +64,10 @@ export const APP_ROUTES = {
   DASHBOARD_COMPONENTS: "/components",
   DASHBOARD_FAVORITES: "/favorites",
   DASHBOARD_RECENTLY_VIEWED: "/recently-viewed",
+  LEARN: LEARN_BASE_PATH,
+  LEARN_EXAMPLES: `${LEARN_BASE_PATH}/examples`,
+  LEARN_TIPS: `${LEARN_BASE_PATH}/tips`,
+  LEARN_TOURS: `${LEARN_BASE_PATH}/tours`,
   QUICK_START: QUICK_START_PATH,
   IMPORT: IMPORT_PATH,
   PIPELINE_EDITOR: `${EDITOR_PATH}/$name`,
@@ -138,6 +147,30 @@ const dashboardRecentlyViewedRoute = createRoute({
   getParentRoute: () => dashboardRoute,
   path: "/recently-viewed",
   component: DashboardRecentlyViewedView,
+});
+
+const learnIndexRoute = createRoute({
+  getParentRoute: () => dashboardRoute,
+  path: LEARN_BASE_PATH,
+  component: LearnHomeView,
+});
+
+const learnExamplesRoute = createRoute({
+  getParentRoute: () => dashboardRoute,
+  path: APP_ROUTES.LEARN_EXAMPLES,
+  component: LearnExamplesView,
+});
+
+const learnTipsRoute = createRoute({
+  getParentRoute: () => dashboardRoute,
+  path: APP_ROUTES.LEARN_TIPS,
+  component: LearnTipsView,
+});
+
+const learnToursRoute = createRoute({
+  getParentRoute: () => dashboardRoute,
+  path: APP_ROUTES.LEARN_TOURS,
+  component: LearnToursView,
 });
 
 const quickStartRoute = createRoute({
@@ -299,6 +332,10 @@ const dashboardRouteTree = dashboardRoute.addChildren([
   dashboardComponentsRoute,
   dashboardFavoritesRoute,
   dashboardRecentlyViewedRoute,
+  learnIndexRoute,
+  learnExamplesRoute,
+  learnTipsRoute,
+  learnToursRoute,
 ]);
 
 const appRouteTree = mainLayout.addChildren([

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,6 +1,7 @@
 /* Environment Config */
-export const ABOUT_URL =
-  import.meta.env.VITE_ABOUT_URL || "https://tangleml.com/";
+export const TANGLE_WEBSITE_URL = "https://tangleml.com/";
+
+export const ABOUT_URL = import.meta.env.VITE_ABOUT_URL || TANGLE_WEBSITE_URL;
 
 export const GIVE_FEEDBACK_URL =
   import.meta.env.VITE_GIVE_FEEDBACK_URL ||
@@ -11,7 +12,7 @@ export const PRIVACY_POLICY_URL =
   "https://tangleml.com/docs/privacy_policy/";
 
 export const DOCUMENTATION_URL =
-  import.meta.env.VITE_DOCUMENTATION_URL || "https://tangleml.com/docs/";
+  import.meta.env.VITE_DOCUMENTATION_URL || `${TANGLE_WEBSITE_URL}docs/`;
 
 export const API_URL = import.meta.env.VITE_BACKEND_API_URL || "";
 export const BASE_URL = import.meta.env.VITE_BASE_URL || "/";


### PR DESCRIPTION
## Description

Foundational/scaffold PR  
  
Adds a new set of routes under `/learn` and a series of placeholder pages to go with. This will serve as the home of all things learnability going forward. Future PRs, features and migrations can simply replace the existing placeholder content within each page. The main `/learn` route loads a dashboard overview of all the proposed learnability features (all with placeholder content and UI)



This PR does all the wiring, new routes, sidebar options and placeholder components. The main focus is on getting the scaffold and foundation set up.



All content is placeholder and will be molded and filled-out over the rest of this stack.

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

Commences https://github.com/Shopify/oasis-frontend/issues/584

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

- [x] New feature

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

![image.png](https://app.graphite.com/user-attachments/assets/c85168ec-6f48-434e-a911-4182d67ebcd2.png)





<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

1. Open Tangle Homepage
2. Confirm that "Learning Hub" is an option in the sidebar
3. Click "Learning Hub"
4. A new dashboard page loads with placeholder content covering a variety of learning topics.

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->