### PR TITLE
feat: Guided Tours Framework (First Pipeline)

### DIFF
--- a/src/components/Learn/tours/registry.ts
+++ b/src/components/Learn/tours/registry.ts
@@ -5,6 +5,10 @@ import { publicAsset } from "@/utils/publicAsset";
 
 export type TourStep = StepType &
   TourAction & {
+    ringSelectors?: string[];
+    resetLibrarySearch?: boolean;
+    ensureWindowRestored?: string;
+    requiresTaskSelected?: string;
     fallbackContent?: string;
   };
 

--- a/src/providers/TourProvider/TourPopover.tsx
+++ b/src/providers/TourProvider/TourPopover.tsx
@@ -36,6 +36,10 @@ export const POPOVER_STYLES = {
     ...base,
     rx: 6,
   }),
+  clickArea: (base: object) => ({
+    ...base,
+    pointerEvents: "none" as const,
+  }),
   highlightedArea: (
     base: object,
     state?: { width?: number; height?: number },
@@ -75,18 +79,28 @@ export function computeDefaultPopoverPosition(
   props: PositionProps,
 ): ResolvedPosition {
   const targetHeight = props.bottom - props.top;
+  const isTallStrip = targetHeight > props.windowHeight * 0.5;
+  const margin = 16;
 
-  const isFullHeightRightStrip =
-    props.right >= props.windowWidth - 4 &&
-    targetHeight > props.windowHeight * 0.5;
-
-  if (isFullHeightRightStrip) {
+  // Right-anchored full-height strip (e.g. right sidebar): place popover to
+  // its LEFT. Reactour's "left" fallback can swap to "top"/"bottom" for tall
+  // targets, so we return explicit coords.
+  if (isTallStrip && props.right >= props.windowWidth - 4) {
     const popoverWidth = props.width || 380;
-    const margin = 16;
     return [
       Math.max(margin, props.left - popoverWidth - margin),
       Math.max(props.top + margin, 64),
     ];
+  }
+
+  // Left-anchored full-height strip (e.g. left dock): place popover to its
+  // RIGHT. Same reason — reactour's "right" fallback drops to "top" for tall
+  // targets even when there's plenty of room horizontally. We test the
+  // target's right edge against the viewport midline rather than its left
+  // edge against zero, so a dock that isn't flush to the window edge still
+  // qualifies.
+  if (isTallStrip && props.right < props.windowWidth * 0.5) {
+    return [props.right + margin, Math.max(props.top + margin, 64)];
   }
 
   return "bottom";

--- a/src/providers/TourProvider/tourActionLabels.ts
+++ b/src/providers/TourProvider/tourActionLabels.ts
@@ -18,6 +18,28 @@ export function tourActionLabel(step: TourAction): string {
       return step.targetWindowName
         ? `Dock the **${step.targetWindowName}** panel back into place`
         : "Dock the panel back into place";
+    case "expand-folder":
+      return step.targetFolderName
+        ? `Open the **${step.targetFolderName}** folder`
+        : "Open the highlighted folder";
+    case "library-search":
+      return step.targetSearchTerm
+        ? `Search the library for **${step.targetSearchTerm}**`
+        : "Search the component library";
+    case "add-task":
+      return step.targetTaskName
+        ? `Add **${step.targetTaskName}** to the canvas`
+        : "Add the highlighted component to the canvas";
+    case "add-input":
+      return "Add an input node to the canvas";
+    case "add-output":
+      return "Add an output node to the canvas";
+    case "connect-edge":
+      return "Connect the highlighted ports";
+    case "set-argument":
+      return step.targetArgumentName
+        ? `Set the **${step.targetArgumentName}** value`
+        : "Set the highlighted value";
     default:
       return GENERIC_LABEL;
   }

--- a/src/routes/v2/pages/Editor/components/EditorTourBridge.test.tsx
+++ b/src/routes/v2/pages/Editor/components/EditorTourBridge.test.tsx
@@ -1,0 +1,135 @@
+import { render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { EditorTourBridge } from "./EditorTourBridge";
+
+type Task = { $id: string; name: string; arguments: unknown[] };
+
+const setCurrentStep = vi.fn();
+const selectNode = vi.fn();
+const markStepComplete = vi.fn();
+const isStepComplete = vi.fn<(step: number) => boolean>(() => false);
+
+let editorState: {
+  selectedNodeType: string | null;
+  selectedNodeId: string | null;
+  multiSelection: unknown[];
+  selectNode: typeof selectNode;
+};
+let navigationState: { activeSpec: { tasks: Task[] } | null };
+let tourState: {
+  isOpen: boolean;
+  currentStep: number;
+  steps: Record<string, unknown>[];
+  setCurrentStep: typeof setCurrentStep;
+  setSteps: ReturnType<typeof vi.fn>;
+};
+
+vi.mock("@reactour/tour", () => ({
+  useTour: () => tourState,
+}));
+
+vi.mock("@xyflow/react", () => ({
+  useViewport: () => ({ x: 0, y: 0, zoom: 1 }),
+}));
+
+vi.mock("@/routes/v2/shared/store/SharedStoreContext", () => ({
+  useSharedStores: () => ({
+    windows: { getWindowById: () => undefined, getAllWindows: () => [] },
+    navigation: navigationState,
+    editor: editorState,
+  }),
+}));
+
+vi.mock("@/providers/TourProvider/TourProgressContext", () => ({
+  useTourProgress: () => ({ markStepComplete, isStepComplete }),
+}));
+
+const trainTask: Task = {
+  $id: "task-train",
+  name: "Train XGBoost model on CSV",
+  arguments: [],
+};
+
+function renderBridge(opts: {
+  selectedNodeId?: string | null;
+  selectedNodeType?: string | null;
+  tasks?: Task[];
+  stepComplete?: boolean;
+}) {
+  isStepComplete.mockReturnValue(opts.stepComplete ?? false);
+  editorState = {
+    selectedNodeType: opts.selectedNodeType ?? null,
+    selectedNodeId: opts.selectedNodeId ?? null,
+    multiSelection: [],
+    selectNode,
+  };
+  navigationState = {
+    activeSpec: { tasks: opts.tasks ?? [trainTask] },
+  };
+  tourState = {
+    isOpen: true,
+    currentStep: 1,
+    steps: [
+      {
+        selector: "body",
+        content: "select",
+        interaction: "select-task",
+        targetTaskName: trainTask.name,
+      },
+      {
+        selector: "body",
+        content: "requires",
+        requiresTaskSelected: trainTask.name,
+      },
+    ],
+    setCurrentStep,
+    setSteps: vi.fn(),
+  };
+  return render(<EditorTourBridge />);
+}
+
+describe("EditorTourBridge requiresTaskSelected guard", () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it("re-asserts the required selection instead of navigating backward", () => {
+    renderBridge({ selectedNodeType: null, selectedNodeId: null });
+
+    expect(selectNode).toHaveBeenCalledWith(trainTask.$id, "task");
+    expect(setCurrentStep).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when the required task is already selected", () => {
+    renderBridge({
+      selectedNodeType: "task",
+      selectedNodeId: trainTask.$id,
+    });
+
+    expect(selectNode).not.toHaveBeenCalled();
+    expect(setCurrentStep).not.toHaveBeenCalled();
+  });
+
+  it("never bounces back onto an already-completed select-task step", () => {
+    renderBridge({
+      selectedNodeType: null,
+      selectedNodeId: null,
+      tasks: [],
+      stepComplete: true,
+    });
+
+    expect(selectNode).not.toHaveBeenCalled();
+    expect(setCurrentStep).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the select-task step only when the task is gone and that step is not complete", () => {
+    renderBridge({
+      selectedNodeType: null,
+      selectedNodeId: null,
+      tasks: [],
+      stepComplete: false,
+    });
+
+    expect(selectNode).not.toHaveBeenCalled();
+    expect(setCurrentStep).toHaveBeenCalledWith(0);
+  });
+});

--- a/src/routes/v2/pages/Editor/components/EditorTourBridge.tsx
+++ b/src/routes/v2/pages/Editor/components/EditorTourBridge.tsx
@@ -3,9 +3,41 @@ import { reaction } from "mobx";
 import { useEffect } from "react";
 
 import type { TourStep } from "@/components/Learn/tours/registry";
+import type { ComponentSpec } from "@/models/componentSpec";
 import { useTourProgress } from "@/providers/TourProvider/TourProgressContext";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 import type { WindowStoreImpl } from "@/routes/v2/shared/windows/windowStore";
+
+type CountInteraction =
+  "add-task" | "add-input" | "add-output" | "connect-edge";
+
+function isCountInteraction(
+  interaction: TourStep["interaction"],
+): interaction is CountInteraction {
+  return (
+    interaction === "add-task" ||
+    interaction === "add-input" ||
+    interaction === "add-output" ||
+    interaction === "connect-edge"
+  );
+}
+
+function countForInteraction(
+  spec: ComponentSpec | null,
+  interaction: CountInteraction,
+): number {
+  if (!spec) return 0;
+  switch (interaction) {
+    case "add-task":
+      return spec.tasks.length;
+    case "add-input":
+      return spec.inputs.length;
+    case "add-output":
+      return spec.outputs.length;
+    case "connect-edge":
+      return spec.bindings.length;
+  }
+}
 
 function followWindowPosition(
   windows: WindowStoreImpl,
@@ -78,13 +110,188 @@ function trackDockStateTransition(
 }
 
 export function EditorTourBridge() {
-  const { steps, currentStep, isOpen } = useTour();
-  const { windows } = useSharedStores();
-  const { markStepComplete } = useTourProgress();
+  const { steps, currentStep, setCurrentStep, setSteps, isOpen } = useTour();
+  const { windows, navigation, editor } = useSharedStores();
+  const { markStepComplete, isStepComplete } = useTourProgress();
 
   const step = steps[currentStep] as TourStep | undefined;
   const interaction = step?.interaction;
   const targetWindowId = step?.targetWindowId;
+  const ringSelectors = step?.ringSelectors;
+  const resetLibrarySearchFlag = step?.resetLibrarySearch ?? false;
+  const ensureWindowRestoredId = step?.ensureWindowRestored;
+  const requiresTaskSelected = step?.requiresTaskSelected;
+  const libraryDragAllow = step?.targetComponentName ?? step?.targetTaskName;
+
+  useEffect(() => {
+    if (!isOpen) return;
+    if (!ensureWindowRestoredId) return;
+    const w = windows.getWindowById(ensureWindowRestoredId);
+    if (w && (w.state === "hidden" || w.isMinimized)) {
+      w.restore();
+    }
+  }, [isOpen, ensureWindowRestoredId, currentStep, windows]);
+
+  useEffect(() => {
+    if (!isOpen) return undefined;
+    if (!requiresTaskSelected) return undefined;
+
+    const requiredName = requiresTaskSelected.toLowerCase();
+    const findSelectStep = (): number | null => {
+      for (let i = currentStep - 1; i >= 0; i--) {
+        const s = steps[i] as TourStep | undefined;
+        if (
+          s?.interaction === "select-task" &&
+          s.targetTaskName?.toLowerCase() === requiredName
+        ) {
+          return i;
+        }
+      }
+      return null;
+    };
+
+    const findRequiredTask = () =>
+      navigation.activeSpec?.tasks.find(
+        (t) => t.name.toLowerCase() === requiredName,
+      );
+
+    const isRequiredTaskSelected = () => {
+      if (editor.selectedNodeType !== "task") return false;
+      const spec = navigation.activeSpec;
+      if (!spec) return false;
+      const task = spec.tasks.find((t) => t.$id === editor.selectedNodeId);
+      return task?.name.toLowerCase() === requiredName;
+    };
+
+    const dispose = reaction(
+      () => isRequiredTaskSelected(),
+      (matches) => {
+        if (matches) return;
+        const task = findRequiredTask();
+        if (task) {
+          editor.selectNode(task.$id, "task");
+          return;
+        }
+        const target = findSelectStep();
+        if (target !== null && !isStepComplete(target)) {
+          setCurrentStep(target);
+        }
+      },
+      { fireImmediately: true },
+    );
+
+    return () => dispose();
+  }, [
+    isOpen,
+    requiresTaskSelected,
+    currentStep,
+    steps,
+    editor,
+    navigation,
+    isStepComplete,
+    setCurrentStep,
+  ]);
+
+  useEffect(() => {
+    if (!isOpen) return undefined;
+    if (!libraryDragAllow) return undefined;
+    const allow = libraryDragAllow.toLowerCase();
+    const handleDragStart = (event: DragEvent) => {
+      const target = event.target as Element | null;
+      if (!target?.closest('[data-dock-window-content="component-library"]')) {
+        return;
+      }
+      const item =
+        target.querySelector("[data-component-name]") ??
+        target.closest("[data-component-name]");
+      if (!item) return;
+      const name = (
+        item.getAttribute("data-component-name") ?? ""
+      ).toLowerCase();
+      if (!name.includes(allow)) {
+        event.preventDefault();
+        event.stopPropagation();
+      }
+    };
+    document.addEventListener("dragstart", handleDragStart, true);
+    return () => {
+      document.removeEventListener("dragstart", handleDragStart, true);
+    };
+  }, [isOpen, libraryDragAllow]);
+
+  const stepSelector = step?.selector;
+  useEffect(() => {
+    if (!isOpen) return;
+    if (!resetLibrarySearchFlag) return;
+
+    const input = document.querySelector<HTMLInputElement>(
+      '[data-testid="search-input"]',
+    );
+    if (input?.value) {
+      const setter = Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype,
+        "value",
+      )?.set;
+      if (setter) {
+        setter.call(input, "");
+        input.dispatchEvent(new Event("input", { bubbles: true }));
+      }
+    }
+
+    let cancelled = false;
+    const start = Date.now();
+    const wantSelector = typeof stepSelector === "string" ? stepSelector : null;
+    const tryRefresh = () => {
+      if (cancelled) return;
+      const found = wantSelector
+        ? document.querySelector(wantSelector)
+        : document.querySelector("[data-folder-name]");
+      if (found || Date.now() - start > 1500) {
+        // Force a re-render in reactour so step.selector is re-queried.
+        setSteps?.((prev) => [...prev]);
+        return;
+      }
+      window.setTimeout(tryRefresh, 50);
+    };
+    window.setTimeout(tryRefresh, 50);
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, currentStep, resetLibrarySearchFlag, setSteps, stepSelector]);
+
+  useEffect(() => {
+    if (!isOpen) return undefined;
+    if (!ringSelectors?.length) return undefined;
+
+    const ringed = new Set<Element>();
+
+    const update = () => {
+      const current = new Set<Element>();
+      for (const sel of ringSelectors) {
+        document.querySelectorAll(sel).forEach((el) => current.add(el));
+      }
+      for (const el of ringed) {
+        if (!current.has(el)) el.classList.remove("tour-ring");
+      }
+      for (const el of current) {
+        el.classList.add("tour-ring");
+        ringed.add(el);
+      }
+      for (const el of ringed) {
+        if (!current.has(el)) ringed.delete(el);
+      }
+    };
+
+    update();
+    const observer = new MutationObserver(update);
+    observer.observe(document.body, { childList: true, subtree: true });
+
+    return () => {
+      observer.disconnect();
+      for (const el of ringed) el.classList.remove("tour-ring");
+    };
+  }, [isOpen, ringSelectors]);
 
   useEffect(() => {
     if (!isOpen) return undefined;
@@ -153,16 +360,224 @@ export function EditorTourBridge() {
     }
 
     if (interaction === "select-task") {
+      const targetName = step?.targetTaskName?.toLowerCase();
       const handleClick = (event: MouseEvent) => {
         const target = event.target as Element | null;
-        if (target?.closest('[data-tour-node="task"]')) {
-          advance();
+        const node = target?.closest('[data-tour-node="task"]');
+        if (!node) return;
+        if (targetName) {
+          const name = (
+            node.getAttribute("data-task-name") ?? ""
+          ).toLowerCase();
+          if (!name.includes(targetName)) return;
         }
+        advance();
       };
       document.addEventListener("click", handleClick);
       return () => {
         stopFollow();
         document.removeEventListener("click", handleClick);
+      };
+    }
+
+    if (interaction === "expand-folder") {
+      const targetFolderName = step?.targetFolderName;
+      if (!targetFolderName) return stopFollow;
+
+      const expandedSelector = `[data-folder-name="${targetFolderName}"] [aria-expanded="true"]`;
+      const isExpanded = () => !!document.querySelector(expandedSelector);
+
+      if (isExpanded()) {
+        skip();
+        return stopFollow;
+      }
+
+      const observer = new MutationObserver(() => {
+        if (isExpanded()) advance();
+      });
+      observer.observe(document.body, {
+        attributes: true,
+        attributeFilter: ["aria-expanded"],
+        subtree: true,
+      });
+
+      return () => {
+        stopFollow();
+        observer.disconnect();
+      };
+    }
+
+    if (interaction === "library-search") {
+      const sel = '[data-testid="search-input"]';
+      const targetTerm = step?.targetSearchTerm?.toLowerCase();
+      const matches = () => {
+        const el = document.querySelector<HTMLInputElement>(sel);
+        if (!el) return false;
+        const value = el.value.trim().toLowerCase();
+        if (targetTerm) return value.includes(targetTerm);
+        return value.length > 0;
+      };
+
+      let advanceTimer: ReturnType<typeof setTimeout> | null = null;
+      const scheduleStep = (move: () => void) => {
+        if (advanceTimer !== null) return;
+        advanceTimer = setTimeout(() => {
+          advanceTimer = null;
+          move();
+        }, 600);
+      };
+
+      if (matches()) {
+        scheduleStep(skip);
+      }
+
+      const handleInput = (event: Event) => {
+        const target = event.target as Element | null;
+        if (target?.matches(sel) && matches()) scheduleStep(advance);
+      };
+      document.addEventListener("input", handleInput, true);
+
+      return () => {
+        stopFollow();
+        document.removeEventListener("input", handleInput, true);
+        if (advanceTimer !== null) clearTimeout(advanceTimer);
+      };
+    }
+
+    if (interaction === "set-argument") {
+      const targetArgumentName = step?.targetArgumentName;
+      if (!targetArgumentName) return stopFollow;
+
+      const hasArgumentValue = () => {
+        const spec = navigation.activeSpec;
+        if (!spec) return false;
+        return spec.tasks.some((task) =>
+          task.arguments.some(
+            (arg) =>
+              arg.name === targetArgumentName &&
+              typeof arg.value === "string" &&
+              arg.value.trim() !== "",
+          ),
+        );
+      };
+
+      if (hasArgumentValue()) {
+        skip();
+        return stopFollow;
+      }
+
+      const dispose = reaction(
+        () => hasArgumentValue(),
+        (matches) => {
+          if (matches) {
+            dispose();
+            advance();
+          }
+        },
+      );
+
+      return () => {
+        stopFollow();
+        dispose();
+      };
+    }
+
+    if (interaction === "connect-edge" && step?.targetEdge) {
+      const target = step.targetEdge;
+      const hasTargetEdge = () => {
+        const spec = navigation.activeSpec;
+        if (!spec) return false;
+        const sourceTask = spec.tasks.find(
+          (t) => t.name === target.sourceTaskName,
+        );
+        if (!sourceTask) return false;
+
+        if (!target.targetTaskName) {
+          return spec.bindings.some(
+            (b) =>
+              b.sourceEntityId === sourceTask.$id &&
+              b.sourcePortName === target.sourcePortName,
+          );
+        }
+
+        const targetTask = spec.tasks.find(
+          (t) => t.name === target.targetTaskName,
+        );
+        if (!targetTask) return false;
+        return spec.bindings.some(
+          (b) =>
+            b.sourceEntityId === sourceTask.$id &&
+            b.targetEntityId === targetTask.$id &&
+            b.sourcePortName === target.sourcePortName &&
+            b.targetPortName === target.targetPortName,
+        );
+      };
+
+      if (hasTargetEdge()) {
+        skip();
+        return stopFollow;
+      }
+
+      const dispose = reaction(
+        () => hasTargetEdge(),
+        (matches) => {
+          if (matches) {
+            dispose();
+            advance();
+          }
+        },
+      );
+
+      return () => {
+        stopFollow();
+        dispose();
+      };
+    }
+
+    if (interaction === "add-task" && step?.targetTaskName) {
+      const targetName = step.targetTaskName.toLowerCase();
+
+      const countMatches = () => {
+        const spec = navigation.activeSpec;
+        if (!spec) return 0;
+        return spec.tasks.filter((t) =>
+          t.name.toLowerCase().includes(targetName),
+        ).length;
+      };
+      const baseline = countMatches();
+
+      const dispose = reaction(
+        () => countMatches(),
+        (current) => {
+          if (current > baseline) {
+            dispose();
+            advance();
+          }
+        },
+      );
+
+      return () => {
+        stopFollow();
+        dispose();
+      };
+    }
+
+    if (isCountInteraction(interaction)) {
+      const baseline = countForInteraction(navigation.activeSpec, interaction);
+
+      const dispose = reaction(
+        () => countForInteraction(navigation.activeSpec, interaction),
+        (current) => {
+          if (current > baseline) {
+            dispose();
+            advance();
+          }
+        },
+      );
+
+      return () => {
+        stopFollow();
+        dispose();
       };
     }
 
@@ -172,7 +587,9 @@ export function EditorTourBridge() {
     interaction,
     targetWindowId,
     step,
+    steps,
     windows,
+    navigation,
     markStepComplete,
     currentStep,
   ]);

--- a/src/styles/editor.css
+++ b/src/styles/editor.css
@@ -1,3 +1,20 @@
+/* Tour step ring: reactour merges highlightedSelectors into one bounding rect,
+   so per-element rings need their own mechanism. EditorTourBridge applies
+   this class to elements matching a step's ringSelectors. */
+.tour-ring {
+  outline: 2px solid #60a5fa;
+  outline-offset: 2px;
+  border-radius: 6px;
+  position: relative;
+  z-index: 1;
+}
+
+/* Handles are absolutely positioned by React Flow — don't let .tour-ring
+   clobber that to relative, which would dump the handle into normal flow. */
+.tour-ring.react-flow__handle {
+  position: absolute;
+}
+
 /* Use the proper box layout model by default, but allow elements to override */
 html {
   box-sizing: border-box;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -33,7 +33,7 @@ export const ENABLE_GOOGLE_CLOUD_SUBMITTER =
 export const USER_PIPELINES_LIST_NAME = "user_pipelines";
 
 export const defaultPipelineYamlWithName = (name: string) => `
-name: ${name}
+name: ${JSON.stringify(name)}
 metadata:
   annotations:
     sdk: https://cloud-pipelines.net/pipeline-editor/


### PR DESCRIPTION
## Description

The interaction primitives, popover positioning, and CSS utilities needed to power the second guided tour (#2312 — _Build Your First Pipeline_). No visible behavior on its own; all testing happens in #2312.

Builds directly on #2299 (the first three interactions). This PR introduces the remaining interactions a build-from-scratch tour needs, plus a handful of cross-cutting tour-step features.

## What's new

### New interaction types (`EditorTourBridge.tsx`)

Each is declared on a tour step via `interaction: "<name>"`. Following the model established in #2299, a detected interaction **marks the step complete** in the shared tour-progress state — it does not advance the tour itself; the gated "Next" / auto-advance in #2340 handle progression.

- **`expand-folder`** — completes when the named folder in the component library is expanded (matches `[data-folder-name=...] [aria-expanded="true"]`).
- **`library-search`** — completes when the search box value contains a target substring; debounced so the user finishes typing first.
- **`add-task`** — completes when a task whose name matches a target substring is added to the canvas. Baseline counted at step start so pre-existing tasks don't false-trigger.
- **`add-input`** / **`add-output`** — count-based: complete when `spec.inputs.length` / `spec.outputs.length` increases.
- **`connect-edge`** — completes when a specific edge is drawn, matched by `(sourceTaskName, sourcePortName, targetTaskName, targetPortName)`. The target task/port pair is optional.
- **`set-argument`** — completes when a specific argument on any task is set to a non-empty string.

Existing `select-task` (from #2299) gets a `targetTaskName` narrowing — only the named task counts, not any task.

### Contextual checklist labels

Adds the checklist copy for the interactions this PR introduces (using the contextual bold-target support from #2340):

- `add-task` → "Add **{targetTaskName}** to the canvas"
- `expand-folder` → "Open the **{targetFolderName}** folder"
- `library-search` → "Search the library for **{targetSearchTerm}**"
- `set-argument` → "Set the **{targetArgumentName}** value"
- `add-input` / `add-output` / `connect-edge` → generic phrasings

Each falls back to a generic label when its target field isn't set.

### Cross-cutting step features

- **`ringSelectors`** — paint per-element rings via the new `.tour-ring` CSS class (reactour merges `highlightedSelectors` into one bounding box; per-handle rings need a separate mechanism).
- **`requiresTaskSelected`** — auto-rewind to a previous `select-task` step if the required task is no longer selected.
- **`ensureWindowRestored`** — auto-restore a minimized/hidden dock window at step start.
- **`resetLibrarySearch`** — clear the component-library search box before the step's selector is queried.
- **`libraryDragAllow`** — block drags of library items that don't match the step's target.

### Popover positioning

- `computeDefaultPopoverPosition` gets a symmetric **left-anchored** tall-strip branch (mirrors the right-anchored branch from #2348) for steps that highlight the component library.
- `POPOVER_STYLES.clickArea` set to `pointer-events: none` so the spotlight click-area doesn't intercept drags onto the canvas.

### Misc

- **`TourStep` registry types** extended with the new interaction fields (`targetFolderName`, `targetSearchTerm`, `targetTaskName`, `targetComponentName`, `targetEdge`, `targetArgumentName`, plus the cross-cutting flags above).
- **`.tour-ring` CSS utility** in `editor.css`, with a React Flow handle override (`position: absolute`).
- **`defaultPipelineYamlWithName`** now `JSON.stringify`s the name (pipelines named with YAML-special characters were breaking the YAML).

## Related Issue and Pull requests

Progresses https://github.com/Shopify/oasis-frontend/issues/583

Builds on #2299. Consumed by #2312 (First Pipeline tour content).

## Type of Change

- [x] New feature

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

No visible behavior on its own — every new utility is unused until #2312 lands. Regression-only checks in isolation:

- _Navigating the Editor_ tour (#2306) still works end-to-end; none of the new interactions or cross-cutting features affect tours that don't use them.
- `select-task` without `targetTaskName` still completes on click of any task (the narrowing is opt-in).
- Editor opens normally, no console errors from the new CSS utility or popover-style additions.

## Additional Comments

Originally bundled into #2312 alongside the tour content; split out so reviewers can read the mechanics and the tour JSON separately.
