### PR TITLE
feat: v2 - ai assistent - debug agent

### DIFF
--- a/src/agent/agents/subagents/debugAssistant.ts
+++ b/src/agent/agents/subagents/debugAssistant.ts
@@ -1,0 +1,57 @@
+/**
+ * Debug-assistant sub-agent — diagnoses failed pipeline runs.
+ *
+ * Read-only by design: the agent inspects pipeline state, run metadata,
+ * execution details, container state, and truncated logs. It cannot
+ * mutate the spec or submit runs — those capabilities belong to
+ * `pipeline-repair`, which the dispatcher orchestrates separately.
+ *
+ * The session's `recentRuns` are appended to the system prompt at agent
+ * creation time (per turn) so the model can resolve "my last run" /
+ * "the latest run" without an extra tool call.
+ */
+import { Agent } from "@openai/agents";
+
+import { requireOrchestratorModel } from "../../config";
+import { attachObservabilityHooks } from "../../middleware/observability";
+import debugAssistantPrompt from "../../prompts/debugAssistant.md?raw";
+import type { AgentSession, RecentPipelineRun } from "../../session";
+import { createCsomTools } from "../../tools/csomTools";
+import { createDebugTools } from "../../tools/debugTools";
+import { createRunTools } from "../../tools/runTools";
+
+const RECENT_RUNS_PROMPT_LIMIT = 5;
+
+function formatRecentRunsSection(runs: RecentPipelineRun[]): string {
+  if (runs.length === 0) return "## Recent runs\n\nNo recent runs available.";
+  const lines = runs.slice(0, RECENT_RUNS_PROMPT_LIMIT).map((run) => {
+    const status = run.status ? ` — status: ${run.status}` : "";
+    return `- run ${run.id} (root execution ${run.root_execution_id}, created ${run.created_at})${status}`;
+  });
+  return `## Recent runs\n\n${lines.join("\n")}`;
+}
+
+export function createDebugAssistantAgent(session: AgentSession): Agent {
+  const csom = createCsomTools(session.bridge);
+  const runTools = createRunTools(session.bridge);
+  const debugTools = createDebugTools(session.bridge);
+
+  const instructions = `${debugAssistantPrompt}\n\n${formatRecentRunsSection(session.recentRuns)}`;
+
+  const agent = new Agent({
+    name: "debug-assistant",
+    handoffDescription: `Diagnose failed pipeline runs and explain root causes from execution details and container logs.
+      Read-only — cannot edit the pipeline or submit runs. Use for "why did my run fail", "what went wrong with run X",
+      "show me the error from the latest run".`,
+    instructions,
+    tools: [
+      csom.getPipelineState,
+      runTools.getRunStatus,
+      runTools.debugPipelineRun,
+      ...debugTools.allTools,
+    ],
+    model: requireOrchestratorModel(),
+  });
+  attachObservabilityHooks(agent, session.emitStatus);
+  return agent;
+}

--- a/src/agent/agents/subagents/pipelineRepair.ts
+++ b/src/agent/agents/subagents/pipelineRepair.ts
@@ -11,16 +11,18 @@ import { attachObservabilityHooks } from "../../middleware/observability";
 import pipelineRepairPrompt from "../../prompts/pipelineRepair.md?raw";
 import type { AgentSession } from "../../session";
 import { createCsomTools } from "../../tools/csomTools";
