### PR TITLE
Extract shared component detail view

### DIFF
--- a/react-compiler.config.js
+++ b/react-compiler.config.js
@@ -19,6 +19,7 @@ export const REACT_COMPILER_ENABLED_DIRS = [
   "src/components/shared/FullscreenElement",
   "src/components/shared/CopyText",
   "src/components/shared/TaskDetails",
+  "src/components/shared/ComponentDetail",
   "src/components/shared/GitHubAuth",
   "src/components/shared/Authentication",
   "src/routes",

--- a/src/components/shared/ComponentDetail/ComponentDetail.tsx
+++ b/src/components/shared/ComponentDetail/ComponentDetail.tsx
@@ -1,3 +1,5 @@
+import type { ReactNode } from "react";
+
 import { CodeViewer } from "@/components/shared/CodeViewer";
 import { CopyText } from "@/components/shared/CopyText/CopyText";
 import { GithubDetails } from "@/components/shared/TaskDetails/GithubDetails";
@@ -13,7 +15,27 @@ import type {
   OutputSpec,
 } from "@/utils/componentSpec";
 import { TOP_NAV_HEIGHT } from "@/utils/constants";
+import { getComponentName } from "@/utils/getComponentName";
 import { buildComponentSourceUrl } from "@/utils/URL";
+
+// Repeated label style used for "Inputs"/"Outputs"/"Source" headings — small,
+// subdued, uppercase. Extracted so the three call sites stay in sync.
+const SectionLabel = ({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) => (
+  <Text
+    size="xs"
+    tone="subdued"
+    weight="semibold"
+    className={cn("uppercase tracking-wide", className)}
+  >
+    {children}
+  </Text>
+);
 
 // ─── Compact I/O table ───────────────────────────────────────────────────────
 
@@ -40,11 +62,12 @@ const IORow = ({
       <Text
         size="sm"
         weight="semibold"
-        className="font-mono truncate min-w-0 flex-1"
+        font="mono"
+        className="truncate min-w-0 flex-1"
       >
         {name}
       </Text>
-      {type !== undefined && type !== null && (
+      {!!type && (
         <Text size="xs" tone="subdued" className="shrink-0">
           {String(type)}
         </Text>
@@ -52,25 +75,23 @@ const IORow = ({
       <Text
         size="xs"
         weight="semibold"
-        className={cn(
-          "shrink-0 uppercase tracking-wide",
-          required ? "text-rose-600" : "text-muted-foreground",
-        )}
+        tone={required ? "critical" : "subdued"}
+        className="shrink-0 uppercase tracking-wide"
       >
         {required ? "required" : "optional"}
       </Text>
     </InlineStack>
     {description && (
-      <Text
-        size="xs"
-        className="text-muted-foreground leading-snug block mt-0.5"
-      >
+      <Text size="xs" tone="subdued" className="leading-snug block mt-0.5">
         {description}
       </Text>
     )}
     {defaultValue !== undefined && (
-      <Text size="xs" className="text-muted-foreground block mt-0.5">
-        Default: <span className="font-mono">{String(defaultValue)}</span>
+      <Text size="xs" tone="subdued" className="block mt-0.5">
+        Default:{" "}
+        <Text as="span" font="mono">
+          {String(defaultValue)}
+        </Text>
       </Text>
     )}
   </div>
@@ -89,15 +110,8 @@ const IOSection = ({
     description?: string;
   }>;
 }) => (
-  // align="stretch" so the row list fills the section's width; BlockStack
-  // defaults to items-start otherwise.
   <BlockStack gap="1" align="stretch">
-    <Text
-      size="xs"
-      className="text-muted-foreground font-medium uppercase tracking-wide"
-    >
-      {label}
-    </Text>
+    <SectionLabel>{label}</SectionLabel>
     <div>
       {rows.map((row, idx) => (
         <IORow
@@ -244,9 +258,9 @@ export const ComponentDetail = ({
   // ── Shared sub-blocks ──────────────────────────────────────────────────
   const header = (
     <BlockStack gap="2">
-      <Heading level={2}>{spec.name ?? hydrated.digest ?? ""}</Heading>
+      <Heading level={2}>{getComponentName(hydrated)}</Heading>
       {author && (
-        <Text size="sm" className="text-muted-foreground">
+        <Text size="sm" tone="subdued">
           {author}
         </Text>
       )}
@@ -289,17 +303,12 @@ export const ComponentDetail = ({
   if (layout === "stacked") {
     const stackedSourceHeight = sourcePanelHeight ?? "60vh";
     return (
-      // align="stretch" so every child fills the container's width. Without
-      // this, BlockStack defaults to `items-start` and children collapse to
-      // their intrinsic width, which looks broken in wide panes.
       <BlockStack gap="6" align="stretch">
         {header}
         {description}
         {githubLinks}
         {io}
         {hydrated.text && (
-          // CodeViewer already provides its own dark frame + header bar, so
-          // no extra border/card chrome around it — keeps the look minimal.
           <div
             style={{ height: stackedSourceHeight }}
             className="min-h-0 rounded-md overflow-hidden"
@@ -320,32 +329,26 @@ export const ComponentDetail = ({
     sourcePanelHeight ?? `calc(100vh - ${TOP_NAV_HEIGHT + 48}px)`;
   return (
     <InlineStack gap="6" blockAlign="start">
-      <div className="flex-2 min-w-0 flex flex-col gap-4">
+      <BlockStack gap="4" className="flex-2 min-w-0">
         {header}
         {description}
         {githubLinks}
         {io}
-      </div>
+      </BlockStack>
 
       {hydrated.text && (
         <div className="flex-3 min-w-0">
-          <div
-            className="sticky top-0 flex flex-col gap-1.5"
-            style={{ height: splitSourceHeight }}
-          >
-            <Text
-              size="xs"
-              className="text-muted-foreground font-medium uppercase tracking-wide shrink-0"
-            >
-              Source
-            </Text>
-            <div className="flex-1 min-h-0">
-              <CodeViewer
-                code={hydrated.text}
-                language="yaml"
-                filename={spec.name ?? "component.yaml"}
-              />
-            </div>
+          <div className="sticky top-0" style={{ height: splitSourceHeight }}>
+            <BlockStack className="gap-1.5 h-full" align="stretch">
+              <SectionLabel className="shrink-0">Source</SectionLabel>
+              <div className="flex-1 min-h-0">
+                <CodeViewer
+                  code={hydrated.text}
+                  language="yaml"
+                  filename={spec.name ?? "component.yaml"}
+                />
+              </div>
+            </BlockStack>
           </div>
         </div>
       )}
@@ -355,12 +358,12 @@ export const ComponentDetail = ({
 
 export const ComponentDetailSkeleton = () => (
   <InlineStack gap="6">
-    <div className="flex-1 flex flex-col gap-3">
+    <BlockStack gap="3" className="flex-1">
       <Skeleton className="h-6 w-48" />
       <Skeleton className="h-4 w-32" />
       <Skeleton className="h-4 w-full" />
       <Skeleton className="h-4 w-3/4" />
-    </div>
+    </BlockStack>
     <Skeleton className="flex-3 min-w-0 h-64" />
   </InlineStack>
 );

--- a/src/components/shared/ComponentDetail/ComponentDetail.tsx
+++ b/src/components/shared/ComponentDetail/ComponentDetail.tsx
@@ -1,0 +1,366 @@
+import { CodeViewer } from "@/components/shared/CodeViewer";
+import { CopyText } from "@/components/shared/CopyText/CopyText";
+import { GithubDetails } from "@/components/shared/TaskDetails/GithubDetails";
+import { Badge } from "@/components/ui/badge";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Heading, Paragraph, Text } from "@/components/ui/typography";
+import { useHydrateComponentReference } from "@/hooks/useHydrateComponentReference";
+import { cn } from "@/lib/utils";
+import type {
+  ComponentReference,
+  InputSpec,
+  OutputSpec,
+} from "@/utils/componentSpec";
+import { TOP_NAV_HEIGHT } from "@/utils/constants";
+import { buildComponentSourceUrl } from "@/utils/URL";
+
+// ─── Compact I/O table ───────────────────────────────────────────────────────
+
+// Minimal I/O row: name on the left, type+req/opt on the right, optional
+// description on its own line. No box borders — a subtle divider between
+// rows is enough to read as a list.
+const IORow = ({
+  name,
+  type,
+  required,
+  defaultValue,
+  description,
+  isLast,
+}: {
+  name: string;
+  type?: unknown;
+  required?: boolean;
+  defaultValue?: unknown;
+  description?: string;
+  isLast?: boolean;
+}) => (
+  <div className={cn("py-2.5", !isLast && "border-b border-border/40")}>
+    <InlineStack gap="3" blockAlign="center" wrap="nowrap">
+      <Text
+        size="sm"
+        weight="semibold"
+        className="font-mono truncate min-w-0 flex-1"
+      >
+        {name}
+      </Text>
+      {type !== undefined && type !== null && (
+        <Text size="xs" tone="subdued" className="shrink-0">
+          {String(type)}
+        </Text>
+      )}
+      <Text
+        size="xs"
+        weight="semibold"
+        className={cn(
+          "shrink-0 uppercase tracking-wide",
+          required ? "text-rose-600" : "text-muted-foreground",
+        )}
+      >
+        {required ? "required" : "optional"}
+      </Text>
+    </InlineStack>
+    {description && (
+      <Text
+        size="xs"
+        className="text-muted-foreground leading-snug block mt-0.5"
+      >
+        {description}
+      </Text>
+    )}
+    {defaultValue !== undefined && (
+      <Text size="xs" className="text-muted-foreground block mt-0.5">
+        Default: <span className="font-mono">{String(defaultValue)}</span>
+      </Text>
+    )}
+  </div>
+);
+
+const IOSection = ({
+  label,
+  rows,
+}: {
+  label: string;
+  rows: ReadonlyArray<{
+    name: string;
+    type?: unknown;
+    required?: boolean;
+    defaultValue?: unknown;
+    description?: string;
+  }>;
+}) => (
+  // align="stretch" so the row list fills the section's width; BlockStack
+  // defaults to items-start otherwise.
+  <BlockStack gap="1" align="stretch">
+    <Text
+      size="xs"
+      className="text-muted-foreground font-medium uppercase tracking-wide"
+    >
+      {label}
+    </Text>
+    <div>
+      {rows.map((row, idx) => (
+        <IORow
+          key={row.name}
+          name={row.name}
+          type={row.type}
+          required={row.required}
+          defaultValue={row.defaultValue}
+          description={row.description}
+          isLast={idx === rows.length - 1}
+        />
+      ))}
+    </div>
+  </BlockStack>
+);
+
+const CompactIO = ({
+  inputs,
+  outputs,
+}: {
+  inputs?: InputSpec[];
+  outputs?: OutputSpec[];
+}) => (
+  <BlockStack gap="5" align="stretch">
+    {inputs && inputs.length > 0 && (
+      <IOSection
+        label="Inputs"
+        rows={inputs.map((i) => ({
+          name: i.name,
+          type: i.type,
+          required: !i.optional,
+          defaultValue: i.default,
+          description: i.description,
+        }))}
+      />
+    )}
+    {outputs && outputs.length > 0 && (
+      <IOSection
+        label="Outputs"
+        rows={outputs.map((o) => ({
+          name: o.name,
+          type: o.type,
+          description: o.description,
+        }))}
+      />
+    )}
+  </BlockStack>
+);
+
+// ─── Detail panel (suspends on hydration) ───────────────────────────────────
+
+interface ComponentDetailProps {
+  /**
+   * The reference to render. Callers pass whatever they have — a hydrated ref
+   * (no network needed) or a stub with `digest`+`url` (one hydration round-trip).
+   * Hydration is keyed by digest/url, so cache is shared with other usages.
+   */
+  reference: ComponentReference;
+  /**
+   * - `split` (V1 default): metadata+I/O on the left, sticky source code panel
+   *   on the right. Best for full-bleed detail pages.
+   * - `stacked`: single column — metadata, I/O, then source code in a card with
+   *   a capped height. Best for narrower detail panes alongside other content.
+   */
+  layout?: "split" | "stacked";
+  /**
+   * CSS height for the source code panel. In `split` layout this is the sticky
+   * right column's height (defaults to the remaining viewport height under the
+   * top nav). In `stacked` layout this caps the inline source card's height.
+   */
+  sourcePanelHeight?: string;
+}
+
+export const ComponentDetail = ({
+  reference,
+  layout = "split",
+  sourcePanelHeight,
+}: ComponentDetailProps) => {
+  const hydrated = useHydrateComponentReference(reference);
+
+  if (!hydrated?.spec) {
+    return (
+      <Paragraph tone="subdued" size="sm">
+        Could not load component details.
+      </Paragraph>
+    );
+  }
+
+  const { spec } = hydrated;
+  const annotations = spec.metadata?.annotations ?? {};
+  const author =
+    typeof annotations.author === "string" ? annotations.author : undefined;
+  const canonicalUrl =
+    typeof annotations.canonical_location === "string"
+      ? annotations.canonical_location
+      : undefined;
+  const gitRemoteUrl =
+    typeof annotations.git_remote_url === "string"
+      ? annotations.git_remote_url
+      : undefined;
+  const gitRemoteBranch =
+    typeof annotations.git_remote_branch === "string"
+      ? annotations.git_remote_branch
+      : undefined;
+  const gitRelativeDir =
+    typeof annotations.git_relative_dir === "string"
+      ? annotations.git_relative_dir
+      : undefined;
+  const componentYamlPath =
+    typeof annotations.component_yaml_path === "string"
+      ? annotations.component_yaml_path
+      : undefined;
+  const documentationPath =
+    typeof annotations.documentation_path === "string"
+      ? annotations.documentation_path
+      : undefined;
+
+  let reconstructedUrl: string | undefined;
+  let documentationUrl: string | undefined;
+
+  if (gitRemoteUrl && gitRemoteBranch && gitRelativeDir) {
+    if (!hydrated.url && componentYamlPath) {
+      reconstructedUrl = buildComponentSourceUrl({
+        remoteUrl: gitRemoteUrl,
+        branch: gitRemoteBranch,
+        relativeDir: gitRelativeDir,
+        filePath: componentYamlPath,
+      });
+    }
+    if (documentationPath) {
+      documentationUrl = buildComponentSourceUrl({
+        remoteUrl: gitRemoteUrl,
+        branch: gitRemoteBranch,
+        relativeDir: gitRelativeDir,
+        filePath: documentationPath,
+      });
+    }
+  }
+
+  const hasIO =
+    (spec.inputs && spec.inputs.length > 0) ||
+    (spec.outputs && spec.outputs.length > 0);
+
+  // ── Shared sub-blocks ──────────────────────────────────────────────────
+  const header = (
+    <BlockStack gap="2">
+      <Heading level={2}>{spec.name ?? hydrated.digest ?? ""}</Heading>
+      {author && (
+        <Text size="sm" className="text-muted-foreground">
+          {author}
+        </Text>
+      )}
+      {hydrated.digest && (
+        <Badge
+          variant="outline"
+          className="font-mono text-xs min-w-0 max-w-full overflow-hidden self-start"
+        >
+          <CopyText size="xs" className="font-mono truncate">
+            {hydrated.digest}
+          </CopyText>
+        </Badge>
+      )}
+    </BlockStack>
+  );
+
+  const description = spec.description && (
+    // `[overflow-wrap:anywhere]` breaks at any character so long URLs/paths
+    // wrap inside the pane. `break-words` is insufficient — it only breaks
+    // at word boundaries, which doesn't help for URLs without spaces.
+    <Paragraph size="sm" tone="subdued" className="[overflow-wrap:anywhere]">
+      {spec.description}
+    </Paragraph>
+  );
+
+  const githubLinks = (
+    <GithubDetails
+      url={hydrated.url ?? reconstructedUrl}
+      canonicalUrl={canonicalUrl}
+      documentationUrl={documentationUrl}
+    />
+  );
+
+  const io = hasIO && <CompactIO inputs={spec.inputs} outputs={spec.outputs} />;
+
+  // ── Stacked layout ────────────────────────────────────────────────────
+  // Single column — metadata, links, I/O, then source. Wraps source in a
+  // card so it's visually distinct from the rest and capped to a fixed
+  // height to keep the page scannable in narrower containers.
+  if (layout === "stacked") {
+    const stackedSourceHeight = sourcePanelHeight ?? "60vh";
+    return (
+      // align="stretch" so every child fills the container's width. Without
+      // this, BlockStack defaults to `items-start` and children collapse to
+      // their intrinsic width, which looks broken in wide panes.
+      <BlockStack gap="6" align="stretch">
+        {header}
+        {description}
+        {githubLinks}
+        {io}
+        {hydrated.text && (
+          // CodeViewer already provides its own dark frame + header bar, so
+          // no extra border/card chrome around it — keeps the look minimal.
+          <div
+            style={{ height: stackedSourceHeight }}
+            className="min-h-0 rounded-md overflow-hidden"
+          >
+            <CodeViewer
+              code={hydrated.text}
+              language="yaml"
+              filename={spec.name ?? "component.yaml"}
+            />
+          </div>
+        )}
+      </BlockStack>
+    );
+  }
+
+  // ── Split layout (V1 default) ─────────────────────────────────────────
+  const splitSourceHeight =
+    sourcePanelHeight ?? `calc(100vh - ${TOP_NAV_HEIGHT + 48}px)`;
+  return (
+    <InlineStack gap="6" blockAlign="start">
+      <div className="flex-2 min-w-0 flex flex-col gap-4">
+        {header}
+        {description}
+        {githubLinks}
+        {io}
+      </div>
+
+      {hydrated.text && (
+        <div className="flex-3 min-w-0">
+          <div
+            className="sticky top-0 flex flex-col gap-1.5"
+            style={{ height: splitSourceHeight }}
+          >
+            <Text
+              size="xs"
+              className="text-muted-foreground font-medium uppercase tracking-wide shrink-0"
+            >
+              Source
+            </Text>
+            <div className="flex-1 min-h-0">
+              <CodeViewer
+                code={hydrated.text}
+                language="yaml"
+                filename={spec.name ?? "component.yaml"}
+              />
+            </div>
+          </div>
+        </div>
+      )}
+    </InlineStack>
+  );
+};
+
+export const ComponentDetailSkeleton = () => (
+  <InlineStack gap="6">
+    <div className="flex-1 flex flex-col gap-3">
+      <Skeleton className="h-6 w-48" />
+      <Skeleton className="h-4 w-32" />
+      <Skeleton className="h-4 w-full" />
+      <Skeleton className="h-4 w-3/4" />
+    </div>
+    <Skeleton className="flex-3 min-w-0 h-64" />
+  </InlineStack>
+);

--- a/src/routes/Dashboard/DashboardComponentsView.test.ts
+++ b/src/routes/Dashboard/DashboardComponentsView.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { readSelectedComponentDigest } from "./DashboardComponentsView";
+
+describe("readSelectedComponentDigest", () => {
+  it("returns the digest from a search record with a string `component`", () => {
+    expect(readSelectedComponentDigest({ component: "abc123" })).toBe("abc123");
+  });
+
+  it("returns undefined when the `component` key is missing", () => {
+    expect(readSelectedComponentDigest({})).toBeUndefined();
+    expect(readSelectedComponentDigest({ other: "value" })).toBeUndefined();
+  });
+
+  it("returns undefined when `component` is present but not a string", () => {
+    expect(readSelectedComponentDigest({ component: 42 })).toBeUndefined();
+    expect(readSelectedComponentDigest({ component: null })).toBeUndefined();
+    expect(readSelectedComponentDigest({ component: ["abc"] })).toBeUndefined();
+  });
+
+  it("returns undefined for non-record inputs", () => {
+    expect(readSelectedComponentDigest(undefined)).toBeUndefined();
+    expect(readSelectedComponentDigest(null)).toBeUndefined();
+    expect(readSelectedComponentDigest("abc")).toBeUndefined();
+    expect(readSelectedComponentDigest(["abc"])).toBeUndefined();
+  });
+});

--- a/src/routes/Dashboard/DashboardComponentsView.tsx
+++ b/src/routes/Dashboard/DashboardComponentsView.tsx
@@ -3,11 +3,11 @@ import { useNavigate, useSearch } from "@tanstack/react-router";
 import { type ReactNode, useEffect, useState } from "react";
 
 import type { ListPublishedComponentsResponse } from "@/api/types.gen";
-import { CodeViewer } from "@/components/shared/CodeViewer";
-import { CopyText } from "@/components/shared/CopyText/CopyText";
+import {
+  ComponentDetail,
+  ComponentDetailSkeleton,
+} from "@/components/shared/ComponentDetail/ComponentDetail";
 import { SuspenseWrapper } from "@/components/shared/SuspenseWrapper";
-import { GithubDetails } from "@/components/shared/TaskDetails/GithubDetails";
-import { Badge } from "@/components/ui/badge";
 import {
   Collapsible,
   CollapsibleContent,
@@ -17,8 +17,7 @@ import { Icon } from "@/components/ui/icon";
 import { Input } from "@/components/ui/input";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Heading, Paragraph, Text } from "@/components/ui/typography";
-import { useHydrateComponentReference } from "@/hooks/useHydrateComponentReference";
+import { Paragraph, Text } from "@/components/ui/typography";
 import { cn } from "@/lib/utils";
 import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { useBackend } from "@/providers/BackendProvider";
@@ -29,21 +28,22 @@ import {
 import { APP_ROUTES } from "@/routes/router";
 import { fetchAndStoreComponentLibrary } from "@/services/componentService";
 import type { ComponentFolder } from "@/types/componentLibrary";
-import type {
-  ComponentReference,
-  InputSpec,
-  OutputSpec,
-} from "@/utils/componentSpec";
+import type { ComponentReference } from "@/utils/componentSpec";
 import { componentMetadata } from "@/utils/componentTracking";
 import { TOP_NAV_HEIGHT } from "@/utils/constants";
 import { fetchWithErrorHandling } from "@/utils/fetchWithErrorHandling";
 import { getComponentName } from "@/utils/getComponentName";
 import { tracking } from "@/utils/tracking";
-import { buildComponentSourceUrl } from "@/utils/URL";
+import { isRecord } from "@/utils/typeGuards";
 
 type ComponentRowSection = "user" | "library" | "published";
 
 const PUBLISHED_COMPONENTS_URL = "/api/published_components/";
+
+function readSelectedComponentDigest(search: unknown): string | undefined {
+  if (!isRecord(search)) return undefined;
+  return typeof search.component === "string" ? search.component : undefined;
+}
 
 // ─── Collapsible section header ──────────────────────────────────────────────
 
@@ -366,255 +366,16 @@ const ComponentList = ({
   );
 };
 
-// ─── Compact I/O table ───────────────────────────────────────────────────────
-
-const IORow = ({
-  name,
-  type,
-  required,
-  defaultValue,
-  description,
-}: {
-  name: string;
-  type?: unknown;
-  required?: boolean;
-  defaultValue?: unknown;
-  description?: string;
-}) => (
-  <div className="grid grid-cols-[1fr_auto_auto] items-start gap-x-3 gap-y-0.5 px-3 py-2 border-b border-border/50 last:border-0">
-    <div className="flex flex-col gap-0.5 min-w-0">
-      <Text size="xs" weight="semibold" className="truncate font-mono">
-        {name}
-      </Text>
-      {description && (
-        <Text size="xs" className="text-muted-foreground leading-snug">
-          {description}
-        </Text>
-      )}
-      {defaultValue !== undefined && (
-        <Text size="xs" className="text-muted-foreground">
-          Default: <span className="font-mono">{String(defaultValue)}</span>
-        </Text>
-      )}
-    </div>
-    <Text size="xs" className="text-muted-foreground shrink-0 pt-0.5">
-      {type ? String(type) : "—"}
-    </Text>
-    <Badge
-      className={cn(
-        "shrink-0 mt-0.5 text-[10px] font-semibold leading-none",
-        required
-          ? "bg-rose-100 text-rose-700 hover:bg-rose-100"
-          : "bg-muted text-muted-foreground hover:bg-muted",
-      )}
-    >
-      {required ? "req" : "opt"}
-    </Badge>
-  </div>
-);
-
-const CompactIO = ({
-  inputs,
-  outputs,
-}: {
-  inputs?: InputSpec[];
-  outputs?: OutputSpec[];
-}) => (
-  <BlockStack gap="3">
-    {inputs && inputs.length > 0 && (
-      <div>
-        <Text
-          size="xs"
-          className="text-muted-foreground font-medium uppercase tracking-wide px-1 mb-1"
-        >
-          Inputs
-        </Text>
-        <div className="border border-border rounded-md overflow-hidden">
-          {inputs.map((input) => (
-            <IORow
-              key={input.name}
-              name={input.name}
-              type={input.type}
-              required={!input.optional}
-              defaultValue={input.default}
-              description={input.description}
-            />
-          ))}
-        </div>
-      </div>
-    )}
-    {outputs && outputs.length > 0 && (
-      <div>
-        <Text
-          size="xs"
-          className="text-muted-foreground font-medium uppercase tracking-wide px-1 mb-1"
-        >
-          Outputs
-        </Text>
-        <div className="border border-border rounded-md overflow-hidden">
-          {outputs.map((output) => (
-            <IORow
-              key={output.name}
-              name={output.name}
-              type={output.type}
-              description={output.description}
-            />
-          ))}
-        </div>
-      </div>
-    )}
-  </BlockStack>
-);
-
-// ─── Detail Panel (Suspense) ────────────────────────────────────────────────
-
-const ComponentDetailInner = ({ digest }: { digest: string }) => {
-  const { backendUrl } = useBackend();
-  const componentRef: ComponentReference = {
-    digest,
-    url: `${backendUrl}/api/components/${digest}`,
-  };
-  const hydrated = useHydrateComponentReference(componentRef);
-
-  if (!hydrated?.spec) {
-    return (
-      <Paragraph tone="subdued" size="sm">
-        Could not load component details.
-      </Paragraph>
-    );
-  }
-
-  const { spec } = hydrated;
-  const annotations = spec.metadata?.annotations ?? {};
-  const author =
-    typeof annotations.author === "string" ? annotations.author : undefined;
-  const canonicalUrl =
-    typeof annotations.canonical_location === "string"
-      ? annotations.canonical_location
-      : undefined;
-  const gitRemoteUrl =
-    typeof annotations.git_remote_url === "string"
-      ? annotations.git_remote_url
-      : undefined;
-  const gitRemoteBranch =
-    typeof annotations.git_remote_branch === "string"
-      ? annotations.git_remote_branch
-      : undefined;
-  const gitRelativeDir =
-    typeof annotations.git_relative_dir === "string"
-      ? annotations.git_relative_dir
-      : undefined;
-  const componentYamlPath =
-    typeof annotations.component_yaml_path === "string"
-      ? annotations.component_yaml_path
-      : undefined;
-  const documentationPath =
-    typeof annotations.documentation_path === "string"
-      ? annotations.documentation_path
-      : undefined;
-
-  let reconstructedUrl: string | undefined;
-  let documentationUrl: string | undefined;
-
-  if (gitRemoteUrl && gitRemoteBranch && gitRelativeDir) {
-    if (!hydrated.url && componentYamlPath) {
-      reconstructedUrl = buildComponentSourceUrl({
-        remoteUrl: gitRemoteUrl,
-        branch: gitRemoteBranch,
-        relativeDir: gitRelativeDir,
-        filePath: componentYamlPath,
-      });
-    }
-    if (documentationPath) {
-      documentationUrl = buildComponentSourceUrl({
-        remoteUrl: gitRemoteUrl,
-        branch: gitRemoteBranch,
-        relativeDir: gitRelativeDir,
-        filePath: documentationPath,
-      });
-    }
-  }
-
-  const hasIO =
-    (spec.inputs && spec.inputs.length > 0) ||
-    (spec.outputs && spec.outputs.length > 0);
-
-  return (
-    // Side-by-side layout: info+IO on left, source code sticky on right
-    <InlineStack gap="6" blockAlign="start">
-      {/* Left: metadata + I/O — flows naturally with the page scroll */}
-      <div className="flex-2 min-w-0 flex flex-col gap-4">
-        {/* Header */}
-        <BlockStack gap="1">
-          <Heading level={2}>{spec.name ?? digest}</Heading>
-          {author && (
-            <Text size="sm" className="text-muted-foreground">
-              {author}
-            </Text>
-          )}
-          {hydrated.digest && (
-            <Badge
-              variant="outline"
-              className="font-mono text-xs min-w-0 max-w-full overflow-hidden"
-            >
-              <CopyText size="xs" className="font-mono truncate">
-                {hydrated.digest}
-              </CopyText>
-            </Badge>
-          )}
-        </BlockStack>
-
-        {spec.description && (
-          <Paragraph size="sm" tone="subdued">
-            {spec.description}
-          </Paragraph>
-        )}
-
-        <GithubDetails
-          url={hydrated.url ?? reconstructedUrl}
-          canonicalUrl={canonicalUrl}
-          documentationUrl={documentationUrl}
-        />
-
-        {hasIO && <CompactIO inputs={spec.inputs} outputs={spec.outputs} />}
-      </div>
-
-      {/* Right: source code — sticky so it stays in view while left side scrolls */}
-      {hydrated.text && (
-        <div className="flex-3 min-w-0">
-          <div
-            className="sticky top-0 flex flex-col gap-1.5"
-            style={{ height: `calc(100vh - ${TOP_NAV_HEIGHT + 48}px)` }}
-          >
-            <Text
-              size="xs"
-              className="text-muted-foreground font-medium uppercase tracking-wide shrink-0"
-            >
-              Source
-            </Text>
-            <div className="flex-1 min-h-0">
-              <CodeViewer
-                code={hydrated.text}
-                language="yaml"
-                filename={spec.name ?? "component.yaml"}
-              />
-            </div>
-          </div>
-        </div>
-      )}
-    </InlineStack>
-  );
-};
-
 // ─── Main View ──────────────────────────────────────────────────────────────
 
 export function DashboardComponentsView() {
   const [query, setQuery] = useState("");
   const navigate = useNavigate();
+  const { backendUrl } = useBackend();
   // useSearch strict:false is required here — this route has no validateSearch defined
-  const { component: selectedDigest } = useSearch({ strict: false }) as {
-    component?: string;
-  };
+  const selectedDigest = readSelectedComponentDigest(
+    useSearch({ strict: false }),
+  );
   const handleSelect = (component: ComponentReference) => {
     navigate({
       to: APP_ROUTES.DASHBOARD_COMPONENTS,
@@ -648,20 +409,13 @@ export function DashboardComponentsView() {
       {/* Right: detail panel — single scroll, source sticky on right */}
       <div className="flex-1 min-w-0 overflow-y-auto p-6">
         {selectedDigest ? (
-          <SuspenseWrapper
-            fallback={
-              <InlineStack gap="6">
-                <div className="flex-1 flex flex-col gap-3">
-                  <Skeleton className="h-6 w-48" />
-                  <Skeleton className="h-4 w-32" />
-                  <Skeleton className="h-4 w-full" />
-                  <Skeleton className="h-4 w-3/4" />
-                </div>
-                <Skeleton className="flex-3 min-w-0 h-64" />
-              </InlineStack>
-            }
-          >
-            <ComponentDetailInner digest={selectedDigest} />
+          <SuspenseWrapper fallback={<ComponentDetailSkeleton />}>
+            <ComponentDetail
+              reference={{
+                digest: selectedDigest,
+                url: `${backendUrl}/api/components/${selectedDigest}`,
+              }}
+            />
           </SuspenseWrapper>
         ) : (
           <InlineStack fill>

--- a/src/routes/Dashboard/DashboardComponentsView.tsx
+++ b/src/routes/Dashboard/DashboardComponentsView.tsx
@@ -40,7 +40,9 @@ type ComponentRowSection = "user" | "library" | "published";
 
 const PUBLISHED_COMPONENTS_URL = "/api/published_components/";
 
-function readSelectedComponentDigest(search: unknown): string | undefined {
+export function readSelectedComponentDigest(
+  search: unknown,
+): string | undefined {
   if (!isRecord(search)) return undefined;
   return typeof search.component === "string" ? search.component : undefined;
 }


### PR DESCRIPTION
## Tophatting

Manual tophatting recommended because this changes component detail rendering.

1. Open the existing Components page.
2. Select a component.
3. Confirm the detail view still shows metadata, inputs, outputs, and source code.

## What changed

Extracts the component detail view into a shared component.

This lets both the existing Components page and the new Components V2 page show the same component details without duplicating the rendering code.

## Why

The new search page needs a detail panel. Sharing the detail view keeps the UI consistent and avoids maintaining two versions of the same layout.

## Test plan

- Open the existing Components page
- Select a component and confirm details still render
- Confirm inputs, outputs, metadata, and source code still appear
- Run `pnpm run typecheck --pretty false`
