### PR TITLE
feat: Guided Tour - Navigating the Editor

### DIFF
--- a/public/tour-pipelines/Hello World.pipeline.component.yaml
+++ b/public/tour-pipelines/Hello World.pipeline.component.yaml
@@ -1,0 +1,134 @@
+name: Hello World
+description: A simple pipeline that demonstrates the hello world component.
+inputs:
+  - name: name
+    type: String
+    description: The name to greet.
+    default: ''
+    annotations:
+      editor.position: '{"x":140,"y":0}'
+    value: ''
+    optional: false
+outputs:
+  - name: greeting
+    type: Text
+    description: The generated greeting message.
+    annotations:
+      editor.position: '{"x": 850, "y": 0}'
+implementation:
+  graph:
+    tasks:
+      Greet:
+        componentRef:
+          name: Hello world
+          digest: 8cf1bcc31ce9cd9be6982a7ba95cf233f23efcb7769842b6b03e917ad5dfdd0a
+          spec:
+            name: Hello world
+            description: A simple hello world component that generates a greeting.
+            metadata:
+              annotations:
+                cloud_pipelines.net: 'true'
+                component_yaml_path: hello_world.component.yaml
+                python_original_code: |
+                  from cloud_pipelines import components
+
+
+                  def hello_world(
+                      name: str,
+                      greeting_output: components.OutputPath("Text"),
+                      greeting_prefix: str = "Hello",
+                  ):
+                      """A simple hello world component that generates a greeting.
+
+                      Args:
+                          name: The name to greet.
+                          greeting_output: Output file containing the greeting message.
+                          greeting_prefix: Prefix for the greeting (default: Hello).
+                      """
+                      greeting = f"{greeting_prefix}, {name}! Welcome to Tangle."
+                      print(greeting)
+                      with open(greeting_output, "w") as f:
+                          f.write(greeting)
+                components new regenerate python-function-component: 'true'
+            inputs:
+              - name: name
+                type: String
+                description: The name to greet.
+              - name: greeting_prefix
+                type: String
+                description: 'Prefix for the greeting (default: Hello).'
+                default: Hello
+                optional: true
+            outputs:
+              - name: greeting_output
+                type: Text
+                description: Output file containing the greeting message.
+            implementation:
+              container:
+                image: python:3.12
+                command:
+                  - sh
+                  - '-ec'
+                  - |
+                    program_path=$(mktemp)
+                    printf "%s" "$0" > "$program_path"
+                    python3 -u "$program_path" "$@"
+                  - |
+                    def _make_parent_dirs_and_return_path(file_path: str):
+                        import os
+
+                        os.makedirs(os.path.dirname(file_path), exist_ok=True)
+                        return file_path
+
+                    def hello_world(
+                        name,
+                        greeting_output,
+                        greeting_prefix = "Hello",
+                    ):
+                        """A simple hello world component that generates a greeting.
+
+                        Args:
+                            name: The name to greet.
+                            greeting_output: Output file containing the greeting message.
+                            greeting_prefix: Prefix for the greeting (default: Hello).
+                        """
+                        greeting = f"{greeting_prefix}, {name}! Welcome to Tangle."
+                        print(greeting)
+                        with open(greeting_output, "w") as f:
+                            f.write(greeting)
+
+                    import argparse
+                    _parser = argparse.ArgumentParser(prog='Hello world', description='A simple hello world component that generates a greeting.')
+                    _parser.add_argument("--name", dest="name", type=str, required=True, default=argparse.SUPPRESS)
+                    _parser.add_argument("--greeting-prefix", dest="greeting_prefix", type=str, required=False, default=argparse.SUPPRESS)
+                    _parser.add_argument("--greeting-output", dest="greeting_output", type=_make_parent_dirs_and_return_path, required=True, default=argparse.SUPPRESS)
+                    _parsed_args = vars(_parser.parse_args())
+
+                    _outputs = hello_world(**_parsed_args)
+                args:
+                  - '--name'
+                  - inputValue: name
+                  - if:
+                      cond:
+                        isPresent: greeting_prefix
+                      then:
+                        - '--greeting-prefix'
+                        - inputValue: greeting_prefix
+                  - '--greeting-output'
+                  - outputPath: greeting_output
+        arguments:
+          name:
+            graphInput:
+              inputName: name
+        annotations:
+          editor.position: '{"x":430,"y":0}'
+          editor.collapsed: 'true'
+    outputValues:
+      greeting:
+        taskOutput:
+          outputName: greeting_output
+          taskId: Greet
+metadata:
+  annotations:
+    editor.flow-direction: left-to-right
+    notes: Enter a name in the Input Node or configure it when submitting the pipeline.

