### PR TITLE
refator: v2 - tune up ui primitives

### DIFF
--- a/.claude/skills/ui-primitives/SKILL.md
+++ b/.claude/skills/ui-primitives/SKILL.md
@@ -1,67 +1,169 @@
 ---
 name: ui-primitives
-description: UI primitive components for this project (BlockStack, InlineStack, Text, Heading, Paragraph, Button, Icon). Use when writing JSX, creating components, or working with layout and typography.
+description: UI primitive components for this project (Box, Surface/Card/Section, BlockStack, InlineStack, Text/Heading/Paragraph, Button/IconButton, Icon, Pill, ListRow, ScrollRegion, Truncating, HoverReveal, ...). Use when writing JSX, creating components, or working with layout and typography.
 ---
 
 # UI Primitives
 
-Always prefer UI primitives over raw HTML elements.
+Tangle UI is organized in four layers. Pick the highest layer that fits — reaching for a lower one is a smell.
 
-## Layout
+```
+Layer 4: domain compositions   TaskNodeCard, IONodeCard, PipelineDigestBar, ...
+                                       ▲
+Layer 3: semantic primitives   Surface · Section · Card · ScrollRegion · Truncating
+                               · ListRow · ZebraList · Toolbar · HoverReveal
+                               · EmptyState · StickyHeader · IconButton · Pill · FieldRow · Divider
+                                       ▲
+Layer 2: tiny base primitives  BlockStack · InlineStack · Text · Heading · Paragraph
+                               · Button · Icon · Input · Label
+                                       ▲
+Layer 1: low-level escape hatch  Box
+```
 
-Use `BlockStack` and `InlineStack` from `@/components/ui/layout` instead of `<div className="flex ...">`:
+**`className` is forbidden on every primitive in layers 1-3.** The
+`tangle-ui/no-classname-on-primitives` ESLint rule warns today and will be
+promoted to `error` once the migration is complete.
 
-- `BlockStack` = vertical flex (`flex-col`)
-- `InlineStack` = horizontal flex (`flex-row`)
-- Both support `gap`, `align`, `blockAlign` props
-- Use `as` prop for semantic elements: `<BlockStack as="ul">`, `<InlineStack as="li">`
+## Layer 1 — Box
 
-## Typography
+`<Box>` (from `@/components/ui/box`) is the **only** escape hatch for "I need a
+styled container". Every prop is a token-bound enum (no Tailwind strings):
 
-All typography components are exported from `@/components/ui/typography`.
+```tsx
+<Box
+  background="subdued"
+  padding="base"
+  borderRadius="base"
+  border="sm"
+  shadow="xs"
+  inlineSize="full"
+  overflow="hidden"
+>
+  {children}
+</Box>
+```
 
-**Use `Heading` for headings** instead of raw `<h1-h6>` or `Text as="h*"`:
+Box has **no flex helpers** — use BlockStack/InlineStack inside it for layout.
+Importing Box anywhere under `src/routes/v2/**` triggers an ESLint soft-warning;
+prefer a Layer-3 primitive whenever one fits. Layer-3 primitive _implementations_
+may use Box freely.
 
-- `<Heading level={2}>Title</Heading>` — renders `<h2>` with `role="heading"` and `aria-level`
-- Automatically sets `size="md"` + `weight="semibold"` for level 1, `size="sm"` for others
-- Supports `tone`, `size`, `weight`, `font` overrides
+## Layer 2 — Base primitives
 
-**Use `Paragraph` for paragraph text** instead of raw `<p>` or `Text as="p"`:
+### Layout
 
-- `<Paragraph size="sm" tone="subdued">` instead of `<p className="text-sm text-muted">`
+- `BlockStack` (vertical) and `InlineStack` (horizontal) from `@/components/ui/layout`.
+- Props: `as`, `gap` (`'0' | '0.5' | '1' | '1.5' | '2' | '3' | '4' | '5' | '6' | '8'`),
+  `align`, `blockAlign` / `inlineAlign`, `wrap`, `fill`.
+- **No** width/height/min/max/padding/border/overflow/position/flex/shrink/grow/group props.
+  Each of those intents is owned by a Layer-3 primitive.
 
-**Use `Text` for inline text** (`<span>`, `<dt>`, `<dd>`, etc.):
+### Typography
 
-- `<Text as="dt" weight="semibold">` instead of `<dt className="font-semibold">`
-- Supports: `as`, `size`, `weight`, `tone`, `font` props
+All from `@/components/ui/typography`:
 
-## Buttons
+- `Heading` — semantic heading (`<h1>`-`<h6>`) with `level`, `size`, `weight`, `tone`, `truncate`, `align`, `wrap`.
+- `Paragraph` — `<p>` with the same semantic prop set as `Text`.
+- `Text` — inline `<span>` / `<dt>` / `<dd>` etc. Props: `as`, `size`, `weight`, `tone`,
+  `font`, `align`, `wrap`, `italic`, `leading`, `transform`, `decoration`, `truncate`.
 
-Use `Button` from `@/components/ui/button`
+`tone` accepts: `inherit | subdued | strong | weak | critical | warning | success | info | inverted | accent | magic`.
+Raw `text-gray-*` / `text-slate-*` / `text-*-500` colour classes are forbidden.
 
-## Icons
+For multi-line truncation use `truncate={2}` (line-clamp 2).
 
-Use `Icon` from `@/components/ui/icon`
+### Button / Icon
 
-## Styling
+- `Button` adds semantic props: `tone`, `fullWidth`, `align`, `truncate`, plus
+  `variant="menubar" | "menubar-light" | "toolbar"` for chrome buttons.
+- `Icon` defaults `shrink-0` and exposes `tone`, `rotate`, `spin`, `pulse`.
 
-- Use shadcn/ui components from `@/components/ui/` for all UI primitives
-- Use TailwindCSS v4 for styling (not CSS modules or styled-components)
-- **Only use inline styling** (`style={...}`) for dynamic/variable CSS values (e.g., `style={{height: h}}`). Never use inline styles for static values — use Tailwind classes instead
-- Use `cn()` utility for conditional classes (from `@/lib/utils`)
-- Prefer composition over prop drilling for complex components
+## Layer 3 — Semantic primitives
 
-## Suggest Abstractions for Repeated Patterns
+All in `@/components/ui/patterns/*`. Each replaces a specific className cluster.
 
-When you see similar Tailwind class combinations used multiple times, suggest creating reusable components or utility classes:
+### Surface · Card · Section — nested elevation
 
-- Multiple buttons with similar styling -> Create a Button variant or new component
-- Repeated container/card patterns -> Abstract into reusable Card component
-- Common spacing/layout patterns -> Suggest utility classes or component abstractions
-- Similar form field styling -> Create form field components
+`<Surface>` is **finite and nesting-aware**. There are exactly three levels
+(Container → Inset → Nested-inset), auto-detected from `SurfaceLevelContext`:
 
-## When Raw HTML is Acceptable
+```tsx
+<Surface>
+  {" "}
+  {/* level 1: card on the app background */}
+  <BlockStack gap="3">
+    <Heading level={3}>Inputs</Heading>
+    <Surface>
+      {" "}
+      {/* level 2: inset section */}
+      <Surface>
+        {" "}
+        {/* level 3: nested-inset strip */}
+        ...key/value...
+      </Surface>
+    </Surface>
+  </BlockStack>
+</Surface>
+```
 
-- Semantic elements not supported by primitives (e.g., `<dl>`, `<ul>`, `<ol>`, `<table>`)
-- Complex layouts where primitives don't fit
-- Performance-critical sections where abstraction overhead matters
+- Padding & border radius are derived from `level` — never user-set.
+- Hard cap at level 3 (throws in dev mode).
+- `tone` enum (`default | critical | warning | info | success | magic`) tints
+  the background per level.
+- `hoverable` boolean + `onClick` for clickable surfaces.
+- `level={1|2|3}` is allowed as an explicit override for portal'd content
+  (popovers, dialogs).
+- `Card` is `<Surface level={1}>` with header/content/footer slots and a
+  `density` prop (`'compact' | 'cozy' | 'comfortable'`).
+- `Section` is `<Surface>` with a built-in title + actions + optional `divider`
+  (Polaris rule: dividers only for data-like content).
+
+### Other intents
+
+| Primitive                                    | Replaces                                                    | Notes                                                                                         |
+| -------------------------------------------- | ----------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| `<ScrollRegion axis="y">`                    | `flex-1 min-h-0 overflow-y-auto`                            | Use inside flex columns.                                                                      |
+| `<Truncating>`                               | `min-w-0 flex-1` wrappers around shrinkable cells           | Apply `truncate` on the inner `<Text>`.                                                       |
+| `<ListRow hoverable onClick>`                | `<InlineStack className="group hover:bg-* px-* py-*">` rows | Establishes a `group` so `HoverReveal` works. Supports `density`, `gap`, `selected`, `zebra`. |
+| `<HoverReveal>`                              | `opacity-0 group-hover:opacity-100 transition-opacity`      | Place inside a `ListRow` or any `group` parent.                                               |
+| `<Toolbar density chrome sticky align>`      | dense horizontal action bars                                | Encapsulates `InlineStack gap-1 shrink-0 + chrome`.                                           |
+| `<ZebraList>`                                | `even:bg-* odd:bg-*`                                        | Auto-passes `zebra` to row children.                                                          |
+| `<EmptyState icon title description action>` | centered empty placeholder                                  |                                                                                               |
+| `<StickyHeader>`                             | `sticky top-0 z-* bg-*` inside ScrollRegion                 |                                                                                               |
+| `<Divider inset orientation>`                | toolbar separators                                          |                                                                                               |
+| `<IconButton icon size variant tone>`        | `<Button h-5 w-5 p-0>` + `<Icon>` combos                    | Sizes: `xs` (h-5), `sm` (h-6), `md` (h-7), `lg` (h-9).                                        |
+| `<Pill tone size>`                           | small `text-xs rounded-md px-2 py-1 bg-black/5` chips       | TaskNode handle labels, etc.                                                                  |
+| `<FieldRow label help error required>`       | label + control + help/error                                | Auto-wires `htmlFor`.                                                                         |
+
+## When raw HTML or `className` is acceptable
+
+- Raw HTML elements (`<div>`, `<dl>`, `<table>`, etc.) — not a primitive.
+- The internal implementation of new primitives (e.g. `cva` inside `Surface`).
+- Performance-critical leaf nodes (xyflow `<Handle>` styling) where shadcn primitives aren't a fit.
+- Layer-4 domain components are permitted to use `style={{...}}` for _dynamic_
+  CSS values (e.g. per-node palette colours) — never for static styling.
+
+Everywhere else, the `tangle-ui/no-classname-on-primitives` ESLint rule will
+reject it.
+
+## Codemod
+
+A pure-Node codemod is available for mechanical conversions:
+
+```bash
+node scripts/codemods/ban-classname-on-primitives.mjs --dry     # preview
+node scripts/codemods/ban-classname-on-primitives.mjs           # apply
+```
+
+It rewrites:
+
+- `<Icon className="shrink-0">` → drop (default)
+- `<Icon className="text-muted-foreground">` → `tone="subdued"` (and the rest of the colour map)
+- `<Text className="truncate">` → `truncate`
+- `<Text className="text-center">` → `align="center"`
+- `<Text className="italic">` → `italic`
+- `<Text className="font-mono">` → `font="mono"`
+
+Complex cluster signatures (`<div className="flex-1 min-h-0 overflow-y-auto">`,
+`<InlineStack className="group hover:bg-...">`, etc.) require hand migration to
+the matching layer-3 primitive.

--- a/eslint-rules/index.js
+++ b/eslint-rules/index.js
@@ -1,0 +1,16 @@
+import noClassnameOnPrimitives from "./no-classname-on-primitives.js";
+
+/**
+ * Local ESLint plugin: tangle-ui.
+ * Rules live in `./eslint-rules/*.js` and are wired into eslint.config.js.
+ *
+ * @type {import('eslint').ESLint.Plugin}
+ */
+const plugin = {
+  meta: { name: "tangle-ui" },
+  rules: {
+    "no-classname-on-primitives": noClassnameOnPrimitives,
+  },
+};
+
+export default plugin;

