### PR TITLE
fix: stale input nodes when switching between v1 and v2 editors

### DIFF
--- a/src/providers/ComponentSpecProvider.tsx
+++ b/src/providers/ComponentSpecProvider.tsx
@@ -10,6 +10,7 @@ import {
 
 import { type UndoRedo, useUndoRedo } from "@/hooks/useUndoRedo";
 import { loadPipelineByName } from "@/services/pipelineService";
+import { emitPipelineFileChanged } from "@/services/pipelineStorage/pipelineFileEvents";
 import { USER_PIPELINES_LIST_NAME } from "@/utils/constants";
 import { prepareComponentRefForEditor } from "@/utils/prepareComponentRefForEditor";
 import {
@@ -214,6 +215,7 @@ export const ComponentSpecProvider = ({
         name,
         componentText,
       );
+      emitPipelineFileChanged({ storageKey: name, source: "v1" });
     },
     [componentSpec, readOnly],
   );

--- a/src/routes/v2/pages/Editor/hooks/useLoadSpec.ts
+++ b/src/routes/v2/pages/Editor/hooks/useLoadSpec.ts
@@ -1,9 +1,10 @@
-import { useSuspenseQuery } from "@tanstack/react-query";
+import { useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 import yaml from "js-yaml";
 import {
   registerRootStore,
   type UndoStore as MobxUndoStore,
 } from "mobx-keystone";
+import { useEffect } from "react";
 
 import {
   type ComponentSpec,
@@ -18,6 +19,10 @@ import {
 } from "@/routes/v2/pages/Editor/utils/undoHistoryStorage";
 import { RootFolderDbStorageDriver } from "@/services/pipelineStorage/drivers/RootFolderDbStorageDriver";
 import type { PipelineFile } from "@/services/pipelineStorage/PipelineFile";
+import {
+  getLastForeignWriteTime,
+  subscribePipelineFileChanged,
+} from "@/services/pipelineStorage/pipelineFileEvents";
 import { usePipelineStorage } from "@/services/pipelineStorage/PipelineStorageProvider";
 import type { PipelineStorageService } from "@/services/pipelineStorage/PipelineStorageService";
 import type { PipelineRef } from "@/services/pipelineStorage/types";
@@ -69,9 +74,45 @@ async function resolveSpecData(
 
 export function useLoadSpec(ref: PipelineRef) {
   const storage = usePipelineStorage();
+  const queryClient = useQueryClient();
+  const queryKey = ["editor-v2-spec", ref.fileId ?? ref.name];
+
+  // When the v1 editor writes to the same IndexedDB file, drop our cached
+  // deserialization so the next read of this query goes back to disk. We
+  // ignore "v2" emissions because those are our own autosaves — reloading the
+  // spec under our feet would discard MobX editor state (selection, undo, …)
+  // and the in-memory model is already authoritative for v2.
+  useEffect(() => {
+    const matchKey = ["editor-v2-spec", ref.fileId ?? ref.name];
+
+    const state = queryClient.getQueryState(matchKey);
+    const lastFetched = state?.dataUpdatedAt;
+    if (lastFetched !== undefined) {
+      const candidates = [ref.name, ref.fileId].filter(
+        (k): k is string => typeof k === "string",
+      );
+      const lastForeign = candidates
+        .map((key) => getLastForeignWriteTime(key, "v2") ?? 0)
+        .reduce((a, b) => Math.max(a, b), 0);
+      if (lastForeign > lastFetched) {
+        queryClient.invalidateQueries({ queryKey: matchKey });
+      }
+    }
+
+    // Contract: v1 emits with storageKey === the pipeline name, which must
+    // match this query's ref.name (or ref.fileId). If v1 ever writes under a
+    // different key (e.g. after a rename), invalidation silently stops and v2
+    // looks stale until a refresh. This coupling is acceptable only because the
+    // v1 editor is slated for removal once v2 becomes the default.
+    return subscribePipelineFileChanged(({ storageKey, source }) => {
+      if (source === "v2") return;
+      if (storageKey !== ref.name && storageKey !== ref.fileId) return;
+      queryClient.invalidateQueries({ queryKey: matchKey });
+    });
+  }, [queryClient, ref.fileId, ref.name]);
 
   return useSuspenseQuery({
-    queryKey: ["editor-v2-spec", ref.fileId ?? ref.name],
+    queryKey,
     queryFn: async (): Promise<LoadedSpec> => {
       const [specData, undoHistory] = await Promise.all([
         resolveSpecData(ref, storage),

--- a/src/routes/v2/shared/nodes/registry.ts
+++ b/src/routes/v2/shared/nodes/registry.ts
@@ -5,6 +5,22 @@ import type { ComponentSpec } from "@/models/componentSpec";
 import { buildBindingEdges } from "./buildUtils";
 import type { NodeTypeManifest } from "./types";
 
+type EntityOwnership = "owns" | "missing" | "unknown";
+
+function manifestOwnership(
+  manifest: NodeTypeManifest,
+  spec: ComponentSpec,
+  nodeId: string,
+): EntityOwnership {
+  if (typeof manifest.findEntity === "function") {
+    return manifest.findEntity(spec, nodeId) !== undefined ? "owns" : "missing";
+  }
+  if (typeof manifest.hasEntityId === "function") {
+    return manifest.hasEntityId(spec, nodeId) ? "owns" : "missing";
+  }
+  return "unknown";
+}
+
 /**
  * Central registry of node-type plugins.
  *
@@ -38,22 +54,27 @@ export class NodeTypeRegistry {
     return this.byEntityType.get(entityType);
   }
 
-  /** Derive the manifest from a node ID (replaces `getNodeTypeFromId`). */
+  /**
+   * Derive the manifest from a node ID (replaces `getNodeTypeFromId`).
+   */
   getByNodeId(
     spec: ComponentSpec | null,
     nodeId: string,
   ): NodeTypeManifest | undefined {
     for (const entry of this.prefixes) {
-      if (nodeId.startsWith(entry.prefix)) return entry.manifest;
+      if (!nodeId.startsWith(entry.prefix)) continue;
+      if (!spec) return entry.manifest;
+      if (manifestOwnership(entry.manifest, spec, nodeId) !== "missing") {
+        return entry.manifest;
+      }
+      break;
     }
 
-    const candidates = !spec
-      ? []
-      : this.all().filter(
-          (manifest) =>
-            typeof manifest.hasEntityId === "function" &&
-            manifest.hasEntityId(spec, nodeId),
-        );
+    if (!spec) return undefined;
+
+    const candidates = this.all().filter(
+      (manifest) => manifestOwnership(manifest, spec, nodeId) === "owns",
+    );
     if (candidates.length === 1) return candidates[0];
 
     return undefined;

--- a/src/services/pipelineStorage/PipelineFile.ts
+++ b/src/services/pipelineStorage/PipelineFile.ts
@@ -1,5 +1,6 @@
 import { action, makeObservable, observable, runInAction } from "mobx";
 
+import { emitPipelineFileChanged } from "./pipelineFileEvents";
 import type { PipelineFolder } from "./PipelineFolder";
 import { deleteEntry, updateEntry } from "./pipelineRegistry";
 
@@ -35,6 +36,7 @@ export class PipelineFile {
 
   async write(content: string): Promise<void> {
     await this.folder.driver.write(this.storageKey, content);
+    emitPipelineFileChanged({ storageKey: this.storageKey, source: "v2" });
   }
 
   @action

--- a/src/services/pipelineStorage/pipelineFileEvents.ts
+++ b/src/services/pipelineStorage/pipelineFileEvents.ts
@@ -1,0 +1,46 @@
+export type PipelineFileSource = "v1" | "v2";
+
+export interface PipelineFileChange {
+  storageKey: string;
+  source: PipelineFileSource;
+}
+
+const events = new EventTarget();
+
+const EVENT_NAME = "change";
+
+const lastWriteTimes = new Map<string, Map<PipelineFileSource, number>>();
+
+export function emitPipelineFileChanged(detail: PipelineFileChange): void {
+  let perSource = lastWriteTimes.get(detail.storageKey);
+  if (!perSource) {
+    perSource = new Map();
+    lastWriteTimes.set(detail.storageKey, perSource);
+  }
+  perSource.set(detail.source, Date.now());
+  events.dispatchEvent(new CustomEvent(EVENT_NAME, { detail }));
+}
+
+export function subscribePipelineFileChanged(
+  listener: (detail: PipelineFileChange) => void,
+): () => void {
+  const handler = (event: Event) => {
+    listener((event as CustomEvent<PipelineFileChange>).detail);
+  };
+  events.addEventListener(EVENT_NAME, handler);
+  return () => events.removeEventListener(EVENT_NAME, handler);
+}
+
+export function getLastForeignWriteTime(
+  storageKey: string,
+  ownSource: PipelineFileSource,
+): number | undefined {
+  const perSource = lastWriteTimes.get(storageKey);
+  if (!perSource) return undefined;
+  let latest: number | undefined;
+  for (const [source, time] of perSource) {
+    if (source === ownSource) continue;
+    if (latest === undefined || time > latest) latest = time;
+  }
+  return latest;
+}


### PR DESCRIPTION
## Description

Two independent fixes for issues observed when bouncing the same pipeline between the v1 and v2 editors.

**1. v2 selection/deletion broken for nodes whose IDs got a wrong prefix.** When v2 reloads a pipeline that was modified by v1, `ReplayIdGenerator` (driven by the saved undo `idStack`) can hand out IDs whose prefix no longer matches the entity type — e.g. a new input ends up with a `task_*` id. The IONode still renders fine because it looks up the entity by `data.entityId`, but `registry.getByNodeId` trusted the prefix and returned the *task* manifest, so clicking the node selected it as a task (empty properties panel) and Delete was silently aborted by `selectedNodesFromFlowNodes` (`getPosition` returned `undefined`). Fix: when the prefix-matched manifest's `findEntity`/`hasEntityId` positively reports the entity doesn't exist there, fall through to scan every manifest. Manifests with no ownership hook (conduit, ghost) keep the original prefix-only fast path.

**2. v2 didn't see v1's writes until a page refresh.** `useLoadSpec`'s React Query cache was `staleTime: Infinity` with no invalidation path, so v1 saves went unnoticed by v2. Replaced with event-driven invalidation: `PipelineFile.write` (v2 path) and `ComponentSpecProvider.saveComponentSpec` (v1 path) emit through a new in-process bus in `pipelineFileEvents.ts`. `useLoadSpec` subscribes and invalidates only on foreign writes (skips its own `source: "v2"` emissions, otherwise every autosave would discard MobX editor state). The bus also records per-source last-write timestamps so writes that fire while v2 is unmounted aren't lost — on remount, `useLoadSpec` compares the latest foreign write with the query's `dataUpdatedAt` and invalidates if newer. Swapping the `EventTarget` for a `BroadcastChannel` later would extend this to cross-tab.

## Related Issue and Pull requests

## Type of Change

- [x] Bug fix

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

**Selection/deletion of v1-created IO nodes in v2**
1. In v1, cmd+drag from a task input to create a graph input.
2. Switch to v2 for the same pipeline. The new input node should appear.
3. Click the input node — properties panel should populate (name, type, default).
4. Press Delete/Backspace — node should be removed.

**v1 → v2 visibility**
1. Open a pipeline in v2, then switch to v1.
2. In v1, cmd+drag to create or delete an input.
3. Switch back to v2 — the change should be reflected without a page refresh.
4. Repeat the round-trip a few times to confirm the cache invalidation isn't single-shot.

**Regression smoke**
- Normal v2 selection, deletion, copy/paste of task/input/output/conduit nodes still works.
- v2 autosave still works (status indicator, undo across page refresh) — and crucially does **not** reload/reset the editor on every save (would manifest as selection clearing every ~second).

## Additional Comments

Known follow-up not addressed here: v2's saved undo `idStack` can still be misaligned with the on-disk YAML after v1 modifies it. The registry fix means the misalignment no longer breaks selection/deletion, but the in-memory undo events themselves still reference the stale IDs — undo/redo across v1↔v2 edits may target wrong entities. Proper fix is to detect the mismatch in `useLoadSpec` and discard the stale undo history. Worth a follow-up PR.