### PR TITLE
poc: scaffold basic tangent dashboard ux

### DIFF
--- a/react-compiler.config.js
+++ b/react-compiler.config.js
@@ -23,6 +23,7 @@ export const REACT_COMPILER_ENABLED_DIRS = [
   "src/components/shared/GitHubAuth",
   "src/components/shared/Authentication",
   "src/routes",
+  "src/routes/tangent",
   "src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx",
   "src/components/shared/ComponentEditor",
   "src/components/shared/Settings",

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -40,6 +40,9 @@ import { BetaFeaturesSettings } from "./Settings/sections/BetaFeaturesSettings";
 import { PreferencesSettings } from "./Settings/sections/PreferencesSettings";
 import { SecretsSettings } from "./Settings/sections/SecretsSettings";
 import { SettingsLayout } from "./Settings/SettingsLayout";
+import { TangentDashboardView } from "./tangent/TangentDashboardView";
+import { TangentLayout } from "./tangent/TangentLayout";
+import { TangentProjectDetailView } from "./tangent/TangentProjectDetailView";
 import { EditorV2 } from "./v2/pages/Editor/EditorV2";
 import { PipelineFoldersPage } from "./v2/pages/PipelineFolders/PipelineFoldersPage";
 import { RunViewV2 } from "./v2/pages/RunView/RunViewV2";
@@ -93,6 +96,8 @@ export const APP_ROUTES = {
   PIPELINE_FOLDERS: "/pipeline-folders",
   PLAYGROUND: "/playground",
   ARTIFACT_PREVIEW: "/artifact/$artifactId",
+  TANGENT: "/tangent",
+  TANGENT_PROJECT: "/tangent/$runId",
 } as const;
 
 const rootRoute = createRootRoute({
@@ -355,6 +360,29 @@ const artifactPreviewRoute = createRoute({
   component: ArtifactPreviewPage,
 });
 
+const tangentLayoutRoute = createRoute({
+  id: "tangent-layout",
+  getParentRoute: () => mainLayout,
+  component: TangentLayout,
+});
+
+const tangentRoute = createRoute({
+  getParentRoute: () => tangentLayoutRoute,
+  path: APP_ROUTES.TANGENT,
+  component: TangentDashboardView,
+});
+
+const tangentProjectRoute = createRoute({
+  getParentRoute: () => tangentLayoutRoute,
+  path: APP_ROUTES.TANGENT_PROJECT,
+  component: TangentProjectDetailView,
+});
+
+const tangentRouteTree = tangentLayoutRoute.addChildren([
+  tangentRoute,
+  tangentProjectRoute,
+]);
+
 const dashboardRouteTree = dashboardRoute.addChildren([
   dashboardIndexRoute,
   dashboardRunsRoute,
@@ -383,6 +411,7 @@ const appRouteTree = mainLayout.addChildren([
   runV2WithSubgraphRoute,
   pipelineFoldersRoute,
   artifactPreviewRoute,
+  tangentRouteTree,
 ]);
 
 const rootRouteTree = rootRoute.addChildren([

--- a/src/routes/tangent/TangentDashboardView.tsx
+++ b/src/routes/tangent/TangentDashboardView.tsx
@@ -1,0 +1,160 @@
+import { useSearch } from "@tanstack/react-router";
+
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icon";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Spinner } from "@/components/ui/spinner";
+import {
+  Table,
+  TableBody,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Heading, Paragraph, Text } from "@/components/ui/typography";
+import { AnalyzeRunBlock } from "@/routes/tangent/components/AnalyzeRunBlock";
+import { HeroBanner } from "@/routes/tangent/components/HeroBanner";
+import { PipelineRow } from "@/routes/tangent/components/PipelineRow";
+import { useReanalyzeAll } from "@/routes/tangent/hooks/useReanalyzeAll";
+import { useTangentPipelines } from "@/routes/tangent/hooks/useTangentPipelines";
+import { PIPELINE_FILTERS } from "@/routes/tangent/labels";
+import type { PipelineFilter, TangentPipeline } from "@/routes/tangent/types";
+
+interface TangentSearch {
+  filter?: string;
+}
+
+function isPipelineFilter(value: unknown): value is PipelineFilter {
+  return (
+    typeof value === "string" && (PIPELINE_FILTERS as string[]).includes(value)
+  );
+}
+
+function matchesFilter(
+  pipeline: TangentPipeline,
+  filter: PipelineFilter,
+): boolean {
+  if (filter === "my_pipelines") return pipeline.builtByCurrentUser;
+  if (filter === "no_scenario")
+    return pipeline.scenarioStatus === "no_scenario";
+  if (filter === "has_results") {
+    return pipeline.scenarioStatus === "results_available";
+  }
+  return true;
+}
+
+/** Sorts by opportunity score (highest first); unscored pipelines sink last. */
+function byOpportunity(a: TangentPipeline, b: TangentPipeline): number {
+  if (a.opportunityScore === null && b.opportunityScore === null) return 0;
+  if (a.opportunityScore === null) return 1;
+  if (b.opportunityScore === null) return -1;
+  return b.opportunityScore - a.opportunityScore;
+}
+
+export function TangentDashboardView() {
+  const search = useSearch({ strict: false }) as TangentSearch;
+  const activeFilter: PipelineFilter = isPipelineFilter(search.filter)
+    ? search.filter
+    : "all";
+
+  const { data: pipelines, isPending, isError } = useTangentPipelines();
+  const reanalyze = useReanalyzeAll();
+
+  const allPipelines = pipelines ?? [];
+  const sorted = [...allPipelines].sort(byOpportunity);
+  const visible = sorted.filter((pipeline) =>
+    matchesFilter(pipeline, activeFilter),
+  );
+  const scoredCount = allPipelines.filter(
+    (pipeline) => pipeline.opportunityScore !== null,
+  ).length;
+
+  const subtitle = isPending
+    ? "Loading pipelines…"
+    : `Ranked by Tangent improvement opportunity · Search team · ${allPipelines.length} pipelines · ${scoredCount} analyzed`;
+
+  return (
+    <BlockStack gap="6">
+      <InlineStack
+        align="space-between"
+        blockAlign="center"
+        wrap="wrap"
+        gap="3"
+      >
+        <BlockStack gap="0">
+          <Heading level={1}>Tangent</Heading>
+          <Text size="sm" tone="subdued">
+            Search Team
+          </Text>
+        </BlockStack>
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={reanalyze.isPending}
+          onClick={() => reanalyze.mutate()}
+        >
+          <Icon
+            name="RefreshCw"
+            size="sm"
+            className={reanalyze.isPending ? "animate-spin" : undefined}
+          />
+          Re-analyze all
+        </Button>
+      </InlineStack>
+
+      <HeroBanner />
+
+      <AnalyzeRunBlock />
+
+      <BlockStack gap="4">
+        <BlockStack gap="1">
+          <Heading level={2}>Pipelines</Heading>
+          <Text size="sm" tone="subdued">
+            {subtitle}
+          </Text>
+        </BlockStack>
+
+        {isPending && (
+          <InlineStack gap="2" blockAlign="center">
+            <Spinner size={18} />
+            <Text size="sm" tone="subdued">
+              Loading…
+            </Text>
+          </InlineStack>
+        )}
+
+        {isError && (
+          <Paragraph size="sm" tone="critical">
+            ⚠️ Could not load pipelines
+          </Paragraph>
+        )}
+
+        {!isPending && !isError && visible.length === 0 && (
+          <Paragraph size="sm" tone="subdued">
+            📭 No pipelines match this filter
+          </Paragraph>
+        )}
+
+        {!isPending && !isError && visible.length > 0 && (
+          <Table>
+            <TableHeader>
+              <TableRow className="text-xs">
+                <TableHead className="w-2/5">Name</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead>Last run</TableHead>
+                <TableHead>Metric</TableHead>
+                <TableHead>Owner</TableHead>
+                <TableHead>Score</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {visible.map((pipeline) => (
+                <PipelineRow key={pipeline.runId} pipeline={pipeline} />
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </BlockStack>
+    </BlockStack>
+  );
+}

--- a/src/routes/tangent/TangentLayout.tsx
+++ b/src/routes/tangent/TangentLayout.tsx
@@ -1,0 +1,176 @@
+import { Link, Outlet, useSearch } from "@tanstack/react-router";
+
+import { Icon, type IconName } from "@/components/ui/icon";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Link as UILink } from "@/components/ui/link";
+import { Text } from "@/components/ui/typography";
+import { cn } from "@/lib/utils";
+import { APP_ROUTES } from "@/routes/router";
+import { PIPELINE_FILTER_LABELS } from "@/routes/tangent/labels";
+import type { PipelineFilter } from "@/routes/tangent/types";
+import {
+  ABOUT_URL,
+  DOCUMENTATION_URL,
+  GIT_COMMIT,
+  GIT_REPO_URL,
+  GIVE_FEEDBACK_URL,
+  PRIVACY_POLICY_URL,
+  TOP_NAV_HEIGHT,
+} from "@/utils/constants";
+
+interface TangentSearch {
+  filter?: string;
+}
+
+interface FilterLink {
+  filter: Exclude<PipelineFilter, "all">;
+  icon: IconName;
+}
+
+const FILTER_LINKS: FilterLink[] = [
+  { filter: "my_pipelines", icon: "GitBranch" },
+  { filter: "no_scenario", icon: "CircleDashed" },
+  { filter: "has_results", icon: "ChartLine" },
+];
+
+const navItemClass = (isActive: boolean) =>
+  cn(
+    "w-full px-3 py-2 rounded-md text-sm cursor-pointer hover:bg-accent",
+    isActive && "bg-accent font-medium",
+  );
+
+export function TangentLayout() {
+  const search = useSearch({ strict: false }) as TangentSearch;
+  const activeFilter = search.filter;
+
+  return (
+    <div
+      className="flex w-full overflow-hidden"
+      style={{ height: `calc(100vh - ${TOP_NAV_HEIGHT}px)` }}
+    >
+      {/* Sidebar — fixed height, independent scroll */}
+      <div className="w-56 shrink-0 border-r border-border flex flex-col overflow-y-auto">
+        {/* Tangent heading */}
+        <div className="px-6 pt-6 pb-4 shrink-0">
+          <Text size="lg" weight="semibold">
+            Tangent
+          </Text>
+        </div>
+
+        <BlockStack gap="1" className="px-3">
+          <Link
+            to={APP_ROUTES.TANGENT}
+            search={{ filter: undefined }}
+            className="w-full"
+          >
+            {({ isActive }) => (
+              <InlineStack
+                gap="2"
+                blockAlign="center"
+                className={navItemClass(isActive && !activeFilter)}
+              >
+                <Icon name="LayoutDashboard" size="sm" />
+                <Text size="sm">Tangent Dashboard</Text>
+              </InlineStack>
+            )}
+          </Link>
+
+          {FILTER_LINKS.map(({ filter, icon }) => (
+            <Link
+              key={filter}
+              to={APP_ROUTES.TANGENT}
+              search={{ filter }}
+              className="w-full"
+            >
+              <InlineStack
+                gap="2"
+                blockAlign="center"
+                className={navItemClass(activeFilter === filter)}
+              >
+                <Icon name={icon} size="sm" />
+                <Text size="sm">{PIPELINE_FILTER_LABELS[filter]}</Text>
+              </InlineStack>
+            </Link>
+          ))}
+        </BlockStack>
+
+        {/* Spacer */}
+        <div className="flex-1 min-h-4" />
+
+        {/* Bottom utilities */}
+        <BlockStack gap="1" className="px-3 border-t border-border pt-3 pb-3">
+          <Link to={APP_ROUTES.DASHBOARD} className="w-full">
+            <InlineStack
+              gap="2"
+              blockAlign="center"
+              className={navItemClass(false)}
+            >
+              <Icon name="ArrowLeft" size="sm" />
+              <Text size="sm">Back to My Dashboard</Text>
+            </InlineStack>
+          </Link>
+          <UILink
+            href={DOCUMENTATION_URL}
+            external
+            variant="block"
+            size="sm"
+            className={cn("w-full", navItemClass(false))}
+          >
+            <InlineStack gap="2" blockAlign="center" className="flex-1">
+              <Icon name="CircleQuestionMark" size="sm" />
+              <Text size="sm">Docs</Text>
+            </InlineStack>
+          </UILink>
+          <Link to={APP_ROUTES.SETTINGS_BACKEND} className="w-full">
+            {({ isActive }) => (
+              <InlineStack
+                gap="2"
+                blockAlign="center"
+                className={navItemClass(isActive)}
+              >
+                <Icon name="Settings" size="sm" />
+                <Text size="sm">Settings</Text>
+              </InlineStack>
+            )}
+          </Link>
+
+          {/* Footer links */}
+          <BlockStack className="gap-0.5 pt-2 mt-1 border-t border-border">
+            {[
+              { label: "About", href: ABOUT_URL },
+              { label: "Give feedback", href: GIVE_FEEDBACK_URL },
+              { label: "Privacy policy", href: PRIVACY_POLICY_URL },
+            ].map(({ label, href }) => (
+              <UILink
+                key={label}
+                href={href}
+                target="_blank"
+                rel="noopener noreferrer"
+                variant="block"
+                size="xs"
+                className="px-3 py-1 text-muted-foreground hover:text-foreground rounded-md hover:bg-accent"
+              >
+                {label}
+              </UILink>
+            ))}
+            <UILink
+              href={`${GIT_REPO_URL}/commit/${GIT_COMMIT}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              variant="block"
+              size="xs"
+              className="px-3 py-1 text-muted-foreground hover:text-foreground rounded-md hover:bg-accent font-mono"
+            >
+              ver: {GIT_COMMIT.substring(0, 6)}
+            </UILink>
+          </BlockStack>
+        </BlockStack>
+      </div>
+
+      {/* Main content — independent scroll */}
+      <div className="flex-1 min-w-0 overflow-y-auto px-8 pb-6 pt-4">
+        <Outlet />
+      </div>
+    </div>
+  );
+}

--- a/src/routes/tangent/TangentProjectDetailView.tsx
+++ b/src/routes/tangent/TangentProjectDetailView.tsx
@@ -1,0 +1,118 @@
+import { Link, useParams } from "@tanstack/react-router";
+
+import { Icon } from "@/components/ui/icon";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Spinner } from "@/components/ui/spinner";
+import { Heading, Paragraph, Text } from "@/components/ui/typography";
+import { APP_ROUTES } from "@/routes/router";
+import { CurrentPerformance } from "@/routes/tangent/components/detail/CurrentPerformance";
+import { ResultsSection } from "@/routes/tangent/components/detail/ResultsSection";
+import { ScenarioSection } from "@/routes/tangent/components/detail/ScenarioSection";
+import { TangentAnalysis } from "@/routes/tangent/components/detail/TangentAnalysis";
+import { OpportunityScoreRing } from "@/routes/tangent/components/OpportunityScoreRing";
+import { RunStatusIndicator } from "@/routes/tangent/components/RunStatusIndicator";
+import { ScenarioStatusBadge } from "@/routes/tangent/components/ScenarioStatusBadge";
+import { useTangentPipeline } from "@/routes/tangent/hooks/useTangentPipeline";
+import { getCreatorHandle } from "@/routes/tangent/labels";
+
+export function TangentProjectDetailView() {
+  const { runId = "" } = useParams({ strict: false });
+  const { data: pipeline, isPending, isError } = useTangentPipeline(runId);
+
+  const backLink = (
+    <Link
+      to={APP_ROUTES.TANGENT}
+      className="text-sm text-muted-foreground hover:text-foreground inline-flex items-center gap-1"
+    >
+      ← All projects
+    </Link>
+  );
+
+  if (isPending) {
+    return (
+      <BlockStack gap="4">
+        {backLink}
+        <InlineStack gap="2" blockAlign="center">
+          <Spinner size={18} />
+          <Text size="sm" tone="subdued">
+            Loading…
+          </Text>
+        </InlineStack>
+      </BlockStack>
+    );
+  }
+
+  if (isError || !pipeline) {
+    return (
+      <BlockStack gap="4">
+        {backLink}
+        <Paragraph size="sm" tone="critical">
+          ⚠️ Could not load this pipeline
+        </Paragraph>
+      </BlockStack>
+    );
+  }
+
+  const creator = getCreatorHandle(pipeline.ownerEmail);
+
+  return (
+    <BlockStack gap="6">
+      <InlineStack
+        align="space-between"
+        blockAlign="center"
+        wrap="wrap"
+        gap="3"
+      >
+        {backLink}
+        <InlineStack gap="3" blockAlign="center" wrap="wrap">
+          <RunStatusIndicator status={pipeline.runStatus} />
+          <Text size="sm" font="mono" tone="subdued">
+            Run {pipeline.runId}
+          </Text>
+          {pipeline.oasisUrl && (
+            <a
+              href={pipeline.oasisUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-sm text-muted-foreground hover:text-foreground inline-flex items-center gap-1"
+            >
+              View in Oasis
+              <Icon name="ExternalLink" size="xs" />
+            </a>
+          )}
+        </InlineStack>
+      </InlineStack>
+
+      <InlineStack align="space-between" blockAlign="start" wrap="wrap" gap="4">
+        <BlockStack gap="2" className="min-w-0 flex-1">
+          <InlineStack gap="3" blockAlign="center" wrap="wrap">
+            <Heading level={1}>{pipeline.name}</Heading>
+            <ScenarioStatusBadge status={pipeline.scenarioStatus} />
+          </InlineStack>
+          <Text size="sm" tone="subdued">
+            {pipeline.metricName ? `${pipeline.metricName} · ` : ""}
+            {pipeline.baselineValue !== undefined
+              ? `Baseline: ${pipeline.baselineValue.toFixed(4)}`
+              : "No baseline set"}
+            {creator ? ` · ${creator}` : ""}
+          </Text>
+        </BlockStack>
+        {pipeline.analyzing ? (
+          <Spinner size={28} />
+        ) : (
+          <OpportunityScoreRing score={pipeline.opportunityScore} showLabel />
+        )}
+      </InlineStack>
+
+      <CurrentPerformance pipeline={pipeline} />
+
+      <TangentAnalysis pipeline={pipeline} />
+
+      {pipeline.scenarioStatus === "results_available" && pipeline.results && (
+        <ResultsSection results={pipeline.results} />
+      )}
+
+      <ScenarioSection ideas={pipeline.ideas} />
+    </BlockStack>
+  );
+}

--- a/src/routes/tangent/components/AnalyzeRunBlock.tsx
+++ b/src/routes/tangent/components/AnalyzeRunBlock.tsx
@@ -1,0 +1,68 @@
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Heading, Paragraph, Text } from "@/components/ui/typography";
+import useToastNotification from "@/hooks/useToastNotification";
+
+const RUN_ID_PATTERN = /^019[0-9a-f]{17}$/;
+
+const INVALID_ID_MESSAGE =
+  'Run IDs are 20 hex characters starting with "019", e.g. 019db6c661691a51840d';
+
+export function AnalyzeRunBlock() {
+  const notify = useToastNotification();
+  const [value, setValue] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const handleAnalyze = () => {
+    const normalized = value.trim().toLowerCase();
+    if (!RUN_ID_PATTERN.test(normalized)) {
+      setError(INVALID_ID_MESSAGE);
+      return;
+    }
+    setError(null);
+    // Phase 1: the analyze flow is mocked and not yet wired.
+    notify(
+      "Analyzing arbitrary runs is coming soon — browse the pipelines below for now.",
+      "info",
+    );
+  };
+
+  return (
+    <BlockStack
+      gap="3"
+      className="rounded-xl border border-border bg-background p-6"
+    >
+      <BlockStack gap="1">
+        <Heading level={2}>Add your run here</Heading>
+        <Paragraph size="sm" tone="subdued">
+          Get an instant optimization score and scenario recommendations for any
+          Tangle run
+        </Paragraph>
+      </BlockStack>
+      <InlineStack gap="2" blockAlign="start" wrap="nowrap">
+        <BlockStack gap="1" className="flex-1">
+          <Input
+            value={value}
+            placeholder="Paste a Tangle run ID to analyze…"
+            aria-invalid={error !== null}
+            aria-label="Tangle run ID"
+            onChange={(event) => {
+              setValue(event.target.value);
+              if (error) setError(null);
+            }}
+            onEnter={handleAnalyze}
+          />
+          {error && (
+            <Text size="xs" tone="critical">
+              {error}
+            </Text>
+          )}
+        </BlockStack>
+        <Button onClick={handleAnalyze}>Analyze</Button>
+      </InlineStack>
+    </BlockStack>
+  );
+}

--- a/src/routes/tangent/components/HeroBanner.tsx
+++ b/src/routes/tangent/components/HeroBanner.tsx
@@ -1,0 +1,24 @@
+import { BlockStack } from "@/components/ui/layout";
+import { Heading, Paragraph } from "@/components/ui/typography";
+import { StatBoxes } from "@/routes/tangent/components/StatBoxes";
+
+export function HeroBanner() {
+  return (
+    <BlockStack
+      gap="4"
+      className="rounded-xl border border-border bg-muted/30 p-6"
+    >
+      <BlockStack gap="2">
+        <Heading level={1}>
+          Scenarios in. Optimized models out. Tangent ships.
+        </Heading>
+        <Paragraph size="sm" tone="subdued" className="max-w-3xl">
+          Drop a pipeline. Build a scenario in minutes. Tangent runs the
+          experiments autonomously — Bayesian search, failure recovery,
+          best-config promotion. No babysitting required.
+        </Paragraph>
+      </BlockStack>
+      <StatBoxes />
+    </BlockStack>
+  );
+}

--- a/src/routes/tangent/components/IdeaTypeChip.tsx
+++ b/src/routes/tangent/components/IdeaTypeChip.tsx
@@ -1,0 +1,15 @@
+import { Badge } from "@/components/ui/badge";
+import { IDEA_TYPE_LABELS } from "@/routes/tangent/labels";
+import type { IdeaType } from "@/routes/tangent/types";
+
+interface IdeaTypeChipProps {
+  type: IdeaType;
+}
+
+export function IdeaTypeChip({ type }: IdeaTypeChipProps) {
+  return (
+    <Badge variant="outline" shape="rounded" size="sm">
+      {IDEA_TYPE_LABELS[type]}
+    </Badge>
+  );
+}

--- a/src/routes/tangent/components/MetricDelta.tsx
+++ b/src/routes/tangent/components/MetricDelta.tsx
@@ -1,0 +1,29 @@
+import { Text } from "@/components/ui/typography";
+import { cn } from "@/lib/utils";
+
+interface MetricDeltaProps {
+  /** Percentage change vs baseline; positive renders green, negative red. */
+  deltaPct: number;
+  className?: string;
+}
+
+export function MetricDelta({ deltaPct, className }: MetricDeltaProps) {
+  const isPositive = deltaPct >= 0;
+  const arrow = isPositive ? "▲" : "▼";
+  const sign = isPositive ? "+" : "";
+  return (
+    <Text
+      size="sm"
+      weight="semibold"
+      className={cn(
+        isPositive
+          ? "text-emerald-600 dark:text-emerald-400"
+          : "text-destructive",
+        className,
+      )}
+    >
+      {arrow} {sign}
+      {deltaPct.toFixed(1)}%
+    </Text>
+  );
+}

--- a/src/routes/tangent/components/OpportunityScoreRing.tsx
+++ b/src/routes/tangent/components/OpportunityScoreRing.tsx
@@ -1,0 +1,93 @@
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { Text } from "@/components/ui/typography";
+import { cn } from "@/lib/utils";
+import {
+  getScoreColorClass,
+  getScoreStrokeClass,
+} from "@/routes/tangent/labels";
+
+interface OpportunityScoreRingProps {
+  score: number | null;
+  /** Pixel diameter of the ring. */
+  size?: number;
+  /** Show the "Opportunity" label beneath the ring. */
+  showLabel?: boolean;
+}
+
+const STROKE_WIDTH = 6;
+
+export function OpportunityScoreRing({
+  score,
+  size = 64,
+  showLabel = false,
+}: OpportunityScoreRingProps) {
+  const radius = (size - STROKE_WIDTH) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const progress = score === null ? 0 : Math.max(0, Math.min(100, score)) / 100;
+  const dashOffset = circumference * (1 - progress);
+
+  const tooltip =
+    score === null
+      ? "Not yet analyzed — click Re-analyze"
+      : "Tangent Opportunity Score";
+
+  return (
+    <div className="flex flex-col items-center gap-1">
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div
+            className="relative flex items-center justify-center"
+            style={{ width: size, height: size }}
+          >
+            <svg
+              width={size}
+              height={size}
+              viewBox={`0 0 ${size} ${size}`}
+              className="-rotate-90"
+              aria-hidden
+            >
+              <circle
+                cx={size / 2}
+                cy={size / 2}
+                r={radius}
+                fill="none"
+                strokeWidth={STROKE_WIDTH}
+                className="stroke-muted"
+              />
+              {score !== null && (
+                <circle
+                  cx={size / 2}
+                  cy={size / 2}
+                  r={radius}
+                  fill="none"
+                  strokeWidth={STROKE_WIDTH}
+                  strokeLinecap="round"
+                  className={getScoreStrokeClass(score)}
+                  strokeDasharray={circumference}
+                  style={{ strokeDashoffset: dashOffset }}
+                />
+              )}
+            </svg>
+            <Text
+              size="md"
+              weight="bold"
+              className={cn("absolute", getScoreColorClass(score))}
+            >
+              {score === null ? "—" : score}
+            </Text>
+          </div>
+        </TooltipTrigger>
+        <TooltipContent>{tooltip}</TooltipContent>
+      </Tooltip>
+      {showLabel && (
+        <Text size="xs" tone="subdued">
+          Opportunity
+        </Text>
+      )}
+    </div>
+  );
+}

--- a/src/routes/tangent/components/PipelineRow.tsx
+++ b/src/routes/tangent/components/PipelineRow.tsx
@@ -1,0 +1,85 @@
+import { useNavigate } from "@tanstack/react-router";
+import type { MouseEvent } from "react";
+
+import { InlineStack } from "@/components/ui/layout";
+import { Spinner } from "@/components/ui/spinner";
+import { TableCell, TableRow } from "@/components/ui/table";
+import { Text } from "@/components/ui/typography";
+import { APP_ROUTES } from "@/routes/router";
+import { MetricDelta } from "@/routes/tangent/components/MetricDelta";
+import { OpportunityScoreRing } from "@/routes/tangent/components/OpportunityScoreRing";
+import { RunStatusIndicator } from "@/routes/tangent/components/RunStatusIndicator";
+import { ScenarioStatusBadge } from "@/routes/tangent/components/ScenarioStatusBadge";
+import { getCreatorHandle } from "@/routes/tangent/labels";
+import type { TangentPipeline } from "@/routes/tangent/types";
+import { formatRelativeTime } from "@/utils/date";
+
+interface PipelineRowProps {
+  pipeline: TangentPipeline;
+}
+
+export function PipelineRow({ pipeline }: PipelineRowProps) {
+  const navigate = useNavigate();
+  const creator = getCreatorHandle(pipeline.ownerEmail);
+  const detailPath = `/tangent/${pipeline.runId}`;
+
+  const handleRowClick = (event: MouseEvent<HTMLElement>) => {
+    if (event.ctrlKey || event.metaKey) {
+      window.open(detailPath, "_blank");
+      return;
+    }
+    void navigate({
+      to: APP_ROUTES.TANGENT_PROJECT,
+      params: { runId: pipeline.runId },
+    });
+  };
+
+  return (
+    <TableRow onClick={handleRowClick} className="cursor-pointer h-12">
+      <TableCell>
+        <InlineStack gap="2" blockAlign="center" wrap="nowrap">
+          <Text size="sm" weight="semibold" className="truncate max-w-80">
+            {pipeline.name}
+          </Text>
+          <ScenarioStatusBadge status={pipeline.scenarioStatus} />
+        </InlineStack>
+      </TableCell>
+      <TableCell>
+        <RunStatusIndicator status={pipeline.runStatus} />
+      </TableCell>
+      <TableCell>
+        <Text size="sm" tone="subdued">
+          {formatRelativeTime(new Date(pipeline.lastRunAt))}
+        </Text>
+      </TableCell>
+      <TableCell>
+        {pipeline.metricName && pipeline.metricValue !== undefined ? (
+          <InlineStack gap="2" blockAlign="center" wrap="nowrap">
+            <Text size="sm">
+              {pipeline.metricName}: {pipeline.metricValue.toFixed(4)}
+            </Text>
+            {pipeline.metricDeltaPct !== undefined && (
+              <MetricDelta deltaPct={pipeline.metricDeltaPct} />
+            )}
+          </InlineStack>
+        ) : (
+          <Text size="sm" tone="subdued">
+            —
+          </Text>
+        )}
+      </TableCell>
+      <TableCell>
+        <Text size="sm" tone="subdued">
+          {creator ?? "—"}
+        </Text>
+      </TableCell>
+      <TableCell className="w-0">
+        {pipeline.analyzing ? (
+          <Spinner size={20} />
+        ) : (
+          <OpportunityScoreRing score={pipeline.opportunityScore} size={36} />
+        )}
+      </TableCell>
+    </TableRow>
+  );
+}

--- a/src/routes/tangent/components/RunStatusIndicator.tsx
+++ b/src/routes/tangent/components/RunStatusIndicator.tsx
@@ -1,0 +1,27 @@
+import { InlineStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
+import { cn } from "@/lib/utils";
+import { RUN_STATUS_LABELS } from "@/routes/tangent/labels";
+import type { RunStatus } from "@/routes/tangent/types";
+
+interface RunStatusIndicatorProps {
+  status: RunStatus;
+}
+
+const DOT_CLASS: Record<RunStatus, string> = {
+  succeeded: "bg-emerald-500",
+  failed: "bg-destructive",
+  running: "bg-amber-500 animate-pulse",
+};
+
+export function RunStatusIndicator({ status }: RunStatusIndicatorProps) {
+  return (
+    <InlineStack gap="2" blockAlign="center" wrap="nowrap">
+      <span
+        className={cn("inline-block size-2 rounded-full", DOT_CLASS[status])}
+        aria-hidden
+      />
+      <Text size="sm">{RUN_STATUS_LABELS[status]}</Text>
+    </InlineStack>
+  );
+}

--- a/src/routes/tangent/components/ScenarioStatusBadge.tsx
+++ b/src/routes/tangent/components/ScenarioStatusBadge.tsx
@@ -1,0 +1,34 @@
+import { Badge } from "@/components/ui/badge";
+import { SCENARIO_STATUS_LABELS } from "@/routes/tangent/labels";
+import type { ScenarioStatus } from "@/routes/tangent/types";
+
+interface ScenarioStatusBadgeProps {
+  status: ScenarioStatus;
+}
+
+const STATUS_PREFIX: Record<ScenarioStatus, string> = {
+  no_scenario: "○",
+  scenario_built: "✓",
+  scenario_ready: "●",
+  tangent_running: "◎",
+  results_available: "✓",
+};
+
+const STATUS_VARIANT: Record<
+  ScenarioStatus,
+  "secondary" | "default" | "outline"
+> = {
+  no_scenario: "outline",
+  scenario_built: "secondary",
+  scenario_ready: "secondary",
+  tangent_running: "default",
+  results_available: "default",
+};
+
+export function ScenarioStatusBadge({ status }: ScenarioStatusBadgeProps) {
+  return (
+    <Badge variant={STATUS_VARIANT[status]} shape="rounded">
+      {STATUS_PREFIX[status]} {SCENARIO_STATUS_LABELS[status]}
+    </Badge>
+  );
+}

--- a/src/routes/tangent/components/StatBoxes.tsx
+++ b/src/routes/tangent/components/StatBoxes.tsx
@@ -1,0 +1,42 @@
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
+import { useTangentStats } from "@/routes/tangent/hooks/useTangentStats";
+
+interface StatBoxProps {
+  label: string;
+  value: number | null | undefined;
+}
+
+/** Renders an em dash while loading and when a count is zero, never `0`. */
+function StatBox({ label, value }: StatBoxProps) {
+  const display =
+    value === null || value === undefined || value === 0 ? "—" : value;
+
+  return (
+    <BlockStack
+      gap="1"
+      className="flex-1 rounded-lg border border-border bg-background p-4"
+    >
+      <Text size="2xl" weight="bold">
+        {display}
+      </Text>
+      <Text size="sm" tone="subdued">
+        {label}
+      </Text>
+    </BlockStack>
+  );
+}
+
+export function StatBoxes() {
+  const { data: stats, isPending } = useTangentStats();
+
+  const resolved = isPending ? undefined : stats;
+
+  return (
+    <InlineStack gap="4" wrap="nowrap" className="w-full">
+      <StatBox label="Members" value={resolved?.members} />
+      <StatBox label="Scenarios" value={resolved?.scenarios} />
+      <StatBox label="With Results" value={resolved?.withResults} />
+    </InlineStack>
+  );
+}

--- a/src/routes/tangent/components/detail/CurrentPerformance.tsx
+++ b/src/routes/tangent/components/detail/CurrentPerformance.tsx
@@ -1,0 +1,84 @@
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
+import { cn } from "@/lib/utils";
+import type { TangentPipeline } from "@/routes/tangent/types";
+
+interface CurrentPerformanceProps {
+  pipeline: TangentPipeline;
+}
+
+function PerformanceBox({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <BlockStack
+      gap="1"
+      className="flex-1 rounded-lg border border-border bg-background p-4"
+    >
+      <Text size="xs" tone="subdued">
+        {label}
+      </Text>
+      {children}
+    </BlockStack>
+  );
+}
+
+export function CurrentPerformance({ pipeline }: CurrentPerformanceProps) {
+  const hasMetric =
+    pipeline.metricName !== undefined && pipeline.metricValue !== undefined;
+  if (!pipeline.metricName) return null;
+
+  const deltaPct = pipeline.metricDeltaPct;
+
+  return (
+    <InlineStack gap="4" wrap="wrap" className="w-full">
+      <PerformanceBox label={`${pipeline.metricName} (current)`}>
+        {hasMetric ? (
+          <InlineStack gap="2" blockAlign="baseline" wrap="wrap">
+            <Text size="lg" weight="bold">
+              {pipeline.metricValue?.toFixed(4)}
+            </Text>
+            {deltaPct !== undefined && (
+              <Text
+                size="sm"
+                weight="semibold"
+                className={cn(
+                  deltaPct >= 0
+                    ? "text-emerald-600 dark:text-emerald-400"
+                    : "text-destructive",
+                )}
+              >
+                {deltaPct >= 0 ? "+" : ""}
+                {deltaPct.toFixed(1)}% vs baseline
+              </Text>
+            )}
+          </InlineStack>
+        ) : (
+          <Text size="sm" tone="subdued">
+            last run had no result
+          </Text>
+        )}
+      </PerformanceBox>
+
+      <PerformanceBox label="Baseline">
+        <Text size="lg" weight="bold">
+          {pipeline.baselineValue !== undefined
+            ? pipeline.baselineValue.toFixed(4)
+            : "—"}
+        </Text>
+      </PerformanceBox>
+
+      <PerformanceBox label="Opportunity Score">
+        <Text size="lg" weight="bold">
+          {pipeline.opportunityScore !== null
+            ? `${pipeline.opportunityScore}/100`
+            : "Not scored"}
+        </Text>
+      </PerformanceBox>
+    </InlineStack>
+  );
+}

--- a/src/routes/tangent/components/detail/IdeaCard.tsx
+++ b/src/routes/tangent/components/detail/IdeaCard.tsx
@@ -1,0 +1,161 @@
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Spinner } from "@/components/ui/spinner";
+import { Text } from "@/components/ui/typography";
+import useToastNotification from "@/hooks/useToastNotification";
+import { IdeaTypeChip } from "@/routes/tangent/components/IdeaTypeChip";
+import type { ExperimentIdea } from "@/routes/tangent/types";
+import { formatRelativeTime } from "@/utils/date";
+
+interface IdeaCardProps {
+  idea: ExperimentIdea;
+}
+
+const STUB_MESSAGE =
+  "This action is not wired up in the Phase 1 prototype yet.";
+
+function BuildStatePill({ idea }: { idea: ExperimentIdea }) {
+  if (idea.buildState === "building") {
+    return (
+      <InlineStack gap="1" blockAlign="center" wrap="nowrap">
+        <Spinner size={12} />
+        <Badge variant="default" shape="rounded" size="sm">
+          Building
+        </Badge>
+      </InlineStack>
+    );
+  }
+  if (idea.buildState === "built") {
+    return (
+      <Badge variant="default" shape="rounded" size="sm">
+        ✓ Built
+      </Badge>
+    );
+  }
+  if (idea.buildState === "failed") {
+    return (
+      <Badge variant="destructive" shape="rounded" size="sm">
+        ⚠ Failed
+      </Badge>
+    );
+  }
+  return null;
+}
+
+function IdeaActions({ idea }: { idea: ExperimentIdea }) {
+  const notify = useToastNotification();
+  const stub = () => notify(STUB_MESSAGE, "info");
+
+  if (idea.buildState === "built") {
+    return (
+      <InlineStack gap="2" wrap="wrap">
+        <Button size="xs" variant="outline" onClick={stub}>
+          View YAML
+        </Button>
+        <Button size="xs" variant="outline" onClick={stub}>
+          ↗ Send to River
+        </Button>
+        <Button size="xs" variant="ghost" onClick={stub}>
+          ↻ Rebuild
+        </Button>
+      </InlineStack>
+    );
+  }
+  if (idea.buildState === "unbuilt") {
+    return idea.source === "tangent" ? (
+      <Button size="xs" variant="outline" onClick={stub}>
+        ⚡ Auto build
+      </Button>
+    ) : (
+      <Button size="xs" variant="outline" onClick={stub}>
+        ▶ Run
+      </Button>
+    );
+  }
+  if (idea.buildState === "failed") {
+    return (
+      <Button size="xs" variant="outline" onClick={stub}>
+        ↻ Retry
+      </Button>
+    );
+  }
+  return null;
+}
+
+function IdeaVotes({ idea }: { idea: ExperimentIdea }) {
+  const notify = useToastNotification();
+  if (idea.source !== "tangent") return null;
+  const stub = () => notify(STUB_MESSAGE, "info");
+  return (
+    <InlineStack gap="2" wrap="nowrap">
+      <Button size="xs" variant="ghost" onClick={stub}>
+        👍 {idea.upvotes ? idea.upvotes : ""}
+      </Button>
+      <Button size="xs" variant="ghost" onClick={stub}>
+        👎 {idea.downvotes ? idea.downvotes : ""}
+      </Button>
+    </InlineStack>
+  );
+}
+
+export function IdeaCard({ idea }: IdeaCardProps) {
+  return (
+    <BlockStack
+      gap="3"
+      className="rounded-lg border border-border bg-background p-4"
+    >
+      <InlineStack gap="3" blockAlign="start" align="space-between" wrap="wrap">
+        <BlockStack gap="2" className="min-w-0 flex-1">
+          <InlineStack gap="2" blockAlign="center" wrap="wrap">
+            <Badge
+              variant={idea.source === "tangent" ? "secondary" : "outline"}
+              shape="rounded"
+              size="sm"
+            >
+              {idea.source === "tangent" ? "Tangent" : "Human"}
+            </Badge>
+            <IdeaTypeChip type={idea.type} />
+            {idea.impact && (
+              <Text size="xs" tone="subdued">
+                Impact: {idea.impact}
+              </Text>
+            )}
+            <BuildStatePill idea={idea} />
+          </InlineStack>
+          <Text size="sm" weight="semibold">
+            {idea.title}
+          </Text>
+          <Text size="sm" tone="subdued">
+            {idea.evidence}
+          </Text>
+          {idea.author && (
+            <Text size="xs" tone="subdued">
+              by {idea.author}
+            </Text>
+          )}
+          {idea.buildState === "built" && idea.builtBy && (
+            <InlineStack gap="2" blockAlign="center" wrap="wrap">
+              <Text
+                size="xs"
+                className="text-emerald-600 dark:text-emerald-400"
+              >
+                ✓ Built by {idea.builtBy}
+                {idea.builtAt
+                  ? ` · ${formatRelativeTime(new Date(idea.builtAt))}`
+                  : ""}
+              </Text>
+              {idea.unverifiedCount ? (
+                <Text size="xs" tone="critical">
+                  {idea.unverifiedCount} UNVERIFIED
+                </Text>
+              ) : null}
+            </InlineStack>
+          )}
+        </BlockStack>
+        <IdeaVotes idea={idea} />
+      </InlineStack>
+      <IdeaActions idea={idea} />
+    </BlockStack>
+  );
+}

--- a/src/routes/tangent/components/detail/ResultsSection.tsx
+++ b/src/routes/tangent/components/detail/ResultsSection.tsx
@@ -1,0 +1,92 @@
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Heading, Paragraph, Text } from "@/components/ui/typography";
+import type { ResultsCase, TangentResults } from "@/routes/tangent/types";
+
+interface ResultsSectionProps {
+  results: TangentResults;
+}
+
+function CaseTable({ title, cases }: { title: string; cases: ResultsCase[] }) {
+  return (
+    <BlockStack gap="2" className="flex-1">
+      <Text size="sm" weight="semibold">
+        {title}
+      </Text>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Example</TableHead>
+            <TableHead>Baseline</TableHead>
+            <TableHead>Best</TableHead>
+            <TableHead>Δ</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {cases.map((row) => (
+            <TableRow key={row.example}>
+              <TableCell>{row.example}</TableCell>
+              <TableCell>{row.baseline}</TableCell>
+              <TableCell>{row.best}</TableCell>
+              <TableCell>{row.delta}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </BlockStack>
+  );
+}
+
+export function ResultsSection({ results }: ResultsSectionProps) {
+  return (
+    <BlockStack gap="3">
+      <Heading level={2}>Previous Tangent Results</Heading>
+      <Paragraph
+        size="sm"
+        className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 p-3"
+      >
+        ✓ Optimization complete — {results.metricDelta}
+      </Paragraph>
+
+      <InlineStack gap="6" wrap="wrap">
+        <BlockStack gap="1">
+          <Text size="xs" tone="subdued">
+            Best delta
+          </Text>
+          <Text size="sm" weight="semibold">
+            {results.bestDelta}
+          </Text>
+        </BlockStack>
+        <BlockStack gap="1">
+          <Text size="xs" tone="subdued">
+            Best run
+          </Text>
+          <Text size="sm" font="mono">
+            {results.bestRunId}
+          </Text>
+        </BlockStack>
+      </InlineStack>
+
+      <BlockStack gap="1">
+        <Text size="xs" tone="subdued">
+          Config changes
+        </Text>
+        <pre className="overflow-x-auto rounded-md border border-border bg-muted/40 p-3 text-xs font-mono whitespace-pre">
+          {results.configChanges}
+        </pre>
+      </BlockStack>
+
+      <InlineStack gap="6" wrap="wrap" blockAlign="start">
+        <CaseTable title="Top winning cases" cases={results.topWinningCases} />
+        <CaseTable title="Top losing cases" cases={results.topLosingCases} />
+      </InlineStack>
+    </BlockStack>
+  );
+}

--- a/src/routes/tangent/components/detail/ScenarioSection.tsx
+++ b/src/routes/tangent/components/detail/ScenarioSection.tsx
@@ -1,0 +1,92 @@
+import { Button } from "@/components/ui/button";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Heading, Paragraph, Text } from "@/components/ui/typography";
+import useToastNotification from "@/hooks/useToastNotification";
+import { IdeaCard } from "@/routes/tangent/components/detail/IdeaCard";
+import type { ExperimentIdea } from "@/routes/tangent/types";
+
+interface ScenarioSectionProps {
+  ideas: ExperimentIdea[];
+}
+
+function builtCount(ideas: ExperimentIdea[]): number {
+  return ideas.filter((idea) => idea.buildState === "built").length;
+}
+
+function IdeaSubsection({
+  title,
+  ideas,
+  emptyMessage,
+}: {
+  title: string;
+  ideas: ExperimentIdea[];
+  emptyMessage: string;
+}) {
+  return (
+    <BlockStack gap="2">
+      <Text size="sm" weight="semibold">
+        {title} ({builtCount(ideas)}/{ideas.length} built)
+      </Text>
+      {ideas.length === 0 ? (
+        <Paragraph size="sm" tone="subdued">
+          {emptyMessage}
+        </Paragraph>
+      ) : (
+        <BlockStack gap="2">
+          {ideas
+            .slice()
+            .sort((a, b) => a.rank - b.rank)
+            .map((idea) => (
+              <IdeaCard key={idea.id} idea={idea} />
+            ))}
+        </BlockStack>
+      )}
+    </BlockStack>
+  );
+}
+
+export function ScenarioSection({ ideas }: ScenarioSectionProps) {
+  const notify = useToastNotification();
+  const tangentIdeas = ideas.filter((idea) => idea.source === "tangent");
+  const humanIdeas = ideas.filter((idea) => idea.source === "human");
+
+  return (
+    <BlockStack gap="4">
+      <InlineStack
+        align="space-between"
+        blockAlign="center"
+        wrap="wrap"
+        gap="3"
+      >
+        <Heading level={2}>Scenarios</Heading>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={() =>
+            notify(
+              "Creating scenarios is not wired up in the Phase 1 prototype yet.",
+              "info",
+            )
+          }
+        >
+          + New Scenario
+        </Button>
+      </InlineStack>
+      <Paragraph size="sm" tone="subdued">
+        Each scenario starts as an idea. Click ⚡ Auto build on a Tangent idea
+        to generate scenario.yaml + MEMORY.md in the background.
+      </Paragraph>
+
+      <IdeaSubsection
+        title="Tangent recommended"
+        ideas={tangentIdeas}
+        emptyMessage="No Tangent-generated ideas yet — click Re-analyze in the top nav."
+      />
+      <IdeaSubsection
+        title="Human recommended"
+        ideas={humanIdeas}
+        emptyMessage="Be the first — click + New Scenario above."
+      />
+    </BlockStack>
+  );
+}

--- a/src/routes/tangent/components/detail/TangentAnalysis.tsx
+++ b/src/routes/tangent/components/detail/TangentAnalysis.tsx
@@ -1,0 +1,33 @@
+import { BlockStack } from "@/components/ui/layout";
+import { Heading, Paragraph } from "@/components/ui/typography";
+import type { TangentPipeline } from "@/routes/tangent/types";
+
+interface TangentAnalysisProps {
+  pipeline: TangentPipeline;
+}
+
+export function TangentAnalysis({ pipeline }: TangentAnalysisProps) {
+  return (
+    <BlockStack gap="3">
+      <Heading level={2}>Tangent Analysis</Heading>
+      {pipeline.analyzing ? (
+        <Paragraph size="sm" tone="subdued">
+          ◎ Analyzing pipeline with Claude — this takes a few seconds…
+        </Paragraph>
+      ) : pipeline.summary ? (
+        <BlockStack gap="2">
+          {pipeline.summary.split("\n\n").map((paragraph, index) => (
+            <Paragraph key={index} size="sm">
+              {paragraph}
+            </Paragraph>
+          ))}
+        </BlockStack>
+      ) : (
+        <Paragraph size="sm" tone="subdued">
+          No analysis yet. Click Re-analyze in the top nav to have the Tangent
+          Researcher evaluate this pipeline.
+        </Paragraph>
+      )}
+    </BlockStack>
+  );
+}

--- a/src/routes/tangent/hooks/useReanalyzeAll.ts
+++ b/src/routes/tangent/hooks/useReanalyzeAll.ts
@@ -1,0 +1,26 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import useToastNotification from "@/hooks/useToastNotification";
+import { reanalyzeAllPipelines } from "@/routes/tangent/services/tangentApi";
+import { TangentQueryKeys } from "@/routes/tangent/types";
+
+export function useReanalyzeAll() {
+  const queryClient = useQueryClient();
+  const notify = useToastNotification();
+
+  return useMutation({
+    mutationFn: reanalyzeAllPipelines,
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: TangentQueryKeys.Pipelines(),
+      });
+      notify(
+        "Re-analysis queued for all pipelines. Scores will update in ~5–10 min as the Tangent Researcher runs.",
+        "success",
+      );
+    },
+    onError: () => {
+      notify("Failed to queue re-analysis", "error");
+    },
+  });
+}

--- a/src/routes/tangent/hooks/useTangentPipeline.ts
+++ b/src/routes/tangent/hooks/useTangentPipeline.ts
@@ -1,0 +1,15 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { fetchTangentPipeline } from "@/routes/tangent/services/tangentApi";
+import { TangentQueryKeys } from "@/routes/tangent/types";
+import { MINUTES } from "@/utils/constants";
+
+export function useTangentPipeline(runId: string) {
+  return useQuery({
+    queryKey: TangentQueryKeys.Pipeline(runId),
+    queryFn: () => fetchTangentPipeline(runId),
+    enabled: runId.length > 0,
+    staleTime: 5 * MINUTES,
+    refetchOnWindowFocus: false,
+  });
+}

--- a/src/routes/tangent/hooks/useTangentPipelines.ts
+++ b/src/routes/tangent/hooks/useTangentPipelines.ts
@@ -1,0 +1,14 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { fetchTangentPipelines } from "@/routes/tangent/services/tangentApi";
+import { TangentQueryKeys } from "@/routes/tangent/types";
+import { MINUTES } from "@/utils/constants";
+
+export function useTangentPipelines() {
+  return useQuery({
+    queryKey: TangentQueryKeys.Pipelines(),
+    queryFn: fetchTangentPipelines,
+    staleTime: 5 * MINUTES,
+    refetchOnWindowFocus: false,
+  });
+}

--- a/src/routes/tangent/hooks/useTangentStats.ts
+++ b/src/routes/tangent/hooks/useTangentStats.ts
@@ -1,0 +1,14 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { fetchTangentStats } from "@/routes/tangent/services/tangentApi";
+import { TangentQueryKeys } from "@/routes/tangent/types";
+import { MINUTES } from "@/utils/constants";
+
+export function useTangentStats() {
+  return useQuery({
+    queryKey: TangentQueryKeys.Stats(),
+    queryFn: fetchTangentStats,
+    staleTime: 5 * MINUTES,
+    refetchOnWindowFocus: false,
+  });
+}

--- a/src/routes/tangent/labels.ts
+++ b/src/routes/tangent/labels.ts
@@ -1,0 +1,75 @@
+import type {
+  IdeaType,
+  PipelineFilter,
+  RunStatus,
+  ScenarioStatus,
+} from "@/routes/tangent/types";
+
+export const IDEA_TYPE_LABELS: Record<IdeaType, string> = {
+  feature_engineering: "Feature Engineering",
+  hyper_parameter_optimization: "Hyper Parameter Optimization",
+  input_data: "Input Data",
+  model_architecture: "Model Architecture",
+};
+
+export const RUN_STATUS_LABELS: Record<RunStatus, string> = {
+  succeeded: "Succeeded",
+  failed: "Failed",
+  running: "Running",
+};
+
+export const SCENARIO_STATUS_LABELS: Record<ScenarioStatus, string> = {
+  no_scenario: "No scenario",
+  scenario_built: "Scenario built",
+  scenario_ready: "Scenario ready",
+  tangent_running: "Tangent running",
+  results_available: "Results available",
+};
+
+export const PIPELINE_FILTER_LABELS: Record<PipelineFilter, string> = {
+  all: "All",
+  my_pipelines: "My pipelines",
+  no_scenario: "No scenario",
+  has_results: "Has results",
+};
+
+export const PIPELINE_FILTERS: PipelineFilter[] = [
+  "all",
+  "my_pipelines",
+  "no_scenario",
+  "has_results",
+];
+
+type ScoreBand = "high" | "medium" | "low";
+
+/** Maps an opportunity score to its color band per the product spec. */
+function getScoreBand(score: number): ScoreBand {
+  if (score >= 70) return "high";
+  if (score >= 45) return "medium";
+  return "low";
+}
+
+/** Tailwind text color class for a score band (and the unscored case). */
+export function getScoreColorClass(score: number | null): string {
+  if (score === null) return "text-muted-foreground";
+  const band = getScoreBand(score);
+  if (band === "high") return "text-emerald-600 dark:text-emerald-400";
+  if (band === "medium") return "text-amber-600 dark:text-amber-400";
+  return "text-muted-foreground";
+}
+
+/** Stroke color (currentColor-friendly) for the score ring per band. */
+export function getScoreStrokeClass(score: number | null): string {
+  if (score === null) return "stroke-muted-foreground/40";
+  const band = getScoreBand(score);
+  if (band === "high") return "stroke-emerald-500";
+  if (band === "medium") return "stroke-amber-500";
+  return "stroke-muted-foreground/50";
+}
+
+/** Derives the creator handle from an owner email (part before `@`). */
+export function getCreatorHandle(ownerEmail?: string): string | undefined {
+  if (!ownerEmail) return undefined;
+  const [handle] = ownerEmail.split("@");
+  return handle || undefined;
+}

--- a/src/routes/tangent/mocks/mockData.ts
+++ b/src/routes/tangent/mocks/mockData.ts
@@ -1,0 +1,278 @@
+import type {
+  ExperimentIdea,
+  TangentPipeline,
+  TeamStats,
+} from "@/routes/tangent/types";
+
+const CURRENT_USER_NAME = "you";
+
+const daysAgo = (days: number): string =>
+  new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+
+const tangentIdea = (
+  idea: Omit<ExperimentIdea, "source"> &
+    Partial<Pick<ExperimentIdea, "source">>,
+): ExperimentIdea => ({ source: "tangent", ...idea });
+
+const humanIdea = (
+  idea: Omit<ExperimentIdea, "source" | "impact">,
+): ExperimentIdea => ({ source: "human", ...idea });
+
+const queryEncoderPipeline: TangentPipeline = {
+  runId: "019db6c661691a51840d",
+  name: "Query Encoder Distillation",
+  ownerEmail: "rin.tanaka@shopify.com",
+  runStatus: "succeeded",
+  lastRunAt: daysAgo(1),
+  metricName: "ndcg@10",
+  metricValue: 0.6421,
+  baselineValue: 0.619,
+  metricDeltaPct: 3.7,
+  scenarioStatus: "results_available",
+  opportunityScore: 88,
+  analyzing: false,
+  rationale:
+    "Relies on a manual grid search over KD temperature and alpha with no Bayesian optimization. Wide unexplored hyperparameter space suggests substantial headroom.",
+  summary:
+    "Query Encoder Distillation trains a compact query tower by distilling from a larger teacher. The pipeline currently tunes knowledge-distillation alpha and temperature through a hand-run grid, leaving most of the search space unexplored.\n\nTangent can add the most value by replacing the grid with Bayesian search across KD alpha, temperature, learning-rate schedule, and warmup. Early evidence shows the baseline sits well below the achievable frontier on ndcg@10.\n\nPrioritize KD hyperparameter optimization first, then revisit feature pooling once the tuning frontier is mapped.",
+  oasisUrl: "https://oasis.example.com/runs/019db6c661691a51840d",
+  builtByCurrentUser: true,
+  ideas: [
+    tangentIdea({
+      id: "qed-1",
+      rank: 1,
+      title: "Bayesian sweep over KD alpha and temperature",
+      type: "hyper_parameter_optimization",
+      impact: "high",
+      evidence:
+        "Current tuning is a 3x3 manual grid; neighboring configs show monotonic gains, implying an unexplored optimum.",
+      buildState: "built",
+      builtBy: CURRENT_USER_NAME,
+      builtAt: daysAgo(2),
+      unverifiedCount: 2,
+      upvotes: 3,
+      downvotes: 0,
+    }),
+    tangentIdea({
+      id: "qed-2",
+      rank: 2,
+      title: "Add cross-shop interaction features",
+      type: "feature_engineering",
+      impact: "medium",
+      evidence:
+        "Shops with shared catalogs show correlated relevance; interaction terms are not yet modeled.",
+      buildState: "unbuilt",
+      upvotes: 1,
+      downvotes: 1,
+    }),
+    humanIdea({
+      id: "qed-3",
+      rank: 1,
+      title: "Try a wider warmup schedule",
+      type: "hyper_parameter_optimization",
+      evidence:
+        "Loss curves plateau early — a longer warmup may stabilize the distillation signal.",
+      author: "marco.silva",
+      buildState: "built",
+      builtBy: "marco.silva",
+      builtAt: daysAgo(4),
+    }),
+  ],
+  results: {
+    metricDelta: "+3.7% ndcg@10",
+    bestDelta: "+3.7%",
+    bestRunId: "019db6c661691a51999f",
+    configChanges:
+      "- kd_alpha: 0.5 -> 0.72\n- kd_temperature: 2.0 -> 3.5\n- warmup_steps: 500 -> 1500",
+    topWinningCases: [
+      {
+        example: "winter boots",
+        baseline: "0.61",
+        best: "0.74",
+        delta: "+0.13",
+      },
+      {
+        example: "linen dress",
+        baseline: "0.58",
+        best: "0.69",
+        delta: "+0.11",
+      },
+    ],
+    topLosingCases: [
+      { example: "gift card", baseline: "0.81", best: "0.77", delta: "-0.04" },
+    ],
+  },
+};
+
+const rerankerPipeline: TangentPipeline = {
+  runId: "019dc1a2b3c4d5e6f708",
+  name: "Catalog Reranker v3",
+  ownerEmail: "marco.silva@shopify.com",
+  runStatus: "running",
+  lastRunAt: daysAgo(0),
+  metricName: "mrr",
+  metricValue: 0.4123,
+  baselineValue: 0.415,
+  metricDeltaPct: -0.7,
+  scenarioStatus: "tangent_running",
+  opportunityScore: 72,
+  analyzing: false,
+  rationale:
+    "Deep architecture with many tunable knobs but stale tuning from six months ago. Recent regression vs baseline indicates drift worth re-optimizing.",
+  summary:
+    "Catalog Reranker v3 is a cross-encoder reranking model with a large number of tunable layers and heads. Tuning has not been revisited in months and the latest run regressed slightly against baseline.\n\nTangent can drive value by re-optimizing learning rate, layer freezing, and head capacity together, and by exploring negative-mining strategies that the current data pipeline does not use.",
+  oasisUrl: "https://oasis.example.com/runs/019dc1a2b3c4d5e6f708",
+  builtByCurrentUser: false,
+  ideas: [
+    tangentIdea({
+      id: "rr-1",
+      rank: 1,
+      title: "Unfreeze top transformer layers",
+      type: "model_architecture",
+      impact: "high",
+      evidence:
+        "Only the head is trainable today; unfreezing the top 2 layers is cheap and commonly lifts reranking quality.",
+      buildState: "building",
+      upvotes: 2,
+      downvotes: 0,
+    }),
+    tangentIdea({
+      id: "rr-2",
+      rank: 2,
+      title: "Hard negative mining from impression logs",
+      type: "input_data",
+      impact: "medium",
+      evidence:
+        "Training uses random negatives; impression logs contain harder negatives that better match serving.",
+      buildState: "unbuilt",
+    }),
+  ],
+};
+
+const embeddingPipeline: TangentPipeline = {
+  runId: "019dc9f8e7d6c5b4a302",
+  name: "Product Embedding Tower",
+  ownerEmail: "rin.tanaka@shopify.com",
+  runStatus: "succeeded",
+  lastRunAt: daysAgo(3),
+  metricName: "recall@100",
+  metricValue: 0.8312,
+  baselineValue: 0.8205,
+  metricDeltaPct: 1.3,
+  scenarioStatus: "scenario_ready",
+  opportunityScore: 58,
+  analyzing: false,
+  rationale:
+    "Already uses partial Bayesian tuning, so opportunity is moderate. Embedding pooling choices remain unexplored and could yield incremental gains.",
+  summary:
+    "Product Embedding Tower learns dense product representations for retrieval. It already uses a partial Bayesian sweep, so the highest-leverage remaining opportunities are around embedding pooling and feature crosses.",
+  oasisUrl: "https://oasis.example.com/runs/019dc9f8e7d6c5b4a302",
+  builtByCurrentUser: true,
+  ideas: [
+    tangentIdea({
+      id: "emb-1",
+      rank: 1,
+      title: "Compare mean vs attention pooling",
+      type: "feature_engineering",
+      impact: "medium",
+      evidence:
+        "Mean pooling discards positional signal; attention pooling is inexpensive to trial.",
+      buildState: "built",
+      builtBy: CURRENT_USER_NAME,
+      builtAt: daysAgo(5),
+      unverifiedCount: 0,
+      upvotes: 1,
+      downvotes: 0,
+    }),
+  ],
+};
+
+const intentPipeline: TangentPipeline = {
+  runId: "019dd0112233445566aa",
+  name: "Search Intent Classifier",
+  ownerEmail: "amara.okafor@shopify.com",
+  runStatus: "failed",
+  lastRunAt: daysAgo(2),
+  metricName: "f1",
+  metricValue: undefined,
+  baselineValue: 0.774,
+  scenarioStatus: "scenario_built",
+  opportunityScore: 49,
+  analyzing: false,
+  rationale:
+    "Moderate opportunity with a mature tuning history. The last run failed, so re-establishing a clean baseline is the first step before optimization.",
+  summary:
+    "Search Intent Classifier routes queries to downstream rankers. Tuning is relatively mature, so opportunity is moderate. The most recent run failed and should be re-run to restore a reliable baseline.",
+  oasisUrl: "https://oasis.example.com/runs/019dd0112233445566aa",
+  builtByCurrentUser: false,
+  ideas: [
+    humanIdea({
+      id: "int-1",
+      rank: 1,
+      title: "Rebalance training labels by intent class",
+      type: "input_data",
+      evidence:
+        "Tail intent classes are under-represented; class weighting may recover F1 on rare intents.",
+      author: "amara.okafor",
+      buildState: "built",
+      builtBy: "amara.okafor",
+      builtAt: daysAgo(6),
+    }),
+  ],
+};
+
+const spellPipeline: TangentPipeline = {
+  runId: "019dd44556677889900b",
+  name: "Spell Correction Seq2Seq",
+  ownerEmail: "amara.okafor@shopify.com",
+  runStatus: "succeeded",
+  lastRunAt: daysAgo(8),
+  metricName: "exact_match",
+  metricValue: 0.9012,
+  baselineValue: 0.901,
+  metricDeltaPct: 0.02,
+  scenarioStatus: "no_scenario",
+  opportunityScore: 31,
+  analyzing: false,
+  rationale:
+    "Low opportunity: the model is near a well-explored optimum with stable, mature tuning and little remaining search space.",
+  summary:
+    "Spell Correction Seq2Seq is a mature pipeline operating close to its explored optimum. Remaining opportunity is low; gains would likely require new data sources rather than tuning.",
+  oasisUrl: "https://oasis.example.com/runs/019dd44556677889900b",
+  builtByCurrentUser: false,
+  ideas: [],
+};
+
+const newPipeline: TangentPipeline = {
+  runId: "019dd8899aabbccddee0",
+  name: "Multimodal Ranker (experimental)",
+  ownerEmail: "rin.tanaka@shopify.com",
+  runStatus: "succeeded",
+  lastRunAt: daysAgo(0),
+  metricName: "ndcg@10",
+  metricValue: 0.598,
+  baselineValue: undefined,
+  scenarioStatus: "no_scenario",
+  opportunityScore: null,
+  analyzing: true,
+  rationale: undefined,
+  summary: undefined,
+  oasisUrl: "https://oasis.example.com/runs/019dd8899aabbccddee0",
+  builtByCurrentUser: false,
+  ideas: [],
+};
+
+export const MOCK_PIPELINES: TangentPipeline[] = [
+  queryEncoderPipeline,
+  rerankerPipeline,
+  embeddingPipeline,
+  intentPipeline,
+  spellPipeline,
+  newPipeline,
+];
+
+export const MOCK_TEAM_STATS: TeamStats = {
+  members: 4,
+  scenarios: 7,
+  withResults: 1,
+};

--- a/src/routes/tangent/services/tangentApi.ts
+++ b/src/routes/tangent/services/tangentApi.ts
@@ -1,0 +1,42 @@
+import {
+  MOCK_PIPELINES,
+  MOCK_TEAM_STATS,
+} from "@/routes/tangent/mocks/mockData";
+import type { TangentPipeline, TeamStats } from "@/routes/tangent/types";
+
+/**
+ * Mocked Tangent API service for Phase 1.
+ *
+ * Every function simulates a short network round-trip and resolves data from
+ * the in-memory fixtures. When the real `Tangent/*` endpoints land, these
+ * functions are the single place to swap in the generated SDK calls.
+ */
+
+const SIMULATED_LATENCY_MS = 350;
+
+const delay = <T>(value: T, ms = SIMULATED_LATENCY_MS): Promise<T> =>
+  new Promise((resolve) => {
+    setTimeout(() => resolve(value), ms);
+  });
+
+const clone = <T>(value: T): T =>
+  typeof structuredClone === "function"
+    ? structuredClone(value)
+    : JSON.parse(JSON.stringify(value));
+
+export const fetchTangentStats = (): Promise<TeamStats> =>
+  delay(clone(MOCK_TEAM_STATS));
+
+export const fetchTangentPipelines = (): Promise<TangentPipeline[]> =>
+  delay(clone(MOCK_PIPELINES));
+
+export const fetchTangentPipeline = (
+  runId: string,
+): Promise<TangentPipeline | undefined> =>
+  delay(clone(MOCK_PIPELINES.find((pipeline) => pipeline.runId === runId)));
+
+/**
+ * Stubbed re-analyze trigger. In Phase 1 this is a no-op that resolves after a
+ * simulated delay so the UI can show a queued/refresh affordance.
+ */
+export const reanalyzeAllPipelines = (): Promise<void> => delay(undefined, 600);

--- a/src/routes/tangent/types.ts
+++ b/src/routes/tangent/types.ts
@@ -1,0 +1,116 @@
+/**
+ * Local domain types for the Tangent Phase 1 prototype.
+ *
+ * These intentionally live outside `src/api/types.gen.ts`: the real backend
+ * `Tangent/*` endpoints currently only cover instances, so for Phase 1 the
+ * dashboard and project-detail screens are driven entirely by a mocked API
+ * layer that resolves these shapes.
+ */
+
+export type RunStatus = "succeeded" | "failed" | "running";
+
+export type ScenarioStatus =
+  | "no_scenario"
+  | "scenario_built"
+  | "scenario_ready"
+  | "tangent_running"
+  | "results_available";
+
+export type IdeaType =
+  | "feature_engineering"
+  | "hyper_parameter_optimization"
+  | "input_data"
+  | "model_architecture";
+
+type IdeaImpact = "high" | "medium" | "low";
+
+type IdeaSource = "tangent" | "human";
+
+type IdeaBuildState = "unbuilt" | "building" | "built" | "failed";
+
+export interface ExperimentIdea {
+  id: string;
+  rank: number;
+  title: string;
+  type: IdeaType;
+  source: IdeaSource;
+  impact?: IdeaImpact;
+  /** One-sentence evidence (Tangent ideas) or description (human ideas). */
+  evidence: string;
+  /** Display name of the human author (human ideas only). */
+  author?: string;
+  buildState: IdeaBuildState;
+  /** Display name of whoever built the scenario, when built. */
+  builtBy?: string;
+  builtAt?: string;
+  unverifiedCount?: number;
+  upvotes?: number;
+  downvotes?: number;
+}
+
+export interface ResultsCase {
+  example: string;
+  baseline: string;
+  best: string;
+  delta: string;
+}
+
+export interface TangentResults {
+  metricDelta: string;
+  bestDelta: string;
+  bestRunId: string;
+  configChanges: string;
+  topWinningCases: ResultsCase[];
+  topLosingCases: ResultsCase[];
+}
+
+export interface TangentPipeline {
+  /** Tangle run ID — 20 hex characters beginning with `019`. */
+  runId: string;
+  name: string;
+  /** Owner email; the part before `@` is the displayed creator handle. */
+  ownerEmail?: string;
+  runStatus: RunStatus;
+  lastRunAt: string;
+  metricName?: string;
+  metricValue?: number;
+  baselineValue?: number;
+  /** Percentage change vs baseline; positive is an improvement. */
+  metricDeltaPct?: number;
+  scenarioStatus: ScenarioStatus;
+  /** 0-100 opportunity score; `null` means not yet analyzed. */
+  opportunityScore: number | null;
+  /** Whether Tangent is currently scoring this pipeline. */
+  analyzing: boolean;
+  /** Two-sentence rationale shown on the card. */
+  rationale?: string;
+  /** Longer summary shown in the project-detail analysis section. */
+  summary?: string;
+  oasisUrl?: string;
+  /** Whether the signed-in user has built a scenario for this pipeline. */
+  builtByCurrentUser: boolean;
+  ideas: ExperimentIdea[];
+  results?: TangentResults;
+}
+
+export interface TeamStats {
+  /** Distinct people who built at least one scenario, or `null` while loading. */
+  members: number | null;
+  /** Total scenarios built across the team, or `null` while loading. */
+  scenarios: number | null;
+  /** Pipelines that completed optimization and have results, or `null`. */
+  withResults: number | null;
+}
+
+export type PipelineFilter =
+  | "all"
+  | "my_pipelines"
+  | "no_scenario"
+  | "has_results";
+
+export const TangentQueryKeys = {
+  All: () => ["tangent"] as const,
+  Stats: () => ["tangent", "stats"] as const,
+  Pipelines: () => ["tangent", "pipelines"] as const,
+  Pipeline: (runId: string) => ["tangent", "pipeline", runId] as const,
+} as const;


### PR DESCRIPTION
## Description

Introduces the Tangent dashboard as a Phase 1 prototype — a new section of the app that surfaces ML pipeline optimization opportunities for the Search team. The feature is entirely driven by a mocked API layer (with simulated network latency) so the UI can be built and reviewed before the real backend endpoints are available.

**Routes added:**
- `/tangent` — `TangentDashboardView`: lists all pipelines ranked by opportunity score, with filter support (`my_pipelines`, `no_scenario`, `has_results`) and a "Re-analyze all" action.
- `/tangent/$runId` — `TangentProjectDetailView`: shows per-pipeline details including current performance metrics vs baseline, Tangent analysis summary, experiment ideas (both Tangent-generated and human-submitted), and previous optimization results.

**Layout:**
- `TangentLayout` wraps both routes with a fixed sidebar containing navigation filters, links back to the main dashboard, docs, settings, footer links, and a git commit version stamp.

**Components:**
- `OpportunityScoreRing` — SVG ring that renders a 0–100 score with color bands (green ≥ 70, amber ≥ 45, grey below).
- `PipelineRow` — clickable table row with cmd/ctrl+click support for opening in a new tab.
- `ScenarioStatusBadge`, `RunStatusIndicator`, `MetricDelta`, `IdeaTypeChip` — status and metric display primitives.
- `HeroBanner` + `StatBoxes` — hero section with team-level stats (members, scenarios, pipelines with results).
- `AnalyzeRunBlock` — input for pasting a Tangle run ID, with format validation (stub in Phase 1).
- Detail sub-components: `CurrentPerformance`, `TangentAnalysis`, `ScenarioSection`, `IdeaCard`, `ResultsSection`.

**Data layer:**
- `types.ts` defines all domain types (`TangentPipeline`, `ExperimentIdea`, `TangentResults`, `TeamStats`, etc.) and `TangentQueryKeys`.
- `tangentApi.ts` provides mocked fetch functions (`fetchTangentPipelines`, `fetchTangentPipeline`, `fetchTangentStats`, `reanalyzeAllPipelines`) that resolve from in-memory fixtures with a 350 ms simulated delay. These are the single swap point when real endpoints land.
- React Query hooks: `useTangentPipelines`, `useTangentPipeline`, `useTangentStats`, `useReanalyzeAll`.

The `src/routes/tangent` directory is also added to the React Compiler enabled paths.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Navigate to `/tangent` — the dashboard should load with the pipeline table ranked by opportunity score.
2. Use the sidebar filters (`My pipelines`, `No scenario`, `Has results`) to verify the table filters correctly.
3. Click a pipeline row to navigate to `/tangent/<runId>` and verify the detail view renders performance metrics, analysis, scenarios, and (for `queryEncoderPipeline`) the results section.
4. Cmd/Ctrl+click a row to confirm it opens in a new tab.
5. Click "Re-analyze all" and confirm the spinner appears and a success toast is shown after ~600 ms.
6. Paste an invalid run ID into the "Add your run here" input and click Analyze — confirm the validation error message appears.
7. Paste a valid-format run ID and confirm the "coming soon" info toast appears.

## Additional Comments

All API calls in this phase resolve from `mockData.ts` fixtures. No real network requests are made. The mocked service layer in `tangentApi.ts` is the only file that needs to change when the backend `Tangent/*` endpoints are ready.