### PR TITLE
feat: Learning Hub Tip of the Day

### DIFF
--- a/src/components/Learn/TipOfTheDay.tsx
+++ b/src/components/Learn/TipOfTheDay.tsx
@@ -4,50 +4,81 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
-import { Heading, Paragraph } from "@/components/ui/typography";
+import { Heading, Text } from "@/components/ui/typography";
 import { tracking } from "@/utils/tracking";
 
-const STUB_TIP = {
-  id: "subgraph-navigation",
-  category: "Editor",
-  title: "Use subgraphs to keep complex pipelines readable",
-  body: "Double-click any task to dive into its subgraph. Use the breadcrumbs at the top of the editor to navigate back up — perfect for organising large pipelines without clutter.",
-};
+import { tips } from "./tips";
 
-export function TipOfTheDay() {
+function getDayOfYear(date: Date) {
+  const start = Date.UTC(date.getUTCFullYear(), 0, 0);
+
+  const now = Date.UTC(
+    date.getUTCFullYear(),
+    date.getUTCMonth(),
+    date.getUTCDate(),
+  );
+
+  return Math.floor((now - start) / 86_400_000);
+}
+
+interface TipOfTheDayProps {
+  variant?: "card" | "compact";
+}
+
+export function TipOfTheDay({ variant = "card" }: TipOfTheDayProps = {}) {
+  const index = getDayOfYear(new Date()) % tips.length;
+  const tip = tips[index];
+  const isCompact = variant === "compact";
+  const textSize = isCompact ? "xs" : "sm";
+
+  const badge = (
+    <Badge size="sm" variant="secondary">
+      {tip.category}
+    </Badge>
+  );
+
   return (
-    <div className="h-full rounded-xl border border-border bg-card p-5">
-      <BlockStack gap="3" className="h-full">
-        <InlineStack gap="2" blockAlign="center" align="space-between">
-          <InlineStack gap="2" blockAlign="center">
-            <Icon
-              name="Lightbulb"
-              size="md"
-              className="text-amber-500"
-              aria-hidden="true"
-            />
-            <Heading level={3}>Tip of the day</Heading>
+    <div
+      className={
+        isCompact
+          ? "h-full p-2"
+          : "h-full rounded-xl border border-border bg-card p-5"
+      }
+    >
+      <BlockStack gap={isCompact ? "2" : "3"} className="h-full">
+        {!isCompact && (
+          <InlineStack gap="2" blockAlign="center" align="space-between">
+            <InlineStack gap="2" blockAlign="center">
+              <Icon
+                name="Lightbulb"
+                size="md"
+                className="text-amber-500"
+                aria-hidden="true"
+              />
+              <Heading level={3}>Tip of the day</Heading>
+            </InlineStack>
+            {badge}
           </InlineStack>
-          <Badge size="sm" variant="secondary">
-            {STUB_TIP.category}
-          </Badge>
-        </InlineStack>
+        )}
 
         <BlockStack gap="1" className="flex-1">
-          <Paragraph size="sm" weight="semibold">
-            {STUB_TIP.title}
-          </Paragraph>
-          <Paragraph size="sm" tone="subdued">
-            {STUB_TIP.body}
-          </Paragraph>
+          <InlineStack gap="2" blockAlign="center" align="space-between">
+            <Text as="p" size={textSize} weight="semibold">
+              {tip.title}
+            </Text>
+            {isCompact && badge}
+          </InlineStack>
+          <Text as="p" size={textSize} tone="subdued">
+            {tip.body}
+          </Text>
         </BlockStack>
 
-        <InlineStack gap="2" align="space-between" blockAlign="center">
+        <InlineStack gap="2" blockAlign="center">
           <Button
             asChild
             size="sm"
             variant="link"
-            className="px-0"
+            className={isCompact ? "px-0 text-xs" : "px-0"}
             {...tracking("learning_hub.tip.browse_all")}
           >
             <Link to="/learn/tips">

--- a/src/routes/Dashboard/DashboardHomeView.tsx
+++ b/src/routes/Dashboard/DashboardHomeView.tsx
@@ -1,6 +1,7 @@
 import { Link } from "@tanstack/react-router";
 
 import { RunSection } from "@/components/Home/RunSection/RunSection";
+import { TipOfTheDay } from "@/components/Learn/TipOfTheDay";
 import { AnnouncementBanners } from "@/components/shared/AnnouncementBanners";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import {
@@ -170,10 +171,13 @@ export function DashboardHomeView() {
     <BlockStack gap="6">
       <AnnouncementBanners />
 
-      <div className="grid grid-cols-3 gap-6 overflow-hidden">
+      <div className="w-full grid grid-cols-3 xl:grid-cols-6 gap-6 overflow-hidden">
         <FavoritesPreview />
         <RecentlyViewedPreview />
         <RecentComponentsPreview />
+        <div className="col-span-3 max-w-4xl mx-auto">
+          <TipOfTheDay />
+        </div>
       </div>
 
       <BlockStack gap="3">

--- a/src/routes/v2/pages/Editor/EditorV2.tsx
+++ b/src/routes/v2/pages/Editor/EditorV2.tsx
@@ -48,6 +48,7 @@ import { useRunsAndSubmissionWindow } from "./hooks/useRunsAndSubmissionWindow";
 import { useSeedInitialDockLayoutFromPreset } from "./hooks/useSeedInitialDockLayoutFromPreset";
 import { useSelectionWindowSync } from "./hooks/useSelectionWindowSync";
 import { useSpecLifecycle } from "./hooks/useSpecLifecycle";
+import { useTipOfTheDayWindow } from "./hooks/useTipOfTheDayWindow";
 import { useUndoRedoKeyboard } from "./hooks/useUndoRedoKeyboard";
 import { editorRegistry } from "./nodes";
 import { EditorSessionProvider } from "./store/EditorSessionContext";
@@ -91,6 +92,7 @@ const PipelineEditor = withSuspenseWrapper(
     useShortcutListener();
     useEditorEscapeShortcut();
     useDebugPanelWindow();
+    useTipOfTheDayWindow();
     useSeedInitialDockLayoutFromPreset();
 
     const aiEnabled = useFlagValue("ai-assistant");

--- a/src/routes/v2/pages/Editor/hooks/useTipOfTheDayWindow.tsx
+++ b/src/routes/v2/pages/Editor/hooks/useTipOfTheDayWindow.tsx
@@ -1,0 +1,21 @@
+import { useEffect } from "react";
+
+import { TipOfTheDay } from "@/components/Learn/TipOfTheDay";
+import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
+
+const TIP_OF_THE_DAY_WINDOW_ID = "tip-of-the-day";
+
+export function useTipOfTheDayWindow() {
+  const { windows } = useSharedStores();
+  useEffect(() => {
+    if (windows.getWindowById(TIP_OF_THE_DAY_WINDOW_ID)) return;
+    windows.openWindow(<TipOfTheDay variant="compact" />, {
+      id: TIP_OF_THE_DAY_WINDOW_ID,
+      title: "Tip of the Day",
+      position: { x: 0, y: 820 },
+      size: { width: 280, height: 240 },
+      persisted: true,
+      defaultDockState: "left",
+    });
+  }, [windows]);
+}

--- a/src/routes/v2/shared/windows/viewPresets.ts
+++ b/src/routes/v2/shared/windows/viewPresets.ts
@@ -14,6 +14,7 @@ export interface ViewPreset {
 
 export const DEFAULT_DOCK_AREAS: PresetDockAreas = {
   left: [
+    "tip-of-the-day",
     "runs-and-submission",
     "component-library",
     "pipeline-tree",
@@ -46,6 +47,7 @@ export const DEFAULT_VIEW_PRESET: ViewPreset = {
     "recent-runs",
     "component-library",
     "pipeline-details",
+    "tip-of-the-day",
   ]),
   dockAreas: DEFAULT_DOCK_AREAS,
 };
@@ -64,6 +66,7 @@ export const VIEW_PRESETS: ViewPreset[] = [
       "pipeline-details",
       "debug-panel",
       "recent-runs",
+      "tip-of-the-day",
     ]),
     dockAreas: DEFAULT_DOCK_AREAS,
   },


### PR DESCRIPTION
## Description

Adds a "Tip of the Day" section to the dashboard homepage (top right).

Also adds it as a window in the v2 editor (in compact mode).

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

Closes https://github.com/Shopify/oasis-frontend/issues/581

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

- [x] New feature

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

![image.png](https://app.graphite.com/user-attachments/assets/0082fc29-5fb8-4783-bf9f-86c53754c7bb.png)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

![image.png](https://app.graphite.com/user-attachments/assets/36453f74-095d-4c09-abaf-610fd5f8edca.png)

## Test Instructions

tip of the day changes each day

tip of the day shows on learning hub

tip of the day shows on homepage

tip of the day shows in the v2 editor

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

Later, after selectors have been added to the UI for the guided tours, we can explore adding highlight or go-to features for in-editor tips.

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->