### PR TITLE
feat: v2 - ai assistent - repair subagent

### DIFF
--- a/src/agent/agents/subagents/pipelineRepair.ts
+++ b/src/agent/agents/subagents/pipelineRepair.ts
@@ -1,0 +1,28 @@
+/**
+ * Pipeline-repair sub-agent — diagnoses validation issues and broken
+ * connections in an existing pipeline and applies fixes through the
+ * CSOM tool surface (which proxies to the main-thread MobX spec inside
+ * a single undo group).
+ */
+import { Agent } from "@openai/agents";
+
+import { requireOrchestratorModel } from "../../config";
+import { attachObservabilityHooks } from "../../middleware/observability";
+import pipelineRepairPrompt from "../../prompts/pipelineRepair.md?raw";
+import type { AgentSession } from "../../session";
+import { createCsomTools } from "../../tools/csomTools";
+
+export function createPipelineRepairAgent(session: AgentSession): Agent {
+  const csom = createCsomTools(session.bridge);
+  const agent = new Agent({
+    name: "pipeline-repair",
+    handoffDescription: `Diagnose and fix validation issues, broken connections, missing inputs, and other 
+      structural problems in existing pipelines. Can mutate the pipeline via CSOM tools. 
+      Asks the user for input when fixes are ambiguous.`,
+    instructions: pipelineRepairPrompt,
+    tools: csom.allTools,
+    model: requireOrchestratorModel(),
+  });
+  attachObservabilityHooks(agent, session.emitStatus);
+  return agent;
+}

--- a/src/agent/agents/tangleDispatcher.ts
+++ b/src/agent/agents/tangleDispatcher.ts
@@ -14,6 +14,7 @@ import { attachObservabilityHooks } from "../middleware/observability";
 import dispatcherPrompt from "../prompts/dispatcher.md?raw";
 import type { AgentSession } from "../session";
 import { createGeneralHelpAgent } from "./subagents/generalHelp";
+import { createPipelineRepairAgent } from "./subagents/pipelineRepair";
 
 interface DispatcherInvokeParams {
   message: string;
@@ -38,7 +39,10 @@ function createDispatcherAgent(session: AgentSession): Agent {
     model: requireOrchestratorModel(),
     instructions: `${RECOMMENDED_PROMPT_PREFIX}\n\n${dispatcherPrompt}`,
     tools: [],
-    handoffs: [createGeneralHelpAgent(session)],
+    handoffs: [
+      createGeneralHelpAgent(session),
+      createPipelineRepairAgent(session),
+    ],
   });
   attachObservabilityHooks(agent, session.emitStatus);
   return agent;

--- a/src/agent/prompts/dispatcher.md
+++ b/src/agent/prompts/dispatcher.md
@@ -4,20 +4,24 @@ You are the **Tangle Dispatcher**, the entry point for the Tangle Pipeline Studi
 
 ## Available specialists
 
-| Specialist     | When to hand off                                                                                                                                                                                         |
-| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `general-help` | Any question about Tangle concepts, features, how things work, best practices, getting started, or documentation lookups (e.g. "what is a pipeline?", "how do I connect tasks?", "what are subgraphs?"). |
+| Specialist        | When to hand off                                                                                                                                                                                                                                                                            |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `general-help`    | Any question about Tangle concepts, features, how things work, best practices, getting started, or documentation lookups (e.g. "what is a pipeline?", "how do I connect tasks?", "what are subgraphs?").                                                                                    |
+| `pipeline-repair` | Any request to inspect, validate, or fix the user's current pipeline — broken connections, validation errors, dangling bindings, missing arguments, structural cleanup (e.g. "fix my pipeline", "what's wrong with this?", "clean up the validation issues", "repair the broken bindings"). |
 
-Future releases will add specialists for building, fixing, and debugging pipelines. Until then, hand off **every** Tangle / pipeline / ML / docs question to `general-help`.
+Future releases will add specialists for building new pipelines from scratch and for debugging failed runs. Until then, hand off conceptual questions to `general-help` and any "fix / validate / repair my pipeline" requests to `pipeline-repair`.
 
 ## Your workflow
 
 1. Read the user's message.
-2. If it is a Tangle / pipeline / ML / docs question, hand off to `general-help` using its handoff tool. The specialist will produce the final response — do not announce the hand-off to the user.
-3. If it is off-topic (weather, jokes, general coding help unrelated to Tangle, etc.), respond directly with a brief polite message such as:
+2. If it is a request to inspect, fix, validate, or otherwise modify the structure of the user's open pipeline, hand off to `pipeline-repair` using its handoff tool.
+3. Otherwise, if it is a Tangle / pipeline / ML / docs question, hand off to `general-help` using its handoff tool.
+4. Either way the specialist produces the final response — do not announce the hand-off to the user.
+5. If it is generic question about your capabilities - answer freely, do not hand-off.
+6. If it is off-topic (weather, jokes, general coding help unrelated to Tangle, etc.), respond directly with a brief polite message such as:
    > "I'm the Tangle Assistant — I can help with Tangle concepts and how to use the product. That question is outside what I can help with today."
    > Do not hand off off-topic questions.
-4. If you genuinely cannot tell whether a question is Tangle-related, ask one brief clarifying question instead of guessing.
+7. If you genuinely cannot tell whether a question is Tangle-related, ask one brief clarifying question instead of guessing.
 
 ## Response formatting
 

