### PR TITLE
Add Components V2 route shell

### DIFF
--- a/src/flags.ts
+++ b/src/flags.ts
@@ -62,4 +62,12 @@ export const ExistingFlags: ConfigFlags = {
     default: false,
     category: "beta",
   },
+
+  ["component-search-v2"]: {
+    name: "Component Search V2",
+    description:
+      "Show the experimental Components V2 page that searches across standard, published, registered, and user component sources, with optional AI rerank.",
+    default: false,
+    category: "beta",
+  },
 };

--- a/src/routes/Dashboard/DashboardComponentsV2View.tsx
+++ b/src/routes/Dashboard/DashboardComponentsV2View.tsx
@@ -17,33 +17,37 @@ export const DashboardComponentsV2View = () => {
   };
 
   return (
+    // Outer wrapper carries the inline height; BlockStack's typed props don't
+    // include `style`, so the height stays on a plain div and BlockStack owns
+    // the vertical flex semantic.
     <div
-      className="flex flex-col -mt-4 -mb-6 -mx-8 overflow-hidden"
+      className="-mt-4 -mb-6 -mx-8 overflow-hidden"
       style={{ height: `calc(100vh - ${TOP_NAV_HEIGHT}px)` }}
     >
-      <div className="shrink-0 px-8 pt-4 pb-4 border-b border-border">
-        <BlockStack gap="3" align="stretch">
-          <BlockStack gap="1">
-            <Heading level={2}>Components V2</Heading>
-            <Paragraph size="sm" tone="subdued">
-              Search across component sources from one experimental dashboard.
-            </Paragraph>
+      <BlockStack className="h-full">
+        <div className="shrink-0 px-8 pt-4 pb-4 border-b border-border">
+          <BlockStack gap="3" align="stretch">
+            <BlockStack gap="1">
+              <Heading level={2}>Components V2</Heading>
+              <Paragraph size="sm" tone="subdued">
+                Search across component sources from one experimental dashboard.
+              </Paragraph>
+            </BlockStack>
+            <Input
+              type="search"
+              placeholder="e.g. train_test_split, pandas, clean up my data"
+              value={query}
+              onChange={handleQueryChange}
+              aria-label="Search components"
+            />
           </BlockStack>
-          <Input
-            type="search"
-            placeholder="e.g. train_test_split, pandas, clean up my data"
-            value={query}
-            onChange={handleQueryChange}
-            aria-label="Search components"
-            className="flex-1"
-          />
-        </BlockStack>
-      </div>
-      <div className="flex-1 min-h-0 overflow-y-auto px-8 py-4">
-        <Paragraph size="sm" tone="subdued">
-          Component results will appear here.
-        </Paragraph>
-      </div>
+        </div>
+        <div className="flex-1 min-h-0 overflow-y-auto px-8 py-4">
+          <Paragraph size="sm" tone="subdued">
+            Component results will appear here.
+          </Paragraph>
+        </div>
+      </BlockStack>
     </div>
   );
 };

--- a/src/routes/Dashboard/DashboardComponentsV2View.tsx
+++ b/src/routes/Dashboard/DashboardComponentsV2View.tsx
@@ -1,0 +1,49 @@
+import { type ChangeEvent, useState } from "react";
+
+import { Input } from "@/components/ui/input";
+import { BlockStack } from "@/components/ui/layout";
+import { Heading, Paragraph } from "@/components/ui/typography";
+import { TOP_NAV_HEIGHT } from "@/utils/constants";
+
+/**
+ * Experimental Components V2 route shell. Search data sources and result
+ * ranking land in the follow-up PRs in this stack.
+ */
+export const DashboardComponentsV2View = () => {
+  const [query, setQuery] = useState("");
+
+  const handleQueryChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setQuery(event.target.value);
+  };
+
+  return (
+    <div
+      className="flex flex-col -mt-4 -mb-6 -mx-8 overflow-hidden"
+      style={{ height: `calc(100vh - ${TOP_NAV_HEIGHT}px)` }}
+    >
+      <div className="shrink-0 px-8 pt-4 pb-4 border-b border-border">
+        <BlockStack gap="3" align="stretch">
+          <BlockStack gap="1">
+            <Heading level={2}>Components V2</Heading>
+            <Paragraph size="sm" tone="subdued">
+              Search across component sources from one experimental dashboard.
+            </Paragraph>
+          </BlockStack>
+          <Input
+            type="search"
+            placeholder="e.g. train_test_split, pandas, clean up my data"
+            value={query}
+            onChange={handleQueryChange}
+            aria-label="Search components"
+            className="flex-1"
+          />
+        </BlockStack>
+      </div>
+      <div className="flex-1 min-h-0 overflow-y-auto px-8 py-4">
+        <Paragraph size="sm" tone="subdued">
+          Component results will appear here.
+        </Paragraph>
+      </div>
+    </div>
+  );
+};

