### PR TITLE
feat: Guided Tours Custom Navigation

### DIFF
--- a/src/components/Learn/tours/registry.ts
+++ b/src/components/Learn/tours/registry.ts
@@ -1,8 +1,9 @@
 import type { StepType } from "@reactour/tour";
 
+import type { TourAction } from "@/providers/TourProvider/tourActions";
 import { publicAsset } from "@/utils/publicAsset";
 
-type TourStep = StepType;
+type TourStep = StepType & TourAction;
 
 export interface TourDefinition {
   id: string;

--- a/src/providers/TourProvider/TourContent.tsx
+++ b/src/providers/TourProvider/TourContent.tsx
@@ -4,7 +4,7 @@ import { Paragraph } from "@/components/ui/typography";
 
 const INLINE_TOKEN = /(\*\*[^*]+\*\*|_[^_]+_|`[^`]+`)/g;
 
-function renderInline(text: string): ReactNode[] {
+export function renderInline(text: string): ReactNode[] {
   return text.split(INLINE_TOKEN).map((part, index) => {
     if (part.startsWith("**") && part.endsWith("**")) {
       return <strong key={index}>{part.slice(2, -2)}</strong>;

--- a/src/providers/TourProvider/TourNavigation.test.tsx
+++ b/src/providers/TourProvider/TourNavigation.test.tsx
@@ -1,0 +1,232 @@
+import type { StepType } from "@reactour/tour";
+import { act, render, screen } from "@testing-library/react";
+import type { PropsWithChildren } from "react";
+import { useEffect } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  renderNextButton,
+  TourAutoAdvance,
+  TourStepChecklist,
+} from "./TourNavigation";
+import { TourProgressProvider, useTourProgress } from "./TourProgressContext";
+
+type TourState = {
+  isOpen: boolean;
+  currentStep: number;
+  steps: unknown[];
+  setCurrentStep: ReturnType<typeof vi.fn>;
+};
+
+let tourState: TourState;
+
+vi.mock("@reactour/tour", () => ({
+  useTour: () => tourState,
+}));
+
+function makeStep(overrides: Record<string, unknown>): StepType {
+  return {
+    selector: "body",
+    content: "step",
+    ...overrides,
+  } as unknown as StepType;
+}
+
+function MarkComplete({ step }: { step: number }) {
+  const { markStepComplete } = useTourProgress();
+  useEffect(() => {
+    markStepComplete(step);
+  }, [step, markStepComplete]);
+  return null;
+}
+
+type NavButtonProps = PropsWithChildren<{
+  onClick?: () => void;
+  kind?: "next" | "prev";
+  hideArrow?: boolean;
+  disabled?: boolean;
+}>;
+
+function FakeButton({ onClick, disabled, children }: NavButtonProps) {
+  return (
+    <button data-testid="next" onClick={onClick} disabled={disabled}>
+      {children ?? "next"}
+    </button>
+  );
+}
+
+function renderNext(opts: {
+  steps: StepType[];
+  currentStep: number;
+  complete?: number;
+}) {
+  const props = {
+    Button: FakeButton,
+    setCurrentStep: vi.fn(),
+    stepsLength: opts.steps.length,
+    currentStep: opts.currentStep,
+    setIsOpen: vi.fn(),
+    steps: opts.steps,
+  };
+  return render(
+    <TourProgressProvider>
+      {opts.complete !== undefined && <MarkComplete step={opts.complete} />}
+      {renderNextButton(props as Parameters<typeof renderNextButton>[0])}
+    </TourProgressProvider>,
+  );
+}
+
+describe("TourStepChecklist", () => {
+  it("renders a labeled row for an interactive step", () => {
+    render(
+      <TourProgressProvider>
+        <TourStepChecklist
+          step={makeStep({ interaction: "select-task" })}
+          stepIndex={0}
+        />
+      </TourProgressProvider>,
+    );
+    expect(
+      screen.getByText("Complete the highlighted action to continue"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders nothing for a non-interactive step", () => {
+    const { container } = render(
+      <TourProgressProvider>
+        <TourStepChecklist step={makeStep({})} stepIndex={0} />
+      </TourProgressProvider>,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("strikes through the label once the step is complete", () => {
+    render(
+      <TourProgressProvider>
+        <MarkComplete step={1} />
+        <TourStepChecklist
+          step={makeStep({ interaction: "undock-window" })}
+          stepIndex={1}
+        />
+      </TourProgressProvider>,
+    );
+    const label = screen.getByText(
+      "Complete the highlighted action to continue",
+    );
+    expect(label.className).toContain("line-through");
+  });
+});
+
+describe("renderNextButton gating", () => {
+  it("disables Next on an interactive step that is not complete", () => {
+    renderNext({
+      steps: [makeStep({ interaction: "select-task" }), makeStep({})],
+      currentStep: 0,
+    });
+    expect(screen.getByTestId("next")).toBeDisabled();
+  });
+
+  it("enables Next once the interactive step is complete", () => {
+    renderNext({
+      steps: [makeStep({ interaction: "select-task" }), makeStep({})],
+      currentStep: 0,
+      complete: 0,
+    });
+    expect(screen.getByTestId("next")).toBeEnabled();
+  });
+
+  it("enables Next on a non-interactive step", () => {
+    renderNext({
+      steps: [makeStep({}), makeStep({})],
+      currentStep: 0,
+    });
+    expect(screen.getByTestId("next")).toBeEnabled();
+  });
+
+  it("hides the Next button on the last step", () => {
+    const { container } = renderNext({
+      steps: [makeStep({}), makeStep({ interaction: "select-task" })],
+      currentStep: 1,
+    });
+    expect(container.querySelector("[aria-hidden]")).not.toBeNull();
+  });
+});
+
+const progress: { markComplete: (step: number) => void } = {
+  markComplete: () => undefined,
+};
+function CaptureProgress() {
+  const { markStepComplete } = useTourProgress();
+  useEffect(() => {
+    progress.markComplete = markStepComplete;
+  }, [markStepComplete]);
+  return null;
+}
+
+function renderController(currentStep: number, stepCount = 3) {
+  tourState = {
+    isOpen: true,
+    currentStep,
+    steps: Array.from({ length: stepCount }, () => ({})),
+    setCurrentStep: vi.fn(),
+  };
+  const tree = (
+    <TourProgressProvider>
+      <CaptureProgress />
+      <TourAutoAdvance />
+    </TourProgressProvider>
+  );
+  const result = render(tree);
+  const navigateTo = (step: number) => {
+    tourState = { ...tourState, currentStep: step };
+    result.rerender(tree);
+  };
+  return { navigateTo };
+}
+
+describe("TourAutoAdvance", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("auto-advances after a fresh completion, once the delay elapses", () => {
+    renderController(0);
+    act(() => progress.markComplete(0));
+
+    act(() => vi.advanceTimersByTime(500));
+    expect(tourState.setCurrentStep).not.toHaveBeenCalled();
+
+    act(() => vi.advanceTimersByTime(400));
+    expect(tourState.setCurrentStep).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not auto-advance a step that has not been completed", () => {
+    renderController(0);
+    act(() => vi.advanceTimersByTime(2000));
+    expect(tourState.setCurrentStep).not.toHaveBeenCalled();
+  });
+
+  it("does not auto-advance the last step", () => {
+    renderController(2, 3);
+    act(() => progress.markComplete(2));
+    act(() => vi.advanceTimersByTime(2000));
+    expect(tourState.setCurrentStep).not.toHaveBeenCalled();
+  });
+
+  it("does not auto-advance a step already complete on arrival (revisit)", () => {
+    const { navigateTo } = renderController(0);
+
+    act(() => progress.markComplete(0));
+    act(() => vi.advanceTimersByTime(900));
+    expect(tourState.setCurrentStep).toHaveBeenCalledTimes(1);
+    tourState.setCurrentStep.mockClear();
+
+    // Navigate forward, then back to step 0 (which is already complete).
+    act(() => navigateTo(1));
+    act(() => navigateTo(0));
+    act(() => vi.advanceTimersByTime(2000));
+    expect(tourState.setCurrentStep).not.toHaveBeenCalled();
+  });
+});

--- a/src/providers/TourProvider/TourNavigation.tsx
+++ b/src/providers/TourProvider/TourNavigation.tsx
@@ -1,0 +1,331 @@
+import { type ProviderProps, type StepType, useTour } from "@reactour/tour";
+import type { FC, PropsWithChildren, ReactNode } from "react";
+import { useEffect, useRef } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icon";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
+import {
+  createRequiredContext,
+  useRequiredContext,
+} from "@/hooks/useRequiredContext";
+import { cn } from "@/lib/utils";
+
+import { tourActionLabel } from "./tourActionLabels";
+import type { TourAction } from "./tourActions";
+import { renderInline } from "./TourContent";
+import { useTourProgress } from "./TourProgressContext";
+
+type NextButtonProps = Parameters<NonNullable<ProviderProps["nextButton"]>>[0];
+
+type NavButtonProps = {
+  onClick?: () => void;
+  kind?: "next" | "prev";
+  hideArrow?: boolean;
+  disabled?: boolean;
+};
+
+type NavButtonContext = {
+  currentStep: number;
+  stepsLength: number;
+  setCurrentStep: NextButtonProps["setCurrentStep"];
+  disableAll?: boolean;
+  rtl?: boolean;
+};
+
+const NavButtonContext =
+  createRequiredContext<NavButtonContext>("NavButtonContext");
+
+function BoundNavButton({
+  children,
+  ...rest
+}: PropsWithChildren<NavButtonProps>) {
+  const ctx = useRequiredContext(NavButtonContext);
+  return (
+    <NavButton {...rest} {...ctx}>
+      {children}
+    </NavButton>
+  );
+}
+
+function NavButton({
+  currentStep,
+  stepsLength,
+  setCurrentStep,
+  disableAll,
+  rtl,
+  onClick,
+  kind = "next",
+  hideArrow,
+  disabled,
+  children,
+}: PropsWithChildren<NavButtonProps & NavButtonContext>) {
+  const baseDisabled =
+    kind === "next" ? stepsLength - 1 === currentStep : currentStep === 0;
+  const isDisabled = disableAll ? true : baseDisabled || !!disabled;
+  const handleClick = () => {
+    if (isDisabled) return;
+    if (onClick) onClick();
+    else if (kind === "next")
+      setCurrentStep(Math.min(currentStep + 1, stepsLength - 1));
+    else setCurrentStep(Math.max(currentStep - 1, 0));
+  };
+  const inverted = rtl ? kind === "prev" : kind === "next";
+  return (
+    <Button
+      variant="ghost"
+      size={children ? "sm" : "icon"}
+      onClick={handleClick}
+      disabled={isDisabled}
+      aria-label={`Go to ${kind} step`}
+    >
+      {!hideArrow ? (
+        <Icon name={inverted ? "ChevronRight" : "ChevronLeft"} />
+      ) : null}
+      {children}
+    </Button>
+  );
+}
+
+type GatedNextButtonProps = Omit<NextButtonProps, "Button"> & {
+  Button: FC<PropsWithChildren<NavButtonProps>>;
+};
+
+function GatedNextButton(props: GatedNextButtonProps) {
+  const { Button, currentStep, stepsLength, setCurrentStep, steps } = props;
+  const { isStepComplete, visitedMax } = useTourProgress();
+
+  const hiddenPlaceholder = (
+    <span aria-hidden className="invisible pointer-events-none">
+      <Button onClick={() => undefined} kind="next" />
+    </span>
+  );
+
+  const isLastStep = currentStep === stepsLength - 1;
+  if (isLastStep) {
+    return hiddenPlaceholder;
+  }
+
+  const step = steps?.[currentStep];
+  if (!step) {
+    return hiddenPlaceholder;
+  }
+
+  const isRevisit = currentStep < visitedMax;
+  const advance = () =>
+    setCurrentStep((s: number) => Math.min(s + 1, stepsLength - 1));
+
+  const disabled = isChecklistStep(step) && !isStepComplete(currentStep);
+
+  if (isRevisit) {
+    return <Button onClick={advance} kind="next" disabled={disabled} />;
+  }
+
+  return (
+    <Button onClick={advance} kind="next" hideArrow disabled={disabled}>
+      Next
+    </Button>
+  );
+}
+
+export function renderNextButton(props: GatedNextButtonProps) {
+  return <GatedNextButton {...props} />;
+}
+
+type ComponentsProp = NonNullable<ProviderProps["components"]>;
+type NavigationProps = React.ComponentProps<
+  NonNullable<ComponentsProp["Navigation"]>
+>;
+
+type ChecklistStep = StepType & TourAction;
+
+function isChecklistStep(step: StepType | undefined): step is ChecklistStep {
+  return (
+    step != null &&
+    "interaction" in step &&
+    typeof step.interaction === "string" &&
+    step.interaction.length > 0
+  );
+}
+
+export function TourStepChecklist({
+  step,
+  stepIndex,
+}: {
+  step: StepType | undefined;
+  stepIndex: number;
+}) {
+  const { isStepComplete } = useTourProgress();
+  if (!isChecklistStep(step)) return null;
+
+  const complete = isStepComplete(stepIndex);
+  return (
+    <InlineStack
+      gap="2"
+      blockAlign="center"
+      className="rounded-md bg-muted px-3 py-2"
+    >
+      <Icon
+        key={complete ? "complete" : "pending"}
+        name={complete ? "CircleCheck" : "Circle"}
+        size="sm"
+        className={cn(
+          "transition-colors",
+          complete
+            ? "text-green-600 animate-in zoom-in-50 duration-300"
+            : "text-muted-foreground",
+        )}
+      />
+      <Text
+        size="sm"
+        tone={complete ? "subdued" : undefined}
+        className={cn("transition-colors", complete && "line-through")}
+      >
+        {renderInline(tourActionLabel(step))}
+      </Text>
+    </InlineStack>
+  );
+}
+
+export function TourNavigation(props: NavigationProps) {
+  const {
+    setCurrentStep,
+    currentStep,
+    steps,
+    nextButton,
+    prevButton,
+    setIsOpen,
+    hideButtons,
+    hideDots,
+    disableAll,
+    rtl,
+  } = props;
+
+  const stepsLength = steps.length;
+
+  const { visitedMax: visited, recordVisited } = useTourProgress();
+
+  useEffect(() => {
+    recordVisited(currentStep);
+  }, [recordVisited, currentStep]);
+
+  const navButtonContext: NavButtonContext = {
+    currentStep,
+    stepsLength,
+    setCurrentStep,
+    disableAll,
+    rtl,
+  };
+
+  const btnCtx = {
+    Button: BoundNavButton,
+    setCurrentStep,
+    currentStep,
+    stepsLength,
+    setIsOpen,
+    steps,
+  };
+
+  const renderPrev: ReactNode = !hideButtons ? (
+    typeof prevButton === "function" ? (
+      prevButton(btnCtx)
+    ) : (
+      <BoundNavButton kind="prev" />
+    )
+  ) : null;
+
+  const renderNext: ReactNode = !hideButtons ? (
+    typeof nextButton === "function" ? (
+      nextButton(btnCtx)
+    ) : (
+      <BoundNavButton kind="next" />
+    )
+  ) : null;
+
+  return (
+    <NavButtonContext.Provider value={navButtonContext}>
+      <BlockStack gap="3" align="stretch" className="mt-6">
+        <TourStepChecklist step={steps[currentStep]} stepIndex={currentStep} />
+        <div
+          dir={rtl ? "rtl" : "ltr"}
+          className="flex flex-row items-center justify-between"
+        >
+          {renderPrev}
+          {!hideDots ? (
+            <div
+              aria-hidden
+              className="flex flex-row items-center justify-between flex-nowrap"
+            >
+              {Array.from({ length: stepsLength }, (_, i) => i).map((index) => {
+                const isCurrent = index === currentStep;
+                const isVisited = index <= visited && !isCurrent;
+                return (
+                  <Badge
+                    key={`tour-dot-${index}`}
+                    variant="dot"
+                    className={cn(
+                      "m-1 transition-all",
+                      isCurrent && "text-blue-500 scale-125",
+                      isVisited && "text-blue-300",
+                      !isCurrent && !isVisited && "text-zinc-300",
+                    )}
+                  />
+                );
+              })}
+            </div>
+          ) : null}
+          {renderNext}
+        </div>
+      </BlockStack>
+    </NavButtonContext.Provider>
+  );
+}
+
+const AUTO_ADVANCE_DELAY_MS = 800;
+
+export function TourAutoAdvance() {
+  const { isOpen, currentStep, steps, setCurrentStep } = useTour();
+  const { completedSteps, isStepComplete } = useTourProgress();
+
+  const armedStepRef = useRef<number | null>(null);
+  const visitedStepRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!isOpen) {
+      visitedStepRef.current = null;
+      armedStepRef.current = null;
+      return undefined;
+    }
+
+    // On arrival at a step, auto-advance only if it isn't already complete.
+    if (visitedStepRef.current !== currentStep) {
+      visitedStepRef.current = currentStep;
+      armedStepRef.current = isStepComplete(currentStep) ? null : currentStep;
+    }
+
+    const isLastStep = currentStep >= steps.length - 1;
+    if (
+      armedStepRef.current !== currentStep ||
+      !isStepComplete(currentStep) ||
+      isLastStep
+    ) {
+      return undefined;
+    }
+
+    const timer = setTimeout(() => {
+      setCurrentStep((s: number) => Math.min(s + 1, steps.length - 1));
+    }, AUTO_ADVANCE_DELAY_MS);
+    return () => clearTimeout(timer);
+  }, [
+    isOpen,
+    currentStep,
+    completedSteps,
+    isStepComplete,
+    steps,
+    setCurrentStep,
+  ]);
+
+  return null;
+}

--- a/src/providers/TourProvider/TourPopover.tsx
+++ b/src/providers/TourProvider/TourPopover.tsx
@@ -1,4 +1,4 @@
-import { type ProviderProps, useTour } from "@reactour/tour";
+import { useTour } from "@reactour/tour";
 import { useNavigate } from "@tanstack/react-router";
 import { useEffect } from "react";
 
@@ -9,8 +9,14 @@ import { APP_ROUTES } from "@/routes/router";
 import { setTourActive } from "@/utils/tourActive";
 import { tracking } from "@/utils/tracking";
 
+import { useTourProgress } from "./TourProgressContext";
+
 // Matches the step-number badge's ≈13px outside offset plus a small margin.
 const POPOVER_VIEWPORT_MARGIN = 16;
+// Popover padding (40) + prev icon button (~32) + "Next" text button (~60) + buffer.
+const POPOVER_NAV_BASE_WIDTH = 140;
+const POPOVER_DOT_WIDTH = 16;
+const POPOVER_DEFAULT_MAX_WIDTH = 420;
 
 export const POPOVER_STYLES = {
   popover: (base: object) => ({
@@ -18,7 +24,7 @@ export const POPOVER_STYLES = {
     borderRadius: "0.75rem",
     padding: "1.25rem",
     boxShadow: "0 10px 30px rgba(0,0,0,0.12)",
-    maxWidth: "420px",
+    maxWidth: `${POPOVER_DEFAULT_MAX_WIDTH}px`,
   }),
   maskWrapper: (base: object) => ({
     ...base,
@@ -84,8 +90,6 @@ export function computeDefaultPopoverPosition(
   return "bottom";
 }
 
-type NextButtonProps = Parameters<NonNullable<ProviderProps["nextButton"]>>[0];
-
 export function TourCompletionActions() {
   const navigate = useNavigate();
   const { setIsOpen } = useTour();
@@ -107,40 +111,6 @@ export function TourCompletionActions() {
         Finish Tour
       </Button>
     </BlockStack>
-  );
-}
-
-export function renderNextButton(props: NextButtonProps) {
-  const { Button, currentStep, stepsLength, setCurrentStep, steps } = props;
-
-  const hiddenPlaceholder = (
-    <span aria-hidden style={{ visibility: "hidden", pointerEvents: "none" }}>
-      <Button onClick={() => undefined} kind="next" />
-    </span>
-  );
-
-  const isLastStep = currentStep === stepsLength - 1;
-  if (isLastStep) {
-    return hiddenPlaceholder;
-  }
-
-  const step = steps?.[currentStep];
-  if (!step) {
-    return hiddenPlaceholder;
-  }
-
-  // Interaction steps advance via the prompted action, not a Next click.
-  if ("interaction" in step && step.interaction) {
-    return hiddenPlaceholder;
-  }
-
-  return (
-    <Button
-      onClick={() =>
-        setCurrentStep((step: number) => Math.min(step + 1, stepsLength - 1))
-      }
-      kind="next"
-    />
   );
 }
 
@@ -166,8 +136,19 @@ function clampPopoverElement(el: HTMLElement): void {
   }
 }
 
+// Reactour has no viewport-padding setting and lets the popover snap flush to
+// edges, which clips our step-number badge. We observe its inline transform
+// and clamp it to stay POPOVER_VIEWPORT_MARGIN inside the viewport.
 export function PopoverClampBridge() {
-  const { isOpen } = useTour();
+  const { isOpen, steps } = useTour();
+  const { reset: resetTourProgress } = useTourProgress();
+  const stepCount = steps?.length ?? 0;
+
+  useEffect(() => {
+    if (isOpen) {
+      resetTourProgress();
+    }
+  }, [isOpen, resetTourProgress]);
 
   // Expose tour-open state to non-React callers (e.g. dispatchResizeOnToggle)
   // so app-wide popover/dropdown side effects can no-op outside tours.
@@ -182,7 +163,15 @@ export function PopoverClampBridge() {
     let styleObserver: MutationObserver | null = null;
     let findObserver: MutationObserver | null = null;
 
+    const applyMinWidth = (el: HTMLElement) => {
+      const required = POPOVER_NAV_BASE_WIDTH + stepCount * POPOVER_DOT_WIDTH;
+      const width = Math.max(POPOVER_DEFAULT_MAX_WIDTH, required);
+      el.style.minWidth = `${width}px`;
+      el.style.maxWidth = `${width}px`;
+    };
+
     const observe = (el: HTMLElement) => {
+      applyMinWidth(el);
       styleObserver = new MutationObserver(() => clampPopoverElement(el));
       styleObserver.observe(el, {
         attributes: true,
@@ -213,7 +202,7 @@ export function PopoverClampBridge() {
       styleObserver?.disconnect();
       findObserver?.disconnect();
     };
-  }, [isOpen]);
+  }, [isOpen, stepCount]);
 
   return null;
 }

--- a/src/providers/TourProvider/TourProgressContext.test.tsx
+++ b/src/providers/TourProvider/TourProgressContext.test.tsx
@@ -1,0 +1,40 @@
+import { act, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it } from "vitest";
+
+import { TourProgressProvider, useTourProgress } from "./TourProgressContext";
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <TourProgressProvider>{children}</TourProgressProvider>
+);
+
+describe("TourProgressContext", () => {
+  it("marks a step complete and reflects it in isStepComplete", () => {
+    const { result } = renderHook(() => useTourProgress(), { wrapper });
+
+    expect(result.current.isStepComplete(2)).toBe(false);
+    act(() => result.current.markStepComplete(2));
+    expect(result.current.isStepComplete(2)).toBe(true);
+    expect(result.current.completedSteps.has(2)).toBe(true);
+  });
+
+  it("reset clears all completed steps", () => {
+    const { result } = renderHook(() => useTourProgress(), { wrapper });
+
+    act(() => {
+      result.current.markStepComplete(0);
+      result.current.markStepComplete(1);
+    });
+    expect(result.current.completedSteps.size).toBe(2);
+
+    act(() => result.current.reset());
+    expect(result.current.completedSteps.size).toBe(0);
+    expect(result.current.isStepComplete(0)).toBe(false);
+  });
+
+  it("throws when used outside of a provider", () => {
+    expect(() => renderHook(() => useTourProgress())).toThrow(
+      /TourProgressContext/,
+    );
+  });
+});

--- a/src/providers/TourProvider/TourProgressContext.tsx
+++ b/src/providers/TourProvider/TourProgressContext.tsx
@@ -1,0 +1,65 @@
+import { type ReactNode, useState } from "react";
+
+import {
+  createRequiredContext,
+  useRequiredContext,
+} from "@/hooks/useRequiredContext";
+
+export interface TourProgressValue {
+  completedSteps: ReadonlySet<number>;
+  isStepComplete(step: number): boolean;
+  markStepComplete(step: number): void;
+  visitedMax: number;
+  recordVisited(step: number): void;
+  reset(): void;
+}
+
+const TourProgressContext = createRequiredContext<TourProgressValue>(
+  "TourProgressContext",
+);
+
+export function TourProgressProvider({ children }: { children: ReactNode }) {
+  const [completedSteps, setCompletedSteps] = useState<Set<number>>(
+    () => new Set(),
+  );
+  const [visitedMax, setVisitedMax] = useState(0);
+
+  const isStepComplete = (step: number) => completedSteps.has(step);
+
+  const markStepComplete = (step: number) => {
+    setCompletedSteps((prev) => {
+      if (prev.has(step)) return prev;
+      const next = new Set(prev);
+      next.add(step);
+      return next;
+    });
+  };
+
+  const recordVisited = (step: number) => {
+    setVisitedMax((prev) => (step > prev ? step : prev));
+  };
+
+  const reset = () => {
+    setCompletedSteps((prev) => (prev.size === 0 ? prev : new Set()));
+    setVisitedMax(0);
+  };
+
+  const value: TourProgressValue = {
+    completedSteps,
+    isStepComplete,
+    markStepComplete,
+    visitedMax,
+    recordVisited,
+    reset,
+  };
+
+  return (
+    <TourProgressContext.Provider value={value}>
+      {children}
+    </TourProgressContext.Provider>
+  );
+}
+
+export function useTourProgress(): TourProgressValue {
+  return useRequiredContext(TourProgressContext);
+}

--- a/src/providers/TourProvider/TourProvider.tsx
+++ b/src/providers/TourProvider/TourProvider.tsx
@@ -2,30 +2,39 @@ import { TourProvider as ReactourProvider } from "@reactour/tour";
 import type { ReactNode } from "react";
 
 import {
+  renderNextButton,
+  TourAutoAdvance,
+  TourNavigation,
+} from "./TourNavigation";
+import {
   computeDefaultPopoverPosition,
   POPOVER_STYLES,
   PopoverClampBridge,
-  renderNextButton,
 } from "./TourPopover";
+import { TourProgressProvider } from "./TourProgressContext";
 
 export function TourProvider({ children }: { children: ReactNode }) {
   return (
-    <ReactourProvider
-      steps={[]}
-      styles={POPOVER_STYLES}
-      scrollSmooth
-      showBadge
-      showCloseButton={false}
-      showNavigation
-      showPrevNextButtons
-      disableKeyboardNavigation={["esc"]}
-      padding={{ mask: 0, popover: 10 }}
-      position={computeDefaultPopoverPosition}
-      nextButton={renderNextButton}
-      onClickMask={() => undefined}
-    >
-      <PopoverClampBridge />
-      {children}
-    </ReactourProvider>
+    <TourProgressProvider>
+      <ReactourProvider
+        steps={[]}
+        styles={POPOVER_STYLES}
+        components={{ Navigation: TourNavigation }}
+        scrollSmooth
+        showBadge
+        showCloseButton={false}
+        showNavigation
+        showPrevNextButtons
+        disableKeyboardNavigation={["esc"]}
+        padding={{ mask: 0, popover: 10 }}
+        position={computeDefaultPopoverPosition}
+        nextButton={renderNextButton}
+        onClickMask={() => undefined}
+      >
+        <PopoverClampBridge />
+        <TourAutoAdvance />
+        {children}
+      </ReactourProvider>
+    </TourProgressProvider>
   );
 }

--- a/src/providers/TourProvider/tourActionLabels.ts
+++ b/src/providers/TourProvider/tourActionLabels.ts
@@ -1,0 +1,12 @@
+import type { TourAction } from "./tourActions";
+
+const GENERIC_LABEL = "Complete the highlighted action to continue";
+
+// Labels may embed **bold** spans (rendered by the checklist via renderInline)
+// to highlight the contextual target, e.g. the task or folder name.
+export function tourActionLabel(step: TourAction): string {
+  switch (step.interaction) {
+    default:
+      return GENERIC_LABEL;
+  }
+}

--- a/src/providers/TourProvider/tourActions.ts
+++ b/src/providers/TourProvider/tourActions.ts
@@ -1,0 +1,47 @@
+type TourInteraction =
+  | "undock-window"
+  | "redock-window"
+  | "select-task"
+  | "add-task"
+  | "add-input"
+  | "add-output"
+  | "connect-edge"
+  | "expand-folder"
+  | "library-search"
+  | "set-argument"
+  | "navigate-into-subgraph"
+  | "navigate-to-root"
+  | "unpack-subgraph"
+  | "multi-select-tasks"
+  | "create-subgraph"
+  | "open-secret-dialog"
+  | "open-settings-panel"
+  | "open-submit-dialog"
+  | "assign-secret-argument"
+  | "assign-secret-submit";
+
+interface TourActionEdge {
+  sourceTaskName: string;
+  sourcePortName: string;
+  targetTaskName?: string;
+  targetPortName?: string;
+}
+
+/**
+ * The interaction contract for a hands-on tour step: which action the user
+ * must perform and the element it targets. Shared between the checklist label
+ * (tourActionLabel) and the interaction-detection bridge so the kind union and
+ * its target params are defined once.
+ */
+export interface TourAction {
+  interaction?: TourInteraction;
+  targetTaskName?: string;
+  targetComponentName?: string;
+  targetWindowId?: string;
+  targetWindowName?: string;
+  targetFolderName?: string;
+  targetSearchTerm?: string;
+  targetArgumentName?: string;
+  targetMinCount?: number;
+  targetEdge?: TourActionEdge;
+}


### PR DESCRIPTION
## Description

Replaces reactour's default Prev/Next with a custom tour navigation **and** the interactive-step UX layer that sits on top of it: progress dots, a completion-gated "Next", an action checklist in the popover, and auto-progress. Visible behavior becomes observable once the registry has tours (#2306 onwards).

## What's in it

### Custom navigation

- **Progress dots** between Prev and Next, one per step, colored by visit state (`current` / `visited` / `unvisited`). Non-clickable — bouncing between arbitrary steps would leave reactour inconsistent on tours with interaction gates.
- The **furthest-reached step** is tracked at module level so the indicator survives popover remounts and stays accurate on tours that swap step content via `setSteps`.
- **Visit-aware Next**: a "Next" text label on the furthest-reached step, a chevron-only button on revisits.

### Step completion + gated "Next"

- `TourProgressContext` tracks per-step completion (a `Set` of completed step indices), reset whenever a tour opens.
- On an **interactive step**, "Next" is **disabled until the step's interaction is reported complete** (the editor bridge in #2299 reports completion). On non-interactive steps, and on already-complete/revisited steps, it's enabled.

### Action checklist

- `TourStepChecklist` renders the step's required action in the popover and ticks it off — `Circle` → `CircleCheck` with a check animation and strike-through — when complete.
- Labels come from `tourActionLabel` and may embed **bold targets** (e.g. "Select the **Greet** task"), rendered via `renderInline` (exported from `TourContent`). Each interaction's label is authored in the PR that introduces that interaction (#2299 / #2347 / #2365).

### Auto-progress

- `TourAutoAdvance` advances ~800ms after a **fresh** completion — long enough to see the tick register. Steps already complete on arrival (e.g. revisited via Back) stay on a **manual** click; clicking "Next" advances immediately and cancels the pending auto-advance.

### File layout

- Navigation components live in `TourNavigation.tsx` (`TourNavigation`, `NavButton`, `GatedNextButton`/`renderNextButton`, `TourStepChecklist`, `TourAutoAdvance`, and the module-level visit-tracking helpers).
- `TourPopover.tsx` keeps popover styling/positioning, the viewport clamp bridge, and the completion actions.
- `TourProgressContext.tsx` holds the completion state + `useTourProgress` hook. Tests: `TourNavigation.test.tsx` and `TourProgressContext.test.tsx`.

### Popover polish

- The navigation row fills the popover width, and the checklist is spaced from the step content above it.

## Related Issue and Pull requests

Progresses https://github.com/Shopify/oasis-frontend/issues/583

Depends on #2348 (foundation). The interaction detection that drives completion lands in #2299; interaction-specific checklist labels are authored in #2299 / #2347 / #2365.

## Type of Change

- [x] New feature

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

With a tour registered (use this branch with #2306 on top):

**Dots**

- Step through the tour. Each dot fills in as you reach it — current is enlarged + saturated, visited is lighter blue, unvisited is zinc-gray. Clicking a dot does nothing (intentionally disabled).

**Checklist + gated Next**

- On an interactive step (e.g. step 7's "click the Greet task"), a checklist row shows the required action and "Next" is **disabled**.
- Complete the action — the row ticks (check animation + strike-through) and, after ~800ms, the tour auto-advances. Clicking "Next" while it's enabled advances immediately.
- A step whose action is already satisfied on arrival shows pre-checked with "Next" enabled.

**Visit-aware Next + revisits**

- On the furthest step reached, "Next" shows a text label; stepping back via Prev collapses it to a chevron. Revisited (already-complete) steps do **not** auto-advance — they wait for a manual click.

**Reset between tours**

- Finish a tour, return to `/learn/tours`, start a different one. Completion + visited-max reset for the new tour.