--- a/src/agent/prompts/pipelineRepair.md
+++ b/src/agent/prompts/pipelineRepair.md
@@ -1,0 +1,78 @@
+# Pipeline Repair — System Prompt
+
+You are the **Pipeline Repair** specialist for Tangle Pipeline Studio. Your job is to diagnose and fix validation issues, broken connections, missing inputs, and other structural problems in existing pipelines.
+
+## Your Workflow
+
+1. Call `get_pipeline_state` to understand the current pipeline.
+2. If `tasks` is empty, stop here. Do not call `validate_pipeline` or any other CSOM tools. Reply directly with a short message such as: "I can't fix an empty pipeline — add at least one task to the canvas first, then ask me to fix validation or connection issues."
+3. Call `validate_pipeline` to get all validation issues. If issue is an empty pipeline (message `Pipeline must contain at least one task`) - stop here. Reply directly with a short message such as: "I can't fix an empty pipeline — add at least one task to the canvas first, then ask me to fix validation or connection issues."
+4. Analyze each issue — understand the root cause and determine the fix.
+5. For issues you can resolve automatically (e.g. dangling bindings, obvious type mismatches), apply the fix using CSOM tools.
+6. For issues that require user input (e.g. ambiguous fixes, missing information), explain the problem clearly and ask the user what they'd like to do.
+7. After applying fixes, call `validate_pipeline` again to confirm the issues are resolved.
+
+## Fix Strategy
+
+### Auto-fixable (apply immediately)
+
+- Orphaned bindings (source or target entity deleted) → `delete_edge`
+- Duplicate bindings to the same target port → delete the older one
+- Missing required task arguments with obvious defaults → `set_task_argument`
+
+### Requires user input (ask first)
+
+- Missing pipeline inputs that could be added or connected in multiple ways
+- Type mismatches where the correct resolution is ambiguous
+- Tasks referencing components that don't exist in the registry
+- Structural issues with multiple valid fixes (e.g. delete the task vs. reconnect it)
+
+### Out of scope (explain and defer)
+
+- Building new pipeline stages from scratch (that's the architect's job — coming in a later release)
+- Debugging runtime failures (that's the debug assistant's job — coming in a later release)
+- Adding tasks for components you don't already have access to. Component lookup will land in a future release; until then, only operate on tasks and components already present in the pipeline spec.
+
+## CSOM Entity Model
+
+- **Tasks** — nodes referencing components, each with `$id`, `name`, `componentRef`.
+- **Inputs** — pipeline-level input ports with `$id`, `name`, `type`.
+- **Outputs** — pipeline-level output ports with `$id`, `name`, `type`.
+- **Bindings** — directed edges from source entity/port to target entity/port.
+
+Every entity has a stable `$id`. Use these IDs when referencing entities in tool calls.
+
+## Active subgraph context
+
+`get_pipeline_state` may include an `activeSubgraphPath` field — a breadcrumb of subgraph task names from the root pipeline to whatever subgraph the user is currently viewing. Treat this as a hint about what part of the pipeline the user cares about, but remember: every CSOM mutation always applies to the root spec. If a fix targets an entity inside a nested subgraph, point that out and ask the user before editing.
+
+## Response Formatting
+
+When referring to pipeline entities (tasks, inputs, outputs) in your response, use this markdown link format so the UI can render them as interactive chips:
+
+```
+[Entity Name](entity://$id)
+```
+
+Examples:
+
+- "The [Load CSV Data](entity://task-abc123) task has a missing input binding."
+- "I fixed the connection to [output_data](entity://output-xyz789)."
+
+After applying fixes, include a summary using entity links:
+
+```
+## Changes Made
+- Fixed dangling binding on [Transform](entity://task-def)
+- Added missing argument to [Upload](entity://task-ghi)
+```
+
+## Response Style
+
+Be systematic and transparent. For each issue:
+
+1. State the problem clearly.
+2. Explain why it's a problem.
+3. State what you're doing to fix it (or what you need from the user).
+
+After all fixes, provide a summary of what was changed.

--- a/src/agent/session.ts
+++ b/src/agent/session.ts
@@ -1,24 +1,27 @@
 /**
  * Per-request session for the in-browser agent.
- *
  */
 import type { ProxyClient } from "./config";
+import type { ToolBridgeApi } from "./toolBridgeApi";
 import type { StatusCallback } from "./types";
 
 export interface AgentSession {
   threadId: string;
   emitStatus: StatusCallback;
   proxyClient: ProxyClient;
+  bridge: ToolBridgeApi;
 }
 
 export function createSession(params: {
   threadId: string;
   proxyClient: ProxyClient;
+  bridge: ToolBridgeApi;
   emitStatus?: StatusCallback;
 }): AgentSession {
   return {
     threadId: params.threadId,
     emitStatus: params.emitStatus ?? (() => {}),
     proxyClient: params.proxyClient,
+    bridge: params.bridge,
   };
 }

--- a/src/agent/toolBridgeApi.ts
+++ b/src/agent/toolBridgeApi.ts
@@ -1,0 +1,92 @@
+/**
+ * Contract for the worker → main-thread tool bridge.
+ *
+ * The worker invokes these methods via a Comlink-proxied implementation;
+ * the main thread implements them in `toolBridge.ts` by calling editor
+ * actions on the live MobX spec inside an undo group. Both sides import
+ * this file purely for types — there is no runtime code here.
+ *
+ * Method signatures intentionally mirror the CSOM tool surface so each
+ * `csomTools.ts` tool is a one-line wrapper. Result shapes carry a
+ * `success` flag plus contextual ids so the model can chain calls
+ * (e.g. take the returned `taskId` and call `set_task_argument`).
+ */
+import type { ArgumentType, ComponentReference } from "@/models/componentSpec";
+import type { AiSpec } from "@/routes/v2/pages/Editor/components/AiChat/serializeSpecForAi";
+
+interface ValidationIssue {
+  type: string;
+  severity: string;
+  message: string;
+  entityId?: string;
+  issueCode?: string;
+}
+
+export interface ValidationResult {
+  valid: boolean;
+  issueCount: number;
+  issues: ValidationIssue[];
+}
+
+export interface ConnectArgs {
+  sourceEntityId: string;
+  sourcePortName: string;
+  targetEntityId: string;
+  targetPortName: string;
+}
+
+export interface ToolBridgeApi {
+  getPipelineState(): Promise<AiSpec>;
+
+  setPipelineName(name: string): Promise<{ success: boolean }>;
+  setPipelineDescription(description: string): Promise<{ success: boolean }>;
+
+  addTask(args: { name: string; componentRef: ComponentReference }): Promise<{
+    success: boolean;
+    taskId?: string;
+    name?: string;
+    error?: string;
+  }>;
+  deleteTask(entityId: string): Promise<{ success: boolean }>;
+  renameTask(entityId: string, newName: string): Promise<{ success: boolean }>;
+
+  addInput(args: {
+    name: string;
+    type?: string;
+    description?: string;
+    defaultValue?: string;
+    optional?: boolean;
+  }): Promise<{ success: boolean; inputId: string; name: string }>;
+  deleteInput(entityId: string): Promise<{ success: boolean }>;
+  renameInput(entityId: string, newName: string): Promise<{ success: boolean }>;
+
+  addOutput(args: {
+    name: string;
+    type?: string;
+    description?: string;
+  }): Promise<{ success: boolean; outputId: string; name: string }>;
+  deleteOutput(entityId: string): Promise<{ success: boolean }>;
+  renameOutput(
+    entityId: string,
+    newName: string,
+  ): Promise<{ success: boolean }>;
+
+  connectNodes(
+    args: ConnectArgs,
+  ): Promise<{ success: boolean; bindingId?: string; error?: string }>;
+  deleteEdge(entityId: string): Promise<{ success: boolean }>;
+
+  setTaskArgument(
+    taskEntityId: string,
+    inputName: string,
+    value: ArgumentType,
+  ): Promise<{ success: boolean; error?: string }>;
+
+  createSubgraph(
+    taskEntityIds: string[],
+    subgraphName: string,
+  ): Promise<{ success: boolean; subgraphTaskId?: string; error?: string }>;
+  unpackSubgraph(taskEntityId: string): Promise<{ success: boolean }>;
+
+  validatePipeline(): Promise<ValidationResult>;
+}

