### PR TITLE
feat: Run Origin Icons

### DIFF
--- a/src/components/Home/RunSection/RunRow.tsx
+++ b/src/components/Home/RunSection/RunRow.tsx
@@ -5,6 +5,7 @@ import { type MouseEvent } from "react";
 import type { PipelineRunResponse } from "@/api/types.gen";
 import { CopyText } from "@/components/shared/CopyText/CopyText";
 import { FavoriteToggle } from "@/components/shared/FavoriteToggle";
+import { RunSourceIcon } from "@/components/shared/RunSource";
 import { StatusBar, StatusIcon } from "@/components/shared/Status";
 import { TagList } from "@/components/shared/Tags/TagList";
 import { Button } from "@/components/ui/button";
@@ -19,7 +20,11 @@ import useToastNotification from "@/hooks/useToastNotification";
 import { useBackend } from "@/providers/BackendProvider";
 import { APP_ROUTES } from "@/routes/router";
 import { fetchRunAnnotations } from "@/services/pipelineRunService";
-import { getPipelineTagsFromAnnotations } from "@/utils/annotations";
+import {
+  getAnnotationValue,
+  getPipelineTagsFromAnnotations,
+  RUN_SOURCE_ANNOTATION,
+} from "@/utils/annotations";
 import { TWENTY_FOUR_HOURS_IN_MS } from "@/utils/constants";
 import { formatDate } from "@/utils/date";
 import { getOverallExecutionStatusFromStats } from "@/utils/executionStatus";
@@ -41,6 +46,7 @@ const RunRow = ({ run }: { run: PipelineRunResponse }) => {
 
   const name = run.pipeline_name ?? "Unknown pipeline";
   const tags = getPipelineTagsFromAnnotations(annotations);
+  const source = getAnnotationValue(annotations, RUN_SOURCE_ANNOTATION);
 
   const createdBy = run.created_by ?? "Unknown user";
   const truncatedCreatedBy = truncateMiddle(createdBy);
@@ -131,7 +137,10 @@ const RunRow = ({ run }: { run: PipelineRunResponse }) => {
         {tags && tags.length > 0 && <TagList tags={tags} />}
       </TableCell>
       <TableCell className="w-0">
-        <FavoriteToggle type="run" id={runId} name={name} />
+        <InlineStack gap="2" blockAlign="center" wrap="nowrap">
+          <RunSourceIcon source={source} className="opacity-50" />
+          <FavoriteToggle type="run" id={runId} name={name} />
+        </InlineStack>
       </TableCell>
     </TableRow>
   );

--- a/src/components/PipelineRun/RunDetails.tsx
+++ b/src/components/PipelineRun/RunDetails.tsx
@@ -1,3 +1,5 @@
+import { useQuery } from "@tanstack/react-query";
+
 import { ContentBlock } from "@/components/shared/ContextPanel/Blocks/ContentBlock";
 import { KeyValueList } from "@/components/shared/ContextPanel/Blocks/KeyValueList";
 import { TextBlock } from "@/components/shared/ContextPanel/Blocks/TextBlock";
@@ -5,6 +7,7 @@ import { CopyText } from "@/components/shared/CopyText/CopyText";
 import PipelineIO from "@/components/shared/Execution/PipelineIO";
 import { InfoBox } from "@/components/shared/InfoBox";
 import { LoadingScreen } from "@/components/shared/LoadingScreen";
+import { RunSourceIcon } from "@/components/shared/RunSource";
 import { StatusBar } from "@/components/shared/Status";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Paragraph, Text } from "@/components/ui/typography";
@@ -13,12 +16,15 @@ import { useUserDetails } from "@/hooks/useUserDetails";
 import { useBackend } from "@/providers/BackendProvider";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 import { useExecutionData } from "@/providers/ExecutionDataProvider";
+import { fetchRunAnnotations } from "@/services/pipelineRunService";
 import {
   getAnnotationValue,
   getPipelineTagsFromSpec,
   PIPELINE_NOTES_ANNOTATION,
+  RUN_SOURCE_ANNOTATION,
   SYSTEM_ANNOTATIONS,
 } from "@/utils/annotations";