--- a/eslint-rules/no-classname-on-primitives.js
+++ b/eslint-rules/no-classname-on-primitives.js
@@ -1,0 +1,86 @@
+/**
+ * ESLint rule: no-classname-on-primitives
+ *
+ * Forbids the `className` attribute on Tangle UI primitives. Encourages using
+ * semantic props (tone, truncate, align, italic, etc.) or layer-3 wrappers
+ * (Surface, ListRow, ScrollRegion, Truncating, IconButton, ...).
+ *
+ * See `.local/.../ban-classname-on-primitives` plan.
+ *
+ * @type {import('eslint').Rule.RuleModule}
+ */
+const rule = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Forbid className on Tangle UI primitives; use semantic props or layer-3 patterns",
+      recommended: false,
+    },
+    schema: [
+      {
+        type: "object",
+        properties: {
+          components: {
+            type: "array",
+            items: { type: "string" },
+            description: "Component names that should reject `className`.",
+          },
+          // Used to surface a friendlier message for the soft-banned Box primitive
+          // (allowed, but warned-on in product code).
+          softBanned: {
+            type: "array",
+            items: { type: "string" },
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      noClassname:
+        '<{{component}}> does not accept `className`. Use semantic props instead. See ".claude/skills/ui-primitives/SKILL.md".',
+      softBanned:
+        "<{{component}}> is the low-level escape hatch. Prefer a Layer-3 semantic primitive (Surface, ListRow, ScrollRegion, ...) when one fits. Acceptable as a last resort.",
+    },
+  },
+  create(context) {
+    const options = context.options[0] ?? {};
+    const banned = new Set(options.components ?? []);
+    const softBanned = new Set(options.softBanned ?? []);
+
+    return {
+      JSXOpeningElement(node) {
+        const nameNode = node.name;
+        if (nameNode.type !== "JSXIdentifier") return;
+        const name = nameNode.name;
+
+        // Soft-ban: warn on any Box usage in this file glob.
+        if (softBanned.has(name)) {
+          context.report({
+            node: nameNode,
+            messageId: "softBanned",
+            data: { component: name },
+          });
+        }
+
+        if (!banned.has(name)) return;
+
+        const classNameAttr = node.attributes.find(
+          (attr) =>
+            attr.type === "JSXAttribute" &&
+            attr.name.type === "JSXIdentifier" &&
+            attr.name.name === "className",
+        );
+        if (classNameAttr) {
+          context.report({
+            node: classNameAttr,
+            messageId: "noClassname",
+            data: { component: name },
+          });
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,7 +7,51 @@ import simpleImportSort from "eslint-plugin-simple-import-sort";
 import globals from "globals";
 import tseslint from "typescript-eslint";
 
+import tangleUi from "./eslint-rules/index.js";
 import { REACT_COMPILER_ENABLED_GLOBS } from "./react-compiler.config.js";
+
+/**
+ * Primitive components whose `className` prop is being phased out. The ESLint rule
+ * `tangle-ui/no-classname-on-primitives` warns on any usage; once all sites are
+ * migrated the rule is promoted to `error` and the prop is removed from each
+ * primitive's type. See `.local/.../ban-classname-on-primitives` plan.
+ */
+const BANNED_CLASSNAME_PRIMITIVES = [
+  "BlockStack",
+  "InlineStack",
+  "Text",
+  "Paragraph",
+  "Heading",
+  "Button",
+  "Icon",
+  "IconButton",
+  "Surface",
+  "Section",
+  "Card",
+  "CardHeader",
+  "CardContent",
+  "CardFooter",
+  "CardTitle",
+  "CardDescription",
+  "ScrollRegion",
+  "Truncating",
+  "Toolbar",
+  "ListRow",
+  "ZebraList",
+  "HoverReveal",
+  "EmptyState",
+  "StickyHeader",
+  "Pill",
+  "FieldRow",
+  "Divider",
+  "TabsList",
+  "TabsTrigger",
+  "TabsContent",
+  "Label",
+  "Skeleton",
+  "TableHead",
+  "TableCell",
+];
 
 const baseRestrictedImportPaths = [
   {
@@ -86,6 +130,7 @@ export default [
     files: ["src/routes/v2/**/*.{ts,tsx}"],
     plugins: {
       "no-relative-import-paths": noRelativeImportPaths,
+      "tangle-ui": tangleUi,
     },
     rules: {
       "no-relative-import-paths/no-relative-import-paths": [
@@ -94,6 +139,20 @@ export default [
           allowSameFolder: true,
           rootDir: "src",
           prefix: "@",
+        },
+      ],
+      // Forbid className on Tangle UI primitives and the new layer-3 patterns.
+      // Soft-warn on Box imports (Box is the low-level escape hatch).
+      //
+      // Severity is "warn" today. To promote to "error" once `pnpm lint`
+      // reports 0 className warnings, change the severity below and delete the
+      // `className?: string` field from each primitive's type (see plan
+      // `.local/.../ban-classname-on-primitives`).
+      "tangle-ui/no-classname-on-primitives": [
+        "warn",
+        {
+          components: BANNED_CLASSNAME_PRIMITIVES,
+          softBanned: ["Box"],
         },
       ],
     },

--- a/scripts/codemods/ban-classname-on-primitives.mjs
+++ b/scripts/codemods/ban-classname-on-primitives.mjs
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+/**
+ * Codemod: ban-classname-on-primitives (pure-Node version).
+ *
+ * Rewrites the most mechanical className → semantic-prop conversions on the
+ * Tangle UI primitives. Operates on src/routes/v2/ by default.
+ *
+ * Conservative by design — only rewrites cases where the className contains
+ * exactly the recognized cluster signature (no other classes).
+ *
+ * Usage:
+ *   node scripts/codemods/ban-classname-on-primitives.mjs          # apply
+ *   node scripts/codemods/ban-classname-on-primitives.mjs --dry    # preview
+ *   node scripts/codemods/ban-classname-on-primitives.mjs src/routes/v2/pages/Editor
+ */
+
+import { readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+const TONE_BY_COLOR_CLASS = {
+  "text-muted-foreground": "subdued",
+  "text-foreground": "strong",
+  "text-destructive": "critical",
+  "text-warning": "warning",
+  "text-success": "success",
+  "text-info": "info",
+  "text-amber-400": "warning",
+  "text-amber-500": "warning",
+  "text-amber-600": "warning",
+  "text-amber-700": "warning",
+  "text-red-500": "critical",
+  "text-red-600": "critical",
+  "text-red-700": "critical",
+  "text-green-500": "success",
+  "text-green-600": "success",
+  "text-blue-500": "info",
+  "text-blue-600": "info",
+  "text-gray-300": "weak",
+  "text-gray-400": "weak",
+  "text-gray-500": "subdued",
+  "text-gray-600": "subdued",
+  "text-gray-700": "subdued",
+  "text-slate-300": "weak",
+  "text-slate-500": "subdued",
+  "text-slate-700": "subdued",
+  "text-slate-800": "strong",
+  "text-slate-900": "strong",
+  "text-stone-400": "subdued",
+  "text-stone-500": "subdued",
+};
+
+/** @type {Array<{name: string, pattern: RegExp, rewrite: (m: RegExpExecArray) => string|null}>} */
+const RULES = [
+  {
+    name: "Icon: className='shrink-0' → (default, drop attribute)",
+    pattern: /<Icon\b([^/>]*?)\sclassName="shrink-0"([^/>]*?)(\/?)>/g,
+    rewrite: (m) => `<Icon${m[1]}${m[2]}${m[3]}>`,
+  },
+  {
+    name: "Icon: className='<color>' → tone=...",
+    pattern: /<Icon\b([^/>]*?)\sclassName="([\w-]+)"([^/>]*?)(\/?)>/g,
+    rewrite: (m) => {
+      const tone = TONE_BY_COLOR_CLASS[m[2]];
+      if (!tone) return null;
+      return `<Icon${m[1]} tone="${tone}"${m[3]}${m[4]}>`;
+    },
+  },
+  {
+    name: "Icon: className='shrink-0 <color>' / '<color> shrink-0' → tone=...",
+    pattern:
+      /<Icon\b([^/>]*?)\sclassName="((?:shrink-0\s+[\w-]+)|(?:[\w-]+\s+shrink-0))"([^/>]*?)(\/?)>/g,
+    rewrite: (m) => {
+      const parts = m[2].split(/\s+/);
+      const color = parts.find((p) => p !== "shrink-0");
+      if (!color) return null;
+      const tone = TONE_BY_COLOR_CLASS[color];
+      if (!tone) return null;
+      return `<Icon${m[1]} tone="${tone}"${m[3]}${m[4]}>`;
+    },
+  },
+  {
+    name: "Icon: className='rotate-90|rotate-180|-rotate-90' → rotate=...",
+    pattern:
+      /<Icon\b([^/>]*?)\sclassName="(-?rotate-(?:90|180))"([^/>]*?)(\/?)>/g,
+    rewrite: (m) => {
+      const ROTATE_BY_CLASS = {
+        "rotate-90": "90",
+        "rotate-180": "180",
+        "-rotate-90": "-90",
+      };
+      const value = ROTATE_BY_CLASS[m[2]];
+      if (!value) return null;
+      return `<Icon${m[1]} rotate="${value}"${m[3]}${m[4]}>`;
+    },
+  },
+  {
+    name: "Text/Paragraph: className='truncate' → truncate",
+    pattern:
+      /<(Text|Paragraph)\b([^/>]*?)\sclassName="truncate"([^/>]*?)(\/?)>/g,
+    rewrite: (m) => `<${m[1]}${m[2]} truncate${m[3]}${m[4]}>`,
+  },
+  {
+    name: "Text/Paragraph: className='italic' → italic",
+    pattern: /<(Text|Paragraph)\b([^/>]*?)\sclassName="italic"([^/>]*?)(\/?)>/g,
+    rewrite: (m) => `<${m[1]}${m[2]} italic${m[3]}${m[4]}>`,
+  },
+  {
+    name: "Text/Paragraph: className='text-center' → align='center'",
+    pattern:
+      /<(Text|Paragraph)\b([^/>]*?)\sclassName="text-center"([^/>]*?)(\/?)>/g,
+    rewrite: (m) => `<${m[1]}${m[2]} align="center"${m[3]}${m[4]}>`,
+  },
+  {
+    name: "Text/Paragraph: className='<color>' → tone=...",
+    pattern:
+      /<(Text|Paragraph)\b([^/>]*?)\sclassName="([\w-]+)"([^/>]*?)(\/?)>/g,
+    rewrite: (m) => {
+      const tone = TONE_BY_COLOR_CLASS[m[3]];
+      if (!tone) return null;
+      return `<${m[1]}${m[2]} tone="${tone}"${m[4]}${m[5]}>`;
+    },
+  },
+  {
+    name: "Text/Paragraph: className='font-mono' → font='mono'",
+    pattern:
+      /<(Text|Paragraph)\b([^/>]*?)\sclassName="font-mono!?"([^/>]*?)(\/?)>/g,
+    rewrite: (m) => `<${m[1]}${m[2]} font="mono"${m[3]}${m[4]}>`,
+  },
+];
+
+function walk(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    if (entry === "node_modules" || entry === ".git" || entry.startsWith(".")) {
+      continue;
+    }
+    const full = join(dir, entry);
+    const s = statSync(full);
+    if (s.isDirectory()) {
+      out.push(...walk(full));
+    } else if (entry.endsWith(".tsx") || entry.endsWith(".ts")) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function applyRules(content, stats) {
+  let out = content;
+  for (const rule of RULES) {
+    out = out.replace(rule.pattern, (matchedText, ...rest) => {
+      const groups = rest.slice(0, -2).map((g) => g ?? "");
+      const fakeExec = [matchedText, ...groups];
+      const replacement = rule.rewrite(fakeExec);
+      if (replacement == null) return matchedText;
+      stats.replacements[rule.name] = (stats.replacements[rule.name] ?? 0) + 1;
+      return replacement;
+    });
+  }
+  return out;
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const dry = args.includes("--dry");
+  const positional = args.filter((a) => !a.startsWith("--"));
+  const targetRel = positional[0] ?? "src/routes/v2";
+  const target = resolve(process.cwd(), targetRel);
+
+  const files = walk(target);
+  const stats = { files: files.length, filesChanged: 0, replacements: {} };
+
+  for (const file of files) {
+    const before = readFileSync(file, "utf8");
+    const after = applyRules(before, stats);
+    if (after !== before) {
+      stats.filesChanged += 1;
+      if (!dry) writeFileSync(file, after, "utf8");
+    }
+  }
+
+  const summaryLines = Object.entries(stats.replacements)
+    .sort((a, b) => b[1] - a[1])
+    .map(([name, n]) => `  ${String(n).padStart(4)} × ${name}`);
+
+  console.log(
+    [
+      `[${dry ? "dry" : "applied"}] ban-classname-on-primitives`,
+      `target: ${target}`,
+      `files scanned:  ${stats.files}`,
+      `files changed:  ${stats.filesChanged}`,
+      `replacements by rule:`,
+      ...(summaryLines.length ? summaryLines : ["  (none)"]),
+    ].join("\n"),
+  );
+}
+
+main();

--- a/scripts/codemods/ban-classname-on-primitives.ts
+++ b/scripts/codemods/ban-classname-on-primitives.ts
@@ -1,0 +1,229 @@
+#!/usr/bin/env tsx
+/**
+ * Codemod: ban-classname-on-primitives
+ *
+ * Rewrites the most mechanical className -> semantic-prop conversions on the
+ * Tangle UI primitives. Operates on src/routes/v2/ by default.
+ *
+ * Conservative by design — it only rewrites cases where the className contains
+ * exactly the recognized cluster signature (no other classes). Anything else is
+ * left for hand migration.
+ *
+ * Usage:
+ *   pnpm tsx scripts/codemods/ban-classname-on-primitives.ts          # apply
+ *   pnpm tsx scripts/codemods/ban-classname-on-primitives.ts --dry    # preview
+ *   pnpm tsx scripts/codemods/ban-classname-on-primitives.ts src/routes/v2/pages/Editor
+ */
+
+import { readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+interface Rule {
+  /** Pretty name for reporting. */
+  name: string;
+  /** Regex that matches a complete JSX opening tag, with capturing groups. */
+  pattern: RegExp;
+  /** Function that returns the replacement string, or null to skip. */
+  rewrite: (match: RegExpExecArray) => string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Rule library — small, surgical transforms that are safe to run in bulk.
+// ---------------------------------------------------------------------------
+
+// Maps a literal "text-*" class to an Icon/Text `tone` value.
+const TONE_BY_COLOR_CLASS: Record<string, string> = {
+  "text-muted-foreground": "subdued",
+  "text-foreground": "strong",
+  "text-destructive": "critical",
+  "text-warning": "warning",
+  "text-success": "success",
+  "text-info": "info",
+  "text-amber-400": "warning",
+  "text-amber-500": "warning",
+  "text-amber-600": "warning",
+  "text-amber-700": "warning",
+  "text-red-500": "critical",
+  "text-red-600": "critical",
+  "text-red-700": "critical",
+  "text-green-500": "success",
+  "text-green-600": "success",
+  "text-blue-500": "info",
+  "text-blue-600": "info",
+  "text-gray-400": "weak",
+  "text-gray-500": "subdued",
+  "text-gray-600": "subdued",
+  "text-gray-700": "subdued",
+  "text-slate-300": "weak",
+  "text-slate-500": "subdued",
+  "text-slate-700": "subdued",
+  "text-slate-800": "strong",
+  "text-slate-900": "strong",
+  "text-stone-400": "subdued",
+  "text-stone-500": "subdued",
+};
+
+function buildIconRules(): Rule[] {
+  return [
+    {
+      name: "Icon: className='shrink-0' → (default, drop attribute)",
+      pattern: /<Icon\b([^/>]*?)\sclassName="shrink-0"([^/>]*?)\/?>/g,
+      rewrite: (m) => `<Icon${m[1]}${m[2]}/>`,
+    },
+    {
+      name: "Icon: className='<color>' → tone=...",
+      pattern: /<Icon\b([^/>]*?)\sclassName="([\w-]+)"([^/>]*?)\/?>/g,
+      rewrite: (m) => {
+        const tone = TONE_BY_COLOR_CLASS[m[2]];
+        if (!tone) return null;
+        return `<Icon${m[1]} tone="${tone}"${m[3]}/>`;
+      },
+    },
+    {
+      name: "Icon: className='shrink-0 <color>' / '<color> shrink-0' → tone=...",
+      pattern:
+        /<Icon\b([^/>]*?)\sclassName="((?:shrink-0\s+[\w-]+)|(?:[\w-]+\s+shrink-0))"([^/>]*?)\/?>/g,
+      rewrite: (m) => {
+        const parts = m[2].split(/\s+/);
+        const color = parts.find((p) => p !== "shrink-0");
+        if (!color) return null;
+        const tone = TONE_BY_COLOR_CLASS[color];
+        if (!tone) return null;
+        return `<Icon${m[1]} tone="${tone}"${m[3]}/>`;
+      },
+    },
+  ];
+}
+
+function buildTextRules(): Rule[] {
+  return [
+    {
+      name: "Text: className='truncate' → truncate",
+      pattern:
+        /<(Text|Paragraph)\b([^/>]*?)\sclassName="truncate"([^/>]*?)(\/?)>/g,
+      rewrite: (m) => `<${m[1]}${m[2]} truncate${m[3]}${m[4]}>`,
+    },
+    {
+      name: "Text: className='italic' → italic",
+      pattern:
+        /<(Text|Paragraph)\b([^/>]*?)\sclassName="italic"([^/>]*?)(\/?)>/g,
+      rewrite: (m) => `<${m[1]}${m[2]} italic${m[3]}${m[4]}>`,
+    },
+    {
+      name: "Text: className='text-center' → align='center'",
+      pattern:
+        /<(Text|Paragraph)\b([^/>]*?)\sclassName="text-center"([^/>]*?)(\/?)>/g,
+      rewrite: (m) => `<${m[1]}${m[2]} align="center"${m[3]}${m[4]}>`,
+    },
+    {
+      name: "Text: className='<color>' → tone=...",
+      pattern:
+        /<(Text|Paragraph)\b([^/>]*?)\sclassName="([\w-]+)"([^/>]*?)(\/?)>/g,
+      rewrite: (m) => {
+        const tone = TONE_BY_COLOR_CLASS[m[3]];
+        if (!tone) return null;
+        return `<${m[1]}${m[2]} tone="${tone}"${m[4]}${m[5]}>`;
+      },
+    },
+    {
+      name: "Text: className='font-mono' → font='mono'",
+      pattern:
+        /<(Text|Paragraph)\b([^/>]*?)\sclassName="font-mono!?"([^/>]*?)(\/?)>/g,
+      rewrite: (m) => `<${m[1]}${m[2]} font="mono"${m[3]}${m[4]}>`,
+    },
+  ];
+}
+
+const RULES: Rule[] = [...buildIconRules(), ...buildTextRules()];
+
+// ---------------------------------------------------------------------------
+// Driver
+// ---------------------------------------------------------------------------
+
+interface Stats {
+  files: number;
+  filesChanged: number;
+  replacements: Record<string, number>;
+}
+
+function walk(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    if (entry === "node_modules" || entry === ".git" || entry.startsWith(".")) {
+      continue;
+    }
+    const full = join(dir, entry);
+    const s = statSync(full);
+    if (s.isDirectory()) {
+      out.push(...walk(full));
+    } else if (entry.endsWith(".tsx") || entry.endsWith(".ts")) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function applyRules(content: string, stats: Stats): string {
+  let out = content;
+  for (const rule of RULES) {
+    out = out.replace(rule.pattern, (matchedText, ...rest) => {
+      // String.prototype.replace passes (match, p1, p2, ..., offset, string)
+      // We want the capture groups: drop the last 2 entries (offset + string).
+      const groups = rest.slice(0, -2).map((g) => (g as string) ?? "");
+      const fakeExec = Object.assign([matchedText, ...groups], {
+        index: 0,
+        input: "",
+      }) as unknown as RegExpExecArray;
+      const replacement = rule.rewrite(fakeExec);
+      if (replacement == null) return matchedText;
+      stats.replacements[rule.name] = (stats.replacements[rule.name] ?? 0) + 1;
+      return replacement;
+    });
+  }
+  return out;
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const dry = args.includes("--dry");
+  const positional = args.filter((a) => !a.startsWith("--"));
+  const targetRel = positional[0] ?? "src/routes/v2";
+  const target = resolve(process.cwd(), targetRel);
+
+  const files = walk(target);
+  const stats: Stats = {
+    files: files.length,
+    filesChanged: 0,
+    replacements: {},
+  };
+
+  for (const file of files) {
+    const before = readFileSync(file, "utf8");
+    const after = applyRules(before, stats);
+    if (after !== before) {
+      stats.filesChanged += 1;
+      if (!dry) {
+        writeFileSync(file, after, "utf8");
+      }
+    }
+  }
+
+  const summaryLines = Object.entries(stats.replacements)
+    .sort((a, b) => b[1] - a[1])
+    .map(([name, n]) => `  ${n.toString().padStart(4)} × ${name}`);
+
+  const header = dry ? "[dry run]" : "[applied]";
+  // eslint-disable-next-line no-console
+  console.log(
+    [
+      `${header} ban-classname-on-primitives`,
+      `target: ${target}`,
+      `files scanned:  ${stats.files}`,
+      `files changed:  ${stats.filesChanged}`,
+      `replacements by rule:`,
+      ...(summaryLines.length ? summaryLines : ["  (none)"]),
+    ].join("\n"),
+  );
+}
+
+main();

--- a/src/components/ui/box.tsx
+++ b/src/components/ui/box.tsx
@@ -1,0 +1,291 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import type { AriaAttributes, AriaRole, PropsWithChildren, Ref } from "react";
+import { forwardRef } from "react";
+
+import { cn } from "@/lib/utils";
+
+/**
+ * Box — Layer 1 "configurable container" primitive (Tangle UI).
+ *
+ * Modeled on Shopify Polaris Box:
+ * https://shopify.dev/docs/api/app-home/web-components/layout-and-structure/box
+ *
+ * Token-only escape hatch. No `className`. No flex helpers (use BlockStack / InlineStack for layout).
+ * Product code should prefer Layer-3 semantic primitives; an ESLint warning fires on Box imports
+ * inside `src/routes/v2/**`. Layer-3 primitive implementations may use Box freely.
+ */
+
+type BoxElement =
+  | "div"
+  | "section"
+  | "article"
+  | "header"
+  | "footer"
+  | "aside"
+  | "main"
+  | "nav";
+
+const boxVariants = cva("", {
+  variants: {
+    background: {
+      transparent: "",
+      subdued: "bg-muted/50",
+      base: "bg-background",
+      strong: "bg-secondary",
+      card: "bg-card",
+      inverted: "bg-foreground text-background",
+      "critical-subtle": "bg-destructive/10",
+      "warning-subtle": "bg-warning/15",
+      "info-subtle": "bg-info/10",
+      "success-subtle": "bg-success/10",
+    },
+    padding: {
+      none: "p-0",
+      xs: "p-1",
+      sm: "p-2",
+      base: "p-3",
+      lg: "p-4",
+      xl: "p-6",
+    },
+    paddingBlock: {
+      none: "py-0",
+      xs: "py-1",
+      sm: "py-2",
+      base: "py-3",
+      lg: "py-4",
+      xl: "py-6",
+    },
+    paddingInline: {
+      none: "px-0",
+      xs: "px-1",
+      sm: "px-2",
+      base: "px-3",
+      lg: "px-4",
+      xl: "px-6",
+    },
+    paddingBlockStart: {
+      none: "pt-0",
+      xs: "pt-1",
+      sm: "pt-2",
+      base: "pt-3",
+      lg: "pt-4",
+      xl: "pt-6",
+    },
+    paddingBlockEnd: {
+      none: "pb-0",
+      xs: "pb-1",
+      sm: "pb-2",
+      base: "pb-3",
+      lg: "pb-4",
+      xl: "pb-6",
+    },
+    paddingInlineStart: {
+      none: "ps-0",
+      xs: "ps-1",
+      sm: "ps-2",
+      base: "ps-3",
+      lg: "ps-4",
+      xl: "ps-6",
+    },
+    paddingInlineEnd: {
+      none: "pe-0",
+      xs: "pe-1",
+      sm: "pe-2",
+      base: "pe-3",
+      lg: "pe-4",
+      xl: "pe-6",
+    },
+    borderRadius: {
+      none: "rounded-none",
+      xs: "rounded-xs",
+      sm: "rounded-sm",
+      base: "rounded-md",
+      lg: "rounded-lg",
+      xl: "rounded-xl",
+      full: "rounded-full",
+    },
+    border: {
+      none: "border-0",
+      sm: "border",
+      base: "border-2",
+    },
+    borderColor: {
+      base: "border-border",
+      subdued: "border-border/50",
+      strong: "border-foreground/30",
+      critical: "border-destructive",
+      warning: "border-warning",
+      info: "border-info",
+      success: "border-success",
+    },
+    shadow: {
+      none: "shadow-none",
+      xs: "shadow-xs",
+      sm: "shadow-sm",
+      md: "shadow-md",
+      lg: "shadow-lg",
+    },
+    inlineSize: {
+      auto: "w-auto",
+      full: "w-full",
+      fit: "w-fit",
+      screen: "w-screen",
+      "1/2": "w-1/2",
+      "1/3": "w-1/3",
+      "2/3": "w-2/3",
+      "1/4": "w-1/4",
+      "3/4": "w-3/4",
+    },
+    blockSize: {
+      auto: "h-auto",
+      full: "h-full",
+      fit: "h-fit",
+      screen: "h-screen",
+    },
+    minInlineSize: {
+      "0": "min-w-0",
+      auto: "min-w-auto",
+      full: "min-w-full",
+    },
+    minBlockSize: {
+      "0": "min-h-0",
+      auto: "min-h-auto",
+      full: "min-h-full",
+      screen: "min-h-screen",
+    },
+    maxInlineSize: {
+      none: "max-w-none",
+      full: "max-w-full",
+      sm: "max-w-sm",
+      md: "max-w-md",
+      lg: "max-w-lg",
+      xl: "max-w-xl",
+      "2xl": "max-w-2xl",
+      "5xl": "max-w-5xl",
+      screen: "max-w-screen",
+    },
+    maxBlockSize: {
+      none: "max-h-none",
+      full: "max-h-full",
+      screen: "max-h-screen",
+      xs: "max-h-32",
+      sm: "max-h-48",
+      md: "max-h-64",
+      lg: "max-h-80",
+      xl: "max-h-96",
+    },
+    overflow: {
+      visible: "overflow-visible",
+      hidden: "overflow-hidden",
+      auto: "overflow-auto",
+      "scroll-y": "overflow-y-auto overflow-x-hidden",
+      "scroll-x": "overflow-x-auto overflow-y-hidden",
+      clip: "overflow-clip",
+    },
+    position: {
+      static: "static",
+      relative: "relative",
+      absolute: "absolute",
+      sticky: "sticky",
+      fixed: "fixed",
+    },
+    zIndex: {
+      "0": "z-0",
+      "10": "z-10",
+      "20": "z-20",
+      "30": "z-30",
+      "40": "z-40",
+      "50": "z-50",
+    },
+  },
+});
+
+type BoxVariantProps = VariantProps<typeof boxVariants>;
+
+interface BoxOwnProps extends AriaAttributes {
+  /** HTML Element tag. @default 'div' */
+  as?: BoxElement;
+  /** ARIA role for assistive technologies. */
+  role?: AriaRole;
+  /** Native browser tooltip text. */
+  title?: string;
+  /** Inline event handler for click. */
+  onClick?: React.MouseEventHandler<HTMLElement>;
+  /** Pointer-events policy. */
+  pointerEvents?: "auto" | "none";
+}
+
+export interface BoxProps extends BoxOwnProps, BoxVariantProps {}
+
+export const Box = forwardRef<HTMLElement, PropsWithChildren<BoxProps>>(
+  function Box(
+    {
+      as: Element = "div",
+      children,
+      background,
+      padding,
+      paddingBlock,
+      paddingInline,
+      paddingBlockStart,
+      paddingBlockEnd,
+      paddingInlineStart,
+      paddingInlineEnd,
+      borderRadius,
+      border,
+      borderColor,
+      shadow,
+      inlineSize,
+      blockSize,
+      minInlineSize,
+      minBlockSize,
+      maxInlineSize,
+      maxBlockSize,
+      overflow,
+      position,
+      zIndex,
+      pointerEvents,
+      role,
+      ...rest
+    },
+    ref,
+  ) {
+    return (
+      <Element
+        ref={ref as Ref<any>}
+        role={role}
+        className={cn(
+          boxVariants({
+            background,
+            padding,
+            paddingBlock,
+            paddingInline,
+            paddingBlockStart,
+            paddingBlockEnd,
+            paddingInlineStart,
+            paddingInlineEnd,
+            borderRadius,
+            border,
+            borderColor,
+            shadow,
+            inlineSize,
+            blockSize,
+            minInlineSize,
+            minBlockSize,
+            maxInlineSize,
+            maxBlockSize,
+            overflow,
+            position,
+            zIndex,
+          }),
+          pointerEvents === "none" && "pointer-events-none",
+          pointerEvents === "auto" && "pointer-events-auto",
+        )}
+        {...rest}
+      >
+        {children}
+      </Element>
+    );
+  },
+);
+
+Box.displayName = "Box";

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -25,6 +25,15 @@ const buttonVariants = cva(
           "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
         link: "text-primary underline-offset-4 hover:underline",
         "link-info": "text-info underline decoration-dotted",
+        // Dark-chrome menubar button (top app menubar, window chrome).
+        menubar:
+          "text-stone-400 hover:text-white hover:bg-stone-700 data-[state=open]:bg-stone-700 data-[state=open]:text-white",
+        // Light-chrome menubar button (light theme menubars / window chrome).
+        "menubar-light":
+          "text-white/80 hover:text-white hover:bg-stone-700/30 data-[state=open]:bg-stone-700/30",
+        // Dense toolbar action (small height, no chrome).
+        toolbar:
+          "hover:bg-accent hover:text-accent-foreground text-foreground/80",
       },
       size: {
         default: "h-9 px-4 py-2 has-[>svg]:px-3",
@@ -35,10 +44,62 @@ const buttonVariants = cva(
         icon: "size-9",
         min: "h-fit w-fit p-1 rounded-sm",
       },
+      tone: {
+        default: "",
+        critical: "",
+        warning: "",
+        success: "",
+      },
+      align: {
+        center: "justify-center",
+        start: "justify-start text-left",
+        end: "justify-end text-right",
+        "space-between": "justify-between",
+      },
+      fullWidth: {
+        true: "w-full",
+        false: "",
+      },
+      truncate: {
+        true: "[&>span]:truncate min-w-0",
+        false: "",
+      },
     },
+    compoundVariants: [
+      // tone on ghost/link
+      {
+        variant: "ghost",
+        tone: "critical",
+        className:
+          "text-destructive hover:bg-destructive/10 hover:text-destructive",
+      },
+      {
+        variant: "ghost",
+        tone: "warning",
+        className: "text-warning hover:bg-warning/10 hover:text-warning",
+      },
+      {
+        variant: "ghost",
+        tone: "success",
+        className: "text-success hover:bg-success/10 hover:text-success",
+      },
+      { variant: "link", tone: "critical", className: "text-destructive" },
+      { variant: "link", tone: "warning", className: "text-warning" },
+      { variant: "link", tone: "success", className: "text-success" },
+      // tone on toolbar
+      {
+        variant: "toolbar",
+        tone: "critical",
+        className: "text-destructive hover:bg-destructive/10",
+      },
+    ],
     defaultVariants: {
       variant: "default",
       size: "default",
+      tone: "default",
+      align: "center",
+      fullWidth: false,
+      truncate: false,
     },
   },
 );
@@ -52,6 +113,10 @@ function Button({
   className,
   variant,
   size,
+  tone,
+  align,
+  fullWidth,
+  truncate,
   asChild = false,
   ...props
 }: ButtonProps) {
@@ -60,7 +125,17 @@ function Button({
   return (
     <Comp
       data-slot="button"
-      className={cn(buttonVariants({ variant, size, className }))}
+      className={cn(
+        buttonVariants({
+          variant,
+          size,
+          tone,
+          align,
+          fullWidth,
+          truncate,
+          className,
+        }),
+      )}
       {...props}
     />
   );

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,25 +1,75 @@
+import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
 
+import { SurfaceLevelProvider } from "@/components/ui/patterns/surface";
 import { cn } from "@/lib/utils";
 
-function Card({ className, ...props }: React.ComponentProps<"div">) {
+const cardVariants = cva(
+  "bg-card text-card-foreground flex flex-col rounded-xl border shadow-sm",
+  {
+    variants: {
+      density: {
+        compact: "gap-2 py-2",
+        cozy: "gap-3 py-3",
+        comfortable: "gap-6 py-6",
+      },
+    },
+    defaultVariants: {
+      density: "comfortable",
+    },
+  },
+);
+
+type CardVariantProps = VariantProps<typeof cardVariants>;
+
+interface CardProps extends React.ComponentProps<"div">, CardVariantProps {}
+
+function Card({ className, density, ...props }: CardProps) {
   return (
-    <div
-      data-slot="card"
-      className={cn(
-        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
-        className,
-      )}
-      {...props}
-    />
+    // Card establishes Surface level 1, so nested <Surface> defaults to level 2.
+    <SurfaceLevelProvider level={1}>
+      <div
+        data-slot="card"
+        className={cn(cardVariants({ density }), className)}
+        {...props}
+      />
+    </SurfaceLevelProvider>
   );
 }
 
-function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+const cardHeaderVariants = cva("flex flex-col gap-1.5", {
+  variants: {
+    density: {
+      compact: "px-2",
+      cozy: "px-3",
+      comfortable: "px-6",
+    },
+    divider: {
+      true: "border-b pb-3",
+      false: "",
+    },
+  },
+  defaultVariants: {
+    density: "comfortable",
+    divider: false,
+  },
+});
+
+interface CardHeaderProps
+  extends
+    React.ComponentProps<"div">,
+    VariantProps<typeof cardHeaderVariants> {}
+
+function CardHeader({
+  className,
+  density,
+  divider,
+  ...props
+}: CardHeaderProps) {
   return (
     <div
       data-slot="card-header"
-      className={cn("flex flex-col gap-1.5 px-6", className)}
+      className={cn(cardHeaderVariants({ density, divider }), className)}
       {...props}
     />
   );
@@ -45,21 +95,57 @@ function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
   );
 }
 
-function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+const cardContentVariants = cva("", {
+  variants: {
+    density: {
+      compact: "px-2",
+      cozy: "px-3",
+      comfortable: "px-6",
+    },
+  },
+  defaultVariants: {
+    density: "comfortable",
+  },
+});
+
+interface CardContentProps
+  extends
+    React.ComponentProps<"div">,
+    VariantProps<typeof cardContentVariants> {}
+
+function CardContent({ className, density, ...props }: CardContentProps) {
   return (
     <div
       data-slot="card-content"
-      className={cn("px-6", className)}
+      className={cn(cardContentVariants({ density }), className)}
       {...props}
     />
   );
 }
 
-function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+const cardFooterVariants = cva("flex items-center", {
+  variants: {
+    density: {
+      compact: "px-2",
+      cozy: "px-3",
+      comfortable: "px-6",
+    },
+  },
+  defaultVariants: {
+    density: "comfortable",
+  },
+});
+
+interface CardFooterProps
+  extends
+    React.ComponentProps<"div">,
+    VariantProps<typeof cardFooterVariants> {}
+
+function CardFooter({ className, density, ...props }: CardFooterProps) {
   return (
     <div
       data-slot="card-footer"
-      className={cn("flex items-center px-6", className)}
+      className={cn(cardFooterVariants({ density }), className)}
       {...props}
     />
   );

--- a/src/components/ui/collapsible.tsx
+++ b/src/components/ui/collapsible.tsx
@@ -1,4 +1,8 @@
 import * as CollapsiblePrimitive from "@radix-ui/react-collapsible";
+import { cva, type VariantProps } from "class-variance-authority";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
 
 function Collapsible({
   ...props
@@ -17,12 +21,34 @@ function CollapsibleTrigger({
   );
 }
 
+const collapsibleContentVariants = cva("w-full", {
+  variants: {
+    density: {
+      none: "",
+      compact: "px-2 py-1",
+      cozy: "px-3 py-2",
+      comfortable: "px-4 py-3",
+    },
+  },
+  defaultVariants: {
+    density: "none",
+  },
+});
+
+interface CollapsibleContentProps
+  extends
+    React.ComponentProps<typeof CollapsiblePrimitive.CollapsibleContent>,
+    VariantProps<typeof collapsibleContentVariants> {}
+
 function CollapsibleContent({
+  className,
+  density,
   ...props
-}: React.ComponentProps<typeof CollapsiblePrimitive.CollapsibleContent>) {
+}: CollapsibleContentProps) {
   return (
     <CollapsiblePrimitive.CollapsibleContent
       data-slot="collapsible-content"
+      className={cn(collapsibleContentVariants({ density }), className)}
       {...props}
     />
   );

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { cva, type VariantProps } from "class-variance-authority";
 import { XIcon } from "lucide-react";
 import * as React from "react";
 
+import { SurfaceLevelProvider } from "@/components/ui/patterns/surface";
 import { cn } from "@/lib/utils";
 
 function Dialog({
@@ -46,16 +48,42 @@ function DialogOverlay({
   );
 }
 
+const dialogContentVariants = cva(
+  "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200",
+  {
+    variants: {
+      size: {
+        sm: "sm:max-w-sm",
+        md: "sm:max-w-md",
+        lg: "sm:max-w-lg",
+        xl: "sm:max-w-xl",
+        "2xl": "sm:max-w-2xl",
+        "3xl": "sm:max-w-3xl",
+        full: "sm:max-w-[95vw] sm:max-h-[95vh]",
+      },
+    },
+    defaultVariants: {
+      size: "lg",
+    },
+  },
+);
+
+interface DialogContentProps
+  extends
+    React.ComponentProps<typeof DialogPrimitive.Content>,
+    VariantProps<typeof dialogContentVariants> {
+  showCloseButton?: boolean;
+  preventKeyboardPropagation?: boolean;
+}
+
 function DialogContent({
   className,
   children,
+  size,
   showCloseButton = true,
   preventKeyboardPropagation = true,
   ...props
-}: React.ComponentProps<typeof DialogPrimitive.Content> & {
-  showCloseButton?: boolean;
-  preventKeyboardPropagation?: boolean;
-}) {
+}: DialogContentProps) {
   const handleKeyDown = React.useCallback(
     (e: React.KeyboardEvent) => {
       if (!preventKeyboardPropagation) return;
@@ -81,14 +109,12 @@ function DialogContent({
       <DialogOverlay />
       <DialogPrimitive.Content
         data-slot="dialog-content"
-        className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
-          className,
-        )}
+        className={cn(dialogContentVariants({ size }), className)}
         onKeyDown={handleKeyDown}
         {...props}
       >
-        {children}
+        {/* Dialog establishes a fresh Surface level-1 context (portal'd content). */}
+        <SurfaceLevelProvider level={0}>{children}</SurfaceLevelProvider>
         {showCloseButton && (
           <DialogPrimitive.Close
             data-slot="dialog-close"

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -43,14 +43,38 @@ const DropdownMenuSubTrigger = forwardRef<
 DropdownMenuSubTrigger.displayName =
   DropdownMenuPrimitive.SubTrigger.displayName;
 
+const subContentWidthClass = {
+  sm: "w-32",
+  md: "w-44",
+  lg: "w-52",
+  xl: "w-64",
+  "2xl": "w-80",
+  auto: "",
+} as const;
+
+const subContentMaxHeightClass = {
+  sm: "max-h-32",
+  md: "max-h-48",
+  lg: "max-h-64",
+  xl: "max-h-80",
+  screen: "max-h-[80vh]",
+  none: "",
+} as const;
+
 const DropdownMenuSubContent = forwardRef<
   ComponentRef<typeof DropdownMenuPrimitive.SubContent>,
-  ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
->(({ className, ...props }, ref) => (
+  ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent> & {
+    width?: keyof typeof subContentWidthClass;
+    maxHeight?: keyof typeof subContentMaxHeightClass;
+  }
+>(({ className, width = "auto", maxHeight = "none", ...props }, ref) => (
   <DropdownMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-dropdown-menu-content-transform-origin]",
+      "z-[9999] min-w-[8rem] rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-dropdown-menu-content-transform-origin]",
+      subContentWidthClass[width],
+      subContentMaxHeightClass[maxHeight],
+      maxHeight !== "none" ? "overflow-y-auto" : "overflow-hidden",
       className,
     )}
     {...props}

--- a/src/components/ui/icon.tsx
+++ b/src/components/ui/icon.tsx
@@ -3,7 +3,7 @@ import { icons, type LucideProps } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 
-const iconVariants = cva("", {
+const iconVariants = cva("shrink-0", {
   variants: {
     size: {
       xs: "!w-3 !h-3",
@@ -11,28 +11,75 @@ const iconVariants = cva("", {
       md: "!w-4 !h-4",
       lg: "!w-5 !h-5",
       xl: "!w-6 !h-6",
+      "2xl": "!w-8 !h-8",
       fill: "!w-full !h-full",
     },
+    tone: {
+      inherit: "",
+      subdued: "text-muted-foreground",
+      strong: "text-foreground",
+      weak: "text-muted-foreground/60",
+      critical: "text-destructive",
+      warning: "text-warning",
+      success: "text-success",
+      info: "text-info",
+      accent: "text-accent-foreground",
+      magic: "text-accent-foreground",
+    },
+    rotate: {
+      "0": "",
+      "90": "rotate-90",
+      "180": "rotate-180",
+      "-90": "-rotate-90",
+    },
+    spin: {
+      true: "animate-spin",
+      false: "",
+    },
+    pulse: {
+      true: "animate-pulse",
+      false: "",
+    },
+  },
+  defaultVariants: {
+    size: "md",
+    tone: "inherit",
+    spin: false,
+    pulse: false,
   },
 });
 
 export type IconName = keyof typeof icons;
+type IconVariantProps = VariantProps<typeof iconVariants>;
 
-interface IconProps extends VariantProps<typeof iconVariants> {
+interface IconProps extends IconVariantProps {
   name: IconName;
+  /**
+   * Escape-hatch className. Kept for backward compatibility during the
+   * ban-classname-on-primitives migration. Will be removed once the
+   * `tangle-ui/no-classname-on-primitives` rule is promoted to `error`.
+   * @deprecated Use semantic props (`tone`, `size`, `rotate`, `spin`, `pulse`) instead.
+   */
   className?: string;
 }
 
 export const Icon = ({
   name: icon,
   size = "md",
+  tone = "inherit",
+  rotate,
+  spin = false,
+  pulse = false,
   className,
   ...lucideIconProps
 }: IconProps & LucideProps) => {
-  const Icon = icons[icon];
+  const Component = icons[icon];
   return (
-    <Icon
-      className={cn(iconVariants({ size }), className)}
+    <Component
+      className={cn(
+        iconVariants({ size, tone, rotate, spin, pulse }),
+        className,
+      )}
       {...lucideIconProps}
     />
   );

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -4,44 +4,61 @@ import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
-const inputVariants = cva("", {
-  variants: {
-    variant: {
-      default:
-        "border-input border aria-invalid:border-destructive shadow-xs focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] rounded-md aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40",
-      noBorder: "",
-      readOnly:
-        "text-gray-500 bg-gray-100 cursor-not-allowed border-input border shadow-xs rounded-md",
+const inputVariants = cva(
+  "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 flex w-full min-w-0 bg-transparent transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-input border aria-invalid:border-destructive shadow-xs focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] rounded-md aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40",
+        noBorder: "",
+        readOnly:
+          "text-gray-500 bg-gray-100 cursor-not-allowed border-input border shadow-xs rounded-md",
+      },
+      inputSize: {
+        xs: "h-6 px-2 py-0.5 text-xs",
+        sm: "h-8 px-2.5 py-1 text-sm",
+        md: "h-9 px-3 py-1 text-base md:text-sm",
+        lg: "h-10 px-4 py-2 text-base",
+      },
+      font: {
+        default: "",
+        mono: "!font-mono",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      inputSize: "md",
+      font: "default",
     },
   },
-  defaultVariants: {
-    variant: "default",
-  },
-});
+);
+
+type InputVariantProps = VariantProps<typeof inputVariants>;
+
+interface InputProps
+  extends Omit<React.ComponentProps<"input">, "size">, InputVariantProps {
+  onEnter?: () => void;
+  onEscape?: () => void;
+}
 
 function Input({
   className,
   type,
   readOnly,
   variant = readOnly ? "readOnly" : "default",
+  inputSize,
+  font,
   onEnter,
   onEscape,
   onKeyDown,
   ...props
-}: React.ComponentProps<"input"> &
-  VariantProps<typeof inputVariants> & {
-    onEnter?: () => void;
-    onEscape?: () => void;
-  }) {
+}: InputProps) {
   return (
     <input
       type={type}
       data-slot="input"
-      className={cn(
-        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 flex h-9 w-full min-w-0 bg-transparent px-3 py-1 text-base transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
-        inputVariants({ variant }),
-        className,
-      )}
+      className={cn(inputVariants({ variant, inputSize, font }), className)}
       readOnly={readOnly}
       onKeyDown={(e) => {
         if (e.key === "Enter" && onEnter) {

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,19 +1,41 @@
 import * as LabelPrimitive from "@radix-ui/react-label";
+import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
-function Label({
-  className,
-  ...props
-}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+const labelVariants = cva(
+  "flex items-center gap-2 leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+  {
+    variants: {
+      size: {
+        xs: "text-xs",
+        sm: "text-sm",
+        md: "text-base",
+      },
+      tone: {
+        default: "text-foreground",
+        subdued: "text-muted-foreground",
+        critical: "text-destructive",
+      },
+    },
+    defaultVariants: {
+      size: "sm",
+      tone: "default",
+    },
+  },
+);
+
+interface LabelProps
+  extends
+    React.ComponentProps<typeof LabelPrimitive.Root>,
+    VariantProps<typeof labelVariants> {}
+
+function Label({ className, size, tone, ...props }: LabelProps) {
   return (
     <LabelPrimitive.Root
       data-slot="label"
-      className={cn(
-        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
-        className,
-      )}
+      className={cn(labelVariants({ size, tone }), className)}
       {...props}
     />
   );

--- a/src/components/ui/layout.tsx
+++ b/src/components/ui/layout.tsx
@@ -28,7 +28,9 @@ const blockStackVariants = cva("flex flex-col w-full", {
     },
     gap: {
       "0": "gap-0",
+      "0.5": "gap-0.5",
       "1": "gap-1",
+      "1.5": "gap-1.5",
       "2": "gap-2",
       "3": "gap-3",
       "4": "gap-4",
@@ -47,7 +49,13 @@ interface BlockStackProps
   as?: StackElement;
   /** Fill the container and center content */
   fill?: boolean;
-  /** Additional CSS classes */
+  /**
+   * Escape-hatch className. Kept for backward compatibility during the
+   * ban-classname-on-primitives migration. Will be removed once the
+   * `tangle-ui/no-classname-on-primitives` rule is promoted to `error`.
+   * @deprecated Use a Layer-3 semantic primitive (Surface, ScrollRegion,
+   * Truncating, ListRow, ...) instead of stacking utility classes here.
+   */
   className?: string;
 }
 
@@ -102,7 +110,9 @@ const inlineStackVariants = cva("flex flex-row", {
     },
     gap: {
       "0": "gap-0",
+      "0.5": "gap-0.5",
       "1": "gap-1",
+      "1.5": "gap-1.5",
       "2": "gap-2",
       "3": "gap-3",
       "4": "gap-4",
@@ -125,7 +135,13 @@ interface InlineStackProps
   as?: StackElement;
   /** Fill the container and center content */
   fill?: boolean;
-  /** Additional CSS classes */
+  /**
+   * Escape-hatch className. Kept for backward compatibility during the
+   * ban-classname-on-primitives migration. Will be removed once the
+   * `tangle-ui/no-classname-on-primitives` rule is promoted to `error`.
+   * @deprecated Use a Layer-3 semantic primitive (Surface, ScrollRegion,
+   * Truncating, ListRow, ...) instead of stacking utility classes here.
+   */
   className?: string;
 }
 

--- a/src/components/ui/patterns/divider.tsx
+++ b/src/components/ui/patterns/divider.tsx
@@ -1,0 +1,51 @@
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { Separator } from "@/components/ui/separator";
+import { cn } from "@/lib/utils";
+
+/**
+ * Divider — Layer 3 semantic primitive.
+ *
+ * Thin wrapper over Separator with `inset` and `orientation` semantics
+ * (covers the `mx-0.5 self-stretch` toolbar-divider pattern).
+ */
+
+const dividerVariants = cva("", {
+  variants: {
+    inset: {
+      none: "",
+      sm: "mx-1",
+      md: "mx-2",
+    },
+    orientation: {
+      vertical: "self-stretch",
+      horizontal: "w-full",
+    },
+  },
+  defaultVariants: {
+    inset: "none",
+    orientation: "vertical",
+  },
+});
+
+type DividerVariantProps = VariantProps<typeof dividerVariants>;
+
+interface DividerProps extends DividerVariantProps {
+  decorative?: boolean;
+}
+
+export function Divider({
+  inset = "none",
+  orientation = "vertical",
+  decorative = true,
+}: DividerProps) {
+  return (
+    <Separator
+      orientation={orientation ?? "vertical"}
+      decorative={decorative}
+      className={cn(dividerVariants({ inset, orientation }))}
+    />
+  );
+}
+
+Divider.displayName = "Divider";

--- a/src/components/ui/patterns/empty-state.tsx
+++ b/src/components/ui/patterns/empty-state.tsx
@@ -1,0 +1,49 @@
+import { forwardRef, type ReactNode, type Ref } from "react";
+
+import { Icon, type IconName } from "@/components/ui/icon";
+import { BlockStack } from "@/components/ui/layout";
+import { Heading, Paragraph } from "@/components/ui/typography";
+
+/**
+ * EmptyState — Layer 3 semantic primitive.
+ *
+ * Centered placeholder for empty content (no rows, no results, no data).
+ * Encodes the recurring `flex items-center justify-center text-center p-*` pattern
+ * (~10 hits across v2).
+ */
+
+interface EmptyStateProps {
+  /** Optional decorative icon shown above the title. */
+  icon?: IconName;
+  /** Headline. */
+  title: ReactNode;
+  /** Supporting description. */
+  description?: ReactNode;
+  /** Optional call-to-action (button, link, etc.). */
+  action?: ReactNode;
+}
+
+export const EmptyState = forwardRef<HTMLDivElement, EmptyStateProps>(
+  function EmptyState({ icon, title, description, action }, ref) {
+    return (
+      <BlockStack
+        ref={ref as Ref<HTMLDivElement>}
+        fill
+        gap="3"
+        align="center"
+        inlineAlign="center"
+      >
+        {icon && <Icon name={icon} size="xl" tone="subdued" />}
+        <Heading level={3}>{title}</Heading>
+        {description && (
+          <Paragraph tone="subdued" align="center">
+            {description}
+          </Paragraph>
+        )}
+        {action}
+      </BlockStack>
+    );
+  },
+);
+
+EmptyState.displayName = "EmptyState";

--- a/src/components/ui/patterns/field-row.tsx
+++ b/src/components/ui/patterns/field-row.tsx
@@ -1,0 +1,82 @@
+import {
+  forwardRef,
+  type PropsWithChildren,
+  type ReactNode,
+  type Ref,
+  useId,
+} from "react";
+
+import { Label } from "@/components/ui/label";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
+
+/**
+ * FieldRow — Layer 3 semantic primitive.
+ *
+ * Label + control + optional help text + optional error. Encodes the recurring
+ * `BlockStack gap-1` + Label + Input form-row pattern (~12 hits across v2).
+ *
+ *   <FieldRow label="Pipeline name" help="Used in URLs">
+ *     <Input value={name} onChange={...} />
+ *   </FieldRow>
+ *
+ * Handles `htmlFor` wiring automatically: the first focusable control receives
+ * the generated id, or you can pass `controlId` explicitly.
+ */
+
+interface FieldRowProps {
+  /** Visible label. */
+  label: ReactNode;
+  /** Helper text (subdued, shown below the control). */
+  help?: ReactNode;
+  /** Error message (overrides `help` styling when present). */
+  error?: ReactNode;
+  /** Required asterisk + aria-required. */
+  required?: boolean;
+  /** Provide an explicit id for the control; otherwise an id is generated. */
+  controlId?: string;
+  /** Lay out label inline with control instead of stacked. */
+  inline?: boolean;
+}
+
+export const FieldRow = forwardRef<
+  HTMLDivElement,
+  PropsWithChildren<FieldRowProps>
+>(function FieldRow(
+  { label, help, error, required, controlId, inline = false, children },
+  ref,
+) {
+  const generatedId = useId();
+  const id = controlId ?? generatedId;
+  const helpId = help || error ? `${id}-help` : undefined;
+  const Container = inline ? InlineStack : BlockStack;
+  return (
+    <BlockStack ref={ref as Ref<HTMLDivElement>} gap="1">
+      <Container
+        gap={inline ? "2" : "1"}
+        {...(inline ? { blockAlign: "center" } : {})}
+      >
+        <Label htmlFor={id}>
+          {label}
+          {required && (
+            <Text tone="critical" aria-hidden="true">
+              {" *"}
+            </Text>
+          )}
+        </Label>
+        {children}
+      </Container>
+      {error ? (
+        <Text id={helpId} size="xs" tone="critical">
+          {error}
+        </Text>
+      ) : help ? (
+        <Text id={helpId} size="xs" tone="subdued">
+          {help}
+        </Text>
+      ) : null}
+    </BlockStack>
+  );
+});
+
+FieldRow.displayName = "FieldRow";

--- a/src/components/ui/patterns/hover-reveal.tsx
+++ b/src/components/ui/patterns/hover-reveal.tsx
@@ -1,0 +1,63 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import { forwardRef, type PropsWithChildren, type Ref } from "react";
+
+import { cn } from "@/lib/utils";
+
+/**
+ * HoverReveal — Layer 3 semantic primitive.
+ *
+ * Wrap actions that should appear on hover/focus of an enclosing `ListRow` or `group`.
+ * Encodes the recurring `opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity`
+ * pattern (~14 hits across v2).
+ *
+ * Must live inside a Tailwind `group` parent (ListRow sets it automatically).
+ */
+
+const hoverRevealVariants = cva(
+  "transition-opacity duration-150 motion-reduce:transition-none",
+  {
+    variants: {
+      mode: {
+        // Hidden by default, revealed on hover/focus.
+        "on-hover":
+          "opacity-0 group-hover:opacity-100 focus-within:opacity-100",
+        // Always visible, dim by default, full opacity on hover/focus.
+        "dim-until-hover":
+          "opacity-60 group-hover:opacity-100 focus-within:opacity-100",
+      },
+      shrink: {
+        true: "shrink-0",
+        false: "",
+      },
+    },
+    defaultVariants: {
+      mode: "on-hover",
+      shrink: true,
+    },
+  },
+);
+
+type HoverRevealVariantProps = VariantProps<typeof hoverRevealVariants>;
+
+interface HoverRevealProps extends HoverRevealVariantProps {
+  as?: "div" | "span";
+}
+
+export const HoverReveal = forwardRef<
+  HTMLElement,
+  PropsWithChildren<HoverRevealProps>
+>(function HoverReveal(
+  { children, mode = "on-hover", shrink = true, as: Element = "div" },
+  ref,
+) {
+  return (
+    <Element
+      ref={ref as Ref<any>}
+      className={cn(hoverRevealVariants({ mode, shrink }))}
+    >
+      {children}
+    </Element>
+  );
+});
+
+HoverReveal.displayName = "HoverReveal";

--- a/src/components/ui/patterns/icon-button.tsx
+++ b/src/components/ui/patterns/icon-button.tsx
@@ -1,0 +1,115 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import { forwardRef } from "react";
+
+import { Icon, type IconName } from "@/components/ui/icon";
+import { cn } from "@/lib/utils";
+
+/**
+ * IconButton — Layer 3 semantic primitive.
+ *
+ * Square icon-only button. Replaces the recurring `<Button size="..." className="h-5 w-5 p-0">` +
+ * `<Icon className="text-..." />` combo (~15 hits across v2).
+ */
+
+const iconButtonVariants = cva(
+  "inline-flex items-center justify-center rounded-md transition-colors outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 shrink-0 cursor-pointer",
+  {
+    variants: {
+      size: {
+        xs: "h-5 w-5",
+        sm: "h-6 w-6",
+        md: "h-7 w-7",
+        lg: "h-9 w-9",
+      },
+      variant: {
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        outline: "border border-input bg-background hover:bg-accent",
+        solid: "bg-primary text-primary-foreground hover:bg-primary/90",
+        subtle: "bg-muted hover:bg-muted/70",
+        chrome: "text-stone-400 hover:text-white hover:bg-stone-700",
+      },
+      tone: {
+        default: "",
+        critical: "",
+        warning: "",
+        success: "",
+      },
+    },
+    compoundVariants: [
+      {
+        variant: "ghost",
+        tone: "critical",
+        className:
+          "text-destructive hover:bg-destructive/10 hover:text-destructive",
+      },
+      {
+        variant: "ghost",
+        tone: "warning",
+        className: "text-warning hover:bg-warning/10",
+      },
+      {
+        variant: "ghost",
+        tone: "success",
+        className: "text-success hover:bg-success/10",
+      },
+      {
+        variant: "outline",
+        tone: "critical",
+        className:
+          "border-destructive text-destructive hover:bg-destructive/10",
+      },
+    ],
+    defaultVariants: {
+      size: "sm",
+      variant: "ghost",
+      tone: "default",
+    },
+  },
+);
+
+type IconButtonVariantProps = VariantProps<typeof iconButtonVariants>;
+
+interface IconButtonProps
+  extends
+    Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "children">,
+    IconButtonVariantProps {
+  icon: IconName;
+  /** ARIA label is required because there is no visible text. */
+  "aria-label": string;
+}
+
+const iconSizeForButton = {
+  xs: "xs",
+  sm: "xs",
+  md: "sm",
+  lg: "md",
+} as const;
+
+export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
+  function IconButton(
+    {
+      icon,
+      size = "sm",
+      variant = "ghost",
+      tone = "default",
+      disabled,
+      type = "button",
+      ...rest
+    },
+    ref,
+  ) {
+    return (
+      <button
+        ref={ref}
+        type={type}
+        disabled={disabled}
+        className={cn(iconButtonVariants({ size, variant, tone }))}
+        {...rest}
+      >
+        <Icon name={icon} size={iconSizeForButton[size ?? "sm"]} />
+      </button>
+    );
+  },
+);
+
+IconButton.displayName = "IconButton";

--- a/src/components/ui/patterns/list-row.tsx
+++ b/src/components/ui/patterns/list-row.tsx
@@ -1,0 +1,107 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import {
+  forwardRef,
+  type KeyboardEventHandler,
+  type MouseEventHandler,
+  type PropsWithChildren,
+  type Ref,
+} from "react";
+
+import { InlineStack } from "@/components/ui/layout";
+import { cn } from "@/lib/utils";
+
+/**
+ * ListRow — Layer 3 semantic primitive.
+ *
+ * Horizontal row inside a list. Composes InlineStack + the `group` class so that
+ * children can use `HoverReveal` and group-hover-aware styling.
+ *
+ * Replaces the recurring `<InlineStack className="group hover:bg-* px-* py-*">` pattern
+ * (~18 hits across v2).
+ */
+
+const listRowVariants = cva("group w-full rounded-sm transition-colors", {
+  variants: {
+    density: {
+      compact: "px-1 py-0.5",
+      cozy: "px-2 py-1",
+      comfortable: "px-3 py-2",
+    },
+    hoverable: {
+      true: "hover:bg-muted/60 cursor-pointer",
+      false: "",
+    },
+    selected: {
+      true: "bg-muted",
+      false: "",
+    },
+    zebra: {
+      true: "even:bg-muted/30",
+      false: "",
+    },
+  },
+  defaultVariants: {
+    density: "cozy",
+    hoverable: false,
+    selected: false,
+    zebra: false,
+  },
+});
+
+type ListRowVariantProps = VariantProps<typeof listRowVariants>;
+
+interface ListRowProps extends ListRowVariantProps {
+  as?: "li" | "div";
+  onClick?: MouseEventHandler<HTMLElement>;
+  /** Inter-item gap. @default '2' */
+  gap?: "0" | "0.5" | "1" | "1.5" | "2" | "3" | "4" | "5" | "6" | "8";
+}
+
+export const ListRow = forwardRef<HTMLElement, PropsWithChildren<ListRowProps>>(
+  function ListRow(
+    {
+      children,
+      as: Element = "div",
+      density = "cozy",
+      hoverable = false,
+      selected = false,
+      zebra = false,
+      onClick,
+      gap = "2",
+    },
+    ref,
+  ) {
+    const isInteractive = hoverable || onClick != null;
+    const handleKeyDown: KeyboardEventHandler<HTMLElement> | undefined = onClick
+      ? (event) => {
+          if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            onClick(event as unknown as Parameters<typeof onClick>[0]);
+          }
+        }
+      : undefined;
+    return (
+      <Element
+        ref={ref as Ref<any>}
+        onClick={onClick}
+        onKeyDown={handleKeyDown}
+        role={onClick ? "button" : undefined}
+        tabIndex={onClick ? 0 : undefined}
+        className={cn(
+          listRowVariants({
+            density,
+            hoverable: isInteractive,
+            selected,
+            zebra,
+          }),
+        )}
+      >
+        <InlineStack gap={gap} wrap="nowrap" blockAlign="center">
+          {children}
+        </InlineStack>
+      </Element>
+    );
+  },
+);
+
+ListRow.displayName = "ListRow";

--- a/src/components/ui/patterns/pill.tsx
+++ b/src/components/ui/patterns/pill.tsx
@@ -1,0 +1,88 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import { forwardRef, type PropsWithChildren, type Ref } from "react";
+
+import { cn } from "@/lib/utils";
+
+/**
+ * Pill — Layer 3 semantic primitive.
+ *
+ * Small chip/tag label, optionally interactive. Encodes the recurring
+ * `text-xs rounded-md px-2 py-1 bg-black/5 hover:bg-black/10` pattern
+ * used for TaskNode handle labels (~10 hits).
+ */
+
+const pillVariants = cva(
+  "inline-flex items-center gap-1 truncate font-medium",
+  {
+    variants: {
+      size: {
+        xs: "text-xs px-1.5 py-0.5 rounded-sm",
+        sm: "text-xs px-2 py-1 rounded-md",
+        md: "text-sm px-2.5 py-1 rounded-md",
+      },
+      tone: {
+        default: "bg-black/5 text-foreground",
+        subdued: "bg-muted text-muted-foreground",
+        critical: "bg-destructive/10 text-destructive",
+        warning: "bg-warning/15 text-warning-foreground",
+        info: "bg-info/10 text-info",
+        success: "bg-success/10 text-success",
+        magic: "bg-accent text-accent-foreground",
+      },
+      hoverable: {
+        true: "cursor-pointer hover:opacity-90",
+        false: "",
+      },
+      muted: {
+        true: "opacity-50 italic",
+        false: "",
+      },
+    },
+    defaultVariants: {
+      size: "sm",
+      tone: "default",
+      hoverable: false,
+      muted: false,
+    },
+  },
+);
+
+type PillVariantProps = VariantProps<typeof pillVariants>;
+
+interface PillProps extends PillVariantProps {
+  as?: "span" | "div" | "button";
+  title?: string;
+  onClick?: React.MouseEventHandler<HTMLElement>;
+}
+
+export const Pill = forwardRef<HTMLElement, PropsWithChildren<PillProps>>(
+  function Pill(
+    {
+      children,
+      size = "sm",
+      tone = "default",
+      hoverable = false,
+      muted = false,
+      as: Element = "span",
+      title,
+      onClick,
+    },
+    ref,
+  ) {
+    const isInteractive = hoverable || onClick != null;
+    return (
+      <Element
+        ref={ref as Ref<any>}
+        title={title}
+        onClick={onClick}
+        className={cn(
+          pillVariants({ size, tone, hoverable: isInteractive, muted }),
+        )}
+      >
+        {children}
+      </Element>
+    );
+  },
+);
+
+Pill.displayName = "Pill";

--- a/src/components/ui/patterns/scroll-region.tsx
+++ b/src/components/ui/patterns/scroll-region.tsx
@@ -1,0 +1,78 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import { forwardRef, type PropsWithChildren, type Ref } from "react";
+
+import { cn } from "@/lib/utils";
+
+/**
+ * ScrollRegion — Layer 3 semantic primitive.
+ *
+ * Encapsulates the recurring `flex-1 min-h-0 overflow-y-auto` pattern
+ * (a flex-child that fills available space and scrolls its own content).
+ *
+ * Replaces 22+ raw className uses across v2.
+ */
+
+const scrollRegionVariants = cva("flex-1", {
+  variants: {
+    axis: {
+      y: "min-h-0 overflow-y-auto overflow-x-hidden",
+      x: "min-w-0 overflow-x-auto overflow-y-hidden",
+      both: "min-h-0 min-w-0 overflow-auto",
+    },
+    scrollbar: {
+      default: "",
+      subtle: "subtle-scrollbar",
+      hidden: "hide-scrollbar",
+    },
+    position: {
+      static: "static",
+      relative: "relative",
+    },
+    zIndex: {
+      "0": "z-0",
+      "10": "z-10",
+      "20": "z-20",
+      "30": "z-30",
+    },
+  },
+  defaultVariants: {
+    axis: "y",
+    scrollbar: "default",
+  },
+});
+
+type ScrollRegionVariantProps = VariantProps<typeof scrollRegionVariants>;
+
+interface ScrollRegionProps extends ScrollRegionVariantProps {
+  as?: "div" | "section" | "main" | "article";
+  /** ARIA role override. */
+  role?: string;
+}
+
+export const ScrollRegion = forwardRef<
+  HTMLElement,
+  PropsWithChildren<ScrollRegionProps>
+>(function ScrollRegion(
+  {
+    children,
+    axis = "y",
+    scrollbar = "default",
+    position,
+    zIndex,
+    as: Element = "div",
+    role,
+  },
+  ref,
+) {
+  return (
+    <Element
+      ref={ref as Ref<any>}
+      role={role}
+      className={cn(scrollRegionVariants({ axis, scrollbar, position, zIndex }))}
+    >
+      {children}
+    </Element>
+  );
+});
+
+ScrollRegion.displayName = "ScrollRegion";

--- a/src/components/ui/patterns/section.tsx
+++ b/src/components/ui/patterns/section.tsx
@@ -1,0 +1,72 @@
+import { forwardRef, type PropsWithChildren, type ReactNode } from "react";
+
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Heading } from "@/components/ui/typography";
+
+import { Surface, type SurfaceLevel, type SurfaceTone } from "./surface";
+
+/**
+ * Section — Layer 3 semantic primitive.
+ *
+ * A Surface with a built-in header (title + optional actions + optional divider).
+ * Replaces the recurring `Surface + InlineStack + Heading + actions` template.
+ *
+ * Polaris rule: no horizontal dividers inside a Surface unless it's a data/index table.
+ * `divider` is therefore opt-in.
+ */
+
+interface SectionProps {
+  /** Section title (rendered as a heading). */
+  title?: ReactNode;
+  /** Optional trailing actions in the header (buttons, icon buttons). */
+  actions?: ReactNode;
+  /** Show a divider line between header and body. Use only for data-like content. */
+  divider?: boolean;
+  /** Override the auto-derived surface level. */
+  level?: SurfaceLevel;
+  /** Semantic background tone. */
+  tone?: SurfaceTone;
+  /** Heading level for the title. @default 3 */
+  headingLevel?: 1 | 2 | 3 | 4 | 5 | 6;
+}
+
+export const Section = forwardRef<HTMLElement, PropsWithChildren<SectionProps>>(
+  function Section(
+    {
+      title,
+      actions,
+      divider = false,
+      level,
+      tone = "default",
+      headingLevel = 3,
+      children,
+    },
+    ref,
+  ) {
+    return (
+      <Surface ref={ref} as="section" level={level} tone={tone}>
+        <BlockStack gap="3">
+          {(title || actions) && (
+            <BlockStack gap="2">
+              <InlineStack
+                wrap="nowrap"
+                blockAlign="center"
+                align="space-between"
+                gap="2"
+              >
+                {title && <Heading level={headingLevel}>{title}</Heading>}
+                {actions}
+              </InlineStack>
+              {divider && (
+                <div className="h-px w-full bg-border" aria-hidden="true" />
+              )}
+            </BlockStack>
+          )}
+          {children}
+        </BlockStack>
+      </Surface>
+    );
+  },
+);
+
+Section.displayName = "Section";

--- a/src/components/ui/patterns/sticky-header.tsx
+++ b/src/components/ui/patterns/sticky-header.tsx
@@ -1,0 +1,53 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import { forwardRef, type PropsWithChildren, type Ref } from "react";
+
+import { cn } from "@/lib/utils";
+
+/**
+ * StickyHeader — Layer 3 semantic primitive.
+ *
+ * `sticky top-0 z-* bg-*` header inside a ScrollRegion (~4 hits across v2).
+ */
+
+const stickyHeaderVariants = cva("sticky top-0 z-10", {
+  variants: {
+    background: {
+      base: "bg-background",
+      subdued: "bg-muted/95 backdrop-blur",
+      card: "bg-card",
+    },
+    divider: {
+      true: "border-b border-border",
+      false: "",
+    },
+  },
+  defaultVariants: {
+    background: "base",
+    divider: true,
+  },
+});
+
+type StickyHeaderVariantProps = VariantProps<typeof stickyHeaderVariants>;
+
+interface StickyHeaderProps extends StickyHeaderVariantProps {
+  as?: "div" | "header";
+}
+
+export const StickyHeader = forwardRef<
+  HTMLElement,
+  PropsWithChildren<StickyHeaderProps>
+>(function StickyHeader(
+  { children, background = "base", divider = true, as: Element = "header" },
+  ref,
+) {
+  return (
+    <Element
+      ref={ref as Ref<any>}
+      className={cn(stickyHeaderVariants({ background, divider }))}
+    >
+      {children}
+    </Element>
+  );
+});
+
+StickyHeader.displayName = "StickyHeader";

--- a/src/components/ui/patterns/surface.tsx
+++ b/src/components/ui/patterns/surface.tsx
@@ -1,0 +1,203 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import {
+  type AriaAttributes,
+  createContext,
+  type CSSProperties,
+  forwardRef,
+  type MouseEventHandler,
+  type PropsWithChildren,
+  type Ref,
+  useContext,
+} from "react";
+
+import { cn } from "@/lib/utils";
+
+/**
+ * Surface — Layer 3 semantic primitive.
+ *
+ * Finite, nesting-aware container with predefined visual treatment.
+ * Inspired by Shopify Polaris (spatial organization) and Material Design (surfaces).
+ *
+ * - `level` is auto-detected from `SurfaceLevelContext`. Explicit override allowed for portal'd content.
+ * - Padding, radius, background are derived from `level` and `tone` — never user-set.
+ * - Hard cap at level 3. Attempting to nest deeper throws a dev-mode error.
+ */
+
+export type SurfaceLevel = 1 | 2 | 3;
+
+const SurfaceLevelContext = createContext<0 | SurfaceLevel>(0);
+
+/**
+ * Provider that explicitly sets the next surface depth for portal'd content
+ * (popovers, dialogs, dropdowns) whose React tree disagrees with their visual nesting.
+ */
+export function SurfaceLevelProvider({
+  level,
+  children,
+}: PropsWithChildren<{ level: 0 | SurfaceLevel }>) {
+  return (
+    <SurfaceLevelContext.Provider value={level}>
+      {children}
+    </SurfaceLevelContext.Provider>
+  );
+}
+
+/**
+ * Read the current surface depth (0 if no enclosing Surface).
+ * Useful when deciding header/divider treatment inside a layer-4 composition.
+ */
+export function useSurfaceLevel(): 0 | SurfaceLevel {
+  return useContext(SurfaceLevelContext);
+}
+
+const surfaceVariants = cva("transition-colors", {
+  variants: {
+    level: {
+      1: "bg-card text-card-foreground border border-border rounded-lg shadow-sm p-4",
+      2: "bg-muted/40 rounded-md p-3",
+      3: "bg-muted/60 rounded-sm p-2",
+    },
+    tone: {
+      default: "",
+      critical: "",
+      warning: "",
+      info: "",
+      success: "",
+      magic: "",
+    },
+    hoverable: {
+      true: "cursor-pointer",
+      false: "",
+    },
+  },
+  compoundVariants: [
+    // Level 1 tones — saturated subtle background + tinted border
+    {
+      level: 1,
+      tone: "critical",
+      className: "bg-destructive/5 border-destructive/40",
+    },
+    { level: 1, tone: "warning", className: "bg-warning/10 border-warning/40" },
+    { level: 1, tone: "info", className: "bg-info/5 border-info/40" },
+    { level: 1, tone: "success", className: "bg-success/5 border-success/40" },
+    {
+      level: 1,
+      tone: "magic",
+      className: "bg-accent border-accent-foreground/20",
+    },
+    // Level 2 tones
+    { level: 2, tone: "critical", className: "bg-destructive/10" },
+    { level: 2, tone: "warning", className: "bg-warning/15" },
+    { level: 2, tone: "info", className: "bg-info/10" },
+    { level: 2, tone: "success", className: "bg-success/10" },
+    { level: 2, tone: "magic", className: "bg-accent/70" },
+    // Level 3 tones
+    { level: 3, tone: "critical", className: "bg-destructive/15" },
+    { level: 3, tone: "warning", className: "bg-warning/20" },
+    { level: 3, tone: "info", className: "bg-info/15" },
+    { level: 3, tone: "success", className: "bg-success/15" },
+    { level: 3, tone: "magic", className: "bg-accent" },
+    // Hover treatment per level
+    { level: 1, hoverable: true, className: "hover:bg-muted/30" },
+    { level: 2, hoverable: true, className: "hover:bg-muted/60" },
+    { level: 3, hoverable: true, className: "hover:bg-muted/80" },
+  ],
+  defaultVariants: {
+    tone: "default",
+    hoverable: false,
+  },
+});
+
+type SurfaceVariantProps = VariantProps<typeof surfaceVariants>;
+
+export type SurfaceTone = NonNullable<SurfaceVariantProps["tone"]>;
+
+interface SurfaceProps extends AriaAttributes {
+  /**
+   * Explicit nesting level override. Use only for portal'd content (popovers, dialogs).
+   * Otherwise the level is auto-derived from SurfaceLevelContext.
+   */
+  level?: SurfaceLevel;
+  /** Semantic background tone. @default 'default' */
+  tone?: SurfaceTone;
+  /** Render as a clickable surface (hover bg, cursor). */
+  hoverable?: boolean;
+  /** Click handler — sets role="button" + tabIndex when present. */
+  onClick?: MouseEventHandler<HTMLElement>;
+  /** HTML element to render as. @default 'div' */
+  as?: "div" | "section" | "article" | "aside";
+  /** ARIA role override. */
+  role?: string;
+  /**
+   * Inline style — reserved for *dynamic* CSS values that can't be expressed via
+   * tokens (e.g. layer-4 cards that compute palette colours at runtime).
+   * Static styling is forbidden here; use tone/level instead.
+   */
+  style?: CSSProperties;
+}
+
+function resolveLevel(
+  explicit: SurfaceLevel | undefined,
+  contextLevel: 0 | SurfaceLevel,
+): SurfaceLevel {
+  if (explicit != null) return explicit;
+  const next = (contextLevel + 1) as SurfaceLevel | 4;
+  if (next > 3) {
+    if (process.env.NODE_ENV !== "production") {
+      throw new Error(
+        "[Surface] Maximum nesting depth (3) exceeded. " +
+          "See https://polaris-react.shopify.com/design/layout/spacial-organization. " +
+          "Either flatten the structure or use a layer-4 domain component.",
+      );
+    }
+    return 3;
+  }
+  return next as SurfaceLevel;
+}
+
+export const Surface = forwardRef<HTMLElement, PropsWithChildren<SurfaceProps>>(
+  function Surface(
+    {
+      children,
+      level: levelProp,
+      tone = "default",
+      hoverable = false,
+      onClick,
+      as: Element = "div",
+      role,
+      style,
+      ...rest
+    },
+    ref,
+  ) {
+    const contextLevel = useContext(SurfaceLevelContext);
+    const level = resolveLevel(levelProp, contextLevel);
+    const isInteractive = hoverable || onClick != null;
+    return (
+      <SurfaceLevelContext.Provider value={level}>
+        <Element
+          ref={ref as Ref<any>}
+          role={role ?? (onClick ? "button" : undefined)}
+          tabIndex={onClick ? 0 : undefined}
+          onClick={onClick}
+          style={style}
+          className={cn(
+            surfaceVariants({ level, tone, hoverable: isInteractive }),
+          )}
+          {...rest}
+        >
+          {children}
+        </Element>
+      </SurfaceLevelContext.Provider>
+    );
+  },
+);
+
+Surface.displayName = "Surface";
+
+/**
+ * Internal helper used by Layer-3 wrapper primitives (Card, Section, ListRow, etc.)
+ * to manually set the SurfaceLevelContext when a primitive *acts* as a surface
+ * but doesn't render `<Surface>` directly.
+ */
+export { SurfaceLevelContext as _SurfaceLevelContext };

--- a/src/components/ui/patterns/toolbar.tsx
+++ b/src/components/ui/patterns/toolbar.tsx
@@ -1,0 +1,83 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import { forwardRef, type PropsWithChildren, type Ref } from "react";
+
+import { InlineStack } from "@/components/ui/layout";
+import { cn } from "@/lib/utils";
+
+/**
+ * Toolbar — Layer 3 semantic primitive.
+ *
+ * Horizontal bar of action controls. Encodes the recurring
+ * `InlineStack gap-1 shrink-0 px-* py-*` chrome (~14 hits across v2).
+ */
+
+const toolbarVariants = cva("shrink-0 w-full", {
+  variants: {
+    density: {
+      compact: "px-1 py-0.5",
+      cozy: "px-2 py-1",
+      comfortable: "px-3 py-2",
+    },
+    chrome: {
+      none: "",
+      light: "bg-background border-b border-border",
+      dark: "bg-stone-800 text-white",
+      muted: "bg-muted/40",
+    },
+    sticky: {
+      true: "sticky top-0 z-10",
+      false: "",
+    },
+  },
+  defaultVariants: {
+    density: "cozy",
+    chrome: "none",
+    sticky: false,
+  },
+});
+
+type ToolbarVariantProps = VariantProps<typeof toolbarVariants>;
+
+interface ToolbarProps extends ToolbarVariantProps {
+  as?: "div" | "header" | "footer" | "nav";
+  /** Inter-action gap. @default '1' */
+  gap?: "0" | "0.5" | "1" | "1.5" | "2" | "3" | "4" | "5" | "6" | "8";
+  /** Distribution of toolbar items. @default 'start' */
+  align?: "start" | "center" | "end" | "space-between";
+  /** ARIA role override; defaults to 'toolbar'. */
+  role?: string;
+  /** ARIA label for the toolbar (recommended). */
+  "aria-label"?: string;
+}
+
+export const Toolbar = forwardRef<HTMLElement, PropsWithChildren<ToolbarProps>>(
+  function Toolbar(
+    {
+      children,
+      as: Element = "div",
+      density = "cozy",
+      chrome = "none",
+      sticky = false,
+      gap = "1",
+      align = "start",
+      role = "toolbar",
+      "aria-label": ariaLabel,
+    },
+    ref,
+  ) {
+    return (
+      <Element
+        ref={ref as Ref<any>}
+        role={role}
+        aria-label={ariaLabel}
+        className={cn(toolbarVariants({ density, chrome, sticky }))}
+      >
+        <InlineStack gap={gap} wrap="nowrap" blockAlign="center" align={align}>
+          {children}
+        </InlineStack>
+      </Element>
+    );
+  },
+);
+
+Toolbar.displayName = "Toolbar";

--- a/src/components/ui/patterns/truncating.tsx
+++ b/src/components/ui/patterns/truncating.tsx
@@ -1,0 +1,45 @@
+import { forwardRef, type PropsWithChildren, type Ref } from "react";
+
+import { cn } from "@/lib/utils";
+
+/**
+ * Truncating — Layer 3 semantic primitive.
+ *
+ * Wraps a flex child that should shrink. Encodes the recurring `min-w-0 flex-1`
+ * boilerplate (~28+20 hits across v2). Apply `truncate` on the inner `<Text>`
+ * for the actual ellipsis behavior:
+ *
+ *   <InlineStack gap="2" wrap="nowrap" blockAlign="center">
+ *     <Icon name="..." />
+ *     <Truncating>
+ *       <Text truncate>Long label that should truncate</Text>
+ *     </Truncating>
+ *     <Button>Action</Button>
+ *   </InlineStack>
+ */
+
+interface TruncatingProps {
+  /** How wide the truncating cell may grow. Default: fill remaining space. */
+  grow?: "fill" | "fit";
+  as?: "div" | "span";
+}
+
+export const Truncating = forwardRef<
+  HTMLElement,
+  PropsWithChildren<TruncatingProps>
+>(function Truncating({ children, grow = "fill", as: Element = "div" }, ref) {
+  return (
+    <Element
+      ref={ref as Ref<any>}
+      className={cn(
+        "min-w-0",
+        grow === "fill" && "flex-1",
+        grow === "fit" && "w-fit",
+      )}
+    >
+      {children}
+    </Element>
+  );
+});
+
+Truncating.displayName = "Truncating";

--- a/src/components/ui/patterns/zebra-list.tsx
+++ b/src/components/ui/patterns/zebra-list.tsx
@@ -1,0 +1,48 @@
+import {
+  Children,
+  cloneElement,
+  type ReactElement,
+  type ReactNode,
+} from "react";
+
+import { BlockStack } from "@/components/ui/layout";
+
+/**
+ * ZebraList — Layer 3 semantic primitive.
+ *
+ * Vertical stack of children with alternating row tinting.
+ * Replaces the recurring `odd:bg-secondary even:bg-white` pattern (~6 hits).
+ *
+ * Children should be `ListRow` (or anything that accepts `zebra={true}`).
+ * For arbitrary children, the zebra effect is applied via a wrapper data-attribute
+ * so the row component can opt in to styling.
+ */
+
+interface ZebraListProps {
+  children: ReactNode;
+  /** Stack gap between rows. @default '0' (tight zebra list) */
+  gap?: "0" | "0.5" | "1" | "1.5" | "2" | "3" | "4" | "5" | "6" | "8";
+  as?: "div" | "ul" | "ol";
+}
+
+export function ZebraList({ children, gap = "0", as = "div" }: ZebraListProps) {
+  const decorated = Children.toArray(children).map((child, index) => {
+    if (typeof child !== "object" || child == null) return child;
+    const element = child as ReactElement<{
+      zebra?: boolean;
+      "data-zebra"?: string;
+    }>;
+    return cloneElement(element, {
+      key: element.key ?? index,
+      zebra: true,
+      "data-zebra": index % 2 === 0 ? "odd" : "even",
+    });
+  });
+  return (
+    <BlockStack as={as} gap={gap}>
+      {decorated}
+    </BlockStack>
+  );
+}
+
+ZebraList.displayName = "ZebraList";

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,4 +1,4 @@
-import { cva } from "class-variance-authority";
+import { cva, type VariantProps } from "class-variance-authority";
 
 import { cn } from "@/lib/utils";
 
@@ -8,6 +8,10 @@ const skeletonVariants = cva("bg-accent animate-pulse rounded-md", {
       default: "bg-accent",
       dark: "bg-gray-200",
     },
+    /**
+     * Legacy size (preserved for backward compat during migration).
+     * Prefer `shape` + `width`.
+     */
     size: {
       sm: "h-4 w-24",
       lg: "h-4 w-32",
@@ -15,28 +19,47 @@ const skeletonVariants = cva("bg-accent animate-pulse rounded-md", {
       half: "h-4 w-1/2",
     },
     shape: {
+      // Legacy shapes (kept for compat)
       square: "rounded-md",
       circle: "rounded-full",
       button: "rounded-md h-8",
+      // New semantic shapes
+      line: "h-4 rounded-sm",
+      block: "h-8 rounded-md",
+      panel: "min-h-32 flex-1 rounded-md",
+      avatar: "h-10 w-10 rounded-full",
+    },
+    width: {
+      none: "",
+      xs: "w-12",
+      sm: "w-24",
+      md: "w-32",
+      lg: "w-48",
+      xl: "w-64",
+      "2xl": "w-96",
+      half: "w-1/2",
+      full: "w-full",
     },
   },
 });
 
+interface SkeletonProps
+  extends
+    Omit<React.ComponentProps<"div">, "color">,
+    VariantProps<typeof skeletonVariants> {}
+
 function Skeleton({
   className,
-  size = "sm",
+  size,
   shape = "square",
   color = "default",
+  width,
   ...props
-}: React.ComponentProps<"div"> & {
-  size?: "sm" | "lg" | "full" | "half";
-  shape?: "square" | "circle" | "button";
-  color?: "default" | "dark";
-}) {
+}: SkeletonProps) {
   return (
     <div
       data-slot="skeleton"
-      className={cn(skeletonVariants({ size, shape, color }), className)}
+      className={cn(skeletonVariants({ size, shape, color, width }), className)}
       {...props}
     />
   );

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,3 +1,4 @@
+import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
 
 import { cn } from "@/lib/utils";
@@ -67,12 +68,33 @@ function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
   );
 }
 
-function TableHead({ className, ...props }: React.ComponentProps<"th">) {
+const cellWidthVariants = cva("", {
+  variants: {
+    width: {
+      auto: "",
+      xs: "w-10",
+      sm: "w-16",
+      md: "w-20",
+      lg: "w-28",
+      xl: "w-36",
+      "2xl": "w-48",
+    },
+  },
+});
+
+type CellWidth = NonNullable<VariantProps<typeof cellWidthVariants>["width"]>;
+
+interface TableHeadProps extends React.ComponentProps<"th"> {
+  width?: CellWidth;
+}
+
+function TableHead({ className, width, ...props }: TableHeadProps) {
   return (
     <th
       data-slot="table-head"
       className={cn(
         "text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 *:[[role=checkbox]]:translate-y-0.5",
+        cellWidthVariants({ width }),
         className,
       )}
       {...props}
@@ -80,12 +102,17 @@ function TableHead({ className, ...props }: React.ComponentProps<"th">) {
   );
 }
 
-function TableCell({ className, ...props }: React.ComponentProps<"td">) {
+interface TableCellProps extends React.ComponentProps<"td"> {
+  width?: CellWidth;
+}
+
+function TableCell({ className, width, ...props }: TableCellProps) {
   return (
     <td
       data-slot="table-cell"
       className={cn(
         "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 *:[[role=checkbox]]:translate-y-0.5",
+        cellWidthVariants({ width }),
         className,
       )}
       {...props}

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,4 +1,5 @@
 import * as TabsPrimitive from "@radix-ui/react-tabs";
+import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
 
 import { cn } from "@/lib/utils";
@@ -16,17 +17,39 @@ function Tabs({
   );
 }
 
-function TabsList({
-  className,
-  ...props
-}: React.ComponentProps<typeof TabsPrimitive.List>) {
+const tabsListVariants = cva(
+  "bg-muted text-muted-foreground inline-flex h-9 items-center justify-center rounded-lg p-0.75 shrink-0",
+  {
+    variants: {
+      fullWidth: {
+        true: "w-full",
+        false: "w-fit",
+      },
+      gutter: {
+        none: "",
+        compact: "mx-2 mt-1",
+        cozy: "mx-3 mt-2",
+        comfortable: "mx-4 mt-3",
+      },
+    },
+    defaultVariants: {
+      fullWidth: false,
+      gutter: "none",
+    },
+  },
+);
+
+interface TabsListProps
+  extends
+    React.ComponentProps<typeof TabsPrimitive.List>,
+    VariantProps<typeof tabsListVariants> {}
+
+function TabsList({ className, fullWidth, gutter, ...props }: TabsListProps) {
   return (
     <TabsPrimitive.List
       data-slot="tabs-list"
-      className={cn(
-        "bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-0.75",
-        className,
-      )}
+      data-fullwidth={fullWidth ? "true" : undefined}
+      className={cn(tabsListVariants({ fullWidth, gutter }), className)}
       {...props}
     />
   );
@@ -48,14 +71,38 @@ function TabsTrigger({
   );
 }
 
-function TabsContent({
-  className,
-  ...props
-}: React.ComponentProps<typeof TabsPrimitive.Content>) {
+const tabsContentVariants = cva("outline-none", {
+  variants: {
+    layout: {
+      // Default: only grow within the tabs flex column.
+      flow: "flex-1",
+      // Fills available height; common for tabs that own a vertical layout below.
+      fill: "flex-1 min-h-0 flex flex-col",
+      // Fills + adds y-scroll; common for content panes that scroll independently.
+      scroll: "flex-1 min-h-0 overflow-y-auto",
+    },
+    flush: {
+      // Remove the default top spacing emitted by Tabs root (`gap-2`).
+      true: "mt-0",
+      false: "",
+    },
+  },
+  defaultVariants: {
+    layout: "flow",
+    flush: false,
+  },
+});
+
+interface TabsContentProps
+  extends
+    React.ComponentProps<typeof TabsPrimitive.Content>,
+    VariantProps<typeof tabsContentVariants> {}
+
+function TabsContent({ className, layout, flush, ...props }: TabsContentProps) {
   return (
     <TabsPrimitive.Content
       data-slot="tabs-content"
-      className={cn("flex-1 outline-none", className)}
+      className={cn(tabsContentVariants({ layout, flush }), className)}
       {...props}
     />
   );

--- a/src/components/ui/typography.tsx
+++ b/src/components/ui/typography.tsx
@@ -1,5 +1,10 @@
 import { cva, type VariantProps } from "class-variance-authority";
-import type { AriaAttributes, AriaRole, PropsWithChildren } from "react";
+import type {
+  AriaAttributes,
+  AriaRole,
+  HTMLAttributes,
+  PropsWithChildren,
+} from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -27,10 +32,16 @@ const textVariants = cva("", {
     tone: {
       inherit: "text-foreground",
       subdued: "text-muted-foreground",
+      strong: "text-foreground",
+      weak: "text-muted-foreground/70",
       critical: "text-destructive",
-      inverted: "text-inverted",
+      inverted: "text-background",
+      // 'info' preserves the existing dotted-underline behavior used as inline help.
       info: "text-foreground underline decoration-dotted",
       warning: "text-warning",
+      success: "text-success",
+      accent: "text-accent-foreground",
+      magic: "text-accent-foreground",
     },
     size: {
       xs: "text-xs",
@@ -45,12 +56,48 @@ const textVariants = cva("", {
       semibold: "font-semibold",
       bold: "font-bold",
       light: "font-light",
+      medium: "font-medium",
+    },
+    align: {
+      start: "text-start",
+      center: "text-center",
+      end: "text-end",
+      justify: "text-justify",
+    },
+    wrap: {
+      normal: "whitespace-normal",
+      "break-anywhere": "wrap-anywhere",
+      "break-word": "wrap-break-word",
+      pre: "whitespace-pre",
+      "pre-wrap": "whitespace-pre-wrap",
+      nowrap: "whitespace-nowrap",
+    },
+    italic: {
+      true: "italic",
+      false: "",
+    },
+    leading: {
+      tight: "leading-tight",
+      normal: "leading-normal",
+      relaxed: "leading-relaxed",
+    },
+    transform: {
+      none: "",
+      uppercase: "uppercase",
+      lowercase: "lowercase",
+      capitalize: "capitalize",
+    },
+    decoration: {
+      none: "no-underline",
+      underline: "underline",
     },
   },
 });
 
+type TextVariantProps = VariantProps<typeof textVariants>;
+
 interface TextProps
-  extends PropsWithChildren<AriaAttributes>, VariantProps<typeof textVariants> {
+  extends PropsWithChildren<AriaAttributes>, TextVariantProps {
   /**
    * The role of the text element.
    * @default 'text'
@@ -62,19 +109,39 @@ interface TextProps
    */
   as?: TextElement;
 
-  /** Custom class name
-   * @default ''
+  /**
+   * Truncate to one line (true) or N lines (number).
+   * Use inside `<Truncating>` for proper flex behavior, or on a width-constrained parent.
    */
-  className?: string;
+  truncate?: boolean | number;
 
   /** Native browser tooltip text */
   title?: string;
+
+  /** Optional id for a11y / label-for wiring. */
+  id?: string;
+
+  /**
+   * Escape-hatch className. Kept for backward compatibility during migration.
+   * Will be removed once the codemod has run and the no-classname-on-primitives
+   * ESLint rule is promoted to error.
+   * @deprecated Use semantic props (`tone`, `truncate`, `wrap`, `align`, `italic`, `leading`) instead.
+   */
+  className?: string;
+}
+
+function truncateClass(truncate: boolean | number | undefined): string {
+  if (truncate === true) return "truncate";
+  if (typeof truncate === "number" && truncate > 0) {
+    if (truncate === 1) return "truncate";
+    // line-clamp-N for finite values; tailwind ships 1..6 by default.
+    return `line-clamp-${truncate} break-words`;
+  }
+  return "";
 }
 
 /**
  * Text component. Wraps any text element and provides a set of default styles.
- * @param param0
- * @returns
  */
 export function Text({
   as: Element = "span",
@@ -82,14 +149,36 @@ export function Text({
   size = "md",
   weight = "regular",
   font = "default",
-  children,
+  align,
+  wrap,
+  italic,
+  leading,
+  transform,
+  decoration,
+  truncate,
   className,
+  children,
   ...rest
 }: TextProps) {
   return (
     <Element
-      className={cn(textVariants({ tone, size, weight, font }), className)}
-      {...rest}
+      className={cn(
+        textVariants({
+          tone,
+          size,
+          weight,
+          font,
+          align,
+          wrap,
+          italic,
+          leading,
+          transform,
+          decoration,
+        }),
+        truncateClass(truncate),
+        className,
+      )}
+      {...(rest as HTMLAttributes<HTMLElement>)}
     >
       {children}
     </Element>
@@ -100,10 +189,8 @@ Text.displayName = "Text";
 
 /**
  * Paragraph component. Wraps the Text component and sets the element to 'p'.
- * @param param0
- * @returns
  */
-export function Paragraph({ children, ...rest }: TextProps) {
+export function Paragraph({ children, ...rest }: Omit<TextProps, "as">) {
   return (
     <Text as="p" {...rest}>
       {children}
@@ -113,20 +200,82 @@ export function Paragraph({ children, ...rest }: TextProps) {
 
 Paragraph.displayName = "Paragraph";
 
+type HeadingLevel = 1 | 2 | 3 | 4 | 5 | 6;
+
+interface HeadingProps extends PropsWithChildren {
+  level: HeadingLevel;
+  /** Override default size for the level. */
+  size?: TextVariantProps["size"];
+  /** Override default weight for the level. */
+  weight?: TextVariantProps["weight"];
+  /** Semantic tone (e.g. 'critical' for error titles). */
+  tone?: TextVariantProps["tone"];
+  /** Mono font. */
+  font?: TextVariantProps["font"];
+  /** Truncate (single line) or line-clamp (N lines). */
+  truncate?: boolean | number;
+  /** Text alignment. */
+  align?: TextVariantProps["align"];
+  /** Wrap behavior. */
+  wrap?: TextVariantProps["wrap"];
+  /**
+   * Escape-hatch className. Kept for backward compatibility during migration.
+   * @deprecated Use semantic props instead.
+   */
+  className?: string;
+}
+
+const HEADING_SIZE: Record<
+  HeadingLevel,
+  NonNullable<TextVariantProps["size"]>
+> = {
+  1: "md",
+  2: "sm",
+  3: "sm",
+  4: "sm",
+  5: "sm",
+  6: "sm",
+};
+
+const HEADING_WEIGHT: Record<
+  HeadingLevel,
+  NonNullable<TextVariantProps["weight"]>
+> = {
+  1: "semibold",
+  2: "semibold",
+  3: "regular",
+  4: "regular",
+  5: "regular",
+  6: "regular",
+};
+
 /**
- * Heading component. Wraps the Text component and sets the element to 'h1', 'h2', 'h3', 'h4', 'h5', or 'h6'.
- * @param param0
- * @returns
+ * Heading component. Renders h1-h6 with role and aria-level set.
+ * Accepts the same semantic overrides as Text.
  */
 export const Heading = ({
   children,
   level = 1,
-}: PropsWithChildren<{ level: 1 | 2 | 3 | 4 | 5 | 6 }>) => {
+  size,
+  weight,
+  tone,
+  font,
+  truncate,
+  align,
+  wrap,
+  className,
+}: HeadingProps) => {
   return (
     <Text
       as={`h${level}`}
-      size={level === 1 ? "md" : "sm"}
-      weight={level < 3 ? "semibold" : "regular"}
+      size={size ?? HEADING_SIZE[level]}
+      weight={weight ?? HEADING_WEIGHT[level]}
+      tone={tone}
+      font={font}
+      truncate={truncate}
+      align={align}
+      wrap={wrap}
+      className={className}
       role="heading"
       aria-level={level}
     >

--- a/src/routes/v2/DESIGN_SYSTEM.md
+++ b/src/routes/v2/DESIGN_SYSTEM.md
@@ -1,0 +1,225 @@
+# v2 Design System
+
+The single rule for v2 feature code:
+
+> **Do not pass `className` to a Tangle UI primitive.** Use a semantic prop or a layer-3 pattern.
+
+`tangle-ui/no-classname-on-primitives` warns today (340 legacy sites). It is promoted to `error` once the warnings reach zero. Every primitive's `className?: string` is `@deprecated`.
+
+## The four layers
+
+```mermaid
+flowchart TB
+    subgraph L4 [Layer 4: domain compositions]
+        TaskNodeCard
+        IONodeCard
+        PipelineDigestBar
+    end
+    subgraph L3 [Layer 3: semantic primitives]
+        Surface
+        Section
+        Card
+        ScrollRegion
+        Truncating
+        ListRow
+        ZebraList
+        Toolbar
+        HoverReveal
+        EmptyState
+        StickyHeader
+        IconButton
+        Pill
+        FieldRow
+        Divider
+    end
+    subgraph L2 [Layer 2: base primitives]
+        BlockStack
+        InlineStack
+        Text
+        Heading
+        Paragraph
+        Button
+        Icon
+        Input
+        Label
+    end
+    subgraph L1 [Layer 1: escape hatch]
+        Box
+    end
+    L4 --> L3 --> L2 --> L1
+```
+
+| Layer                   | Where                                                         | Use it when                                                                               |
+| ----------------------- | ------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| 4 — domain compositions | `pages/*/components/`, `pages/*/nodes/`                       | The component encodes business behavior specific to a page.                               |
+| 3 — semantic primitives | `@/components/ui/patterns/*`                                  | An intent is named (a panel, a scroll region, a clickable row, an icon-only button, ...). |
+| 2 — base primitives     | `@/components/ui/{layout,typography,button,icon,input,label}` | You need raw layout, text, or interactive controls.                                       |
+| 1 — `Box`               | `@/components/ui/box`                                         | Nothing higher fits and you need a styled container. Soft-warned in `src/routes/v2/**`.   |
+
+Code is expected to live in the upper layers. Reaching for a lower one is a smell.
+
+## Surface — finite, nesting-aware
+
+`Surface` is **not** a configurable container. It is a 3-level enumeration with predefined visual treatment, inspired by Polaris spatial organization and Material Design surfaces.
+
+```tsx
+<Surface>
+  {" "}
+  {/* level 1: card on app background */}
+  <BlockStack gap="3">
+    <Heading level={3}>Inputs</Heading>
+    <Surface>
+      {" "}
+      {/* level 2: inset section */}
+      <Surface>
+        {" "}
+        {/* level 3: nested-inset strip */}
+        ...key/value...
+      </Surface>
+    </Surface>
+  </BlockStack>
+</Surface>
+```
+
+Rules (all encoded in code, not docs):
+
+- `level` is auto-derived from `SurfaceLevelContext`.
+- `padding`, `borderRadius`, `background` are derived from `level` — never user-set.
+- Nesting depth > 3 throws in dev mode (Polaris rule: stop nesting).
+- `tone` (`default | critical | warning | info | success | magic`) tints the background per level.
+- `hoverable` + `onClick` make the surface clickable.
+- `level={1|2|3}` is allowed only as an explicit override for portal'd content (popovers, dialogs, dropdowns).
+- `Card` is an alias for `<Surface level={1}>` with header/content/footer slots and a `density` prop.
+- `Section` is `<Surface>` with a built-in title + actions + optional `divider` (dividers are for data-like content only).
+
+See [src/components/ui/patterns/surface.tsx](../../components/ui/patterns/surface.tsx) for the implementation and [.claude/skills/ui-primitives/SKILL.md](../../../.claude/skills/ui-primitives/SKILL.md) for the full prop tables.
+
+## Intent catalog
+
+Use these when you find yourself reaching for the listed className signature.
+
+| Layer-3 primitive                            | Replaces className signature                                                       |
+| -------------------------------------------- | ---------------------------------------------------------------------------------- |
+| `<Surface>` / `<Section>` / `<Card>`         | `bg-* rounded-* border-* p-*` panels                                               |
+| `<ScrollRegion axis="y">`                    | `flex-1 min-h-0 overflow-y-auto`                                                   |
+| `<Truncating>`                               | `min-w-0 flex-1` around a shrinkable cell (apply `truncate` on the inner `<Text>`) |
+| `<ListRow hoverable onClick>`                | `<InlineStack className="group hover:bg-* px-* py-*">` rows                        |
+| `<ZebraList>`                                | `even:bg-* odd:bg-*` lists                                                         |
+| `<HoverReveal>`                              | `opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity`    |
+| `<Toolbar density chrome sticky>`            | `InlineStack gap-1 shrink-0 px-* py-*` action bars                                 |
+| `<EmptyState icon title description action>` | centered `flex items-center justify-center text-center p-*` placeholders           |
+| `<StickyHeader>`                             | `sticky top-0 z-* bg-*` inside a `ScrollRegion`                                    |
+| `<IconButton icon size variant tone>`        | `<Button h-5 w-5 p-0><Icon /></Button>`                                            |
+| `<Pill tone size>`                           | `text-xs rounded-md px-2 py-1 bg-black/5` chips                                    |
+| `<FieldRow label help error required>`       | `<Label> + control + help/error` form rows                                         |
+| `<Divider inset orientation>`                | `<Separator className="mx-0.5 self-stretch">`                                      |
+
+For text-only patterns the equivalent is a `Text` / `Paragraph` / `Heading` prop:
+
+| Prop on `Text` / `Paragraph` / `Heading`                                  | Replaces                                                                                                                                |
+| ------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `truncate={true \| N}`                                                    | `truncate`, `line-clamp-N`                                                                                                              |
+| `align="center"`                                                          | `text-center`                                                                                                                           |
+| `italic`                                                                  | `italic`                                                                                                                                |
+| `wrap="break-anywhere"` / `"nowrap"` / `"pre-wrap"`                       | `wrap-anywhere`, `whitespace-nowrap`, `whitespace-pre-wrap`                                                                             |
+| `tone="subdued" \| "critical" \| "warning" \| "success" \| "info" \| ...` | `text-muted-foreground`, `text-destructive`, `text-amber-*`, `text-green-*`, `text-blue-*`, `text-red-*`, `text-gray-*`, `text-slate-*` |
+| `font="mono"`                                                             | `font-mono`                                                                                                                             |
+
+Same idea for `Icon`: `tone`, `rotate`, `spin`, `pulse`, default `shrink-0`.
+
+For `Button`: `tone`, `fullWidth`, `align`, `truncate`, plus `variant="menubar" | "menubar-light" | "toolbar"`.
+
+## Escalation ladder
+
+When writing new code, work top-down:
+
+1. **Is the visual intent named by a base primitive?** Use it. `<Text tone="subdued">`, `<BlockStack gap="2">`, `<Button variant="ghost">`.
+2. **Does a layer-3 primitive name the _combination_ you need?** Use it. A clickable row → `<ListRow hoverable>`. A scrollable pane → `<ScrollRegion>`. A nested panel → `<Surface>`.
+3. **Is this domain-specific (a TaskNode header, a pipeline digest bar)?** Add a layer-4 component under `pages/<page>/components/` or `pages/<page>/nodes/`. It is allowed to use any layer below.
+4. **Still no fit?** Use `<Box>` (soft-warned in v2). `Box` takes only token-bound props — never `className`.
+5. **Reaching for `Box` repeatedly with the same shape?** That is a missing layer-3 primitive. File an issue or open a PR adding it to `@/components/ui/patterns/`.
+
+## Migration workflow for existing code
+
+```bash
+# Preview the mechanical conversions
+node scripts/codemods/ban-classname-on-primitives.mjs --dry
+
+# Apply them
+node scripts/codemods/ban-classname-on-primitives.mjs
+
+# See what is left
+pnpm lint
+```
+
+The codemod handles the high-volume mechanical cases (Icon `text-*` → `tone`, Icon `shrink-0` → drop, Text `truncate`/`italic`/`text-center`/`font-mono`/`text-*` → corresponding props). Anything more structural is hand-fixed using the intent catalog above.
+
+Before/after example, taken from the real migration of [pages/Editor/components/AnnotationsBlock/AnnotationsBlock.tsx](pages/Editor/components/AnnotationsBlock/AnnotationsBlock.tsx):
+
+Before:
+
+```tsx
+<InlineStack
+  gap="2"
+  wrap="nowrap"
+  blockAlign="center"
+  className="group w-full rounded-xs px-1 py-0.5 hover:bg-gray-50"
+>
+  <BlockStack className="flex-1 min-w-0">…</BlockStack>
+  <InlineStack className="shrink-0 opacity-0 group-hover:opacity-100 focus-within:opacity-100">
+    <Button variant="ghost" size="xs" onClick={onStartEdit}>
+      <Icon name="Pencil" size="xs" />
+    </Button>
+    <Button variant="ghost" size="xs" onClick={handleRemove}>
+      <Icon name="Trash" className="text-destructive" />
+    </Button>
+  </InlineStack>
+</InlineStack>
+```
+
+After:
+
+```tsx
+<ListRow density="compact" gap="2">
+  <Truncating>
+    <BlockStack>…</BlockStack>
+  </Truncating>
+  <HoverReveal>
+    <IconButton
+      icon="Pencil"
+      size="xs"
+      onClick={onStartEdit}
+      aria-label="Edit annotation"
+    />
+    <IconButton
+      icon="Trash"
+      size="xs"
+      tone="critical"
+      onClick={handleRemove}
+      aria-label="Remove annotation"
+    />
+  </HoverReveal>
+</ListRow>
+```
+
+No `className`. No `flex-1 min-w-0`. No `opacity-0 group-hover:opacity-100`. Every intent is named.
+
+## Acceptable escape hatches
+
+`className` (or `style={{...}}`) is still acceptable in a narrow set of cases — the ESLint rule does not flag these because they are not on Tangle UI primitives:
+
+- Raw HTML elements: `<div>`, `<dl>`, `<table>`, `<svg>`, etc.
+- `style={{ ... }}` for _dynamic_ CSS values inside a layer-4 component (e.g. per-node palette colours computed at runtime). Never for static styling.
+- xyflow `<Handle>` styling (it isn't a Tangle primitive and has its own conventions).
+- The internal implementation of new layer-3 primitives — they own their own `cn` / `cva` calls.
+
+If you find yourself adding `// eslint-disable-next-line tangle-ui/no-classname-on-primitives`, that is a signal to instead extract a new layer-3 primitive or extend an existing one.
+
+## See also
+
+- [.claude/skills/ui-primitives/SKILL.md](../../../.claude/skills/ui-primitives/SKILL.md) — full prop tables for every primitive.
+- [.cursor/rules/required-workflow.mdc](../../../.cursor/rules/required-workflow.mdc) — workspace rule that points back here.
+- [CVA_COMPOUND_VARIANTS.md](./CVA_COMPOUND_VARIANTS.md) — pattern for priority-based variant styling (selected > hovered > ...) used inside layer-3 and layer-4 components.
+- [ARCHITECTURE.md](./ARCHITECTURE.md) — where v2 code lives (shared/, pages/) and the dependency rules.
+- [eslint-rules/no-classname-on-primitives.js](../../../eslint-rules/no-classname-on-primitives.js) — the enforcement rule and its options.
+- [scripts/codemods/ban-classname-on-primitives.mjs](../../../scripts/codemods/ban-classname-on-primitives.mjs) — the codemod that handles mechanical conversions.


### PR DESCRIPTION
## Description

Introduces a four-layer UI primitive system ("Tangle UI") for the v2 codebase, replacing ad-hoc Tailwind class strings on shared components with token-bound semantic props and named layer-3 pattern primitives.

**Layer 1 — `Box`**: A token-only styled container (`background`, `padding`, `borderRadius`, `shadow`, `overflow`, etc.) with no `className` and no flex helpers. Soft-warned via ESLint when used directly in `src/routes/v2/**`.

**Layer 2 — base primitives**: Expanded `BlockStack`/`InlineStack` with additional gap values (`0.5`, `1.5`). `Text`/`Paragraph`/`Heading` gain `align`, `wrap`, `italic`, `leading`, `transform`, `decoration`, `truncate` (single-line or line-clamp), and an extended `tone` set. `Icon` defaults to `shrink-0` and adds `tone`, `rotate`, `spin`, `pulse`. `Button` adds `tone`, `fullWidth`, `align`, `truncate`, and `variant="menubar" | "menubar-light" | "toolbar"`. `Input` gains `inputSize` and `font`. `Label` gains `size` and `tone`.

**Layer 3 — semantic primitives** (`src/components/ui/patterns/`):
- `Surface` — nesting-aware container (3 levels, auto-detected via `SurfaceLevelContext`, throws in dev at depth > 3). `Card` and `Section` are built on top.
- `ScrollRegion` — encodes `flex-1 min-h-0 overflow-y-auto`.
- `Truncating` — encodes `min-w-0 flex-1` for shrinkable flex cells.
- `ListRow` — horizontal row with `group`, hover, density, zebra, and keyboard interaction.
- `ZebraList` — auto-passes `zebra` to row children.
- `HoverReveal` — `opacity-0 group-hover:opacity-100` wrapper.
- `Toolbar` — horizontal action bar with density, chrome, and sticky variants.
- `IconButton` — square icon-only button replacing `<Button size="..." className="h-* w-* p-0"><Icon /></Button>`.
- `Pill` — small chip/tag label.
- `EmptyState` — centered empty placeholder.
- `StickyHeader` — `sticky top-0 z-*` header inside a `ScrollRegion`.
- `FieldRow` — label + control + help/error with auto-wired `htmlFor`.
- `Divider` — thin wrapper over `Separator` with `inset` and `orientation`.

**ESLint enforcement**: A new local plugin (`eslint-rules/`) provides the `tangle-ui/no-classname-on-primitives` rule, which warns on `className` passed to any listed primitive and soft-warns on direct `Box` usage in v2 routes. The rule is currently set to `"warn"` and will be promoted to `"error"` once all legacy sites are migrated.

**Codemod**: `scripts/codemods/ban-classname-on-primitives.mjs` (and `.ts`) handles mechanical conversions — `Icon className="shrink-0"` → drop, `Icon className="text-*"` → `tone`, `Text className="truncate"` → `truncate`, `Text className="italic"` → `italic`, `Text className="text-center"` → `align="center"`, `Text className="font-mono"` → `font="mono"`.

**Documentation**: `.claude/skills/ui-primitives/SKILL.md` and `src/routes/v2/DESIGN_SYSTEM.md` are updated with the full layer diagram, intent catalog, escalation ladder, migration workflow, and before/after examples.

Existing shadcn components (`Card`, `Dialog`, `Tabs`, `Collapsible`, `DropdownMenu`, `Skeleton`, `Table`) are updated with density/size/layout variant props and wired into `SurfaceLevelContext` where appropriate.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Improvement
- [x] Cleanup/Refactor
- [ ] Breaking change
- [x] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Run `pnpm lint` and confirm the `tangle-ui/no-classname-on-primitives` rule emits warnings (not errors) for existing legacy sites.
2. Run `node scripts/codemods/ban-classname-on-primitives.mjs --dry` against `src/routes/v2/` and verify the preview output lists expected replacements.
3. Apply the codemod (`node scripts/codemods/ban-classname-on-primitives.mjs`) and confirm changed files compile and render correctly.
4. Verify that nesting four `<Surface>` components deep throws a dev-mode error.
5. Confirm `<Box>` usage inside `src/routes/v2/**` triggers the soft-ban ESLint warning.

## Additional Comments

The `className` prop is marked `@deprecated` on all affected primitives but is not removed yet — removal is gated on the ESLint warning count reaching zero. The migration path is: run the codemod, hand-fix structural patterns using the intent catalog, then promote the rule to `error` and delete the deprecated prop from each primitive's type.