### PR TITLE
component search v2 - unify component search across standard, user, published, and registered sources

### DIFF
--- a/src/components/shared/ComponentDetail/ComponentDetail.tsx
+++ b/src/components/shared/ComponentDetail/ComponentDetail.tsx
@@ -1,0 +1,357 @@
+import { CodeViewer } from "@/components/shared/CodeViewer";
+import { CopyText } from "@/components/shared/CopyText/CopyText";
+import { GithubDetails } from "@/components/shared/TaskDetails/GithubDetails";
+import { Badge } from "@/components/ui/badge";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Heading, Paragraph, Text } from "@/components/ui/typography";
+import { useHydrateComponentReference } from "@/hooks/useHydrateComponentReference";
+import { cn } from "@/lib/utils";
+import type {
+  ComponentReference,
+  InputSpec,
+  OutputSpec,
+} from "@/utils/componentSpec";
+import { TOP_NAV_HEIGHT } from "@/utils/constants";
+
+// ─── Compact I/O table ───────────────────────────────────────────────────────
+
+// Minimal I/O row: name on the left, type+req/opt on the right, optional
+// description on its own line. No box borders — a subtle divider between
+// rows is enough to read as a list.
+const IORow = ({
+  name,
+  type,
+  required,
+  defaultValue,
+  description,
+  isLast,
+}: {
+  name: string;
+  type?: unknown;
+  required?: boolean;
+  defaultValue?: unknown;
+  description?: string;
+  isLast?: boolean;
+}) => (
+  <div className={cn("py-2.5", !isLast && "border-b border-border/40")}>
+    <InlineStack gap="3" blockAlign="center" wrap="nowrap">
+      <Text
+        size="sm"
+        weight="semibold"
+        className="font-mono truncate min-w-0 flex-1"
+      >
+        {name}
+      </Text>
+      {type !== undefined && type !== null && (
+        <Text size="xs" tone="subdued" className="shrink-0">
+          {String(type)}
+        </Text>
+      )}
+      <Text
+        size="xs"
+        weight="semibold"
+        className={cn(
+          "shrink-0 uppercase tracking-wide",
+          required ? "text-rose-600" : "text-muted-foreground",
+        )}
+      >
+        {required ? "required" : "optional"}
+      </Text>
+    </InlineStack>
+    {description && (
+      <Text
+        size="xs"
+        className="text-muted-foreground leading-snug block mt-0.5"
+      >
+        {description}
+      </Text>
+    )}
+    {defaultValue !== undefined && (
+      <Text size="xs" className="text-muted-foreground block mt-0.5">
+        Default: <span className="font-mono">{String(defaultValue)}</span>
+      </Text>
+    )}
+  </div>
+);
+
+const IOSection = ({
+  label,
+  rows,
+}: {
+  label: string;
+  rows: ReadonlyArray<{
+    name: string;
+    type?: unknown;
+    required?: boolean;
+    defaultValue?: unknown;
+    description?: string;
+  }>;
+}) => (
+  // align="stretch" so the row list fills the section's width; BlockStack
+  // defaults to items-start otherwise.
+  <BlockStack gap="1" align="stretch">
+    <Text
+      size="xs"
+      className="text-muted-foreground font-medium uppercase tracking-wide"
+    >
+      {label}
+    </Text>
+    <div>
+      {rows.map((row, idx) => (
+        <IORow
+          key={row.name}
+          name={row.name}
+          type={row.type}
+          required={row.required}
+          defaultValue={row.defaultValue}
+          description={row.description}
+          isLast={idx === rows.length - 1}
+        />
+      ))}
+    </div>
+  </BlockStack>
+);
+
+const CompactIO = ({
+  inputs,
+  outputs,
+}: {
+  inputs?: InputSpec[];
+  outputs?: OutputSpec[];
+}) => (
+  <BlockStack gap="5" align="stretch">
+    {inputs && inputs.length > 0 && (
+      <IOSection
+        label="Inputs"
+        rows={inputs.map((i) => ({
+          name: i.name,
+          type: i.type,
+          required: !i.optional,
+          defaultValue: i.default,
+          description: i.description,
+        }))}
+      />
+    )}
+    {outputs && outputs.length > 0 && (
+      <IOSection
+        label="Outputs"
+        rows={outputs.map((o) => ({
+          name: o.name,
+          type: o.type,
+          description: o.description,
+        }))}
+      />
+    )}
+  </BlockStack>
+);
+
+// ─── Detail panel (suspends on hydration) ───────────────────────────────────
+
+interface ComponentDetailProps {
+  /**
+   * The reference to render. Callers pass whatever they have — a hydrated ref
+   * (no network needed) or a stub with `digest`+`url` (one hydration round-trip).
+   * Hydration is keyed by digest/url, so cache is shared with other usages.
+   */
+  reference: ComponentReference;
+  /**
+   * - `split` (V1 default): metadata+I/O on the left, sticky source code panel
+   *   on the right. Best for full-bleed detail pages.
+   * - `stacked`: single column — metadata, I/O, then source code in a card with
+   *   a capped height. Best for narrower detail panes alongside other content.
+   */
+  layout?: "split" | "stacked";
+  /**
+   * CSS height for the source code panel. In `split` layout this is the sticky
+   * right column's height (defaults to the remaining viewport height under the
+   * top nav). In `stacked` layout this caps the inline source card's height.
+   */
+  sourcePanelHeight?: string;
+}
+
+export const ComponentDetail = ({
+  reference,
+  layout = "split",
+  sourcePanelHeight,
+}: ComponentDetailProps) => {
+  const hydrated = useHydrateComponentReference(reference);
+
+  if (!hydrated?.spec) {
+    return (
+      <Paragraph tone="subdued" size="sm">
+        Could not load component details.
+      </Paragraph>
+    );
+  }
+
+  const { spec } = hydrated;
+  const annotations = spec.metadata?.annotations ?? {};
+  const author =
+    typeof annotations.author === "string" ? annotations.author : undefined;
+  const canonicalUrl =
+    typeof annotations.canonical_location === "string"
+      ? annotations.canonical_location
+      : undefined;
+  const gitRemoteUrl =
+    typeof annotations.git_remote_url === "string"
+      ? annotations.git_remote_url
+      : undefined;
+  const gitRemoteBranch =
+    typeof annotations.git_remote_branch === "string"
+      ? annotations.git_remote_branch
+      : undefined;
+  const gitRelativeDir =
+    typeof annotations.git_relative_dir === "string"
+      ? annotations.git_relative_dir
+      : undefined;
+  const componentYamlPath =
+    typeof annotations.component_yaml_path === "string"
+      ? annotations.component_yaml_path
+      : undefined;
+  const documentationPath =
+    typeof annotations.documentation_path === "string"
+      ? annotations.documentation_path
+      : undefined;
+
+  let reconstructedUrl: string | undefined;
+  let documentationUrl: string | undefined;
+
+  if (gitRemoteUrl && gitRemoteBranch && gitRelativeDir) {
+    const repoPath = gitRemoteUrl
+      .replace(/^https:\/\/github\.com\//, "")
+      .replace(/\.git$/, "");
+    const buildGitHubUrl = (filePath: string) =>
+      `https://github.com/${repoPath}/blob/${gitRemoteBranch}/${gitRelativeDir}/${filePath}`;
+    if (!hydrated.url && componentYamlPath)
+      reconstructedUrl = buildGitHubUrl(componentYamlPath);
+    if (documentationPath) documentationUrl = buildGitHubUrl(documentationPath);
+  }
+
+  const hasIO =
+    (spec.inputs && spec.inputs.length > 0) ||
+    (spec.outputs && spec.outputs.length > 0);
+
+  // ── Shared sub-blocks ──────────────────────────────────────────────────
+  const header = (
+    <BlockStack gap="2">
+      <Heading level={2}>{spec.name ?? hydrated.digest ?? ""}</Heading>
+      {author && (
+        <Text size="sm" className="text-muted-foreground">
+          {author}
+        </Text>
+      )}
+      {hydrated.digest && (
+        <Badge
+          variant="outline"
+          className="font-mono text-xs min-w-0 max-w-full overflow-hidden self-start"
+        >
+          <CopyText size="xs" className="font-mono truncate">
+            {hydrated.digest}
+          </CopyText>
+        </Badge>
+      )}
+    </BlockStack>
+  );
+
+  const description = spec.description && (
+    // `[overflow-wrap:anywhere]` breaks at any character so long URLs/paths
+    // wrap inside the pane. `break-words` is insufficient — it only breaks
+    // at word boundaries, which doesn't help for URLs without spaces.
+    <Paragraph size="sm" tone="subdued" className="[overflow-wrap:anywhere]">
+      {spec.description}
+    </Paragraph>
+  );
+
+  const githubLinks = (
+    <GithubDetails
+      url={hydrated.url ?? reconstructedUrl}
+      canonicalUrl={canonicalUrl}
+      documentationUrl={documentationUrl}
+    />
+  );
+
+  const io = hasIO && <CompactIO inputs={spec.inputs} outputs={spec.outputs} />;
+
+  // ── Stacked layout ────────────────────────────────────────────────────
+  // Single column — metadata, links, I/O, then source. Wraps source in a
+  // card so it's visually distinct from the rest and capped to a fixed
+  // height to keep the page scannable in narrower containers.
+  if (layout === "stacked") {
+    const stackedSourceHeight = sourcePanelHeight ?? "60vh";
+    return (
+      // align="stretch" so every child fills the container's width. Without
+      // this, BlockStack defaults to `items-start` and children collapse to
+      // their intrinsic width, which looks broken in wide panes.
+      <BlockStack gap="6" align="stretch">
+        {header}
+        {description}
+        {githubLinks}
+        {io}
+        {hydrated.text && (
+          // CodeViewer already provides its own dark frame + header bar, so
+          // no extra border/card chrome around it — keeps the look minimal.
+          <div
+            style={{ height: stackedSourceHeight }}
+            className="min-h-0 rounded-md overflow-hidden"
+          >
+            <CodeViewer
+              code={hydrated.text}
+              language="yaml"
+              filename={spec.name ?? "component.yaml"}
+            />
+          </div>
+        )}
+      </BlockStack>
+    );
+  }
+
+  // ── Split layout (V1 default) ─────────────────────────────────────────
+  const splitSourceHeight =
+    sourcePanelHeight ?? `calc(100vh - ${TOP_NAV_HEIGHT + 48}px)`;
+  return (
+    <InlineStack gap="6" blockAlign="start">
+      <div className="flex-2 min-w-0 flex flex-col gap-4">
+        {header}
+        {description}
+        {githubLinks}
+        {io}
+      </div>
+
+      {hydrated.text && (
+        <div className="flex-3 min-w-0">
+          <div
+            className="sticky top-0 flex flex-col gap-1.5"
+            style={{ height: splitSourceHeight }}
+          >
+            <Text
+              size="xs"
+              className="text-muted-foreground font-medium uppercase tracking-wide shrink-0"
+            >
+              Source
+            </Text>
+            <div className="flex-1 min-h-0">
+              <CodeViewer
+                code={hydrated.text}
+                language="yaml"
+                filename={spec.name ?? "component.yaml"}
+              />
+            </div>
+          </div>
+        </div>
+      )}
+    </InlineStack>
+  );
+};
+
+export const ComponentDetailSkeleton = () => (
+  <InlineStack gap="6">
+    <div className="flex-1 flex flex-col gap-3">
+      <Skeleton className="h-6 w-48" />
+      <Skeleton className="h-4 w-32" />
+      <Skeleton className="h-4 w-full" />
+      <Skeleton className="h-4 w-3/4" />
+    </div>
+    <Skeleton className="flex-3 min-w-0 h-64" />
+  </InlineStack>
+);

--- a/src/components/ui/typography.tsx
+++ b/src/components/ui/typography.tsx
@@ -67,6 +67,9 @@ interface TextProps
    */
   className?: string;
 
+  /** HTML id used to associate text with form controls and ARIA descriptions. */
+  id?: string;
+
   /** Native browser tooltip text */
   title?: string;
 }

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -58,7 +58,7 @@ export const ExistingFlags: ConfigFlags = {
   ["component-search-v2"]: {
     name: "Component Search V2",
     description:
-      "Show the experimental Components V2 page in the dashboard. Uses placeholder data for now.",
+      "Show the experimental Components V2 page that searches across standard, published, registered, and user component sources, with optional AI rerank.",
     default: false,
     category: "beta",
   },

--- a/src/hooks/useComponentSearchSettings.test.ts
+++ b/src/hooks/useComponentSearchSettings.test.ts
@@ -1,0 +1,149 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { useComponentSearchSettings } from "./useComponentSearchSettings";
+
+const STORAGE_KEY = "tangle.componentSearchV2.config";
+
+describe("useComponentSearchSettings", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("returns defaults when nothing is stored", () => {
+    const { result } = renderHook(() => useComponentSearchSettings());
+
+    expect(result.current.config).toEqual({
+      apiBase: "",
+      apiKey: "",
+      model: "",
+    });
+    expect(result.current.isConfigured).toBe(false);
+  });
+
+  it("reads stored values from localStorage", () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        apiBase: "https://api.example.com/v1",
+        apiKey: "sk-test",
+        model: "gpt-4o-mini",
+      }),
+    );
+
+    const { result } = renderHook(() => useComponentSearchSettings());
+
+    expect(result.current.config).toEqual({
+      apiBase: "https://api.example.com/v1",
+      apiKey: "sk-test",
+      model: "gpt-4o-mini",
+    });
+    expect(result.current.isConfigured).toBe(true);
+  });
+
+  it("isConfigured requires apiBase, apiKey, and model", () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        apiBase: "https://api.example.com/v1",
+        apiKey: "sk-test",
+        model: "",
+      }),
+    );
+
+    const { result } = renderHook(() => useComponentSearchSettings());
+    expect(result.current.isConfigured).toBe(false);
+  });
+
+  it("update() writes to localStorage and merges partial values", () => {
+    const { result } = renderHook(() => useComponentSearchSettings());
+
+    act(() => {
+      result.current.update({
+        apiBase: "https://api.example.com/v1",
+        apiKey: "sk-test",
+        model: "gpt-4o-mini",
+      });
+    });
+
+    expect(result.current.config.model).toBe("gpt-4o-mini");
+    expect(result.current.isConfigured).toBe(true);
+
+    act(() => {
+      result.current.update({ model: "claude-3-5-haiku" });
+    });
+
+    const stored = JSON.parse(
+      window.localStorage.getItem(STORAGE_KEY) as string,
+    );
+    expect(stored).toEqual({
+      apiBase: "https://api.example.com/v1",
+      apiKey: "sk-test",
+      model: "claude-3-5-haiku",
+    });
+  });
+
+  it("clear() removes the stored config", () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        apiBase: "https://api.example.com/v1",
+        apiKey: "sk-test",
+        model: "gpt-4o-mini",
+      }),
+    );
+
+    const { result } = renderHook(() => useComponentSearchSettings());
+
+    act(() => {
+      result.current.clear();
+    });
+
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+    expect(result.current.isConfigured).toBe(false);
+  });
+
+  it("migrates legacy `thinkingModel` into `model` when model is unset", () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        apiBase: "https://api.example.com/v1",
+        apiKey: "sk-test",
+        thinkingModel: "gpt-5-mini",
+      }),
+    );
+
+    const { result } = renderHook(() => useComponentSearchSettings());
+    expect(result.current.config.model).toBe("gpt-5-mini");
+  });
+
+  it("preserves legacy `thinkingModel` precedence when both models exist", () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        apiBase: "https://api.example.com/v1",
+        apiKey: "sk-test",
+        model: "gpt-4o-mini",
+        thinkingModel: "gpt-5-mini",
+      }),
+    );
+
+    const { result } = renderHook(() => useComponentSearchSettings());
+    expect(result.current.config.model).toBe("gpt-5-mini");
+  });
+
+  it("falls back to defaults when stored JSON is malformed", () => {
+    window.localStorage.setItem(STORAGE_KEY, "not json");
+
+    const { result } = renderHook(() => useComponentSearchSettings());
+    expect(result.current.config).toEqual({
+      apiBase: "",
+      apiKey: "",
+      model: "",
+    });
+  });
+});

