### PR TITLE
feat: Guided Tours Ephemeral Pipelines

### DIFF
--- a/react-compiler.config.js
+++ b/react-compiler.config.js
@@ -67,6 +67,7 @@ export const REACT_COMPILER_ENABLED_DIRS = [
   "src/components/shared/ReactFlow/FlowCanvas/Multiselect",
   "src/components/shared/CodeViewer/CodeEditor.tsx",
   "src/components/shared/Dialogs/MultilineTextInputDialog.tsx",
+  "src/components/shared/Dialogs/PipelineNameDialog.tsx",
   "src/components/shared/HighlightText.tsx",
   "src/components/shared/AnnouncementBanners.tsx",
   "src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection",

--- a/src/components/Editor/Context/RenamePipeline.tsx
+++ b/src/components/Editor/Context/RenamePipeline.tsx
@@ -66,6 +66,7 @@ const RenamePipeline = () => {
       onSubmit={handleTitleUpdate}
       submitButtonText="Update Title"
       isSubmitDisabled={isSubmitDisabled}
+      excludeNames={title ? [title] : undefined}
       onOpenChange={(open) => {
         if (open) track("pipeline_editor.name_pipeline_dialog_impression");
       }}

--- a/src/components/Learn/FeaturedTours.tsx
+++ b/src/components/Learn/FeaturedTours.tsx
@@ -1,3 +1,4 @@
+import { useQueryClient } from "@tanstack/react-query";
 import { Link, useNavigate } from "@tanstack/react-router";
 
 import { Badge } from "@/components/ui/badge";
@@ -5,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Heading, Paragraph, Text } from "@/components/ui/typography";
+import { resetAllTourPipelineState } from "@/providers/TourProvider/tourPipelineStorage/resetAllTourPipelineState";
 import { APP_ROUTES } from "@/routes/router";
 import { tracking } from "@/utils/tracking";
 
@@ -45,8 +47,10 @@ function buildFeaturedTours(): FeaturedTour[] {
 export function FeaturedTours() {
   const featured = buildFeaturedTours();
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
 
   const startTour = (tourId: string) => {
+    resetAllTourPipelineState(queryClient);
     void navigate({ to: APP_ROUTES.TOUR_DETAIL, params: { tourId } });
   };
 

--- a/src/components/Learn/ToursLibrary.tsx
+++ b/src/components/Learn/ToursLibrary.tsx
@@ -1,3 +1,4 @@
+import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 
 import { Badge } from "@/components/ui/badge";
@@ -12,6 +13,7 @@ import {
 import { Icon } from "@/components/ui/icon";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Heading, Paragraph, Text } from "@/components/ui/typography";
+import { resetAllTourPipelineState } from "@/providers/TourProvider/tourPipelineStorage/resetAllTourPipelineState";
 import { APP_ROUTES } from "@/routes/router";
 import { tracking } from "@/utils/tracking";
 
@@ -29,8 +31,10 @@ import { getTour } from "./tours/registry";
 function TourCard({ tour }: { tour: Tour }) {
   const isAvailable = getTour(tour.id) !== undefined;
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
 
   const startTour = () => {
+    resetAllTourPipelineState(queryClient);
     void navigate({
       to: APP_ROUTES.TOUR_DETAIL,
       params: { tourId: tour.id },

--- a/src/components/shared/Dialogs/PipelineNameDialog.tsx
+++ b/src/components/shared/Dialogs/PipelineNameDialog.tsx
@@ -1,10 +1,4 @@
-import {
-  Activity,
-  type ChangeEvent,
-  type ReactNode,
-  useCallback,
-  useState,
-} from "react";
+import { Activity, type ChangeEvent, type ReactNode, useState } from "react";
 
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
@@ -29,9 +23,12 @@ interface PipelineNameDialogProps {
   title: string;
   description?: string;
   initialName: string;
+  excludeNames?: string[];
   submitButtonText: string;
   submitButtonIcon?: ReactNode;
   onSubmit: (name: string) => void;
+  // Receives the trimmed name — the exact value that will be submitted — so
+  // callers' equality checks stay aligned with the duplicate-name guard.
   isSubmitDisabled?: (name: string, error: string | null) => boolean;
   onOpenChange?: (open: boolean) => void;
 }
@@ -42,14 +39,15 @@ const PipelineNameDialog = ({
   title,
   description = "Please, name your pipeline.",
   initialName,
+  excludeNames,
   submitButtonText,
   submitButtonIcon,
   onSubmit,
   isSubmitDisabled,
   onOpenChange,
 }: PipelineNameDialogProps) => {
-  const [error, setError] = useState<string | null>(null);
   const [name, setName] = useState(initialName);
+  const [touched, setTouched] = useState(false);
 
   const {
     userPipelines,
@@ -57,50 +55,49 @@ const PipelineNameDialog = ({
     refetch: refetchUserPipelines,
   } = useLoadUserPipelines();
 
-  const handleOnChange = useCallback(
-    (e: ChangeEvent<HTMLInputElement>) => {
-      const newName = e.target.value;
-      const existingPipelineNames = new Set(
-        Array.from(userPipelines.keys()).map((name) => name.toLowerCase()),
-      );
-
-      const normalizedNewName = newName.trim().toLowerCase();
-
-      if (normalizedNewName === "") {
-        setError("Name cannot be empty");
-      } else if (existingPipelineNames.has(normalizedNewName)) {
-        setError("Name already exists");
-      } else {
-        setError(null);
-      }
-
-      setName(newName);
-    },
-    [userPipelines],
+  const normalized = name.trim().toLowerCase();
+  const excluded = new Set(
+    (excludeNames ?? []).map((n) => n.trim().toLowerCase()),
   );
+  const nameIsTaken = Array.from(userPipelines.keys()).some((n) => {
+    const lower = n.toLowerCase();
+    return lower === normalized && !excluded.has(lower);
+  });
 
-  const handleDialogOpenChange = useCallback(
-    (open: boolean) => {
-      if (!open) {
-        setError(null);
-      } else {
-        setName(initialName);
-        refetchUserPipelines();
-      }
-      onOpenChange?.(open);
-    },
-    [initialName, onOpenChange, refetchUserPipelines],
-  );
+  let error: string | null = null;
+  if (!isLoadingUserPipelines) {
+    if (normalized === "") {
+      error = "Name cannot be empty";
+    } else if (nameIsTaken) {
+      error = "Name already exists";
+    }
+  }
 
-  const handleSubmit = useCallback(() => {
-    onSubmit(name.trim());
-  }, [name, onSubmit]);
+  const handleOnChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setName(e.target.value);
+    setTouched(true);
+  };
+
+  const handleDialogOpenChange = (open: boolean) => {
+    if (open) {
+      setName(initialName);
+      setTouched(false);
+      refetchUserPipelines();
+    }
+    onOpenChange?.(open);
+  };
+
+  const trimmedName = name.trim();
+
+  const handleSubmit = () => {
+    onSubmit(trimmedName);
+  };
 
   const isDisabled =
     isLoadingUserPipelines ||
     !!error ||
-    !name ||
-    !!isSubmitDisabled?.(name, error);
+    !trimmedName ||
+    !!isSubmitDisabled?.(trimmedName, error);
 
   return (
     <Dialog open={open} onOpenChange={handleDialogOpenChange}>
@@ -112,7 +109,7 @@ const PipelineNameDialog = ({
         </DialogHeader>
         <BlockStack gap="2">
           <Input value={name} onChange={handleOnChange} />
-          <Activity mode={error ? "visible" : "hidden"}>
+          <Activity mode={error && touched ? "visible" : "hidden"}>
             <Alert variant="destructive">
               <Icon name="CircleAlert" />
               <AlertDescription>{error}</AlertDescription>

--- a/src/hooks/useLoadUserPipelines.ts
+++ b/src/hooks/useLoadUserPipelines.ts
@@ -7,7 +7,7 @@ import {
 import { USER_PIPELINES_LIST_NAME } from "@/utils/constants";
 
 const useLoadUserPipelines = () => {
-  const [isLoadingUserPipelines, setIsLoadingUserPipelines] = useState(false);
+  const [isLoadingUserPipelines, setIsLoadingUserPipelines] = useState(true);
   const [userPipelines, setUserPipelines] = useState<
     Map<string, ComponentFileEntry>
   >(new Map());

--- a/src/providers/TourProvider/tourPipelineStorage/SessionStoragePipelineDriver.ts
+++ b/src/providers/TourProvider/tourPipelineStorage/SessionStoragePipelineDriver.ts
@@ -1,0 +1,62 @@
+import type {
+  PipelineFileDescriptor,
+  PipelineStorageDriver,
+} from "@/services/pipelineStorage/types";
+
+import { SESSION_KEY_PREFIX } from "./constants";
+
+export class SessionStoragePipelineDriver implements PipelineStorageDriver {
+  readonly type = "session-storage";
+  readonly allowsMoveIn = false;
+  readonly allowsMoveOut = false;
+
+  private key(storageKey: string): string {
+    return `${SESSION_KEY_PREFIX}${storageKey}`;
+  }
+
+  async list(): Promise<PipelineFileDescriptor[]> {
+    const descriptors: PipelineFileDescriptor[] = [];
+    for (let i = 0; i < sessionStorage.length; i++) {
+      const fullKey = sessionStorage.key(i);
+      if (fullKey?.startsWith(SESSION_KEY_PREFIX)) {
+        descriptors.push({
+          storageKey: fullKey.slice(SESSION_KEY_PREFIX.length),
+        });
+      }
+    }
+    return descriptors;
+  }
+
+  async read(storageKey: string): Promise<string> {
+    const content = sessionStorage.getItem(this.key(storageKey));
+    if (content === null) {
+      throw new Error(
+        `Tour pipeline "${storageKey}" not found in sessionStorage`,
+      );
+    }
+    return content;
+  }
+
+  async write(storageKey: string, content: string): Promise<void> {
+    sessionStorage.setItem(this.key(storageKey), content);
+  }
+
+  async delete(storageKey: string): Promise<void> {
+    sessionStorage.removeItem(this.key(storageKey));
+  }
+
+  async rename(oldStorageKey: string, newStorageKey: string): Promise<void> {
+    const content = sessionStorage.getItem(this.key(oldStorageKey));
+    if (content === null) {
+      throw new Error(
+        `Tour pipeline "${oldStorageKey}" not found in sessionStorage`,
+      );
+    }
+    sessionStorage.setItem(this.key(newStorageKey), content);
+    sessionStorage.removeItem(this.key(oldStorageKey));
+  }
+
+  async hasKey(storageKey: string): Promise<boolean> {
+    return sessionStorage.getItem(this.key(storageKey)) !== null;
+  }
+}

--- a/src/providers/TourProvider/tourPipelineStorage/TourPipelineFolder.ts
+++ b/src/providers/TourProvider/tourPipelineStorage/TourPipelineFolder.ts
@@ -1,0 +1,57 @@
+import { PipelineFile } from "@/services/pipelineStorage/PipelineFile";
+import { PipelineFolder } from "@/services/pipelineStorage/PipelineFolder";
+
+/**
+ * Session-storage-backed folder for ephemeral tour pipelines. Files are built
+ * with `id: storageKey` and have no IndexedDB registry entry, so the inherited
+ * `PipelineFile.rename()` / `deleteFile()` — which call `updateEntry` /
+ * `deleteEntry` against that registry — are unsupported in tour mode and would
+ * no-op or error against the missing row. Latent today: the tour UI disables
+ * rename/delete, so these paths are never reached.
+ */
+export class TourPipelineFolder extends PipelineFolder {
+  override async listPipelines(): Promise<PipelineFile[]> {
+    const descriptors = await this.driver.list();
+    return descriptors.map(
+      (d) =>
+        new PipelineFile({
+          id: d.storageKey,
+          storageKey: d.storageKey,
+          folder: this,
+          createdAt: d.createdAt,
+          modifiedAt: d.modifiedAt,
+        }),
+    );
+  }
+
+  override async findFile(
+    storageKey: string,
+  ): Promise<PipelineFile | undefined> {
+    if (!(await this.driver.hasKey(storageKey))) return undefined;
+    return new PipelineFile({
+      id: storageKey,
+      storageKey,
+      folder: this,
+    });
+  }
+
+  override async assignFile(storageKey: string): Promise<PipelineFile> {
+    return new PipelineFile({
+      id: storageKey,
+      storageKey,
+      folder: this,
+    });
+  }
+
+  override async addFile(
+    storageKey: string,
+    content: string,
+  ): Promise<PipelineFile> {
+    await this.driver.write(storageKey, content);
+    return new PipelineFile({
+      id: storageKey,
+      storageKey,
+      folder: this,
+    });
+  }
+}

--- a/src/providers/TourProvider/tourPipelineStorage/TourPipelineStorageProvider.tsx
+++ b/src/providers/TourProvider/tourPipelineStorage/TourPipelineStorageProvider.tsx
@@ -1,0 +1,20 @@
+import type { ReactNode } from "react";
+import { useState } from "react";
+
+import { PipelineStorageCtx } from "@/services/pipelineStorage/PipelineStorageProvider";
+
+import { TourPipelineStorageService } from "./TourPipelineStorageService";
+
+export function TourPipelineStorageProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const [service] = useState(() => new TourPipelineStorageService());
+
+  return (
+    <PipelineStorageCtx.Provider value={service}>
+      {children}
+    </PipelineStorageCtx.Provider>
+  );
+}

--- a/src/providers/TourProvider/tourPipelineStorage/TourPipelineStorageService.ts
+++ b/src/providers/TourProvider/tourPipelineStorage/TourPipelineStorageService.ts
@@ -1,0 +1,48 @@
+import type { PipelineFile } from "@/services/pipelineStorage/PipelineFile";
+import { PipelineFolder } from "@/services/pipelineStorage/PipelineFolder";
+import { PipelineStorageService } from "@/services/pipelineStorage/PipelineStorageService";
+
+import { TOUR_FOLDER_ID } from "./constants";
+import { SessionStoragePipelineDriver } from "./SessionStoragePipelineDriver";
+import { TourPipelineFolder } from "./TourPipelineFolder";
+
+export class TourPipelineStorageService extends PipelineStorageService {
+  constructor() {
+    super();
+    this.rootFolder = new TourPipelineFolder({
+      id: TOUR_FOLDER_ID,
+      name: "Tour",
+      parentId: null,
+      driver: new SessionStoragePipelineDriver(),
+    });
+  }
+
+  override async findPipelineById(id: string): Promise<PipelineFile> {
+    const file = await this.rootFolder.findFile(id);
+    if (!file) {
+      throw new Error(`Tour pipeline not found: ${id}`);
+    }
+    return file;
+  }
+
+  override async resolvePipelineByName(
+    name: string,
+  ): Promise<PipelineFile | undefined> {
+    return this.rootFolder.findFile(name);
+  }
+
+  override async findFolderById(id: string): Promise<PipelineFolder> {
+    if (id === TOUR_FOLDER_ID || id === this.rootFolder.id) {
+      return this.rootFolder;
+    }
+    throw new Error(`Folder not available in tour mode: ${id}`);
+  }
+
+  override async getAllFolders(): Promise<PipelineFolder[]> {
+    return [this.rootFolder];
+  }
+
+  override async getFavoriteFolders(): Promise<PipelineFolder[]> {
+    return [];
+  }
+}

--- a/src/providers/TourProvider/tourPipelineStorage/constants.ts
+++ b/src/providers/TourProvider/tourPipelineStorage/constants.ts
@@ -1,0 +1,2 @@
+export const SESSION_KEY_PREFIX = "tour-pipeline:";
+export const TOUR_FOLDER_ID = "__tour_folder__";

--- a/src/providers/TourProvider/tourPipelineStorage/resetAllTourPipelineState.ts
+++ b/src/providers/TourProvider/tourPipelineStorage/resetAllTourPipelineState.ts
@@ -1,0 +1,30 @@
+import type { QueryClient } from "@tanstack/react-query";
+
+import { TOUR_PIPELINE_PREFIX } from "@/providers/TourProvider/tourPipelineLifecycle";
+import { EDITOR_SPEC_QUERY_KEY } from "@/routes/v2/pages/Editor/hooks/useLoadSpec";
+
+import { SESSION_KEY_PREFIX } from "./constants";
+
+export function resetAllTourPipelineState(queryClient: QueryClient): void {
+  const sessionKeys: string[] = [];
+  for (let i = 0; i < sessionStorage.length; i++) {
+    const key = sessionStorage.key(i);
+    if (key?.startsWith(SESSION_KEY_PREFIX)) {
+      sessionKeys.push(key);
+    }
+  }
+  for (const key of sessionKeys) {
+    sessionStorage.removeItem(key);
+  }
+
+  queryClient.removeQueries({
+    predicate: (query) => {
+      const [head, second] = query.queryKey;
+      return (
+        head === EDITOR_SPEC_QUERY_KEY &&
+        typeof second === "string" &&
+        second.startsWith(TOUR_PIPELINE_PREFIX)
+      );
+    },
+  });
+}

--- a/src/routes/Dashboard/Learn/Tour.tsx
+++ b/src/routes/Dashboard/Learn/Tour.tsx
@@ -17,6 +17,7 @@ import {
   buildTourPipelineYaml,
   TOUR_PIPELINE_PREFIX,
 } from "@/providers/TourProvider/tourPipelineLifecycle";
+import { TourPipelineStorageProvider } from "@/providers/TourProvider/tourPipelineStorage/TourPipelineStorageProvider";
 import { TourCompletionActions } from "@/providers/TourProvider/TourPopover";
 import { APP_ROUTES } from "@/routes/router";
 import { EditorV2 } from "@/routes/v2/pages/Editor/EditorV2";
@@ -40,7 +41,7 @@ function tourPipelineName(tour: TourDefinition): string {
   return `${TOUR_PIPELINE_PREFIX}${tour.id}`;
 }
 
-async function createTourPipeline(
+async function findOrCreateTourPipeline(
   tour: TourDefinition,
   storage: PipelineStorageService,
 ): Promise<ResolvedPipeline> {
@@ -142,38 +143,52 @@ function TourReactourBridge({
 
 export function TourPage() {
   const params = useParams({ strict: false });
-  const search = useSearch({ strict: false });
-  const navigate = useNavigate();
-  const storage = usePipelineStorage();
-
   const tourId =
     "tourId" in params && typeof params.tourId === "string"
       ? params.tourId
       : "";
-
   const tour = getTour(tourId);
 
+  if (!tour) {
+    return <Navigate to={APP_ROUTES.LEARN_TOURS} replace />;
+  }
+
+  return (
+    <TourPipelineStorageProvider>
+      <TourPageBody tour={tour} tourId={tourId} />
+    </TourPipelineStorageProvider>
+  );
+}
+
+function TourPageBody({
+  tour,
+  tourId,
+}: {
+  tour: TourDefinition;
+  tourId: string;
+}) {
+  const search = useSearch({ strict: false });
+  const navigate = useNavigate();
+  const storage = usePipelineStorage();
   const [resolved, setResolved] = useState<ResolvedPipeline | null>(null);
 
   useEffect(() => {
-    if (!tour) return;
     snapshotLayout(EDITOR_LAYOUT_ID);
     return () => {
       restoreLayout(EDITOR_LAYOUT_ID);
     };
-  }, [tour]);
+  }, []);
 
   useEffect(() => {
-    if (!tour) return undefined;
     setResolved(null);
     let cancelled = false;
     void (async () => {
       try {
-        const created = await createTourPipeline(tour, storage);
+        const result = await findOrCreateTourPipeline(tour, storage);
         if (cancelled) return;
-        setResolved(created);
+        setResolved(result);
       } catch (error) {
-        console.warn("Failed to create tour pipeline:", error);
+        console.warn("Failed to resolve tour pipeline:", error);
       }
     })();
     return () => {
@@ -189,10 +204,6 @@ export function TourPage() {
       replace: true,
     });
   };
-
-  if (!tour) {
-    return <Navigate to={APP_ROUTES.LEARN_TOURS} replace />;
-  }
 
   const rawStep = isRecord(search) ? search.step : undefined;
   const parsedStep =

--- a/src/routes/v2/pages/Editor/components/EditorMenuBar/EditorMenuBar.tsx
+++ b/src/routes/v2/pages/Editor/components/EditorMenuBar/EditorMenuBar.tsx
@@ -124,6 +124,7 @@ export const EditorMenuBar = observer(function EditorMenuBar() {
                   onSubmit={handlePipelineRename}
                   submitButtonText="Rename"
                   isSubmitDisabled={(name) => name === pipelineNameFromSpec}
+                  excludeNames={[pipelineNameFromSpec]}
                 />
               )}
 

--- a/src/routes/v2/pages/Editor/components/EditorMenuBar/components/FileMenu.tsx
+++ b/src/routes/v2/pages/Editor/components/EditorMenuBar/components/FileMenu.tsx
@@ -58,6 +58,8 @@ export function FileMenu() {
   const canMove = activePipeline?.folder.canMoveFilesOut ?? false;
   const tourMode = useTourMode();
 
+  const isTour = !!tourMode;
+
   return (
     <>
       <DropdownMenu>
@@ -68,6 +70,7 @@ export function FileMenu() {
         </DropdownMenuTrigger>
         <DropdownMenuContent align="start" sideOffset={2}>
           <DropdownMenuItem
+            disabled={isTour}
             onClick={() => {
               track("v2.pipeline_editor.file_menu.open.click");
               setOpenDialogOpen(true);
@@ -90,6 +93,7 @@ export function FileMenu() {
             Save
           </DropdownMenuItem>
           <DropdownMenuItem
+            disabled={isTour}
             onClick={() => {
               track("v2.pipeline_editor.file_menu.save_as.click");
               setSaveAsDialogOpen(true);
@@ -98,19 +102,19 @@ export function FileMenu() {
             <Icon name="SaveAll" size="sm" />
             Save as
           </DropdownMenuItem>
-          {!tourMode && (
-            <DropdownMenuItem
-              onClick={() => {
-                track("v2.pipeline_editor.file_menu.rename.click");
-                setRenameDialogOpen(true);
-              }}
-            >
-              <Icon name="Pencil" size="sm" />
-              Rename
-            </DropdownMenuItem>
-          )}
+          <DropdownMenuItem
+            disabled={isTour}
+            onClick={() => {
+              track("v2.pipeline_editor.file_menu.rename.click");
+              setRenameDialogOpen(true);
+            }}
+          >
+            <Icon name="Pencil" size="sm" />
+            Rename
+          </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuItem
+            disabled={isTour}
             onClick={() => {
               track("v2.pipeline_editor.file_menu.new_pipeline.click");
               void handleNewPipeline();
@@ -120,6 +124,7 @@ export function FileMenu() {
             New pipeline
           </DropdownMenuItem>
           <DropdownMenuItem
+            disabled={isTour}
             onClick={() => {
               track("v2.pipeline_editor.file_menu.import.click");
               setImportOpen(true);
@@ -151,21 +156,18 @@ export function FileMenu() {
               </DropdownMenuItem>
             </>
           )}
-          {!tourMode && (
-            <>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem
-                onClick={() => {
-                  track("v2.pipeline_editor.file_menu.delete_pipeline.click");
-                  setDeleteDialogOpen(true);
-                }}
-                className="text-destructive focus:text-destructive"
-              >
-                <Icon name="Trash2" size="sm" />
-                Delete pipeline
-              </DropdownMenuItem>
-            </>
-          )}
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            disabled={isTour}
+            onClick={() => {
+              track("v2.pipeline_editor.file_menu.delete_pipeline.click");
+              setDeleteDialogOpen(true);
+            }}
+            className="text-destructive focus:text-destructive"
+          >
+            <Icon name="Trash2" size="sm" />
+            Delete pipeline
+          </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
 
@@ -193,6 +195,7 @@ export function FileMenu() {
         onSubmit={renamePipeline}
         submitButtonText="Rename"
         isSubmitDisabled={(name) => name === getRenameInitialName()}
+        excludeNames={[getRenameInitialName()]}
       />
 
       {canMove && activePipeline && (

--- a/src/routes/v2/pages/Editor/components/EditorMenuBar/components/useFileMenuState.ts
+++ b/src/routes/v2/pages/Editor/components/EditorMenuBar/components/useFileMenuState.ts
@@ -2,6 +2,7 @@ import { useNavigate } from "@tanstack/react-router";
 import { type RefObject, useEffect, useRef, useState } from "react";
 
 import useToastNotification from "@/hooks/useToastNotification";
+import { useTourMode } from "@/providers/TourProvider/TourModeContext";
 import { APP_ROUTES } from "@/routes/router";
 import { usePipelineRename } from "@/routes/v2/pages/Editor/hooks/usePipelineRename";
 import { useEditorSession } from "@/routes/v2/pages/Editor/store/EditorSessionContext";
@@ -43,6 +44,7 @@ export function useFileMenuState(): FileMenuState {
   const { autoSave, pipelineFile: pipelineFileStore } = useEditorSession();
   const renamePipeline = usePipelineRename();
   const storage = usePipelineStorage();
+  const tourMode = useTourMode();
   const navigate = useNavigate();
   const notify = useToastNotification();
   const [importOpen, setImportOpen] = useState(false);
@@ -53,13 +55,14 @@ export function useFileMenuState(): FileMenuState {
   const importTriggerRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
+    if (tourMode) return;
     return keyboard.registerShortcut({
       id: "open-pipeline",
       keys: [CTRL, "O"],
       label: "Open Pipeline",
       action: () => setOpenDialogOpen(true),
     });
-  }, [keyboard]);
+  }, [keyboard, tourMode]);
 
   useEffect(() => {
     if (importOpen) {

--- a/src/routes/v2/pages/Editor/hooks/useLoadSpec.ts
+++ b/src/routes/v2/pages/Editor/hooks/useLoadSpec.ts
@@ -73,10 +73,12 @@ async function resolveSpecData(
   return yaml.load(yamlContent, PIPELINE_YAML_LOAD_OPTIONS);
 }
 
+export const EDITOR_SPEC_QUERY_KEY = "editor-v2-spec";
+
 export function useLoadSpec(ref: PipelineRef) {
   const storage = usePipelineStorage();
   const queryClient = useQueryClient();
-  const queryKey = ["editor-v2-spec", ref.fileId ?? ref.name];
+  const queryKey = [EDITOR_SPEC_QUERY_KEY, ref.fileId ?? ref.name];
 
   // When the v1 editor writes to the same IndexedDB file, drop our cached
   // deserialization so the next read of this query goes back to disk. We
@@ -84,7 +86,7 @@ export function useLoadSpec(ref: PipelineRef) {
   // spec under our feet would discard MobX editor state (selection, undo, …)
   // and the in-memory model is already authoritative for v2.
   useEffect(() => {
-    const matchKey = ["editor-v2-spec", ref.fileId ?? ref.name];
+    const matchKey = [EDITOR_SPEC_QUERY_KEY, ref.fileId ?? ref.name];
 
     const state = queryClient.getQueryState(matchKey);
     const lastFetched = state?.dataUpdatedAt;

--- a/src/routes/v2/pages/Editor/store/autoSaveStore.ts
+++ b/src/routes/v2/pages/Editor/store/autoSaveStore.ts
@@ -21,6 +21,8 @@ export class AutoSaveStore {
   private spec: ComponentSpec | null = null;
   private pipelineName: string | null = null;
   private disposeReaction: (() => void) | null = null;
+  // Last content written to disk; used to skip a redundant flush on dispose.
+  private lastSavedYaml: string | null = null;
 
   private debouncedSave = debounce((yamlText: string) => {
     void this.performSave(yamlText);
@@ -39,6 +41,9 @@ export class AutoSaveStore {
     this.pipelineName = pipelineName;
     this.isSaving = false;
     this.lastSavedAt = null;
+    // The freshly-loaded spec matches what's on disk, so seed the baseline to
+    // avoid flushing an unchanged pipeline on dispose.
+    this.lastSavedYaml = this.serializeSpec();
 
     this.disposeReaction = reaction(
       () => this.serializeSpec(),
@@ -48,9 +53,16 @@ export class AutoSaveStore {
   }
 
   @action dispose() {
+    const yaml = this.serializeSpec();
+    const file = this.pipelineFileStore.activePipelineFile;
+    if (yaml && file && yaml !== this.lastSavedYaml) {
+      void file.write(yaml).catch((error) => {
+        console.error("Auto-save flush on dispose failed:", error);
+      });
+    }
+    this.debouncedSave.cancel();
     this.disposeReaction?.();
     this.disposeReaction = null;
-    this.debouncedSave.cancel();
     this.spec = null;
     this.pipelineName = null;
   }
@@ -98,6 +110,7 @@ export class AutoSaveStore {
       try {
         await this.pipelineFileStore.activePipelineFile?.write(yamlText);
         await this.persistUndoHistory();
+        this.lastSavedYaml = yamlText;
         return new Date();
       } catch (error) {
         console.error("Auto-save failed:", error);

--- a/src/services/pipelineService.ts
+++ b/src/services/pipelineService.ts
@@ -19,9 +19,16 @@ import { USER_PIPELINES_LIST_NAME } from "@/utils/constants";
 import { componentSpecToYaml } from "@/utils/yaml";
 import { componentSpecFromYaml } from "@/utils/yaml";
 
+import {
+  deleteEntry,
+  findByStorageKey,
+} from "./pipelineStorage/pipelineRegistry";
+
 export const deletePipeline = async (name: string, onDelete?: () => void) => {
   try {
     await deleteComponentFileFromList(USER_PIPELINES_LIST_NAME, name);
+    const entry = await findByStorageKey(name);
+    if (entry) await deleteEntry(entry.id);
     onDelete?.();
   } catch (error) {
     console.error("Error deleting pipeline:", error);

--- a/src/services/pipelineStorage/PipelineStorageProvider.tsx
+++ b/src/services/pipelineStorage/PipelineStorageProvider.tsx
@@ -8,7 +8,7 @@ import {
 
 import { PipelineStorageService } from "./PipelineStorageService";
 
-const PipelineStorageCtx = createRequiredContext<PipelineStorageService>(
+export const PipelineStorageCtx = createRequiredContext<PipelineStorageService>(
   "PipelineStorageContext",
 );
 


### PR DESCRIPTION
## Description

Moves tour pipelines out of the durable IndexedDB store and into session storage, so they are truly ephemeral. Before this change, a tour-pipeline lived alongside the user's real pipelines: it showed up in the pipelines list, contended for unique names, and survived browser refresh — none of which is what we want from a guided demo.

The fix is a scoped storage override that only applies while the user is on `/tour/$tourId`. Inside the tour route, `usePipelineStorage()` returns a `TourPipelineStorageService` backed by `sessionStorage`; everywhere else, it still returns the durable IndexedDB service. The autosave path, the spec loader, and the editor's storage consumers don't need to know which one they're talking to.

## What changed

**New scoped storage layer** (`src/providers/TourProvider/tourPipelineStorage/`)

- `SessionStoragePipelineDriver.ts` — driver that reads/writes pipeline YAML against `sessionStorage` keys, matching the shape the existing `PipelineStorageService` expects from a driver.
- `TourPipelineFolder.ts` — single root folder that holds the tour pipeline, with `canMoveFilesOut: false` etc. so the rest of the app can't accidentally relocate it.
- `TourPipelineStorageService.ts` — `PipelineStorageService` subclass whose `rootFolder`, `resolvePipelineByName`, etc. all go through the session-storage driver.
- `TourPipelineStorageProvider.tsx` — context override that the tour route wraps its body in. Inside, `usePipelineStorage()` resolves to the tour service.
- `resetAllTourPipelineState.ts` — clears every `__tour__*` key from session storage and evicts matching entries from the react-query spec cache. Called when starting any tour so each run begins clean.

**Tour route plumbing** (`src/routes/Dashboard/Learn/Tour.tsx`)

- `TourPage` is split into `TourPage` (resolves the tour, guards on `!tour`) and `TourPageBody` (does the pipeline resolution and rendering). The split exists so `TourPipelineStorageProvider` can wrap the body — `usePipelineStorage()` inside `TourPageBody` then resolves to the tour storage.
- `createTourPipeline` is renamed `findOrCreateTourPipeline` to reflect that browser refresh mid-tour reuses the existing session-storage file (so the tour resumes on the same step with edits intact). Re-entering the tour from the Learn page still starts fresh — `FeaturedTours` / `ToursLibrary` call `resetAllTourPipelineState` before navigating, which wipes session storage and the react-query spec cache.

**Pipeline registry orphan fix** (`src/services/pipelineService.ts`)

- Fixes a pre-existing bug surfaced by the storage change: `deletePipeline` removed the file from its folder driver but didn't delete the corresponding entry from the pipeline registry. The orphaned registry entry caused later "name already exists" errors for tour pipelines whose files had been cleared but whose registry rows lived on. Now both are deleted.

**Name-dialog race fix** (`src/components/shared/Dialogs/PipelineNameDialog.tsx`)

- The dialog's error state was computed via a separate `setError` effect that didn't always settle before the user clicked Submit, occasionally letting through a name that should have been rejected. Rewrote it as a `useMemo` so the error is always in sync with the current input. Also added `excludeNames` so a rename-to-self in the regular editor doesn't flag itself as a collision.

## Why scoped override rather than a flag

Threading a `isTour: true` flag through every storage call would have leaked tour-awareness into a layer that doesn't need it. The provider override is opaque to consumers — same `usePipelineStorage()`, same `PipelineFile` shape, different backing store.

## Related Issue and Pull requests

Progresses https://github.com/Shopify/oasis-frontend/issues/583

## Type of Change

- [x] Improvement
- [x] Bug fix

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

Pre-req: at least one registered tour exists (so use this branch with #2306 / #2312 on top, or open a Storybook-style local entry).

**Ephemerality**

- Start a tour. Open DevTools → Application → Local Storage / IndexedDB. The tour pipeline should be in **Session Storage**, not IndexedDB. The pipelines list on the dashboard should not show it.
- Make an edit to the tour pipeline (e.g. drag a node).
- Refresh the browser tab. The tour resumes on the same step (URL `?step=N`) and the edit you made is **still there** (session storage survives same-tab refresh, as intended).
- Close the tab, open a new one, return to the tour. The tour pipeline is gone — start fresh.

**Name-collision regression**

- In the regular editor, rename a pipeline to its current name (no change). The dialog should not flag it as "Name already exists" (this used to fail).
- Start a tour, then start the same tour again from `/learn/tours`. No "Name already exists" error — `resetAllTourPipelineState` clears the prior run.

**Registry orphan regression**

- Create a regular pipeline, delete it, then create a new pipeline with the same name. Should succeed (previously, the stale registry row blocked re-use of the name).

**Regression**

- Normal pipeline create / edit / autosave / delete still work end-to-end (no tour involved).

