### PR TITLE
refactor: v2 - run view - windows top menu

### DIFF
--- a/src/routes/v2/pages/Editor/components/EditorMenuBar/EditorMenuBar.tsx
+++ b/src/routes/v2/pages/Editor/components/EditorMenuBar/EditorMenuBar.tsx
@@ -16,6 +16,7 @@ import { APP_ROUTES } from "@/routes/router";
 import { usePipelineRename } from "@/routes/v2/pages/Editor/hooks/usePipelineRename";
 import { useEditorSession } from "@/routes/v2/pages/Editor/store/EditorSessionContext";
 import { AppMenuActions } from "@/routes/v2/shared/components/AppMenuActions";
+import { WindowsMenu } from "@/routes/v2/shared/components/WindowsMenu";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 import { TOP_NAV_HEIGHT } from "@/utils/constants";
 import { tracking } from "@/utils/tracking";
@@ -27,7 +28,6 @@ import { NodeMenu } from "./components/NodeMenu";
 import { QuickRunButton } from "./components/QuickRunButton";
 import { RunsMenu } from "./components/RunsMenu";
 import { ViewMenu } from "./components/ViewMenu";
-import { WindowsMenu } from "./components/WindowsMenu";
 
 export const EditorMenuBar = observer(function EditorMenuBar() {
   const { navigation } = useSharedStores();
@@ -138,7 +138,7 @@ export const EditorMenuBar = observer(function EditorMenuBar() {
                 <ViewMenu />
                 <RunsMenu />
                 <ComponentsLibraryMenu />
-                <WindowsMenu />
+                <WindowsMenu trackingPrefix="v2.pipeline_editor.windows_menu" />
                 <NodeMenu />
               </InlineStack>
             </BlockStack>

--- a/src/routes/v2/pages/RunView/components/RunViewMenuBar/RunViewMenuBar.tsx
+++ b/src/routes/v2/pages/RunView/components/RunViewMenuBar/RunViewMenuBar.tsx
@@ -5,6 +5,7 @@ import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Link } from "@/components/ui/link";
 import { Text } from "@/components/ui/typography";
 import { AppMenuActions } from "@/routes/v2/shared/components/AppMenuActions";
+import { WindowsMenu } from "@/routes/v2/shared/components/WindowsMenu";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 import { TOP_NAV_HEIGHT } from "@/utils/constants";
 import { tracking } from "@/utils/tracking";
@@ -62,6 +63,7 @@ export const RunViewMenuBar = observer(function RunViewMenuBar() {
             <InlineStack wrap="nowrap" blockAlign="center">
               <RunMenu />
               <RunViewViewMenu />
+              <WindowsMenu trackingPrefix="v2.run_view.windows_menu" />
             </InlineStack>
           </BlockStack>
         </InlineStack>

--- a/src/routes/v2/shared/components/WindowsMenu.tsx
+++ b/src/routes/v2/shared/components/WindowsMenu.tsx
@@ -23,7 +23,14 @@ import {
 } from "@/routes/v2/shared/windows/viewPresets";
 import { tracking } from "@/utils/tracking";
 
-export const WindowsMenu = observer(function WindowsMenu() {
+interface WindowsMenuProps {
+  /** Tracking id for the menu trigger; sub-events are derived from it. */
+  trackingPrefix: string;
+}
+
+export const WindowsMenu = observer(function WindowsMenu({
+  trackingPrefix,
+}: WindowsMenuProps) {
   const { track } = useAnalytics();
   const componentSearchV2Enabled = useFlagValue("component-search-v2");
   const { windows } = useSharedStores();
@@ -32,7 +39,7 @@ export const WindowsMenu = observer(function WindowsMenu() {
     .sort((a, b) => a.title.localeCompare(b.title));
 
   const applyPreset = (preset: ViewPreset) => {
-    track("v2.pipeline_editor.windows_menu.view_preset.click", {
+    track(`${trackingPrefix}.view_preset.click`, {
       preset_label: preset.label,
     });
     windows.applyViewPreset(
@@ -43,7 +50,7 @@ export const WindowsMenu = observer(function WindowsMenu() {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <MenuTriggerButton {...tracking("v2.pipeline_editor.windows_menu")}>
+        <MenuTriggerButton {...tracking(trackingPrefix)}>
           Windows
         </MenuTriggerButton>
       </DropdownMenuTrigger>
@@ -58,13 +65,10 @@ export const WindowsMenu = observer(function WindowsMenu() {
             checked={win.state !== "hidden"}
             onSelect={(e) => e.preventDefault()}
             onCheckedChange={(checked) => {
-              track(
-                "v2.pipeline_editor.windows_menu.window_visibility.toggle",
-                {
-                  window_id: win.id,
-                  visible: checked,
-                },
-              );
+              track(`${trackingPrefix}.window_visibility.toggle`, {
+                window_id: win.id,
+                visible: checked,
+              });
               if (checked) {
                 win.restore();
               } else {


### PR DESCRIPTION
## Description

The `WindowsMenu` component has been moved from `src/routes/v2/pages/Editor/components/EditorMenuBar/components/` to `src/routes/v2/shared/components/` so it can be reused across different views. A `trackingPrefix` prop has been introduced to allow each consumer to supply its own tracking namespace. The `EditorMenuBar` passes `v2.pipeline_editor.windows_menu` and the `RunViewMenuBar` passes `v2.run_view.windows_menu`, with the `WindowsMenu` now also rendered in the `RunViewMenuBar`.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [x] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Open the pipeline editor and verify the Windows menu renders correctly and tracking events fire with the `v2.pipeline_editor.windows_menu` prefix.
2. Open a run view and verify the Windows menu now appears in the menu bar and tracking events fire with the `v2.run_view.windows_menu` prefix.
3. Toggle window visibility and apply view presets in both views to confirm the correct tracking payloads are sent.

## Additional Comments