### PR TITLE
Add component search index service

### DIFF
--- a/src/services/componentSearchIndex.test.ts
+++ b/src/services/componentSearchIndex.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it } from "vitest";
+
+import type { ComponentReference } from "@/utils/componentSpec";
+
+import {
+  buildSearchIndex,
+  type ComponentSource,
+  lexicalSearch,
+  type SourcedReference,
+} from "./componentSearchIndex";
+
+const STANDARD: ComponentSource = {
+  kind: "standard",
+  label: "Standard",
+  id: "standard",
+};
+const USER: ComponentSource = { kind: "user", label: "User", id: "user" };
+
+function makeRef(
+  partial: Partial<ComponentReference> & { digest?: string },
+): ComponentReference {
+  return {
+    digest: partial.digest,
+    url: partial.url,
+    name: partial.name,
+    spec: partial.spec,
+  };
+}
+
+function makeSourced(
+  partial: Partial<ComponentReference> & { digest?: string },
+  source: ComponentSource = STANDARD,
+): SourcedReference {
+  return { reference: makeRef(partial), source };
+}
+
+describe("buildSearchIndex", () => {
+  it("skips references without a digest", () => {
+    const index = buildSearchIndex([
+      makeSourced({
+        digest: undefined,
+        spec: {
+          name: "no_digest",
+          inputs: [],
+          outputs: [],
+          implementation: { container: { image: "x" } },
+        },
+      }),
+    ]);
+    expect(index).toHaveLength(0);
+  });
+
+  it("skips references with no useful metadata", () => {
+    const index = buildSearchIndex([
+      makeSourced({
+        digest: "abc",
+        // No name, description, inputs, or outputs.
+        spec: {
+          inputs: [],
+          outputs: [],
+          implementation: { container: { image: "x" } },
+        },
+      }),
+    ]);
+    expect(index).toHaveLength(0);
+  });
+
+  it("preserves the source on each indexed entry", () => {
+    const index = buildSearchIndex([
+      makeSourced(
+        {
+          digest: "a",
+          spec: {
+            name: "train_model",
+            inputs: [],
+            outputs: [],
+            implementation: { container: { image: "x" } },
+          },
+        },
+        USER,
+      ),
+    ]);
+    expect(index).toHaveLength(1);
+    expect(index[0].source).toEqual(USER);
+  });
+
+  it("indexes name, description, io, and container command text", () => {
+    const index = buildSearchIndex([
+      makeSourced({
+        digest: "a",
+        spec: {
+          name: "train_model",
+          description: "Train a regression model on a dataset.",
+          inputs: [{ name: "dataset" }],
+          outputs: [{ name: "model" }],
+          implementation: {
+            container: {
+              image: "python:3.11",
+              command: ["python", "-m", "pandas.train"],
+              args: ["--epochs", "10"],
+            },
+          },
+        },
+      }),
+    ]);
+    expect(index).toHaveLength(1);
+    expect(index[0].searchable.name).toContain("train_model");
+    expect(index[0].searchable.description).toContain("regression");
+    expect(index[0].searchable.io).toContain("dataset");
+    expect(index[0].searchable.io).toContain("model");
+    expect(index[0].searchable.implementation).toContain("pandas.train");
+    expect(index[0].searchable.implementation).toContain("--epochs");
+  });
+});
+
+describe("lexicalSearch", () => {
+  const fixtures: SourcedReference[] = [
+    makeSourced({
+      digest: "a",
+      spec: {
+        name: "train_test_split",
+        description: "Split a dataset into train and test partitions.",
+        inputs: [{ name: "dataset" }],
+        outputs: [{ name: "train" }, { name: "test" }],
+        implementation: {
+          container: {
+            image: "python:3.11",
+            command: ["python", "-m", "sklearn"],
+          },
+        },
+      },
+    }),
+    makeSourced({
+      digest: "b",
+      spec: {
+        name: "drop_nulls",
+        description: "Drop rows containing null values from a dataframe.",
+        inputs: [{ name: "dataframe" }],
+        outputs: [{ name: "clean" }],
+        implementation: {
+          container: {
+            image: "python:3.11",
+            command: ["python", "-m", "pandas"],
+          },
+        },
+      },
+    }),
+    makeSourced(
+      {
+        digest: "c",
+        spec: {
+          name: "my_custom_train",
+          description: "User-built trainer.",
+          inputs: [],
+          outputs: [],
+          implementation: { container: { image: "x" } },
+        },
+      },
+      USER,
+    ),
+  ];
+
+  it("returns no results below the minimum query length", () => {
+    expect(lexicalSearch(buildSearchIndex(fixtures), "", {})).toHaveLength(0);
+    expect(
+      lexicalSearch(buildSearchIndex(fixtures), "tr", { minLength: 3 }),
+    ).toHaveLength(0);
+  });
+
+  it("ranks name matches higher than description-only matches", () => {
+    const index = buildSearchIndex(fixtures);
+    const results = lexicalSearch(index, "train");
+    expect(results.length).toBeGreaterThanOrEqual(2);
+    // Both train_test_split and my_custom_train match the name; drop_nulls
+    // doesn't match anywhere, so it must not appear.
+    expect(results.map((r) => r.digest)).not.toContain("b");
+  });
+
+  it("applies the multi-token full-substring bonus on the name", () => {
+    const index = buildSearchIndex(fixtures);
+    const results = lexicalSearch(index, "train test split");
+    expect(results[0]?.digest).toBe("a");
+  });
+
+  it("tokenizes snake_case queries so each segment matches independently", () => {
+    const index = buildSearchIndex(fixtures);
+    const results = lexicalSearch(index, "drop nulls");
+    expect(results[0]?.digest).toBe("b");
+  });
+
+  it("matches implementation/command text with the lowest weight", () => {
+    const index = buildSearchIndex(fixtures);
+    const results = lexicalSearch(index, "pandas");
+    expect(results[0]?.digest).toBe("b");
+    expect(results[0]?.matchedFields).toContain("implementation");
+  });
+
+  it("preserves the source on each returned match", () => {
+    const index = buildSearchIndex(fixtures);
+    const results = lexicalSearch(index, "my_custom_train");
+    expect(results[0]?.source).toEqual(USER);
+  });
+
+  it("respects the limit option", () => {
+    const many: SourcedReference[] = Array.from({ length: 10 }, (_, i) =>
+      makeSourced({
+        digest: `d${i}`,
+        spec: {
+          name: `train_${i}`,
+          inputs: [],
+          outputs: [],
+          implementation: { container: { image: "x" } },
+        },
+      }),
+    );
+    const results = lexicalSearch(buildSearchIndex(many), "train", {
+      limit: 3,
+    });
+    expect(results).toHaveLength(3);
+  });
+});