--- a/src/routes/Dashboard/DashboardLayout.tsx
+++ b/src/routes/Dashboard/DashboardLayout.tsx
@@ -9,6 +9,7 @@ import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Link as UILink } from "@/components/ui/link";
 import { Text } from "@/components/ui/typography";
 import { cn } from "@/lib/utils";
+import { APP_ROUTES } from "@/routes/router";
 import {
   ABOUT_URL,
   DOCUMENTATION_URL,
@@ -54,12 +55,17 @@ export function DashboardLayout() {
 
   // Insert the Components V2 entry directly after "Components" when the
   // beta flag is on. Keeps the nav order intuitive without touching the
-  // base list.
+  // base list and stays correct if BASE_SIDEBAR_ITEMS gets reordered.
+  const componentsIndex = BASE_SIDEBAR_ITEMS.findIndex(
+    (item) => item.to === APP_ROUTES.DASHBOARD_COMPONENTS,
+  );
+  const insertAt =
+    componentsIndex >= 0 ? componentsIndex + 1 : BASE_SIDEBAR_ITEMS.length;
   const sidebarItems = isComponentsV2Enabled
     ? [
-        ...BASE_SIDEBAR_ITEMS.slice(0, 4),
+        ...BASE_SIDEBAR_ITEMS.slice(0, insertAt),
         COMPONENTS_V2_ITEM,
-        ...BASE_SIDEBAR_ITEMS.slice(4),
+        ...BASE_SIDEBAR_ITEMS.slice(insertAt),
       ]
     : BASE_SIDEBAR_ITEMS;
 

--- a/src/routes/Dashboard/DashboardLayout.tsx
+++ b/src/routes/Dashboard/DashboardLayout.tsx
@@ -3,6 +3,7 @@ import { Link, Outlet } from "@tanstack/react-router";
 import { TipOfTheDay } from "@/components/Learn/TipOfTheDay";
 import { isAuthorizationRequired } from "@/components/shared/Authentication/helpers";
 import { TopBarAuthentication } from "@/components/shared/Authentication/TopBarAuthentication";
+import { useFlagValue } from "@/components/shared/Settings/useFlags";
 import { Icon, type IconName } from "@/components/ui/icon";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Link as UILink } from "@/components/ui/link";
@@ -25,7 +26,7 @@ interface SidebarItem {
   exact?: boolean;
 }
 
-const SIDEBAR_ITEMS: SidebarItem[] = [
+const BASE_SIDEBAR_ITEMS: SidebarItem[] = [
   { to: "/", label: "My Dashboard", icon: "LayoutDashboard", exact: true },
   { to: "/pipelines", label: "My Pipelines", icon: "GitBranch" },
   { to: "/runs", label: "All Runs", icon: "Play" },
@@ -35,6 +36,12 @@ const SIDEBAR_ITEMS: SidebarItem[] = [
   { to: "/learn", label: "Learning Hub", icon: "GraduationCap" },
 ];
 
+const COMPONENTS_V2_ITEM: SidebarItem = {
+  to: "/components-v2",
+  label: "Components V2",
+  icon: "PackageSearch",
+};
+
 const navItemClass = (isActive: boolean) =>
   cn(
     "w-full px-3 py-2 rounded-md text-sm cursor-pointer hover:bg-accent",
@@ -43,6 +50,18 @@ const navItemClass = (isActive: boolean) =>
 
 export function DashboardLayout() {
   const requiresAuthorization = isAuthorizationRequired();
+  const isComponentsV2Enabled = useFlagValue("component-search-v2");
+
+  // Insert the Components V2 entry directly after "Components" when the
+  // beta flag is on. Keeps the nav order intuitive without touching the
+  // base list.
+  const sidebarItems = isComponentsV2Enabled
+    ? [
+        ...BASE_SIDEBAR_ITEMS.slice(0, 4),
+        COMPONENTS_V2_ITEM,
+        ...BASE_SIDEBAR_ITEMS.slice(4),
+      ]
+    : BASE_SIDEBAR_ITEMS;
 
   return (
     <div
@@ -59,7 +78,7 @@ export function DashboardLayout() {
         </div>
 
         <BlockStack gap="1" className="px-3">
-          {SIDEBAR_ITEMS.map((item) => (
+          {sidebarItems.map((item) => (
             <Link
               key={item.to}
               to={item.to}

--- a/src/routes/Settings/SettingsLayout.tsx
+++ b/src/routes/Settings/SettingsLayout.tsx
@@ -1,5 +1,6 @@
 import { Link, Outlet, useRouter } from "@tanstack/react-router";
 
+import { useFlagValue } from "@/components/shared/Settings/useFlags";
 import { Button } from "@/components/ui/button";
 import { Icon, type IconName } from "@/components/ui/icon";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
@@ -42,8 +43,19 @@ const SIDEBAR_ITEMS: SidebarItem[] = [
   },
 ];
 
+const AGENT_ITEM: SidebarItem = {
+  to: "/settings/agent",
+  label: "Agent Configuration",
+  icon: "Bot",
+  testId: "settings-nav-agent",
+};
+
 export function SettingsLayout() {
   const router = useRouter();
+  const agentSettingsEnabled = useFlagValue("component-search-v2");
+  const sidebarItems = agentSettingsEnabled
+    ? [...SIDEBAR_ITEMS, AGENT_ITEM]
+    : SIDEBAR_ITEMS;
 
   const handleGoBack = () => {
     router.history.back();
@@ -76,7 +88,7 @@ export function SettingsLayout() {
               gap="1"
               className="w-48 shrink-0 border-r border-border pr-4"
             >
-              {SIDEBAR_ITEMS.map((item) => (
+              {sidebarItems.map((item) => (
                 <Link
                   key={item.to}
                   to={item.to}

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -13,9 +13,11 @@ import { AuthorizationResultScreen as HuggingFaceAuthorizationResultScreen } fro
 import { AddSecretView } from "@/components/shared/SecretsManagement/components/AddSecretView";
 import { ReplaceSecretView } from "@/components/shared/SecretsManagement/components/ReplaceSecretView";
 import { SecretsListView } from "@/components/shared/SecretsManagement/components/SecretsListView";
+import { isFlagEnabled } from "@/components/shared/Settings/useFlags";
 import { BASE_URL, IS_GITHUB_PAGES } from "@/utils/constants";
 
 import RootLayout from "../components/layout/RootLayout";
+import { DashboardComponentsV2View } from "./Dashboard/DashboardComponentsV2View";
 import { DashboardComponentsView } from "./Dashboard/DashboardComponentsView";
 import { DashboardFavoritesView } from "./Dashboard/DashboardFavoritesView";
 import { DashboardHomeView } from "./Dashboard/DashboardHomeView";
@@ -32,6 +34,7 @@ import { ImportPage } from "./Import";
 import NotFoundPage from "./NotFoundPage";
 import PipelineRun from "./PipelineRun";
 import ArtifactPreviewPage from "./PipelineRun/ArtifactPreview";
+import { AgentSettings } from "./Settings/sections/AgentSettings";
 import { BackendSettings } from "./Settings/sections/BackendSettings";
 import { BetaFeaturesSettings } from "./Settings/sections/BetaFeaturesSettings";
 import { PreferencesSettings } from "./Settings/sections/PreferencesSettings";
@@ -60,6 +63,7 @@ export const APP_ROUTES = {
   DASHBOARD_RUNS: "/runs",
   DASHBOARD_PIPELINES: "/pipelines",
   DASHBOARD_COMPONENTS: "/components",
+  DASHBOARD_COMPONENTS_V2: "/components-v2",
   DASHBOARD_FAVORITES: "/favorites",
   DASHBOARD_RECENTLY_VIEWED: "/recently-viewed",
   LEARN: LEARN_BASE_PATH,
@@ -75,6 +79,7 @@ export const APP_ROUTES = {
   SETTINGS_BACKEND: `${SETTINGS_PATH}/backend`,
   SETTINGS_PREFERENCES: `${SETTINGS_PATH}/preferences`,
   SETTINGS_BETA_FEATURES: `${SETTINGS_PATH}/beta-features`,
+  SETTINGS_AGENT: `${SETTINGS_PATH}/agent`,
   SETTINGS_SECRETS: `${SETTINGS_PATH}/secrets`,
   SETTINGS_SECRETS_ADD: `${SETTINGS_PATH}/secrets/add`,
   SETTINGS_SECRETS_REPLACE: `${SETTINGS_PATH}/secrets/$secretId/replace`,
@@ -132,6 +137,17 @@ const dashboardComponentsRoute = createRoute({
   getParentRoute: () => dashboardRoute,
   path: "/components",
   component: DashboardComponentsView,
+});
+
+const dashboardComponentsV2Route = createRoute({
+  getParentRoute: () => dashboardRoute,
+  path: "/components-v2",
+  component: DashboardComponentsV2View,
+  beforeLoad: () => {
+    if (!isFlagEnabled("component-search-v2")) {
+      throw redirect({ to: APP_ROUTES.DASHBOARD_COMPONENTS });
+    }
+  },
 });
 
 const dashboardFavoritesRoute = createRoute({
@@ -210,6 +226,17 @@ const settingsBetaFeaturesRoute = createRoute({
   component: BetaFeaturesSettings,
 });
 
+const settingsAgentRoute = createRoute({
+  getParentRoute: () => settingsLayoutRoute,
+  path: "/agent",
+  component: AgentSettings,
+  beforeLoad: () => {
+    if (!isFlagEnabled("component-search-v2")) {
+      throw redirect({ to: APP_ROUTES.SETTINGS_BACKEND });
+    }
+  },
+});
+
 const settingsSecretsRoute = createRoute({
   getParentRoute: () => settingsLayoutRoute,
   path: "/secrets",
@@ -285,6 +312,7 @@ const settingsRouteTree = settingsLayoutRoute.addChildren([
   settingsBackendRoute,
   settingsPreferencesRoute,
   settingsBetaFeaturesRoute,
+  settingsAgentRoute,
   secretsRouteTree,
 ]);
 
@@ -329,6 +357,7 @@ const dashboardRouteTree = dashboardRoute.addChildren([
   dashboardRunsRoute,
   dashboardPipelinesRoute,
   dashboardComponentsRoute,
+  dashboardComponentsV2Route,
   dashboardFavoritesRoute,
   dashboardRecentlyViewedRoute,
   learnIndexRoute,


### PR DESCRIPTION
## Tophatting

Manual tophatting recommended because this adds a new route.

1. Turn on the Components V2 beta flag.
2. Confirm the dashboard sidebar shows “Components V2”.
3. Open `/components-v2`.
4. Turn the flag off and confirm direct navigation redirects away.

## What changed

Adds the first shell of the experimental Components V2 page.

This PR adds:

- the `component-search-v2` feature flag
- the `/components-v2` route
- the dashboard sidebar link when the flag is on
- the basic page header and search input

It does not add real search results yet. That comes in the next PR.

## Why

This keeps routing and feature-flag review separate from the larger search implementation.

## Test plan

- Turn on the Components V2 beta flag
- Confirm the dashboard sidebar shows “Components V2”
- Open `/components-v2`
- Turn the flag off and confirm direct navigation redirects away
- Run `pnpm run typecheck --pretty false`