--- a/src/agent/tools/csomTools.ts
+++ b/src/agent/tools/csomTools.ts
@@ -1,0 +1,368 @@
+/**
+ * CSOM tools for the in-browser agent.
+ *
+ * Each tool is a thin OpenAI Agents `tool()` wrapper around a method on
+ * the Comlink-proxied `ToolBridgeApi`. The bridge runs on the main
+ * thread and mutates the live MobX `ComponentSpec` inside an undo
+ * group, so the agent's edits are immediately reflected in the editor
+ * and undoable as a single user action.
+ *
+ * Schema note: OpenAI's structured-outputs strict mode requires every
+ * Zod field to be required or `.nullable().optional()` — `.optional()`
+ * alone is rejected. The model passes `null` for fields it wants to
+ * omit; the execute functions normalize `null` to `undefined` before
+ * handing data to the bridge, since the bridge contract uses `T?`.
+ */
+import { tool } from "@openai/agents";
+import { z } from "zod";
+
+import type { ArgumentType, ComponentReference } from "@/models/componentSpec";
+
+import type { ToolBridgeApi } from "../toolBridgeApi";
+
+type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+function asJson(value: unknown): string {
+  return JSON.stringify(value);
+}
+
+const jsonValueSchema: z.ZodType<JsonValue> = z.lazy(() =>
+  z.union([
+    z.string(),
+    z.number(),
+    z.boolean(),
+    z.null(),
+    z.array(jsonValueSchema),
+    z.object({}).catchall(jsonValueSchema),
+  ]),
+);
+
+const arbitraryObjectSchema = z.object({}).catchall(jsonValueSchema);
+
+/**
+ * Recursively strips `null` values from an object so the bridge contract
+ * (which uses `T?` for optional fields) sees missing keys instead of
+ * explicit nulls. Used for the nested `componentRef` payload in
+ * `add_task`.
+ */
+function dropNulls<T>(value: T): T {
+  return JSON.parse(
+    JSON.stringify(value, (_key, v: unknown) => (v === null ? undefined : v)),
+  ) as T;
+}
+
+export function createCsomTools(bridge: ToolBridgeApi) {
+  const getPipelineState = tool({
+    name: "get_pipeline_state",
+    description:
+      "Get the current pipeline spec as JSON. Call this first to understand what exists.",
+    parameters: z.object({}),
+    execute: async () => asJson(await bridge.getPipelineState()),
+  });
+
+  const setPipelineName = tool({
+    name: "set_pipeline_name",
+    description: "Set the pipeline name.",
+    parameters: z.object({ name: z.string().describe("New pipeline name") }),
+    execute: async ({ name }) => asJson(await bridge.setPipelineName(name)),
+  });
+
+  const setPipelineDescription = tool({
+    name: "set_pipeline_description",
+    description: "Set the pipeline description.",
+    parameters: z.object({
+      description: z.string().describe("New pipeline description"),
+    }),
+    execute: async ({ description }) =>
+      asJson(await bridge.setPipelineDescription(description)),
+  });
+
+  const addTask = tool({
+    name: "add_task",
+    description:
+      "Add a new task node to the pipeline. Pass the full componentRef from a search_components result (with `url` and/or `spec`).",
+    parameters: z.object({
+      name: z.string().describe("Human-readable task name"),
+      componentRef: z
+        .object({
+          name: z.string(),
+          url: z.string().nullable().optional(),
+          spec: z
+            .object({
+              name: z.string(),
+              description: z.string().nullable().optional(),
+              inputs: z
+                .array(
+                  z.object({
+                    name: z.string(),
+                    type: z.string().nullable().optional(),
+                    description: z.string().nullable().optional(),
+                    default: z.string().nullable().optional(),
+                    optional: z.boolean().nullable().optional(),
+                  }),
+                )
+                .nullable()
+                .optional(),
+              outputs: z
+                .array(
+                  z.object({
+                    name: z.string(),
+                    type: z.string().nullable().optional(),
+                    description: z.string().nullable().optional(),
+                  }),
+                )
+                .nullable()
+                .optional(),
+              // `z.record(z.string(), …)` emits `propertyNames` in its JSON
+              // Schema, which OpenAI's strict mode rejects at tool registration
+              // (failing every request routed to this agent before the model
+              // ever runs). Keep the field opaque; the bridge accepts arbitrary
+              // implementation shapes, but force an explicit object type so
+              // strict JSON Schema validation does not see typeless `anyOf`.
+              implementation: arbitraryObjectSchema.nullable().optional(),
+            })
+            .nullable()
+            .optional(),
+        })
+        .refine(
+          (ref) => ref.url != null || ref.spec != null,
+          "componentRef must include either a url or an inline spec — name alone is not enough",
+        )
+        .describe(
+          "Component reference from search_components — must include url and/or spec.",
+        ),
+    }),
+    execute: async ({ name, componentRef }) =>
+      asJson(
+        await bridge.addTask({
+          name,
+          componentRef: dropNulls(componentRef) as ComponentReference,
+        }),
+      ),
+  });
+
+  const deleteTask = tool({
+    name: "delete_task",
+    description: "Delete a task and all its connections by $id.",
+    parameters: z.object({
+      entityId: z.string().describe("The $id of the task to delete"),
+    }),
+    execute: async ({ entityId }) => asJson(await bridge.deleteTask(entityId)),
+  });
+
+  const renameTask = tool({
+    name: "rename_task",
+    description: "Rename a task.",
+    parameters: z.object({
+      entityId: z.string().describe("The $id of the task"),
+      newName: z.string().describe("New task name"),
+    }),
+    execute: async ({ entityId, newName }) =>
+      asJson(await bridge.renameTask(entityId, newName)),
+  });
+
+  const addInput = tool({
+    name: "add_input",
+    description: "Add a pipeline-level input.",
+    parameters: z.object({
+      name: z.string().describe("Input name"),
+      type: z
+        .string()
+        .nullable()
+        .optional()
+        .describe("Type (e.g. String, Integer, Float)"),
+      description: z.string().nullable().optional(),
+      defaultValue: z.string().nullable().optional().describe("Default value"),
+      optional: z.boolean().nullable().optional(),
+    }),
+    execute: async ({ name, type, description, defaultValue, optional }) =>
+      asJson(
+        await bridge.addInput({
+          name,
+          type: type ?? undefined,
+          description: description ?? undefined,
+          defaultValue: defaultValue ?? undefined,
+          optional: optional ?? undefined,
+        }),
+      ),
+  });
+
+  const deleteInput = tool({
+    name: "delete_input",
+    description: "Delete a pipeline input and its connections.",
+    parameters: z.object({
+      entityId: z.string().describe("The $id of the input to delete"),
+    }),
+    execute: async ({ entityId }) => asJson(await bridge.deleteInput(entityId)),
+  });
+
+  const renameInput = tool({
+    name: "rename_input",
+    description: "Rename a pipeline input.",
+    parameters: z.object({
+      entityId: z.string().describe("The $id of the input"),
+      newName: z.string().describe("New input name"),
+    }),
+    execute: async ({ entityId, newName }) =>
+      asJson(await bridge.renameInput(entityId, newName)),
+  });
+
+  const addOutput = tool({
+    name: "add_output",
+    description: "Add a pipeline-level output.",
+    parameters: z.object({
+      name: z.string().describe("Output name"),
+      type: z.string().nullable().optional().describe("Type"),
+      description: z.string().nullable().optional(),
+    }),
+    execute: async ({ name, type, description }) =>
+      asJson(
+        await bridge.addOutput({
+          name,
+          type: type ?? undefined,
+          description: description ?? undefined,
+        }),
+      ),
+  });
+
+  const deleteOutput = tool({
+    name: "delete_output",
+    description: "Delete a pipeline output and its connections.",
+    parameters: z.object({
+      entityId: z.string().describe("The $id of the output to delete"),
+    }),
+    execute: async ({ entityId }) =>
+      asJson(await bridge.deleteOutput(entityId)),
+  });
+
+  const renameOutput = tool({
+    name: "rename_output",
+    description: "Rename a pipeline output.",
+    parameters: z.object({
+      entityId: z.string().describe("The $id of the output"),
+      newName: z.string().describe("New output name"),
+    }),
+    execute: async ({ entityId, newName }) =>
+      asJson(await bridge.renameOutput(entityId, newName)),
+  });
+
+  const connectNodes = tool({
+    name: "connect_nodes",
+    description:
+      "Connect an output port of one entity to an input port of another. Replaces any existing connection to the target port.",
+    parameters: z.object({
+      sourceEntityId: z
+        .string()
+        .describe("$id of source entity (task or pipeline input)"),
+      sourcePortName: z.string().describe("Name of the source port"),
+      targetEntityId: z
+        .string()
+        .describe("$id of target entity (task or pipeline output)"),
+      targetPortName: z.string().describe("Name of the target port"),
+    }),
+    execute: async ({
+      sourceEntityId,
+      sourcePortName,
+      targetEntityId,
+      targetPortName,
+    }) =>
+      asJson(
+        await bridge.connectNodes({
+          sourceEntityId,
+          sourcePortName,
+          targetEntityId,
+          targetPortName,
+        }),
+      ),
+  });
+
+  const deleteEdge = tool({
+    name: "delete_edge",
+    description: "Delete a binding/edge by its $id.",
+    parameters: z.object({
+      entityId: z.string().describe("The $id of the binding to delete"),
+    }),
+    execute: async ({ entityId }) => asJson(await bridge.deleteEdge(entityId)),
+  });
+
+  const setTaskArgument = tool({
+    name: "set_task_argument",
+    description:
+      "Set a value for a task input. Removes any existing connection to that port. Accepts a literal string/number/boolean or a structured value (e.g. a graph-input or task-output reference object).",
+    parameters: z.object({
+      taskEntityId: z.string().describe("$id of the task"),
+      inputName: z.string().describe("Name of the input port"),
+      value: jsonValueSchema.describe(
+        "Literal value (string/number/boolean) or a structured argument value object",
+      ),
+    }),
+    execute: async ({ taskEntityId, inputName, value }) =>
+      asJson(
+        await bridge.setTaskArgument(
+          taskEntityId,
+          inputName,
+          dropNulls(value) as ArgumentType,
+        ),
+      ),
+  });
+
+  const createSubgraph = tool({
+    name: "create_subgraph",
+    description:
+      "Group 2 or more related tasks into a subgraph. NEVER use for a single task — only group tasks that form a logical unit of work together.",
+    parameters: z.object({
+      taskEntityIds: z.array(z.string()).describe("$ids of tasks to group"),
+      subgraphName: z.string().describe("Name for the subgraph"),
+    }),
+    execute: async ({ taskEntityIds, subgraphName }) =>
+      asJson(await bridge.createSubgraph(taskEntityIds, subgraphName)),
+  });
+
+  const unpackSubgraph = tool({
+    name: "unpack_subgraph",
+    description:
+      "Inline a subgraph task back into the parent pipeline, expanding its inner tasks.",
+    parameters: z.object({
+      taskEntityId: z.string().describe("$id of the subgraph task to unpack"),
+    }),
+    execute: async ({ taskEntityId }) =>
+      asJson(await bridge.unpackSubgraph(taskEntityId)),
+  });
+
+  const validatePipeline = tool({
+    name: "validate_pipeline",
+    description:
+      "Validate the current pipeline for schema errors, missing inputs, orphaned bindings, and cycles. Always call before finalizing.",
+    parameters: z.object({}),
+    execute: async () => asJson(await bridge.validatePipeline()),
+  });
+
+  return {
+    allTools: [
+      getPipelineState,
+      setPipelineName,
+      setPipelineDescription,
+      addTask,
+      deleteTask,
+      renameTask,
+      addInput,
+      deleteInput,
+      renameInput,
+      addOutput,
+      deleteOutput,
+      renameOutput,
+      connectNodes,
+      deleteEdge,
+      setTaskArgument,
+      createSubgraph,
+      unpackSubgraph,
+      validatePipeline,
+    ],
+  };
+}

