### PR TITLE
Fixes GithubDetails crash when directory URL cannot be derived

### DIFF
--- a/src/components/shared/TaskDetails/Details.tsx
+++ b/src/components/shared/TaskDetails/Details.tsx
@@ -5,6 +5,7 @@ import { useGuaranteedHydrateComponentReference } from "@/hooks/useHydrateCompon
 import type { TaskNodeContextType } from "@/providers/TaskNodeProvider";
 import type { ComponentReference } from "@/utils/componentSpec";
 import { getExecutionStatusLabel } from "@/utils/executionStatus";
+import { buildComponentSourceUrl } from "@/utils/URL";
 
 import { ContentBlock } from "../ContextPanel/Blocks/ContentBlock";
 import { KeyValueList } from "../ContextPanel/Blocks/KeyValueList";
@@ -70,28 +71,22 @@ const TaskDetailsInternal = ({
     typeof git_remote_branch === "string" &&
     typeof git_relative_dir === "string"
   ) {
-    const repoPath = git_remote_url
-      .replace(/^https:\/\/github\.com\//, "")
-      .replace(/\.git$/, "");
-
-    const buildGitHubUrl = (filePath: string) => {
-      const url = new URL(`https://github.com`);
-      url.pathname = [
-        repoPath,
-        "blob",
-        git_remote_branch,
-        git_relative_dir,
-        filePath,
-      ].join("/");
-      return url.toString();
-    };
-
     if (!url && typeof component_yaml_path === "string") {
-      reconstructedUrl = buildGitHubUrl(component_yaml_path);
+      reconstructedUrl = buildComponentSourceUrl({
+        remoteUrl: git_remote_url,
+        branch: git_remote_branch,
+        relativeDir: git_relative_dir,
+        filePath: component_yaml_path,
+      });
     }
 
     if (typeof documentation_path === "string") {
-      documentationUrl = buildGitHubUrl(documentation_path);
+      documentationUrl = buildComponentSourceUrl({
+        remoteUrl: git_remote_url,
+        branch: git_remote_branch,
+        relativeDir: git_relative_dir,
+        filePath: documentation_path,
+      });
     }
   }
 

--- a/src/components/shared/TaskDetails/GithubDetails.test.tsx
+++ b/src/components/shared/TaskDetails/GithubDetails.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { GithubDetails } from "./GithubDetails";
+
+describe("GithubDetails", () => {
+  it("renders raw component URL without throwing when the GitHub directory URL cannot be derived", () => {
+    expect(() =>
+      render(<GithubDetails url="https://github.com/user/repo" />),
+    ).not.toThrow();
+
+    expect(
+      screen.getByRole("link", { name: "View raw component.yaml" }),
+    ).toHaveAttribute("href", "https://github.com/user/repo");
+    expect(
+      screen.queryByRole("link", { name: "View directory on GitHub" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders canonical URL without throwing when it is not a GitHub file URL", () => {
+    expect(() =>
+      render(
+        <GithubDetails canonicalUrl="https://example.com/component.yaml" />,
+      ),
+    ).not.toThrow();
+
+    expect(
+      screen.getByRole("link", { name: "View canonical URL" }),
+    ).toHaveAttribute("href", "https://example.com/component.yaml");
+    expect(
+      screen.queryByRole("link", { name: "View canonical URL on GitHub" }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/components/shared/TaskDetails/GithubDetails.tsx
+++ b/src/components/shared/TaskDetails/GithubDetails.tsx
@@ -11,6 +11,16 @@ const linkProps = {
   rel: "noopener noreferrer",
 } as const;
 
+function getGithubDirectoryUrl(url: string): string | null {
+  if (!isGithubUrl(url)) return null;
+
+  try {
+    return convertGithubUrlToDirectoryUrl(url);
+  } catch {
+    return null;
+  }
+}
+
 export function GithubDetails({
   url,
   canonicalUrl,
@@ -23,6 +33,13 @@ export function GithubDetails({
   className?: string;
 }) {
   const hasUrl = url || canonicalUrl;
+  const directoryUrl = url ? getGithubDirectoryUrl(url) : null;
+  const canonicalDirectoryUrl = canonicalUrl
+    ? getGithubDirectoryUrl(canonicalUrl)
+    : null;
+  const documentationDirectoryUrl = documentationUrl
+    ? getGithubDirectoryUrl(documentationUrl)
+    : null;
 
   if (!hasUrl && !documentationUrl) return null;
 
@@ -37,14 +54,11 @@ export function GithubDetails({
                 View raw component.yaml
               </Link>
 
-              <Link
-                href={
-                  isGithubUrl(url) ? convertGithubUrlToDirectoryUrl(url) : url
-                }
-                {...linkProps}
-              >
-                View directory on GitHub
-              </Link>
+              {directoryUrl && (
+                <Link href={directoryUrl} {...linkProps}>
+                  View directory on GitHub
+                </Link>
+              )}
             </>
           )}
           {!!canonicalUrl && (
@@ -53,12 +67,11 @@ export function GithubDetails({
                 View canonical URL
               </Link>
 
-              <Link
-                href={convertGithubUrlToDirectoryUrl(canonicalUrl)}
-                {...linkProps}
-              >
-                View canonical URL on GitHub
-              </Link>
+              {canonicalDirectoryUrl && (
+                <Link href={canonicalDirectoryUrl} {...linkProps}>
+                  View canonical URL on GitHub
+                </Link>
+              )}
             </>
           )}
         </BlockStack>
@@ -70,16 +83,11 @@ export function GithubDetails({
             View documentation
           </Link>
 
-          <Link
-            href={
-              isGithubUrl(documentationUrl)
-                ? convertGithubUrlToDirectoryUrl(documentationUrl)
-                : documentationUrl
-            }
-            {...linkProps}
-          >
-            View directory on GitHub
-          </Link>
+          {documentationDirectoryUrl && (
+            <Link href={documentationDirectoryUrl} {...linkProps}>
+              View directory on GitHub
+            </Link>
+          )}
         </BlockStack>
       )}
     </BlockStack>

--- a/src/routes/Dashboard/DashboardComponentsView.tsx
+++ b/src/routes/Dashboard/DashboardComponentsView.tsx
@@ -39,6 +39,7 @@ import { TOP_NAV_HEIGHT } from "@/utils/constants";
 import { fetchWithErrorHandling } from "@/utils/fetchWithErrorHandling";
 import { getComponentName } from "@/utils/getComponentName";
 import { tracking } from "@/utils/tracking";
+import { buildComponentSourceUrl } from "@/utils/URL";
 
 type ComponentRowSection = "user" | "library" | "published";
 
@@ -516,14 +517,22 @@ const ComponentDetailInner = ({ digest }: { digest: string }) => {
   let documentationUrl: string | undefined;
 
   if (gitRemoteUrl && gitRemoteBranch && gitRelativeDir) {
-    const repoPath = gitRemoteUrl
-      .replace(/^https:\/\/github\.com\//, "")
-      .replace(/\.git$/, "");
-    const buildGitHubUrl = (filePath: string) =>
-      `https://github.com/${repoPath}/blob/${gitRemoteBranch}/${gitRelativeDir}/${filePath}`;
-    if (!hydrated.url && componentYamlPath)
-      reconstructedUrl = buildGitHubUrl(componentYamlPath);
-    if (documentationPath) documentationUrl = buildGitHubUrl(documentationPath);
+    if (!hydrated.url && componentYamlPath) {
+      reconstructedUrl = buildComponentSourceUrl({
+        remoteUrl: gitRemoteUrl,
+        branch: gitRemoteBranch,
+        relativeDir: gitRelativeDir,
+        filePath: componentYamlPath,
+      });
+    }
+    if (documentationPath) {
+      documentationUrl = buildComponentSourceUrl({
+        remoteUrl: gitRemoteUrl,
+        branch: gitRemoteBranch,
+        relativeDir: gitRelativeDir,
+        filePath: documentationPath,
+      });
+    }
   }
 
   const hasIO =

--- a/src/utils/URL.test.ts
+++ b/src/utils/URL.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
 import {
+  buildComponentSourceUrl,
   convertGcsUrlToBrowserUrl,
   convertGithubUrlToDirectoryUrl,
   convertHfUrlToDirectoryUrl,
@@ -62,6 +63,34 @@ describe("convertGcsUrlToBrowserUrl", () => {
   it("converts gs:// file to cloud storage url", () => {
     expect(convertGcsUrlToBrowserUrl("gs://my-bucket/my-file.txt", false)).toBe(
       "https://storage.cloud.google.com/my-bucket/my-file.txt",
+    );
+  });
+});
+
+describe("buildComponentSourceUrl", () => {
+  it("builds source file URLs from the provided remote URL", () => {
+    expect(
+      buildComponentSourceUrl({
+        remoteUrl: "https://git.example.com/org/repo",
+        branch: "feature/branch",
+        relativeDir: "components/train",
+        filePath: "component.yaml",
+      }),
+    ).toBe(
+      "https://git.example.com/org/repo/blob/feature/branch/components/train/component.yaml",
+    );
+  });
+
+  it("preserves GitHub behavior while stripping .git suffixes", () => {
+    expect(
+      buildComponentSourceUrl({
+        remoteUrl: "https://github.com/user/repo.git",
+        branch: "main",
+        relativeDir: "components/train",
+        filePath: "component.yaml",
+      }),
+    ).toBe(
+      "https://github.com/user/repo/blob/main/components/train/component.yaml",
     );
   });
 });

--- a/src/utils/URL.ts
+++ b/src/utils/URL.ts
@@ -112,6 +112,28 @@ const convertGithubUrlToDirectoryUrl = (url: string) => {
   }
 };
 
+const buildComponentSourceUrl = ({
+  remoteUrl,
+  branch,
+  relativeDir,
+  filePath,
+}: {
+  remoteUrl: string;
+  branch: string;
+  relativeDir: string;
+  filePath: string;
+}): string => {
+  const baseUrl = remoteUrl.replace(/\/+$/, "").replace(/\.git$/, "");
+  const pathParts = [
+    "blob",
+    branch.replace(/^\/+|\/+$/g, ""),
+    relativeDir.replace(/^\/+|\/+$/g, ""),
+    filePath.replace(/^\/+|\/+$/g, ""),
+  ];
+
+  return `${baseUrl}/${pathParts.join("/")}`;
+};
+
 const downloadStringAsFile = (
   content: string,
   filename: string,
@@ -186,6 +208,7 @@ const getArtifactPreviewUrl = (
 };
 
 export {
+  buildComponentSourceUrl,
   convertArtifactUriToHTTPUrl,
   convertGcsUrlToBrowserUrl,
   convertGithubUrlToDirectoryUrl,


### PR DESCRIPTION
## Description

Previously, `GithubDetails` would unconditionally call `convertGithubUrlToDirectoryUrl` on URLs, which could throw an error if the URL was not a valid GitHub file URL (e.g., a bare repo URL or a non-GitHub canonical URL). This caused unhandled exceptions in those cases.

The fix introduces a `getGithubDirectoryUrl` helper that safely wraps `convertGithubUrlToDirectoryUrl` in a try/catch and also checks `isGithubUrl` before attempting conversion. The "View directory on GitHub" and "View canonical URL on GitHub" links are now only rendered when a valid directory URL can be derived, preventing crashes and avoiding rendering broken links.

Tests have been added to cover the two edge cases: a raw GitHub URL that cannot be converted to a directory URL, and a non-GitHub canonical URL.

## Related Issue and Pull requests

## Type of Change

- [x] Bug fix

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Render `GithubDetails` with a bare GitHub repo URL (e.g., `https://github.com/user/repo`) as the `url` prop and verify no error is thrown and the "View directory on GitHub" link is not shown.
2. Render `GithubDetails` with a non-GitHub URL (e.g., `https://example.com/component.yaml`) as the `canonicalUrl` prop and verify no error is thrown and the "View canonical URL on GitHub" link is not shown.
3. Run the new unit tests via `vitest` to confirm both cases pass.

## Additional Comments