--- a/src/components/Learn/tours/navigatingEditor.tour.json
+++ b/src/components/Learn/tours/navigatingEditor.tour.json
@@ -53,7 +53,8 @@
       "content": "Try clicking the **Greet** task on the canvas to select it.",
       "position": "top",
       "stepInteraction": true,
-      "interaction": "select-task"
+      "interaction": "select-task",
+      "targetTaskName": "Greet"
     },
     {
       "selector": "[data-window-id=\"context-panel\"]",
@@ -80,6 +81,7 @@
       "stepInteraction": true,
       "interaction": "undock-window",
       "targetWindowId": "context-panel",
+      "targetWindowName": "Task Properties",
       "fallbackContent": "Windows are flexible. Try grabbing the Task Properties header and dragging it around the canvas."
     },
     {
@@ -89,6 +91,7 @@
       "stepInteraction": true,
       "interaction": "redock-window",
       "targetWindowId": "context-panel",
+      "targetWindowName": "Task Properties",
       "fallbackContent": "Windows can be docked in either sidebar. Create the perfect layout that suits you!"
     },
     {

--- a/src/components/Learn/tours/navigatingEditor.tour.json
+++ b/src/components/Learn/tours/navigatingEditor.tour.json
@@ -1,0 +1,110 @@
+{
+  "id": "navigating-the-editor",
+  "displayName": "Guided Tour: Navigating the Editor",
+  "requiresEditor": true,
+  "starterPipelineUrl": "tour-pipelines/Hello World.pipeline.component.yaml",
+  "steps": [
+    {
+      "selector": "[data-tour-anchor=\"no-spotlight\"]",
+      "content": "Welcome to the pipeline editor! This quick tour will show you around so you know where to find everything: the menu bar, canvas, dockable panels, and floating windows.",
+      "position": "center"
+    },
+    {
+      "selector": "[data-tour=\"editor-top-bar-left\"]",
+      "highlightedSelectors": [
+        "[data-tour=\"editor-top-bar-left\"]",
+        "[data-tour=\"editor-menu-items\"]"
+      ],
+      "content": "The top bar holds your pipeline name and editor menus.\n\nEach menu groups one type of command: **File** for pipeline operations, **View** for layout presets, **Runs** for submissions, **Components** for your libraries, and **Windows** for panels. A **Node** menu also appears here when you have a task selected.",
+      "position": "bottom"
+    },
+    {
+      "selector": "[data-tour=\"editor-top-bar-actions\"]",
+      "content": "Over on the right are your quick actions. Submit a run, check autosave status, jump to Settings, or open the documentation.",
+      "position": "bottom"
+    },
+    {
+      "selector": "[data-tour=\"editor-canvas\"]",
+      "content": "This is your workspace. Drag components onto it, connect tasks by linking their input and output handles, and pan or zoom around larger graphs.\n\nUseful controls sit along the bottom: a **minimap** in the bottom-left, and **viewport controls** with **undo/redo** in the bottom-right.",
+      "position": "center",
+      "resizeObservables": ["[data-tour=\"editor-canvas\"]"]
+    },
+    {
+      "selector": "[data-dock-area=\"left\"]",
+      "highlightedSelectors": [
+        "[data-dock-window=\"component-library\"]",
+        "[data-dock-window-content=\"component-library\"]",
+        "[data-dock-window=\"runs-and-submission\"]",
+        "[data-dock-window-content=\"runs-and-submission\"]",
+        "[data-dock-window=\"recent-runs\"]",
+        "[data-dock-window-content=\"recent-runs\"]"
+      ],
+      "content": "The left sidebar holds your docked panels.\n\n**Components** lets you browse and drag tasks onto the canvas. **Runs and submission** lets you submit your pipeline, and **Recent runs** shows the latest runs of this pipeline.",
+      "position": "right",
+      "resizeObservables": ["[data-dock-area=\"left\"]"]
+    },
+    {
+      "selector": "[data-dock-area=\"right\"]",
+      "content": "The right sidebar holds Pipeline Details and its properties. Set the pipeline description, tags, and notes here, and review any validation warnings.",
+      "resizeObservables": ["[data-dock-area=\"right\"]"]
+    },
+    {
+      "selector": "[data-tour-node=\"task\"][data-task-name=\"Greet\"]",
+      "content": "Try clicking the **Greet** task on the canvas to select it.",
+      "position": "top",
+      "stepInteraction": true,
+      "interaction": "select-task"
+    },
+    {
+      "selector": "[data-window-id=\"context-panel\"]",
+      "position": "left",
+      "highlightedSelectors": [
+        "[data-window-id=\"context-panel\"]",
+        "[data-dock-window-content=\"context-panel\"]"
+      ],
+      "mutationObservables": [
+        "[data-window-id=\"context-panel\"]",
+        "[data-dock-window-content=\"context-panel\"]"
+      ],
+      "resizeObservables": [
+        "[data-window-id=\"context-panel\"]",
+        "[data-dock-window-content=\"context-panel\"]"
+      ],
+      "targetWindowId": "context-panel",
+      "content": "Selecting a task opens its Task Properties panel here in the right sidebar. From this panel you can edit input arguments, configure node settings, define annotations, and inspect the component spec."
+    },
+    {
+      "selector": "[data-window-id=\"context-panel\"]",
+      "content": "Windows are flexible. Try grabbing the Task Properties header and dragging it out of the dock to float it as its own window.",
+      "position": "left",
+      "stepInteraction": true,
+      "interaction": "undock-window",
+      "targetWindowId": "context-panel",
+      "fallbackContent": "Windows are flexible. Try grabbing the Task Properties header and dragging it around the canvas."
+    },
+    {
+      "selector": "[data-window-id=\"context-panel\"]",
+      "content": "Nice! Now drag that floating window back onto the left or right sidebar to re-dock it.",
+      "position": "left",
+      "stepInteraction": true,
+      "interaction": "redock-window",
+      "targetWindowId": "context-panel",
+      "fallbackContent": "Windows can be docked in either sidebar. Create the perfect layout that suits you!"
+    },
+    {
+      "selector": "[data-tracking-id=\"v2.pipeline_editor.windows_menu\"]",
+      "highlightedSelectors": [
+        "[data-tracking-id=\"v2.pipeline_editor.windows_menu\"]",
+        "[data-tour=\"windows-menu-content\"]",
+        "[data-tour=\"windows-menu-submenu-content\"]"
+      ],
+      "mutationObservables": [
+        "[data-tour=\"windows-menu-content\"]",
+        "[data-tour=\"windows-menu-submenu-content\"]"
+      ],
+      "content": "Last one. If you ever need to reconfigure your layout, the Windows menu lets you toggle panels on or off and apply a layout preset.",
+      "position": "right",
+      "stepInteraction": true
+    }
+  ]
+}

--- a/src/routes/v2/pages/Editor/EditorV2.tsx
+++ b/src/routes/v2/pages/Editor/EditorV2.tsx
@@ -122,7 +122,10 @@ const PipelineEditor = withSuspenseWrapper(
             data-editor-ready="true"
           >
             <DockArea side="left" />
-            <div className="relative flex-1 min-w-0 h-full">
+            <div
+              className="relative flex-1 min-w-0 h-full"
+              data-tour="editor-canvas"
+            >
               <FlowCanvas
                 key={activeSpec?.$id ?? "root"}
                 spec={activeSpec}

--- a/src/routes/v2/pages/Editor/components/EditorMenuBar/EditorMenuBar.tsx
+++ b/src/routes/v2/pages/Editor/components/EditorMenuBar/EditorMenuBar.tsx
@@ -54,6 +54,7 @@ export const EditorMenuBar = observer(function EditorMenuBar() {
     <div
       className="relative w-full bg-stone-900 px-3 py-1 md:px-4"
       style={{ height: `${TOP_NAV_HEIGHT}px` }}
+      data-tour="editor-top-bar"
     >
       <InlineStack
         align="space-between"
@@ -67,6 +68,7 @@ export const EditorMenuBar = observer(function EditorMenuBar() {
           align="start"
           blockAlign="center"
           className="min-w-0"
+          data-tour="editor-top-bar-left"
         >
           <Link
             href="/"
@@ -128,7 +130,11 @@ export const EditorMenuBar = observer(function EditorMenuBar() {
                 />
               )}
 
-              <InlineStack wrap="nowrap" blockAlign="center">
+              <InlineStack
+                wrap="nowrap"
+                blockAlign="center"
+                data-tour="editor-menu-items"
+              >
                 <FileMenu />
                 <ViewMenu />
                 <RunsMenu />
@@ -159,6 +165,7 @@ export const EditorMenuBar = observer(function EditorMenuBar() {
           wrap="nowrap"
           blockAlign="center"
           className="shrink-0"
+          data-tour="editor-top-bar-actions"
         >
           {displayMenu && (
             <>

--- a/src/routes/v2/pages/Editor/components/EditorMenuBar/components/WindowsMenu.tsx
+++ b/src/routes/v2/pages/Editor/components/EditorMenuBar/components/WindowsMenu.tsx
@@ -40,14 +40,29 @@ export const WindowsMenu = observer(function WindowsMenu() {
     );
   };
 
+  const notifyOpenStateChange = (open: boolean) => {
+    requestAnimationFrame(() => {
+      window.dispatchEvent(new Event("resize"));
+    });
+    if (!open) {
+      setTimeout(() => {
+        window.dispatchEvent(new Event("resize"));
+      }, 250);
+    }
+  };
+
   return (
-    <DropdownMenu>
+    <DropdownMenu onOpenChange={notifyOpenStateChange}>
       <DropdownMenuTrigger asChild>
         <MenuTriggerButton {...tracking("v2.pipeline_editor.windows_menu")}>
           Windows
         </MenuTriggerButton>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" sideOffset={2}>
+      <DropdownMenuContent
+        align="start"
+        sideOffset={2}
+        data-tour="windows-menu-content"
+      >
         {sortedWindows.map((win) => (
           <DropdownMenuCheckboxItem
             key={win.id}
@@ -72,12 +87,12 @@ export const WindowsMenu = observer(function WindowsMenu() {
           </DropdownMenuCheckboxItem>
         ))}
         <DropdownMenuSeparator />
-        <DropdownMenuSub>
+        <DropdownMenuSub onOpenChange={notifyOpenStateChange}>
           <DropdownMenuSubTrigger>
             <Icon name="LayoutDashboard" size="sm" />
             Views
           </DropdownMenuSubTrigger>
-          <DropdownMenuSubContent>
+          <DropdownMenuSubContent data-tour="windows-menu-submenu-content">
             {viewPresetsForComponentSearchMode(componentSearchV2Enabled).map(
               (preset) => (
                 <DropdownMenuItem

--- a/src/routes/v2/pages/Editor/components/EditorMenuBar/components/WindowsMenu.tsx
+++ b/src/routes/v2/pages/Editor/components/EditorMenuBar/components/WindowsMenu.tsx
@@ -40,19 +40,8 @@ export const WindowsMenu = observer(function WindowsMenu() {
     );
   };
 
-  const notifyOpenStateChange = (open: boolean) => {
-    requestAnimationFrame(() => {
-      window.dispatchEvent(new Event("resize"));
-    });
-    if (!open) {
-      setTimeout(() => {
-        window.dispatchEvent(new Event("resize"));
-      }, 250);
-    }
-  };
-
   return (
-    <DropdownMenu onOpenChange={notifyOpenStateChange}>
+    <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <MenuTriggerButton {...tracking("v2.pipeline_editor.windows_menu")}>
           Windows
@@ -87,7 +76,7 @@ export const WindowsMenu = observer(function WindowsMenu() {
           </DropdownMenuCheckboxItem>
         ))}
         <DropdownMenuSeparator />
-        <DropdownMenuSub onOpenChange={notifyOpenStateChange}>
+        <DropdownMenuSub>
           <DropdownMenuSubTrigger>
             <Icon name="LayoutDashboard" size="sm" />
             Views

--- a/src/routes/v2/pages/Editor/components/EditorTourBridge.tsx
+++ b/src/routes/v2/pages/Editor/components/EditorTourBridge.tsx
@@ -155,7 +155,7 @@ export function EditorTourBridge() {
     if (interaction === "select-task") {
       const handleClick = (event: MouseEvent) => {
         const target = event.target as Element | null;
-        if (target?.closest(".react-flow__node")) {
+        if (target?.closest('[data-tour-node="task"]')) {
           advance();
         }
       };

--- a/src/routes/v2/pages/Editor/components/FlowCanvas/components/CanvasUndoRedo.tsx
+++ b/src/routes/v2/pages/Editor/components/FlowCanvas/components/CanvasUndoRedo.tsx
@@ -27,7 +27,10 @@ export const CanvasUndoRedo = observer(function CanvasUndoRedo() {
   };
 
   return (
-    <div className="absolute right-16 bottom-4 z-10 flex gap-1">
+    <div
+      className="absolute right-16 bottom-4 z-10 flex gap-1"
+      data-tour="canvas-undo-redo"
+    >
       <TooltipProvider>
         <Tooltip>
           <TooltipTrigger asChild>

--- a/src/routes/v2/shared/nodes/IONode/inputManifestBase.ts
+++ b/src/routes/v2/shared/nodes/IONode/inputManifestBase.ts
@@ -64,11 +64,17 @@ export const inputManifestBase: ManifestPartial = {
 
   buildNodes(spec) {
     return [...spec.inputs].map((input, index) =>
-      createEntityNode(input, "input", ioDefaultPosition(index, -200), {
-        entityId: input.$id,
-        ioType: "input",
-        name: input.name,
-      } satisfies IONodeData),
+      createEntityNode(
+        input,
+        "input",
+        ioDefaultPosition(index, -200),
+        {
+          entityId: input.$id,
+          ioType: "input",
+          name: input.name,
+        } satisfies IONodeData,
+        { "data-task-name": input.name },
+      ),
     );
   },
 

--- a/src/routes/v2/shared/nodes/IONode/outputManifestBase.ts
+++ b/src/routes/v2/shared/nodes/IONode/outputManifestBase.ts
@@ -59,11 +59,17 @@ export const outputManifestBase: ManifestPartial = {
 
   buildNodes(spec) {
     return [...spec.outputs].map((output, index) =>
-      createEntityNode(output, "output", ioDefaultPosition(index, 800), {
-        entityId: output.$id,
-        ioType: "output",
-        name: output.name,
-      } satisfies IONodeData),
+      createEntityNode(
+        output,
+        "output",
+        ioDefaultPosition(index, 800),
+        {
+          entityId: output.$id,
+          ioType: "output",
+          name: output.name,
+        } satisfies IONodeData,
+        { "data-task-name": output.name },
+      ),
     );
   },
 

--- a/src/routes/v2/shared/nodes/TaskNode/taskManifestBase.ts
+++ b/src/routes/v2/shared/nodes/TaskNode/taskManifestBase.ts
@@ -72,10 +72,16 @@ export const taskManifestBase: ManifestPartial = {
 
   buildNodes(spec) {
     return [...spec.tasks].map((task, index) =>
-      createEntityNode(task, "task", taskDefaultPosition(index), {
-        entityId: task.$id,
-        name: task.name,
-      } satisfies TaskNodeData),
+      createEntityNode(
+        task,
+        "task",
+        taskDefaultPosition(index),
+        {
+          entityId: task.$id,
+          name: task.name,
+        } satisfies TaskNodeData,
+        { "data-task-name": task.name, "data-tour-node": "task" },
+      ),
     );
   },
 

--- a/src/routes/v2/shared/nodes/buildUtils.ts
+++ b/src/routes/v2/shared/nodes/buildUtils.ts
@@ -47,6 +47,7 @@ export function createEntityNode(
   nodeType: string,
   fallback: { x: number; y: number },
   data: Record<string, unknown>,
+  domAttributes?: Record<string, string>,
 ): Node {
   const position = entity.annotations.get(EDITOR_POSITION_ANNOTATION) as {
     x: number;
@@ -59,6 +60,7 @@ export function createEntityNode(
     position: resolvePosition(position, fallback),
     zIndex,
     data,
+    domAttributes,
   };
 }
 

--- a/src/routes/v2/shared/windows/components/DockedWindow.tsx
+++ b/src/routes/v2/shared/windows/components/DockedWindow.tsx
@@ -134,6 +134,7 @@ export const DockedWindow = observer(function DockedWindow() {
         <div
           ref={panelRef}
           data-dock-window={model.id}
+          data-window-id={model.id}
           className={cn(
             "group/window w-full sticky text-left",
             (isDragging || isResizing) && "select-none",
@@ -170,7 +171,10 @@ export const DockedWindow = observer(function DockedWindow() {
         </div>
       </CollapsibleTrigger>
 
-      <CollapsibleContent className="w-full">
+      <CollapsibleContent
+        className="w-full"
+        data-dock-window-content={model.id}
+      >
         <div
           className={cn(
             "w-full bg-white text-gray-900",

--- a/src/routes/v2/shared/windows/components/FloatingWindow.tsx
+++ b/src/routes/v2/shared/windows/components/FloatingWindow.tsx
@@ -187,6 +187,7 @@ export const FloatingWindow = observer(function FloatingWindow() {
     <>
       <div
         ref={panelRef}
+        data-window-id={model.id}
         className={containerVariants({
           interacting: isDragging || isResizing,
           dragging: isDragging,


### PR DESCRIPTION
## Description

The first registered guided tour against the framework stack (#2348 / #2299 / #2340) — `Navigating the Editor`.

An 11-step walkthrough of the v2 editor with markdown-formatted copy, stable `data-*` selectors, and three interactive moments. Boots into a temporary tour pipeline seeded from `example-pipelines/Intro-Hello World.pipeline.component.yaml`.

## What's in the tour

1. Welcome (centered popover, no spotlight)
2. Top bar — pipeline name + editor menus (File, View, Runs, Components, Windows)
3. Top bar — quick actions (submit, autosave status, Settings, docs)
4. Canvas — workspace plus the controls along the bottom (minimap, viewport controls, undo/redo)
5. Left sidebar — Components, Runs & submission, and Recent runs (all three docked windows highlighted together)
6. Right sidebar — Pipeline Details
7. **Interactive** — click the Greet task (`select-task`)
8. Task Properties panel
9. **Interactive** — drag Task Properties out of the dock (`undock-window`, `targetWindowName: "Task Properties"`)
10. **Interactive** — re-dock Task Properties (`redock-window`)
11. Windows menu

Interactive steps show a **checklist** of the required action alongside a **gated "Next"**; completing the action ticks the checklist and the tour auto-advances after a short beat (framework behavior from #2299 / #2340). If the prompted state is already satisfied when the step lands (e.g. the window is already floating), the step opens pre-completed.

## Stable selectors

Every step selector targets a `data-*` attribute — no `.react-flow__*` library classes — so the tour doesn't break when the underlying library renames CSS.

DOM anchors added in this PR:

- `data-tour="editor-top-bar"`, `editor-top-bar-left`, `editor-menu-items`, `editor-top-bar-actions` on `EditorMenuBar`
- `data-tour="editor-canvas"` on the canvas wrapper in `EditorV2`
- `data-tour="canvas-undo-redo"` on the undo/redo cluster
- `data-tour="windows-menu-content"` / `windows-menu-submenu-content` on the Windows dropdown content
- `data-window-id` / `data-dock-window-content` on docked and floating windows
- `data-task-name` on task / IO nodes plus `data-tour-node="task"` on task nodes only (so step 7 scopes to tasks and not IO ports, which share `data-task-name`)
- A new `domAttributes` arg on `createEntityNode` injects these onto the xyflow DOM nodes

## One behavior change

`WindowsMenu` now dispatches a `resize` event on dropdown open/close (with a 250ms follow-up for Radix's exit animation). Without this, reactour can't re-measure the portalled dropdown content during step 11 — the highlight would otherwise stay frozen at the trigger's pre-open coordinates.

## Related Issue and Pull requests

Progresses https://github.com/Shopify/oasis-frontend/issues/583

## Type of Change

- [x] New feature

## Screenshots

![image.png](https://app.graphite.com/user-attachments/assets/16264c2a-dea0-42d0-8e9a-97aa5b3aa8fe.png)

![image.png](https://app.graphite.com/user-attachments/assets/4de51760-a24d-402c-89ed-2aaf2ba180dd.png)

![image.png](https://app.graphite.com/user-attachments/assets/9c7ca06f-ec79-41ed-a258-04ab4d301d1d.png)

![image.png](https://app.graphite.com/user-attachments/assets/f92f8d6a-a469-4c31-bb53-dab0aa1bb17b.png)

![image.png](https://app.graphite.com/user-attachments/assets/e0f58049-7832-4084-b4bb-ec8f0175b3a1.png)

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

Dashboard → Learning Hub → Featured Tours → "Find your way around the editor". Walk through all 11 steps end-to-end.

The tour cannot be paused or dismissed mid-run — ESC, clicks on the mask, and the (hidden) close button are all no-ops; the only mid-tour exit is the **Exit Tour** button.

- **Interactive steps** show a checklist row; completing the action ticks it and the tour auto-advances after a short beat (or click "Next").
- **Step 7 (select-task)** — clicking the Greet task advances; clicking an IO port on the same task does not.
- **Steps 9–10 (undock/redock)** — the checklist reads "Drag the **Task Properties** panel…"; dragging the panel out / back completes the step. If it's already floating/docked on arrival, the step opens pre-completed.
- **URL deep-link** — refresh mid-tour resumes on the same step (`/tour/navigating-the-editor?step=N`).
- **Browser back/forward** — navigates between steps.
- **Entry loading** — menu bar appears immediately; body shows a small "Loading pipeline…" skeleton, no full-screen flash.
- **Step 11 (Windows menu)** — opening the dropdown highlights the menu content correctly (the `resize` dispatch).
- **Done** — returns to `/learn/tours`; the tour pipeline does **not** appear in the regular pipelines list.
- **Save this pipeline** (from #2339) — promotes the temp pipeline to a regular one and opens `/editor/<name>`.
