### PR TITLE
fix: v2 ghost inputs don't copy argument value

### DIFF
--- a/src/routes/v2/pages/Editor/store/actions/io.actions.ts
+++ b/src/routes/v2/pages/Editor/store/actions/io.actions.ts
@@ -205,10 +205,20 @@ export function createConnectedIONode(
       const inputSpec = taskComponentSpec?.inputs?.find(
         (i) => i.name === portName,
       );
+      const existingArgValue = task.arguments.find(
+        (a) => a.name === portName,
+      )?.value;
+      const literalArgValue =
+        typeof existingArgValue === "string" ? existingArgValue : undefined;
+      const defaultValue = literalArgValue ?? inputSpec?.default;
+
       const newInput = addInput(undo, spec, position, portName);
 
       if (inputSpec?.type) {
         newInput.setType(inputSpec.type);
+      }
+      if (defaultValue !== undefined) {
+        newInput.setDefaultValue(defaultValue);
       }
 
       spec.connectNodes(


### PR DESCRIPTION
## Description

When cmd+dragging from a task's input handle in the v2 editor, the newly created graph input did not inherit a default value. The v1 editor copies one over (preferring the task's existing literal argument, falling back to the input spec's `default`), so behaviour now matches.

`createConnectedIONode` reads the task's existing argument before connecting — if the value is a string literal, that's used as the new input's `defaultValue`; otherwise it falls back to the input spec's `default`. Object-shaped argument values are skipped because those are bindings, not literals. Mirrors the v1 rule in [`createConnectedIONode.ts`](src/components/shared/ReactFlow/FlowCanvas/utils/createConnectedIONode.ts).

## Related Issue and Pull requests

## Type of Change

- [x] Bug fix

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

**Default copied from input spec**
1. In v2, drop a task that has an input with a literal default (e.g. an integer input with default `1000`).
2. Cmd+drag from that task's input handle to create a connected graph input.
3. Open the input's properties panel — `Default Value` should show `1000`. Before this PR it was empty.

**Default copied from task argument override**
1. On a task, override an input's value at the task level with a string literal (e.g. set the arg to `2000`).
2. Cmd+drag from that input handle — the new graph input's default should be `2000`, not the spec default.

**No leakage from a binding-shaped argument**
1. Wire a task input to another task's output (so the argument is a binding object, not a literal).
2. Cmd+drag from that input handle — the new graph input should have no default value (object-shaped arguments are intentionally skipped).

**Regression smoke**
- Output node cmd+drag still works (output side is unchanged).
- Existing graph inputs continue to render with whatever default they were saved with.

## Additional Comments