### PR TITLE
feat: Guided Tours Framework (Subgraphs)

### DIFF
--- a/src/providers/TourProvider/tourActionLabels.ts
+++ b/src/providers/TourProvider/tourActionLabels.ts
@@ -40,6 +40,18 @@ export function tourActionLabel(step: TourAction): string {
       return step.targetArgumentName
         ? `Set the **${step.targetArgumentName}** value`
         : "Set the highlighted value";
+    case "navigate-into-subgraph":
+      return step.targetTaskName
+        ? `Open the **${step.targetTaskName}** subgraph`
+        : "Open the highlighted subgraph";
+    case "navigate-to-root":
+      return "Return to the top level";
+    case "unpack-subgraph":
+      return "Unpack the subgraph";
+    case "multi-select-tasks":
+      return `Select **${step.targetMinCount ?? 2}** tasks`;
+    case "create-subgraph":
+      return "Create a subgraph from the selected tasks";
     default:
       return GENERIC_LABEL;
   }

--- a/src/routes/v2/pages/Editor/components/EditorTourBridge.tsx
+++ b/src/routes/v2/pages/Editor/components/EditorTourBridge.tsx
@@ -1,4 +1,5 @@
 import { useTour } from "@reactour/tour";
+import { useViewport } from "@xyflow/react";
 import { reaction } from "mobx";
 import { useEffect } from "react";
 
@@ -113,6 +114,15 @@ export function EditorTourBridge() {
   const { steps, currentStep, setCurrentStep, setSteps, isOpen } = useTour();
   const { windows, navigation, editor } = useSharedStores();
   const { markStepComplete, isStepComplete } = useTourProgress();
+  const { x: viewportX, y: viewportY, zoom: viewportZoom } = useViewport();
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const rafId = requestAnimationFrame(() => {
+      window.dispatchEvent(new Event("resize"));
+    });
+    return () => cancelAnimationFrame(rafId);
+  }, [isOpen, viewportX, viewportY, viewportZoom]);
 
   const step = steps[currentStep] as TourStep | undefined;
   const interaction = step?.interaction;
@@ -122,15 +132,47 @@ export function EditorTourBridge() {
   const ensureWindowRestoredId = step?.ensureWindowRestored;
   const requiresTaskSelected = step?.requiresTaskSelected;
   const libraryDragAllow = step?.targetComponentName ?? step?.targetTaskName;
+  const stepSelector = step?.selector;
 
   useEffect(() => {
     if (!isOpen) return;
     if (!ensureWindowRestoredId) return;
     const w = windows.getWindowById(ensureWindowRestoredId);
-    if (w && (w.state === "hidden" || w.isMinimized)) {
+    const wasHidden = !!w && (w.state === "hidden" || w.isMinimized);
+    if (wasHidden) {
       w.restore();
     }
-  }, [isOpen, ensureWindowRestoredId, currentStep, windows]);
+    if (!w) return;
+
+    let cancelled = false;
+    const start = Date.now();
+    const wantSelector = typeof stepSelector === "string" ? stepSelector : null;
+    const waitForDom = () => {
+      if (cancelled) return;
+      const found = wantSelector
+        ? document.querySelector(wantSelector)
+        : document.querySelector(
+            `[data-dock-window="${ensureWindowRestoredId}"]`,
+          );
+      if (found || Date.now() - start > 1500) {
+        setSteps?.((prev) => [...prev]);
+        return;
+      }
+      window.setTimeout(waitForDom, 50);
+    };
+    window.setTimeout(waitForDom, 50);
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    isOpen,
+    ensureWindowRestoredId,
+    currentStep,
+    windows,
+    stepSelector,
+    setSteps,
+  ]);
 
   useEffect(() => {
     if (!isOpen) return undefined;
@@ -219,7 +261,6 @@ export function EditorTourBridge() {
     };
   }, [isOpen, libraryDragAllow]);
 
