### PR TITLE
feat: Guided Tours Framework (Navigating the Editor)

### DIFF
--- a/src/components/Learn/tours/registry.ts
+++ b/src/components/Learn/tours/registry.ts
@@ -3,7 +3,10 @@ import type { StepType } from "@reactour/tour";
 import type { TourAction } from "@/providers/TourProvider/tourActions";
 import { publicAsset } from "@/utils/publicAsset";
 
-type TourStep = StepType & TourAction;
+export type TourStep = StepType &
+  TourAction & {
+    fallbackContent?: string;
+  };
 
 export interface TourDefinition {
   id: string;

--- a/src/providers/TourProvider/TourNavigation.test.tsx
+++ b/src/providers/TourProvider/TourNavigation.test.tsx
@@ -86,9 +86,7 @@ describe("TourStepChecklist", () => {
         />
       </TourProgressProvider>,
     );
-    expect(
-      screen.getByText("Complete the highlighted action to continue"),
-    ).toBeInTheDocument();
+    expect(screen.getByText("Select the highlighted task")).toBeInTheDocument();
   });
 
   it("renders nothing for a non-interactive step", () => {
@@ -110,9 +108,7 @@ describe("TourStepChecklist", () => {
         />
       </TourProgressProvider>,
     );
-    const label = screen.getByText(
-      "Complete the highlighted action to continue",
-    );
+    const label = screen.getByText("Drag the panel out of its dock");
     expect(label.className).toContain("line-through");
   });
 });

