### PR TITLE
feat: Learning Hub - Milestone 1

### DIFF
--- a/src/routes/Dashboard/Learn/LearnHomeView.test.tsx
+++ b/src/routes/Dashboard/Learn/LearnHomeView.test.tsx
@@ -60,7 +60,7 @@ describe("<LearnHomeView/>", () => {
     ).toBeInTheDocument();
   });
 
-  test("renders the onboarding hero with progress", () => {
+  test.skip("renders the onboarding hero with progress", () => {
     renderWithClient(<LearnHomeView />);
     expect(
       screen.getByRole("heading", { level: 2, name: /welcome to tangle/i }),
@@ -77,19 +77,23 @@ describe("<LearnHomeView/>", () => {
     expect(screen.getByText("Full docs")).toBeInTheDocument();
   });
 
-  test("renders the tip, tours, examples and FAQ sections", () => {
+  test("renders the tip, examples and FAQ sections", () => {
     renderWithClient(<LearnHomeView />);
     expect(
       screen.getByRole("heading", { level: 3, name: /tip of the day/i }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("heading", { level: 3, name: /featured tours/i }),
     ).toBeInTheDocument();
     expect(
       screen.getByRole("heading", { level: 2, name: /example pipelines/i }),
     ).toBeInTheDocument();
     expect(
       screen.getByRole("heading", { level: 2, name: /frequently asked/i }),
+    ).toBeInTheDocument();
+  });
+
+  test.skip("renders the featured tours section", () => {
+    renderWithClient(<LearnHomeView />);
+    expect(
+      screen.getByRole("heading", { level: 3, name: /featured tours/i }),
     ).toBeInTheDocument();
   });
 });

--- a/src/routes/Dashboard/Learn/LearnHomeView.tsx
+++ b/src/routes/Dashboard/Learn/LearnHomeView.tsx
@@ -9,6 +9,10 @@ import { OnboardingHero } from "@/components/Learn/OnboardingHero";
 import { TipOfTheDay } from "@/components/Learn/TipOfTheDay";
 import { BlockStack } from "@/components/ui/layout";
 
+// Learning Hub Milestone 1: Documentation, FAQ, Example Pipelines & Tips
+// Not included: Guided Tours & Onboarding
+const SHOW_WIP_FEATURES = false;
+
 export function LearnHomeView() {
   return (
     <BlockStack gap="6">
@@ -24,11 +28,11 @@ export function LearnHomeView() {
         </BlockStack>
       </BlockStack>
 
-      <OnboardingHero />
+      {SHOW_WIP_FEATURES && <OnboardingHero />}
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
         <TipOfTheDay />
-        <FeaturedTours />
+        {SHOW_WIP_FEATURES && <FeaturedTours />}
       </div>
 
       <FeaturedExamples />


### PR DESCRIPTION
## Description

Shapes the Learning Hub stack into Milestone 1, covering:

- Documentation Search
- Documentation Quicklinks
- Tip of the Day + Tip Browser
- Example Pipelines
- FAQ
- Help Card

Excluded from Milestone 1 is:

- Guided Tours
- Onboarding

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

Progresses https://github.com/Shopify/oasis-frontend/issues/584

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

- [x] New feature

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

![image.png](https://app.graphite.com/user-attachments/assets/95da49e3-4427-4994-862b-d6b750498714.png)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

This PR just disables the placeholder Guided Tours & Onboarding sections. If the previous PRs in this stack have been tested and approved, this one should be good to go as well.

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->