-  const stepSelector = step?.selector;
   useEffect(() => {
     if (!isOpen) return;
     if (!resetLibrarySearchFlag) return;
@@ -548,6 +589,138 @@ export function EditorTourBridge() {
 
       const dispose = reaction(
         () => countMatches(),
+        (current) => {
+          if (current > baseline) {
+            dispose();
+            advance();
+          }
+        },
+      );
+
+      return () => {
+        stopFollow();
+        dispose();
+      };
+    }
+
+    if (interaction === "navigate-into-subgraph") {
+      const targetName = step?.targetTaskName?.toLowerCase();
+      const baselineDepth = navigation.navigationDepth;
+
+      const matches = () => {
+        if (navigation.navigationDepth <= baselineDepth) return false;
+        if (!targetName) return true;
+        const last =
+          navigation.navigationPath[navigation.navigationPath.length - 1];
+        return last?.displayName.toLowerCase() === targetName;
+      };
+
+      if (matches()) {
+        skip();
+        return stopFollow;
+      }
+
+      const dispose = reaction(
+        () => matches(),
+        (m) => {
+          if (m) {
+            dispose();
+            advance();
+          }
+        },
+      );
+
+      return () => {
+        stopFollow();
+        dispose();
+      };
+    }
+
+    if (interaction === "navigate-to-root") {
+      const isAtRoot = () => navigation.navigationDepth === 0;
+
+      if (isAtRoot()) {
+        skip();
+        return stopFollow;
+      }
+
+      const dispose = reaction(
+        () => isAtRoot(),
+        (m) => {
+          if (m) {
+            dispose();
+            advance();
+          }
+        },
+      );
+
+      return () => {
+        stopFollow();
+        dispose();
+      };
+    }
+
+    if (interaction === "unpack-subgraph") {
+      const countSubgraphTasks = () => {
+        const spec = navigation.activeSpec;
+        if (!spec) return 0;
+        return spec.tasks.filter((t) => t.subgraphSpec !== undefined).length;
+      };
+      const baseline = countSubgraphTasks();
+
+      const dispose = reaction(
+        () => countSubgraphTasks(),
+        (current) => {
+          if (current < baseline) {
+            dispose();
+            advance();
+          }
+        },
+      );
+
+      return () => {
+        stopFollow();
+        dispose();
+      };
+    }
+
+    if (interaction === "multi-select-tasks") {
+      const minCount = step?.targetMinCount ?? 2;
+
+      const taskSelectionCount = () =>
+        editor.multiSelection.filter((n) => n.type === "task").length;
+
+      if (taskSelectionCount() >= minCount) {
+        skip();
+        return stopFollow;
+      }
+
+      const dispose = reaction(
+        () => taskSelectionCount(),
+        (current) => {
+          if (current >= minCount) {
+            dispose();
+            advance();
+          }
+        },
+      );
+
+      return () => {
+        stopFollow();
+        dispose();
+      };
+    }
+
+    if (interaction === "create-subgraph") {
+      const countSubgraphTasks = () => {
+        const spec = navigation.activeSpec;
+        if (!spec) return 0;
+        return spec.tasks.filter((t) => t.subgraphSpec !== undefined).length;
+      };
+      const baseline = countSubgraphTasks();
+
+      const dispose = reaction(
+        () => countSubgraphTasks(),
         (current) => {
           if (current > baseline) {
             dispose();


### PR DESCRIPTION
## Description

The subgraph-specific interaction mechanics for the guided-tour framework, layered on the framework stack (#2348 / #2299 / #2347 / #2340). Foundation for the **Subgraphs** tour (#2366) — this PR adds the interaction *types* and the bridge logic that detects them; the tour content lands in #2366.

Five new tour interactions cover navigating and authoring subgraphs, plus a canvas re-measurement fix so spotlights track the viewport when navigation changes the view.

## What changed

**Interaction vocabulary** (`src/components/Learn/tours/registry.ts`)

Five new `TourStep.interaction` values, plus a `targetMinCount` field:

- `navigate-into-subgraph` — descends a level (optionally gated to a specific `targetTaskName`)
- `navigate-to-root` — returns to the top level
- `unpack-subgraph` — the active spec's subgraph-task count *drops* (a subgraph was flattened)
- `multi-select-tasks` — ≥ `targetMinCount` (default 2) task nodes are selected
- `create-subgraph` — the subgraph-task count *rises* (a subgraph was created)

**Bridge handlers** (`src/routes/v2/pages/Editor/components/EditorTourBridge.tsx`)

Each interaction is detected by observing the existing MobX stores — `navigation.navigationDepth` / `navigationPath` for level changes, `navigation.activeSpec.tasks` (counting `subgraphSpec`) for unpack/create, and `editor.multiSelection` for multi-select. Following the model from #2299, a detected interaction **marks the step complete** in the shared tour-progress state (it does not advance the tour itself); already-satisfied-on-entry states are marked complete immediately. Gated "Next" / auto-advance (#2340) handle progression.

**Contextual checklist labels**

Adds the checklist copy for these interactions (using the contextual bold-target support from #2340):

- `navigate-into-subgraph` → "Open the **{targetTaskName}** subgraph"
- `multi-select-tasks` → "Select **{targetMinCount}** tasks"
- `navigate-to-root` → "Return to the top level"
- `unpack-subgraph` → "Unpack the subgraph"
- `create-subgraph` → "Create a subgraph from the selected tasks"

**Spotlight re-measurement while navigating**

- Dispatches a `resize` event (via `requestAnimationFrame`) whenever the xyflow viewport pans/zooms during an open tour, so reactour re-positions the highlight/popover after navigating into a subgraph shifts the canvas.
- `ensureWindowRestored` now waits for the target DOM to actually appear — the step's own `selector`, else the dock window — polling up to 1.5s before forcing a re-measure, instead of measuring against a not-yet-rendered target.

## Related Issue and Pull requests

Progresses https://github.com/Shopify/oasis-frontend/issues/583

Builds on the framework stack (#2348 / #2299 / #2347 / #2340); consumed by the Subgraphs tour in #2366.

## Type of Change

- [x] New feature

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

The registry is otherwise inert in this PR — the interactions are exercised end-to-end by the Subgraphs tour in #2366. To verify in isolation:

- **No regressions** in the existing tours ("Find your way around the editor", "Build your first pipeline"): interaction completion, `ensureWindowRestored` steps, and the dock/window highlight steps still work.
- **Re-measurement** — in any canvas-anchored tour step, pan/zoom the viewport; the spotlight/popover should re-position to follow rather than freeze.

## Additional Comments

Selector/anchor additions and the seed pipeline for the subgraph tour live in #2366, following the convention that tour-specific DOM anchors ship alongside the tour that needs them.
