### PR TITLE
Add component search support utilities

### DIFF
--- a/src/providers/ComponentLibraryProvider/ComponentLibraryProvider.tsx
+++ b/src/providers/ComponentLibraryProvider/ComponentLibraryProvider.tsx
@@ -9,8 +9,6 @@ import {
 } from "react";
 
 import ComponentDuplicateDialog from "@/components/shared/Dialogs/ComponentDuplicateDialog";
-import { GitHubFlatComponentLibrary } from "@/components/shared/GitHubLibrary/githubFlatComponentLibrary";
-import { isGitHubLibraryConfiguration } from "@/components/shared/GitHubLibrary/types";
 import { getComponentQueryKey } from "@/hooks/useHydrateComponentReference";
 import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { useBackend } from "@/providers/BackendProvider";
@@ -67,11 +65,9 @@ import {
   populateComponentRefs,
 } from "./componentLibrary";
 import { useForcedSearchContext } from "./ForcedSearchProvider";
-import {
-  createLibraryObject,
-  registerLibraryFactory,
-} from "./libraries/factory";
+import { createLibraryObject } from "./libraries/factory";
 import { PublishedComponentsLibrary } from "./libraries/publishedComponentsLibrary";
+import { ensureLibraryFactoriesRegistered } from "./libraries/setup";
 import { LibraryDB, type StoredLibrary } from "./libraries/storage";
 import type { Library } from "./libraries/types";
 
@@ -113,18 +109,11 @@ const ComponentLibraryContext =
     "ComponentLibraryProvider",
   );
 
-/**
- * Register the GitHub library factory. This allows to have multiple instances of the same library type.
- */
-registerLibraryFactory("github", (library) => {
-  if (!isGitHubLibraryConfiguration(library.configuration)) {
-    throw new Error(
-      `GitHub library configuration is not valid for "${library.id}"`,
-    );
-  }
-
-  return new GitHubFlatComponentLibrary(library.configuration.repo_name);
-});
+// Register library factories at module load. The same helper is also called
+// from places that read libraries from Dexie without mounting this provider
+// (e.g. the dashboard search page), so the factory body stays in exactly one
+// place — see `./libraries/setup`.
+ensureLibraryFactoriesRegistered();
 
 function useComponentLibraryRegistry() {
   const queryClient = useQueryClient();

--- a/src/providers/ComponentLibraryProvider/libraries/setup.test.ts
+++ b/src/providers/ComponentLibraryProvider/libraries/setup.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createLibraryObject } from "./factory";
+import { ensureLibraryFactoriesRegistered } from "./setup";
+import type { StoredLibrary } from "./storage";
+
+const { mockGitHubFlatComponentLibrary } = vi.hoisted(() => ({
+  mockGitHubFlatComponentLibrary: vi.fn(),
+}));
+
+vi.mock("@/components/shared/GitHubLibrary/githubFlatComponentLibrary", () => ({
+  GitHubFlatComponentLibrary: mockGitHubFlatComponentLibrary,
+}));
+
+describe("ensureLibraryFactoriesRegistered", () => {
+  it("registers the GitHub component library factory", () => {
+    ensureLibraryFactoriesRegistered();
+
+    const library = createLibraryObject({
+      id: "github-lib",
+      name: "GitHub library",
+      type: "github",
+      knownDigests: [],
+      configuration: {
+        created_at: "2026-01-01T00:00:00Z",
+        last_updated_at: "2026-01-01T00:00:00Z",
+        repo_name: "owner/repo",
+        access_token: "",
+        auto_update: false,
+      },
+    } satisfies StoredLibrary);
+
+    expect(library).toBeInstanceOf(mockGitHubFlatComponentLibrary);
+    expect(mockGitHubFlatComponentLibrary).toHaveBeenCalledWith("owner/repo");
+  });
+});

--- a/src/providers/ComponentLibraryProvider/libraries/setup.ts
+++ b/src/providers/ComponentLibraryProvider/libraries/setup.ts
@@ -1,0 +1,28 @@
+import { GitHubFlatComponentLibrary } from "@/components/shared/GitHubLibrary/githubFlatComponentLibrary";
+import { isGitHubLibraryConfiguration } from "@/components/shared/GitHubLibrary/types";
+
+import { registerLibraryFactory } from "./factory";
+
+/**
+ * Idempotent registration of library factories. The provider already registers
+ * the same factories at module load, but the dashboard search page reads
+ * libraries from Dexie directly (without mounting `ComponentLibraryProvider`,
+ * which is editor-scoped and depends on `ComponentSpecProvider`). Anywhere
+ * that needs to instantiate a stored library can call this first.
+ */
+let registered = false;
+
+export function ensureLibraryFactoriesRegistered() {
+  if (registered) return;
+
+  registerLibraryFactory("github", (library) => {
+    if (!isGitHubLibraryConfiguration(library.configuration)) {
+      throw new Error(
+        `GitHub library configuration is not valid for "${library.id}"`,
+      );
+    }
+    return new GitHubFlatComponentLibrary(library.configuration.repo_name);
+  });
+
+  registered = true;
+}

