### PR TITLE
refactor: v2 - run view - run menu

### DIFF
--- a/src/routes/v2/pages/Editor/components/AiChat/editorAgentWorker.ts
+++ b/src/routes/v2/pages/Editor/components/AiChat/editorAgentWorker.ts
@@ -1,11 +1,16 @@
 /**
  * Worker factory for the Editor AI assistant.
  *
- * The Editor window owns spawning its agent worker so the URL literal
- * stays statically analyzable for Vite's worker bundling.
+ * The Editor window owns spawning its agent worker. We import the worker
+ * via `?worker&url` so Vite still runs it through the worker build pipeline
+ * (applying the `worker.plugins` shims), then hand the URL to
+ * `createCrossOriginWorker` which tolerates CDN-hosted (cross-origin) scripts.
  */
+import editorWorkerUrl from "@/agent/editorWorker.ts?worker&url";
+import { createCrossOriginWorker } from "@/utils/createCrossOriginWorker";
+
 export function createEditorAgentWorker(): Worker {
-  return new Worker(new URL("@/agent/editorWorker.ts", import.meta.url), {
+  return createCrossOriginWorker(editorWorkerUrl, {
     type: "module",
     name: "tangle-editor-agent",
   });

--- a/src/routes/v2/pages/Editor/components/EditorMenuBar/EditorMenuBar.tsx
+++ b/src/routes/v2/pages/Editor/components/EditorMenuBar/EditorMenuBar.tsx
@@ -11,6 +11,7 @@ import { Text } from "@/components/ui/typography";
 import { usePipelineRename } from "@/routes/v2/pages/Editor/hooks/usePipelineRename";
 import { useEditorSession } from "@/routes/v2/pages/Editor/store/EditorSessionContext";
 import { AppMenuActions } from "@/routes/v2/shared/components/AppMenuActions";
+import { WindowsMenu } from "@/routes/v2/shared/components/WindowsMenu";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 import { TOP_NAV_HEIGHT } from "@/utils/constants";
 import { tracking } from "@/utils/tracking";
@@ -22,7 +23,6 @@ import { NodeMenu } from "./components/NodeMenu";
 import { QuickRunButton } from "./components/QuickRunButton";
 import { RunsMenu } from "./components/RunsMenu";
 import { ViewMenu } from "./components/ViewMenu";
-import { WindowsMenu } from "./components/WindowsMenu";
 
 export const EditorMenuBar = observer(function EditorMenuBar() {
   const { navigation } = useSharedStores();
@@ -107,7 +107,7 @@ export const EditorMenuBar = observer(function EditorMenuBar() {
                 <ViewMenu />
                 <RunsMenu />
                 <ComponentsLibraryMenu />
-                <WindowsMenu />
+                <WindowsMenu trackingPrefix="v2.pipeline_editor.windows_menu" />
                 <NodeMenu />
               </InlineStack>
             </BlockStack>

--- a/src/routes/v2/pages/RunView/components/RunViewMenuBar/RunViewMenuBar.tsx
+++ b/src/routes/v2/pages/RunView/components/RunViewMenuBar/RunViewMenuBar.tsx
@@ -5,6 +5,7 @@ import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Link } from "@/components/ui/link";
 import { Text } from "@/components/ui/typography";
 import { AppMenuActions } from "@/routes/v2/shared/components/AppMenuActions";
+import { WindowsMenu } from "@/routes/v2/shared/components/WindowsMenu";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 import { TOP_NAV_HEIGHT } from "@/utils/constants";
 import { tracking } from "@/utils/tracking";
@@ -62,6 +63,7 @@ export const RunViewMenuBar = observer(function RunViewMenuBar() {
             <InlineStack wrap="nowrap" blockAlign="center">
               <RunMenu />
               <RunViewViewMenu />
+              <WindowsMenu trackingPrefix="v2.run_view.windows_menu" />
             </InlineStack>
           </BlockStack>
         </InlineStack>

--- a/src/routes/v2/pages/RunView/components/RunViewMenuBar/components/RunMenu.tsx
+++ b/src/routes/v2/pages/RunView/components/RunViewMenuBar/components/RunMenu.tsx
@@ -1,5 +1,5 @@
-import { useNavigate } from "@tanstack/react-router";
-
+import ConfirmationDialog from "@/components/shared/Dialogs/ConfirmationDialog";
+import TaskImplementation from "@/components/shared/TaskDetails/Implementation";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -8,13 +8,29 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Icon } from "@/components/ui/icon";
-import { useRunViewActions } from "@/routes/v2/pages/RunView/hooks/useRunViewActions";
 import { MenuTriggerButton } from "@/routes/v2/shared/components/MenuTriggerButton";
 import { tracking } from "@/utils/tracking";
 
+import { useRunMenuActions } from "./useRunMenuActions";
+
 export function RunMenu() {
-  const navigate = useNavigate();
-  const actions = useRunViewActions();
+  const {
+    actions,
+    yamlViewerOpen,
+    cancelDialogOpen,
+    isCloning,
+    isCancelling,
+    isRerunning,
+    openYamlViewer,
+    closeYamlViewer,
+    requestCancel,
+    dismissCancel,
+    handleInspect,
+    handleClone,
+    confirmCancel,
+    handleRerun,
+    handleExportYaml,
+  } = useRunMenuActions();
 
   if (!actions.ready) {
     return (
@@ -32,6 +48,7 @@ export function RunMenu() {
   }
 
   const {
+    componentSpec,
     canAccessEditorSpec,
     isRunCreator,
     isInProgress,
@@ -39,46 +56,95 @@ export function RunMenu() {
     pipelineName,
   } = actions;
 
-  const handleInspect = () => {
-    if (pipelineName) {
-      navigate({ to: `/editor/${encodeURIComponent(pipelineName)}` });
-    }
-  };
-
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <MenuTriggerButton {...tracking("v2.run_view.menu_bar.run_menu")}>
-          Run
-        </MenuTriggerButton>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" sideOffset={2}>
-        {canAccessEditorSpec && pipelineName && (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <MenuTriggerButton {...tracking("v2.run_view.menu_bar.run_menu")}>
+            Run
+          </MenuTriggerButton>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" sideOffset={2}>
           <DropdownMenuItem
-            onSelect={handleInspect}
-            {...tracking("v2.run_view.menu_bar.inspect_pipeline")}
+            onSelect={openYamlViewer}
+            {...tracking("v2.run_view.menu_bar.view_yaml")}
           >
-            <Icon name="ExternalLink" size="sm" />
-            Inspect Pipeline
+            <Icon name="FileCode" size="sm" />
+            View YAML
           </DropdownMenuItem>
-        )}
 
-        <DropdownMenuSeparator />
+          {canAccessEditorSpec && pipelineName && (
+            <DropdownMenuItem
+              onSelect={handleInspect}
+              {...tracking("v2.run_view.menu_bar.inspect_pipeline")}
+            >
+              <Icon name="ExternalLink" size="sm" />
+              Inspect Pipeline
+            </DropdownMenuItem>
+          )}
 
-        {isInProgress && isRunCreator && (
-          <DropdownMenuItem className="text-destructive" disabled>
-            <Icon name="CircleX" size="sm" />
-            Cancel Run
+          <DropdownMenuItem
+            onSelect={handleClone}
+            disabled={isCloning}
+            {...tracking("v2.run_view.menu_bar.clone_pipeline")}
+          >
+            <Icon name="CopyPlus" size="sm" />
+            Clone Pipeline
           </DropdownMenuItem>
-        )}
 
-        {isComplete && (
-          <DropdownMenuItem disabled>
-            <Icon name="RefreshCcw" size="sm" />
-            Rerun Pipeline
+          <DropdownMenuItem
+            onSelect={handleExportYaml}
+            {...tracking("v2.run_view.menu_bar.export_yaml")}
+          >
+            <Icon name="FileDown" size="sm" />
+            Export YAML
           </DropdownMenuItem>
-        )}
-      </DropdownMenuContent>
-    </DropdownMenu>
+
+          {(isInProgress && isRunCreator) || isComplete ? (
+            <DropdownMenuSeparator />
+          ) : null}
+
+          {isInProgress && isRunCreator && (
+            <DropdownMenuItem
+              onSelect={requestCancel}
+              disabled={isCancelling}
+              className="text-destructive focus:text-destructive"
+              {...tracking("v2.run_view.menu_bar.cancel_run")}
+            >
+              <Icon name="CircleX" size="sm" />
+              Cancel Run
+            </DropdownMenuItem>
+          )}
+
+          {isComplete && (
+            <DropdownMenuItem
+              onSelect={handleRerun}
+              disabled={isRerunning}
+              {...tracking("v2.run_view.menu_bar.rerun_pipeline")}
+            >
+              <Icon name="RefreshCcw" size="sm" />
+              Rerun Pipeline
+            </DropdownMenuItem>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <ConfirmationDialog
+        isOpen={cancelDialogOpen}
+        title="Cancel run"
+        description="The run will be scheduled for cancellation. This action cannot be undone."
+        onConfirm={confirmCancel}
+        onCancel={dismissCancel}
+      />
+
+      {yamlViewerOpen && (
+        <TaskImplementation
+          componentSpec={componentSpec}
+          displayName={pipelineName ?? componentSpec.name ?? "Pipeline"}
+          fullscreen
+          onClose={closeYamlViewer}
+        />
+      )}
+    </>
   );
 }

--- a/src/routes/v2/pages/RunView/components/RunViewMenuBar/components/useRunMenuActions.ts
+++ b/src/routes/v2/pages/RunView/components/RunViewMenuBar/components/useRunMenuActions.ts
@@ -1,0 +1,45 @@
+import { useCancelPipelineRun } from "@/routes/v2/pages/RunView/hooks/useCancelPipelineRun";
+import { useClonePipelineRun } from "@/routes/v2/pages/RunView/hooks/useClonePipelineRun";
+import { useExportPipelineYaml } from "@/routes/v2/pages/RunView/hooks/useExportPipelineYaml";
+import { useInspectPipeline } from "@/routes/v2/pages/RunView/hooks/useInspectPipeline";
+import { useRerunPipelineRun } from "@/routes/v2/pages/RunView/hooks/useRerunPipelineRun";
+import { useRunViewActions } from "@/routes/v2/pages/RunView/hooks/useRunViewActions";
+import { useYamlViewer } from "@/routes/v2/pages/RunView/hooks/useYamlViewer";
+
+export function useRunMenuActions() {
+  const actions = useRunViewActions();
+  const componentSpec = actions.ready ? actions.componentSpec : undefined;
+  const runId = actions.ready ? actions.runId : undefined;
+  const pipelineName = actions.ready ? actions.pipelineName : undefined;
+
+  const { yamlViewerOpen, openYamlViewer, closeYamlViewer } = useYamlViewer();
+  const { clone, isCloning } = useClonePipelineRun(componentSpec, runId);
+  const { rerun, isRerunning } = useRerunPipelineRun(componentSpec);
+  const {
+    cancelDialogOpen,
+    isCancelling,
+    requestCancel,
+    confirmCancel,
+    dismissCancel,
+  } = useCancelPipelineRun(runId);
+  const { inspect } = useInspectPipeline(pipelineName);
+  const { exportYaml } = useExportPipelineYaml(componentSpec, pipelineName);
+
+  return {
+    actions,
+    yamlViewerOpen,
+    cancelDialogOpen,
+    isCloning,
+    isCancelling,
+    isRerunning,
+    openYamlViewer,
+    closeYamlViewer,
+    requestCancel,
+    dismissCancel,
+    handleInspect: inspect,
+    handleClone: clone,
+    confirmCancel,
+    handleRerun: rerun,
+    handleExportYaml: exportYaml,
+  };
+}

--- a/src/routes/v2/pages/RunView/hooks/useCancelPipelineRun.ts
+++ b/src/routes/v2/pages/RunView/hooks/useCancelPipelineRun.ts
@@ -1,0 +1,55 @@
+import { useMutation } from "@tanstack/react-query";
+import { useState } from "react";
+
+import useToastNotification from "@/hooks/useToastNotification";
+import { useBackend } from "@/providers/BackendProvider";
+import { cancelPipelineRun } from "@/services/pipelineRunService";
+
+export function useCancelPipelineRun(runId?: string | null) {
+  const notify = useToastNotification();
+  const { backendUrl, available } = useBackend();
+
+  const [cancelDialogOpen, setCancelDialogOpen] = useState(false);
+
+  const { mutate: cancelRun, isPending: isCancelling } = useMutation({
+    mutationFn: (runId: string) => cancelPipelineRun(runId, backendUrl),
+    onSuccess: () => {
+      notify("Pipeline run cancelled", "success");
+    },
+    onError: (error) => {
+      notify(`Error cancelling run: ${error}`, "error");
+    },
+  });
+
+  const requestCancel = () => {
+    setCancelDialogOpen(true);
+  };
+
+  const dismissCancel = () => {
+    setCancelDialogOpen(false);
+  };
+
+  const confirmCancel = () => {
+    setCancelDialogOpen(false);
+
+    if (!runId) {
+      notify("Failed to cancel run. No run ID found.", "warning");
+      return;
+    }
+
+    if (!available) {
+      notify("Backend is not available. Cannot cancel run.", "warning");
+      return;
+    }
+
+    cancelRun(runId);
+  };
+
+  return {
+    cancelDialogOpen,
+    isCancelling,
+    requestCancel,
+    confirmCancel,
+    dismissCancel,
+  };
+}

--- a/src/routes/v2/pages/RunView/hooks/useClonePipelineRun.ts
+++ b/src/routes/v2/pages/RunView/hooks/useClonePipelineRun.ts
@@ -1,0 +1,86 @@
+import { useMutation } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
+
+import { buildTaskSpecShape } from "@/components/shared/PipelineRunNameTemplate/types";
+import useToastNotification from "@/hooks/useToastNotification";
+import { useExecutionData } from "@/providers/ExecutionDataProvider";
+import { copyRunToPipeline } from "@/services/pipelineRunService";
+import { extractCanonicalName } from "@/utils/canonicalPipelineName";
+import {
+  type ArgumentType,
+  type ComponentSpec,
+  isSecretArgument,
+} from "@/utils/componentSpec";
+import { getInitialName } from "@/utils/getComponentName";
+import { extractTaskArguments } from "@/utils/nodes/taskArguments";
+
+interface CloneVariables {
+  componentSpec: ComponentSpec;
+  runId: string | null | undefined;
+  name: string;
+  taskArguments: Record<string, string>;
+}
+
+export function useClonePipelineRun(
+  componentSpec?: ComponentSpec,
+  runId?: string | null,
+) {
+  const navigate = useNavigate();
+  const notify = useToastNotification();
+  const { rootDetails } = useExecutionData();
+
+  const { mutate: clonePipeline, isPending: isCloning } = useMutation({
+    mutationFn: ({
+      componentSpec,
+      runId,
+      name,
+      taskArguments,
+    }: CloneVariables) =>
+      copyRunToPipeline(componentSpec, runId, name, taskArguments),
+    onSuccess: (result) => {
+      if (!result?.url) return;
+      notify(`Pipeline "${result.name}" cloned`, "success");
+      navigate({ to: result.url });
+    },
+    onError: (error) => {
+      notify(`Error cloning pipeline: ${error}`, "error");
+    },
+  });
+
+  const clone = () => {
+    if (!componentSpec) return;
+
+    const taskSpecArguments = rootDetails?.task_spec.arguments ?? {};
+
+    /**
+     * SecretArguments cannot be converted into strings compatible with inputs,
+     * so drop them from the cloned pipeline's arguments.
+     */
+    const secretArgumentKeys = new Set(
+      Object.entries(taskSpecArguments)
+        .filter(([, value]) => isSecretArgument(value as ArgumentType))
+        .map(([key]) => key),
+    );
+
+    const plainTaskArguments = extractTaskArguments(taskSpecArguments);
+    const taskArguments: Record<string, string> = Object.fromEntries(
+      Object.entries(plainTaskArguments).filter(
+        ([key]) => !secretArgumentKeys.has(key),
+      ),
+    );
+
+    const canonicalName = extractCanonicalName(
+      buildTaskSpecShape(rootDetails?.task_spec, componentSpec),
+    );
+    const name = getInitialName(componentSpec, canonicalName);
+
+    clonePipeline({
+      componentSpec,
+      runId,
+      name,
+      taskArguments,
+    });
+  };
+
+  return { clone, isCloning };
+}

--- a/src/routes/v2/pages/RunView/hooks/useExportPipelineYaml.ts
+++ b/src/routes/v2/pages/RunView/hooks/useExportPipelineYaml.ts
@@ -1,0 +1,19 @@
+import { exportPipeline } from "@/components/shared/ReactFlow/FlowSidebar/sections/components/ExportPipelineButton";
+import type { ComponentSpec } from "@/utils/componentSpec";
+import { componentSpecToYaml } from "@/utils/yaml";
+
+export function useExportPipelineYaml(
+  componentSpec?: ComponentSpec,
+  pipelineName?: string,
+) {
+  const exportYaml = () => {
+    if (!componentSpec) return;
+    const yaml = componentSpecToYaml(componentSpec);
+    exportPipeline(
+      pipelineName ?? componentSpec.name ?? "Untitled Pipeline",
+      yaml,
+    );
+  };
+
+  return { exportYaml };
+}

--- a/src/routes/v2/pages/RunView/hooks/useInspectPipeline.ts
+++ b/src/routes/v2/pages/RunView/hooks/useInspectPipeline.ts
@@ -1,0 +1,12 @@
+import { useNavigate } from "@tanstack/react-router";
+
+export function useInspectPipeline(pipelineName?: string) {
+  const navigate = useNavigate();
+
+  const inspect = () => {
+    if (!pipelineName) return;
+    navigate({ to: `/editor/${encodeURIComponent(pipelineName)}` });
+  };
+
+  return { inspect };
+}

--- a/src/routes/v2/pages/RunView/hooks/useRerunPipelineRun.ts
+++ b/src/routes/v2/pages/RunView/hooks/useRerunPipelineRun.ts
@@ -1,0 +1,87 @@
+import { useMutation } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
+
+import { isAuthorizationRequired } from "@/components/shared/Authentication/helpers";
+import { useAuthLocalStorage } from "@/components/shared/Authentication/useAuthLocalStorage";
+import { useAwaitAuthorization } from "@/components/shared/Authentication/useAwaitAuthorization";
+import { buildTaskSpecShape } from "@/components/shared/PipelineRunNameTemplate/types";
+import { useFlagValue } from "@/components/shared/Settings/useFlags";
+import useToastNotification from "@/hooks/useToastNotification";
+import { useBackend } from "@/providers/BackendProvider";
+import { useExecutionData } from "@/providers/ExecutionDataProvider";
+import { APP_ROUTES } from "@/routes/router";
+import type { PipelineRun } from "@/types/pipelineRun";
+import { extractCanonicalName } from "@/utils/canonicalPipelineName";
+import type { ArgumentType, ComponentSpec } from "@/utils/componentSpec";
+import { submitPipelineRun } from "@/utils/submitPipeline";
+
+interface RerunVariables {
+  componentSpec: ComponentSpec;
+  canonicalName?: string;
+  taskArguments?: Record<string, ArgumentType>;
+}
+
+export function useRerunPipelineRun(componentSpec?: ComponentSpec) {
+  const navigate = useNavigate();
+  const notify = useToastNotification();
+  const { backendUrl } = useBackend();
+  const runNameOverride = useFlagValue("templatized-pipeline-run-name");
+  const { awaitAuthorization, isAuthorized } = useAwaitAuthorization();
+  const { getToken } = useAuthLocalStorage();
+  const { rootDetails } = useExecutionData();
+
+  const getAuthToken = async (): Promise<string | undefined> => {
+    if (isAuthorizationRequired() && !isAuthorized) {
+      const token = await awaitAuthorization();
+      if (token) {
+        return token;
+      }
+    }
+    return getToken();
+  };
+
+  const { mutate: rerunPipeline, isPending: isRerunning } = useMutation({
+    mutationFn: async ({
+      componentSpec,
+      canonicalName,
+      taskArguments,
+    }: RerunVariables) => {
+      const authorizationToken = await getAuthToken();
+      return new Promise<PipelineRun>((resolve, reject) => {
+        submitPipelineRun(componentSpec, backendUrl, {
+          canonicalName,
+          taskArguments,
+          authorizationToken,
+          runNameOverride,
+          onSuccess: resolve,
+          onError: reject,
+        });
+      });
+    },
+    onSuccess: (response) => {
+      navigate({ to: `${APP_ROUTES.RUNS}/${response.id}` });
+    },
+    onError: (error) => {
+      const message = `Failed to submit pipeline. ${error instanceof Error ? error.message : String(error)}`;
+      notify(message, "error");
+    },
+  });
+
+  const rerun = () => {
+    if (!componentSpec) return;
+
+    const canonicalName = extractCanonicalName(
+      buildTaskSpecShape(rootDetails?.task_spec, componentSpec),
+    );
+
+    rerunPipeline({
+      componentSpec,
+      canonicalName,
+      taskArguments: rootDetails?.task_spec.arguments as
+        | Record<string, ArgumentType>
+        | undefined,
+    });
+  };
+
+  return { rerun, isRerunning };
+}

--- a/src/routes/v2/pages/RunView/hooks/useYamlViewer.ts
+++ b/src/routes/v2/pages/RunView/hooks/useYamlViewer.ts
@@ -1,0 +1,15 @@
+import { useState } from "react";
+
+export function useYamlViewer() {
+  const [yamlViewerOpen, setYamlViewerOpen] = useState(false);
+
+  const openYamlViewer = () => {
+    setYamlViewerOpen(true);
+  };
+
+  const closeYamlViewer = () => {
+    setYamlViewerOpen(false);
+  };
+
+  return { yamlViewerOpen, openYamlViewer, closeYamlViewer };
+}

--- a/src/routes/v2/pages/RunView/toolBridge/runViewAgentWorker.ts
+++ b/src/routes/v2/pages/RunView/toolBridge/runViewAgentWorker.ts
@@ -1,11 +1,16 @@
 /**
  * Worker factory for the Run View AI assistant.
  *
- * The Run View window owns spawning its agent worker so the URL literal
- * stays statically analyzable for Vite's worker bundling.
+ * The Run View window owns spawning its agent worker. We import the worker
+ * via `?worker&url` so Vite still runs it through the worker build pipeline
+ * (applying the `worker.plugins` shims), then hand the URL to
+ * `createCrossOriginWorker` which tolerates CDN-hosted (cross-origin) scripts.
  */
+import runViewWorkerUrl from "@/agent/runViewWorker.ts?worker&url";
+import { createCrossOriginWorker } from "@/utils/createCrossOriginWorker";
+
 export function createRunViewAgentWorker(): Worker {
-  return new Worker(new URL("@/agent/runViewWorker.ts", import.meta.url), {
+  return createCrossOriginWorker(runViewWorkerUrl, {
     type: "module",
     name: "tangle-run-view-agent",
   });

--- a/src/routes/v2/shared/components/WindowsMenu.tsx
+++ b/src/routes/v2/shared/components/WindowsMenu.tsx
@@ -21,7 +21,14 @@ import {
 } from "@/routes/v2/shared/windows/viewPresets";
 import { tracking } from "@/utils/tracking";
 
-export const WindowsMenu = observer(function WindowsMenu() {
+interface WindowsMenuProps {
+  /** Tracking id for the menu trigger; sub-events are derived from it. */
+  trackingPrefix: string;
+}
+
+export const WindowsMenu = observer(function WindowsMenu({
+  trackingPrefix,
+}: WindowsMenuProps) {
   const { track } = useAnalytics();
   const { windows } = useSharedStores();
   const sortedWindows = [...windows.getAllWindows()]
@@ -29,7 +36,7 @@ export const WindowsMenu = observer(function WindowsMenu() {
     .sort((a, b) => a.title.localeCompare(b.title));
 
   const applyPreset = (preset: ViewPreset) => {
-    track("v2.pipeline_editor.windows_menu.view_preset.click", {
+    track(`${trackingPrefix}.view_preset.click`, {
       preset_label: preset.label,
     });
     windows.applyViewPreset(preset);
@@ -38,7 +45,7 @@ export const WindowsMenu = observer(function WindowsMenu() {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <MenuTriggerButton {...tracking("v2.pipeline_editor.windows_menu")}>
+        <MenuTriggerButton {...tracking(trackingPrefix)}>
           Windows
         </MenuTriggerButton>
       </DropdownMenuTrigger>
@@ -49,13 +56,10 @@ export const WindowsMenu = observer(function WindowsMenu() {
             checked={win.state !== "hidden"}
             onSelect={(e) => e.preventDefault()}
             onCheckedChange={(checked) => {
-              track(
-                "v2.pipeline_editor.windows_menu.window_visibility.toggle",
-                {
-                  window_id: win.id,
-                  visible: checked,
-                },
-              );
+              track(`${trackingPrefix}.window_visibility.toggle`, {
+                window_id: win.id,
+                visible: checked,
+              });
               if (checked) {
                 win.restore();
               } else {

--- a/src/utils/createCrossOriginWorker.ts
+++ b/src/utils/createCrossOriginWorker.ts
@@ -1,0 +1,40 @@
+/**
+ * Constructs a module Web Worker that works even when the worker script is
+ * served from a different origin than the page (e.g. JS bundles on a CDN
+ * while the document is on the app origin).
+ *
+ * Browsers fetch the top-level worker script in `same-origin` mode, so a
+ * cross-origin script URL is rejected with a `DOMException` thrown
+ * synchronously inside `new Worker`. The fix is to build the worker from a
+ * same-origin `blob:` URL whose only content is an ESM `import` of the real
+ * (cross-origin) worker script. The blob inherits the page origin, satisfying
+ * the same-origin check, and the cross-origin module import is permitted by
+ * CORS. The worker's own relative imports keep resolving against the CDN.
+ *
+ * See https://github.com/vitejs/vite/issues/12662 and
+ * https://github.com/vitejs/vite/issues/13680.
+ */
+export function createCrossOriginWorker(
+  workerUrl: string,
+  options?: WorkerOptions,
+): Worker {
+  const url = new URL(workerUrl, import.meta.url);
+  const workerOptions: WorkerOptions = { type: "module", ...options };
+
+  if (url.origin === self.location.origin) {
+    return new Worker(url, workerOptions);
+  }
+
+  const source = `import ${JSON.stringify(url.href)};`;
+  const blob = new Blob([source], { type: "text/javascript" });
+  const blobUrl = URL.createObjectURL(blob);
+  const worker = new Worker(blobUrl, workerOptions);
+
+  // The blob only needs to live until the worker has fetched it. Revoke on
+  // error immediately, and best-effort after construction, to avoid leaking
+  // object URLs.
+  worker.addEventListener("error", () => URL.revokeObjectURL(blobUrl));
+  setTimeout(() => URL.revokeObjectURL(blobUrl), 0);
+
+  return worker;
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -71,6 +71,20 @@ export default defineConfig(({ mode }) => {
         : []),
     ],
     base: "/",
+    experimental: {
+      // Deploy base is unknown at build time: production serves assets from
+      // the origin root, tophat from a CDN subpath. Emit in-bundle asset
+      // URLs (notably the `?worker&url` scripts) as `import.meta.url`-relative
+      // so they resolve against the chunk location instead of an absolute
+      // `/assets/...` path that drops the tophat prefix. See
+      // `src/utils/createCrossOriginWorker.ts`.
+      renderBuiltUrl(filename, { hostType }) {
+        if (hostType === "js") {
+          return { relative: true };
+        }
+        return { relative: false };
+      },
+    },
     build: {
       manifest: "assets-registry.json",
       sourcemap: "hidden",


### PR DESCRIPTION
## Description

The Run menu in the Run View has been expanded with functional implementations for previously disabled actions, and new actions have been added. Menu items that were placeholders (Cancel Run, Rerun Pipeline) are now fully wired up, and new options for viewing YAML inline, cloning a pipeline, and exporting YAML have been introduced.

Each action has been extracted into its own dedicated hook:

- `useCancelPipelineRun` — manages a confirmation dialog flow before calling the cancel API, with toast notifications on success or failure
- `useClonePipelineRun` — copies the current run's component spec and arguments (excluding secret arguments) into a new pipeline and navigates to it
- `useRerunPipelineRun` — resubmits the pipeline with the original arguments and authorization token, then navigates to the new run
- `useInspectPipeline` — navigates to the pipeline editor for the given pipeline name
- `useExportPipelineYaml` — serializes the component spec to YAML and triggers a file download
- `useYamlViewer` — controls open/close state for the inline YAML viewer

These hooks are composed in `useRunMenuActions`, which is consumed by `RunMenu`. The component now renders a `ConfirmationDialog` for cancel confirmation and a fullscreen `TaskImplementation` viewer when the YAML viewer is open.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Improvement
- [x] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Navigate to a run in the Run View.
2. Open the **Run** menu and verify the following items appear:
   - **View YAML** — opens a fullscreen YAML viewer for the pipeline spec
   - **Inspect Pipeline** — navigates to the editor (only visible when the user has editor access and a pipeline name is available)
   - **Clone Pipeline** — clones the run into a new pipeline and navigates to it
   - **Export YAML** — downloads the pipeline spec as a YAML file
   - **Cancel Run** — visible for in-progress runs created by the current user; clicking opens a confirmation dialog before cancelling
   - **Rerun Pipeline** — visible for completed runs; clicking resubmits the pipeline and navigates to the new run
3. Confirm that loading/disabled states are shown correctly during async operations.
4. Confirm that toast notifications appear on success and error for cancel, clone, and rerun actions.

## Additional Comments

Secret arguments are intentionally excluded when cloning a pipeline run, as they cannot be safely serialized into plain string inputs.