+import { TWENTY_FOUR_HOURS_IN_MS } from "@/utils/constants";
 import {
   flattenExecutionStatusStats,
   getExecutionStatusLabel,
@@ -31,7 +37,7 @@ import { TagList } from "../shared/Tags/TagList";
 import { RunNotesEditor } from "./RunNotesEditor";
 
 export const RunDetails = () => {
-  const { configured } = useBackend();
+  const { backendUrl, configured } = useBackend();
   const { componentSpec } = useComponentSpec();
   const { data: currentUserDetails } = useUserDetails();
   const {
@@ -42,6 +48,16 @@ export const RunDetails = () => {
     error,
   } = useExecutionData();
   const notify = useToastNotification();
+
+  const runId = metadata?.id;
+  const { data: runAnnotations } = useQuery({
+    queryKey: ["pipeline-run-annotations", runId],
+    queryFn: () => fetchRunAnnotations(runId!, backendUrl),
+    enabled: !!runId,
+    refetchOnWindowFocus: false,
+    staleTime: TWENTY_FOUR_HOURS_IN_MS,
+  });
+  const runSource = getAnnotationValue(runAnnotations, RUN_SOURCE_ANNOTATION);
 
   const handleCopyUrl = () => {
     copyToClipboard(window.location.href);
@@ -116,6 +132,7 @@ export const RunDetails = () => {
       {metadata && (
         <KeyValueList
           title="Run Info"
+          titleAction={<RunSourceIcon source={runSource} />}
           items={[
             { label: "Run Id", value: metadata.id },
             { label: "Execution Id", value: metadata.root_execution_id },

--- a/src/components/shared/RunSource.tsx
+++ b/src/components/shared/RunSource.tsx
@@ -1,0 +1,68 @@
+import { Icon, type IconName } from "@/components/ui/icon";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+export type RunSourceBucket = "web-app" | "programmatic" | "unknown";
+
+interface SourceConfig {
+  icon: IconName;
+  label: string;
+  tooltip: string;
+}
+
+const SOURCE_BUCKETS: Record<RunSourceBucket, SourceConfig> = {
+  "web-app": {
+    icon: "AppWindow",
+    label: "Web app",
+    tooltip: "Submitted via Tangle web app",
+  },
+  programmatic: {
+    icon: "Bot",
+    label: "Programmatic",
+    tooltip: "Submitted by AI or via CLI",
+  },
+  unknown: {
+    icon: "CircleQuestionMark",
+    label: "Unknown",
+    tooltip: "Source unknown",
+  },
+};
+
+const getRunSourceBucket = (source?: string | null): RunSourceBucket => {
+  if (!source) return "unknown";
+  if (source === "web-app") return "web-app";
+  return "programmatic";
+};
+
+const getRunSourceConfig = (source?: string | null): SourceConfig =>
+  SOURCE_BUCKETS[getRunSourceBucket(source)];
+
+interface RunSourceIconProps {
+  source?: string | null;
+  size?: "xs" | "sm" | "md";
+  className?: string;
+}
+
+export const RunSourceIcon = ({
+  source,
+  size = "sm",
+  className,
+}: RunSourceIconProps) => {
+  const { icon, tooltip } = getRunSourceConfig(source);
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className={className}>
+          <Icon name={icon} size={size} className="text-muted-foreground" />
+        </span>
+      </TooltipTrigger>
+      <TooltipContent>
+        <span>{tooltip}</span>
+      </TooltipContent>
+    </Tooltip>
+  );
+};


### PR DESCRIPTION
## Description

Adds an icon showing the run origin to the run list table and the run details.

Works by reading the `source` annotation on a run and sorting into one of three buckets:

- `AppWindow` - runs submitted via the web-app (explicitly state `source: web-app`)
- `Bot` - runs submitted by any other means (generally assumed to be AI or CLI)
- `Circle QuestionMark` - runs with no source provided (unknown)

The intent is to make it easier to see at a glance where a run originated.

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

- [x] New feature

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

![image.png](https://app.graphite.com/user-attachments/assets/e7c0789e-d623-4036-8204-dd9c6c5d9aa6.png)

![image.png](https://app.graphite.com/user-attachments/assets/f6a8dae1-fe29-4d41-82ec-8fe0fbc1236a.png)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->