### PR TITLE
Ads cooldown to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,9 @@ updates:
       interval: daily
     open-pull-requests-limit: 100
     registries: "*"
+    cooldown:
+      default-days: 2
+      semver-major-days: 7
     groups:
       npm-minor-patch:
         patterns:


### PR DESCRIPTION
## Description

Adds a cooldown configuration to Dependabot's npm update settings. A default cooldown of 2 days is applied for standard updates, while major version updates are given a longer cooldown of 7 days to allow for more deliberate review before opening pull requests.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

No direct testing required. Dependabot will apply the cooldown settings on its next scheduled run.

## Additional Comments

The cooldown periods help reduce noise from frequent dependency update PRs, particularly for major version bumps which may require more careful evaluation before merging.