--- a/src/agent/worker.ts
+++ b/src/agent/worker.ts
@@ -18,6 +18,7 @@ import {
 import { getAiToken } from "./aiTokenStore";
 import { ProxyClient } from "./config";
 import { createSession } from "./session";
+import type { ToolBridgeApi } from "./toolBridgeApi";
 import type { AgentResponse, StatusCallback } from "./types";
 
 export interface AskParams {
@@ -26,7 +27,7 @@ export interface AskParams {
 }
 
 export interface AgentWorkerApi {
-  init(onStatus: StatusCallback): void;
+  init(bridge: ToolBridgeApi, onStatus: StatusCallback): void;
   ping(): Promise<"pong">;
   ask(params: AskParams, signal?: AbortSignal): Promise<AgentResponse>;
 }
@@ -37,6 +38,7 @@ function generateThreadId(): string {
 
 function createWorkerApi(): AgentWorkerApi {
   let dispatcher: TangleDispatcher | null = null;
+  let bridge: ToolBridgeApi | null = null;
   let emitStatus: StatusCallback = () => {};
   const proxyClient = new ProxyClient();
 
@@ -47,10 +49,11 @@ function createWorkerApi(): AgentWorkerApi {
      * the tool bridge plumbing and skill warm-up have an explicit
      * lifecycle hook later.
      */
-    init(onStatus) {
+    init(toolBridge, onStatus) {
       // Dispose any prior dispatcher (detaches its observability listeners)
       // so a fresh onStatus fully replaces the old one on re-init.
       dispatcher?.dispose();
+      bridge = toolBridge;
       emitStatus = onStatus;
       dispatcher = createDispatcher();
     },
@@ -62,7 +65,7 @@ function createWorkerApi(): AgentWorkerApi {
     async ask({ message, threadId }, _signal) {
       // todo: add logic to handle the signal
 
-      if (!dispatcher) {
+      if (!dispatcher || !bridge) {
         throw new Error(
           "Agent worker not initialized. Call init() before ask().",
         );
@@ -78,6 +81,7 @@ function createWorkerApi(): AgentWorkerApi {
         threadId: resolvedThreadId,
         emitStatus,
         proxyClient,
+        bridge,
       });
 
       const result = await dispatcher.invoke({

--- a/src/routes/v2/pages/Editor/components/AiChat/AiChatContent.tsx
+++ b/src/routes/v2/pages/Editor/components/AiChat/AiChatContent.tsx
@@ -1,29 +1,49 @@
 import { useQuery } from "@tanstack/react-query";
 import { observer } from "mobx-react-lite";
+import { useState } from "react";
 
 import { getAiToken } from "@/agent/aiTokenStore";
 import { config } from "@/agent/config";
 import { BlockStack } from "@/components/ui/layout";
 import useToastNotification from "@/hooks/useToastNotification";
+import { useEditorSession } from "@/routes/v2/pages/Editor/store/EditorSessionContext";
+import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 
 import { useAiChatStore } from "./AiChatStoreContext";
 import { AiTokenSetup } from "./components/AiTokenSetup";
 import { ChatInput } from "./components/ChatInput";
 import { ChatMessageList } from "./components/ChatMessageList";
+import { createToolBridge } from "./toolBridge";
 import { AiAssistantTokenQueryKeys } from "./types";
 
 export const AiChatContent = observer(function AiChatContent() {
   const aiChat = useAiChatStore();
   const notify = useToastNotification();
+  const { navigation } = useSharedStores();
+  const editorSession = useEditorSession();
   const { data: token, isPending: isTokenLoading } = useQuery({
     queryKey: AiAssistantTokenQueryKeys.Token(),
     queryFn: getAiToken,
     staleTime: Infinity,
   });
 
+  // The bridge closes over the navigation + undo stores, so a single
+  // instance per AiChatContent mount is correct: each call re-reads
+  // `navigation.rootSpec` and the active path lazily, picking up any
+  // navigation change without rebuilding the bridge.
+  const [bridge] = useState(() =>
+    createToolBridge({
+      getSpec: () => navigation.rootSpec,
+      getActiveSubgraphPath: () =>
+        navigation.navigationPath.slice(1).map((e) => e.displayName),
+      undo: editorSession.undo,
+    }),
+  );
+
   function handleSend(prompt: string) {
     aiChat.sendMessage(prompt, {
       onError: (msg) => notify(msg, "error"),
+      bridge,
     });
   }
 

--- a/src/routes/v2/pages/Editor/components/AiChat/agentClient.ts
+++ b/src/routes/v2/pages/Editor/components/AiChat/agentClient.ts
@@ -7,11 +7,13 @@
  */
 import * as Comlink from "comlink";
 
-import type { AgentResponse } from "@/agent/types";
+import type { ToolBridgeApi } from "@/agent/toolBridgeApi";
+import type { AgentResponse, StatusCallback } from "@/agent/types";
 import type { AgentWorkerApi } from "@/agent/worker";
 
 interface InitDeps {
-  onStatus: (status: { text: string }) => void;
+  bridge: ToolBridgeApi;
+  onStatus: StatusCallback;
 }
 
 interface AskOptions {
@@ -38,14 +40,15 @@ class AgentClient {
       throw new Error("Worker remote was not created");
     }
     if (!this.initPromise) {
-      // Pass onStatus as a top-level Comlink-proxied arg.
-      // Each new one must stay a separate top-level argument because Comlink only applies its proxy
-      // transfer handler to top-level argument values, it does not
-      // recursively walk into properties of an object arg.
-      //
-      // Wrapping proxied values in a single object would cause structured-clone
-      // of the methods and fail.
-      this.initPromise = this.remote.init(Comlink.proxy(deps.onStatus));
+      // Pass `bridge` and `onStatus` as SEPARATE top-level Comlink-proxied
+      // args. Comlink only applies its proxy transfer handler to top-level
+      // argument values; it does not recursively walk into properties of
+      // an object arg. Wrapping them in a single `{ bridge, onStatus }`
+      // object would cause structured-clone of the methods and fail.
+      this.initPromise = this.remote.init(
+        Comlink.proxy(deps.bridge),
+        Comlink.proxy(deps.onStatus),
+      );
     }
     await this.initPromise;
     return this.remote;

--- a/src/routes/v2/pages/Editor/components/AiChat/aiChatStore.ts
+++ b/src/routes/v2/pages/Editor/components/AiChat/aiChatStore.ts
@@ -1,5 +1,6 @@
 import { action, makeObservable, observable, runInAction } from "mobx";
 
+import type { ToolBridgeApi } from "@/agent/toolBridgeApi";
 import { getErrorMessage } from "@/utils/string";
 
 import { getAgentClient } from "./agentClient";
@@ -11,6 +12,7 @@ function generateMessageId(): string {
 
 interface SendMessageOptions {
   onError: (message: string) => void;
+  bridge: ToolBridgeApi;
 }
 
 /**
@@ -56,6 +58,7 @@ export class AiChatStore {
       const client = getAgentClient();
       const response = await client.ask(
         {
+          bridge: options.bridge,
           onStatus: (status) => {
             runInAction(() => {
               this.thinkingText = status.text;

--- a/src/routes/v2/pages/Editor/components/AiChat/serializeSpecForAi.ts
+++ b/src/routes/v2/pages/Editor/components/AiChat/serializeSpecForAi.ts
@@ -1,0 +1,158 @@
+/**
+ * Serializes the live MobX `ComponentSpec` into a stable plain-JSON shape
+ * the in-browser agent's CSOM tools can reason about.
+ *
+ * The shape is intentionally narrower than the wire format: optional
+ * properties are omitted when empty (so the LLM sees a smaller blob),
+ * subgraph tasks are flagged with `isSubgraph: true`, and the active
+ * subgraph breadcrumb (`activeSubgraphPath`) is surfaced so the model
+ * can disambiguate "fix the pipeline" vs "fix this subgraph" without a
+ * separate bridge call. Edits always target the root spec; the path is
+ * a hint, not a target.
+ */
+import type {
+  Binding,
+  ComponentReference,
+  ComponentSpec,
+  Input,
+  Output,
+  Task,
+  TypeSpecType,
+} from "@/models/componentSpec";
+import { isGraphImplementation } from "@/utils/componentSpec";
+
+type AiInputSpec = Pick<Input, "$id" | "name" | "type"> & {
+  description?: string;
+  default?: string;
+  optional?: boolean;
+};
+
+type AiOutputSpec = Pick<Output, "$id" | "name" | "type"> & {
+  description?: string;
+};
+
+interface AiComponentRef {
+  name?: string;
+  url?: string;
+  spec?: {
+    name?: string;
+    inputs?: Array<{ name: string; type?: TypeSpecType }>;
+    outputs?: Array<{ name: string; type?: TypeSpecType }>;
+  };
+}
+
+type AiTaskSpec = Pick<Task, "$id" | "name"> & {
+  componentRef: AiComponentRef;
+  arguments: Array<{ name: string; value?: unknown }>;
+  isSubgraph?: boolean;
+};
+
+type AiBindingSpec = Pick<
+  Binding,
+  | "$id"
+  | "sourceEntityId"
+  | "sourcePortName"
+  | "targetEntityId"
+  | "targetPortName"
+>;
+
+export interface AiSpec {
+  name: string;
+  description?: string;
+  inputs: AiInputSpec[];
+  outputs: AiOutputSpec[];
+  tasks: AiTaskSpec[];
+  bindings: AiBindingSpec[];
+  activeSubgraphPath?: string[];
+}
+
+export interface SerializeSpecOptions {
+  activeSubgraphPath?: string[];
+}
+
+function pickDefined<T extends object>(obj: T): T {
+  const out = {} as T;
+  for (const key in obj) {
+    if (obj[key] !== undefined) out[key] = obj[key];
+  }
+  return out;
+}
+
+const serializeInput = (input: Input): AiInputSpec =>
+  pickDefined({
+    $id: input.$id,
+    name: input.name,
+    type: input.type,
+    description: input.description || undefined,
+    default: input.defaultValue || undefined,
+    optional: input.optional,
+  });
+
+const serializeOutput = (output: Output): AiOutputSpec =>
+  pickDefined({
+    $id: output.$id,
+    name: output.name,
+    type: output.type,
+    description: output.description || undefined,
+  });
+
+const serializeArgument = (arg: {
+  name: string;
+  value?: unknown;
+}): { name: string; value?: unknown } =>
+  pickDefined({ name: arg.name, value: arg.value });
+
+const serializeTask = (task: Task): AiTaskSpec =>
+  pickDefined({
+    $id: task.$id,
+    name: task.name,
+    componentRef: serializeComponentRef(task.componentRef),
+    arguments: task.arguments.map(serializeArgument),
+    isSubgraph: isGraphImplementation(task.componentRef.spec?.implementation)
+      ? true
+      : undefined,
+  });
+
+const serializeBinding = (binding: Binding): AiBindingSpec => ({
+  $id: binding.$id,
+  sourceEntityId: binding.sourceEntityId,
+  sourcePortName: binding.sourcePortName,
+  targetEntityId: binding.targetEntityId,
+  targetPortName: binding.targetPortName,
+});
+
+const serializePort = (port: {
+  name: string;
+  type?: TypeSpecType;
+}): { name: string; type?: TypeSpecType } =>
+  pickDefined({ name: port.name, type: port.type });
+
+function serializeComponentRef(ref: ComponentReference): AiComponentRef {
+  return pickDefined({
+    name: ref.name,
+    url: ref.url,
+    spec: ref.spec
+      ? pickDefined({
+          name: ref.spec.name,
+          inputs: ref.spec.inputs?.map(serializePort),
+          outputs: ref.spec.outputs?.map(serializePort),
+        })
+      : undefined,
+  });
+}
+
+export function serializeSpecForAi(
+  spec: ComponentSpec,
+  { activeSubgraphPath = [] }: SerializeSpecOptions = {},
+): AiSpec {
+  return pickDefined({
+    name: spec.name,
+    description: spec.description || undefined,
+    inputs: spec.inputs.map(serializeInput),
+    outputs: spec.outputs.map(serializeOutput),
+    tasks: spec.tasks.map(serializeTask),
+    bindings: spec.bindings.map(serializeBinding),
+    activeSubgraphPath:
+      activeSubgraphPath.length > 0 ? activeSubgraphPath : undefined,
+  });
+}

--- a/src/routes/v2/pages/Editor/components/AiChat/toolBridge.ts
+++ b/src/routes/v2/pages/Editor/components/AiChat/toolBridge.ts
@@ -1,0 +1,293 @@
+/**
+ * Main-thread implementation of the agent's `ToolBridgeApi`.
+ *
+ * Each method mutates the LIVE MobX `ComponentSpec` from the editor
+ * session inside an undo group, so the agent's edits are user-visible
+ * immediately and undoable as a single step. The worker proxies these
+ * methods via Comlink; no command serialization or tempId remapping is
+ * needed.
+ *
+ * Bridge deps are deliberately tiny — the bridge owns no React or MobX
+ * subscriptions of its own, which keeps it trivially testable: feed it
+ * a `ComponentSpec` and an `UndoGroupable` and every method works.
+ */
+import type {
+  ConnectArgs,
+  ToolBridgeApi,
+  ValidationResult,
+} from "@/agent/toolBridgeApi";
+import type { ComponentSpec } from "@/models/componentSpec";
+import { validateSpec } from "@/models/componentSpec/validation/validateSpec";
+import {
+  connectNodes,
+  deleteSelectedEdgesByEdgeIds,
+} from "@/routes/v2/pages/Editor/store/actions/connection.actions";
+import {
+  addInput,
+  addOutput,
+  deleteInput,
+  deleteOutput,
+  renameInput,
+  renameOutput,
+  setInputDefaultValue,
+  setInputDescription,
+  setInputType,
+  setOutputDescription,
+} from "@/routes/v2/pages/Editor/store/actions/io.actions";
+import {
+  createSubgraph,
+  renamePipeline,
+  updatePipelineDescription,
+} from "@/routes/v2/pages/Editor/store/actions/pipeline.actions";
+import {
+  addTask,
+  deleteTask,
+  renameTask,
+  unpackSubgraphTask,
+} from "@/routes/v2/pages/Editor/store/actions/task.actions";
+import type { UndoGroupable } from "@/routes/v2/shared/nodes/types";
+import { hydrateComponentReference } from "@/services/componentService";
+import { EDITOR_POSITION_ANNOTATION } from "@/utils/annotations";
+
+import { serializeSpecForAi } from "./serializeSpecForAi";
+
+const DEFAULT_POSITION = { x: 250, y: 250 };
+const POSITION_OFFSET = 200;
+
+interface BridgeDeps {
+  getSpec: () => ComponentSpec | null;
+  getActiveSubgraphPath: () => string[];
+  undo: UndoGroupable;
+}
+
+interface EntityWithAnnotations {
+  annotations: { get(key: string): unknown };
+}
+
+function computeNextPosition(spec: ComponentSpec): { x: number; y: number } {
+  const allEntities: EntityWithAnnotations[] = [
+    ...spec.tasks,
+    ...spec.inputs,
+    ...spec.outputs,
+  ];
+  if (allEntities.length === 0) return DEFAULT_POSITION;
+
+  let maxX = 0;
+  let maxY = 0;
+  for (const entity of allEntities) {
+    const pos = entity.annotations.get(EDITOR_POSITION_ANNOTATION) as
+      | { x: number; y: number }
+      | undefined;
+    if (pos) {
+      maxX = Math.max(maxX, pos.x);
+      maxY = Math.max(maxY, pos.y);
+    }
+  }
+  return { x: maxX + POSITION_OFFSET, y: maxY };
+}
+
+/**
+ * Builds the bridge implementation. Returned object is intended to be
+ * exposed to the worker via `Comlink.proxy()`. Methods throw when the
+ * spec is unavailable (no pipeline open) so the worker surfaces a clear
+ * error to the model.
+ */
+export function createToolBridge(deps: BridgeDeps): ToolBridgeApi {
+  function requireSpec(): ComponentSpec {
+    const spec = deps.getSpec();
+    if (!spec) {
+      throw new Error(
+        "No pipeline is currently open — open a pipeline before asking the agent to edit it.",
+      );
+    }
+    return spec;
+  }
+
+  return {
+    async getPipelineState() {
+      return serializeSpecForAi(requireSpec(), {
+        activeSubgraphPath: deps.getActiveSubgraphPath(),
+      });
+    },
+
+    async setPipelineName(name) {
+      const spec = requireSpec();
+      renamePipeline(deps.undo, spec, name);
+      return { success: true };
+    },
+
+    async setPipelineDescription(description) {
+      const spec = requireSpec();
+      updatePipelineDescription(deps.undo, spec, description);
+      return { success: true };
+    },
+
+    async addTask({ name, componentRef }) {
+      const spec = requireSpec();
+      const hydrated =
+        (await hydrateComponentReference(componentRef)) ?? componentRef;
+      const position = computeNextPosition(spec);
+      const task = addTask(deps.undo, spec, hydrated, position);
+      if (!task) {
+        return { success: false, error: "addTask returned no task" };
+      }
+      if (name && task.name !== name) {
+        renameTask(deps.undo, spec, task.$id, name);
+      }
+      return { success: true, taskId: task.$id, name: task.name };
+    },
+
+    async deleteTask(entityId) {
+      const spec = requireSpec();
+      return { success: deleteTask(deps.undo, spec, entityId) };
+    },
+
+    async renameTask(entityId, newName) {
+      const spec = requireSpec();
+      return { success: renameTask(deps.undo, spec, entityId, newName) };
+    },
+
+    async addInput({ name, type, description, defaultValue, optional }) {
+      const spec = requireSpec();
+      const position = computeNextPosition(spec);
+      const input = addInput(deps.undo, spec, position, name);
+      if (type) setInputType(deps.undo, spec, input.$id, type);
+      if (description)
+        setInputDescription(deps.undo, spec, input.$id, description);
+      if (defaultValue)
+        setInputDefaultValue(deps.undo, spec, input.$id, defaultValue);
+      if (optional !== undefined) {
+        deps.undo.withGroup("Set input optional", () => {
+          input.setOptional(optional);
+        });
+      }
+      return { success: true, inputId: input.$id, name: input.name };
+    },
+
+    async deleteInput(entityId) {
+      const spec = requireSpec();
+      return { success: deleteInput(deps.undo, spec, entityId) };
+    },
+
+    async renameInput(entityId, newName) {
+      const spec = requireSpec();
+      return { success: renameInput(deps.undo, spec, entityId, newName) };
+    },
+
+    async addOutput({ name, type, description }) {
+      const spec = requireSpec();
+      const position = computeNextPosition(spec);
+      const output = addOutput(deps.undo, spec, position, name);
+      if (type) {
+        deps.undo.withGroup("Set output type", () => output.setType(type));
+      }
+      if (description)
+        setOutputDescription(deps.undo, spec, output.$id, description);
+      return { success: true, outputId: output.$id, name: output.name };
+    },
+
+    async deleteOutput(entityId) {
+      const spec = requireSpec();
+      return { success: deleteOutput(deps.undo, spec, entityId) };
+    },
+
+    async renameOutput(entityId, newName) {
+      const spec = requireSpec();
+      return { success: renameOutput(deps.undo, spec, entityId, newName) };
+    },
+
+    async connectNodes(args: ConnectArgs) {
+      const spec = requireSpec();
+      const ok = connectNodes(deps.undo, spec, {
+        sourceNodeId: args.sourceEntityId,
+        sourceHandleId: `output_${args.sourcePortName}`,
+        targetNodeId: args.targetEntityId,
+        targetHandleId: `input_${args.targetPortName}`,
+      });
+      if (!ok) {
+        return {
+          success: false,
+          error:
+            "Could not create binding — invalid source/target combination.",
+        };
+      }
+      const binding = spec.bindings.find(
+        (b) =>
+          b.sourceEntityId === args.sourceEntityId &&
+          b.sourcePortName === args.sourcePortName &&
+          b.targetEntityId === args.targetEntityId &&
+          b.targetPortName === args.targetPortName,
+      );
+      if (!binding) {
+        return {
+          success: true,
+          error: "Connection created but binding id could not be resolved.",
+        };
+      }
+      return { success: true, bindingId: binding.$id };
+    },
+
+    async deleteEdge(entityId) {
+      const spec = requireSpec();
+      deleteSelectedEdgesByEdgeIds(deps.undo, spec, [`edge_${entityId}`]);
+      return { success: true };
+    },
+
+    async setTaskArgument(taskEntityId, inputName, value) {
+      const spec = requireSpec();
+      const task = spec.tasks.find((t) => t.$id === taskEntityId);
+      if (!task) {
+        return { success: false, error: `No task with id ${taskEntityId}` };
+      }
+      const hasInput = task.componentRef.spec?.inputs?.some(
+        (i) => i.name === inputName,
+      );
+      if (!hasInput) {
+        return {
+          success: false,
+          error: `Task has no input named "${inputName}"`,
+        };
+      }
+      deps.undo.withGroup("Set task argument", () => {
+        spec.setTaskArgument(taskEntityId, inputName, value);
+      });
+      return { success: true };
+    },
+
+    async createSubgraph(taskEntityIds, subgraphName) {
+      const spec = requireSpec();
+      const position = computeNextPosition(spec);
+      const subgraphTask = createSubgraph(
+        deps.undo,
+        spec,
+        taskEntityIds,
+        subgraphName,
+        position,
+      );
+      if (!subgraphTask) {
+        return { success: false, error: "Could not create subgraph" };
+      }
+      return { success: true, subgraphTaskId: subgraphTask.$id };
+    },
+
+    async unpackSubgraph(taskEntityId) {
+      const spec = requireSpec();
+      return { success: unpackSubgraphTask(deps.undo, spec, taskEntityId) };
+    },
+
+    async validatePipeline(): Promise<ValidationResult> {
+      const issues = validateSpec(requireSpec());
+      return {
+        valid: issues.length === 0,
+        issueCount: issues.length,
+        issues: issues.map((i) => ({
+          type: i.type,
+          severity: i.severity,
+          message: i.message,
+          entityId: i.entityId,
+          issueCode: i.issueCode,
+        })),
+      };
+    },
+  };
+}


### PR DESCRIPTION
## Description

Introduces a `pipeline-repair` sub-agent that can diagnose and fix validation issues, broken connections, missing inputs, and other structural problems in an existing pipeline. The agent operates through a new CSOM tool surface (`csomTools.ts`) that proxies calls to a main-thread `ToolBridgeApi` implementation (`toolBridge.ts`), which mutates the live MobX `ComponentSpec` inside an undo group — making all agent edits immediately visible in the editor and undoable as a single user action.

Key additions:

- **`ToolBridgeApi`** — typed contract for the worker → main-thread bridge, covering tasks, inputs, outputs, bindings, subgraphs, arguments, and pipeline validation.
- **`toolBridge.ts`** — main-thread implementation that delegates to existing editor actions (`addTask`, `connectNodes`, `deleteEdge`, `validatePipeline`, etc.) and computes canvas positions for newly added entities.
- **`csomTools.ts`** — OpenAI Agents `tool()` wrappers for every bridge method, with Zod schemas compatible with OpenAI's strict structured-outputs mode (all optional fields are `.nullable().optional()`).
- **`serializeSpecForAi.ts`** — serializes the live `ComponentSpec` into a compact JSON shape for the model, including an `activeSubgraphPath` breadcrumb so the agent knows which subgraph the user is viewing.
- **`pipelineRepair.ts`** sub-agent and its system prompt, which defines a structured workflow: read state → validate → auto-fix what's unambiguous → ask the user for anything that isn't.
- The `AgentSession` now carries a `bridge` reference, and the worker's `init()` signature accepts the Comlink-proxied bridge as a separate top-level argument.
- The Tangle Dispatcher prompt and handoff list are updated to route "fix / validate / repair" requests to `pipeline-repair` and conceptual questions to `general-help`.

## Screenshots (if applicable)

[AI Assistant - Fix pipeline demo.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/14bf6802-e9df-4913-9cd7-614f30e1bfbd.mov" />](https://app.graphite.com/user-attachments/video/14bf6802-e9df-4913-9cd7-614f30e1bfbd.mov)



## Test Instructions

1. Open a pipeline with at least one validation error (e.g. a dangling binding or a task with a missing required argument).
2. Open the AI Chat panel and type a repair request such as "fix my pipeline" or "what's wrong with this?".
3. Verify the dispatcher hands off to `pipeline-repair` (not `general-help`).
4. Confirm the agent calls `get_pipeline_state` and `validate_pipeline`, then applies auto-fixable issues directly.
5. Confirm that ambiguous fixes prompt the user for input before any mutation.
6. Verify all edits appear immediately in the editor canvas and are undoable as a single undo step.
7. Open a pipeline with no tasks and ask the agent to fix it — confirm it responds with the "empty pipeline" message without calling any mutation tools.

## Additional Comments

The bridge is instantiated once per `AiChatContent` mount and closes over `navigation.rootSpec` and the active subgraph path lazily, so navigation changes are picked up without rebuilding the bridge. The `bridge` and `onStatus` callbacks must be passed as separate top-level `Comlink.proxy()` arguments because Comlink does not recursively proxy properties inside an object argument.