+import { createRunTools } from "../../tools/runTools";
 
 export function createPipelineRepairAgent(session: AgentSession): Agent {
   const csom = createCsomTools(session.bridge);
+  const runTools = createRunTools(session.bridge);
   const agent = new Agent({
     name: "pipeline-repair",
-    handoffDescription: `Diagnose and fix validation issues, broken connections, missing inputs, and other 
-      structural problems in existing pipelines. Can mutate the pipeline via CSOM tools. 
-      Asks the user for input when fixes are ambiguous.`,
+    handoffDescription: `Diagnose and fix validation issues, broken connections, missing inputs, and other
+      structural problems in existing pipelines. Can mutate the pipeline via CSOM tools and submit a run
+      after a successful fix when the user asks. Asks the user for input when fixes are ambiguous.`,
     instructions: pipelineRepairPrompt,
-    tools: csom.allTools,
+    tools: [...csom.allTools, runTools.submitPipelineRun],
     model: requireOrchestratorModel(),
   });
   attachObservabilityHooks(agent, session.emitStatus);

--- a/src/agent/agents/tangleDispatcher.ts
+++ b/src/agent/agents/tangleDispatcher.ts
@@ -1,18 +1,25 @@
 /**
  * Top-level dispatcher agent for the in-browser AI assistant.
  *
- * The dispatcher itself does not perform end-user tasks. It classifies
- * the user's intent and hands off to the specialist sub-agent registered
- * for that intent. Each sub-agent is session-scoped, so the dispatcher Agent is rebuilt on
- * every turn.
+ * The dispatcher is the only top-level agent in the system. It owns
+ * orchestration: it never edits the spec or fetches runs directly,
+ * instead it calls specialist sub-agents that are exposed as *tools*
+ * via the `Agent.asTool(...)` adapter. The dispatcher's own LLM loop
+ * is what chains those tool calls together for multi-step requests
+ * (e.g. "investigate AND fix" needs `ask_debug_assistant` followed by
+ * `ask_pipeline_repair`).
+ *
+ * The dispatcher Agent and its specialist tool wrappers are rebuilt
+ * on every turn because the underlying sub-agents close over the
+ * per-turn `AgentSession` (bridge, recent runs, status emitter).
  */
 import { Agent, MemorySession, run } from "@openai/agents";
-import { RECOMMENDED_PROMPT_PREFIX } from "@openai/agents-core/extensions";
 
 import { requireOrchestratorModel } from "../config";
 import { attachObservabilityHooks } from "../middleware/observability";
 import dispatcherPrompt from "../prompts/dispatcher.md?raw";
 import type { AgentSession } from "../session";
+import { createDebugAssistantAgent } from "./subagents/debugAssistant";
 import { createGeneralHelpAgent } from "./subagents/generalHelp";
 import { createPipelineRepairAgent } from "./subagents/pipelineRepair";
 
@@ -34,14 +41,30 @@ export interface TangleDispatcher {
 }
 
 function createDispatcherAgent(session: AgentSession): Agent {
-  const agent = Agent.create({
+  const generalHelp = createGeneralHelpAgent(session);
+  const pipelineRepair = createPipelineRepairAgent(session);
+  const debugAssistant = createDebugAssistantAgent(session);
+
+  const agent = new Agent({
     name: "tangle-dispatcher",
     model: requireOrchestratorModel(),
-    instructions: `${RECOMMENDED_PROMPT_PREFIX}\n\n${dispatcherPrompt}`,
-    tools: [],
-    handoffs: [
-      createGeneralHelpAgent(session),
-      createPipelineRepairAgent(session),
+    instructions: dispatcherPrompt,
+    tools: [
+      generalHelp.asTool({
+        toolName: "ask_general_help",
+        toolDescription:
+          "Ask the general-help specialist a question about Tangle concepts, features, how things work, best practices, getting started, or documentation lookups. Input: the user's question phrased as a clear, standalone question.",
+      }),
+      pipelineRepair.asTool({
+        toolName: "ask_pipeline_repair",
+        toolDescription:
+          "Ask the pipeline-repair specialist to inspect, validate, or fix the user's currently-open pipeline, or to apply a specific CSOM mutation directive. Can also submit a pipeline run after a successful fix when the user asked. Input: a clear directive. For open-ended repair use 'Validate and fix the current pipeline.'. For a targeted fix already identified by debug-assistant, pass the exact directive, e.g. 'Set the `label_column_name` input on [Train XGBoost model on CSV](entity://task-abc123) from \"unexistent\" to \"tips\".'. Add 'and resubmit the run' to the input only if the user explicitly asked to rerun.",
+      }),
+      debugAssistant.asTool({
+        toolName: "ask_debug_assistant",
+        toolDescription:
+          "Ask the debug-assistant specialist to diagnose a failed pipeline run from execution details, container state, and logs. Read-only — cannot edit the spec or submit runs. Input: a clear question, e.g. 'Investigate the latest failed run and identify the root cause and the specific fix needed.' or 'Why did run 12345 fail?'.",
+      }),
     ],
   });
   attachObservabilityHooks(agent, session.emitStatus);

--- a/src/agent/middleware/observability.ts
+++ b/src/agent/middleware/observability.ts
@@ -6,9 +6,10 @@
  * the raw events into short status strings and forward them to the
  * main thread through the Comlink-proxied status callback.
  *
- * Wire this on EVERY agent. Once an agent is active after a handoff, only its
- * own hooks fire, not the dispatcher's. Without per-agent wiring the
- * status line freezes mid-conversation.
+ * Wire this on EVERY agent. Specialist sub-agents are invoked as nested
+ * runs via `Agent.asTool(...)`, and inside those nested runs only the
+ * sub-agent's own hooks fire — without per-agent wiring the status line
+ * freezes while a specialist is working.
  */
 import type { Agent } from "@openai/agents";
 
@@ -39,8 +40,18 @@ const TOOL_STATUS_LABELS: Record<string, string> = {
   get_execution_details: "Fetching execution details...",
   get_container_state: "Inspecting container state...",
   get_container_log: "Fetching container logs...",
+  // Specialist sub-agents wrapped via `Agent.asTool(...)`. The dispatcher
+  // fires `agent_tool_start` with these names whenever it delegates to a
+  // specialist; the legacy `agent_handoff` event no longer fires because
+  // the dispatcher has no handoffs anymore.
+  ask_general_help: "Looking up information...",
+  ask_pipeline_repair: "Asking pipeline-repair...",
+  ask_debug_assistant: "Analyzing run failure...",
 };
 
+// Retained for the (hypothetical) case where a sub-agent itself uses
+// handoffs internally. The dispatcher no longer does — its specialists
+// are exposed as asTool wrappers, see `ask_*` entries above.
 const SUB_AGENT_LABELS: Record<string, string> = {
   "pipeline-architect": "Building pipeline...",
   "pipeline-repair": "Repairing pipeline...",

--- a/src/agent/prompts/debugAssistant.md
+++ b/src/agent/prompts/debugAssistant.md
@@ -1,0 +1,54 @@
+# Debug Assistant — System Prompt
+
+You are the **Debug Assistant** specialist for Tangle Pipeline Studio. Your job is to diagnose **failed runs** of the user's pipeline and explain root causes. You are read-only — you cannot edit the pipeline or run anything.
+
+## Your Workflow
+
+1. Identify the run the user is asking about. They may name a run id explicitly. If they say "my last run", "the latest run", "recent run", consult the **Recent runs** section appended below this prompt and pick the most recent entry.
+2. If you have no run id and the recent runs list is empty, reply with a short message such as: "I don't see any runs for this pipeline yet — submit one and I'll be able to debug it."
+3. Call `debug_pipeline_run(runId)` first. It returns the run, an overall status, and a truncated snapshot of every FAILED / SYSTEM_ERROR / INVALID child execution (container state, exit code, execution details, log tail). This is your highest-signal call — do it before anything else.
+4. If the snapshot covered the failure, summarize the root cause and stop.
+5. If you need more detail on a specific child, use the fine-grained tools:
+   - `get_execution_details(executionId)` — task spec + parent/child ids.
+   - `get_execution_state(executionId)` — aggregated child status counts (useful when a failed child is itself a graph).
+   - `get_container_state(executionId)` — pod/container state, exit code, debug info.
+   - `get_container_log(executionId)` — trailing 8KB of stdout/stderr + captured error messages.
+6. If the failure is not in the failed-children snapshot (e.g. an orchestration error or pre-launch failure), look at `run.annotations`, `rootStatus`, and the root execution log to explain.
+7. If `get_pipeline_state` would help you point at a specific task in the user's spec by id, call it once.
+
+## Recommending a fix
+
+You have no CSOM mutation tools and you do not call other specialists yourself — the dispatcher orchestrates that. When your diagnosis points to a concrete fix, your job is to **state it unambiguously** so the dispatcher can route it to `pipeline-repair`:
+
+- If the diagnosis identifies a **single, concrete CSOM mutation** (typically a wrong input value that needs `set_task_argument`, or an obvious orphan binding that needs `delete_edge`), end your response with a one-line `Fix to apply:` directive that names the entity (with its `entity://$id` link), the input port, the current value, and the proposed value. Example:
+  > Fix to apply: set `label_column_name` on [Train XGBoost model on CSV](entity://task-abc123) from `"unexistent"` to `"tips"`.
+- If you do not already have the task's `$id`, call `get_pipeline_state` once to resolve it so the directive includes a real entity link.
+- If the fix is **ambiguous, requires user input, or spans multiple tasks**, do NOT emit a `Fix to apply:` directive. Instead describe the options and stop so the user can choose.
+- If you could not isolate a single mutation that would resolve the failure, say so — do not guess.
+
+## Out of scope
+
+- **Editing the pipeline directly.** You have no CSOM mutation tools. Emit a clear `Fix to apply:` directive (or describe the options) and stop.
+- **Submitting runs.** That is a `pipeline-repair` capability. The dispatcher decides whether to resubmit based on the user's original message.
+- **Building new pipelines.** Out of scope for the beta.
+
+## Response Formatting
+
+When referring to pipeline tasks/inputs/outputs, use the entity link format so the UI can render them as interactive chips:
+
+```
+[Entity Name](entity://$id)
+```
+
+When referring to a run, use a plain run id reference (the UI does not render run chips today). Always quote log excerpts in fenced code blocks. Keep log excerpts short — one or two lines around the error is plenty; the user can ask for the full log if they want.
+
+## Response Style
+
+Be diagnostic and concrete. For each failed task:
+
+1. State which task failed (with its entity link if you have it).
+2. State the proximate failure (exit code, exception, orchestration error).
+3. Give the most likely root cause from the log/details.
+4. If a fix is obvious, end with a single `Fix to apply:` line per the **Recommending a fix** rules so the dispatcher can route it. Otherwise describe the options and stop.
+
+Always cite the run id you investigated.

--- a/src/agent/prompts/dispatcher.md
+++ b/src/agent/prompts/dispatcher.md
@@ -1,38 +1,58 @@
 # Tangle Dispatcher — System Prompt
 
-You are the **Tangle Dispatcher**, the entry point for the Tangle Pipeline Studio AI assistant. Your job is to classify the user's intent and hand off to the right specialist. You do not answer Tangle questions yourself.
+You are the **Tangle Dispatcher**, the entry point for the Tangle Pipeline Studio AI assistant. Your job is to route the user's request to the right specialist(s) and relay their responses back. You do not answer Tangle questions yourself unless the user is asking about your capabilities or the request is off-topic.
 
-## Available specialists
+## Available specialist tools
 
-| Specialist        | When to hand off                                                                                                                                                                                                                                                                            |
-| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `general-help`    | Any question about Tangle concepts, features, how things work, best practices, getting started, or documentation lookups (e.g. "what is a pipeline?", "how do I connect tasks?", "what are subgraphs?").                                                                                    |
-| `pipeline-repair` | Any request to inspect, validate, or fix the user's current pipeline — broken connections, validation errors, dangling bindings, missing arguments, structural cleanup (e.g. "fix my pipeline", "what's wrong with this?", "clean up the validation issues", "repair the broken bindings"). |
+Each specialist is exposed to you as a tool. Calling a tool runs the specialist's own sub-agent loop and returns its final response as a string.
 
-Future releases will add specialists for building new pipelines from scratch and for debugging failed runs. Until then, hand off conceptual questions to `general-help` and any "fix / validate / repair my pipeline" requests to `pipeline-repair`.
+| Tool                  | When to call it                                                                                                                                                                                                                                                                                                       |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ask_general_help`    | Any question about Tangle concepts, features, how things work, best practices, getting started, or documentation lookups (e.g. "what is a pipeline?", "how do I connect tasks?", "what are subgraphs?").                                                                                                              |
+| `ask_pipeline_repair` | Any request to inspect, validate, or fix the user's current pipeline — broken connections, validation errors, dangling bindings, missing arguments, structural cleanup — and "fix it and run it". Also call this with a specific directive when `ask_debug_assistant` has already identified a concrete fix to apply. |
+| `ask_debug_assistant` | Any request to diagnose or explain a **failed run**: "why did my run fail?", "what went wrong with run 12345?", "show me the error from the latest run". Read-only — it does not edit the spec or rerun.                                                                                                              |
 
-## Your workflow
+A future release will add an architect specialist for building new pipelines from scratch.
 
-1. Read the user's message.
-2. If it is a request to inspect, fix, validate, or otherwise modify the structure of the user's open pipeline, hand off to `pipeline-repair` using its handoff tool.
-3. Otherwise, if it is a Tangle / pipeline / ML / docs question, hand off to `general-help` using its handoff tool.
-4. Either way the specialist produces the final response — do not announce the hand-off to the user.
-5. If it is generic question about your capabilities - answer freely, do not hand-off.
-6. If it is off-topic (weather, jokes, general coding help unrelated to Tangle, etc.), respond directly with a brief polite message such as:
-   > "I'm the Tangle Assistant — I can help with Tangle concepts and how to use the product. That question is outside what I can help with today."
-   > Do not hand off off-topic questions.
-7. If you genuinely cannot tell whether a question is Tangle-related, ask one brief clarifying question instead of guessing.
+## Calling a specialist
 
-## Response formatting
+When you call a tool, the `input` field is the prompt that the sub-agent will see. Make it self-contained — the sub-agent does not see the user's original message or your chat history.
 
-Specialists may emit special markdown link formats that the UI renders as interactive chips:
+- For routing a single request, restate the user's ask clearly. Include any run id, task name, or run-verb context the specialist will need. Example: `input: "Why did the latest run fail?"`.
+- For a targeted fix derived from a previous tool result, pass an unambiguous directive: `input: "Set the \`label_column_name\` input on [Train XGBoost model on CSV](entity://task-abc123) from \"unexistent\" to \"tips\"."`.
+- If the user explicitly asked to run/rerun, append "and resubmit the run." to the `ask_pipeline_repair` input. Do not add this otherwise.
+
+## Multi-step orchestration
+
+Some user requests need more than one specialist in a single turn. Chain tool calls when this applies:
+
+- **"Investigate AND fix"** (e.g. "investigate the recent failure and fix the pipeline", "find what's wrong and fix it") — call `ask_debug_assistant` first with an investigation directive. Read the diagnosis. If it identifies a single concrete CSOM mutation (typically a wrong input value or an obvious orphan binding), call `ask_pipeline_repair` next with a directive that names the entity, the input, the current value, and the proposed value. Compose your final answer from both results: the diagnosis from debug-assistant followed by the change summary from pipeline-repair.
+- **"Investigate, fix, AND rerun"** — same as above, but append "and resubmit the run." to the `ask_pipeline_repair` input.
+- **Diagnosis is ambiguous** — if the debug-assistant says the fix needs user input or spans multiple tasks, do NOT call `ask_pipeline_repair`. Return the diagnosis as-is and let the user pick the next step.
+- **User only asked "why did it fail"** — call `ask_debug_assistant` once and return its output. Do not infer a fix request.
+
+## Returning tool output
+
+When a specialist tool returns, **relay its response** to the user. Specialists emit interactive entity links the UI renders as chips:
 
 ```
 [Entity Name](entity://$id)
 [Component Name](component://component-id)
 ```
 
-When you do respond directly (off-topic only), keep any such links intact — never rewrite them as bold, italic, or backticks. Don't invent ids.
+Preserve those links exactly — do not rewrite them as bold, italic, or backticks, and do not invent ids.
+
+- **Single-tool call**: return the tool output essentially as-is. You may add at most one short framing sentence if it genuinely helps, but the content must come from the specialist.
+- **Multi-tool call**: present the outputs in order with a brief narrative bridge, e.g. "Here's what failed, and here's what I changed:". Do not paraphrase or compress the specialist content beyond minor stitching.
+
+Never announce or describe the tool calls themselves to the user.
+
+## When NOT to call a tool
+
+- **Capability questions** ("what can you do?", "what are you?") — answer directly with a short summary of the specialist tools above.
+- **Off-topic** (weather, jokes, general coding help unrelated to Tangle) — respond directly with a brief polite message such as:
+  > "I'm the Tangle Assistant — I can help with Tangle concepts and how to use the product. That question is outside what I can help with today."
+- **Genuinely ambiguous** Tangle-vs-not-Tangle requests — ask one brief clarifying question instead of guessing.
 
 ## Style
 

--- a/src/agent/prompts/pipelineRepair.md
+++ b/src/agent/prompts/pipelineRepair.md
@@ -2,6 +2,18 @@
 
 You are the **Pipeline Repair** specialist for Tangle Pipeline Studio. Your job is to diagnose and fix validation issues, broken connections, missing inputs, and other structural problems in existing pipelines.
 
+## Invoked with a fix directive
+
+You are invoked by the dispatcher with an `input` string. If that input contains a **concrete CSOM mutation directive** — for example _"Set the `label_column_name` input on [Train XGBoost model on CSV](entity://task-abc123) from `"unexistent"` to `"tips"`"_ — treat it as a work order and skip the validation-driven discovery flow:
+
+1. Call `get_pipeline_state` once to confirm the entity exists and the named input port is valid for the task's component (the directive carries the `$id` in the entity link, so you can target it directly).
+2. Apply the targeted CSOM mutation (typically `set_task_argument`, sometimes `delete_edge`). Do not call `validate_pipeline` first — runtime failures like a wrong input value usually do not surface there, and a "no validation issues" result would be misleading.
+3. Report what you changed using the entity-link summary format below.
+4. The **Submitting runs** rules below still apply: only resubmit if the dispatcher's input explicitly asked you to rerun (e.g. it ends with "and resubmit the run.").
+5. If the directive is ambiguous or the named entity / input is missing from the spec, do not guess — return a short message explaining what you'd need clarified.
+
+Use the validation-driven workflow below for every other input ("Validate and fix the current pipeline.", "What's wrong with this?", etc.).
+
 ## Your Workflow
 
 1. Call `get_pipeline_state` to understand the current pipeline.
@@ -30,8 +42,18 @@ You are the **Pipeline Repair** specialist for Tangle Pipeline Studio. Your job 
 ### Out of scope (explain and defer)
 
 - Building new pipeline stages from scratch (that's the architect's job — coming in a later release)
-- Debugging runtime failures (that's the debug assistant's job — coming in a later release)
+- Diagnosing why a previous run failed (that's the **debug-assistant**'s job — defer back to the dispatcher). When the dispatcher invokes you with an already-identified fix directive, follow the **Invoked with a fix directive** rules instead of re-diagnosing.
 - Adding tasks for components you don't already have access to. Component lookup will land in a future release; until then, only operate on tasks and components already present in the pipeline spec.
+
+## Submitting runs
+
+You have access to `submit_pipeline_run`, which submits the current pipeline to the backend. Use it ONLY when:
+
+1. The dispatcher's input to you explicitly asked to run, rerun, submit, or "fix it and run it" (typically the input ends with "and resubmit the run."). Never submit on your own initiative or when the input only said "fix" / "validate".
+2. You have completed your fixes and the most recent `validate_pipeline` call returned no errors. If validation still has errors, do not submit; explain what is still broken so the dispatcher can surface the choice.
+3. On the **fix-directive entry path**, the workflow above tells you to skip the upfront `validate_pipeline` call. If — and only if — the input also asked you to resubmit, call `validate_pipeline` once **after** applying the targeted mutation to satisfy rule 2 above, then submit. If validation surfaces a new error introduced by your change, do not submit; report it and stop.
+
+`submit_pipeline_run` takes no arguments — it always submits whatever pipeline is currently open. After a successful submission, include the returned `runId` in your summary so the dispatcher can mention it to the user.
 
 ## CSOM Entity Model
 

--- a/src/agent/session.ts
+++ b/src/agent/session.ts
@@ -5,11 +5,20 @@ import type { ProxyClient } from "./config";
 import type { ToolBridgeApi } from "./toolBridgeApi";
 import type { StatusCallback } from "./types";
 
+export interface RecentPipelineRun {
+  id: number;
+  root_execution_id: number;
+  created_at: string;
+  pipeline_name: string;
+  status?: string;
+}
+
 export interface AgentSession {
   threadId: string;
   emitStatus: StatusCallback;
   proxyClient: ProxyClient;
   bridge: ToolBridgeApi;
+  recentRuns: RecentPipelineRun[];
 }
 
 export function createSession(params: {
@@ -17,11 +26,13 @@ export function createSession(params: {
   proxyClient: ProxyClient;
   bridge: ToolBridgeApi;
   emitStatus?: StatusCallback;
+  recentRuns?: RecentPipelineRun[];
 }): AgentSession {
   return {
     threadId: params.threadId,
     emitStatus: params.emitStatus ?? (() => {}),
     proxyClient: params.proxyClient,
     bridge: params.bridge,
+    recentRuns: params.recentRuns ?? [],
   };
 }

--- a/src/agent/toolBridgeApi.ts
+++ b/src/agent/toolBridgeApi.ts
@@ -11,6 +11,12 @@
  * `success` flag plus contextual ids so the model can chain calls
  * (e.g. take the returned `taskId` and call `set_task_argument`).
  */
+import type {
+  GetContainerExecutionStateResponse,
+  GetExecutionInfoResponse,
+  GetGraphExecutionStateResponse,
+  PipelineRunResponse,
+} from "@/api/types.gen";
 import type { ArgumentType, ComponentReference } from "@/models/componentSpec";
 import type { AiSpec } from "@/routes/v2/pages/Editor/components/AiChat/serializeSpecForAi";
 
@@ -34,6 +40,45 @@ export interface ConnectArgs {
   targetEntityId: string;
   targetPortName: string;
 }
+
+export interface RunSubmissionResult {
+  success: boolean;
+  runId?: string;
+  rootExecutionId?: string;
+  error?: string;
+}
+
+export interface ContainerLogPayload {
+  log_text?: string;
+  system_error_exception_full?: string;
+  orchestration_error_message?: string;
+  truncated?: boolean;
+}
+
+export interface RunDebugSnapshotChild {
+  taskId: string;
+  executionId: string;
+  status?: string;
+  details?: GetExecutionInfoResponse;
+  containerState?: GetContainerExecutionStateResponse;
+  log?: ContainerLogPayload;
+  error?: string;
+}
+
+export interface RunDebugSnapshot {
+  success: boolean;
+  run?: PipelineRunResponse;
+  rootExecutionId?: string;
+  rootStatus?: string;
+  failedChildren: RunDebugSnapshotChild[];
+  truncatedChildren: number;
+  error?: string;
+}
+
+export type RunDetails = PipelineRunResponse;
+export type ExecutionDetails = GetExecutionInfoResponse;
+export type ExecutionState = GetGraphExecutionStateResponse;
+export type ContainerState = GetContainerExecutionStateResponse;
 
 export interface ToolBridgeApi {
   getPipelineState(): Promise<AiSpec>;
@@ -89,4 +134,12 @@ export interface ToolBridgeApi {
   unpackSubgraph(taskEntityId: string): Promise<{ success: boolean }>;
 
   validatePipeline(): Promise<ValidationResult>;
+
+  submitPipelineRun(): Promise<RunSubmissionResult>;
+  getRunDetails(runId: string): Promise<RunDetails>;
+  getExecutionDetails(executionId: string): Promise<ExecutionDetails>;
+  getExecutionState(executionId: string): Promise<ExecutionState>;
+  getContainerState(executionId: string): Promise<ContainerState>;
+  getContainerLog(executionId: string): Promise<ContainerLogPayload>;
+  debugPipelineRun(runId: string): Promise<RunDebugSnapshot>;
 }

--- a/src/agent/tools/csomTools.ts
+++ b/src/agent/tools/csomTools.ts
@@ -344,6 +344,7 @@ export function createCsomTools(bridge: ToolBridgeApi) {
   });
 
   return {
+    getPipelineState,
     allTools: [
       getPipelineState,
       setPipelineName,

--- a/src/agent/tools/debugTools.ts
+++ b/src/agent/tools/debugTools.ts
@@ -1,0 +1,163 @@
+/**
+ * Read-only debug tools for the in-browser agent.
+ *
+ * Each tool wraps a single fine-grained `ToolBridgeApi` fetch and
+ * truncates the payload before returning to the model so a single
+ * pathological pod log or huge artifact map cannot blow the model's
+ * context window.
+ *
+ * For the high-signal one-shot path use `runTools.debug_pipeline_run`
+ * (composite); these are for surgical follow-ups when the composite
+ * snapshot already pointed at a specific child execution.
+ */
+import { tool } from "@openai/agents";
+import { z } from "zod";
+
+import type {
+  ContainerLogPayload,
+  ContainerState,
+  ExecutionDetails,
+  ToolBridgeApi,
+} from "../toolBridgeApi";
+
+const LOG_BYTE_BUDGET = 8_192;
+const ORCHESTRATION_ERROR_BUDGET = 2_048;
+const STRING_FIELD_BUDGET = 2_048;
+const MAX_DEBUG_INFO_KEYS = 20;
+
+function asJson(value: unknown): string {
+  return JSON.stringify(value);
+}
+
+/**
+ * Keep the trailing window — for execution logs the failure context
+ * almost always lives at the end of the stream, so the head is the
+ * easiest part to drop.
+ */
+function truncateLogText(text: string, budget: number): string {
+  if (text.length <= budget) return text;
+  return `…[truncated ${text.length - budget} chars]\n${text.slice(-budget)}`;
+}
+
+function truncateContainerLog(
+  log: ContainerLogPayload,
+): ContainerLogPayload & { truncated?: boolean } {
+  let truncated = false;
+  const result: ContainerLogPayload & { truncated?: boolean } = {};
+  if (log.log_text != null) {
+    truncated ||= log.log_text.length > LOG_BYTE_BUDGET;
+    result.log_text = truncateLogText(log.log_text, LOG_BYTE_BUDGET);
+  }
+  if (log.system_error_exception_full != null) {
+    truncated ||= log.system_error_exception_full.length > LOG_BYTE_BUDGET;
+    result.system_error_exception_full = truncateLogText(
+      log.system_error_exception_full,
+      LOG_BYTE_BUDGET,
+    );
+  }
+  if (log.orchestration_error_message != null) {
+    truncated ||=
+      log.orchestration_error_message.length > ORCHESTRATION_ERROR_BUDGET;
+    result.orchestration_error_message = truncateLogText(
+      log.orchestration_error_message,
+      ORCHESTRATION_ERROR_BUDGET,
+    );
+  }
+  if (truncated) result.truncated = true;
+  return result;
+}
+
+function truncateContainerState(state: ContainerState): ContainerState {
+  if (!state.debug_info) return state;
+  const entries = Object.entries(state.debug_info).slice(
+    0,
+    MAX_DEBUG_INFO_KEYS,
+  );
+  const truncatedDebugInfo: Record<string, unknown> = {};
+  for (const [key, value] of entries) {
+    if (typeof value === "string" && value.length > STRING_FIELD_BUDGET) {
+      truncatedDebugInfo[key] = truncateLogText(value, STRING_FIELD_BUDGET);
+    } else {
+      truncatedDebugInfo[key] = value;
+    }
+  }
+  return { ...state, debug_info: truncatedDebugInfo };
+}
+
+function truncateExecutionDetails(details: ExecutionDetails): ExecutionDetails {
+  // Drop heavy artifact maps to empty objects so the model still knows
+  // they exist (and can call `get_execution_state` for counts) without
+  // pulling MB of artifact metadata into context.
+  const inputCount = Object.keys(details.input_artifacts ?? {}).length;
+  const outputCount = Object.keys(details.output_artifacts ?? {}).length;
+  return {
+    ...details,
+    input_artifacts: inputCount > 0 ? {} : details.input_artifacts,
+    output_artifacts: outputCount > 0 ? {} : details.output_artifacts,
+  };
+}
+
+export function createDebugTools(bridge: ToolBridgeApi) {
+  const getExecutionDetails = tool({
+    name: "get_execution_details",
+    description:
+      "Fetch task spec, parent/child ids, and artifact id maps for a single execution. Artifact id maps are summarized to keep the payload small.",
+    parameters: z.object({
+      executionId: z.string().describe("Execution id"),
+    }),
+    execute: async ({ executionId }) => {
+      const details = await bridge.getExecutionDetails(executionId);
+      return asJson(truncateExecutionDetails(details));
+    },
+  });
+
+  const getExecutionState = tool({
+    name: "get_execution_state",
+    description:
+      "Fetch aggregated child execution status counts for a graph execution. Useful for figuring out which child tasks failed.",
+    parameters: z.object({
+      executionId: z.string().describe("Execution id"),
+    }),
+    execute: async ({ executionId }) =>
+      asJson(await bridge.getExecutionState(executionId)),
+  });
+
+  const getContainerState = tool({
+    name: "get_container_state",
+    description:
+      "Fetch pod/container state (status, exit code, debug_info) for a leaf execution. `debug_info` is capped at 20 keys with each string value capped at 2KB.",
+    parameters: z.object({
+      executionId: z.string().describe("Execution id"),
+    }),
+    execute: async ({ executionId }) => {
+      const state = await bridge.getContainerState(executionId);
+      return asJson(truncateContainerState(state));
+    },
+  });
+
+  const getContainerLog = tool({
+    name: "get_container_log",
+    description:
+      "Fetch the trailing 8KB of stdout/stderr and any captured error/orchestration messages for a leaf execution. Each field is independently truncated; `truncated: true` flags any drop.",
+    parameters: z.object({
+      executionId: z.string().describe("Execution id"),
+    }),
+    execute: async ({ executionId }) => {
+      const log = await bridge.getContainerLog(executionId);
+      return asJson(truncateContainerLog(log));
+    },
+  });
+
+  return {
+    getExecutionDetails,
+    getExecutionState,
+    getContainerState,
+    getContainerLog,
+    allTools: [
+      getExecutionDetails,
+      getExecutionState,
+      getContainerState,
+      getContainerLog,
+    ],
+  };
+}

--- a/src/agent/tools/runTools.ts
+++ b/src/agent/tools/runTools.ts
@@ -1,0 +1,71 @@
+/**
+ * Run-management tools for the in-browser agent.
+ *
+ * Each tool is a thin OpenAI Agents `tool()` wrapper around a method on
+ * the Comlink-proxied `ToolBridgeApi`. The bridge runs on the main
+ * thread, so existing service helpers (`submitPipelineRun`,
+ * `fetchPipelineRun`, …) plus their cache invalidation and IDB writes
+ * are reused as-is.
+ *
+ * `submit_pipeline_run` and `debug_pipeline_run` are exposed both as
+ * individual tools (composable into different sub-agent tool surfaces)
+ * and as part of `allTools` for convenience. Same factory pattern as
+ * `csomTools.ts`.
+ */
+import { tool } from "@openai/agents";
+import { z } from "zod";
+
+import { getOverallExecutionStatusFromStats } from "@/utils/executionStatus";
+
+import type { RunDetails, ToolBridgeApi } from "../toolBridgeApi";
+
+function asJson(value: unknown): string {
+  return JSON.stringify(value);
+}
+
+function deriveRunStatus(run: RunDetails): string | undefined {
+  return getOverallExecutionStatusFromStats(run.execution_status_stats);
+}
+
+export function createRunTools(bridge: ToolBridgeApi) {
+  const submitPipelineRun = tool({
+    name: "submit_pipeline_run",
+    description:
+      "Submit the currently-open pipeline to the backend for execution. Only call this when the user has explicitly asked to run the pipeline. Does not take parameters — always submits the live pipeline.",
+    parameters: z.object({}),
+    execute: async () => asJson(await bridge.submitPipelineRun()),
+  });
+
+  const getRunStatus = tool({
+    name: "get_run_status",
+    description:
+      "Fetch run metadata and the derived overall execution status (e.g. RUNNING, SUCCEEDED, FAILED) for a pipeline run by id.",
+    parameters: z.object({
+      runId: z.string().describe("Pipeline run id"),
+    }),
+    execute: async ({ runId }) => {
+      const run = await bridge.getRunDetails(runId);
+      return asJson({
+        run,
+        status: deriveRunStatus(run),
+      });
+    },
+  });
+
+  const debugPipelineRun = tool({
+    name: "debug_pipeline_run",
+    description:
+      "Composite debug snapshot for a pipeline run: returns run metadata + each FAILED / SYSTEM_ERROR / INVALID child execution with truncated container state, execution details, and logs. Use this as a single high-signal call before drilling in with the fine-grained debug tools.",
+    parameters: z.object({
+      runId: z.string().describe("Pipeline run id"),
+    }),
+    execute: async ({ runId }) => asJson(await bridge.debugPipelineRun(runId)),
+  });
+
+  return {
+    submitPipelineRun,
+    getRunStatus,
+    debugPipelineRun,
+    allTools: [submitPipelineRun, getRunStatus, debugPipelineRun],
+  };
+}

--- a/src/agent/worker.ts
+++ b/src/agent/worker.ts
@@ -17,13 +17,14 @@ import {
 } from "./agents/tangleDispatcher";
 import { getAiToken } from "./aiTokenStore";
 import { ProxyClient } from "./config";
-import { createSession } from "./session";
+import { createSession, type RecentPipelineRun } from "./session";
 import type { ToolBridgeApi } from "./toolBridgeApi";
 import type { AgentResponse, StatusCallback } from "./types";
 
 export interface AskParams {
   message: string;
   threadId?: string;
+  recentRuns?: RecentPipelineRun[];
 }
 
 export interface AgentWorkerApi {
@@ -62,7 +63,7 @@ function createWorkerApi(): AgentWorkerApi {
       return "pong";
     },
 
-    async ask({ message, threadId }, _signal) {
+    async ask({ message, threadId, recentRuns }, _signal) {
       // todo: add logic to handle the signal
 
       if (!dispatcher || !bridge) {
@@ -82,6 +83,7 @@ function createWorkerApi(): AgentWorkerApi {
         emitStatus,
         proxyClient,
         bridge,
+        recentRuns,
       });
 
       const result = await dispatcher.invoke({

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/logs.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/logs.tsx
@@ -6,6 +6,7 @@ import { InfoBox } from "@/components/shared/InfoBox";
 import { Link } from "@/components/ui/link";
 import { Spinner } from "@/components/ui/spinner";
 import { useBackend } from "@/providers/BackendProvider";
+import { fetchContainerLog } from "@/services/executionService";
 import { getBackendStatusString } from "@/utils/backend";
 import { CONTAINER_STATUSES_PRE_LAUNCH } from "@/utils/executionStatus";
 
@@ -78,13 +79,6 @@ export const shouldStatusHaveLogs = (status?: string): boolean => {
   return !CONTAINER_STATUSES_PRE_LAUNCH.has(status);
 };
 
-const getLogs = async (executionId: string, backendUrl: string) => {
-  const response = await fetch(
-    `${backendUrl}/api/executions/${executionId}/container_log`,
-  );
-  return response.json();
-};
-
 const Logs = ({
   executionId,
   status,
@@ -103,7 +97,7 @@ const Logs = ({
   }>();
   const { data, isLoading, error, refetch } = useQuery({
     queryKey: ["logs", executionId],
-    queryFn: () => getLogs(String(executionId), backendUrl),
+    queryFn: () => fetchContainerLog(String(executionId), backendUrl),
     enabled: shouldFetch,
     refetchInterval: shouldPoll ? 5000 : false,
     refetchIntervalInBackground: false,
@@ -112,8 +106,9 @@ const Logs = ({
   useEffect(() => {
     if (data && !error) {
       setLogs({
-        log_text: data?.log_text,
-        system_error_exception_full: data?.system_error_exception_full,
+        log_text: data?.log_text ?? undefined,
+        system_error_exception_full:
+          data?.system_error_exception_full ?? undefined,
       });
     }
 

--- a/src/routes/v2/pages/Editor/components/AiChat/AiChatContent.tsx
+++ b/src/routes/v2/pages/Editor/components/AiChat/AiChatContent.tsx
@@ -1,13 +1,18 @@
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { observer } from "mobx-react-lite";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { getAiToken } from "@/agent/aiTokenStore";
 import { config } from "@/agent/config";
+import type { RecentPipelineRun } from "@/agent/session";
+import { useAuthLocalStorage } from "@/components/shared/Authentication/useAuthLocalStorage";
 import { BlockStack } from "@/components/ui/layout";
 import useToastNotification from "@/hooks/useToastNotification";
+import { useBackend } from "@/providers/BackendProvider";
 import { useEditorSession } from "@/routes/v2/pages/Editor/store/EditorSessionContext";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
+import { fetchPipelineRuns } from "@/services/pipelineRunService";
+import type { PipelineRun } from "@/types/pipelineRun";
 
 import { useAiChatStore } from "./AiChatStoreContext";
 import { AiTokenSetup } from "./components/AiTokenSetup";
@@ -16,34 +21,85 @@ import { ChatMessageList } from "./components/ChatMessageList";
 import { createToolBridge } from "./toolBridge";
 import { AiAssistantTokenQueryKeys } from "./types";
 
+const RECENT_RUNS_LIMIT = 5;
+
+function projectRecentRuns(runs: PipelineRun[]): RecentPipelineRun[] {
+  return runs.slice(0, RECENT_RUNS_LIMIT).map((run) => ({
+    id: run.id,
+    root_execution_id: run.root_execution_id,
+    created_at: run.created_at,
+    pipeline_name: run.pipeline_name,
+    status: run.status,
+  }));
+}
+
 export const AiChatContent = observer(function AiChatContent() {
   const aiChat = useAiChatStore();
   const notify = useToastNotification();
   const { navigation } = useSharedStores();
   const editorSession = useEditorSession();
+  const { backendUrl } = useBackend();
+  const authStorage = useAuthLocalStorage();
+  const queryClient = useQueryClient();
+
   const { data: token, isPending: isTokenLoading } = useQuery({
     queryKey: AiAssistantTokenQueryKeys.Token(),
     queryFn: getAiToken,
     staleTime: Infinity,
   });
 
-  // The bridge closes over the navigation + undo stores, so a single
-  // instance per AiChatContent mount is correct: each call re-reads
-  // `navigation.rootSpec` and the active path lazily, picking up any
-  // navigation change without rebuilding the bridge.
+  // Refs keep the bridge closure honest about the latest backend/auth
+  // values without rebuilding the bridge. Updated on every render so
+  // tool calls always read the most recent configuration.
+  const backendUrlRef = useRef(backendUrl);
+  const authToken = authStorage.getToken();
+  const authTokenRef = useRef(authToken);
+  useEffect(() => {
+    backendUrlRef.current = backendUrl;
+  }, [backendUrl]);
+  useEffect(() => {
+    authTokenRef.current = authToken;
+  }, [authToken]);
+
+  // The bridge closes over the navigation + undo stores plus the
+  // backend/auth/queryClient deps captured via refs. A single instance
+  // per AiChatContent mount is correct: each method call re-reads
+  // `navigation.rootSpec`, the active path, and the latest backend
+  // values lazily so navigation / backend changes are picked up
+  // without rebuilding the bridge.
   const [bridge] = useState(() =>
     createToolBridge({
       getSpec: () => navigation.rootSpec,
       getActiveSubgraphPath: () =>
         navigation.navigationPath.slice(1).map((e) => e.displayName),
       undo: editorSession.undo,
+      getBackendUrl: () => backendUrlRef.current,
+      getAuthToken: () => authTokenRef.current,
+      queryClient,
     }),
   );
 
+  const pipelineName = navigation.rootSpec?.name;
+  const { data: recentRunsData } = useQuery({
+    queryKey: ["pipelineRuns", pipelineName],
+    queryFn: async () => {
+      if (!pipelineName) return [] as PipelineRun[];
+      const res = await fetchPipelineRuns(pipelineName);
+      return res?.runs ?? [];
+    },
+    enabled: !!pipelineName,
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
+  });
+
   function handleSend(prompt: string) {
+    const recentRuns = recentRunsData
+      ? projectRecentRuns(recentRunsData)
+      : undefined;
     aiChat.sendMessage(prompt, {
       onError: (msg) => notify(msg, "error"),
       bridge,
+      ...(recentRuns && { recentRuns }),
     });
   }
 

--- a/src/routes/v2/pages/Editor/components/AiChat/agentClient.ts
+++ b/src/routes/v2/pages/Editor/components/AiChat/agentClient.ts
@@ -7,6 +7,7 @@
  */
 import * as Comlink from "comlink";
 
+import type { RecentPipelineRun } from "@/agent/session";
 import type { ToolBridgeApi } from "@/agent/toolBridgeApi";
 import type { AgentResponse, StatusCallback } from "@/agent/types";
 import type { AgentWorkerApi } from "@/agent/worker";
@@ -19,6 +20,7 @@ interface InitDeps {
 interface AskOptions {
   message: string;
   threadId?: string;
+  recentRuns?: RecentPipelineRun[];
 }
 
 class AgentClient {

--- a/src/routes/v2/pages/Editor/components/AiChat/aiChatStore.ts
+++ b/src/routes/v2/pages/Editor/components/AiChat/aiChatStore.ts
@@ -1,5 +1,6 @@
 import { action, makeObservable, observable, runInAction } from "mobx";
 
+import type { RecentPipelineRun } from "@/agent/session";
 import type { ToolBridgeApi } from "@/agent/toolBridgeApi";
 import { getErrorMessage } from "@/utils/string";
 
@@ -13,6 +14,7 @@ function generateMessageId(): string {
 interface SendMessageOptions {
   onError: (message: string) => void;
   bridge: ToolBridgeApi;
+  recentRuns?: RecentPipelineRun[];
 }
 
 /**
@@ -68,6 +70,7 @@ export class AiChatStore {
         {
           message: prompt,
           ...(this.threadId && { threadId: this.threadId }),
+          ...(options.recentRuns && { recentRuns: options.recentRuns }),
         },
       );
 

--- a/src/routes/v2/pages/Editor/components/AiChat/toolBridge.ts
+++ b/src/routes/v2/pages/Editor/components/AiChat/toolBridge.ts
@@ -11,12 +11,23 @@
  * subscriptions of its own, which keeps it trivially testable: feed it
  * a `ComponentSpec` and an `UndoGroupable` and every method works.
  */
+import type { QueryClient } from "@tanstack/react-query";
+
 import type {
   ConnectArgs,
+  ContainerLogPayload,
+  ContainerState,
+  ExecutionDetails,
+  ExecutionState,
+  RunDebugSnapshot,
+  RunDebugSnapshotChild,
+  RunDetails,
+  RunSubmissionResult,
   ToolBridgeApi,
   ValidationResult,
 } from "@/agent/toolBridgeApi";
 import type { ComponentSpec } from "@/models/componentSpec";
+import { serializeComponentSpec } from "@/models/componentSpec/serialization/serialize";
 import { validateSpec } from "@/models/componentSpec/validation/validateSpec";
 import {
   connectNodes,
@@ -47,17 +58,37 @@ import {
 } from "@/routes/v2/pages/Editor/store/actions/task.actions";
 import type { UndoGroupable } from "@/routes/v2/shared/nodes/types";
 import { hydrateComponentReference } from "@/services/componentService";
+import {
+  fetchContainerExecutionState,
+  fetchContainerLog,
+  fetchExecutionDetails,
+  fetchExecutionState,
+  fetchPipelineRun,
+} from "@/services/executionService";
+import type { PipelineRun } from "@/types/pipelineRun";
 import { EDITOR_POSITION_ANNOTATION } from "@/utils/annotations";
+import { deepClone } from "@/utils/deepClone";
+import {
+  flattenExecutionStatusStats,
+  getOverallExecutionStatusFromStats,
+} from "@/utils/executionStatus";
+import { submitPipelineRun as submitPipelineRunHelper } from "@/utils/submitPipeline";
 
 import { serializeSpecForAi } from "./serializeSpecForAi";
 
 const DEFAULT_POSITION = { x: 250, y: 250 };
 const POSITION_OFFSET = 200;
 
+const MAX_FAILED_CHILDREN = 10;
+const FAILED_STATUSES = new Set(["FAILED", "SYSTEM_ERROR", "INVALID"]);
+
 interface BridgeDeps {
   getSpec: () => ComponentSpec | null;
   getActiveSubgraphPath: () => string[];
   undo: UndoGroupable;
+  getBackendUrl?: () => string;
+  getAuthToken?: () => string | undefined;
+  queryClient?: QueryClient;
 }
 
 interface EntityWithAnnotations {
@@ -101,6 +132,16 @@ export function createToolBridge(deps: BridgeDeps): ToolBridgeApi {
       );
     }
     return spec;
+  }
+
+  function requireBackendUrl(): string {
+    const url = deps.getBackendUrl?.();
+    if (!url) {
+      throw new Error(
+        "Backend is not configured — agent cannot reach the Tangle backend.",
+      );
+    }
+    return url;
   }
 
   return {
@@ -289,5 +330,246 @@ export function createToolBridge(deps: BridgeDeps): ToolBridgeApi {
         })),
       };
     },
+
+    async submitPipelineRun(): Promise<RunSubmissionResult> {
+      const spec = requireSpec();
+      const backendUrl = deps.getBackendUrl?.();
+      if (!backendUrl) {
+        return {
+          success: false,
+          error:
+            "Backend is not configured — pipeline cannot be submitted from the assistant.",
+        };
+      }
+      const wireSpec = deepClone(serializeComponentSpec(spec));
+      const authorizationToken = deps.getAuthToken?.();
+      const submission = await new Promise<{
+        run: PipelineRun | null;
+        error: string | null;
+      }>((resolve) => {
+        submitPipelineRunHelper(wireSpec, backendUrl, {
+          authorizationToken,
+          onSuccess: (data) => resolve({ run: data, error: null }),
+          onError: (err) => resolve({ run: null, error: errorMessage(err) }),
+        });
+      });
+      if (!submission.run) {
+        return {
+          success: false,
+          error:
+            submission.error ??
+            "Pipeline submission failed — the backend rejected the run.",
+        };
+      }
+      // Refresh both the editor list (per pipeline) and the home runs page.
+      deps.queryClient?.invalidateQueries({ queryKey: ["pipelineRuns"] });
+      return {
+        success: true,
+        runId: String(submission.run.id),
+        rootExecutionId: String(submission.run.root_execution_id),
+      };
+    },
+
+    async getRunDetails(runId): Promise<RunDetails> {
+      return fetchPipelineRun(runId, requireBackendUrl());
+    },
+
+    async getExecutionDetails(executionId): Promise<ExecutionDetails> {
+      return fetchExecutionDetails(executionId, requireBackendUrl());
+    },
+
+    async getExecutionState(executionId): Promise<ExecutionState> {
+      return fetchExecutionState(executionId, requireBackendUrl());
+    },
+
+    async getContainerState(executionId): Promise<ContainerState> {
+      return fetchContainerExecutionState(executionId, requireBackendUrl());
+    },
+
+    async getContainerLog(executionId): Promise<ContainerLogPayload> {
+      const log = await fetchContainerLog(executionId, requireBackendUrl());
+      return {
+        log_text: log.log_text ?? undefined,
+        system_error_exception_full:
+          log.system_error_exception_full ?? undefined,
+        orchestration_error_message:
+          log.orchestration_error_message ?? undefined,
+      };
+    },
+
+    async debugPipelineRun(runId): Promise<RunDebugSnapshot> {
+      const backendUrl = deps.getBackendUrl?.();
+      if (!backendUrl) {
+        return {
+          success: false,
+          failedChildren: [],
+          truncatedChildren: 0,
+          error:
+            "Backend is not configured — cannot fetch debug info for this run.",
+        };
+      }
+      let run: RunDetails;
+      try {
+        run = await fetchPipelineRun(runId, backendUrl);
+      } catch (error) {
+        return {
+          success: false,
+          failedChildren: [],
+          truncatedChildren: 0,
+          error: errorMessage(error),
+        };
+      }
+      const rootId = run.root_execution_id;
+      const [rootDetails, rootStateOrNull] = await Promise.all([
+        fetchExecutionDetails(rootId, backendUrl).catch(() => null),
+        fetchExecutionState(rootId, backendUrl).catch(() => null),
+      ]);
+      if (!rootDetails && !rootStateOrNull) {
+        return {
+          success: false,
+          failedChildren: [],
+          truncatedChildren: 0,
+          error:
+            "Could not fetch execution details for the run (execution details and state both failed).",
+        };
+      }
+      const rootStatus = rootStateOrNull
+        ? getOverallExecutionStatusFromStats(
+            flattenExecutionStatusStats(
+              rootStateOrNull.child_execution_status_stats,
+            ),
+          )
+        : undefined;
+      const candidates = Object.entries(
+        rootDetails?.child_task_execution_ids ?? {},
+      );
+      const inspected = await Promise.all(
+        candidates.map(([taskId, executionId]) =>
+          inspectFailedChildImpl(taskId, executionId, backendUrl),
+        ),
+      );
+      const allFailed = inspected.filter(
+        (c): c is RunDebugSnapshotChild => c !== null,
+      );
+      const failedChildren = allFailed.slice(0, MAX_FAILED_CHILDREN);
+      const truncatedChildren = Math.max(
+        0,
+        allFailed.length - MAX_FAILED_CHILDREN,
+      );
+      return {
+        success: true,
+        run,
+        rootExecutionId: rootId,
+        rootStatus,
+        failedChildren,
+        truncatedChildren,
+      };
+    },
+  };
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  return "An unknown error occurred";
+}
+
+const LOG_BYTE_BUDGET = 8_192;
+const ORCHESTRATION_ERROR_BUDGET = 2_048;
+const STRING_FIELD_BUDGET = 2_048;
+const MAX_DEBUG_INFO_KEYS = 20;
+
+function truncateTrailing(text: string, budget: number): string {
+  if (text.length <= budget) return text;
+  return `…[truncated ${text.length - budget} chars]\n${text.slice(-budget)}`;
+}
+
+function truncateContainerLogPayload(
+  log: Awaited<ReturnType<typeof fetchContainerLog>>,
+): ContainerLogPayload {
+  let truncated = false;
+  const result: ContainerLogPayload = {};
+  if (log.log_text != null) {
+    truncated ||= log.log_text.length > LOG_BYTE_BUDGET;
+    result.log_text = truncateTrailing(log.log_text, LOG_BYTE_BUDGET);
+  }
+  if (log.system_error_exception_full != null) {
+    truncated ||= log.system_error_exception_full.length > LOG_BYTE_BUDGET;
+    result.system_error_exception_full = truncateTrailing(
+      log.system_error_exception_full,
+      LOG_BYTE_BUDGET,
+    );
+  }
+  if (log.orchestration_error_message != null) {
+    truncated ||=
+      log.orchestration_error_message.length > ORCHESTRATION_ERROR_BUDGET;
+    result.orchestration_error_message = truncateTrailing(
+      log.orchestration_error_message,
+      ORCHESTRATION_ERROR_BUDGET,
+    );
+  }
+  if (truncated) result.truncated = true;
+  return result;
+}
+
+function truncateContainerStateForSnapshot(
+  state: ContainerState,
+): ContainerState {
+  if (!state.debug_info) return state;
+  const entries = Object.entries(state.debug_info).slice(
+    0,
+    MAX_DEBUG_INFO_KEYS,
+  );
+  const truncatedDebugInfo: Record<string, unknown> = {};
+  for (const [key, value] of entries) {
+    if (typeof value === "string" && value.length > STRING_FIELD_BUDGET) {
+      truncatedDebugInfo[key] = truncateTrailing(value, STRING_FIELD_BUDGET);
+    } else {
+      truncatedDebugInfo[key] = value;
+    }
+  }
+  return { ...state, debug_info: truncatedDebugInfo };
+}
+
+function truncateExecutionDetailsForSnapshot(
+  details: ExecutionDetails,
+): ExecutionDetails {
+  // Keep top-level identity + spec, drop heavy artifact maps to a count.
+  const inputCount = Object.keys(details.input_artifacts ?? {}).length;
+  const outputCount = Object.keys(details.output_artifacts ?? {}).length;
+  const summarized: ExecutionDetails = {
+    ...details,
+    input_artifacts: inputCount > 0 ? {} : details.input_artifacts,
+    output_artifacts: outputCount > 0 ? {} : details.output_artifacts,
+  };
+  return summarized;
+}
+
+async function inspectFailedChildImpl(
+  taskId: string,
+  executionId: string,
+  backendUrl: string,
+): Promise<RunDebugSnapshotChild | null> {
+  let containerState: ContainerState | null = null;
+  try {
+    containerState = await fetchContainerExecutionState(
+      executionId,
+      backendUrl,
+    );
+  } catch {
+    return null;
+  }
+  if (!FAILED_STATUSES.has(containerState.status)) return null;
+  const [details, log] = await Promise.all([
+    fetchExecutionDetails(executionId, backendUrl).catch(() => null),
+    fetchContainerLog(executionId, backendUrl).catch(() => null),
+  ]);
+  return {
+    taskId,
+    executionId,
+    status: containerState.status,
+    details: details ? truncateExecutionDetailsForSnapshot(details) : undefined,
+    containerState: truncateContainerStateForSnapshot(containerState),
+    log: log ? truncateContainerLogPayload(log) : undefined,
   };
 }

--- a/src/services/executionService.ts
+++ b/src/services/executionService.ts
@@ -5,6 +5,7 @@ import type {
   GetArtifactInfoResponse,
   GetArtifactsApiExecutionsIdArtifactsGetResponse,
   GetArtifactSignedUrlResponse,
+  GetContainerExecutionLogResponse,
   GetContainerExecutionStateResponse,
   GetExecutionInfoResponse,
   PipelineRunResponse,
@@ -65,12 +66,22 @@ export const useFetchPipelineRunMetadata = (runId: string | undefined) => {
   });
 };
 
-const fetchContainerExecutionState = async (
+export const fetchContainerExecutionState = async (
   executionId: string,
   backendUrl: string,
 ): Promise<GetContainerExecutionStateResponse> => {
   const url = `${backendUrl}/api/executions/${executionId}/container_state`;
   return fetchWithErrorHandling(url);
+};
+
+export const fetchContainerLog = async (
+  executionId: string,
+  backendUrl: string,
+): Promise<GetContainerExecutionLogResponse> => {
+  const response = await fetch(
+    `${backendUrl}/api/executions/${executionId}/container_log`,
+  );
+  return response.json();
 };
 
 export const useFetchContainerExecutionState = (


### PR DESCRIPTION
## Description

Introduces a `debug-assistant` sub-agent that diagnoses failed pipeline runs by inspecting execution details, container state, and truncated logs. The agent is read-only and cannot mutate the pipeline spec or submit runs.

The dispatcher is refactored from a handoff-based architecture to an `Agent.asTool(...)` architecture, where each specialist (`ask_general_help`, `ask_pipeline_repair`, `ask_debug_assistant`) is exposed as a tool. This allows the dispatcher's own LLM loop to chain multiple specialist calls in a single turn — for example, calling `ask_debug_assistant` to identify a root cause and then `ask_pipeline_repair` to apply the fix, without requiring a separate user message.

`pipeline-repair` gains access to `submit_pipeline_run` so it can resubmit a run after a successful fix when the user explicitly requests it. The repair prompt is updated with a directive-based entry path: when the dispatcher passes a concrete CSOM mutation directive (e.g. derived from a debug-assistant diagnosis), pipeline-repair skips the validation-driven discovery flow and applies the targeted mutation directly.

The `AgentSession` now carries `recentRuns`, a list of the five most recent pipeline runs for the open pipeline. These are appended to the debug-assistant's system prompt at agent creation time so the model can resolve "my last run" or "the latest run" without an extra tool call.

New `runTools` and `debugTools` factories expose `submit_pipeline_run`, `get_run_status`, `debug_pipeline_run`, `get_execution_details`, `get_execution_state`, `get_container_state`, and `get_container_log` as agent tools. The `toolBridge` implements the corresponding `ToolBridgeApi` methods, including a composite `debugPipelineRun` that fetches the run, root execution state, and a truncated snapshot of every failed child execution in a single call. Payload truncation (log text capped at 8 KB, `debug_info` capped at 20 keys) is applied both in the bridge and in the `debugTools` layer to prevent large pod logs from consuming the model's context window.

The `AiChatContent` component fetches recent runs for the open pipeline via React Query and passes them through to the worker on each `ask` call. The `fetchContainerLog` helper is extracted into `executionService` and reused by both the existing logs UI component and the new bridge methods.

Observability status labels are added for the three new `ask_*` tool names so the status line updates correctly while a specialist is working inside a nested `asTool` run.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

[AI Assistant - Debug agent.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/7ffccc9d-4c76-4e6a-97d0-88db24840e95.mov" />](https://app.graphite.com/user-attachments/video/7ffccc9d-4c76-4e6a-97d0-88db24840e95.mov)



## Test Instructions

1. Open a pipeline that has at least one failed run.
2. Ask the assistant "Why did my last run fail?" — the debug-assistant should identify the failed task, cite the exit code and log excerpt, and emit a `Fix to apply:` directive if the cause is a single concrete input value error.
3. Ask "Investigate the recent failure and fix the pipeline" — the dispatcher should chain `ask_debug_assistant` followed by `ask_pipeline_repair` and return a combined diagnosis + change summary.
4. Ask "Investigate, fix, and rerun" — same as above but pipeline-repair should also submit a run and return the new run id.
5. Ask "Why did run \<id> fail?" with an explicit run id to verify the agent resolves it directly without consulting the recent runs list.
6. Verify the status line updates during each specialist call (e.g. "Analyzing run failure..." while debug-assistant is working).
7. Confirm that asking a general Tangle question still routes correctly to `ask_general_help`.

## Additional Comments

The `Agent.asTool(...)` migration means the `agent_handoff` event no longer fires from the dispatcher. The `SUB_AGENT_LABELS` map in `observability.ts` is retained for any sub-agent that uses internal handoffs, but the dispatcher's specialists are now covered by the `ask_*` entries under `TOOL_STATUS_LABELS`.