### PR TITLE
refactor: v2 - ai assistant - basic chat in RunView

### DIFF
--- a/src/routes/v2/pages/RunView/RunViewV2.tsx
+++ b/src/routes/v2/pages/RunView/RunViewV2.tsx
@@ -9,6 +9,7 @@ import { useEffect, useRef } from "react";
 import { InfoBox } from "@/components/shared/InfoBox";
 import { LoadingScreen } from "@/components/shared/LoadingScreen";
 import { RemoteAuthErrorView } from "@/components/shared/RemoteAuthErrorView";
+import { useFlagValue } from "@/components/shared/Settings/useFlags";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Paragraph } from "@/components/ui/typography";
 import type { ComponentSpec } from "@/models/componentSpec";
@@ -23,6 +24,7 @@ import {
   ExecutionDataProvider,
   useExecutionData,
 } from "@/providers/ExecutionDataProvider";
+import { AiChatStoreProvider } from "@/routes/v2/shared/components/AiChat/AiChatStoreContext";
 import { useDockAreaAccordion } from "@/routes/v2/shared/hooks/useDockAreaAccordion";
 import { NodeRegistryProvider } from "@/routes/v2/shared/nodes/NodeRegistryContext";
 import { SpecProvider } from "@/routes/v2/shared/providers/SpecContext";
@@ -40,6 +42,7 @@ import { RemoteAuthError } from "@/utils/fetchWithErrorHandling";
 
 import { RunViewFlowCanvas } from "./components/RunViewFlowCanvas";
 import { RunViewMenuBar } from "./components/RunViewMenuBar/RunViewMenuBar";
+import { useAiChatWindow } from "./hooks/useAiChatWindow";
 import { useFocusTaskFromUrl } from "./hooks/useFocusTaskFromUrl";
 import { useRunViewSelectionSync } from "./hooks/useRunViewSelectionSync";
 import { useRunViewSpecLifecycle } from "./hooks/useRunViewSpecLifecycle";