--- a/src/hooks/useComponentSearchSettings.ts
+++ b/src/hooks/useComponentSearchSettings.ts
@@ -16,17 +16,14 @@ const STORAGE_KEY = "tangle.componentSearchV2.config";
 export interface ComponentSearchConfig {
   apiBase: string;
   apiKey: string;
-  /** Fast / default model. */
+  /** Model id used for AI search reranking (any OpenAI-compatible model). */
   model: string;
-  /** Better-quality model used when the "Thinking" toggle is on. */
-  thinkingModel: string;
 }
 
 const DEFAULTS: ComponentSearchConfig = {
   apiBase: "",
   apiKey: "",
-  model: "gemini-2.5-flash-lite",
-  thinkingModel: "gpt-5-mini",
+  model: "",
 };
 
 function readStoredConfig(): ComponentSearchConfig {
@@ -36,18 +33,32 @@ function readStoredConfig(): ComponentSearchConfig {
     if (!raw) return DEFAULTS;
     const parsed: unknown = JSON.parse(raw);
     if (!parsed || typeof parsed !== "object") return DEFAULTS;
-    const p = parsed as Partial<ComponentSearchConfig>;
+    const record = parsed;
+    const legacyThinking =
+      "thinkingModel" in record &&
+      typeof record.thinkingModel === "string" &&
+      record.thinkingModel.trim().length > 0
+        ? record.thinkingModel
+        : "";
+    const storedModel =
+      "model" in record &&
+      typeof record.model === "string" &&
+      record.model.trim().length > 0
+        ? record.model
+        : "";
+    // Migration: previous reranking used `thinkingModel` when present, even if
+    // `model` was also stored. Preserve that precedence for existing users.
+    const model = legacyThinking || storedModel || DEFAULTS.model;
     return {
-      apiBase: typeof p.apiBase === "string" ? p.apiBase : DEFAULTS.apiBase,
-      apiKey: typeof p.apiKey === "string" ? p.apiKey : DEFAULTS.apiKey,
-      model:
-        typeof p.model === "string" && p.model.trim().length > 0
-          ? p.model
-          : DEFAULTS.model,
-      thinkingModel:
-        typeof p.thinkingModel === "string" && p.thinkingModel.trim().length > 0
-          ? p.thinkingModel
-          : DEFAULTS.thinkingModel,
+      apiBase:
+        "apiBase" in record && typeof record.apiBase === "string"
+          ? record.apiBase
+          : DEFAULTS.apiBase,
+      apiKey:
+        "apiKey" in record && typeof record.apiKey === "string"
+          ? record.apiKey
+          : DEFAULTS.apiKey,
+      model,
     };
   } catch {
     return DEFAULTS;
@@ -116,7 +127,10 @@ export function useComponentSearchSettings() {
     window.dispatchEvent(new Event("tangle:component-search-config"));
   };
 
-  const isConfigured = config.apiBase.length > 0 && config.apiKey.length > 0;
+  const isConfigured =
+    config.apiBase.length > 0 &&
+    config.apiKey.length > 0 &&
+    config.model.length > 0;
 
   return { config, update, clear, isConfigured };
 }

--- a/src/hooks/useNaturalLanguageComponentSearch.ts
+++ b/src/hooks/useNaturalLanguageComponentSearch.ts
@@ -25,15 +25,10 @@ interface RerankVariables {
 export function useNaturalLanguageComponentRerank() {
   const { config, isConfigured } = useComponentSearchSettings();
 
-  // Prefer the thinking model for rerank — rerank is the moment we *want*
-  // careful judgment, and the payload is small enough that latency is fine.
-  // Fall back to the default model when no thinking model is configured.
-  const model = config.thinkingModel || config.model;
-
   const mutation = useMutation<RerankResult, Error, RerankVariables>({
     mutationFn: ({ query, candidates }) =>
       rerankComponentsByNaturalLanguage(query, candidates, {
-        model,
+        model: config.model,
         apiBase: config.apiBase,
         apiKey: config.apiKey,
       }),

--- a/src/providers/ComponentLibraryProvider/libraries/setup.ts
+++ b/src/providers/ComponentLibraryProvider/libraries/setup.ts
@@ -1,0 +1,28 @@
+import { GitHubFlatComponentLibrary } from "@/components/shared/GitHubLibrary/githubFlatComponentLibrary";
+import { isGitHubLibraryConfiguration } from "@/components/shared/GitHubLibrary/types";
+
+import { registerLibraryFactory } from "./factory";
+
+/**
+ * Idempotent registration of library factories. The provider already registers
+ * the same factories at module load, but the dashboard search page reads
+ * libraries from Dexie directly (without mounting `ComponentLibraryProvider`,
+ * which is editor-scoped and depends on `ComponentSpecProvider`). Anywhere
+ * that needs to instantiate a stored library can call this first.
+ */
+let registered = false;
+
+export function ensureLibraryFactoriesRegistered() {
+  if (registered) return;
+
+  registerLibraryFactory("github", (library) => {
+    if (!isGitHubLibraryConfiguration(library.configuration)) {
+      throw new Error(
+        `GitHub library configuration is not valid for "${library.id}"`,
+      );
+    }
+    return new GitHubFlatComponentLibrary(library.configuration.repo_name);
+  });
+
+  registered = true;
+}

--- a/src/routes/Dashboard/DashboardComponentsV2View.test.tsx
+++ b/src/routes/Dashboard/DashboardComponentsV2View.test.tsx
@@ -1,0 +1,55 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  SourceFilterBar,
+  type SourceFilterOption,
+} from "./DashboardComponentsV2View";
+
+const options: SourceFilterOption[] = [
+  {
+    source: { kind: "standard", label: "Standard", id: "standard" },
+    count: 2,
+  },
+  {
+    source: { kind: "registered", label: "GitHub", id: "github-lib" },
+    count: 3,
+  },
+  {
+    source: { kind: "user", label: "User", id: "user" },
+    count: 1,
+  },
+];
+
+describe("SourceFilterBar", () => {
+  it("toggles source buttons and exposes active state", () => {
+    const onToggle = vi.fn();
+    const onEnableAll = vi.fn();
+
+    render(
+      <SourceFilterBar
+        options={options}
+        disabledSourceKeys={["registered:github-lib"]}
+        onToggle={onToggle}
+        onEnableAll={onEnableAll}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", {
+        name: "Hide Standard source (2 components)",
+      }),
+    ).toHaveAttribute("aria-pressed", "true");
+    expect(
+      screen.getByRole("button", { name: "Show GitHub source (3 components)" }),
+    ).toHaveAttribute("aria-pressed", "false");
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Show GitHub source (3 components)" }),
+    );
+    expect(onToggle).toHaveBeenCalledWith("registered:github-lib");
+
+    fireEvent.click(screen.getByRole("button", { name: "Show all" }));
+    expect(onEnableAll).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/routes/Dashboard/DashboardComponentsV2View.tsx
+++ b/src/routes/Dashboard/DashboardComponentsV2View.tsx
@@ -1,7 +1,14 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { Link } from "@tanstack/react-router";
-import { type ChangeEvent, useDeferredValue, useState } from "react";
+import { Link, useNavigate, useSearch } from "@tanstack/react-router";
+import { useLiveQuery } from "dexie-react-hooks";
+import { type ChangeEvent, useEffect, useState } from "react";
 
+import { listApiPublishedComponentsGet } from "@/api/sdk.gen";
+import {
+  ComponentDetail,
+  ComponentDetailSkeleton,
+} from "@/components/shared/ComponentDetail/ComponentDetail";
+import { SuspenseWrapper } from "@/components/shared/SuspenseWrapper";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
@@ -9,20 +16,31 @@ import { Input } from "@/components/ui/input";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
+import { QuickTooltip } from "@/components/ui/tooltip";
 import { Heading, Paragraph, Text } from "@/components/ui/typography";
 import { getComponentQueryKey } from "@/hooks/useHydrateComponentReference";
 import { useNaturalLanguageComponentRerank } from "@/hooks/useNaturalLanguageComponentSearch";
+import useToastNotification from "@/hooks/useToastNotification";
+import { cn } from "@/lib/utils";
+import { useBackend } from "@/providers/BackendProvider";
 import {
   fetchUserComponents,
-  filterToUniqueByDigest,
   flattenFolders,
 } from "@/providers/ComponentLibraryProvider/componentLibrary";
+import { createLibraryObject } from "@/providers/ComponentLibraryProvider/libraries/factory";
+import { ensureLibraryFactoriesRegistered } from "@/providers/ComponentLibraryProvider/libraries/setup";
+import {
+  LibraryDB,
+  type StoredLibrary,
+} from "@/providers/ComponentLibraryProvider/libraries/storage";
 import {
   buildSearchIndex,
+  type ComponentSource,
   type IndexEntry,
   type LexicalMatch,
   lexicalSearch,
   type MatchField,
+  type SourcedReference,
 } from "@/services/componentSearchIndex";
 import {
   fetchAndStoreComponentLibrary,
@@ -33,18 +51,40 @@ import {
   NaturalLanguageSearchConfigError,
   type RerankedMatch,
 } from "@/services/naturalLanguageComponentSearchService";
+import type { ComponentFolder } from "@/types/componentLibrary";
 import type {
   ComponentReference,
   HydratedComponentReference,
 } from "@/utils/componentSpec";
-import { HOURS } from "@/utils/constants";
+import { componentMetadata } from "@/utils/componentTracking";
+import { HOURS, TOP_NAV_HEIGHT } from "@/utils/constants";
 import { getComponentName } from "@/utils/getComponentName";
+import { tracking } from "@/utils/tracking";
 
 import { APP_ROUTES } from "../router";
+import { copyComponentReferenceToClipboard } from "../v2/shared/clipboard/copyComponentReferenceToClipboard";
 
 // Repeated Tailwind combos extracted as named constants.
 const PANEL_CLASS = "p-3 rounded-lg bg-card border border-border";
-const PAGE_CLASS = "max-w-7xl";
+
+// Maps V2's richer ComponentSource.kind onto the analytics-tracking taxonomy
+// (see analytics-tracking skill: `component_source` enum is fixed).
+const TRACKING_SOURCE_BY_KIND = {
+  standard: "library",
+  registered: "library",
+  published: "published",
+  user: "user",
+} as const;
+
+// Source identity is communicated by the package icon's colour instead of a
+// text badge — cleaner card, and the same colour shows up consistently across
+// the list. Hover for the human-readable source name.
+const SOURCE_ICON_TONE_BY_KIND: Record<ComponentSource["kind"], string> = {
+  standard: "text-blue-500",
+  published: "text-emerald-500",
+  registered: "text-violet-500",
+  user: "text-amber-500",
+};
 
 /** How many lexical hits to display (and to feed into rerank). */
 const LEXICAL_RESULT_LIMIT = 20;
@@ -56,75 +96,320 @@ const MATCH_FIELD_LABEL: Record<MatchField, string> = {
   implementation: "command",
 };
 
-type ComponentLibraryFolder = Parameters<typeof flattenFolders>[0];
-type UserFolder = { components?: ComponentReference[] };
-
-interface ComponentCardProps {
-  reference: ComponentReference;
-  matchedFields?: MatchField[];
-  reason?: string;
+export interface SourceFilterOption {
+  source: ComponentSource;
+  count: number;
 }
 
-const ComponentCard = ({
-  reference,
-  matchedFields,
-  reason,
-}: ComponentCardProps) => {
-  const name = getComponentName(reference);
-  const description = reference.spec?.description;
-  const publishedBy = reference.published_by;
+export function sourceFilterKey(source: ComponentSource): string {
+  return `${source.kind}:${source.id}`;
+}
+
+export function createSourceFilterOptions(
+  index: IndexEntry[],
+): SourceFilterOption[] {
+  const optionsByKey = new Map<string, SourceFilterOption>();
+
+  for (const entry of index) {
+    const key = sourceFilterKey(entry.source);
+    const option = optionsByKey.get(key);
+    if (option) {
+      option.count += 1;
+    } else {
+      optionsByKey.set(key, { source: entry.source, count: 1 });
+    }
+  }
+
+  return Array.from(optionsByKey.values());
+}
+
+interface SourceFilterBarProps {
+  options: SourceFilterOption[];
+  disabledSourceKeys: string[];
+  onToggle: (sourceKey: string) => void;
+  onEnableAll: () => void;
+}
+
+export const SourceFilterBar = ({
+  options,
+  disabledSourceKeys,
+  onToggle,
+  onEnableAll,
+}: SourceFilterBarProps) => {
+  if (options.length <= 1) return null;
+
+  const disabled = new Set(disabledSourceKeys);
+  const activeCount = options.filter(
+    (option) => !disabled.has(sourceFilterKey(option.source)),
+  ).length;
 
   return (
-    <BlockStack gap="2" className={PANEL_CLASS}>
+    <BlockStack gap="2">
       <InlineStack gap="2" blockAlign="center" wrap="wrap">
-        <Icon name="Package" size="sm" />
-        <Text size="sm" weight="semibold">
-          {name}
-        </Text>
-        {matchedFields?.map((field) => (
-          <Badge key={field} variant="secondary">
-            matched: {MATCH_FIELD_LABEL[field]}
-          </Badge>
-        ))}
-      </InlineStack>
-      {publishedBy && (
         <Text size="xs" tone="subdued">
-          by {publishedBy}
+          Sources
         </Text>
-      )}
-      {description && <Paragraph size="sm">{description}</Paragraph>}
-      {reason && (
+        {options.map(({ source, count }) => {
+          const key = sourceFilterKey(source);
+          const active = !disabled.has(key);
+          return (
+            <Button
+              key={key}
+              type="button"
+              size="xs"
+              variant={active ? "secondary" : "outline"}
+              aria-pressed={active}
+              aria-label={`${active ? "Hide" : "Show"} ${source.label} source (${count} component${count === 1 ? "" : "s"})`}
+              onClick={() => onToggle(key)}
+              className={cn(!active && "opacity-60")}
+            >
+              <Icon
+                name="Package"
+                size="sm"
+                className={SOURCE_ICON_TONE_BY_KIND[source.kind]}
+              />
+              {source.label}
+              <Text as="span" size="xs" tone="subdued">
+                {count}
+              </Text>
+            </Button>
+          );
+        })}
+        {activeCount < options.length && (
+          <Button type="button" size="xs" variant="ghost" onClick={onEnableAll}>
+            Show all
+          </Button>
+        )}
+      </InlineStack>
+      {activeCount === 0 && (
         <Paragraph size="xs" tone="subdued">
-          Why: {reason}
+          No sources selected. Turn on at least one source to show components.
         </Paragraph>
       )}
     </BlockStack>
   );
 };
 
+// Built-in sources are constants — only registered libraries vary per row.
+const STANDARD_SOURCE: ComponentSource = {
+  kind: "standard",
+  label: "Standard",
+  id: "standard",
+};
+const PUBLISHED_SOURCE: ComponentSource = {
+  kind: "published",
+  label: "Published",
+  id: "published",
+};
+const USER_SOURCE: ComponentSource = {
+  kind: "user",
+  label: "User",
+  id: "user",
+};
+
+function registeredSource(library: StoredLibrary): ComponentSource {
+  return { kind: "registered", label: library.name, id: library.id };
+}
+
+type ComponentLibraryFolder = Parameters<typeof flattenFolders>[0];
+type UserFolder = { components?: ComponentReference[] };
+
+interface ComponentCardProps {
+  reference: ComponentReference;
+  source?: ComponentSource;
+  matchedFields?: MatchField[];
+  reason?: string;
+  isSelected?: boolean;
+  /** Position within the current result list — passed to analytics. */
+  position?: number;
+  /** Whether the user had typed a query when this card was rendered. */
+  hadQuery?: boolean;
+  onSelect: (reference: ComponentReference) => void;
+}
+
+const ComponentCard = ({
+  reference,
+  source,
+  matchedFields,
+  reason,
+  isSelected,
+  position,
+  hadQuery,
+  onSelect,
+}: ComponentCardProps) => {
+  const name = getComponentName(reference);
+  const description = reference.spec?.description;
+  const publishedBy = reference.published_by;
+  const trackingSource = source
+    ? TRACKING_SOURCE_BY_KIND[source.kind]
+    : "unknown";
+
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(reference)}
+      aria-pressed={isSelected}
+      aria-label={`View details for ${name}`}
+      className={cn(
+        PANEL_CLASS,
+        // Card is a button: align text, full width, subtle hover, focus ring.
+        "w-full text-left cursor-pointer transition-colors",
+        "hover:bg-muted/40",
+        "focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:border-ring",
+        // Selected state: left accent bar + tinted background.
+        isSelected &&
+          "bg-muted/60 border-l-4 border-l-primary pl-[calc(0.75rem-3px)]",
+      )}
+      {...tracking("component_library.result_card_v2", {
+        ...componentMetadata(reference, trackingSource),
+        surface: "dashboard_v2",
+        result_position: position,
+        had_query: hadQuery,
+        source_kind: source?.kind,
+      })}
+    >
+      {/* min-w-0 so the flex column can shrink below its content width;
+          without this, long unbroken URLs in the description force the
+          card to grow horizontally. */}
+      <BlockStack gap="2" className="min-w-0">
+        <InlineStack gap="2" blockAlign="center" wrap="wrap">
+          {source ? (
+            <QuickTooltip content={source.label}>
+              <Icon
+                name="Package"
+                size="sm"
+                className={SOURCE_ICON_TONE_BY_KIND[source.kind]}
+                aria-label={`Source: ${source.label}`}
+              />
+            </QuickTooltip>
+          ) : (
+            <Icon name="Package" size="sm" />
+          )}
+          <Text size="sm" weight="semibold">
+            {name}
+          </Text>
+          {matchedFields?.map((field) => (
+            <Badge key={field} variant="secondary">
+              matched: {MATCH_FIELD_LABEL[field]}
+            </Badge>
+          ))}
+        </InlineStack>
+        {publishedBy && (
+          <Text size="xs" tone="subdued">
+            by {publishedBy}
+          </Text>
+        )}
+        {description && (
+          // `[overflow-wrap:anywhere]` breaks at any character if needed —
+          // `break-words` only breaks at word boundaries, which doesn't help
+          // for long URLs without spaces. Pair with `min-w-0` on the parent
+          // so the flex container actually allows shrinking.
+          <Paragraph size="sm" className="[overflow-wrap:anywhere] min-w-0">
+            {description}
+          </Paragraph>
+        )}
+        {reason && (
+          <Paragraph size="xs" tone="subdued">
+            Why: {reason}
+          </Paragraph>
+        )}
+      </BlockStack>
+    </button>
+  );
+};
+
 /**
- * Build the flat, deduped list of unhydrated component references from the
- * two library sources. Hydration happens separately because the static YAML
- * library returns refs with only `url` and `digest` set — we need to fetch
- * each YAML to get name/description/inputs/outputs.
+ * Merge every component source the rest of the app knows about into a single
+ * deduped, source-attributed list.
+ *
+ * Order matters: the first occurrence of a digest wins. Priority is
+ * `standard > published > registered > user` so the most canonical label
+ * sticks when the same component appears in multiple places.
  */
-function collectRawReferences(
-  componentLibrary: ComponentLibraryFolder | undefined,
-  userFolder: UserFolder | undefined,
-): ComponentReference[] {
-  const standard = componentLibrary ? flattenFolders(componentLibrary) : [];
-  const user = userFolder?.components ?? [];
-  return filterToUniqueByDigest([...standard, ...user]);
+function collectAllSourcedReferences({
+  standardLibrary,
+  publishedRefs,
+  registeredSourced,
+  userFolder,
+}: {
+  standardLibrary: ComponentLibraryFolder | undefined;
+  publishedRefs: ComponentReference[];
+  registeredSourced: SourcedReference[];
+  userFolder: UserFolder | undefined;
+}): SourcedReference[] {
+  const all: SourcedReference[] = [];
+
+  if (standardLibrary) {
+    for (const ref of flattenFolders(standardLibrary)) {
+      all.push({ reference: ref, source: STANDARD_SOURCE });
+    }
+  }
+  for (const ref of publishedRefs) {
+    all.push({ reference: ref, source: PUBLISHED_SOURCE });
+  }
+  for (const sr of registeredSourced) {
+    all.push(sr);
+  }
+  for (const ref of userFolder?.components ?? []) {
+    all.push({ reference: ref, source: USER_SOURCE });
+  }
+
+  // Dedupe by digest, preserving the first occurrence (which carries the
+  // higher-priority source label). Refs without digests are dropped — the
+  // search index requires them for LLM round-trip anyway.
+  const seen = new Set<string>();
+  const out: SourcedReference[] = [];
+  for (const item of all) {
+    const digest = item.reference.digest;
+    if (!digest || seen.has(digest)) continue;
+    seen.add(digest);
+    out.push(item);
+  }
+  return out;
 }
 
 export const DashboardComponentsV2View = () => {
   const queryClient = useQueryClient();
+  const { backendUrl, configured, available } = useBackend();
   const [query, setQuery] = useState("");
+  const [disabledSourceKeys, setDisabledSourceKeys] = useState<string[]>([]);
 
-  // Deferred query lets the input stay snappy while the (cheap) lexical
-  // search runs against the deferred value. React 19 native — no debounce
-  // library, no useEffect timers.
-  const deferredQuery = useDeferredValue(query);
+  // Detail-pane selection lives in the URL so refreshes preserve it and the
+  // selection can be linked-to. The V2 route has no validateSearch defined.
+  const navigate = useNavigate();
+  const { component: selectedDigest } = useSearch({ strict: false }) as {
+    component?: string;
+  };
+  const selectComponent = (reference: ComponentReference) => {
+    navigate({
+      to: APP_ROUTES.DASHBOARD_COMPONENTS_V2,
+      search: { component: reference.digest },
+    });
+  };
+  const closeDetail = () => {
+    navigate({ to: APP_ROUTES.DASHBOARD_COMPONENTS_V2, search: {} });
+  };
+
+  // Close detail on Escape — only when something is open, so we don't fight
+  // other Esc handlers (e.g. inside Inputs). Navigate inline so the effect has
+  // no callback dep that would re-bind on every render.
+  useEffect(() => {
+    if (!selectedDigest) return;
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        navigate({ to: APP_ROUTES.DASHBOARD_COMPONENTS_V2, search: {} });
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [selectedDigest, navigate]);
+
+  // The dashboard search page doesn't mount `ComponentLibraryProvider` (which
+  // is editor-scoped), so the GitHub library factory isn't auto-registered.
+  // This runs once and is idempotent.
+  useEffect(() => {
+    ensureLibraryFactoriesRegistered();
+  }, []);
 
   const { data: componentLibrary, isLoading: libraryLoading } = useQuery({
     queryKey: ["componentLibrary"],
@@ -139,11 +424,94 @@ export const DashboardComponentsV2View = () => {
     refetchOnMount: "always",
   });
 
-  const rawReferences = collectRawReferences(componentLibrary, userFolder);
+  // Published components (backend). Gated on the backend being reachable; if
+  // it isn't, we silently search without published rather than erroring —
+  // matches the V1 dashboard behaviour.
+  const { data: publishedRefs = [], isLoading: publishedLoading } = useQuery({
+    queryKey: ["component-search-v2", "published", backendUrl],
+    enabled: configured && available,
+    staleTime: HOURS,
+    queryFn: async (): Promise<ComponentReference[]> => {
+      const result = await listApiPublishedComponentsGet({});
+      if (result.response.status !== 200 || !result.data) return [];
+      const list = result.data.published_components ?? [];
+      return list
+        .filter((c) => !c.deprecated)
+        .map((c) => ({
+          digest: c.digest,
+          // Backend may return null; normalize to undefined to fit ComponentReference.
+          name: c.name ?? undefined,
+          url: c.url ?? `${backendUrl}/api/components/${c.digest}`,
+          published_by: c.published_by,
+        }));
+    },
+  });
+
+  // Dexie is only the source of which libraries are registered. Fetching
+  // remote/GitHub library contents stays in TanStack Query so loading, errors,
+  // and cache lifetime follow the rest of the app's server-state conventions.
+  const registeredLibraries = useLiveQuery<StoredLibrary[], StoredLibrary[]>(
+    async () => {
+      ensureLibraryFactoriesRegistered();
+      return LibraryDB.component_libraries.toArray();
+    },
+    [],
+    [],
+  );
+
+  const { data: registeredSourced = [], isLoading: registeredQueryLoading } =
+    useQuery({
+      queryKey: [
+        "component-search-v2",
+        "registered-libraries",
+        registeredLibraries,
+      ],
+      enabled: registeredLibraries !== undefined,
+      staleTime: HOURS,
+      queryFn: async (): Promise<SourcedReference[]> => {
+        if (!registeredLibraries || registeredLibraries.length === 0) return [];
+
+        const results = await Promise.allSettled(
+          registeredLibraries.map(async (storage) => {
+            const lib = createLibraryObject(storage);
+            const folder: ComponentFolder = await lib.getComponents({});
+            return { storage, folder };
+          }),
+        );
+
+        const out: SourcedReference[] = [];
+        for (const result of results) {
+          if (result.status !== "fulfilled") {
+            // One broken library shouldn't kill the whole search.
+            console.warn(
+              "Components V2: registered library failed to load",
+              result.reason,
+            );
+            continue;
+          }
+          const source = registeredSource(result.value.storage);
+          for (const ref of flattenFolders(result.value.folder)) {
+            out.push({ reference: ref, source });
+          }
+        }
+        return out;
+      },
+    });
+
+  const registeredLoading =
+    registeredLibraries === undefined || registeredQueryLoading;
+
+  const allSourced = collectAllSourcedReferences({
+    standardLibrary: componentLibrary,
+    publishedRefs,
+    registeredSourced,
+    userFolder,
+  });
+
   // Fingerprint of which refs are in play. Changes when the library set
   // changes, so the hydration cache invalidates appropriately.
-  const referencesFingerprint = rawReferences
-    .map((r) => r.digest ?? r.url ?? "")
+  const referencesFingerprint = allSourced
+    .map((s) => s.reference.digest ?? s.reference.url ?? "")
     .sort()
     .join("|");
 
@@ -151,18 +519,22 @@ export const DashboardComponentsV2View = () => {
   // background refetch shouldn't flip the page back to a skeleton state.
   const { data: hydratedReferences, isLoading: hydrating } = useQuery({
     queryKey: ["component-search-v2", "hydrate-library", referencesFingerprint],
-    enabled: rawReferences.length > 0,
+    enabled: allSourced.length > 0,
     staleTime: HOURS,
     queryFn: async () => {
       const results = await Promise.all(
-        rawReferences.map((ref) =>
+        allSourced.map((sourced) =>
           // Reuse the same cache key as useHydrateComponentReference so
           // individual component cards elsewhere in the app share hydration.
           queryClient
             .ensureQueryData({
-              queryKey: ["component", "hydrate", getComponentQueryKey(ref)],
+              queryKey: [
+                "component",
+                "hydrate",
+                getComponentQueryKey(sourced.reference),
+              ],
               staleTime: HOURS,
-              queryFn: () => hydrateComponentReference(ref),
+              queryFn: () => hydrateComponentReference(sourced.reference),
             })
             .catch(() => null),
         ),
@@ -171,17 +543,35 @@ export const DashboardComponentsV2View = () => {
     },
   });
 
-  // The search index is a pure derivation from hydrated refs. React
-  // Compiler will memoize this; `hydratedReferences` is a stable reference
-  // from React Query when nothing has changed.
-  const index: IndexEntry[] = buildSearchIndex(hydratedReferences ?? []);
-  const total = index.length;
+  // Pair hydrated refs back with their source by digest. Hydration preserves
+  // digests, so this is a straightforward join.
+  const sourceByDigest = new Map(
+    allSourced.map((s) => [s.reference.digest, s.source] as const),
+  );
+  const sourcedHydrated: SourcedReference[] = [];
+  for (const reference of hydratedReferences ?? []) {
+    const source = sourceByDigest.get(reference.digest);
+    if (!source) continue;
+    sourcedHydrated.push({ reference, source });
+  }
+
+  // The search index is a pure derivation. React Compiler will memoize this.
+  const index: IndexEntry[] = buildSearchIndex(sourcedHydrated);
+  const sourceFilterOptions = createSourceFilterOptions(index);
+  const disabledSourceKeySet = new Set(disabledSourceKeys);
+  const filteredIndex = index.filter(
+    (entry) => !disabledSourceKeySet.has(sourceFilterKey(entry.source)),
+  );
+  const total = filteredIndex.length;
+  const totalAcrossSources = index.length;
 
   // Alphabetical order for the browse-all view. Predictable scrolling beats
   // "whatever order the library happened to load in."
-  const sortedIndex = [...index].sort((a, b) => a.name.localeCompare(b.name));
+  const sortedIndex = [...filteredIndex].sort((a, b) =>
+    a.name.localeCompare(b.name),
+  );
 
-  const lexicalMatches: LexicalMatch[] = lexicalSearch(index, deferredQuery, {
+  const lexicalMatches: LexicalMatch[] = lexicalSearch(filteredIndex, query, {
     limit: LEXICAL_RESULT_LIMIT,
   });
 
@@ -201,8 +591,6 @@ export const DashboardComponentsV2View = () => {
 
   const handleQueryChange = (event: ChangeEvent<HTMLInputElement>) => {
     setQuery(event.target.value);
-    // Any edit invalidates the rerank. Cheaper to drop it than to think
-    // about staleness.
     if (rerankedFor !== null) {
       setRerankedFor(null);
       resetRerank();
@@ -223,8 +611,33 @@ export const DashboardComponentsV2View = () => {
     rerank({ query: trimmed, candidates });
   };
 
-  const isLoadingLibrary = libraryLoading || userLoading || hydrating;
-  const noLibraryData = !isLoadingLibrary && total === 0;
+  const handleSourceToggle = (sourceKey: string) => {
+    setDisabledSourceKeys((current) =>
+      current.includes(sourceKey)
+        ? current.filter((key) => key !== sourceKey)
+        : [...current, sourceKey],
+    );
+    if (rerankedFor !== null) {
+      setRerankedFor(null);
+      resetRerank();
+    }
+  };
+
+  const handleEnableAllSources = () => {
+    setDisabledSourceKeys([]);
+    if (rerankedFor !== null) {
+      setRerankedFor(null);
+      resetRerank();
+    }
+  };
+
+  const isLoadingLibrary =
+    libraryLoading ||
+    userLoading ||
+    publishedLoading ||
+    registeredLoading ||
+    hydrating;
+  const noLibraryData = !isLoadingLibrary && totalAcrossSources === 0;
   const trimmedQuery = query.trim();
   const isEmpty = trimmedQuery.length === 0;
   const isConfigError = rerankError instanceof NaturalLanguageSearchConfigError;
@@ -239,117 +652,272 @@ export const DashboardComponentsV2View = () => {
     ? mergeRerankIntoLexical(rerankData.matches, lexicalMatches)
     : lexicalMatches.map((m) => ({ ...m, reason: undefined }));
 
-  return (
-    <BlockStack gap="4" className={PAGE_CLASS}>
-      <BlockStack gap="1">
-        <Heading level={2}>Components V2</Heading>
-        <Paragraph size="sm" tone="subdued">
-          Type to search your component library. Results match on name,
-          description, inputs/outputs, and container command. Use AI search to
-          rerank with an LLM when literal matching isn&apos;t enough.
-        </Paragraph>
-      </BlockStack>
+  // Resolve the full reference for the selected digest. Prefer the already-
+  // hydrated copy (no extra network), fall back to the un-hydrated index
+  // entry, then to a backend stub. The shared ComponentDetail will suspend on
+  // hydration as needed and shares cache with the rest of the app.
+  const selectedReference: ComponentReference | undefined = (() => {
+    if (!selectedDigest) return undefined;
+    const hydrated = sourcedHydrated.find(
+      (s) => s.reference.digest === selectedDigest,
+    );
+    if (hydrated) return hydrated.reference;
+    const indexed = allSourced.find(
+      (s) => s.reference.digest === selectedDigest,
+    );
+    if (indexed) return indexed.reference;
+    return {
+      digest: selectedDigest,
+      url: `${backendUrl}/api/components/${selectedDigest}`,
+    };
+  })();
+  const isDetailOpen = Boolean(selectedDigest);
+  const notify = useToastNotification();
 
-      <InlineStack gap="3" blockAlign="center" wrap="nowrap">
-        <Input
-          type="search"
-          placeholder="e.g. train_test_split, pandas, clean up my data"
-          value={query}
-          onChange={handleQueryChange}
-          aria-label="Search components"
-          disabled={isLoadingLibrary || noLibraryData}
-          className="flex-1"
-        />
-        <Button
-          variant="secondary"
-          size="icon"
-          onClick={handleSmartSearch}
-          disabled={
-            isReranking ||
-            isEmpty ||
-            lexicalMatches.length === 0 ||
-            !isConfigured
-          }
-          aria-label={isReranking ? "AI search in progress" : "AI search"}
-          title="AI search — rerank these results with an LLM"
-        >
-          {isReranking ? <Spinner size={16} /> : <Icon name="Sparkles" />}
-        </Button>
-      </InlineStack>
+  const handleCopyToPipeline = async () => {
+    if (!selectedReference) return;
+    try {
+      await copyComponentReferenceToClipboard(selectedReference);
+      notify(
+        "Component copied. Paste (Cmd/Ctrl+V) into a pipeline to add it.",
+        "success",
+      );
+    } catch {
+      notify(
+        "Couldn't copy to clipboard. Check browser permissions and try again.",
+        "error",
+      );
+    }
+  };
 
-      {isLoadingLibrary && (
+  // Render helpers — keeps the JSX below tidy. These read the closed-over
+  // state from the surrounding component; React Compiler memoises them.
+  const renderResults = () => {
+    if (isLoadingLibrary) {
+      return (
         <BlockStack gap="2">
           <Skeleton className="h-20 w-full" />
           <Skeleton className="h-20 w-full" />
           <Skeleton className="h-20 w-full" />
         </BlockStack>
-      )}
-
-      {noLibraryData && (
+      );
+    }
+    if (noLibraryData) {
+      return (
         <Paragraph size="sm" tone="subdued">
           No components found in your library.
         </Paragraph>
-      )}
-
-      {!isLoadingLibrary && isEmpty && !noLibraryData && (
-        <BlockStack gap="2">
+      );
+    }
+    if (total === 0) {
+      return (
+        <Paragraph size="sm" tone="subdued">
+          No components in the selected sources.
+        </Paragraph>
+      );
+    }
+    if (isEmpty) {
+      return (
+        <BlockStack gap="2" align="stretch">
           <Paragraph size="xs" tone="subdued">
-            {total} components in your library. Start typing to search.
+            {total} component{total === 1 ? "" : "s"} in selected sources. Start
+            typing to search.
           </Paragraph>
-          {sortedIndex.map((entry) => (
-            <ComponentCard key={entry.digest} reference={entry.reference} />
+          {sortedIndex.map((entry, idx) => (
+            <ComponentCard
+              key={entry.digest}
+              reference={entry.reference}
+              source={entry.source}
+              isSelected={entry.digest === selectedDigest}
+              position={idx}
+              hadQuery={false}
+              onSelect={selectComponent}
+            />
           ))}
         </BlockStack>
-      )}
-
-      {!isEmpty && lexicalMatches.length === 0 && !isLoadingLibrary && (
+      );
+    }
+    if (lexicalMatches.length === 0) {
+      return (
         <Paragraph size="sm" tone="subdued">
           No components matched “{trimmedQuery}”. Try different terms or check
           for typos.
         </Paragraph>
-      )}
-
-      {!isConfigured && !isEmpty && lexicalMatches.length > 0 && (
-        <BlockStack gap="1" className={PANEL_CLASS}>
-          <Text size="sm" weight="semibold">
-            AI search unavailable
-          </Text>
-          <Paragraph size="sm" tone="subdued">
-            Configure an OpenAI-compatible API key to use AI search. Lexical
-            results above are unaffected.
-          </Paragraph>
-          <Link to={APP_ROUTES.SETTINGS_AGENT}>
-            <Text size="sm" weight="semibold">
-              Configure in Settings →
-            </Text>
-          </Link>
-        </BlockStack>
-      )}
-
-      {rerankError && !isConfigError && rerankError instanceof Error && (
-        <Paragraph size="sm" tone="subdued">
-          AI search failed: {rerankError.message}
+      );
+    }
+    return (
+      <BlockStack gap="2" align="stretch">
+        <Paragraph size="xs" tone="subdued">
+          {rerankActive
+            ? `AI-reranked ${displayedResults.length} result${displayedResults.length === 1 ? "" : "s"} for “${trimmedQuery}”`
+            : `${displayedResults.length} result${displayedResults.length === 1 ? "" : "s"} for “${trimmedQuery}”`}
         </Paragraph>
-      )}
+        {displayedResults.map((result, idx) => (
+          <ComponentCard
+            key={result.digest}
+            reference={result.reference}
+            source={result.source}
+            matchedFields={result.matchedFields}
+            reason={result.reason}
+            isSelected={result.digest === selectedDigest}
+            position={idx}
+            hadQuery={true}
+            onSelect={selectComponent}
+          />
+        ))}
+      </BlockStack>
+    );
+  };
 
-      {!isEmpty && displayedResults.length > 0 && (
-        <BlockStack gap="2">
-          <Paragraph size="xs" tone="subdued">
-            {rerankActive
-              ? `AI-reranked ${displayedResults.length} result${displayedResults.length === 1 ? "" : "s"} for “${trimmedQuery}”`
-              : `${displayedResults.length} result${displayedResults.length === 1 ? "" : "s"} for “${trimmedQuery}”`}
-          </Paragraph>
-          {displayedResults.map((result) => (
-            <ComponentCard
-              key={result.digest}
-              reference={result.reference}
-              matchedFields={result.matchedFields}
-              reason={result.reason}
+  return (
+    // App-shell layout: escape the dashboard's outer padding (`-mt-4 -mb-6
+    // -mx-8`) so we can paint a fixed-height shell with our own internal
+    // padding per zone. Header is always visible; the body below has two
+    // independent scroll columns.
+    <div
+      className="flex flex-col -mt-4 -mb-6 -mx-8 overflow-hidden"
+      style={{ height: `calc(100vh - ${TOP_NAV_HEIGHT}px)` }}
+    >
+      {/* Header zone: page title, description, search input. shrink-0 so it
+          never gets squeezed by the body below. */}
+      <div className="shrink-0 px-8 pt-4 pb-4 border-b border-border">
+        <BlockStack gap="3" align="stretch">
+          <BlockStack gap="1">
+            <Heading level={2}>Components V2</Heading>
+            <Paragraph size="sm" tone="subdued">
+              Type to search across every component source — standard library,
+              your published components, registered libraries, and local user
+              components. Results match on name, description, inputs/outputs,
+              and container command. Use AI search to rerank with an LLM when
+              literal matching isn&apos;t enough.
+            </Paragraph>
+          </BlockStack>
+          <InlineStack gap="3" blockAlign="center" wrap="nowrap">
+            <Input
+              type="search"
+              placeholder="e.g. train_test_split, pandas, clean up my data"
+              value={query}
+              onChange={handleQueryChange}
+              aria-label="Search components"
+              disabled={isLoadingLibrary || noLibraryData}
+              className="flex-1"
             />
-          ))}
+            <Button
+              variant="secondary"
+              size="icon"
+              onClick={handleSmartSearch}
+              disabled={
+                isReranking ||
+                isEmpty ||
+                lexicalMatches.length === 0 ||
+                !isConfigured
+              }
+              aria-label={isReranking ? "AI search in progress" : "AI search"}
+              title="AI search — rerank these results with an LLM"
+            >
+              {isReranking ? <Spinner size={16} /> : <Icon name="Sparkles" />}
+            </Button>
+          </InlineStack>
+          <SourceFilterBar
+            options={sourceFilterOptions}
+            disabledSourceKeys={disabledSourceKeys}
+            onToggle={handleSourceToggle}
+            onEnableAll={handleEnableAllSources}
+          />
         </BlockStack>
-      )}
-    </BlockStack>
+      </div>
+
+      {/* Body zone: two scroll columns. `min-h-0` is required so the flex
+          children can shrink and scroll instead of growing the parent. */}
+      <div className="flex-1 min-h-0 flex">
+        {/* Results column — own scroll. When detail is open, narrows to a
+            fixed width with a divider; otherwise fills the whole body. */}
+        <div
+          className={cn(
+            "min-w-0 overflow-y-auto px-8 py-4",
+            isDetailOpen
+              ? "w-[360px] shrink-0 border-r border-border"
+              : "flex-1",
+          )}
+        >
+          {/* AI-search-unavailable banner and rerank error live in the
+              results column — they describe what just happened to the search
+              the user is looking at. */}
+          {!isConfigured && !isEmpty && lexicalMatches.length > 0 && (
+            <BlockStack gap="1" className={cn(PANEL_CLASS, "mb-3")}>
+              <Text size="sm" weight="semibold">
+                AI search unavailable
+              </Text>
+              <Paragraph size="sm" tone="subdued">
+                Configure an OpenAI-compatible API key to use AI search. Lexical
+                results above are unaffected.
+              </Paragraph>
+              <Link to={APP_ROUTES.SETTINGS_AGENT}>
+                <Text size="sm" weight="semibold">
+                  Configure in Settings →
+                </Text>
+              </Link>
+            </BlockStack>
+          )}
+          {rerankError && !isConfigError && rerankError instanceof Error && (
+            <Paragraph size="sm" tone="subdued" className="mb-3">
+              AI search failed: {rerankError.message}
+            </Paragraph>
+          )}
+          {renderResults()}
+        </div>
+
+        {/* Detail column — own scroll. Close button sticky to the top of
+            this column's scroll viewport so it stays reachable. */}
+        {isDetailOpen && selectedReference && (
+          <div
+            role="region"
+            aria-label="Component details"
+            className="flex-1 min-w-0 overflow-y-auto px-8 py-4 relative"
+          >
+            {/* Sticky action row: copy + close. `float-right` here is
+                intentional — it lets the row sit above the content without
+                taking flow space, and the detail's first heading flows up
+                next to it. Wrapping in a sticky inline-block keeps both
+                buttons pinned together. */}
+            <div className="sticky top-0 float-right z-10 flex gap-1 bg-background/80 backdrop-blur-sm rounded-md">
+              <QuickTooltip content="Copy to clipboard" side="bottom">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={handleCopyToPipeline}
+                  aria-label="Copy component to clipboard"
+                  {...tracking("component_library.result_detail_v2.copy", {
+                    surface: "dashboard_v2",
+                  })}
+                >
+                  <Icon name="Copy" />
+                </Button>
+              </QuickTooltip>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={closeDetail}
+                aria-label="Close component details"
+                {...tracking("component_library.result_detail_v2.close", {
+                  surface: "dashboard_v2",
+                })}
+              >
+                <Icon name="X" />
+              </Button>
+            </div>
+            <SuspenseWrapper fallback={<ComponentDetailSkeleton />}>
+              <ComponentDetail
+                key={selectedDigest}
+                reference={selectedReference}
+                layout="stacked"
+                sourcePanelHeight="480px"
+              />
+            </SuspenseWrapper>
+          </div>
+        )}
+      </div>
+    </div>
   );
 };
 

--- a/src/routes/Dashboard/DashboardComponentsView.tsx
+++ b/src/routes/Dashboard/DashboardComponentsView.tsx
@@ -3,11 +3,11 @@ import { useNavigate, useSearch } from "@tanstack/react-router";
 import { type ReactNode, useEffect, useState } from "react";
 
 import type { ListPublishedComponentsResponse } from "@/api/types.gen";
-import { CodeViewer } from "@/components/shared/CodeViewer";
-import { CopyText } from "@/components/shared/CopyText/CopyText";
+import {
+  ComponentDetail,
+  ComponentDetailSkeleton,
+} from "@/components/shared/ComponentDetail/ComponentDetail";
 import { SuspenseWrapper } from "@/components/shared/SuspenseWrapper";
-import { GithubDetails } from "@/components/shared/TaskDetails/GithubDetails";
-import { Badge } from "@/components/ui/badge";
 import {
   Collapsible,
   CollapsibleContent,
@@ -17,8 +17,7 @@ import { Icon } from "@/components/ui/icon";
 import { Input } from "@/components/ui/input";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Heading, Paragraph, Text } from "@/components/ui/typography";
-import { useHydrateComponentReference } from "@/hooks/useHydrateComponentReference";
+import { Paragraph, Text } from "@/components/ui/typography";
 import { cn } from "@/lib/utils";
 import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { useBackend } from "@/providers/BackendProvider";
@@ -29,11 +28,7 @@ import {
 import { APP_ROUTES } from "@/routes/router";
 import { fetchAndStoreComponentLibrary } from "@/services/componentService";
 import type { ComponentFolder } from "@/types/componentLibrary";
-import type {
-  ComponentReference,
-  InputSpec,
-  OutputSpec,
-} from "@/utils/componentSpec";
+import type { ComponentReference } from "@/utils/componentSpec";
 import { componentMetadata } from "@/utils/componentTracking";
 import { TOP_NAV_HEIGHT } from "@/utils/constants";
 import { fetchWithErrorHandling } from "@/utils/fetchWithErrorHandling";
@@ -365,243 +360,12 @@ const ComponentList = ({
   );
 };
 
-// ─── Compact I/O table ───────────────────────────────────────────────────────
-
-const IORow = ({
-  name,
-  type,
-  required,
-  defaultValue,
-  description,
-}: {
-  name: string;
-  type?: unknown;
-  required?: boolean;
-  defaultValue?: unknown;
-  description?: string;
-}) => (
-  <div className="grid grid-cols-[1fr_auto_auto] items-start gap-x-3 gap-y-0.5 px-3 py-2 border-b border-border/50 last:border-0">
-    <div className="flex flex-col gap-0.5 min-w-0">
-      <Text size="xs" weight="semibold" className="truncate font-mono">
-        {name}
-      </Text>
-      {description && (
-        <Text size="xs" className="text-muted-foreground leading-snug">
-          {description}
-        </Text>
-      )}
-      {defaultValue !== undefined && (
-        <Text size="xs" className="text-muted-foreground">
-          Default: <span className="font-mono">{String(defaultValue)}</span>
-        </Text>
-      )}
-    </div>
-    <Text size="xs" className="text-muted-foreground shrink-0 pt-0.5">
-      {type ? String(type) : "—"}
-    </Text>
-    <Badge
-      className={cn(
-        "shrink-0 mt-0.5 text-[10px] font-semibold leading-none",
-        required
-          ? "bg-rose-100 text-rose-700 hover:bg-rose-100"
-          : "bg-muted text-muted-foreground hover:bg-muted",
-      )}
-    >
-      {required ? "req" : "opt"}
-    </Badge>
-  </div>
-);
-
-const CompactIO = ({
-  inputs,
-  outputs,
-}: {
-  inputs?: InputSpec[];
-  outputs?: OutputSpec[];
-}) => (
-  <BlockStack gap="3">
-    {inputs && inputs.length > 0 && (
-      <div>
-        <Text
-          size="xs"
-          className="text-muted-foreground font-medium uppercase tracking-wide px-1 mb-1"
-        >
-          Inputs
-        </Text>
-        <div className="border border-border rounded-md overflow-hidden">
-          {inputs.map((input) => (
-            <IORow
-              key={input.name}
-              name={input.name}
-              type={input.type}
-              required={!input.optional}
-              defaultValue={input.default}
-              description={input.description}
-            />
-          ))}
-        </div>
-      </div>
-    )}
-    {outputs && outputs.length > 0 && (
-      <div>
-        <Text
-          size="xs"
-          className="text-muted-foreground font-medium uppercase tracking-wide px-1 mb-1"
-        >
-          Outputs
-        </Text>
-        <div className="border border-border rounded-md overflow-hidden">
-          {outputs.map((output) => (
-            <IORow
-              key={output.name}
-              name={output.name}
-              type={output.type}
-              description={output.description}
-            />
-          ))}
-        </div>
-      </div>
-    )}
-  </BlockStack>
-);
-
-// ─── Detail Panel (Suspense) ────────────────────────────────────────────────
-
-const ComponentDetailInner = ({ digest }: { digest: string }) => {
-  const { backendUrl } = useBackend();
-  const componentRef: ComponentReference = {
-    digest,
-    url: `${backendUrl}/api/components/${digest}`,
-  };
-  const hydrated = useHydrateComponentReference(componentRef);
-
-  if (!hydrated?.spec) {
-    return (
-      <Paragraph tone="subdued" size="sm">
-        Could not load component details.
-      </Paragraph>
-    );
-  }
-
-  const { spec } = hydrated;
-  const annotations = spec.metadata?.annotations ?? {};
-  const author =
-    typeof annotations.author === "string" ? annotations.author : undefined;
-  const canonicalUrl =
-    typeof annotations.canonical_location === "string"
-      ? annotations.canonical_location
-      : undefined;
-  const gitRemoteUrl =
-    typeof annotations.git_remote_url === "string"
-      ? annotations.git_remote_url
-      : undefined;
-  const gitRemoteBranch =
-    typeof annotations.git_remote_branch === "string"
-      ? annotations.git_remote_branch
-      : undefined;
-  const gitRelativeDir =
-    typeof annotations.git_relative_dir === "string"
-      ? annotations.git_relative_dir
-      : undefined;
-  const componentYamlPath =
-    typeof annotations.component_yaml_path === "string"
-      ? annotations.component_yaml_path
-      : undefined;
-  const documentationPath =
-    typeof annotations.documentation_path === "string"
-      ? annotations.documentation_path
-      : undefined;
-
-  let reconstructedUrl: string | undefined;
-  let documentationUrl: string | undefined;
-
-  if (gitRemoteUrl && gitRemoteBranch && gitRelativeDir) {
-    const repoPath = gitRemoteUrl
-      .replace(/^https:\/\/github\.com\//, "")
-      .replace(/\.git$/, "");
-    const buildGitHubUrl = (filePath: string) =>
-      `https://github.com/${repoPath}/blob/${gitRemoteBranch}/${gitRelativeDir}/${filePath}`;
-    if (!hydrated.url && componentYamlPath)
-      reconstructedUrl = buildGitHubUrl(componentYamlPath);
-    if (documentationPath) documentationUrl = buildGitHubUrl(documentationPath);
-  }
-
-  const hasIO =
-    (spec.inputs && spec.inputs.length > 0) ||
-    (spec.outputs && spec.outputs.length > 0);
-
-  return (
-    // Side-by-side layout: info+IO on left, source code sticky on right
-    <InlineStack gap="6" blockAlign="start">
-      {/* Left: metadata + I/O — flows naturally with the page scroll */}
-      <div className="flex-2 min-w-0 flex flex-col gap-4">
-        {/* Header */}
-        <BlockStack gap="1">
-          <Heading level={2}>{spec.name ?? digest}</Heading>
-          {author && (
-            <Text size="sm" className="text-muted-foreground">
-              {author}
-            </Text>
-          )}
-          {hydrated.digest && (
-            <Badge
-              variant="outline"
-              className="font-mono text-xs min-w-0 max-w-full overflow-hidden"
-            >
-              <CopyText size="xs" className="font-mono truncate">
-                {hydrated.digest}
-              </CopyText>
-            </Badge>
-          )}
-        </BlockStack>
-
-        {spec.description && (
-          <Paragraph size="sm" tone="subdued">
-            {spec.description}
-          </Paragraph>
-        )}
-
-        <GithubDetails
-          url={hydrated.url ?? reconstructedUrl}
-          canonicalUrl={canonicalUrl}
-          documentationUrl={documentationUrl}
-        />
-
-        {hasIO && <CompactIO inputs={spec.inputs} outputs={spec.outputs} />}
-      </div>
-
-      {/* Right: source code — sticky so it stays in view while left side scrolls */}
-      {hydrated.text && (
-        <div className="flex-3 min-w-0">
-          <div
-            className="sticky top-0 flex flex-col gap-1.5"
-            style={{ height: `calc(100vh - ${TOP_NAV_HEIGHT + 48}px)` }}
-          >
-            <Text
-              size="xs"
-              className="text-muted-foreground font-medium uppercase tracking-wide shrink-0"
-            >
-              Source
-            </Text>
-            <div className="flex-1 min-h-0">
-              <CodeViewer
-                code={hydrated.text}
-                language="yaml"
-                filename={spec.name ?? "component.yaml"}
-              />
-            </div>
-          </div>
-        </div>
-      )}
-    </InlineStack>
-  );
-};
-
 // ─── Main View ──────────────────────────────────────────────────────────────
 
 export function DashboardComponentsView() {
   const [query, setQuery] = useState("");
   const navigate = useNavigate();
+  const { backendUrl } = useBackend();
   // useSearch strict:false is required here — this route has no validateSearch defined
   const { component: selectedDigest } = useSearch({ strict: false }) as {
     component?: string;
@@ -639,20 +403,13 @@ export function DashboardComponentsView() {
       {/* Right: detail panel — single scroll, source sticky on right */}
       <div className="flex-1 min-w-0 overflow-y-auto p-6">
         {selectedDigest ? (
-          <SuspenseWrapper
-            fallback={
-              <InlineStack gap="6">
-                <div className="flex-1 flex flex-col gap-3">
-                  <Skeleton className="h-6 w-48" />
-                  <Skeleton className="h-4 w-32" />
-                  <Skeleton className="h-4 w-full" />
-                  <Skeleton className="h-4 w-3/4" />
-                </div>
-                <Skeleton className="flex-3 min-w-0 h-64" />
-              </InlineStack>
-            }
-          >
-            <ComponentDetailInner digest={selectedDigest} />
+          <SuspenseWrapper fallback={<ComponentDetailSkeleton />}>
+            <ComponentDetail
+              reference={{
+                digest: selectedDigest,
+                url: `${backendUrl}/api/components/${selectedDigest}`,
+              }}
+            />
           </SuspenseWrapper>
         ) : (
           <InlineStack fill>

--- a/src/routes/Settings/sections/AgentSettings.test.tsx
+++ b/src/routes/Settings/sections/AgentSettings.test.tsx
@@ -1,0 +1,51 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AgentSettings } from "./AgentSettings";
+
+const STORAGE_KEY = "tangle.componentSearchV2.config";
+const mockNotify = vi.fn();
+
+vi.mock("@/hooks/useToastNotification", () => ({
+  default: () => mockNotify,
+}));
+
+describe("AgentSettings", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    mockNotify.mockClear();
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("shows inline feedback instead of saving when model is blank", () => {
+    render(<AgentSettings />);
+
+    fireEvent.change(screen.getByLabelText("API base URL"), {
+      target: { value: "https://api.example.com/v1" },
+    });
+    fireEvent.change(screen.getByLabelText("API key"), {
+      target: { value: "sk-test" },
+    });
+    fireEvent.change(screen.getByLabelText("Model id"), {
+      target: { value: "   " },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(
+      screen.getByText("Enter a model id before saving."),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Model id")).toHaveAttribute(
+      "aria-invalid",
+      "true",
+    );
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+    expect(mockNotify).not.toHaveBeenCalledWith(
+      "Agent settings saved",
+      "success",
+    );
+  });
+});

--- a/src/routes/Settings/sections/AgentSettings.tsx
+++ b/src/routes/Settings/sections/AgentSettings.tsx
@@ -3,6 +3,7 @@ import { type FormEvent, useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
 import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Separator } from "@/components/ui/separator";
 import { Heading, Paragraph, Text } from "@/components/ui/typography";
@@ -21,23 +22,36 @@ export function AgentSettings() {
 
   const [apiBase, setApiBase] = useState(config.apiBase);
   const [apiKey, setApiKey] = useState(config.apiKey);
+  const [model, setModel] = useState(config.model);
+  const [modelError, setModelError] = useState<string | null>(null);
   const [showKey, setShowKey] = useState(false);
   const [testing, setTesting] = useState(false);
 
   // Keep the form in sync if `config` changes externally (other tab, etc.).
   // We snapshot the saved values and rehydrate the inputs whenever they
   // differ — not on every render — so the user can keep editing.
-  const savedRef = useRef({ apiBase: config.apiBase, apiKey: config.apiKey });
+  const savedRef = useRef({
+    apiBase: config.apiBase,
+    apiKey: config.apiKey,
+    model: config.model,
+  });
   useEffect(() => {
     if (
       savedRef.current.apiBase !== config.apiBase ||
-      savedRef.current.apiKey !== config.apiKey
+      savedRef.current.apiKey !== config.apiKey ||
+      savedRef.current.model !== config.model
     ) {
-      savedRef.current = { apiBase: config.apiBase, apiKey: config.apiKey };
+      savedRef.current = {
+        apiBase: config.apiBase,
+        apiKey: config.apiKey,
+        model: config.model,
+      };
       setApiBase(config.apiBase);
       setApiKey(config.apiKey);
+      setModel(config.model);
+      setModelError(null);
     }
-  }, [config.apiBase, config.apiKey]);
+  }, [config.apiBase, config.apiKey, config.model]);
 
   // Abort in-flight test connections if the user navigates away.
   const testAbortRef = useRef<AbortController | null>(null);
@@ -51,11 +65,24 @@ export function AgentSettings() {
     event.preventDefault();
     const trimmedBase = apiBase.trim();
     const trimmedKey = apiKey.trim();
+    const trimmedModel = model.trim();
     // Reflect the trimmed values back into the inputs so what the user sees
     // matches what's stored.
     setApiBase(trimmedBase);
     setApiKey(trimmedKey);
-    update({ apiBase: trimmedBase, apiKey: trimmedKey });
+    setModel(trimmedModel);
+
+    if (!trimmedModel) {
+      setModelError("Enter a model id before saving.");
+      return;
+    }
+
+    setModelError(null);
+    update({
+      apiBase: trimmedBase,
+      apiKey: trimmedKey,
+      model: trimmedModel,
+    });
     notify("Agent settings saved", "success");
   };
 
@@ -63,6 +90,8 @@ export function AgentSettings() {
     clear();
     setApiBase("");
     setApiKey("");
+    setModel("");
+    setModelError(null);
     setShowKey(false);
     notify("Agent settings cleared", "success");
   };
@@ -129,10 +158,9 @@ export function AgentSettings() {
       <form onSubmit={handleSave}>
         <BlockStack gap="4">
           <BlockStack gap="1">
-            <Text size="sm" weight="semibold">
-              API base URL
-            </Text>
+            <Label htmlFor="agent-settings-api-base">API base URL</Label>
             <Input
+              id="agent-settings-api-base"
               type="url"
               placeholder="https://api.openai.com/v1"
               value={apiBase}
@@ -147,11 +175,10 @@ export function AgentSettings() {
           </BlockStack>
 
           <BlockStack gap="1">
-            <Text size="sm" weight="semibold">
-              API key
-            </Text>
+            <Label htmlFor="agent-settings-api-key">API key</Label>
             <InlineStack gap="2" blockAlign="center" wrap="nowrap">
               <Input
+                id="agent-settings-api-key"
                 type={showKey ? "text" : "password"}
                 placeholder="sk-… or provider-specific token"
                 value={apiKey}
@@ -173,6 +200,38 @@ export function AgentSettings() {
             </InlineStack>
             <Text size="xs" tone="subdued">
               Stored in browser localStorage. Clear it when sharing this device.
+            </Text>
+          </BlockStack>
+
+          <BlockStack gap="1">
+            <Label htmlFor="agent-settings-model">Model</Label>
+            <Input
+              id="agent-settings-model"
+              type="text"
+              placeholder="e.g. gpt-4o-mini, gemini-2.5-flash, claude-3-5-haiku"
+              value={model}
+              onChange={(e) => {
+                setModel(e.target.value);
+                if (modelError) setModelError(null);
+              }}
+              aria-label="Model id"
+              aria-invalid={modelError ? true : undefined}
+              aria-describedby={
+                modelError
+                  ? "agent-settings-model-error agent-settings-model-hint"
+                  : "agent-settings-model-hint"
+              }
+              autoComplete="off"
+              spellCheck={false}
+            />
+            {modelError && (
+              <Text id="agent-settings-model-error" size="xs" tone="critical">
+                {modelError}
+              </Text>
+            )}
+            <Text id="agent-settings-model-hint" size="xs" tone="subdued">
+              Model id sent to the provider for AI search reranking. Must be
+              available on the provider above.
             </Text>
           </BlockStack>
 

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -198,6 +198,11 @@ const settingsAgentRoute = createRoute({
   getParentRoute: () => settingsLayoutRoute,
   path: "/agent",
   component: AgentSettings,
+  beforeLoad: () => {
+    if (!isFlagEnabled("component-search-v2")) {
+      throw redirect({ to: APP_ROUTES.SETTINGS_BACKEND });
+    }
+  },
 });
 
 const settingsSecretsRoute = createRoute({

--- a/src/routes/v2/shared/clipboard/copyComponentReferenceToClipboard.ts
+++ b/src/routes/v2/shared/clipboard/copyComponentReferenceToClipboard.ts
@@ -1,0 +1,34 @@
+import type { NodeSnapshot } from "@/routes/v2/shared/nodes/types";
+import type { ComponentReference } from "@/utils/componentSpec";
+
+import { writeToSystemClipboard } from "./clipboardEnvelope";
+
+/**
+ * Build a single-task clipboard envelope from a component reference and write
+ * it to the system clipboard. The user can then paste (Cmd+V) inside the V2
+ * pipeline editor to drop a new task wired to this component.
+ *
+ * The task snapshot is intentionally minimal: no arguments, no execution
+ * options, no annotations. The paste clone handler assigns a fresh `$id` and
+ * positions the node at the paste target, so the entityId/position here are
+ * placeholders that get discarded on paste.
+ */
+export async function copyComponentReferenceToClipboard(
+  reference: ComponentReference,
+): Promise<void> {
+  const name = reference.spec?.name ?? reference.name ?? "task";
+  const snapshot: NodeSnapshot = {
+    $type: "task",
+    entityId: "",
+    name,
+    position: { x: 0, y: 0 },
+    data: {
+      componentRef: reference,
+      isEnabled: undefined,
+      arguments: [],
+      executionOptions: undefined,
+      annotations: [],
+    },
+  };
+  await writeToSystemClipboard([snapshot], []);
+}

--- a/src/services/componentSearchIndex.test.ts
+++ b/src/services/componentSearchIndex.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it } from "vitest";
+
+import type { ComponentReference } from "@/utils/componentSpec";
+
+import {
+  buildSearchIndex,
+  type ComponentSource,
+  lexicalSearch,
+  type SourcedReference,
+} from "./componentSearchIndex";
+
+const STANDARD: ComponentSource = {
+  kind: "standard",
+  label: "Standard",
+  id: "standard",
+};
+const USER: ComponentSource = { kind: "user", label: "User", id: "user" };
+
+function makeRef(
+  partial: Partial<ComponentReference> & { digest?: string },
+): ComponentReference {
+  return {
+    digest: partial.digest,
+    url: partial.url,
+    name: partial.name,
+    spec: partial.spec,
+  };
+}
+
+function makeSourced(
+  partial: Partial<ComponentReference> & { digest?: string },
+  source: ComponentSource = STANDARD,
+): SourcedReference {
+  return { reference: makeRef(partial), source };
+}
+
+describe("buildSearchIndex", () => {
+  it("skips references without a digest", () => {
+    const index = buildSearchIndex([
+      makeSourced({
+        digest: undefined,
+        spec: {
+          name: "no_digest",
+          inputs: [],
+          outputs: [],
+          implementation: { container: { image: "x" } },
+        },
+      }),
+    ]);
+    expect(index).toHaveLength(0);
+  });
+
+  it("skips references with no useful metadata", () => {
+    const index = buildSearchIndex([
+      makeSourced({
+        digest: "abc",
+        // No name, description, inputs, or outputs.
+        spec: {
+          inputs: [],
+          outputs: [],
+          implementation: { container: { image: "x" } },
+        },
+      }),
+    ]);
+    expect(index).toHaveLength(0);
+  });
+
+  it("preserves the source on each indexed entry", () => {
+    const index = buildSearchIndex([
+      makeSourced(
+        {
+          digest: "a",
+          spec: {
+            name: "train_model",
+            inputs: [],
+            outputs: [],
+            implementation: { container: { image: "x" } },
+          },
+        },
+        USER,
+      ),
+    ]);
+    expect(index).toHaveLength(1);
+    expect(index[0].source).toEqual(USER);
+  });
+
+  it("indexes name, description, io, and container command text", () => {
+    const index = buildSearchIndex([
+      makeSourced({
+        digest: "a",
+        spec: {
+          name: "train_model",
+          description: "Train a regression model on a dataset.",
+          inputs: [{ name: "dataset" }],
+          outputs: [{ name: "model" }],
+          implementation: {
+            container: {
+              image: "python:3.11",
+              command: ["python", "-m", "pandas.train"],
+              args: ["--epochs", "10"],
+            },
+          },
+        },
+      }),
+    ]);
+    expect(index).toHaveLength(1);
+    expect(index[0].searchable.name).toContain("train_model");
+    expect(index[0].searchable.description).toContain("regression");
+    expect(index[0].searchable.io).toContain("dataset");
+    expect(index[0].searchable.io).toContain("model");
+    expect(index[0].searchable.implementation).toContain("pandas.train");
+    expect(index[0].searchable.implementation).toContain("--epochs");
+  });
+});
+
+describe("lexicalSearch", () => {
+  const fixtures: SourcedReference[] = [
+    makeSourced({
+      digest: "a",
+      spec: {
+        name: "train_test_split",
+        description: "Split a dataset into train and test partitions.",
+        inputs: [{ name: "dataset" }],
+        outputs: [{ name: "train" }, { name: "test" }],
+        implementation: {
+          container: {
+            image: "python:3.11",
+            command: ["python", "-m", "sklearn"],
+          },
+        },
+      },
+    }),
+    makeSourced({
+      digest: "b",
+      spec: {
+        name: "drop_nulls",
+        description: "Drop rows containing null values from a dataframe.",
+        inputs: [{ name: "dataframe" }],
+        outputs: [{ name: "clean" }],
+        implementation: {
+          container: {
+            image: "python:3.11",
+            command: ["python", "-m", "pandas"],
+          },
+        },
+      },
+    }),
+    makeSourced(
+      {
+        digest: "c",
+        spec: {
+          name: "my_custom_train",
+          description: "User-built trainer.",
+          inputs: [],
+          outputs: [],
+          implementation: { container: { image: "x" } },
+        },
+      },
+      USER,
+    ),
+  ];
+
+  it("returns no results below the minimum query length", () => {
+    expect(lexicalSearch(buildSearchIndex(fixtures), "", {})).toHaveLength(0);
+    expect(
+      lexicalSearch(buildSearchIndex(fixtures), "tr", { minLength: 3 }),
+    ).toHaveLength(0);
+  });
+
+  it("ranks name matches higher than description-only matches", () => {
+    const index = buildSearchIndex(fixtures);
+    const results = lexicalSearch(index, "train");
+    expect(results.length).toBeGreaterThanOrEqual(2);
+    // Both train_test_split and my_custom_train match the name; drop_nulls
+    // doesn't match anywhere, so it must not appear.
+    expect(results.map((r) => r.digest)).not.toContain("b");
+  });
+
+  it("applies the multi-token full-substring bonus on the name", () => {
+    const index = buildSearchIndex(fixtures);
+    const results = lexicalSearch(index, "train test split");
+    expect(results[0]?.digest).toBe("a");
+  });
+
+  it("tokenizes snake_case queries so each segment matches independently", () => {
+    const index = buildSearchIndex(fixtures);
+    const results = lexicalSearch(index, "drop nulls");
+    expect(results[0]?.digest).toBe("b");
+  });
+
+  it("matches implementation/command text with the lowest weight", () => {
+    const index = buildSearchIndex(fixtures);
+    const results = lexicalSearch(index, "pandas");
+    expect(results[0]?.digest).toBe("b");
+    expect(results[0]?.matchedFields).toContain("implementation");
+  });
+
+  it("preserves the source on each returned match", () => {
+    const index = buildSearchIndex(fixtures);
+    const results = lexicalSearch(index, "my_custom_train");
+    expect(results[0]?.source).toEqual(USER);
+  });
+
+  it("respects the limit option", () => {
+    const many: SourcedReference[] = Array.from({ length: 10 }, (_, i) =>
+      makeSourced({
+        digest: `d${i}`,
+        spec: {
+          name: `train_${i}`,
+          inputs: [],
+          outputs: [],
+          implementation: { container: { image: "x" } },
+        },
+      }),
+    );
+    const results = lexicalSearch(buildSearchIndex(many), "train", {
+      limit: 3,
+    });
+    expect(results).toHaveLength(3);
+  });
+});

--- a/src/services/componentSearchIndex.ts
+++ b/src/services/componentSearchIndex.ts
@@ -18,6 +18,28 @@ import { getComponentName } from "@/utils/getComponentName";
 /** Which field of a component matched the query. Surfaced in the UI. */
 export type MatchField = "name" | "description" | "io" | "implementation";
 
+/**
+ * Where a component came from. Attached to every index entry and threaded
+ * through to UI cards as a source badge so users know whether a result is
+ * from the curated standard library, the backend's published catalog, a
+ * registered external library (e.g. GitHub), or their own user components.
+ */
+export interface ComponentSource {
+  kind: "standard" | "user" | "published" | "registered";
+  /** Short label shown in the UI badge (e.g. "Standard", "Published", or a library name). */
+  label: string;
+  /**
+   * Stable identifier for future filter chips / URL state. For built-in kinds
+   * this matches the kind; for `registered` libraries it's the stored library id.
+   */
+  id: string;
+}
+
+export interface SourcedReference {
+  reference: ComponentReference;
+  source: ComponentSource;
+}
+
 export interface IndexEntry {
   /** Full reference, kept so callers can render whatever they need. */
   reference: ComponentReference;
@@ -25,6 +47,8 @@ export interface IndexEntry {
   digest: string;
   /** Display name. */
   name: string;
+  /** Where this component came from. */
+  source: ComponentSource;
   /** Pre-lowercased searchable text, one per logical field. */
   searchable: Record<MatchField, string>;
 }
@@ -33,6 +57,7 @@ export interface LexicalMatch {
   reference: ComponentReference;
   digest: string;
   name: string;
+  source: ComponentSource;
   /** Which fields matched the query (for UX labels like "matched: command"). */
   matchedFields: MatchField[];
 }
@@ -76,17 +101,15 @@ function extractImplementationText(reference: ComponentReference): string {
 }
 
 /**
- * Build the searchable index from hydrated component references. References
- * without a digest are skipped (can't round-trip an LLM rerank without one).
- * References with no useful spec metadata are also skipped — they'd just be
- * noise that ranks below every real result.
+ * Build the searchable index from sourced, hydrated component references.
+ * References without a digest are skipped (can't round-trip an LLM rerank
+ * without one). References with no useful spec metadata are also skipped —
+ * they'd just be noise that ranks below every real result.
  */
-export function buildSearchIndex(
-  references: ComponentReference[],
-): IndexEntry[] {
+export function buildSearchIndex(sourced: SourcedReference[]): IndexEntry[] {
   const entries: IndexEntry[] = [];
 
-  for (const reference of references) {
+  for (const { reference, source } of sourced) {
     if (!reference.digest) continue;
 
     const spec = reference.spec;
@@ -115,6 +138,7 @@ export function buildSearchIndex(
       reference,
       digest: reference.digest,
       name,
+      source,
       searchable: {
         name: name.toLowerCase(),
         description: description.toLowerCase(),
@@ -225,6 +249,7 @@ export function lexicalSearch(
       reference: entry.reference,
       digest: entry.digest,
       name: entry.name,
+      source: entry.source,
       matchedFields,
       score,
     });

--- a/src/services/naturalLanguageComponentSearchService.test.ts
+++ b/src/services/naturalLanguageComponentSearchService.test.ts
@@ -1,0 +1,245 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ComponentReference } from "@/utils/componentSpec";
+
+import {
+  componentReferenceToCandidate,
+  NaturalLanguageSearchConfigError,
+  rerankComponentsByNaturalLanguage,
+} from "./naturalLanguageComponentSearchService";
+
+const VALID_OPTIONS = {
+  apiBase: "https://api.example.com/v1",
+  apiKey: "sk-test",
+  model: "gpt-4o-mini",
+};
+
+function mockChatResponse(content: unknown, status = 200) {
+  return {
+    ok: status === 200,
+    status,
+    statusText: status === 200 ? "OK" : "Internal Server Error",
+    json: () =>
+      Promise.resolve({
+        choices: [{ message: { content: JSON.stringify(content) } }],
+      }),
+    text: () => Promise.resolve("error body"),
+  } as unknown as Response;
+}
+
+describe("componentReferenceToCandidate", () => {
+  it("returns null for references without a digest", () => {
+    const ref: ComponentReference = {
+      spec: {
+        name: "no_digest",
+        inputs: [],
+        outputs: [],
+        implementation: { container: { image: "x" } },
+      },
+    };
+    expect(componentReferenceToCandidate(ref)).toBeNull();
+  });
+
+  it("returns null when the reference has no useful metadata", () => {
+    const ref: ComponentReference = {
+      digest: "abc",
+      spec: {
+        inputs: [],
+        outputs: [],
+        implementation: { container: { image: "x" } },
+      },
+    };
+    expect(componentReferenceToCandidate(ref)).toBeNull();
+  });
+
+  it("omits empty inputs/outputs from the candidate", () => {
+    const ref: ComponentReference = {
+      digest: "abc",
+      spec: {
+        name: "train",
+        description: "trainer",
+        inputs: [],
+        outputs: [],
+        implementation: { container: { image: "x" } },
+      },
+    };
+    const candidate = componentReferenceToCandidate(ref);
+    expect(candidate).toEqual({
+      id: "abc",
+      name: "train",
+      description: "trainer",
+    });
+  });
+
+  it("includes input/output names when present", () => {
+    const ref: ComponentReference = {
+      digest: "abc",
+      spec: {
+        name: "train",
+        description: "",
+        inputs: [{ name: "dataset" }],
+        outputs: [{ name: "model" }],
+        implementation: { container: { image: "x" } },
+      },
+    };
+    expect(componentReferenceToCandidate(ref)).toEqual({
+      id: "abc",
+      name: "train",
+      description: "",
+      inputs: ["dataset"],
+      outputs: ["model"],
+    });
+  });
+});
+
+describe("rerankComponentsByNaturalLanguage", () => {
+  beforeEach(() => {
+    global.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns an empty result for an empty query", async () => {
+    const result = await rerankComponentsByNaturalLanguage(
+      "",
+      [{ id: "a", name: "n", description: "d" }],
+      VALID_OPTIONS,
+    );
+    expect(result.matches).toEqual([]);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("returns an empty result when no candidates are provided", async () => {
+    const result = await rerankComponentsByNaturalLanguage(
+      "train",
+      [],
+      VALID_OPTIONS,
+    );
+    expect(result.matches).toEqual([]);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("throws NaturalLanguageSearchConfigError when API base or key is missing", async () => {
+    await expect(
+      rerankComponentsByNaturalLanguage(
+        "train",
+        [{ id: "a", name: "n", description: "d" }],
+        { ...VALID_OPTIONS, apiKey: "" },
+      ),
+    ).rejects.toBeInstanceOf(NaturalLanguageSearchConfigError);
+
+    await expect(
+      rerankComponentsByNaturalLanguage(
+        "train",
+        [{ id: "a", name: "n", description: "d" }],
+        { ...VALID_OPTIONS, apiBase: "" },
+      ),
+    ).rejects.toBeInstanceOf(NaturalLanguageSearchConfigError);
+  });
+
+  it("throws NaturalLanguageSearchConfigError when model is missing", async () => {
+    await expect(
+      rerankComponentsByNaturalLanguage(
+        "train",
+        [{ id: "a", name: "n", description: "d" }],
+        { ...VALID_OPTIONS, model: "" },
+      ),
+    ).rejects.toBeInstanceOf(NaturalLanguageSearchConfigError);
+  });
+
+  it("filters out hallucinated ids the model returned", async () => {
+    vi.mocked(global.fetch).mockResolvedValue(
+      mockChatResponse({
+        matches: [
+          { id: "a", score: 0.9, reason: "best fit" },
+          { id: "ghost", score: 0.8, reason: "made up" },
+        ],
+      }),
+    );
+
+    const result = await rerankComponentsByNaturalLanguage(
+      "train",
+      [{ id: "a", name: "trainer", description: "" }],
+      VALID_OPTIONS,
+    );
+    expect(result.matches.map((m) => m.id)).toEqual(["a"]);
+  });
+
+  it("clamps out-of-range score values into [0, 1]", async () => {
+    // NaN scores are intentionally not tested here: JSON.stringify({score: NaN})
+    // serializes to `null`, which never reaches `normalizeScore` because
+    // `isValidMatch` rejects it upstream.
+    vi.mocked(global.fetch).mockResolvedValue(
+      mockChatResponse({
+        matches: [
+          { id: "a", score: 1.5, reason: "over" },
+          { id: "b", score: -0.4, reason: "under" },
+        ],
+      }),
+    );
+
+    const result = await rerankComponentsByNaturalLanguage(
+      "train",
+      [
+        { id: "a", name: "a", description: "" },
+        { id: "b", name: "b", description: "" },
+      ],
+      VALID_OPTIONS,
+    );
+    const byId = Object.fromEntries(result.matches.map((m) => [m.id, m.score]));
+    expect(byId.a).toBe(1);
+    expect(byId.b).toBe(0);
+  });
+
+  it("returns empty matches when the response shape is wrong, but keeps raw content", async () => {
+    vi.mocked(global.fetch).mockResolvedValue(
+      mockChatResponse({ matches: "not an array" }),
+    );
+
+    const result = await rerankComponentsByNaturalLanguage(
+      "train",
+      [{ id: "a", name: "trainer", description: "" }],
+      VALID_OPTIONS,
+    );
+    expect(result.matches).toEqual([]);
+    expect(result.rawContent).toContain("not an array");
+  });
+
+  it("uses max_completion_tokens for gpt-5 / o-series models", async () => {
+    vi.mocked(global.fetch).mockResolvedValue(
+      mockChatResponse({ matches: [] }),
+    );
+
+    await rerankComponentsByNaturalLanguage(
+      "train",
+      [{ id: "a", name: "a", description: "" }],
+      { ...VALID_OPTIONS, model: "gpt-5-mini" },
+    );
+
+    const call = vi.mocked(global.fetch).mock.calls[0];
+    const body = JSON.parse(call?.[1]?.body as string);
+    expect(body.max_completion_tokens).toBeDefined();
+    expect(body.max_tokens).toBeUndefined();
+    expect(body.temperature).toBeUndefined();
+  });
+
+  it("uses max_tokens and temperature for non-reasoning models", async () => {
+    vi.mocked(global.fetch).mockResolvedValue(
+      mockChatResponse({ matches: [] }),
+    );
+
+    await rerankComponentsByNaturalLanguage(
+      "train",
+      [{ id: "a", name: "a", description: "" }],
+      VALID_OPTIONS,
+    );
+
+    const call = vi.mocked(global.fetch).mock.calls[0];
+    const body = JSON.parse(call?.[1]?.body as string);
+    expect(body.max_tokens).toBeDefined();
+    expect(body.max_completion_tokens).toBeUndefined();
+    expect(body.temperature).toBe(0);
+  });
+});


### PR DESCRIPTION
## Description

The dashboard Components V2 search page now aggregates components from all four sources — the curated standard library, backend-published components, registered external libraries (e.g. GitHub repos), and local user components — into a single unified, deduplicated search index. Each component card displays a source badge (e.g. "Standard", "Published", or the library name) so users can immediately tell where a result originates.

Previously, the search only covered the standard library and user components. Published components from the backend and registered external libraries were silently omitted.

Key changes:
- A `ComponentSource` type and `SourcedReference` wrapper are introduced in `componentSearchIndex.ts` so that source attribution is carried through the entire pipeline — from collection, through hydration, into the index, and out to the UI.
- `buildSearchIndex` and `lexicalSearch` now accept `SourcedReference[]` instead of plain `ComponentReference[]`, and `IndexEntry` / `LexicalMatch` both carry a `source` field.
- `collectAllSourcedReferences` replaces `collectRawReferences`, merging all four sources with a priority-ordered deduplication strategy (`standard > published > registered > user`).
- Published components are fetched directly from the backend API, gated on the backend being configured and reachable. If unavailable, the search degrades gracefully without erroring.
- Registered external libraries are read directly from Dexie and instantiated via the library factory, without requiring the editor-scoped `ComponentLibraryProvider` to be mounted.
- A new `ensureLibraryFactoriesRegistered` utility provides idempotent factory registration so the dashboard page can instantiate stored libraries independently of the editor.
- `useDeferredValue` is removed in favour of passing the query directly to `lexicalSearch`.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Open the dashboard Components V2 page.
2. Verify components from the standard library, any registered GitHub libraries, published backend components, and user components all appear in the browse list.
3. Confirm each card displays the correct source badge.
4. Search by name, description, input/output, or command and confirm results from multiple sources appear together.
5. Disable backend connectivity and confirm the page loads without errors, omitting published components silently.
6. Add a registered external library and confirm its components appear with the library name as the badge label.

## Additional Comments

The deduplication strategy ensures that when the same component digest appears in multiple sources, the highest-priority source label is shown. Registered libraries that fail to load log a warning but do not prevent the rest of the search from functioning.