--- a/src/routes/v2/shared/clipboard/copyComponentReferenceToClipboard.test.ts
+++ b/src/routes/v2/shared/clipboard/copyComponentReferenceToClipboard.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { ComponentReference } from "@/utils/componentSpec";
+
+import { writeToSystemClipboard } from "./clipboardEnvelope";
+import { copyComponentReferenceToClipboard } from "./copyComponentReferenceToClipboard";
+
+vi.mock("./clipboardEnvelope", () => ({
+  writeToSystemClipboard: vi.fn(),
+}));
+
+describe("copyComponentReferenceToClipboard", () => {
+  it("writes a single task snapshot for the component reference", async () => {
+    const reference: ComponentReference = {
+      digest: "abc",
+      spec: {
+        name: "train_model",
+        inputs: [],
+        outputs: [],
+        implementation: { container: { image: "python:3.11" } },
+      },
+    };
+
+    await copyComponentReferenceToClipboard(reference);
+
+    expect(writeToSystemClipboard).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({
+          $type: "task",
+          name: "train_model",
+          data: expect.objectContaining({ componentRef: reference }),
+        }),
+      ],
+      [],
+    );
+  });
+});

--- a/src/routes/v2/shared/clipboard/copyComponentReferenceToClipboard.ts
+++ b/src/routes/v2/shared/clipboard/copyComponentReferenceToClipboard.ts
@@ -1,3 +1,4 @@
+import type { TaskSnapshotData } from "@/routes/v2/shared/nodes/TaskNode/taskManifestBase";
 import type { NodeSnapshot } from "@/routes/v2/shared/nodes/types";
 import type { ComponentReference } from "@/utils/componentSpec";
 
@@ -17,7 +18,7 @@ export async function copyComponentReferenceToClipboard(
   reference: ComponentReference,
 ): Promise<void> {
   const name = reference.spec?.name ?? reference.name ?? "task";
-  const snapshot: NodeSnapshot = {
+  const snapshot: NodeSnapshot<TaskSnapshotData> = {
     $type: "task",
     entityId: "",
     name,

--- a/src/routes/v2/shared/clipboard/copyComponentReferenceToClipboard.ts
+++ b/src/routes/v2/shared/clipboard/copyComponentReferenceToClipboard.ts
@@ -1,0 +1,34 @@
+import type { NodeSnapshot } from "@/routes/v2/shared/nodes/types";
+import type { ComponentReference } from "@/utils/componentSpec";
+
+import { writeToSystemClipboard } from "./clipboardEnvelope";
+
+/**
+ * Build a single-task clipboard envelope from a component reference and write
+ * it to the system clipboard. The user can then paste (Cmd+V) inside the V2
+ * pipeline editor to drop a new task wired to this component.
+ *
+ * The task snapshot is intentionally minimal: no arguments, no execution
+ * options, no annotations. The paste clone handler assigns a fresh `$id` and
+ * positions the node at the paste target, so the entityId/position here are
+ * placeholders that get discarded on paste.
+ */
+export async function copyComponentReferenceToClipboard(
+  reference: ComponentReference,
+): Promise<void> {
+  const name = reference.spec?.name ?? reference.name ?? "task";
+  const snapshot: NodeSnapshot = {
+    $type: "task",
+    entityId: "",
+    name,
+    position: { x: 0, y: 0 },
+    data: {
+      componentRef: reference,
+      isEnabled: undefined,
+      arguments: [],
+      executionOptions: undefined,
+      annotations: [],
+    },
+  };
+  await writeToSystemClipboard([snapshot], []);
+}

--- a/src/routes/v2/shared/nodes/TaskNode/taskManifestBase.ts
+++ b/src/routes/v2/shared/nodes/TaskNode/taskManifestBase.ts
@@ -22,7 +22,7 @@ import { TaskNode } from "./TaskNode";
 // Task snapshot (shared between Editor and RunView for copy)
 // ---------------------------------------------------------------------------
 
-type TaskSnapshotData = Pick<
+export type TaskSnapshotData = Pick<
   Task,
   "componentRef" | "isEnabled" | "arguments" | "executionOptions"
 > & {


### PR DESCRIPTION
## Tophatting

No manual tophatting required for this PR by itself. These helpers are exercised through later Components V2 PRs.

## What changed

Adds small support utilities used by the Components V2 page.

This includes:

- registering component library factories where the dashboard page needs them
- a helper for copying a component reference so it can be pasted into a pipeline later

## Why

These helpers keep the main Components V2 page smaller and avoid mixing setup/clipboard details into the page component.

## Test plan

- Run `pnpm run typecheck --pretty false`
- Open the app and confirm existing registered component libraries still load normally
- If testing the copy helper through the full stack, copy a component from Components V2 and paste it into a pipeline