@@ -152,6 +155,9 @@ const RunViewLayout = observer(function RunViewLayout({
   useRunViewSelectionSync();
   useFocusTaskFromUrl(spec);
 
+  const aiEnabled = useFlagValue("ai-assistant");
+  useAiChatWindow(aiEnabled);
+
   const { navigation } = useSharedStores();
   const activeSpec = navigation.activeSpec;
 
@@ -199,16 +205,18 @@ export function RunViewV2() {
   return (
     <div className="h-full w-full flex flex-col bg-slate-100 select-none">
       <SharedStoreProvider>
-        <ReactFlowProvider>
-          <ContextPanelProvider /** TODO: remove ContextPanelProvider */>
-            <ExecutionDataProvider
-              pipelineRunId={id}
-              subgraphExecutionId={subgraphExecutionId}
-            >
-              <RunViewContent />
-            </ExecutionDataProvider>
-          </ContextPanelProvider>
-        </ReactFlowProvider>
+        <AiChatStoreProvider>
+          <ReactFlowProvider>
+            <ContextPanelProvider /** TODO: remove ContextPanelProvider */>
+              <ExecutionDataProvider
+                pipelineRunId={id}
+                subgraphExecutionId={subgraphExecutionId}
+              >
+                <RunViewContent />
+              </ExecutionDataProvider>
+            </ContextPanelProvider>
+          </ReactFlowProvider>
+        </AiChatStoreProvider>
       </SharedStoreProvider>
     </div>
   );

--- a/src/routes/v2/pages/RunView/hooks/useAiChatWindow.tsx
+++ b/src/routes/v2/pages/RunView/hooks/useAiChatWindow.tsx
@@ -1,0 +1,32 @@
+import { useEffect } from "react";
+
+import { createRunViewToolBridge } from "@/routes/v2/pages/RunView/toolBridge/runViewToolBridge";
+import { AiChatContent } from "@/routes/v2/shared/components/AiChat/AiChatContent";
+import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
+
+const AI_CHAT_WINDOW_ID = "run-ai-assistant-chat";
+
+export function useAiChatWindow(enabled: boolean) {
+  const { windows } = useSharedStores();
+
+  useEffect(() => {
+    if (!enabled) {
+      windows.closeWindow(AI_CHAT_WINDOW_ID);
+      return;
+    }
+    if (windows.getWindowById(AI_CHAT_WINDOW_ID)) return;
+
+    windows.openWindow(
+      <AiChatContent createBridge={createRunViewToolBridge} />,
+      {
+        id: AI_CHAT_WINDOW_ID,
+        title: "AI Assistant",
+        position: { x: 100, y: 80 },
+        size: { width: 380, height: 520 },
+        disabledActions: ["close"],
+        startVisible: true,
+        persisted: true,
+      },
+    );
+  }, [enabled, windows]);
+}

--- a/src/routes/v2/pages/RunView/toolBridge/runViewToolBridge.ts
+++ b/src/routes/v2/pages/RunView/toolBridge/runViewToolBridge.ts
@@ -1,0 +1,124 @@
+/**
+ * Read-only tool bridge for the RunView AI assistant.
+ *
+ * RunView inspects a completed pipeline run, so its bridge composes the
+ * shared run-lifecycle and debug handlers but exposes a read-only CSOM
+ * slice: `getPipelineState` / `validatePipeline` work against the live
+ * spec, while every spec-mutating method short-circuits with an error.
+ * This satisfies the full `ToolBridgeApi` contract without depending on
+ * the Editor's spec-mutation actions or an undo store.
+ */
+import type { ToolBridgeApi, ValidationResult } from "@/agent/toolBridgeApi";
+import { validateSpec } from "@/models/componentSpec/validation/validateSpec";
+import { serializeSpecForAi } from "@/routes/v2/shared/components/AiChat/serializeSpecForAi";
+import { createDebugBridgeHandlers } from "@/routes/v2/shared/components/AiChat/toolBridge/debugBridge";
+import { createRunBridgeHandlers } from "@/routes/v2/shared/components/AiChat/toolBridge/runBridge";
+import type { BridgeDeps } from "@/routes/v2/shared/components/AiChat/toolBridge/utils";
+import { requireSpec } from "@/routes/v2/shared/components/AiChat/toolBridge/utils";
+
+const READ_ONLY_ERROR =
+  "This is a read-only run view — the pipeline spec cannot be edited here.";
+
+type ReadOnlyCsomHandlers = Pick<
+  ToolBridgeApi,
+  | "getPipelineState"
+  | "setPipelineName"
+  | "setPipelineDescription"
+  | "addTask"
+  | "deleteTask"
+  | "renameTask"
+  | "addInput"
+  | "deleteInput"
+  | "renameInput"
+  | "addOutput"
+  | "deleteOutput"
+  | "renameOutput"
+  | "connectNodes"
+  | "deleteEdge"
+  | "setTaskArgument"
+  | "createSubgraph"
+  | "unpackSubgraph"
+  | "validatePipeline"
+>;
+
+function createReadOnlyCsomHandlers(deps: BridgeDeps): ReadOnlyCsomHandlers {
+  return {
+    async getPipelineState() {
+      return serializeSpecForAi(requireSpec(deps), {
+        activeSubgraphPath: deps.getActiveSubgraphPath(),
+      });
+    },
+
+    async validatePipeline(): Promise<ValidationResult> {
+      const issues = validateSpec(requireSpec(deps));
+      return {
+        valid: issues.length === 0,
+        issueCount: issues.length,
+        issues: issues.map((i) => ({
+          type: i.type,
+          severity: i.severity,
+          message: i.message,
+          entityId: i.entityId,
+          issueCode: i.issueCode,
+        })),
+      };
+    },
+
+    async setPipelineName() {
+      return { success: false };
+    },
+    async setPipelineDescription() {
+      return { success: false };
+    },
+    async addTask() {
+      return { success: false, error: READ_ONLY_ERROR };
+    },
+    async deleteTask() {
+      return { success: false };
+    },
+    async renameTask() {
+      return { success: false };
+    },
+    async addInput() {
+      return { success: false, inputId: "", name: "" };
+    },
+    async deleteInput() {
+      return { success: false };
+    },
+    async renameInput() {
+      return { success: false };
+    },
+    async addOutput() {
+      return { success: false, outputId: "", name: "" };
+    },
+    async deleteOutput() {
+      return { success: false };
+    },
+    async renameOutput() {
+      return { success: false };
+    },
+    async connectNodes() {
+      return { success: false, error: READ_ONLY_ERROR };
+    },
+    async deleteEdge() {
+      return { success: false };
+    },
+    async setTaskArgument() {
+      return { success: false, error: READ_ONLY_ERROR };
+    },
+    async createSubgraph() {
+      return { success: false, error: READ_ONLY_ERROR };
+    },
+    async unpackSubgraph() {
+      return { success: false };
+    },
+  };
+}
+
+export function createRunViewToolBridge(deps: BridgeDeps): ToolBridgeApi {
+  return {
+    ...createReadOnlyCsomHandlers(deps),
+    ...createRunBridgeHandlers(deps),
+    ...createDebugBridgeHandlers(deps),
+  };
+}


### PR DESCRIPTION
## Description

Integrates the AI Assistant chat window into the RunView. The chat window is gated behind the `ai-assistant` feature flag and is opened automatically when the flag is enabled. The window is persisted, non-closeable by the user, and positioned in the top-left area of the view.

A dedicated read-only tool bridge (`runViewToolBridge`) is introduced for the RunView AI assistant. Since RunView inspects a completed pipeline run rather than an editable spec, the bridge exposes `getPipelineState` and `validatePipeline` as functional operations while all spec-mutating methods (`addTask`, `connectNodes`, `setTaskArgument`, etc.) return `{ success: false }` with an appropriate read-only error message. Run-lifecycle and debug handlers are composed in from the shared bridge utilities.

The `AiChatStoreProvider` is also added to the RunView provider tree to supply the necessary store context for the chat component.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

[Demo of AI in RunView - 1.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/8475f73f-975b-4e6f-a073-7f5b2d2cd69d.mov" />](https://app.graphite.com/user-attachments/video/8475f73f-975b-4e6f-a073-7f5b2d2cd69d.mov)



## Test Instructions

1. Enable the `ai-assistant` feature flag.
2. Open a completed pipeline run in RunView.
3. Verify the AI Assistant chat window appears automatically and is positioned correctly.
4. Confirm that read-only operations (viewing pipeline state, validating) work as expected in the chat.
5. Confirm that any spec-mutating requests from the assistant return an appropriate read-only error.
6. Disable the `ai-assistant` flag and verify the chat window closes.

## Additional Comments

The read-only constraint is intentional — RunView is not an editing surface, so spec mutations are explicitly blocked at the bridge level rather than relying on UI restrictions alone.