### PR TITLE
Adds AI-generated component descriptions to Components V2

### DIFF
--- a/src/components/shared/ComponentDetail/ComponentDetail.tsx
+++ b/src/components/shared/ComponentDetail/ComponentDetail.tsx
@@ -183,12 +183,15 @@ interface ComponentDetailProps {
    * top nav). In `stacked` layout this caps the inline source card's height.
    */
   sourcePanelHeight?: string;
+  /** Hide the source-authored description when the caller renders its own description panel. */
+  hideDescription?: boolean;
 }
 
 export const ComponentDetail = ({
   reference,
   layout = "split",
   sourcePanelHeight,
+  hideDescription = false,
 }: ComponentDetailProps) => {
   const hydrated = useHydrateComponentReference(reference);
 
@@ -305,7 +308,7 @@ export const ComponentDetail = ({
     return (
       <BlockStack gap="6" align="stretch">
         {header}
-        {description}
+        {!hideDescription && description}
         {githubLinks}
         {io}
         {hydrated.text && (
@@ -331,7 +334,7 @@ export const ComponentDetail = ({
     <InlineStack gap="6" blockAlign="start">
       <BlockStack gap="4" className="flex-2 min-w-0">
         {header}
-        {description}
+        {!hideDescription && description}
         {githubLinks}
         {io}
       </BlockStack>

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -70,4 +70,12 @@ export const ExistingFlags: ConfigFlags = {
     default: false,
     category: "beta",
   },
+
+  ["component-search-v2-ai-descriptions"]: {
+    name: "Auto-generate Components V2 AI descriptions",
+    description:
+      "Automatically generate an AI description when viewing a component in Components V2.",
+    default: false,
+    category: "beta",
+  },
 };

--- a/src/hooks/useNaturalLanguageComponentSearch.ts
+++ b/src/hooks/useNaturalLanguageComponentSearch.ts
@@ -2,14 +2,21 @@ import { useMutation } from "@tanstack/react-query";
 
 import { useComponentSearchSettings } from "@/hooks/useComponentSearchSettings";
 import {
+  type ComponentDescriptionResult,
+  generateComponentAiDescription,
   type RerankCandidate,
   rerankComponentsByNaturalLanguage,
   type RerankResult,
 } from "@/services/naturalLanguageComponentSearchService";
+import type { ComponentReference } from "@/utils/componentSpec";
 
 interface RerankVariables {
   query: string;
   candidates: RerankCandidate[];
+}
+
+interface DescriptionVariables {
+  reference: ComponentReference;
 }
 
 /**
@@ -28,6 +35,25 @@ export function useNaturalLanguageComponentRerank() {
   const mutation = useMutation<RerankResult, Error, RerankVariables>({
     mutationFn: ({ query, candidates }) =>
       rerankComponentsByNaturalLanguage(query, candidates, {
+        model: config.model,
+        apiBase: config.apiBase,
+        apiKey: config.apiKey,
+      }),
+  });
+
+  return { ...mutation, isConfigured };
+}
+
+export function useComponentAiDescription() {
+  const { config, isConfigured } = useComponentSearchSettings();
+
+  const mutation = useMutation<
+    ComponentDescriptionResult,
+    Error,
+    DescriptionVariables
+  >({
+    mutationFn: ({ reference }) =>
+      generateComponentAiDescription(reference, {
         model: config.model,
         apiBase: config.apiBase,
         apiKey: config.apiKey,

--- a/src/hooks/useNaturalLanguageComponentSearch.ts
+++ b/src/hooks/useNaturalLanguageComponentSearch.ts
@@ -1,4 +1,4 @@
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 
 import { useComponentSearchSettings } from "@/hooks/useComponentSearchSettings";
 import {
@@ -13,10 +13,6 @@ import type { ComponentReference } from "@/utils/componentSpec";
 interface RerankVariables {
   query: string;
   candidates: RerankCandidate[];
-}
-
-interface DescriptionVariables {
-  reference: ComponentReference;
 }
 
 /**
@@ -44,21 +40,68 @@ export function useNaturalLanguageComponentRerank() {
   return { ...mutation, isConfigured };
 }
 
-export function useComponentAiDescription() {
+/**
+ * Generate an AI description for a single component reference, keyed by
+ * digest so each component gets its own cached result, loading state, and
+ * error.
+ *
+ * This is a **query** (not a mutation) so React Query owns:
+ *   - Per-digest cache: rapidly clicking between components doesn't re-fire
+ *     the call if we already have the answer, and switching back to a
+ *     previously-described component shows its description instantly.
+ *   - Per-digest error/pending: errors on one component can't bleed into the
+ *     loading or error UI of another.
+ *   - AbortSignal: switching to a different component (which re-keys the
+ *     query) aborts the in-flight billed call instead of leaving it running.
+ *
+ * `enabled` lets callers opt into auto-generation (e.g. when the
+ * `component-search-v2-ai-descriptions` flag is on); when disabled, the
+ * description is generated only when the caller invokes `refetch()`.
+ */
+export function useComponentAiDescription({
+  reference,
+  enabled,
+}: {
+  reference: ComponentReference | undefined;
+  enabled: boolean;
+}) {
   const { config, isConfigured } = useComponentSearchSettings();
+  const digest = reference?.digest;
+  const hasSpec = Boolean(reference?.spec);
 
-  const mutation = useMutation<
-    ComponentDescriptionResult,
-    Error,
-    DescriptionVariables
-  >({
-    mutationFn: ({ reference }) =>
-      generateComponentAiDescription(reference, {
+  // Key includes apiBase + model so changing provider invalidates cached
+  // descriptions (a different model would have written a different answer).
+  const query = useQuery<ComponentDescriptionResult, Error>({
+    queryKey: ["componentAiDescription", digest, config.apiBase, config.model],
+    queryFn: async ({ signal }) => {
+      // queryFn is only called when `enabled` is true (guarded below),
+      // which itself requires digest + hasSpec, so reference is defined here.
+      if (!reference) {
+        throw new Error("Component reference is required");
+      }
+      return generateComponentAiDescription(reference, {
         model: config.model,
         apiBase: config.apiBase,
         apiKey: config.apiKey,
-      }),
+        signal,
+      });
+    },
+    // Auto-fetch only when the caller opted in AND we have everything we
+    // need; the manual "Generate" button calls refetch() directly.
+    enabled: enabled && isConfigured && Boolean(digest) && hasSpec,
+    // Descriptions are deterministic given (digest, model). Never go stale
+    // on their own — re-key by changing the queryKey above when needed.
+    staleTime: Infinity,
+    // Billed calls — don't auto-retry on transient failures. The user can
+    // hit the "Try again" button in the panel if they want.
+    retry: false,
   });
 
-  return { ...mutation, isConfigured };
+  return {
+    description: query.data?.description,
+    isFetching: query.isFetching,
+    error: query.error,
+    refetch: () => query.refetch(),
+    isConfigured,
+  };
 }

--- a/src/routes/Dashboard/DashboardComponentsV2SourceFilter.tsx
+++ b/src/routes/Dashboard/DashboardComponentsV2SourceFilter.tsx
@@ -1,0 +1,152 @@
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icon";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Paragraph, Text } from "@/components/ui/typography";
+import { cn } from "@/lib/utils";
+import type {
+  ComponentSearchSource,
+  IndexEntry,
+} from "@/services/componentSearchIndex";
+import { tracking } from "@/utils/tracking";
+
+const SOURCE_ICON_TONE_BY_KIND: Record<ComponentSearchSource["kind"], string> =
+  {
+    standard: "text-blue-500",
+    published: "text-emerald-500",
+    registered: "text-violet-500",
+    user: "text-amber-500",
+  };
+
+const SOURCE_FILTER_LABEL_BY_KIND: Record<
+  ComponentSearchSource["kind"],
+  string
+> = {
+  standard: "Standard",
+  published: "Published",
+  registered: "Registered libraries",
+  user: "User generated",
+};
+
+export interface SourceFilterOption {
+  source: ComponentSearchSource;
+  count: number;
+}
+
+function sourceFilterKey(source: ComponentSearchSource): string {
+  return source.kind;
+}
+
+/**
+ * Filter state is keyed by source kind so multiple registered libraries behave
+ * as one source category instead of several per-library toggles.
+ */
+export function createSourceFilterOptions(
+  index: IndexEntry[],
+): SourceFilterOption[] {
+  const optionsByKey = new Map<string, SourceFilterOption>();
+
+  for (const entry of index) {
+    const key = sourceFilterKey(entry.source);
+    const option = optionsByKey.get(key);
+    if (option) {
+      option.count += 1;
+    } else {
+      optionsByKey.set(key, {
+        source: {
+          kind: entry.source.kind,
+          id: entry.source.kind,
+          label: SOURCE_FILTER_LABEL_BY_KIND[entry.source.kind],
+        },
+        count: 1,
+      });
+    }
+  }
+
+  return Array.from(optionsByKey.values());
+}
+
+/** Apply source-type filter state to indexed component results. */
+export function filterIndexByDisabledSourceKeys(
+  index: IndexEntry[],
+  disabledSourceKeys: string[],
+): IndexEntry[] {
+  const disabled = new Set(disabledSourceKeys);
+  return index.filter((entry) => !disabled.has(sourceFilterKey(entry.source)));
+}
+
+interface SourceFilterBarProps {
+  options: SourceFilterOption[];
+  disabledSourceKeys: string[];
+  onToggle: (sourceKey: string) => void;
+  onEnableAll: () => void;
+}
+
+export const SourceFilterBar = ({
+  options,
+  disabledSourceKeys,
+  onToggle,
+  onEnableAll,
+}: SourceFilterBarProps) => {
+  const disabled = new Set(disabledSourceKeys);
+  const activeCount = options.filter(
+    (option) => !disabled.has(sourceFilterKey(option.source)),
+  ).length;
+
+  if (options.length <= 1 && activeCount === options.length) return null;
+
+  return (
+    <BlockStack gap="2">
+      <InlineStack gap="2" blockAlign="center" wrap="wrap">
+        <Text size="xs" tone="subdued">
+          Sources
+        </Text>
+        {options.map(({ source, count }) => {
+          const key = sourceFilterKey(source);
+          const active = !disabled.has(key);
+          return (
+            <Button
+              key={key}
+              type="button"
+              size="xs"
+              variant={active ? "secondary" : "outline"}
+              aria-pressed={active}
+              aria-label={`${source.label} source (${count} component${count === 1 ? "" : "s"})`}
+              onClick={() => onToggle(key)}
+              className={cn(!active && "opacity-60")}
+              {...tracking("component_library.source_filter", {
+                source_kind: source.kind,
+                enabled_after_click: !active,
+              })}
+            >
+              <Icon
+                name="Package"
+                size="sm"
+                className={SOURCE_ICON_TONE_BY_KIND[source.kind]}
+              />
+              {source.label}
+              <Text as="span" size="xs" tone="subdued">
+                {count}
+              </Text>
+            </Button>
+          );
+        })}
+        {activeCount < options.length && (
+          <Button
+            type="button"
+            size="xs"
+            variant="ghost"
+            onClick={onEnableAll}
+            {...tracking("component_library.source_filter.show_all_button")}
+          >
+            Show all
+          </Button>
+        )}
+      </InlineStack>
+      {activeCount === 0 && (
+        <Paragraph size="xs" tone="subdued">
+          No sources selected. Turn on at least one source to show components.
+        </Paragraph>
+      )}
+    </BlockStack>
+  );
+};

--- a/src/routes/Dashboard/DashboardComponentsV2View.test.tsx
+++ b/src/routes/Dashboard/DashboardComponentsV2View.test.tsx
@@ -1,12 +1,180 @@
-import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { StoredLibrary } from "@/providers/ComponentLibraryProvider/libraries/storage";
+import type { IndexEntry } from "@/services/componentSearchIndex";
+import type { ComponentReference } from "@/utils/componentSpec";
+
+interface DashboardComponentsV2Search {
+  component?: string;
+}
+
+const routeMocks = vi.hoisted(() => {
+  const makeComponent = (digest: string, name: string): ComponentReference => ({
+    digest,
+    name,
+    text: "component yaml",
+    spec: {
+      name,
+      description: `${name} description`,
+      implementation: { container: { image: "python:3.11" } },
+    },
+  });
+
+  const search: DashboardComponentsV2Search = {};
+  const descriptionErrorState: { current: Error | null } = { current: null };
+
+  return {
+    standard: makeComponent("standard-digest", "Standard component"),
+    registered: makeComponent("registered-digest", "Registered component"),
+    user: makeComponent("user-digest", "User component"),
+    navigate: vi.fn(),
+    notify: vi.fn(),
+    generateAiDescription: vi.fn(),
+    resetAiDescription: vi.fn(),
+    descriptionErrorState,
+    aiDescriptionsEnabled: false,
+    search,
+  };
+});
+
+vi.mock("@tanstack/react-query", () => ({
+  queryOptions: (options: unknown) => options,
+  useQueryClient: () => ({ ensureQueryData: vi.fn() }),
+  useQuery: ({ queryKey }: { queryKey: readonly unknown[] }) => {
+    const key = queryKey[0];
+
+    if (key === "componentLibrary") {
+      return {
+        data: {
+          name: "Standard",
+          components: [routeMocks.standard],
+          folders: [],
+        },
+        isLoading: false,
+      };
+    }
+
+    if (key === "userComponents") {
+      return {
+        data: { components: [routeMocks.user] },
+        isLoading: false,
+      };
+    }
+
+    if (key === "component-search-v2" && queryKey[1] === "published") {
+      return { data: [], isLoading: false };
+    }
+
+    if (
+      key === "component-search-v2" &&
+      queryKey[1] === "registered-libraries"
+    ) {
+      return {
+        data: [
+          {
+            reference: routeMocks.registered,
+            source: {
+              kind: "registered",
+              label: "GitHub library",
+              id: "github-lib",
+            },
+          },
+        ],
+        isLoading: false,
+      };
+    }
+
+    if (key === "component-search-v2" && queryKey[1] === "hydrate-library") {
+      return {
+        data: [routeMocks.standard, routeMocks.registered, routeMocks.user],
+        isLoading: false,
+      };
+    }
+
+    return { data: undefined, isLoading: false };
+  },
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({ children }: { children: React.ReactNode }) => <a>{children}</a>,
+  useNavigate: () => routeMocks.navigate,
+  useSearch: () => routeMocks.search,
+}));
+
+vi.mock("dexie-react-hooks", () => ({
+  useLiveQuery: () => [],
+}));
+
+vi.mock("@/providers/BackendProvider", () => ({
+  useBackend: () => ({
+    backendUrl: "https://backend.example",
+    configured: false,
+    available: false,
+  }),
+}));
+
+vi.mock("@/components/shared/Settings/useFlags", () => ({
+  useFlagValue: () => routeMocks.aiDescriptionsEnabled,
+}));
+
+vi.mock("@/hooks/useNaturalLanguageComponentSearch", () => ({
+  useComponentAiDescription: () => ({
+    mutate: routeMocks.generateAiDescription,
+    isPending: false,
+    error: routeMocks.descriptionErrorState.current,
+    reset: routeMocks.resetAiDescription,
+    isConfigured: true,
+  }),
+  useNaturalLanguageComponentRerank: () => ({
+    mutate: vi.fn(),
+    data: undefined,
+    isPending: false,
+    error: null,
+    reset: vi.fn(),
+    isConfigured: false,
+  }),
+}));
+
+vi.mock("@/hooks/useToastNotification", () => ({
+  default: () => routeMocks.notify,
+}));
+
+vi.mock("@/components/shared/ComponentDetail/ComponentDetail", () => ({
+  ComponentDetail: () => <div>Component detail</div>,
+  ComponentDetailSkeleton: () => <div>Loading component detail</div>,
+}));
+
+vi.mock("@/components/shared/SuspenseWrapper", () => ({
+  SuspenseWrapper: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  withSuspenseWrapper:
+    (Component: React.ComponentType) => (props: Record<string, unknown>) => (
+      <Component {...props} />
+    ),
+}));
+
+vi.mock("../v2/shared/clipboard/copyComponentReferenceToClipboard", () => ({
+  copyComponentReferenceToClipboard: vi.fn(),
+}));
+
+vi.mock("../router", () => ({
+  APP_ROUTES: {
+    DASHBOARD_COMPONENTS_V2: "/dashboard/components-v2",
+    SETTINGS_AGENT: "/settings/agent",
+  },
+}));
 
 import {
-  createRegisteredLibrariesFingerprint,
+  createSourceFilterOptions,
+  filterIndexByDisabledSourceKeys,
   SourceFilterBar,
   type SourceFilterOption,
+} from "./DashboardComponentsV2SourceFilter";
+import {
+  createRegisteredLibrariesFingerprint,
+  DashboardComponentsV2View,
 } from "./DashboardComponentsV2View";
 
 const options: SourceFilterOption[] = [
@@ -15,14 +183,36 @@ const options: SourceFilterOption[] = [
     count: 2,
   },
   {
-    source: { kind: "registered", label: "GitHub", id: "github-lib" },
+    source: {
+      kind: "registered",
+      label: "Registered libraries",
+      id: "registered",
+    },
     count: 3,
   },
   {
-    source: { kind: "user", label: "User", id: "user" },
+    source: { kind: "user", label: "User generated", id: "user" },
     count: 1,
   },
 ];
+
+function createIndexEntry(
+  digest: string,
+  source: IndexEntry["source"],
+): IndexEntry {
+  return {
+    digest,
+    source,
+    reference: { digest },
+    name: digest,
+    searchable: {
+      name: digest,
+      description: "",
+      io: "",
+      implementation: "",
+    },
+  };
+}
 
 describe("createRegisteredLibrariesFingerprint", () => {
   it("excludes secret-bearing library configuration", () => {
@@ -47,17 +237,103 @@ describe("createRegisteredLibrariesFingerprint", () => {
     expect(fingerprint).not.toContain("ghp_secret-token");
     expect(fingerprint).not.toContain("access_token");
   });
+
+  it("changes when known digest values change without count changes", () => {
+    const createLibrary = (knownDigests: string[]): StoredLibrary => ({
+      id: "github-lib",
+      name: "GitHub",
+      type: "github",
+      knownDigests,
+      configuration: {
+        repo_name: "owner/repo",
+        last_updated_at: "2026-01-01T00:00:00Z",
+        access_token: "ghp_secret-token",
+        auto_update: true,
+      },
+    });
+
+    expect(
+      createRegisteredLibrariesFingerprint([createLibrary(["a", "b"])]),
+    ).not.toEqual(
+      createRegisteredLibrariesFingerprint([createLibrary(["c", "d"])]),
+    );
+  });
+});
+
+describe("createSourceFilterOptions", () => {
+  it("groups multiple registered libraries into one registered filter", () => {
+    const result = createSourceFilterOptions([
+      createIndexEntry("github-component", {
+        kind: "registered",
+        label: "GitHub library",
+        id: "github-lib",
+      }),
+      createIndexEntry("other-registered-component", {
+        kind: "registered",
+        label: "Other registered library",
+        id: "other-lib",
+      }),
+      createIndexEntry("user-component", {
+        kind: "user",
+        label: "User",
+        id: "user",
+      }),
+    ]);
+
+    expect(result).toEqual(
+      expect.arrayContaining([
+        {
+          source: {
+            kind: "registered",
+            label: "Registered libraries",
+            id: "registered",
+          },
+          count: 2,
+        },
+        {
+          source: {
+            kind: "user",
+            label: "User generated",
+            id: "user",
+          },
+          count: 1,
+        },
+      ]),
+    );
+  });
+});
+
+describe("filterIndexByDisabledSourceKeys", () => {
+  it("removes results from disabled source types", () => {
+    const result = filterIndexByDisabledSourceKeys(
+      [
+        createIndexEntry("registered-component", {
+          kind: "registered",
+          label: "Registered library",
+          id: "registered-lib",
+        }),
+        createIndexEntry("user-component", {
+          kind: "user",
+          label: "User",
+          id: "user",
+        }),
+      ],
+      ["registered"],
+    );
+
+    expect(result.map((entry) => entry.digest)).toEqual(["user-component"]);
+  });
 });
 
 describe("SourceFilterBar", () => {
-  it("toggles source buttons and exposes active state", () => {
+  it("toggles source type buttons and exposes active state", () => {
     const onToggle = vi.fn();
     const onEnableAll = vi.fn();
 
     render(
       <SourceFilterBar
         options={options}
-        disabledSourceKeys={["registered:github-lib"]}
+        disabledSourceKeys={["registered"]}
         onToggle={onToggle}
         onEnableAll={onEnableAll}
       />,
@@ -65,19 +341,97 @@ describe("SourceFilterBar", () => {
 
     expect(
       screen.getByRole("button", {
-        name: "Hide Standard source (2 components)",
+        name: "Standard source (2 components)",
       }),
     ).toHaveAttribute("aria-pressed", "true");
     expect(
-      screen.getByRole("button", { name: "Show GitHub source (3 components)" }),
+      screen.getByRole("button", {
+        name: "Registered libraries source (3 components)",
+      }),
     ).toHaveAttribute("aria-pressed", "false");
 
     fireEvent.click(
-      screen.getByRole("button", { name: "Show GitHub source (3 components)" }),
+      screen.getByRole("button", {
+        name: "Registered libraries source (3 components)",
+      }),
     );
-    expect(onToggle).toHaveBeenCalledWith("registered:github-lib");
+    expect(onToggle).toHaveBeenCalledWith("registered");
 
     fireEvent.click(screen.getByRole("button", { name: "Show all" }));
     expect(onEnableAll).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("DashboardComponentsV2View", () => {
+  beforeEach(() => {
+    routeMocks.aiDescriptionsEnabled = false;
+    routeMocks.descriptionErrorState.current = null;
+    routeMocks.search = {};
+    routeMocks.generateAiDescription.mockClear();
+    routeMocks.resetAiDescription.mockClear();
+  });
+
+  it("filters visible component results by source type and restores them", () => {
+    render(<DashboardComponentsV2View />);
+
+    expect(screen.getByText("Registered component")).toBeInTheDocument();
+    expect(screen.getByText("Standard component")).toBeInTheDocument();
+    expect(screen.getByText("User component")).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Registered libraries source (1 component)",
+      }),
+    );
+
+    expect(screen.queryByText("Registered component")).not.toBeInTheDocument();
+    expect(screen.getByText("Standard component")).toBeInTheDocument();
+    expect(screen.getByText("User component")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Show all" }));
+
+    expect(screen.getByText("Registered component")).toBeInTheDocument();
+  });
+
+  it("shows a manual generate button when automatic descriptions are disabled", () => {
+    routeMocks.search = { component: "standard-digest" };
+
+    render(<DashboardComponentsV2View />);
+
+    expect(routeMocks.generateAiDescription).not.toHaveBeenCalled();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Generate AI description" }),
+    );
+
+    expect(routeMocks.generateAiDescription).toHaveBeenCalledWith(
+      { reference: routeMocks.standard },
+      expect.any(Object),
+    );
+  });
+
+  it("generates component descriptions automatically when the flag is enabled", async () => {
+    routeMocks.aiDescriptionsEnabled = true;
+    routeMocks.search = { component: "standard-digest" };
+
+    render(<DashboardComponentsV2View />);
+
+    await waitFor(() => {
+      expect(routeMocks.generateAiDescription).toHaveBeenCalledWith(
+        { reference: routeMocks.standard },
+        expect.any(Object),
+      );
+    });
+  });
+
+  it("does not automatically retry description generation after an error", () => {
+    routeMocks.aiDescriptionsEnabled = true;
+    routeMocks.descriptionErrorState.current = new Error("provider failed");
+    routeMocks.search = { component: "standard-digest" };
+
+    render(<DashboardComponentsV2View />);
+
+    expect(routeMocks.generateAiDescription).not.toHaveBeenCalled();
+    expect(screen.getByText(/provider failed/)).toBeInTheDocument();
   });
 });

--- a/src/routes/Dashboard/DashboardComponentsV2View.test.tsx
+++ b/src/routes/Dashboard/DashboardComponentsV2View.test.tsx
@@ -30,8 +30,7 @@ const routeMocks = vi.hoisted(() => {
     user: makeComponent("user-digest", "User component"),
     navigate: vi.fn(),
     notify: vi.fn(),
-    generateAiDescription: vi.fn(),
-    resetAiDescription: vi.fn(),
+    refetchDescription: vi.fn(),
     descriptionErrorState,
     aiDescriptionsEnabled: false,
     search,
@@ -119,13 +118,29 @@ vi.mock("@/components/shared/Settings/useFlags", () => ({
 }));
 
 vi.mock("@/hooks/useNaturalLanguageComponentSearch", () => ({
-  useComponentAiDescription: () => ({
-    mutate: routeMocks.generateAiDescription,
-    isPending: false,
-    error: routeMocks.descriptionErrorState.current,
-    reset: routeMocks.resetAiDescription,
-    isConfigured: true,
-  }),
+  useComponentAiDescription: ({
+    reference,
+    enabled,
+  }: {
+    reference: ComponentReference | undefined;
+    enabled: boolean;
+  }) => {
+    const error = routeMocks.descriptionErrorState.current;
+    // Simulate React Query's auto-fetch: when `enabled` is true and we have a
+    // hydrated reference, the query fires on mount/key-change. A pre-seeded
+    // error short-circuits the auto-fetch (retry: false → an errored query
+    // stays errored without re-firing).
+    if (enabled && reference?.digest && reference.spec && !error) {
+      routeMocks.refetchDescription(reference);
+    }
+    return {
+      description: undefined,
+      isFetching: false,
+      error,
+      refetch: () => routeMocks.refetchDescription(reference),
+      isConfigured: true,
+    };
+  },
   useNaturalLanguageComponentRerank: () => ({
     mutate: vi.fn(),
     data: undefined,
@@ -367,8 +382,7 @@ describe("DashboardComponentsV2View", () => {
     routeMocks.aiDescriptionsEnabled = false;
     routeMocks.descriptionErrorState.current = null;
     routeMocks.search = {};
-    routeMocks.generateAiDescription.mockClear();
-    routeMocks.resetAiDescription.mockClear();
+    routeMocks.refetchDescription.mockClear();
   });
 
   it("filters visible component results by source type and restores them", () => {
@@ -398,15 +412,15 @@ describe("DashboardComponentsV2View", () => {
 
     render(<DashboardComponentsV2View />);
 
-    expect(routeMocks.generateAiDescription).not.toHaveBeenCalled();
+    // enabled=false → the hook does not auto-fetch.
+    expect(routeMocks.refetchDescription).not.toHaveBeenCalled();
 
     fireEvent.click(
       screen.getByRole("button", { name: "Generate AI description" }),
     );
 
-    expect(routeMocks.generateAiDescription).toHaveBeenCalledWith(
-      { reference: routeMocks.standard },
-      expect.any(Object),
+    expect(routeMocks.refetchDescription).toHaveBeenCalledWith(
+      routeMocks.standard,
     );
   });
 
@@ -416,10 +430,10 @@ describe("DashboardComponentsV2View", () => {
 
     render(<DashboardComponentsV2View />);
 
+    // enabled=true → React Query auto-fetches; the mock fires the spy on render.
     await waitFor(() => {
-      expect(routeMocks.generateAiDescription).toHaveBeenCalledWith(
-        { reference: routeMocks.standard },
-        expect.any(Object),
+      expect(routeMocks.refetchDescription).toHaveBeenCalledWith(
+        routeMocks.standard,
       );
     });
   });
@@ -431,7 +445,8 @@ describe("DashboardComponentsV2View", () => {
 
     render(<DashboardComponentsV2View />);
 
-    expect(routeMocks.generateAiDescription).not.toHaveBeenCalled();
+    // With retry: false the errored query stays errored — no auto-refetch.
+    expect(routeMocks.refetchDescription).not.toHaveBeenCalled();
     expect(screen.getByText(/provider failed/)).toBeInTheDocument();
   });
 });

--- a/src/routes/Dashboard/DashboardComponentsV2View.tsx
+++ b/src/routes/Dashboard/DashboardComponentsV2View.tsx
@@ -9,6 +9,7 @@ import {
   ComponentDetail,
   ComponentDetailSkeleton,
 } from "@/components/shared/ComponentDetail/ComponentDetail";
+import { useFlagValue } from "@/components/shared/Settings/useFlags";
 import { SuspenseWrapper } from "@/components/shared/SuspenseWrapper";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -20,7 +21,10 @@ import { Spinner } from "@/components/ui/spinner";
 import { QuickTooltip } from "@/components/ui/tooltip";
 import { Heading, Paragraph, Text } from "@/components/ui/typography";
 import { getComponentQueryKey } from "@/hooks/useHydrateComponentReference";
-import { useNaturalLanguageComponentRerank } from "@/hooks/useNaturalLanguageComponentSearch";
+import {
+  useComponentAiDescription,
+  useNaturalLanguageComponentRerank,
+} from "@/hooks/useNaturalLanguageComponentSearch";
 import useToastNotification from "@/hooks/useToastNotification";
 import { cn } from "@/lib/utils";
 import { useBackend } from "@/providers/BackendProvider";
@@ -65,6 +69,11 @@ import { tracking } from "@/utils/tracking";
 
 import { APP_ROUTES } from "../router";
 import { copyComponentReferenceToClipboard } from "../v2/shared/clipboard/copyComponentReferenceToClipboard";
+import {
+  createSourceFilterOptions,
+  filterIndexByDisabledSourceKeys,
+  SourceFilterBar,
+} from "./DashboardComponentsV2SourceFilter";
 import { readSelectedComponentDigest } from "./searchParams";
 
 // Repeated Tailwind combos extracted as named constants.
@@ -101,98 +110,6 @@ const MATCH_FIELD_LABEL: Record<MatchField, string> = {
   description: "description",
   io: "inputs/outputs",
   implementation: "command",
-};
-
-export interface SourceFilterOption {
-  source: ComponentSearchSource;
-  count: number;
-}
-
-function sourceFilterKey(source: ComponentSearchSource): string {
-  return `${source.kind}:${source.id}`;
-}
-
-function createSourceFilterOptions(index: IndexEntry[]): SourceFilterOption[] {
-  const optionsByKey = new Map<string, SourceFilterOption>();
-
-  for (const entry of index) {
-    const key = sourceFilterKey(entry.source);
-    const option = optionsByKey.get(key);
-    if (option) {
-      option.count += 1;
-    } else {
-      optionsByKey.set(key, { source: entry.source, count: 1 });
-    }
-  }
-
-  return Array.from(optionsByKey.values());
-}
-
-interface SourceFilterBarProps {
-  options: SourceFilterOption[];
-  disabledSourceKeys: string[];
-  onToggle: (sourceKey: string) => void;
-  onEnableAll: () => void;
-}
-
-export const SourceFilterBar = ({
-  options,
-  disabledSourceKeys,
-  onToggle,
-  onEnableAll,
-}: SourceFilterBarProps) => {
-  if (options.length <= 1) return null;
-
-  const disabled = new Set(disabledSourceKeys);
-  const activeCount = options.filter(
-    (option) => !disabled.has(sourceFilterKey(option.source)),
-  ).length;
-
-  return (
-    <BlockStack gap="2">
-      <InlineStack gap="2" blockAlign="center" wrap="wrap">
-        <Text size="xs" tone="subdued">
-          Sources
-        </Text>
-        {options.map(({ source, count }) => {
-          const key = sourceFilterKey(source);
-          const active = !disabled.has(key);
-          return (
-            <Button
-              key={key}
-              type="button"
-              size="xs"
-              variant={active ? "secondary" : "outline"}
-              aria-pressed={active}
-              aria-label={`${active ? "Hide" : "Show"} ${source.label} source (${count} component${count === 1 ? "" : "s"})`}
-              onClick={() => onToggle(key)}
-              className={cn(!active && "opacity-60")}
-            >
-              <Icon
-                name="Package"
-                size="sm"
-                className={SOURCE_ICON_TONE_BY_KIND[source.kind]}
-              />
-              {source.label}
-              <Text as="span" size="xs" tone="subdued">
-                {count}
-              </Text>
-            </Button>
-          );
-        })}
-        {activeCount < options.length && (
-          <Button type="button" size="xs" variant="ghost" onClick={onEnableAll}>
-            Show all
-          </Button>
-        )}
-      </InlineStack>
-      {activeCount === 0 && (
-        <Paragraph size="xs" tone="subdued">
-          No sources selected. Turn on at least one source to show components.
-        </Paragraph>
-      )}
-    </BlockStack>
-  );
 };
 
 // Built-in sources are constants — only registered libraries vary per row.
@@ -243,7 +160,7 @@ export function createRegisteredLibrariesFingerprint(
         id: library.id,
         type: library.type,
         name: library.name,
-        knownDigestsCount: library.knownDigests.length,
+        knownDigests: [...library.knownDigests].sort(),
         configuration: registeredLibraryConfigurationFingerprint(
           library.configuration,
         ),
@@ -364,6 +281,78 @@ const ComponentCard = ({
   );
 };
 
+interface ComponentDescriptionPanelProps {
+  prefilledDescription?: string;
+  generatedDescription?: string;
+  isGenerating: boolean;
+  generationError: Error | null;
+  isConfigured: boolean;
+  onGenerate: () => void;
+}
+
+const ComponentDescriptionPanel = ({
+  prefilledDescription,
+  generatedDescription,
+  isGenerating,
+  generationError,
+  isConfigured,
+  onGenerate,
+}: ComponentDescriptionPanelProps) => {
+  return (
+    <BlockStack gap="3">
+      <BlockStack gap="1">
+        <Text size="xs" weight="semibold" tone="subdued">
+          Prefilled description
+        </Text>
+        <Paragraph size="sm" className="[overflow-wrap:anywhere]">
+          {prefilledDescription?.trim() || "No prefilled description provided."}
+        </Paragraph>
+      </BlockStack>
+      <BlockStack gap="1">
+        <InlineStack gap="2" blockAlign="center">
+          <Text size="xs" weight="semibold" tone="subdued">
+            AI-generated description
+          </Text>
+          {isGenerating && <Spinner size={14} />}
+        </InlineStack>
+        {!isConfigured ? (
+          <Paragraph size="sm" tone="subdued">
+            Configure Agent settings to generate an AI description.
+          </Paragraph>
+        ) : generationError ? (
+          <BlockStack gap="2" align="start">
+            <Paragraph size="sm" tone="critical">
+              Couldn&apos;t generate a description: {generationError.message}
+            </Paragraph>
+            <Button type="button" size="sm" onClick={onGenerate}>
+              Try again
+            </Button>
+          </BlockStack>
+        ) : generatedDescription ? (
+          <Paragraph size="sm" className="[overflow-wrap:anywhere]">
+            {generatedDescription}
+          </Paragraph>
+        ) : isGenerating ? (
+          <Paragraph size="sm" tone="subdued">
+            Generating description…
+          </Paragraph>
+        ) : (
+          <Button type="button" size="sm" onClick={onGenerate}>
+            Generate AI description
+          </Button>
+        )}
+      </BlockStack>
+      {!isConfigured && (
+        <Link to={APP_ROUTES.SETTINGS_AGENT}>
+          <Text size="sm" weight="semibold">
+            Configure in Settings →
+          </Text>
+        </Link>
+      )}
+    </BlockStack>
+  );
+};
+
 /**
  * Merge every component source the rest of the app knows about into a single
  * deduped, source-attributed list.
@@ -416,6 +405,9 @@ function collectAllSourcedReferences({
 
 export const DashboardComponentsV2View = () => {
   const queryClient = useQueryClient();
+  const aiDescriptionsEnabled = useFlagValue(
+    "component-search-v2-ai-descriptions",
+  );
   const { backendUrl, configured, available } = useBackend();
   const [query, setQuery] = useState("");
   const [disabledSourceKeys, setDisabledSourceKeys] = useState<string[]>([]);
@@ -624,9 +616,9 @@ export const DashboardComponentsV2View = () => {
   // The search index is a pure derivation. React Compiler will memoize this.
   const index: IndexEntry[] = buildSearchIndex(sourcedHydrated);
   const sourceFilterOptions = createSourceFilterOptions(index);
-  const disabledSourceKeySet = new Set(disabledSourceKeys);
-  const filteredIndex = index.filter(
-    (entry) => !disabledSourceKeySet.has(sourceFilterKey(entry.source)),
+  const filteredIndex = filterIndexByDisabledSourceKeys(
+    index,
+    disabledSourceKeys,
   );
   const total = filteredIndex.length;
   const totalAcrossSources = index.length;
@@ -649,11 +641,21 @@ export const DashboardComponentsV2View = () => {
     reset: resetRerank,
     isConfigured,
   } = useNaturalLanguageComponentRerank();
+  const {
+    mutate: generateAiDescription,
+    isPending: isGeneratingDescription,
+    error: descriptionError,
+    reset: resetDescription,
+    isConfigured: canGenerateDescription,
+  } = useComponentAiDescription();
 
   // Reranked results are tied to the exact query that triggered them. If the
   // user types more, we drop the rerank rather than show results for an old
   // query. Tracked here so we can clear on input change.
   const [rerankedFor, setRerankedFor] = useState<string | null>(null);
+  const [generatedDescriptions, setGeneratedDescriptions] = useState<
+    Record<string, string>
+  >({});
 
   const handleQueryChange = (event: ChangeEvent<HTMLInputElement>) => {
     setQuery(event.target.value);
@@ -744,7 +746,59 @@ export const DashboardComponentsV2View = () => {
     };
   })();
   const isDetailOpen = Boolean(selectedDigest);
+  const selectedGeneratedDescription = selectedDigest
+    ? generatedDescriptions[selectedDigest]
+    : undefined;
   const notify = useToastNotification();
+
+  const handleGenerateDescription = () => {
+    if (!selectedReference?.digest || !selectedReference.spec) return;
+    if (!canGenerateDescription) return;
+
+    const digest = selectedReference.digest;
+    resetDescription();
+    generateAiDescription(
+      { reference: selectedReference },
+      {
+        onSuccess: (result) => {
+          setGeneratedDescriptions((current) => ({
+            ...current,
+            [digest]: result.description,
+          }));
+        },
+      },
+    );
+  };
+
+  useEffect(() => {
+    resetDescription();
+  }, [resetDescription, selectedDigest]);
+
+  useEffect(() => {
+    if (!selectedReference?.digest || !selectedReference.spec) {
+      resetDescription();
+      return;
+    }
+    if (!aiDescriptionsEnabled) return;
+    if (!canGenerateDescription) {
+      resetDescription();
+      return;
+    }
+    if (isGeneratingDescription) return;
+    if (descriptionError) return;
+    if (generatedDescriptions[selectedReference.digest]) return;
+
+    handleGenerateDescription();
+  }, [
+    aiDescriptionsEnabled,
+    canGenerateDescription,
+    descriptionError,
+    generatedDescriptions,
+    handleGenerateDescription,
+    isGeneratingDescription,
+    resetDescription,
+    selectedReference,
+  ]);
 
   const handleCopyToPipeline = async () => {
     if (!selectedReference) return;
@@ -995,14 +1049,27 @@ export const DashboardComponentsV2View = () => {
                 </Button>
               </InlineStack>
             </div>
-            <SuspenseWrapper fallback={<ComponentDetailSkeleton />}>
-              <ComponentDetail
-                key={selectedDigest}
-                reference={selectedReference}
-                layout="stacked"
-                sourcePanelHeight="480px"
+            <BlockStack gap="6" align="stretch">
+              <ComponentDescriptionPanel
+                prefilledDescription={selectedReference.spec?.description}
+                generatedDescription={selectedGeneratedDescription}
+                isGenerating={
+                  isGeneratingDescription && !selectedGeneratedDescription
+                }
+                generationError={descriptionError}
+                isConfigured={canGenerateDescription}
+                onGenerate={handleGenerateDescription}
               />
-            </SuspenseWrapper>
+              <SuspenseWrapper fallback={<ComponentDetailSkeleton />}>
+                <ComponentDetail
+                  key={selectedDigest}
+                  reference={selectedReference}
+                  layout="stacked"
+                  sourcePanelHeight="480px"
+                  hideDescription
+                />
+              </SuspenseWrapper>
+            </BlockStack>
           </div>
         )}
       </div>

--- a/src/routes/Dashboard/DashboardComponentsV2View.tsx
+++ b/src/routes/Dashboard/DashboardComponentsV2View.tsx
@@ -290,6 +290,46 @@ interface ComponentDescriptionPanelProps {
   onGenerate: () => void;
 }
 
+/**
+ * Router-Link styled to read as a clickable link (color + hover underline).
+ * Used wherever we point the user at the Agent settings page — keeps the
+ * affordance consistent and avoids duplicating the link target string.
+ */
+const ConfigureInSettingsLink = () => (
+  <Link
+    to={APP_ROUTES.SETTINGS_AGENT}
+    className="text-sm font-semibold text-primary hover:underline"
+  >
+    Configure in Settings →
+  </Link>
+);
+
+type DescriptionPanelStatus =
+  | { kind: "unconfigured" }
+  | { kind: "error"; message: string }
+  | { kind: "done"; text: string }
+  | { kind: "generating" }
+  | { kind: "idle" };
+
+function getDescriptionPanelStatus({
+  isConfigured,
+  generationError,
+  generatedDescription,
+  isGenerating,
+}: {
+  isConfigured: boolean;
+  generationError: Error | null;
+  generatedDescription?: string;
+  isGenerating: boolean;
+}): DescriptionPanelStatus {
+  if (!isConfigured) return { kind: "unconfigured" };
+  if (generationError)
+    return { kind: "error", message: generationError.message };
+  if (generatedDescription) return { kind: "done", text: generatedDescription };
+  if (isGenerating) return { kind: "generating" };
+  return { kind: "idle" };
+}
+
 const ComponentDescriptionPanel = ({
   prefilledDescription,
   generatedDescription,
@@ -298,6 +338,53 @@ const ComponentDescriptionPanel = ({
   isConfigured,
   onGenerate,
 }: ComponentDescriptionPanelProps) => {
+  const status = getDescriptionPanelStatus({
+    isConfigured,
+    generationError,
+    generatedDescription,
+    isGenerating,
+  });
+
+  const renderStatusBody = () => {
+    switch (status.kind) {
+      case "unconfigured":
+        return (
+          <Paragraph size="sm" tone="subdued">
+            Configure Agent settings to generate an AI description.
+          </Paragraph>
+        );
+      case "error":
+        return (
+          <BlockStack gap="2" align="start">
+            <Paragraph size="sm" tone="critical">
+              Couldn&apos;t generate a description: {status.message}
+            </Paragraph>
+            <Button type="button" size="sm" onClick={onGenerate}>
+              Try again
+            </Button>
+          </BlockStack>
+        );
+      case "done":
+        return (
+          <Paragraph size="sm" className="[overflow-wrap:anywhere]">
+            {status.text}
+          </Paragraph>
+        );
+      case "generating":
+        return (
+          <Paragraph size="sm" tone="subdued">
+            Generating description…
+          </Paragraph>
+        );
+      case "idle":
+        return (
+          <Button type="button" size="sm" onClick={onGenerate}>
+            Generate AI description
+          </Button>
+        );
+    }
+  };
+
   return (
     <BlockStack gap="3">
       <BlockStack gap="1">
@@ -315,40 +402,9 @@ const ComponentDescriptionPanel = ({
           </Text>
           {isGenerating && <Spinner size={14} />}
         </InlineStack>
-        {!isConfigured ? (
-          <Paragraph size="sm" tone="subdued">
-            Configure Agent settings to generate an AI description.
-          </Paragraph>
-        ) : generationError ? (
-          <BlockStack gap="2" align="start">
-            <Paragraph size="sm" tone="critical">
-              Couldn&apos;t generate a description: {generationError.message}
-            </Paragraph>
-            <Button type="button" size="sm" onClick={onGenerate}>
-              Try again
-            </Button>
-          </BlockStack>
-        ) : generatedDescription ? (
-          <Paragraph size="sm" className="[overflow-wrap:anywhere]">
-            {generatedDescription}
-          </Paragraph>
-        ) : isGenerating ? (
-          <Paragraph size="sm" tone="subdued">
-            Generating description…
-          </Paragraph>
-        ) : (
-          <Button type="button" size="sm" onClick={onGenerate}>
-            Generate AI description
-          </Button>
-        )}
+        {renderStatusBody()}
       </BlockStack>
-      {!isConfigured && (
-        <Link to={APP_ROUTES.SETTINGS_AGENT}>
-          <Text size="sm" weight="semibold">
-            Configure in Settings →
-          </Text>
-        </Link>
-      )}
+      {!isConfigured && <ConfigureInSettingsLink />}
     </BlockStack>
   );
 };
@@ -641,21 +697,11 @@ export const DashboardComponentsV2View = () => {
     reset: resetRerank,
     isConfigured,
   } = useNaturalLanguageComponentRerank();
-  const {
-    mutate: generateAiDescription,
-    isPending: isGeneratingDescription,
-    error: descriptionError,
-    reset: resetDescription,
-    isConfigured: canGenerateDescription,
-  } = useComponentAiDescription();
 
   // Reranked results are tied to the exact query that triggered them. If the
   // user types more, we drop the rerank rather than show results for an old
   // query. Tracked here so we can clear on input change.
   const [rerankedFor, setRerankedFor] = useState<string | null>(null);
-  const [generatedDescriptions, setGeneratedDescriptions] = useState<
-    Record<string, string>
-  >({});
 
   const handleQueryChange = (event: ChangeEvent<HTMLInputElement>) => {
     setQuery(event.target.value);
@@ -746,59 +792,30 @@ export const DashboardComponentsV2View = () => {
     };
   })();
   const isDetailOpen = Boolean(selectedDigest);
-  const selectedGeneratedDescription = selectedDigest
-    ? generatedDescriptions[selectedDigest]
-    : undefined;
+
+  // AI description query. Keyed by digest so each component gets its own
+  // cached result, isolated error/pending, and an AbortSignal that fires
+  // when the user switches components mid-flight (no more uncancellable
+  // billed calls). `enabled` opts into auto-generation when the flag is on;
+  // when off, the panel's "Generate AI description" button calls
+  // `refetchDescription()` manually.
+  const {
+    description: selectedGeneratedDescription,
+    isFetching: isGeneratingDescription,
+    error: descriptionError,
+    refetch: refetchDescription,
+    isConfigured: canGenerateDescription,
+  } = useComponentAiDescription({
+    reference: selectedReference,
+    enabled: aiDescriptionsEnabled,
+  });
   const notify = useToastNotification();
 
   const handleGenerateDescription = () => {
     if (!selectedReference?.digest || !selectedReference.spec) return;
     if (!canGenerateDescription) return;
-
-    const digest = selectedReference.digest;
-    resetDescription();
-    generateAiDescription(
-      { reference: selectedReference },
-      {
-        onSuccess: (result) => {
-          setGeneratedDescriptions((current) => ({
-            ...current,
-            [digest]: result.description,
-          }));
-        },
-      },
-    );
+    refetchDescription();
   };
-
-  useEffect(() => {
-    resetDescription();
-  }, [resetDescription, selectedDigest]);
-
-  useEffect(() => {
-    if (!selectedReference?.digest || !selectedReference.spec) {
-      resetDescription();
-      return;
-    }
-    if (!aiDescriptionsEnabled) return;
-    if (!canGenerateDescription) {
-      resetDescription();
-      return;
-    }
-    if (isGeneratingDescription) return;
-    if (descriptionError) return;
-    if (generatedDescriptions[selectedReference.digest]) return;
-
-    handleGenerateDescription();
-  }, [
-    aiDescriptionsEnabled,
-    canGenerateDescription,
-    descriptionError,
-    generatedDescriptions,
-    handleGenerateDescription,
-    isGeneratingDescription,
-    resetDescription,
-    selectedReference,
-  ]);
 
   const handleCopyToPipeline = async () => {
     if (!selectedReference) return;
@@ -986,11 +1003,7 @@ export const DashboardComponentsV2View = () => {
                 Configure an OpenAI-compatible API key to use AI search. Lexical
                 results above are unaffected.
               </Paragraph>
-              <Link to={APP_ROUTES.SETTINGS_AGENT}>
-                <Text size="sm" weight="semibold">
-                  Configure in Settings →
-                </Text>
-              </Link>
+              <ConfigureInSettingsLink />
             </BlockStack>
           )}
           {rerankError && !isConfigError && rerankError instanceof Error && (

--- a/src/routes/Settings/sections/BetaFeaturesSettings.test.tsx
+++ b/src/routes/Settings/sections/BetaFeaturesSettings.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Flag } from "@/types/configuration";
+
+const mocks = vi.hoisted(() => {
+  const betaFlags: Flag[] = [];
+  return {
+    betaFlags,
+    handleSetFlag: vi.fn(),
+    track: vi.fn(),
+  };
+});
+
+vi.mock("@/providers/AnalyticsProvider", () => ({
+  useAnalytics: () => ({ track: mocks.track }),
+}));
+
+vi.mock("../SettingsFlagsContext", () => ({
+  useSettingsFlags: () => ({
+    betaFlags: mocks.betaFlags,
+    handleSetFlag: mocks.handleSetFlag,
+  }),
+}));
+
+import { BetaFeaturesSettings } from "./BetaFeaturesSettings";
+
+const componentSearchFlag: Flag = {
+  key: "component-search-v2",
+  name: "Component Search V2",
+  description: "Show Components V2.",
+  default: false,
+  enabled: false,
+  category: "beta",
+};
+
+const aiDescriptionFlag: Flag = {
+  key: "component-search-v2-ai-descriptions",
+  name: "Auto-generate Components V2 AI descriptions",
+  description: "Automatically generate AI descriptions.",
+  default: false,
+  enabled: false,
+  category: "beta",
+};
+
+describe("BetaFeaturesSettings", () => {
+  beforeEach(() => {
+    mocks.betaFlags = [];
+    mocks.handleSetFlag.mockClear();
+    mocks.track.mockClear();
+  });
+
+  it("hides the AI descriptions flag when Components V2 is disabled", () => {
+    mocks.betaFlags = [componentSearchFlag, aiDescriptionFlag];
+
+    render(<BetaFeaturesSettings />);
+
+    expect(screen.getByText("Component Search V2")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Auto-generate Components V2 AI descriptions"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the AI descriptions flag when Components V2 is enabled", () => {
+    mocks.betaFlags = [
+      { ...componentSearchFlag, enabled: true },
+      aiDescriptionFlag,
+    ];
+
+    render(<BetaFeaturesSettings />);
+
+    expect(screen.getByText("Component Search V2")).toBeInTheDocument();
+    expect(
+      screen.getByText("Auto-generate Components V2 AI descriptions"),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/routes/Settings/sections/BetaFeaturesSettings.tsx
+++ b/src/routes/Settings/sections/BetaFeaturesSettings.tsx
@@ -6,6 +6,14 @@ import { useSettingsFlags } from "../SettingsFlagsContext";
 export function BetaFeaturesSettings() {
   const { betaFlags, handleSetFlag } = useSettingsFlags();
   const { track } = useAnalytics();
+  const componentSearchV2Enabled = betaFlags.some(
+    (flag) => flag.key === "component-search-v2" && flag.enabled,
+  );
+  const visibleBetaFlags = componentSearchV2Enabled
+    ? betaFlags
+    : betaFlags.filter(
+        (flag) => flag.key !== "component-search-v2-ai-descriptions",
+      );
 
   const handleChange = (key: string, enabled: boolean) => {
     track("settings.toggle_changed", {
@@ -16,5 +24,5 @@ export function BetaFeaturesSettings() {
     handleSetFlag(key, enabled);
   };
 
-  return <BetaFeatures betaFlags={betaFlags} onChange={handleChange} />;
+  return <BetaFeatures betaFlags={visibleBetaFlags} onChange={handleChange} />;
 }

--- a/src/services/naturalLanguageComponentSearchService.test.ts
+++ b/src/services/naturalLanguageComponentSearchService.test.ts
@@ -5,6 +5,7 @@ import { isRecord } from "@/utils/typeGuards";
 
 import {
   componentReferenceToCandidate,
+  generateComponentAiDescription,
   NaturalLanguageSearchConfigError,
   rerankComponentsByNaturalLanguage,
 } from "./naturalLanguageComponentSearchService";
@@ -259,5 +260,69 @@ describe("rerankComponentsByNaturalLanguage", () => {
     expect(body.max_tokens).toBeDefined();
     expect(body.max_completion_tokens).toBeUndefined();
     expect(body.temperature).toBe(0);
+  });
+});
+
+describe("generateComponentAiDescription", () => {
+  beforeEach(() => {
+    global.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const reference: ComponentReference = {
+    digest: "abc",
+    spec: {
+      name: "train_model",
+      description: "Trains a model.",
+      inputs: [{ name: "dataset", description: "Training data" }],
+      outputs: [{ name: "model", description: "Trained model" }],
+      implementation: {
+        container: {
+          image: "python:3.12",
+          command: ["python", "train.py"],
+        },
+      },
+    },
+  };
+
+  it("generates a description from a component spec", async () => {
+    vi.mocked(global.fetch).mockResolvedValue(
+      mockChatResponse({
+        description:
+          "This component trains a model from the dataset input and writes the trained model output.",
+      }),
+    );
+
+    const result = await generateComponentAiDescription(
+      reference,
+      VALID_OPTIONS,
+    );
+
+    expect(result.description).toContain("trains a model");
+    const call = vi.mocked(global.fetch).mock.calls[0];
+    const body = parseFetchBody(call);
+    const serializedMessages = JSON.stringify(body.messages);
+    expect(serializedMessages).toContain("train_model");
+    expect(serializedMessages).toContain("dataset");
+  });
+
+  it("requires a hydrated component spec", async () => {
+    await expect(
+      generateComponentAiDescription({ digest: "abc" }, VALID_OPTIONS),
+    ).rejects.toThrow("Component details are not loaded yet");
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("throws when the model returns an empty description", async () => {
+    vi.mocked(global.fetch).mockResolvedValue(
+      mockChatResponse({ description: "" }),
+    );
+
+    await expect(
+      generateComponentAiDescription(reference, VALID_OPTIONS),
+    ).rejects.toThrow("empty description");
   });
 });

--- a/src/services/naturalLanguageComponentSearchService.ts
+++ b/src/services/naturalLanguageComponentSearchService.ts
@@ -188,20 +188,29 @@ function validateConfig(options: LlmOptions): {
   return { base: base.replace(/\/+$/, ""), key, model };
 }
 
-/**
- * Rerank lexical candidates against the user's query. Returns an empty result
- * when called with no candidates — callers should fall back to the lexical
- * ordering in that case.
- */
-export async function rerankComponentsByNaturalLanguage(
-  query: string,
-  candidates: RerankCandidate[],
-  options: LlmOptions,
-): Promise<RerankResult> {
-  const trimmed = query.trim();
-  if (trimmed.length === 0) return { matches: [] };
-  if (candidates.length === 0) return { matches: [] };
+interface ChatCompletionCallConfig {
+  systemPrompt: string;
+  userPrompt: string;
+  /**
+   * Token budget for the visible response. Used as `max_tokens` for non-
+   * reasoning models. Reasoning models (gpt-5 / o-series) use a fixed
+   * `max_completion_tokens` of 2000 because they also burn budget on hidden
+   * thinking tokens.
+   */
+  maxTokens: number;
+}
 
+/**
+ * Shared LLM chat-completion call. Owns the request/response plumbing every
+ * AI feature in this service needs: config validation, model-family
+ * detection for `max_tokens` vs `max_completion_tokens`, header construction,
+ * non-JSON / empty / non-2xx error handling. Callers supply the prompts and
+ * parse the returned `rawContent` string themselves.
+ */
+async function callLlmChatCompletion(
+  options: LlmOptions,
+  config: ChatCompletionCallConfig,
+): Promise<string> {
   const { base, key, model } = validateConfig(options);
 
   const response = await fetch(`${base}/chat/completions`, {
@@ -215,16 +224,13 @@ export async function rerankComponentsByNaturalLanguage(
       model,
       // gpt-5 / o-series reject temperature overrides entirely; omit for them.
       ...(usesCompletionTokensParam(model) ? {} : { temperature: 0 }),
-      // Output sizing: at most 20 candidates × roughly {25 id + 30 reason + JSON
-      // structure} ≈ 1200-1500 tokens for a full response. Reasoning models
-      // burn additional budget on hidden thinking, so they get more headroom.
       ...(usesCompletionTokensParam(model)
         ? { max_completion_tokens: 2000 }
-        : { max_tokens: 1500 }),
+        : { max_tokens: config.maxTokens }),
       response_format: { type: "json_object" },
       messages: [
-        { role: "system", content: buildRerankSystemPrompt() },
-        { role: "user", content: buildRerankUserPrompt(trimmed, candidates) },
+        { role: "system", content: config.systemPrompt },
+        { role: "user", content: config.userPrompt },
       ],
     }),
   });
@@ -246,6 +252,30 @@ export async function rerankComponentsByNaturalLanguage(
   if (!rawContent) {
     throw new Error("LLM proxy returned an empty response");
   }
+  return rawContent;
+}
+
+/**
+ * Rerank lexical candidates against the user's query. Returns an empty result
+ * when called with no candidates — callers should fall back to the lexical
+ * ordering in that case.
+ */
+export async function rerankComponentsByNaturalLanguage(
+  query: string,
+  candidates: RerankCandidate[],
+  options: LlmOptions,
+): Promise<RerankResult> {
+  const trimmed = query.trim();
+  if (trimmed.length === 0) return { matches: [] };
+  if (candidates.length === 0) return { matches: [] };
+
+  // Output sizing: at most 20 candidates × roughly {25 id + 30 reason + JSON
+  // structure} ≈ 1200-1500 tokens for a full response.
+  const rawContent = await callLlmChatCompletion(options, {
+    systemPrompt: buildRerankSystemPrompt(),
+    userPrompt: buildRerankUserPrompt(trimmed, candidates),
+    maxTokens: 1500,
+  });
 
   let parsed: unknown;
   try {
@@ -370,41 +400,11 @@ export async function generateComponentAiDescription(
     throw new Error("Component details are not loaded yet.");
   }
 
-  const { base, key, model } = validateConfig(options);
-
-  const response = await fetch(`${base}/chat/completions`, {
-    method: "POST",
-    signal: options.signal,
-    headers: {
-      "content-type": "application/json",
-      authorization: `Bearer ${key}`,
-    },
-    body: JSON.stringify({
-      model,
-      ...(usesCompletionTokensParam(model) ? {} : { temperature: 0 }),
-      ...(usesCompletionTokensParam(model)
-        ? { max_completion_tokens: 2000 }
-        : { max_tokens: 900 }),
-      response_format: { type: "json_object" },
-      messages: [
-        { role: "system", content: buildDescriptionSystemPrompt() },
-        { role: "user", content: buildDescriptionUserPrompt(input) },
-      ],
-    }),
+  const rawContent = await callLlmChatCompletion(options, {
+    systemPrompt: buildDescriptionSystemPrompt(),
+    userPrompt: buildDescriptionUserPrompt(input),
+    maxTokens: 900,
   });
-
-  if (!response.ok) {
-    const detail = await response.text().catch(() => "");
-    throw new Error(
-      `LLM proxy returned ${response.status}: ${detail.slice(0, 200) || response.statusText}`,
-    );
-  }
-
-  const payload: unknown = await response.json();
-  const rawContent = readChatCompletionContent(payload);
-  if (!rawContent) {
-    throw new Error("LLM proxy returned an empty response");
-  }
 
   const description = readDescription(rawContent);
   if (!description) {

--- a/src/services/naturalLanguageComponentSearchService.ts
+++ b/src/services/naturalLanguageComponentSearchService.ts
@@ -12,6 +12,7 @@
  */
 
 import type { ComponentReference } from "@/utils/componentSpec";
+import { getComponentName } from "@/utils/getComponentName";
 import { isRecord } from "@/utils/typeGuards";
 
 import { extractComponentMetadata } from "./componentSearchIndex";
@@ -43,6 +44,12 @@ export interface RerankResult {
   rawContent?: string;
 }
 
+export interface ComponentDescriptionResult {
+  description: string;
+  /** Raw model response, kept for debugging. */
+  rawContent?: string;
+}
+
 export class NaturalLanguageSearchConfigError extends Error {
   constructor(message: string) {
     super(message);
@@ -50,7 +57,7 @@ export class NaturalLanguageSearchConfigError extends Error {
   }
 }
 
-interface RerankOptions {
+interface LlmOptions {
   signal?: AbortSignal;
   /** Model id (OpenAI-compatible). Required. */
   model: string;
@@ -122,7 +129,7 @@ export function componentReferenceToCandidate(
   };
 }
 
-function buildSystemPrompt(): string {
+function buildRerankSystemPrompt(): string {
   return [
     "You are a reranker for an ML pipeline component search.",
     "The user gives you a natural-language query and a small list of candidate components that were already retrieved by lexical search.",
@@ -141,7 +148,10 @@ function buildSystemPrompt(): string {
   ].join("\n");
 }
 
-function buildUserPrompt(query: string, candidates: RerankCandidate[]): string {
+function buildRerankUserPrompt(
+  query: string,
+  candidates: RerankCandidate[],
+): string {
   // No pretty-printing: indentation adds ~25-30% to the payload for no signal.
   // Candidates are wrapped in an explicit delimiter and tagged as untrusted in
   // the system prompt — candidate descriptions can come from published/
@@ -157,7 +167,7 @@ function buildUserPrompt(query: string, candidates: RerankCandidate[]): string {
   ].join("\n");
 }
 
-function validateConfig(options: RerankOptions): {
+function validateConfig(options: LlmOptions): {
   base: string;
   key: string;
   model: string;
@@ -186,7 +196,7 @@ function validateConfig(options: RerankOptions): {
 export async function rerankComponentsByNaturalLanguage(
   query: string,
   candidates: RerankCandidate[],
-  options: RerankOptions,
+  options: LlmOptions,
 ): Promise<RerankResult> {
   const trimmed = query.trim();
   if (trimmed.length === 0) return { matches: [] };
@@ -213,8 +223,8 @@ export async function rerankComponentsByNaturalLanguage(
         : { max_tokens: 1500 }),
       response_format: { type: "json_object" },
       messages: [
-        { role: "system", content: buildSystemPrompt() },
-        { role: "user", content: buildUserPrompt(trimmed, candidates) },
+        { role: "system", content: buildRerankSystemPrompt() },
+        { role: "user", content: buildRerankUserPrompt(trimmed, candidates) },
       ],
     }),
   });
@@ -265,4 +275,141 @@ export async function rerankComponentsByNaturalLanguage(
     .sort((a, b) => b.score - a.score);
 
   return { matches, rawContent };
+}
+
+interface ComponentDescriptionInput {
+  name: string;
+  prefilledDescription: string;
+  inputs?: Array<{
+    name: string;
+    type?: unknown;
+    description?: string;
+    optional?: boolean;
+    default?: unknown;
+  }>;
+  outputs?: Array<{
+    name: string;
+    type?: unknown;
+    description?: string;
+  }>;
+  implementation: unknown;
+}
+
+function componentReferenceToDescriptionInput(
+  reference: ComponentReference,
+): ComponentDescriptionInput | null {
+  const spec = reference.spec;
+  if (!spec) return null;
+
+  return {
+    name: getComponentName(reference),
+    prefilledDescription: spec.description?.trim() ?? "",
+    ...(spec.inputs && spec.inputs.length > 0
+      ? {
+          inputs: spec.inputs.map((input) => ({
+            name: input.name,
+            type: input.type,
+            description: input.description,
+            optional: input.optional,
+            default: input.default,
+          })),
+        }
+      : {}),
+    ...(spec.outputs && spec.outputs.length > 0
+      ? {
+          outputs: spec.outputs.map((output) => ({
+            name: output.name,
+            type: output.type,
+            description: output.description,
+          })),
+        }
+      : {}),
+    implementation: spec.implementation,
+  };
+}
+
+function buildDescriptionSystemPrompt(): string {
+  return [
+    "You explain ML pipeline components for users deciding whether to add a component to a pipeline.",
+    "Use only the component spec provided. Do not invent behavior that is not supported by the spec.",
+    "Explain exactly what the component does, what it consumes, what it produces, and any important implementation detail visible in the spec.",
+    "Respond with a single JSON object:",
+    '{ "description": "<2-4 sentence precise explanation>" }',
+    "Rules:",
+    "- Be specific and concrete.",
+    "- If the spec is sparse, say what is known and what is not specified.",
+    "- Keep the description under 900 characters.",
+  ].join("\n");
+}
+
+function buildDescriptionUserPrompt(input: ComponentDescriptionInput): string {
+  return ["Component spec summary:", JSON.stringify(input)].join("\n");
+}
+
+function readDescription(rawContent: string): string {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawContent);
+  } catch {
+    throw new Error(
+      `Could not parse LLM response as JSON: ${rawContent.slice(0, 200)}`,
+    );
+  }
+
+  if (!isRecord(parsed)) return "";
+  const description = parsed.description;
+  return typeof description === "string" ? description.trim() : "";
+}
+
+export async function generateComponentAiDescription(
+  reference: ComponentReference,
+  options: LlmOptions,
+): Promise<ComponentDescriptionResult> {
+  const input = componentReferenceToDescriptionInput(reference);
+  if (!input) {
+    throw new Error("Component details are not loaded yet.");
+  }
+
+  const { base, key, model } = validateConfig(options);
+
+  const response = await fetch(`${base}/chat/completions`, {
+    method: "POST",
+    signal: options.signal,
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${key}`,
+    },
+    body: JSON.stringify({
+      model,
+      ...(usesCompletionTokensParam(model) ? {} : { temperature: 0 }),
+      ...(usesCompletionTokensParam(model)
+        ? { max_completion_tokens: 2000 }
+        : { max_tokens: 900 }),
+      response_format: { type: "json_object" },
+      messages: [
+        { role: "system", content: buildDescriptionSystemPrompt() },
+        { role: "user", content: buildDescriptionUserPrompt(input) },
+      ],
+    }),
+  });
+
+  if (!response.ok) {
+    const detail = await response.text().catch(() => "");
+    throw new Error(
+      `LLM proxy returned ${response.status}: ${detail.slice(0, 200) || response.statusText}`,
+    );
+  }
+
+  const payload: unknown = await response.json();
+  const rawContent = readChatCompletionContent(payload);
+  if (!rawContent) {
+    throw new Error("LLM proxy returned an empty response");
+  }
+
+  const description = readDescription(rawContent);
+  if (!description) {
+    throw new Error("LLM proxy returned an empty description");
+  }
+
+  return { description, rawContent };
 }


### PR DESCRIPTION
## Description

Adds AI-generated descriptions for components viewed in the Components V2 detail panel. When a component is selected, the panel now shows a dedicated description section with both the source-authored (prefilled) description and an AI-generated description produced by calling the configured LLM provider.

A new `component-search-v2-ai-descriptions` beta flag controls whether descriptions are generated automatically on component selection. When the flag is off, a manual "Generate AI description" button is shown instead. The flag is hidden in Beta Features settings unless the parent `component-search-v2` flag is also enabled.

The `ComponentDetail` component gains a `hideDescription` prop so the detail panel can suppress the built-in description block when the caller renders its own description panel above it.

The source filter logic has been extracted from `DashboardComponentsV2View` into a dedicated `DashboardComponentsV2SourceFilter` module. Filter keys are now based on source `kind` rather than `kind:id`, so all registered libraries are grouped into a single "Registered libraries" toggle instead of one toggle per library. The registered libraries fingerprint now tracks the sorted set of known digests rather than just their count, so the index correctly invalidates when digest values change without a count change.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Improvement
- [x] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Enable the `component-search-v2` beta flag in Settings.
2. Open the Components V2 view and select any component.
3. Verify the detail panel shows a "Prefilled description" section and an "AI-generated description" section with a "Generate AI description" button.
4. Configure Agent settings with a valid LLM provider, then click "Generate AI description" and confirm a description is returned.
5. Enable the `component-search-v2-ai-descriptions` beta flag (visible only when `component-search-v2` is enabled) and re-select a component. Confirm the description is generated automatically without clicking the button.
6. Confirm that after a generation error, the description is not retried automatically and a "Try again" button is shown.
7. Verify the source filter bar groups all registered libraries under a single "Registered libraries" toggle.

## Additional Comments

The `generateComponentAiDescription` service function follows the same OpenAI-compatible chat completions pattern used by the existing rerank service. Internal prompt-builder and config-validation helpers have been renamed to avoid ambiguity now that both rerank and description generation share the same module.