### PR TITLE
fix: v2 - window state for startVisible

### DIFF
--- a/src/routes/v2/shared/windows/windowStore.utils.ts
+++ b/src/routes/v2/shared/windows/windowStore.utils.ts
@@ -64,7 +64,7 @@ function resolveInitialState(
     };
   }
 
-  if (options.persisted && !hasPersistedLayout()) {
+  if (options.persisted && !hasPersistedLayout() && !options.startVisible) {
     if (!DEFAULT_VIEW_PRESET.visible.has(id)) {
       return { state: "hidden", needsPreviousState: true };
     }


### PR DESCRIPTION
## Description

Attemp to fix https://github.com/Shopify/oasis-frontend/issues/654

When `options.startVisible` is set, the window should not be hidden even if there is no persisted layout. Previously, a window with `startVisible` enabled could still be forced into a hidden state when `options.persisted` was true and no persisted layout existed. This fix ensures that `startVisible` takes precedence over the default hidden state logic in that scenario.

## Related Issue and Pull requests

## Type of Change

- [x] Bug fix

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Configure a window with both `persisted: true` and `startVisible: true`.
2. Ensure no persisted layout exists for the window.
3. Verify the window renders as visible rather than being hidden.

## Additional Comments