--- a/src/services/componentSearchIndex.test.ts
+++ b/src/services/componentSearchIndex.test.ts
@@ -4,17 +4,17 @@ import type { ComponentReference } from "@/utils/componentSpec";
 
 import {
   buildSearchIndex,
-  type ComponentSource,
+  type ComponentSearchSource,
   lexicalSearch,
   type SourcedReference,
 } from "./componentSearchIndex";
 
-const STANDARD: ComponentSource = {
+const STANDARD: ComponentSearchSource = {
   kind: "standard",
   label: "Standard",
   id: "standard",
 };
-const USER: ComponentSource = { kind: "user", label: "User", id: "user" };
+const USER: ComponentSearchSource = { kind: "user", label: "User", id: "user" };
 
 function makeRef(
   partial: Partial<ComponentReference> & { digest?: string },
@@ -29,7 +29,7 @@ function makeRef(
 
 function makeSourced(
   partial: Partial<ComponentReference> & { digest?: string },
-  source: ComponentSource = STANDARD,
+  source: ComponentSearchSource = STANDARD,
 ): SourcedReference {
   return { reference: makeRef(partial), source };
 }
@@ -177,9 +177,35 @@ describe("lexicalSearch", () => {
   });
 
   it("applies the multi-token full-substring bonus on the name", () => {
-    const index = buildSearchIndex(fixtures);
+    // Two candidates that match the same three tokens on the name (3*5 = 15
+    // per-token score either way), one scattered and one contiguous. Without
+    // the +10 contiguous-substring bonus, the scattered name wins on the
+    // alphabetical tiebreak ("a_..." < "train..."). With the bonus, the
+    // contiguous snake_case name pulls ahead — this is the case the bonus
+    // exists for.
+    const localFixtures: SourcedReference[] = [
+      makeSourced({
+        digest: "scattered",
+        spec: {
+          name: "a_train_b_test_c_split_d",
+          inputs: [],
+          outputs: [],
+          implementation: { container: { image: "x" } },
+        },
+      }),
+      makeSourced({
+        digest: "contiguous",
+        spec: {
+          name: "train_test_split",
+          inputs: [],
+          outputs: [],
+          implementation: { container: { image: "x" } },
+        },
+      }),
+    ];
+    const index = buildSearchIndex(localFixtures);
     const results = lexicalSearch(index, "train test split");
-    expect(results[0]?.digest).toBe("a");
+    expect(results[0]?.digest).toBe("contiguous");
   });
 
   it("tokenizes snake_case queries so each segment matches independently", () => {

--- a/src/services/componentSearchIndex.ts
+++ b/src/services/componentSearchIndex.ts
@@ -1,0 +1,265 @@
+/**
+ * Lexical search index for the component library.
+ *
+ * Pure, synchronous, in-memory. Sub-10ms for hundreds of components. Runs in
+ * the browser with no API calls — the foundation for instant typeahead search.
+ *
+ * Design rationale: the LLM is bad at exact-string matching and slow for any
+ * retrieval over a closed set. Local lexical search handles 90% of queries
+ * (code names, library names, CLI flags, partial component names) with
+ * predictable behavior. The LLM is reserved for *reranking* a small
+ * pre-filtered candidate set when judgment is needed — see
+ * `naturalLanguageComponentSearchService.ts`.
+ */
+
+import type { ComponentReference } from "@/utils/componentSpec";
+import { getComponentName } from "@/utils/getComponentName";
+
+/** Which field of a component matched the query. Surfaced in the UI. */
+type MatchField = "name" | "description" | "io" | "implementation";
+
+/**
+ * Where a component came from. Attached to every index entry and threaded
+ * through to UI cards as a source badge so users know whether a result is
+ * from the curated standard library, the backend's published catalog, a
+ * registered external library (e.g. GitHub), or their own user components.
+ */
+export interface ComponentSource {
+  kind: "standard" | "user" | "published" | "registered";
+  /** Short label shown in the UI badge (e.g. "Standard", "Published", or a library name). */
+  label: string;
+  /**
+   * Stable identifier for future filter chips / URL state. For built-in kinds
+   * this matches the kind; for `registered` libraries it's the stored library id.
+   */
+  id: string;
+}
+
+export interface SourcedReference {
+  reference: ComponentReference;
+  source: ComponentSource;
+}
+
+export interface IndexEntry {
+  /** Full reference, kept so callers can render whatever they need. */
+  reference: ComponentReference;
+  /** Component digest. Stable id for round-tripping (LLM rerank, dedupe). */
+  digest: string;
+  /** Display name. */
+  name: string;
+  /** Where this component came from. */
+  source: ComponentSource;
+  /** Pre-lowercased searchable text, one per logical field. */
+  searchable: Record<MatchField, string>;
+}
+
+export interface LexicalMatch {
+  reference: ComponentReference;
+  digest: string;
+  name: string;
+  source: ComponentSource;
+  /** Which fields matched the query (for UX labels like "matched: command"). */
+  matchedFields: MatchField[];
+}
+
+/**
+ * Flatten a container implementation's image + command + args into a single
+ * lowercase string. Placeholder objects (e.g. `{ inputValue: "Where" }`) are
+ * serialized so library names and flag references inside them remain
+ * searchable.
+ *
+ * Pure container components only — graph components don't have command text.
+ */
+function extractImplementationText(reference: ComponentReference): string {
+  const impl = reference.spec?.implementation;
+  if (!impl || !("container" in impl)) return "";
+  const container = impl.container;
+
+  const parts: string[] = [];
+  if (container.image) parts.push(container.image);
+
+  const pushPart = (part: unknown) => {
+    if (typeof part === "string") {
+      parts.push(part);
+    } else if (part !== null && part !== undefined) {
+      try {
+        parts.push(JSON.stringify(part));
+      } catch {
+        // Defensive — skip unserializable values.
+      }
+    }
+  };
+
+  if (Array.isArray(container.command)) {
+    for (const p of container.command) pushPart(p);
+  }
+  if (Array.isArray(container.args)) {
+    for (const p of container.args) pushPart(p);
+  }
+
+  return parts.join(" ").toLowerCase();
+}
+
+/**
+ * Build the searchable index from sourced, hydrated component references.
+ * References without a digest are skipped (can't round-trip an LLM rerank
+ * without one). References with no useful spec metadata are also skipped —
+ * they'd just be noise that ranks below every real result.
+ */
+export function buildSearchIndex(sourced: SourcedReference[]): IndexEntry[] {
+  const entries: IndexEntry[] = [];
+
+  for (const { reference, source } of sourced) {
+    if (!reference.digest) continue;
+
+    const spec = reference.spec;
+    const description = spec?.description?.trim() ?? "";
+    const inputNames =
+      spec?.inputs
+        ?.map((i) => i.name)
+        .filter((n): n is string => typeof n === "string" && n.length > 0) ??
+      [];
+    const outputNames =
+      spec?.outputs
+        ?.map((o) => o.name)
+        .filter((n): n is string => typeof n === "string" && n.length > 0) ??
+      [];
+
+    const hasUsefulMetadata =
+      Boolean(spec?.name) ||
+      description.length > 0 ||
+      inputNames.length > 0 ||
+      outputNames.length > 0;
+    if (!hasUsefulMetadata) continue;
+
+    const name = getComponentName(reference);
+
+    entries.push({
+      reference,
+      digest: reference.digest,
+      name,
+      source,
+      searchable: {
+        name: name.toLowerCase(),
+        description: description.toLowerCase(),
+        io: [...inputNames, ...outputNames].join(" ").toLowerCase(),
+        implementation: extractImplementationText(reference),
+      },
+    });
+  }
+
+  return entries;
+}
+
+/**
+ * Split a query into lowercase alphanumeric tokens. `train_test_split` becomes
+ * `["train", "test", "split"]` — users almost always type the parts
+ * individually, and exact-string matches are still caught by substring search
+ * on the original lowercased text.
+ */
+function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .split(/[^a-z0-9]+/i)
+    .filter((t) => t.length > 0);
+}
+
+/**
+ * Per-field weights. Name matches are by far the most signal: `train` in the
+ * name means the component is *about* training. The same word in implementation
+ * text could be a library import in a totally unrelated component.
+ */
+const FIELD_WEIGHTS: Record<MatchField, number> = {
+  name: 5,
+  description: 2,
+  io: 2,
+  implementation: 1,
+};
+
+interface SearchOptions {
+  /** Max results to return. Default 20. */
+  limit?: number;
+  /**
+   * Minimum query length before any results are returned. Default 1. Set to 2
+   * or 3 to suppress noisy results on the first keystroke.
+   */
+  minLength?: number;
+}
+
+/**
+ * Score one entry against the tokenized query. Returns 0 if no field matched.
+ *
+ * Scoring model:
+ * - Per query token: each field that contains the token contributes its weight.
+ * - Bonus: full multi-token query as a substring of the name (+10). Catches
+ *   "train test split" matching `train_test_split` strongly even though we
+ *   tokenized.
+ *
+ * We deliberately do not normalize — raw scores are only used for ordering.
+ */
+function scoreEntry(
+  entry: IndexEntry,
+  tokens: string[],
+  fullQuery: string,
+): { score: number; matchedFields: MatchField[] } {
+  const fields: MatchField[] = ["name", "description", "io", "implementation"];
+  const matched = new Set<MatchField>();
+  let score = 0;
+
+  for (const token of tokens) {
+    for (const field of fields) {
+      if (entry.searchable[field].includes(token)) {
+        score += FIELD_WEIGHTS[field];
+        matched.add(field);
+      }
+    }
+  }
+
+  // Multi-token contiguous match in the name is a very strong signal.
+  if (tokens.length > 1 && entry.searchable.name.includes(fullQuery)) {
+    score += 10;
+    matched.add("name");
+  }
+
+  return { score, matchedFields: [...matched] };
+}
+
+/**
+ * Rank index entries against a query. Synchronous, sub-10ms for ~500 entries.
+ * Empty/too-short queries return an empty array — callers should show an
+ * "all components" or empty-state view instead.
+ */
+export function lexicalSearch(
+  index: IndexEntry[],
+  query: string,
+  options: SearchOptions = {},
+): LexicalMatch[] {
+  const { limit = 20, minLength = 1 } = options;
+  const trimmed = query.trim().toLowerCase();
+  if (trimmed.length < minLength) return [];
+
+  const tokens = tokenize(trimmed);
+  if (tokens.length === 0) return [];
+
+  const scored: Array<LexicalMatch & { score: number }> = [];
+  for (const entry of index) {
+    const { score, matchedFields } = scoreEntry(entry, tokens, trimmed);
+    if (score === 0) continue;
+    scored.push({
+      reference: entry.reference,
+      digest: entry.digest,
+      name: entry.name,
+      source: entry.source,
+      matchedFields,
+      score,
+    });
+  }
+
+  // Stable order: score desc, then name asc for predictable display.
+  scored.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    return a.name.localeCompare(b.name);
+  });
+
+  return scored.slice(0, limit).map(({ score: _score, ...m }) => m);
+}

--- a/src/services/componentSearchIndex.ts
+++ b/src/services/componentSearchIndex.ts
@@ -24,7 +24,7 @@ type MatchField = "name" | "description" | "io" | "implementation";
  * from the curated standard library, the backend's published catalog, a
  * registered external library (e.g. GitHub), or their own user components.
  */
-export interface ComponentSource {
+export interface ComponentSearchSource {
   kind: "standard" | "user" | "published" | "registered";
   /** Short label shown in the UI badge (e.g. "Standard", "Published", or a library name). */
   label: string;
@@ -37,7 +37,7 @@ export interface ComponentSource {
 
 export interface SourcedReference {
   reference: ComponentReference;
-  source: ComponentSource;
+  source: ComponentSearchSource;
 }
 
 export interface IndexEntry {
@@ -48,7 +48,7 @@ export interface IndexEntry {
   /** Display name. */
   name: string;
   /** Where this component came from. */
-  source: ComponentSource;
+  source: ComponentSearchSource;
   /** Pre-lowercased searchable text, one per logical field. */
   searchable: Record<MatchField, string>;
 }
@@ -57,7 +57,7 @@ export interface LexicalMatch {
   reference: ComponentReference;
   digest: string;
   name: string;
-  source: ComponentSource;
+  source: ComponentSearchSource;
   /** Which fields matched the query (for UX labels like "matched: command"). */
   matchedFields: MatchField[];
 }
@@ -160,7 +160,7 @@ export function buildSearchIndex(sourced: SourcedReference[]): IndexEntry[] {
 function tokenize(text: string): string[] {
   return text
     .toLowerCase()
-    .split(/[^a-z0-9]+/i)
+    .split(/[^a-z0-9]+/)
     .filter((t) => t.length > 0);
 }
 
@@ -200,7 +200,6 @@ interface SearchOptions {
 function scoreEntry(
   entry: IndexEntry,
   tokens: string[],
-  fullQuery: string,
 ): { score: number; matchedFields: MatchField[] } {
   const fields: MatchField[] = ["name", "description", "io", "implementation"];
   const matched = new Set<MatchField>();
@@ -215,10 +214,17 @@ function scoreEntry(
     }
   }
 
-  // Multi-token contiguous match in the name is a very strong signal.
-  if (tokens.length > 1 && entry.searchable.name.includes(fullQuery)) {
-    score += 10;
-    matched.add("name");
+  // Multi-token contiguous match in the name is a very strong signal. Both
+  // sides are normalized so the bonus also fires for snake_case names —
+  // query "train test split" should match `train_test_split`, not just
+  // names that happen to contain literal spaces.
+  if (tokens.length > 1) {
+    const normalizedName = entry.searchable.name.replace(/[^a-z0-9]+/g, " ");
+    const normalizedQuery = tokens.join(" ");
+    if (normalizedName.includes(normalizedQuery)) {
+      score += 10;
+      matched.add("name");
+    }
   }
 
   return { score, matchedFields: [...matched] };
@@ -243,7 +249,7 @@ export function lexicalSearch(
 
   const scored: Array<LexicalMatch & { score: number }> = [];
   for (const entry of index) {
-    const { score, matchedFields } = scoreEntry(entry, tokens, trimmed);
+    const { score, matchedFields } = scoreEntry(entry, tokens);
     if (score === 0) continue;
     scored.push({
       reference: entry.reference,


### PR DESCRIPTION
## Tophatting

No manual tophatting required. This PR only adds the local search index service and unit tests.

## What changed

Adds the local search index used by the new Components V2 page.

This is the plain text search layer. It turns hydrated component references into searchable entries and ranks matches by useful fields like name, description, inputs, outputs, and container command text.

## Why

The UI needs fast search before any AI reranking happens. This keeps normal search instant and predictable.

## Test plan

- Run `pnpm exec vitest run src/services/componentSearchIndex.test.ts`
- Run `pnpm run typecheck --pretty false`
- Sanity check that search ranks name matches above weaker matches like command-only matches