--- a/src/providers/TourProvider/tourActionLabels.ts
+++ b/src/providers/TourProvider/tourActionLabels.ts
@@ -6,6 +6,18 @@ const GENERIC_LABEL = "Complete the highlighted action to continue";
 // to highlight the contextual target, e.g. the task or folder name.
 export function tourActionLabel(step: TourAction): string {
   switch (step.interaction) {
+    case "select-task":
+      return step.targetTaskName
+        ? `Select the **${step.targetTaskName}** task`
+        : "Select the highlighted task";
+    case "undock-window":
+      return step.targetWindowName
+        ? `Drag the **${step.targetWindowName}** panel out of its dock`
+        : "Drag the panel out of its dock";
+    case "redock-window":
+      return step.targetWindowName
+        ? `Dock the **${step.targetWindowName}** panel back into place`
+        : "Dock the panel back into place";
     default:
       return GENERIC_LABEL;
   }

--- a/src/routes/v2/pages/Editor/components/EditorTourBridge.tsx
+++ b/src/routes/v2/pages/Editor/components/EditorTourBridge.tsx
@@ -1,3 +1,181 @@
+import { useTour } from "@reactour/tour";
+import { reaction } from "mobx";
+import { useEffect } from "react";
+
+import type { TourStep } from "@/components/Learn/tours/registry";
+import { useTourProgress } from "@/providers/TourProvider/TourProgressContext";
+import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
+import type { WindowStoreImpl } from "@/routes/v2/shared/windows/windowStore";
+
+function followWindowPosition(
+  windows: WindowStoreImpl,
+  targetWindowId: string | undefined,
+): () => void {
+  if (!targetWindowId) return () => undefined;
+
+  let rafId: number | null = null;
+  const dispose = reaction(
+    () => {
+      const w = windows.getWindowById(targetWindowId);
+      return w ? `${w.position.x},${w.position.y}` : "";
+    },
+    () => {
+      if (rafId !== null) return;
+      rafId = requestAnimationFrame(() => {
+        rafId = null;
+        window.dispatchEvent(new Event("resize"));
+      });
+    },
+  );
+
+  return () => {
+    dispose();
+    if (rafId !== null) cancelAnimationFrame(rafId);
+  };
+}
+
+function trackDockStateTransition(
+  windows: WindowStoreImpl,
+  matchInitial: (w: { dockState: string }) => boolean,
+  matchTransition: (w: { dockState: string }) => boolean,
+  targetWindowId?: string,
+): { didTransition: () => boolean; dispose: () => void } {
+  const baseline = new Set<string>();
+  for (const w of windows.getAllWindows()) {
+    if (targetWindowId ? w.id === targetWindowId : matchInitial(w)) {
+      baseline.add(w.id);
+    }
+  }
+  let fired = false;
+
+  const stateReaction = reaction(
+    () =>
+      windows
+        .getAllWindows()
+        .map((w) => `${w.id}:${w.dockState}`)
+        .join("|"),
+    () => {
+      for (const w of windows.getAllWindows()) {
+        if (targetWindowId) {
+          if (w.id === targetWindowId && matchTransition(w)) {
+            fired = true;
+          }
+          continue;
+        }
+        if (matchInitial(w)) {
+          baseline.add(w.id);
+        } else if (baseline.has(w.id) && matchTransition(w)) {
+          fired = true;
+        }
+      }
+    },
+  );
+
+  return {
+    didTransition: () => fired,
+    dispose: stateReaction,
+  };
+}
+
 export function EditorTourBridge() {
+  const { steps, currentStep, isOpen } = useTour();
+  const { windows } = useSharedStores();
+  const { markStepComplete } = useTourProgress();
+
+  const step = steps[currentStep] as TourStep | undefined;
+  const interaction = step?.interaction;
+  const targetWindowId = step?.targetWindowId;
+
+  useEffect(() => {
+    if (!isOpen) return undefined;
+
+    // Run outside the interaction branch so informational/fallback steps that
+    // target a floating window still track its position.
+    const stopFollow = followWindowPosition(windows, targetWindowId);
+
+    if (!interaction) return stopFollow;
+
+    // Gated progression: completing the interaction (or finding it already
+    // satisfied on entry) marks the step done so "Next" enables. Advancing is
+    // the user's click, handled by the popover.
+    const advance = () => markStepComplete(currentStep);
+    const skip = () => markStepComplete(currentStep);
+    const skipWithFallback = (_step: TourStep) => markStepComplete(currentStep);
+
+    if (interaction === "undock-window" || interaction === "redock-window") {
+      const isDocked = (w: { dockState: string }) => w.dockState !== "none";
+      const isUndocked = (w: { dockState: string }) => w.dockState === "none";
+      const matchInitial =
+        interaction === "undock-window" ? isDocked : isUndocked;
+      const matchTransition =
+        interaction === "undock-window" ? isUndocked : isDocked;
+
+      if (targetWindowId) {
+        const target = windows.getWindowById(targetWindowId);
+        if (!target || matchTransition(target)) {
+          skipWithFallback(step);
+          return stopFollow;
+        }
+      } else {
+        const hasSourceWindow = windows
+          .getAllWindows()
+          .some((w) => w.state !== "hidden" && matchInitial(w));
+        if (!hasSourceWindow) {
+          if (step) skipWithFallback(step);
+          else skip();
+          return stopFollow;
+        }
+      }
+
+      const tracker = trackDockStateTransition(
+        windows,
+        matchInitial,
+        matchTransition,
+        targetWindowId,
+      );
+
+      let pendingCheck: ReturnType<typeof setTimeout> | null = null;
+      const handleMouseUp = () => {
+        if (pendingCheck !== null) clearTimeout(pendingCheck);
+        pendingCheck = setTimeout(() => {
+          pendingCheck = null;
+          if (tracker.didTransition()) advance();
+        }, 0);
+      };
+      document.addEventListener("mouseup", handleMouseUp);
+
+      return () => {
+        stopFollow();
+        tracker.dispose();
+        if (pendingCheck !== null) clearTimeout(pendingCheck);
+        document.removeEventListener("mouseup", handleMouseUp);
+      };
+    }
+
+    if (interaction === "select-task") {
+      const handleClick = (event: MouseEvent) => {
+        const target = event.target as Element | null;
+        if (target?.closest(".react-flow__node")) {
+          advance();
+        }
+      };
+      document.addEventListener("click", handleClick);
+      return () => {
+        stopFollow();
+        document.removeEventListener("click", handleClick);
+      };
+    }
+
+    return stopFollow;
+  }, [
+    isOpen,
+    interaction,
+    targetWindowId,
+    step,
+    windows,
+    markStepComplete,
+    currentStep,
+  ]);
+
   return null;
 }


### PR DESCRIPTION
## Description

The editor-side tour bridge and the interaction vocabulary it implements. A single component detects tour-step interactions in the editor and reports their **completion** to the shared tour-progress state; step advancement is gated by the custom navigation (gated "Next" / auto-advance live in #2340). Sufficient to power the first tour, _Navigating the Editor_ (#2306).

The framework foundation (route, provider, popover, hub UI) lives in #2348. This PR replaces the empty `EditorTourBridge` stub with its implementation and moves the interaction vocabulary onto `TourStep`.

## Interaction vocabulary (`registry.ts`)

`TourStep` declares the interaction union and its target fields here (moved down from the foundation so the types live alongside the bridge that implements them):

- `interaction`: `"select-task" | "undock-window" | "redock-window"`
- `targetWindowId` — which dock window an undock/redock step targets
- `targetWindowName` — friendly window name used in the checklist label
- `fallbackContent`

## Architecture

**`EditorTourBridge`** (`src/routes/v2/pages/Editor/components/EditorTourBridge.tsx`)

Reads the current step from `useTour()`. When the step declares an `interaction`, the bridge wires a listener that — instead of advancing the tour itself — **marks the step complete** in the shared `TourProgressContext`. The popover's gated "Next" then enables and the framework auto-advances after a short beat (#2340). Three interactions:

- `select-task` — completes when the user clicks an element under `[data-tour-node="task"]` (a stable selector, not React Flow's CSS class).
- `undock-window` — completes when a docked panel matching `targetWindowId` is dragged out of its dock area.
- `redock-window` — completes when a floating window matching `targetWindowId` is dropped back into a dock.

**Helpers**

- `followWindowPosition` — keeps the spotlight tracking a floating panel as the user drags it (throttled to one resize-event dispatch per animation frame).
- `trackDockStateTransition` — baselines window `dockState` at step start and fires when a baselined window crosses the undock/redock transition.

**Already-satisfied on entry**

If the prompted state already holds when the step lands (e.g. the target window is already floating), the step is **marked complete immediately** — its checklist row shows pre-checked and "Next" is enabled — rather than forcing the user to perform an action they've effectively already done.

## Checklist labels

Adds the checklist copy for these interactions (the contextual bold-target support comes from #2340):

- `select-task` → "Select the highlighted task"
- `undock-window` → "Drag the **{targetWindowName}** panel out of its dock"
- `redock-window` → "Dock the **{targetWindowName}** panel back into place"

Each falls back to a generic phrasing when the target field isn't set.

## Related Issue and Pull requests

Progresses https://github.com/Shopify/oasis-frontend/issues/583

Builds on #2348 (foundation) and #2340 (custom navigation + gating). First consumer is #2306. #2347 adds more interaction types on top.

## Type of Change

- [x] New feature

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

No visible behavior on its own — test with #2306 on top, walking the _Navigating the Editor_ tour:

- Interactive steps show a checklist row + a **disabled "Next"**. Completing the action ticks the row and the tour auto-advances after a short delay (or click "Next" to go immediately).
- `select-task` (step 7) — clicking the Greet task **body** completes it; clicking its IO ports does not.
- `undock-window` / `redock-window` (steps 9–10) — dragging Task Properties out / back completes the step; the checklist reads "Drag the **Task Properties** panel out of its dock".
- **Already-satisfied** — enter the undock step with Task Properties already floating → the step opens pre-completed ("Next" enabled) instead of requiring a drag.
- Walking back via Prev to a completed step leaves it complete (no re-gating).
