### PR TITLE
refactor: v2 - ai assistant - split editor and view agent implementations

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://unpkg.com/knip@5/schema.json",
   "tags": ["-@public"],
-  "entry": ["src/agent/worker.ts"],
+  "entry": ["src/agent/editorWorker.ts", "src/agent/runViewWorker.ts"],
   "ignore": [
     "src/api/**",
     "src/components/ui/**",

--- a/src/agent/agents/dispatcherRuntime.ts
+++ b/src/agent/agents/dispatcherRuntime.ts
@@ -1,0 +1,66 @@
+/**
+ * Shared dispatcher runtime for the in-browser AI assistant.
+ *
+ * Owns the per-thread `MemorySession` map and the `invoke` loop. The
+ * concrete dispatcher Agent is built per turn by a page-specific
+ * `buildAgent` (Editor vs Run View) because the underlying sub-agents
+ * close over the per-turn `AgentSession` (bridge, recent runs, status
+ * emitter).
+ */
+import { type Agent, MemorySession, run } from "@openai/agents";
+
+import type { AiProviderConfig } from "@/types/aiProvider";
+
+import type { AgentSession } from "../session";
+
+interface DispatcherInvokeParams {
+  message: string;
+  threadId: string;
+  aiConfig: AiProviderConfig;
+  session: AgentSession;
+}
+
+interface DispatcherInvokeResult {
+  answer: string;
+  threadId: string;
+}
+
+export interface TangleDispatcher {
+  invoke(params: DispatcherInvokeParams): Promise<DispatcherInvokeResult>;
+  dispose(): void;
+}
+
+export type BuildDispatcherAgent = (session: AgentSession) => Promise<Agent>;
+
+export function createDispatcherRuntime(
+  buildAgent: BuildDispatcherAgent,
+): TangleDispatcher {
+  const sessions = new Map<string, MemorySession>();
+
+  function getOrCreateSessionMemory(threadId: string): MemorySession {
+    const existing = sessions.get(threadId);
+    if (existing) return existing;
+    const created = new MemorySession({ sessionId: threadId });
+    sessions.set(threadId, created);
+    return created;
+  }
+
+  return {
+    async invoke(params) {
+      params.session.proxyClient.ensureConfigured(params.aiConfig);
+      const sessionMemory = getOrCreateSessionMemory(params.threadId);
+      const agent = await buildAgent(params.session);
+      const result = await run(agent, params.message, {
+        session: sessionMemory,
+      });
+      const answer =
+        typeof result.finalOutput === "string"
+          ? result.finalOutput
+          : JSON.stringify(result.finalOutput ?? "");
+      return { answer, threadId: params.threadId };
+    },
+    dispose() {
+      sessions.clear();
+    },
+  };
+}

--- a/src/agent/agents/editorDispatcher.ts
+++ b/src/agent/agents/editorDispatcher.ts
@@ -1,49 +1,34 @@
 /**
- * Top-level dispatcher agent for the in-browser AI assistant.
+ * Editor dispatcher agent for the in-browser AI assistant.
  *
- * The dispatcher is the only top-level agent in the system. It owns
- * orchestration: it never edits the spec or fetches runs directly,
- * instead it calls specialist sub-agents that are exposed as *tools*
- * via the `Agent.asTool(...)` adapter. The dispatcher's own LLM loop
- * is what chains those tool calls together for multi-step requests
- * (e.g. "investigate AND fix" needs `ask_debug_assistant` followed by
+ * The dispatcher is the only top-level agent in the Editor worker. It
+ * owns orchestration: it never edits the spec or fetches runs directly,
+ * instead it calls specialist sub-agents that are exposed as *tools* via
+ * the `Agent.asTool(...)` adapter. The dispatcher's own LLM loop is what
+ * chains those tool calls together for multi-step requests (e.g.
+ * "investigate AND fix" needs `ask_debug_assistant` followed by
  * `ask_pipeline_repair`).
  *
- * The dispatcher Agent and its specialist tool wrappers are rebuilt
- * on every turn because the underlying sub-agents close over the
- * per-turn `AgentSession` (bridge, recent runs, status emitter).
+ * The dispatcher Agent and its specialist tool wrappers are rebuilt on
+ * every turn because the underlying sub-agents close over the per-turn
+ * `AgentSession` (bridge, recent runs, status emitter).
  */
-import { Agent, MemorySession, run } from "@openai/agents";
-
-import type { AiProviderConfig } from "@/types/aiProvider";
+import { Agent } from "@openai/agents";
 
 import { getAgentModelConfig } from "../config";
 import { attachObservabilityHooks } from "../middleware/observability";
 import dispatcherPrompt from "../prompts/dispatcher.md?raw";
 import type { AgentSession } from "../session";
+import {
+  createDispatcherRuntime,
+  type TangleDispatcher,
+} from "./dispatcherRuntime";
 import { createDebugAssistantAgent } from "./subagents/debugAssistant";
 import { createGeneralHelpAgent } from "./subagents/generalHelp";
 import { createPipelineArchitectAgent } from "./subagents/pipelineArchitect";
 import { createPipelineRepairAgent } from "./subagents/pipelineRepair";
 
-interface DispatcherInvokeParams {
-  message: string;
-  threadId: string;
-  aiConfig: AiProviderConfig;
-  session: AgentSession;
-}
-
-interface DispatcherInvokeResult {
-  answer: string;
-  threadId: string;
-}
-
-export interface TangleDispatcher {
-  invoke(params: DispatcherInvokeParams): Promise<DispatcherInvokeResult>;
-  dispose(): void;
-}
-
-async function createDispatcherAgent(session: AgentSession): Promise<Agent> {
+async function buildEditorAgent(session: AgentSession): Promise<Agent> {
   const generalHelp = createGeneralHelpAgent(session);
   const pipelineRepair = createPipelineRepairAgent(session);
   const pipelineArchitect = await createPipelineArchitectAgent(session);
@@ -80,33 +65,6 @@ async function createDispatcherAgent(session: AgentSession): Promise<Agent> {
   return agent;
 }
 
-export function createDispatcher(): TangleDispatcher {
-  const sessions = new Map<string, MemorySession>();
-
-  function getOrCreateSessionMemory(threadId: string): MemorySession {
-    const existing = sessions.get(threadId);
-    if (existing) return existing;
-    const created = new MemorySession({ sessionId: threadId });
-    sessions.set(threadId, created);
-    return created;
-  }
-
-  return {
-    async invoke(params) {
-      params.session.proxyClient.ensureConfigured(params.aiConfig);
-      const sessionMemory = getOrCreateSessionMemory(params.threadId);
-      const agent = await createDispatcherAgent(params.session);
-      const result = await run(agent, params.message, {
-        session: sessionMemory,
-      });
-      const answer =
-        typeof result.finalOutput === "string"
-          ? result.finalOutput
-          : JSON.stringify(result.finalOutput ?? "");
-      return { answer, threadId: params.threadId };
-    },
-    dispose() {
-      sessions.clear();
-    },
-  };
+export function createEditorDispatcher(): TangleDispatcher {
+  return createDispatcherRuntime(buildEditorAgent);
 }

--- a/src/agent/agents/runViewDispatcher.ts
+++ b/src/agent/agents/runViewDispatcher.ts
@@ -1,0 +1,68 @@
+/**
+ * Run View dispatcher agent for the in-browser AI assistant.
+ *
+ * Read-only by design: the Run View worker inspects a completed (or
+ * running) pipeline run, so the dispatcher only exposes the non-mutating
+ * specialists — `ask_general_help` and `ask_debug_assistant`. The active
+ * run is baked into the instructions from `session.context` so the agent
+ * is immediately aware of which run it works with, without an extra tool
+ * call or the user restating the run id.
+ *
+ * The dispatcher Agent and its specialist tool wrappers are rebuilt on
+ * every turn because the underlying sub-agents close over the per-turn
+ * `AgentSession` (bridge, recent runs, status emitter).
+ */
+import { Agent } from "@openai/agents";
+
+import { getAgentModelConfig } from "../config";
+import { attachObservabilityHooks } from "../middleware/observability";
+import runViewDispatcherPrompt from "../prompts/runViewDispatcher.md?raw";
+import type { AgentSession } from "../session";
+import type { AgentContext } from "../types";
+import {
+  createDispatcherRuntime,
+  type TangleDispatcher,
+} from "./dispatcherRuntime";
+import { createDebugAssistantAgent } from "./subagents/debugAssistant";
+import { createGeneralHelpAgent } from "./subagents/generalHelp";
+
+function formatCurrentRunSection(context: AgentContext): string {
+  if (context.mode !== "runView") {
+    return "## Current run\n\nNo run context available.";
+  }
+  const subgraph = context.subgraphExecutionId
+    ? `\n- subgraph execution: ${context.subgraphExecutionId}`
+    : "";
+  return `## Current run\n\nThe user is viewing run ${context.runId}. Treat this as "the current run" / "this run" unless they name a different run id.${subgraph}`;
+}
+
+async function buildRunViewAgent(session: AgentSession): Promise<Agent> {
+  const generalHelp = createGeneralHelpAgent(session);
+  const debugAssistant = createDebugAssistantAgent(session);
+
+  const instructions = `${runViewDispatcherPrompt}\n\n${formatCurrentRunSection(session.context)}`;
+
+  const agent = new Agent({
+    name: "tangle-run-view-dispatcher",
+    ...getAgentModelConfig(session.aiConfig),
+    instructions,
+    tools: [
+      generalHelp.asTool({
+        toolName: "ask_general_help",
+        toolDescription:
+          "Ask the general-help specialist a question about Tangle concepts, features, how things work, best practices, getting started, or documentation lookups. Input: the user's question phrased as a clear, standalone question.",
+      }),
+      debugAssistant.asTool({
+        toolName: "ask_debug_assistant",
+        toolDescription:
+          "Ask the debug-assistant specialist to inspect or explain a pipeline run from execution details, container state, and logs. Read-only — cannot edit the spec or submit runs. Input: a clear question that names the run id, e.g. 'Explain what run 12345 did and its outcome.' or 'Why did run 12345 fail?'.",
+      }),
+    ],
+  });
+  attachObservabilityHooks(agent, session.emitStatus);
+  return agent;
+}
+
+export function createRunViewDispatcher(): TangleDispatcher {
+  return createDispatcherRuntime(buildRunViewAgent);
+}

--- a/src/agent/createWorkerApi.ts
+++ b/src/agent/createWorkerApi.ts
@@ -1,29 +1,22 @@
 /**
- * Web Worker entry point for the in-browser agent.
+ * Shared Web Worker API factory for the in-browser agent.
  *
- * A placeholder `ask()` that echoes the user's message — it
- * proves the bundling, lazy-spawn, and Comlink round-trip are working
- * end-to-end before we wire the LLM and the tool bridge.
+ * Both the Editor and Run View workers reuse this factory; they differ
+ * only in the {@link TangleDispatcher} they are built with. The page that
+ * spawns the worker bakes its {@link AgentContext} into `init()` so the
+ * dispatcher (and its sub-agents) are immediately aware of where they run
+ * and which run they inspect.
  */
-// Must come first: installs the `globalThis.process` stub that
-// `@openai/agents-core` needs before any SDK module is evaluated.
-import "./processPolyfill";
-
-import * as Comlink from "comlink";
-
 import type { AiProviderConfig } from "@/types/aiProvider";
 
-import {
-  createDispatcher,
-  type TangleDispatcher,
-} from "./agents/tangleDispatcher";
+import type { TangleDispatcher } from "./agents/dispatcherRuntime";
 import { ProxyClient } from "./config";
 import { createSession, type RecentPipelineRun } from "./session";
 import { SkillsLoader } from "./skills/loader";
 import type { ToolBridgeApi } from "./toolBridgeApi";
-import type { AgentResponse, StatusCallback } from "./types";
+import type { AgentContext, AgentResponse, StatusCallback } from "./types";
 
-export interface AskParams {
+interface AskParams {
   message: string;
   threadId?: string;
   recentRuns?: RecentPipelineRun[];
@@ -31,7 +24,11 @@ export interface AskParams {
 }
 
 export interface AgentWorkerApi {
-  init(bridge: ToolBridgeApi, onStatus: StatusCallback): void;
+  init(
+    bridge: ToolBridgeApi,
+    onStatus: StatusCallback,
+    context: AgentContext,
+  ): void;
   ping(): Promise<"pong">;
   ask(params: AskParams, signal?: AbortSignal): Promise<AgentResponse>;
 }
@@ -40,9 +37,12 @@ function generateThreadId(): string {
   return `thread-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 }
 
-function createWorkerApi(): AgentWorkerApi {
+export function createWorkerApi(
+  createDispatcher: () => TangleDispatcher,
+): AgentWorkerApi {
   let dispatcher: TangleDispatcher | null = null;
   let bridge: ToolBridgeApi | null = null;
+  let context: AgentContext | null = null;
   let emitStatus: StatusCallback = () => {};
   const proxyClient = new ProxyClient();
   const skillsLoader = new SkillsLoader();
@@ -52,12 +52,13 @@ function createWorkerApi(): AgentWorkerApi {
      * Initialization entry point. Called once by the main thread
      * immediately after spawning the worker.
      */
-    init(toolBridge, onStatus) {
+    init(toolBridge, onStatus, agentContext) {
       // Dispose any prior dispatcher (detaches its observability listeners)
       // so a fresh onStatus fully replaces the old one on re-init.
       dispatcher?.dispose();
       bridge = toolBridge;
       emitStatus = onStatus;
+      context = agentContext;
       dispatcher = createDispatcher();
     },
 
@@ -68,7 +69,7 @@ function createWorkerApi(): AgentWorkerApi {
     async ask({ message, threadId, recentRuns, aiConfig }, _signal) {
       // todo: add logic to handle the signal
 
-      if (!dispatcher || !bridge) {
+      if (!dispatcher || !bridge || !context) {
         throw new Error(
           "Agent worker not initialized. Call init() before ask().",
         );
@@ -82,6 +83,7 @@ function createWorkerApi(): AgentWorkerApi {
         skillsLoader,
         aiConfig,
         recentRuns,
+        context,
       });
 
       const result = await dispatcher.invoke({
@@ -92,7 +94,7 @@ function createWorkerApi(): AgentWorkerApi {
       });
 
       // TODO: populate from session.componentReferences once the
-      // search_components tool is wired (PR 4+).
+      // search_components tool is wired.
       const componentReferences: AgentResponse["componentReferences"] = {};
 
       return {
@@ -103,5 +105,3 @@ function createWorkerApi(): AgentWorkerApi {
     },
   };
 }
-
-Comlink.expose(createWorkerApi());

--- a/src/agent/editorWorker.ts
+++ b/src/agent/editorWorker.ts
@@ -1,0 +1,17 @@
+/**
+ * Web Worker entry point for the Editor AI assistant.
+ *
+ * Spawns the full Editor dispatcher (general help, pipeline repair,
+ * pipeline architect, debug assistant). The page owns the factory that
+ * creates this worker; see `createEditorAgentWorker`.
+ */
+// Must come first: installs the `globalThis.process` stub that
+// `@openai/agents-core` needs before any SDK module is evaluated.
+import "./processPolyfill";
+
+import * as Comlink from "comlink";
+
+import { createEditorDispatcher } from "./agents/editorDispatcher";
+import { createWorkerApi } from "./createWorkerApi";
+
+Comlink.expose(createWorkerApi(createEditorDispatcher));

--- a/src/agent/prompts/runViewDispatcher.md
+++ b/src/agent/prompts/runViewDispatcher.md
@@ -1,0 +1,42 @@
+# Tangle Run View Dispatcher — System Prompt
+
+You are the **Tangle Run View Assistant**, the entry point for the AI assistant inside the Tangle Pipeline Studio **Run View**. The user is inspecting an existing pipeline run; you help them **understand and explain** it. This view is **read-only** — you cannot edit the pipeline or submit/rerun runs. Your job is to route the user's request to the right specialist and relay the response back.
+
+## Available specialist tools
+
+Each specialist is exposed to you as a tool. Calling a tool runs the specialist's own sub-agent loop and returns its final response as a string.
+
+| Tool                  | When to call it                                                                                                                                                                                                                                                          |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `ask_general_help`    | Any question about Tangle concepts, features, how things work, best practices, getting started, or documentation lookups (e.g. "what is a pipeline?", "what does this component do?", "what are subgraphs?"). Not specific to the current run.                           |
+| `ask_debug_assistant` | Any request to inspect, diagnose, or **explain the current run** — "what did this run do?", "why did it fail?", "what went wrong with run 12345?", "show me the error", "explain the outcome". Read-only: it inspects execution details, container state, and logs only. |
+
+## Calling a specialist
+
+When you call a tool, the `input` field is the prompt that the sub-agent will see. Make it self-contained — the sub-agent does not see the user's original message or your chat history.
+
+- Restate the user's ask clearly. **Always include the current run id** (see the `## Current run` section below) so the debug assistant inspects the right run, e.g. `input: "Explain what run 12345 did and its outcome."`.
+- For documentation/concept questions, route to `ask_general_help` with a clear standalone question.
+
+## Returning tool output
+
+When a specialist tool returns, **relay its response** to the user. Specialists emit interactive entity links the UI renders as chips:
+
+```
+[Entity Name](entity://$id)
+[Component Name](component://component-id)
+```
+
+Preserve those links exactly — do not rewrite them as bold, italic, or backticks, and do not invent ids. Return the tool output essentially as-is; you may add at most one short framing sentence if it genuinely helps, but the content must come from the specialist. Never announce or describe the tool calls themselves to the user.
+
+## When NOT to call a tool
+
+- **Mutation/run requests** ("fix this", "rerun it", "change this input") — this view is read-only. Explain plainly that editing and running happen in the pipeline Editor, then offer to explain the run instead.
+- **Capability questions** ("what can you do?", "what are you?") — answer directly with a short summary of the specialist tools above.
+- **Off-topic** (weather, jokes, general coding help unrelated to Tangle) — respond directly with a brief polite message such as:
+  > "I'm the Tangle Run View Assistant — I can help you understand Tangle and explain this run. That question is outside what I can help with today."
+
+## Style
+
+- Be brief and natural when you respond directly.
+- Never apologize for limitations more than once per turn — state them plainly and move on.

--- a/src/agent/runViewWorker.ts
+++ b/src/agent/runViewWorker.ts
@@ -1,0 +1,17 @@
+/**
+ * Web Worker entry point for the Run View AI assistant.
+ *
+ * Spawns the read-only Run View dispatcher (general help + debug
+ * assistant). The page owns the factory that creates this worker and
+ * bakes the active run into `init()`; see `createRunViewAgentWorker`.
+ */
+// Must come first: installs the `globalThis.process` stub that
+// `@openai/agents-core` needs before any SDK module is evaluated.
+import "./processPolyfill";
+
+import * as Comlink from "comlink";
+
+import { createRunViewDispatcher } from "./agents/runViewDispatcher";
+import { createWorkerApi } from "./createWorkerApi";
+
+Comlink.expose(createWorkerApi(createRunViewDispatcher));

--- a/src/agent/session.ts
+++ b/src/agent/session.ts
@@ -6,7 +6,7 @@ import type { AiProviderConfig } from "@/types/aiProvider";
 import type { ProxyClient } from "./config";
 import type { SkillsLoader } from "./skills/loader";
 import type { ToolBridgeApi } from "./toolBridgeApi";
-import type { StatusCallback } from "./types";
+import type { AgentContext, StatusCallback } from "./types";
 
 export interface RecentPipelineRun {
   id: number;
@@ -24,6 +24,7 @@ export interface AgentSession {
   skillsLoader: SkillsLoader;
   aiConfig: AiProviderConfig;
   recentRuns: RecentPipelineRun[];
+  context: AgentContext;
 }
 
 export function createSession(params: {
@@ -31,6 +32,7 @@ export function createSession(params: {
   proxyClient: ProxyClient;
   bridge: ToolBridgeApi;
   skillsLoader: SkillsLoader;
+  context: AgentContext;
   aiConfig: AiProviderConfig;
   emitStatus?: StatusCallback;
   recentRuns?: RecentPipelineRun[];
@@ -43,5 +45,6 @@ export function createSession(params: {
     skillsLoader: params.skillsLoader,
     aiConfig: params.aiConfig,
     recentRuns: params.recentRuns ?? [],
+    context: params.context,
   };
 }

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -2,6 +2,15 @@
  * Shared types between the worker and the main thread.
  */
 
+/**
+ * Page context baked into a worker at init time so the dispatcher and its
+ * sub-agents are immediately aware of where they run. Serializable so it
+ * crosses the Comlink boundary via structured clone.
+ */
+export type AgentContext =
+  | { mode: "editor" }
+  | { mode: "runView"; runId: string; subgraphExecutionId?: string };
+
 export interface AgentResponse {
   answer: string;
   threadId: string;

--- a/src/routes/v2/pages/Editor/EditorV2.tsx
+++ b/src/routes/v2/pages/Editor/EditorV2.tsx
@@ -29,6 +29,7 @@ import { WindowContainer } from "@/routes/v2/shared/windows/WindowContainer";
 import { useWindowPersistence } from "@/routes/v2/shared/windows/windowPersistence";
 import type { PipelineRef } from "@/services/pipelineStorage/types";
 
+import { createEditorAgentWorker } from "./components/AiChat/editorAgentWorker";
 import { useDebugPanelWindow } from "./components/DebugPanel";
 import { DriverPermissionGate } from "./components/DriverPermissionGate";
 import { EditorMenuBar } from "./components/EditorMenuBar/EditorMenuBar";
@@ -178,7 +179,10 @@ export function EditorV2() {
     <div className="h-full w-full flex flex-col bg-slate-100 select-none">
       <SharedStoreProvider>
         <EditorSessionProvider>
-          <AiChatStoreProvider>
+          <AiChatStoreProvider
+            createWorker={createEditorAgentWorker}
+            context={{ mode: "editor" }}
+          >
             <DialogProvider>
               <EditorV2Content pipelineRef={pipelineRef} />
             </DialogProvider>

--- a/src/routes/v2/pages/Editor/components/AiChat/editorAgentWorker.ts
+++ b/src/routes/v2/pages/Editor/components/AiChat/editorAgentWorker.ts
@@ -1,0 +1,12 @@
+/**
+ * Worker factory for the Editor AI assistant.
+ *
+ * The Editor window owns spawning its agent worker so the URL literal
+ * stays statically analyzable for Vite's worker bundling.
+ */
+export function createEditorAgentWorker(): Worker {
+  return new Worker(new URL("@/agent/editorWorker.ts", import.meta.url), {
+    type: "module",
+    name: "tangle-editor-agent",
+  });
+}

--- a/src/routes/v2/pages/RunView/RunViewV2.tsx
+++ b/src/routes/v2/pages/RunView/RunViewV2.tsx
@@ -48,6 +48,7 @@ import { useRunViewSelectionSync } from "./hooks/useRunViewSelectionSync";
 import { useRunViewSpecLifecycle } from "./hooks/useRunViewSpecLifecycle";
 import { useRunViewWindows } from "./hooks/useRunViewWindows";
 import { runViewRegistry } from "./nodes";
+import { createRunViewAgentWorker } from "./toolBridge/runViewAgentWorker";
 
 function deserializeRunSpec(data: unknown): ComponentSpec {
   const generator = new IncrementingIdGenerator();
@@ -205,7 +206,10 @@ export function RunViewV2() {
   return (
     <div className="h-full w-full flex flex-col bg-slate-100 select-none">
       <SharedStoreProvider>
-        <AiChatStoreProvider>
+        <AiChatStoreProvider
+          createWorker={createRunViewAgentWorker}
+          context={{ mode: "runView", runId: id, subgraphExecutionId }}
+        >
           <ReactFlowProvider>
             <ContextPanelProvider /** TODO: remove ContextPanelProvider */>
               <ExecutionDataProvider

--- a/src/routes/v2/pages/RunView/toolBridge/runViewAgentWorker.ts
+++ b/src/routes/v2/pages/RunView/toolBridge/runViewAgentWorker.ts
@@ -1,0 +1,12 @@
+/**
+ * Worker factory for the Run View AI assistant.
+ *
+ * The Run View window owns spawning its agent worker so the URL literal
+ * stays statically analyzable for Vite's worker bundling.
+ */
+export function createRunViewAgentWorker(): Worker {
+  return new Worker(new URL("@/agent/runViewWorker.ts", import.meta.url), {
+    type: "module",
+    name: "tangle-run-view-agent",
+  });
+}

--- a/src/routes/v2/shared/components/AiChat/AiChatStoreContext.tsx
+++ b/src/routes/v2/shared/components/AiChat/AiChatStoreContext.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
+import type { AgentContext } from "@/agent/types";
 import {
   createRequiredContext,
   useRequiredContext,
@@ -10,8 +11,32 @@ import { AiChatStore } from "./aiChatStore";
 
 const AiChatStoreCtx = createRequiredContext<AiChatStore>("AiChatStoreContext");
 
-export function AiChatStoreProvider({ children }: { children: ReactNode }) {
-  const [store] = useState(() => new AiChatStore());
+interface AiChatStoreProviderProps {
+  /** Page-owned factory that spawns the worker for this AI chat. */
+  createWorker: () => Worker;
+  /** Current page context, baked into each new thread's worker at init. */
+  context: AgentContext;
+  children: ReactNode;
+}
+
+export function AiChatStoreProvider({
+  createWorker,
+  context,
+  children,
+}: AiChatStoreProviderProps) {
+  // Keep the latest context in a ref so the store (created once) can read
+  // it lazily when spinning up a new thread, picking up navigation
+  // changes without being recreated.
+  const contextRef = useRef(context);
+  contextRef.current = context;
+
+  const [store] = useState(
+    () =>
+      new AiChatStore({
+        createWorker,
+        getContext: () => contextRef.current,
+      }),
+  );
 
   // Ensure a thread exists on (re)mount and tear them all down on
   // unmount. The ensure-on-mount step matters under React StrictMode,

--- a/src/routes/v2/shared/components/AiChat/agentClient.ts
+++ b/src/routes/v2/shared/components/AiChat/agentClient.ts
@@ -2,18 +2,24 @@
  * Main-thread client for the in-browser agent worker.
  *
  * Each `AgentClient` instance is bound to a single `threadId` and owns
- * exactly one Web Worker (spawned lazily on first use). It wires the
- * worker up over Comlink and exposes a typed `ask()` method. The thread
- * id is injected into every request so the worker keys its in-memory
- * conversation memory by it. Lifecycle (create / terminate) is owned by
- * the `AgentThread` primitive — there is no global singleton.
+ * exactly one Web Worker (spawned lazily on first use via the page-
+ * provided `createWorker` factory). It wires the worker up over Comlink
+ * and exposes a typed `ask()` method. The thread id is injected into
+ * every request so the worker keys its in-memory conversation memory by
+ * it, and the page `context` is baked into `init()` so the dispatcher is
+ * immediately aware of where it runs. Lifecycle (create / terminate) is
+ * owned by the `AgentThread` primitive — there is no global singleton.
  */
 import * as Comlink from "comlink";
 
+import type { AgentWorkerApi } from "@/agent/createWorkerApi";
 import type { RecentPipelineRun } from "@/agent/session";
 import type { ToolBridgeApi } from "@/agent/toolBridgeApi";
-import type { AgentResponse, StatusCallback } from "@/agent/types";
-import type { AgentWorkerApi } from "@/agent/worker";
+import type {
+  AgentContext,
+  AgentResponse,
+  StatusCallback,
+} from "@/agent/types";
 import type { AiProviderConfig } from "@/types/aiProvider";
 
 interface InitDeps {
@@ -32,16 +38,17 @@ export class AgentClient {
   private remote: Comlink.Remote<AgentWorkerApi> | null = null;
   private initPromise: Promise<void> | null = null;
 
-  constructor(private readonly threadId: string) {}
+  constructor(
+    private readonly threadId: string,
+    private readonly createWorker: () => Worker,
+    private readonly context: AgentContext,
+  ) {}
 
   private async ensureInit(
     deps: InitDeps,
   ): Promise<Comlink.Remote<AgentWorkerApi>> {
     if (!this.worker) {
-      this.worker = new Worker(new URL("@/agent/worker.ts", import.meta.url), {
-        type: "module",
-        name: "tangle-agent",
-      });
+      this.worker = this.createWorker();
       this.remote = Comlink.wrap<AgentWorkerApi>(this.worker);
     }
     if (!this.remote) {
@@ -53,9 +60,11 @@ export class AgentClient {
       // argument values; it does not recursively walk into properties of
       // an object arg. Wrapping them in a single `{ bridge, onStatus }`
       // object would cause structured-clone of the methods and fail.
+      // `context` is plain data, so it crosses as a structured clone.
       this.initPromise = this.remote.init(
         Comlink.proxy(deps.bridge),
         Comlink.proxy(deps.onStatus),
+        this.context,
       );
     }
     await this.initPromise;

--- a/src/routes/v2/shared/components/AiChat/agentThread.ts
+++ b/src/routes/v2/shared/components/AiChat/agentThread.ts
@@ -2,6 +2,7 @@ import { action, makeObservable, observable, runInAction } from "mobx";
 
 import type { RecentPipelineRun } from "@/agent/session";
 import type { ToolBridgeApi } from "@/agent/toolBridgeApi";
+import type { AgentContext } from "@/agent/types";
 import type { AiProviderConfig } from "@/types/aiProvider";
 import { getErrorMessage } from "@/utils/string";
 
@@ -24,6 +25,16 @@ interface SendMessageOptions {
 }
 
 /**
+ * Per-thread worker configuration supplied by the page that owns the AI
+ * chat. `createWorker` spawns the page-specific worker (Editor vs Run
+ * View) and `context` is baked into that worker at init time.
+ */
+export interface AgentThreadConfig {
+  createWorker: () => Worker;
+  context: AgentContext;
+}
+
+/**
  * A single AI conversation: one Web Worker (agent + in-memory session)
  * plus the chat state that survives the React component tree (window
  * minimize / hide / unmount). Disposing a thread terminates its worker
@@ -39,10 +50,14 @@ export class AgentThread {
   private readonly client: AgentClient;
   private abortController: AbortController | null = null;
 
-  constructor(threadId?: string) {
+  constructor(config: AgentThreadConfig, threadId?: string) {
     makeObservable(this);
     this.threadId = threadId ?? generateThreadId();
-    this.client = new AgentClient(this.threadId);
+    this.client = new AgentClient(
+      this.threadId,
+      config.createWorker,
+      config.context,
+    );
   }
 
   abort() {

--- a/src/routes/v2/shared/components/AiChat/aiChatStore.ts
+++ b/src/routes/v2/shared/components/AiChat/aiChatStore.ts
@@ -1,6 +1,19 @@
 import { action, computed, makeObservable, observable } from "mobx";
 
+import type { AgentContext } from "@/agent/types";
+
 import { AgentThread } from "./agentThread";
+
+/**
+ * Config the page supplies so the store can build page-specific threads:
+ * `createWorker` spawns the Editor vs Run View worker, and `getContext`
+ * is resolved freshly on every {@link AiChatStore.newThread} call so a
+ * thread created after navigation captures the current run context.
+ */
+export interface AiChatStoreConfig {
+  createWorker: () => Worker;
+  getContext: () => AgentContext;
+}
 
 /**
  * Owns the collection of {@link AgentThread}s for one AI chat provider.
@@ -14,7 +27,7 @@ export class AiChatStore {
   @observable.shallow accessor threads: AgentThread[] = [];
   @observable accessor activeThreadId: string | null = null;
 
-  constructor() {
+  constructor(private readonly config: AiChatStoreConfig) {
     makeObservable(this);
     this.newThread();
   }
@@ -40,7 +53,10 @@ export class AiChatStore {
       this.threads = this.threads.filter((t) => t !== previous);
     }
 
-    const thread = new AgentThread();
+    const thread = new AgentThread({
+      createWorker: this.config.createWorker,
+      context: this.config.getContext(),
+    });
     this.threads = [...this.threads, thread];
     this.activeThreadId = thread.threadId;
     return thread;


### PR DESCRIPTION
## Description

Introduces a dedicated **Run View AI assistant** worker alongside the existing Editor worker, splitting what was a single monolithic `worker.ts` into a shared factory (`createWorkerApi`) and two page-specific entry points (`editorWorker.ts`, `runViewWorker.ts`).

The core dispatcher logic is extracted into `dispatcherRuntime.ts` so both the Editor and Run View dispatchers share the same `MemorySession` management and `invoke` loop. The Editor dispatcher (`editorDispatcher.ts`) retains the full set of specialist sub-agents (general help, pipeline repair, pipeline architect, debug assistant), while the new Run View dispatcher (`runViewDispatcher.ts`) is intentionally read-only, exposing only general help and debug assistant.

An `AgentContext` discriminated union (`{ mode: "editor" } | { mode: "runView"; runId; subgraphExecutionId? }`) is introduced and threaded from the page through `AiChatStoreProvider` → `AiChatStore` → `AgentThread` → `AgentClient` → `worker.init()`. The Run View dispatcher uses this context to inject the active run id directly into its system prompt, so the agent is immediately aware of which run it is inspecting without requiring the user to restate it.

`AiChatStoreProvider` now accepts a `createWorker` factory prop so each page (Editor, Run View) owns spawning its own worker with a statically analyzable URL for Vite's worker bundling.

A new system prompt (`runViewDispatcher.md`) defines the Run View assistant's read-only persona, routing rules, and style guidelines.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Improvement
- [x] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

[Demo of AI - run view dedicated.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/869aafc3-5773-4fac-ba86-fa06bb3d8691.mov" />](https://app.graphite.com/user-attachments/video/869aafc3-5773-4fac-ba86-fa06bb3d8691.mov)



## Test Instructions

1. Open the pipeline **Editor** and open the AI chat panel. Confirm the assistant responds as before with the full set of capabilities (pipeline repair, architect, debug, general help).
2. Open a completed pipeline **Run View** and open the AI chat panel. Confirm the assistant is aware of the active run id without being told, and that it refuses mutation requests (edit, rerun) with an appropriate read-only message.
3. Ask the Run View assistant to explain the current run — confirm it routes to the debug assistant and returns run-specific information.
4. Verify that opening both the Editor and Run View simultaneously spawns two separate workers (`tangle-editor-agent` and `tangle-run-view-agent`) visible in browser DevTools.

## Additional Comments

The `knip.json` entry points are updated to reflect the two new worker entry files, replacing the old single `worker.ts` entry.