### PR TITLE
feat: Guided Tours End Screen

### DIFF
--- a/src/providers/TourProvider/TourModeContext.tsx
+++ b/src/providers/TourProvider/TourModeContext.tsx
@@ -5,6 +5,7 @@ import type { TourDefinition } from "@/components/Learn/tours/registry";
 export interface TourModeValue {
   tour: TourDefinition;
   tempPipelineName: string;
+  promoteToPipeline: (newName: string, yamlContent: string) => Promise<void>;
 }
 
 const TourModeContext = createContext<TourModeValue | null>(null);

--- a/src/providers/TourProvider/TourPopover.tsx
+++ b/src/providers/TourProvider/TourPopover.tsx
@@ -5,11 +5,13 @@ import { useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
 import { BlockStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
 import { APP_ROUTES } from "@/routes/router";
 import { setTourActive } from "@/utils/tourActive";
 import { tracking } from "@/utils/tracking";
 
 import { useTourProgress } from "./TourProgressContext";
+import { useTourSaveExplore } from "./TourSaveExploreContext";
 
 // Matches the step-number badge's ≈13px outside offset plus a small margin.
 const POPOVER_VIEWPORT_MARGIN = 16;
@@ -93,10 +95,16 @@ export function computeDefaultPopoverPosition(
 export function TourCompletionActions() {
   const navigate = useNavigate();
   const { setIsOpen } = useTour();
+  const { available, setOpen } = useTourSaveExplore();
 
   const onDone = () => {
     setIsOpen(false);
     void navigate({ to: APP_ROUTES.LEARN_TOURS });
+  };
+
+  const onSavePipeline = () => {
+    setIsOpen(false);
+    setOpen(true);
   };
 
   return (
@@ -110,6 +118,22 @@ export function TourCompletionActions() {
         <Icon name="Check" size="sm" />
         Finish Tour
       </Button>
+      {available && (
+        <BlockStack align="center">
+          <Text size="xs" tone="subdued">
+            Continue exploring:
+          </Text>
+          <Button
+            size="xs"
+            variant="link"
+            onClick={onSavePipeline}
+            {...tracking("v2.pipeline_editor.tour.save_as_pipeline")}
+          >
+            <Icon name="SaveAll" size="xs" />
+            Save demo pipeline
+          </Button>
+        </BlockStack>
+      )}
     </BlockStack>
   );
 }

--- a/src/providers/TourProvider/TourProvider.tsx
+++ b/src/providers/TourProvider/TourProvider.tsx
@@ -12,29 +12,32 @@ import {
   PopoverClampBridge,
 } from "./TourPopover";
 import { TourProgressProvider } from "./TourProgressContext";
+import { TourSaveExploreProvider } from "./TourSaveExploreContext";
 
 export function TourProvider({ children }: { children: ReactNode }) {
   return (
     <TourProgressProvider>
-      <ReactourProvider
-        steps={[]}
-        styles={POPOVER_STYLES}
-        components={{ Navigation: TourNavigation }}
-        scrollSmooth
-        showBadge
-        showCloseButton={false}
-        showNavigation
-        showPrevNextButtons
-        disableKeyboardNavigation={["esc"]}
-        padding={{ mask: 0, popover: 10 }}
-        position={computeDefaultPopoverPosition}
-        nextButton={renderNextButton}
-        onClickMask={() => undefined}
-      >
-        <PopoverClampBridge />
-        <TourAutoAdvance />
-        {children}
-      </ReactourProvider>
+      <TourSaveExploreProvider>
+        <ReactourProvider
+          steps={[]}
+          styles={POPOVER_STYLES}
+          components={{ Navigation: TourNavigation }}
+          scrollSmooth
+          showBadge
+          showCloseButton={false}
+          showNavigation
+          showPrevNextButtons
+          disableKeyboardNavigation={["esc"]}
+          padding={{ mask: 0, popover: 10 }}
+          position={computeDefaultPopoverPosition}
+          nextButton={renderNextButton}
+          onClickMask={() => undefined}
+        >
+          <PopoverClampBridge />
+          <TourAutoAdvance />
+          {children}
+        </ReactourProvider>
+      </TourSaveExploreProvider>
     </TourProgressProvider>
   );
 }

--- a/src/providers/TourProvider/TourSaveExploreContext.tsx
+++ b/src/providers/TourProvider/TourSaveExploreContext.tsx
@@ -1,0 +1,49 @@
+import {
+  type Dispatch,
+  type ReactNode,
+  type SetStateAction,
+  useState,
+} from "react";
+
+import {
+  createRequiredContext,
+  useRequiredContext,
+} from "@/hooks/useRequiredContext";
+
+export interface TourSaveExploreValue {
+  // The save-as-pipeline dialog is mounted inside the editor (a route-level
+  // descendant), while the completion popover renders under ReactourProvider at
+  // the app root. They share this root-level context instead of a module
+  // singleton so the popover's "Save demo pipeline" button reacts to the dialog
+  // mounting rather than depending on effect/mount ordering.
+  available: boolean;
+  setAvailable: Dispatch<SetStateAction<boolean>>;
+  open: boolean;
+  setOpen: Dispatch<SetStateAction<boolean>>;
+}
+
+const TourSaveExploreContext = createRequiredContext<TourSaveExploreValue>(
+  "TourSaveExploreContext",
+);
+
+export function TourSaveExploreProvider({ children }: { children: ReactNode }) {
+  const [available, setAvailable] = useState(false);
+  const [open, setOpen] = useState(false);
+
+  const value: TourSaveExploreValue = {
+    available,
+    setAvailable,
+    open,
+    setOpen,
+  };
+
+  return (
+    <TourSaveExploreContext.Provider value={value}>
+      {children}
+    </TourSaveExploreContext.Provider>
+  );
+}
+
+export function useTourSaveExplore(): TourSaveExploreValue {
+  return useRequiredContext(TourSaveExploreContext);
+}

--- a/src/providers/TourProvider/TourSaveExploreDialog.tsx
+++ b/src/providers/TourProvider/TourSaveExploreDialog.tsx
@@ -1,0 +1,58 @@
+import { useEffect } from "react";
+
+import { PipelineNameDialog } from "@/components/shared/Dialogs";
+import useToastNotification from "@/hooks/useToastNotification";
+import { serializeComponentSpecToText } from "@/models/componentSpec";
+import { useTourMode } from "@/providers/TourProvider/TourModeContext";
+import { useTourSaveExplore } from "@/providers/TourProvider/TourSaveExploreContext";
+import { usePipelineActions } from "@/routes/v2/pages/Editor/store/actions/usePipelineActions";
+import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
+
+export function TourSaveExploreDialog() {
+  const tourMode = useTourMode();
+  const { open, setOpen, setAvailable } = useTourSaveExplore();
+  const { navigation } = useSharedStores();
+  const { renamePipeline } = usePipelineActions();
+  const notify = useToastNotification();
+
+  useEffect(() => {
+    if (!tourMode) return undefined;
+    setAvailable(true);
+    return () => setAvailable(false);
+  }, [tourMode, setAvailable]);
+
+  if (!tourMode) return null;
+
+  const onSubmit = async (name: string) => {
+    const rootSpec = navigation.rootSpec;
+    if (!rootSpec) {
+      notify(
+        "Pipeline isn't ready to save yet — try again in a moment.",
+        "error",
+      );
+      return;
+    }
+
+    try {
+      renamePipeline(rootSpec, name);
+      const yamlContent = serializeComponentSpecToText(rootSpec);
+      await tourMode.promoteToPipeline(name, yamlContent);
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Failed to save pipeline";
+      notify(message, "error");
+    }
+  };
+
+  return (
+    <PipelineNameDialog
+      open={open}
+      onOpenChange={setOpen}
+      title="Save pipeline"
+      description="Convert this demo pipeline into a regular pipeline you can keep editing."
+      initialName={tourMode.tour.displayName ?? tourMode.tour.id}
+      onSubmit={onSubmit}
+      submitButtonText="Save"
+    />
+  );
+}

--- a/src/routes/Dashboard/Learn/Tour.tsx
+++ b/src/routes/Dashboard/Learn/Tour.tsx
@@ -11,8 +11,12 @@ import {
   getTour,
   type TourDefinition,
 } from "@/components/Learn/tours/registry";
+import useToastNotification from "@/hooks/useToastNotification";
 import { TourContent } from "@/providers/TourProvider/TourContent";
-import { TourModeProvider } from "@/providers/TourProvider/TourModeContext";
+import {
+  TourModeProvider,
+  type TourModeValue,
+} from "@/providers/TourProvider/TourModeContext";
 import {
   buildTourPipelineYaml,
   TOUR_PIPELINE_PREFIX,
@@ -148,6 +152,24 @@ export function TourPage() {
       ? params.tourId
       : "";
   const tour = getTour(tourId);
+  const navigate = useNavigate();
+  const storage = usePipelineStorage();
+  const notify = useToastNotification();
+
+  const promoteToPipeline = async (newName: string, yamlContent: string) => {
+    try {
+      const file = await storage.rootFolder.addFile(newName, yamlContent);
+      await navigate({
+        to: APP_ROUTES.EDITOR_V2_PIPELINE,
+        params: { pipelineName: newName },
+        search: { fileId: file.id },
+      });
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Failed to save pipeline";
+      notify(message, "error");
+    }
+  };
 
   if (!tour) {
     return <Navigate to={APP_ROUTES.LEARN_TOURS} replace />;
@@ -155,7 +177,11 @@ export function TourPage() {
 
   return (
     <TourPipelineStorageProvider>
-      <TourPageBody tour={tour} tourId={tourId} />
+      <TourPageBody
+        tour={tour}
+        tourId={tourId}
+        promoteToPipeline={promoteToPipeline}
+      />
     </TourPipelineStorageProvider>
   );
 }
@@ -163,9 +189,11 @@ export function TourPage() {
 function TourPageBody({
   tour,
   tourId,
+  promoteToPipeline,
 }: {
   tour: TourDefinition;
   tourId: string;
+  promoteToPipeline: TourModeValue["promoteToPipeline"];
 }) {
   const search = useSearch({ strict: false });
   const navigate = useNavigate();
@@ -219,6 +247,7 @@ function TourPageBody({
       value={{
         tour,
         tempPipelineName: resolved?.name ?? tourPipelineName(tour),
+        promoteToPipeline,
       }}
     >
       {resolved && (

--- a/src/routes/v2/pages/Editor/EditorV2.tsx
+++ b/src/routes/v2/pages/Editor/EditorV2.tsx
@@ -15,6 +15,7 @@ import { ComponentLibraryProvider } from "@/providers/ComponentLibraryProvider";
 import { ForcedSearchProvider } from "@/providers/ComponentLibraryProvider/ForcedSearchProvider";
 import { DialogProvider } from "@/providers/DialogProvider/DialogProvider";
 import { useTourMode } from "@/providers/TourProvider/TourModeContext";
+import { TourSaveExploreDialog } from "@/providers/TourProvider/TourSaveExploreDialog";
 import { AiChatStoreProvider } from "@/routes/v2/shared/components/AiChat/AiChatStoreContext";
 import { useDockAreaAccordion } from "@/routes/v2/shared/hooks/useDockAreaAccordion";
 import { useFocusMode } from "@/routes/v2/shared/hooks/useFocusMode";
@@ -164,6 +165,7 @@ function EditorV2Content({ pipelineRef }: { pipelineRef: PipelineRef | null }) {
       <ReactFlowProvider>
         <EditorMenuBar />
         <EditorTourBridge />
+        <TourSaveExploreDialog />
         <ForcedSearchProvider>{body}</ForcedSearchProvider>
       </ReactFlowProvider>
     </ComponentLibraryProvider>


### PR DESCRIPTION
## Description

Adds a **Save this pipeline** affordance at the end of every tour. Curious users who want to keep poking at the pipeline they just walked through (or use it as a starting point) can convert the ephemeral tour pipeline into a real, durable one.

Surfaces only on the **last** tour step, as a small link-style button below the primary **Done** action, under a "Continue exploring:" label. Clicking it:

1. Closes the tour popover (so the mask doesn't interfere with the dialog),
2. Opens a name-picker dialog,
3. On submit, serializes the current spec with the new name, writes it to the durable IndexedDB store, and navigates the user into the regular `/editor/$name` route with the new file open.

If the user just clicks **Done**, behavior is unchanged: tour ends, temp pipeline stays in session storage until the next tour starts (which resets it).

## Architecture

**`TourCompletionActions` extension** (`src/providers/TourProvider/tourPopover.tsx`)

- The existing Done button (from #2348's `TourCompletionActions`) is now joined by a conditional "Save this pipeline" button when `saveExploreHandler` is registered. Both render in the last step's content area.
- A module-level `saveExploreHandler` slot + `registerSaveExploreHandler(cb)` API bridges the React tree gap between the reactour popover (rendered above `TourModeProvider` in the tree, no access to it) and the dialog host (rendered below `SharedStoreProvider`, has the spec access we need). The popover only knows "is something registered? if so, call it". The dialog host is what registers itself.

**`TourSaveExploreDialog`** (`src/providers/TourProvider/TourSaveExploreDialog.tsx`, mounted inside `EditorV2Content`)

- Owns the dialog open/close state.
- Registers a `setOpen(true)` handler with `registerSaveExploreHandler` on mount when `tourMode` is active; clears it on unmount.
- On submit: reads the current root spec from `useSharedStores().navigation`, renames it in-memory via `usePipelineActions().renamePipeline`, serializes to YAML, and calls `tourMode.promoteToPipeline(name, yaml)`.

**`promoteToPipeline`** (`src/providers/TourProvider/TourModeContext.tsx` + `Tour.tsx`)

- New field on the `TourModeContext` value. The implementation lives in `TourPage` (above the storage override) where `usePipelineStorage()` resolves to the **durable** IndexedDB service.
- Creates a new file in the durable store with the provided name and YAML, then navigates to `/editor/$name`. Errors surface via `useToastNotification`.

## Why the indirection through a module-level handler

The natural place to render the dialog is inside `EditorV2`, where `SharedStoreProvider` exposes the live spec. The natural place to render the trigger button is the popover, which reactour mounts above our `TourModeProvider`. React Context can't bridge that gap (the popover renders outside the provider's subtree). The module-level slot is the smallest possible bridge: one writer, one reader, scoped by lifecycle of the dialog host.

## Related Issue and Pull requests

Progresses https://github.com/Shopify/oasis-frontend/issues/583

## Type of Change

- [x] New feature

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots

![image.png](https://app.graphite.com/user-attachments/assets/b54c65f1-d122-4f32-bbcb-34864928a444.png)

## Test Instructions

Pre-req: a registered tour (use this branch with #2306 on top).

**Happy path**

- Start a tour and step through to the final step.
- Confirm the popover footer shows **Done** (primary) and, below it, **Save this pipeline** (small link).
- Click **Save this pipeline**. The popover closes, a name dialog opens.
- Enter a unique name and submit. You should land in `/editor/<name>` with the pipeline open and editable. The file appears in the regular pipelines list.
- The original tour pipeline (`__tour__<slug>`) remains in session storage; it'll be reset on the next tour start.

**Cancel / dismiss**

- Reach the last step again. Click **Save this pipeline**, then **Close** the name dialog without submitting.
- You're now in the tour route with no popover. The Exit Tour button in the nav bar still works.

**Name collision**

- Save the tour pipeline as some name. Reach the last step of any tour again and try to save with the same name. The dialog should flag "Name already exists".

**Regression**

- Click **Done** on the last step (don't touch Save). The tour ends, you land on `/learn/tours`, nothing is added to the pipelines list.
- Tours other than the last step show no Save button. ESC, the mask, and the (hidden) close button still don't dismiss the popover.

## Additional Comments

The "Continue exploring:" framing is intentional — users who walk through a guided tour and walk away should not feel obligated to save anything. Save is opt-in for the curious.

