### PR TITLE
feat: Search Run List by User via Click

### DIFF
--- a/src/components/Home/RunSection/RunRow.tsx
+++ b/src/components/Home/RunSection/RunRow.tsx
@@ -16,7 +16,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import useToastNotification from "@/hooks/useToastNotification";
+import { Text } from "@/components/ui/typography";
 import { useBackend } from "@/providers/BackendProvider";
 import { APP_ROUTES } from "@/routes/router";
 import { fetchRunAnnotations } from "@/services/pipelineRunService";
@@ -29,9 +29,13 @@ import { TWENTY_FOUR_HOURS_IN_MS } from "@/utils/constants";
 import { formatDate } from "@/utils/date";
 import { getOverallExecutionStatusFromStats } from "@/utils/executionStatus";
 
-const RunRow = ({ run }: { run: PipelineRunResponse }) => {
+interface RunRowProps {
+  run: PipelineRunResponse;
+  onFilterByUser?: (createdBy: string) => void;
+}
+
+const RunRow = ({ run, onFilterByUser }: RunRowProps) => {
   const navigate = useNavigate();
-  const notify = useToastNotification();
   const { backendUrl } = useBackend();
 
   const runId = `${run.id}`;
@@ -52,10 +56,9 @@ const RunRow = ({ run }: { run: PipelineRunResponse }) => {
   const truncatedCreatedBy = truncateMiddle(createdBy);
   const isTruncated = createdBy !== truncatedCreatedBy;
 
-  const handleCopy = (e: MouseEvent) => {
+  const handleFilterByUser = (e: MouseEvent) => {
     e.stopPropagation();
-    navigator.clipboard.writeText(createdBy);
-    notify(`"${createdBy}" copied to clipboard`, "success");
+    onFilterByUser?.(createdBy);
   };
 
   const overallStatus = getOverallExecutionStatusFromStats(
@@ -77,20 +80,26 @@ const RunRow = ({ run }: { run: PipelineRunResponse }) => {
     navigate({ to: clickThroughUrl });
   };
 
-  const createdByButton = (
+  const createdByContent = onFilterByUser ? (
     <Button
-      className="truncate underline"
-      onClick={handleCopy}
+      className="underline"
+      onClick={handleFilterByUser}
       tabIndex={0}
       variant="ghost"
     >
-      {truncatedCreatedBy}
+      <Text size="xs" tone="subdued" className="truncate">
+        {truncatedCreatedBy}
+      </Text>
     </Button>
+  ) : (
+    <Text size="xs" tone="subdued" className="truncate">
+      {truncatedCreatedBy}
+    </Text>
   );
 
-  const createdByButtonWithTooltip = (
+  const createdByContentWithTooltip = (
     <Tooltip>
-      <TooltipTrigger asChild>{createdByButton}</TooltipTrigger>
+      <TooltipTrigger asChild>{createdByContent}</TooltipTrigger>
       <TooltipContent>
         <span>{createdBy}</span>
       </TooltipContent>
@@ -131,7 +140,7 @@ const RunRow = ({ run }: { run: PipelineRunResponse }) => {
         {run.created_at ? formatDate(run.created_at) : "Data not found..."}
       </TableCell>
       <TableCell>
-        {isTruncated ? createdByButtonWithTooltip : createdByButton}
+        {isTruncated ? createdByContentWithTooltip : createdByContent}
       </TableCell>
       <TableCell className="max-w-64">
         {tags && tags.length > 0 && <TagList tags={tags} />}

--- a/src/components/Home/RunSection/RunSection.tsx
+++ b/src/components/Home/RunSection/RunSection.tsx
@@ -20,6 +20,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Text } from "@/components/ui/typography";
+import { useRunSearchParams } from "@/hooks/useRunSearchParams";
 import { useBackend } from "@/providers/BackendProvider";
 import { getBackendStatusString } from "@/utils/backend";
 import { fetchWithErrorHandling } from "@/utils/fetchWithErrorHandling";
@@ -41,11 +42,8 @@ type RunSectionSearch = { page_token?: string; filter?: string };
 
 interface RunSectionProps {
   onEmptyList?: () => void;
-  /** When true, hides the built-in filter UI (used when new filter bar is enabled) */
   hideFilters?: boolean;
-  /** When provided, overrides the URL filter param (e.g. "created_by:me") */
   forcedFilter?: string;
-  /** When provided, limits the number of rows shown (pagination still works per backend page) */
   maxItems?: number;
 }
 
@@ -60,7 +58,12 @@ export const RunSection = ({
   const { pathname } = useLocation();
   const search = useSearch({ strict: false }) as RunSectionSearch;
   const isCreatedByMeDefault = useFlagValue("created-by-me-default");
+  const { setFilter } = useRunSearchParams();
   const dataVersion = useRef(0);
+
+  const onFilterByUser = forcedFilter
+    ? undefined
+    : (createdBy: string) => setFilter("created_by", createdBy);
 
   // Supports both JSON (new) and key:value (legacy) URL formats
   const filters = parseFilterParam(forcedFilter ?? search.filter);
@@ -294,7 +297,7 @@ export const RunSection = ({
             ? data.pipeline_runs?.slice(0, maxItems)
             : data.pipeline_runs
           )?.map((run) => (
-            <RunRow key={run.id} run={run} />
+            <RunRow key={run.id} run={run} onFilterByUser={onFilterByUser} />
           ))}
         </TableBody>
       </Table>


### PR DESCRIPTION
## Description

Changes the `onClick` action for the `created_by` column in the run list from `copy_text` to `search_by_user`.

In others, you can now search a user's runs by clicking their name in the list. This feels more impactful & useful than the existing "copy name" callback

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

![image.png](https://app.graphite.com/user-attachments/assets/eed4319f-99ba-46a5-bf70-c992b5586fda.png)



<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

Go to "All Runs" dashboard. Click on a name. Confirm the search filters update to filter to runs by that user.

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->