### PR TITLE
fix: increase nested yaml depth limit

### DIFF
--- a/src/components/shared/ComponentEditor/useComponentSpecValidator.tsx
+++ b/src/components/shared/ComponentEditor/useComponentSpecValidator.tsx
@@ -4,6 +4,8 @@ import { buildSchemaDocument } from "@hyperjump/json-schema/experimental";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import yaml from "js-yaml";
 
+import { PIPELINE_YAML_LOAD_OPTIONS } from "@/utils/yaml";
+
 const COMPONENT_SPEC_SCHEMA_URL =
   "https://raw.githubusercontent.com/Cloud-Pipelines/component_spec_schema/refs/heads/master/component_spec.json_schema.json";
 
@@ -123,7 +125,7 @@ function normalizeValue(value: any): any {
     // assuming it is YAML
     // todo: worth revisiting
     try {
-      return yaml.load(value) as any;
+      return yaml.load(value, PIPELINE_YAML_LOAD_OPTIONS) as any;
     } catch {
       return undefined;
     }

--- a/src/components/shared/ComponentEditor/utils/preserveComponentName.ts
+++ b/src/components/shared/ComponentEditor/utils/preserveComponentName.ts
@@ -2,7 +2,7 @@ import yaml from "js-yaml";
 
 import type { ComponentSpec } from "@/utils/componentSpec";
 import { isValidComponentSpec } from "@/utils/componentSpec";
-import { componentSpecToYaml } from "@/utils/yaml";
+import { componentSpecToYaml, PIPELINE_YAML_LOAD_OPTIONS } from "@/utils/yaml";
 
 export const preserveComponentName = (
   yamlText: string,
@@ -13,7 +13,7 @@ export const preserveComponentName = (
   }
 
   try {
-    const parsed = yaml.load(yamlText);
+    const parsed = yaml.load(yamlText, PIPELINE_YAML_LOAD_OPTIONS);
 
     if (isValidComponentSpec(parsed)) {
       const updatedSpec: ComponentSpec = {

--- a/src/routes/v2/pages/Editor/hooks/useLoadSpec.ts
+++ b/src/routes/v2/pages/Editor/hooks/useLoadSpec.ts
@@ -21,6 +21,7 @@ import type { PipelineFile } from "@/services/pipelineStorage/PipelineFile";
 import { usePipelineStorage } from "@/services/pipelineStorage/PipelineStorageProvider";
 import type { PipelineStorageService } from "@/services/pipelineStorage/PipelineStorageService";
 import type { PipelineRef } from "@/services/pipelineStorage/types";
+import { PIPELINE_YAML_LOAD_OPTIONS } from "@/utils/yaml";
 
 interface LoadedSpec {
   spec: ComponentSpec;
@@ -63,7 +64,7 @@ async function resolveSpecData(
     throw new Error(`Pipeline "${ref.name}" not found`);
   }
   const yamlContent = await pipelineFile.read();
-  return yaml.load(yamlContent);
+  return yaml.load(yamlContent, PIPELINE_YAML_LOAD_OPTIONS);
 }
 
 export function useLoadSpec(ref: PipelineRef) {

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -2,6 +2,7 @@ import yaml from "js-yaml";
 
 import type { TaskSpec } from "./componentSpec";
 import { ISO8601_DURATION_ZERO_DAYS } from "./constants";
+import { PIPELINE_YAML_LOAD_OPTIONS } from "./yaml";
 
 const httpGetDataWithCache = async <T>(
   url: string,
@@ -63,7 +64,7 @@ function loadTextFromData(buffer: ArrayBuffer): string {
 }
 
 export function loadObjectFromYamlData(buffer: ArrayBuffer): object {
-  const obj = yaml.load(loadTextFromData(buffer));
+  const obj = yaml.load(loadTextFromData(buffer), PIPELINE_YAML_LOAD_OPTIONS);
   if (typeof obj === "object" && obj !== undefined && obj !== null) {
     return obj;
   }

--- a/src/utils/yaml.ts
+++ b/src/utils/yaml.ts
@@ -2,6 +2,11 @@ import yaml from "js-yaml";
 
 import { type ComponentSpec, isValidComponentSpec } from "./componentSpec";
 
+// Each subgraph level nests ~6 YAML mappings. A limit of 1000 allows around 150 levels of nested subgraphs.
+export const PIPELINE_YAML_LOAD_OPTIONS = {
+  maxDepth: 1000,
+} as unknown as yaml.LoadOptions;
+
 class ComponentSpecParsingError extends Error {
   readonly name = "ComponentSpecParsingError";
 
@@ -17,7 +22,7 @@ class ComponentSpecParsingError extends Error {
 }
 
 export function componentSpecFromYaml(yamlText: string): ComponentSpec {
-  const loadedSpec = yaml.load(yamlText);
+  const loadedSpec = yaml.load(yamlText, PIPELINE_YAML_LOAD_OPTIONS);
   if (typeof loadedSpec !== "object" || loadedSpec === null) {
     throw new ComponentSpecParsingError(
       "Invalid component specification format",


### PR DESCRIPTION
## Description

Restores the ability to load deeply nested subgraph pipelines/components, which regressed after the `js-yaml` `4.1.1 → 4.2.0` bump.

**Root cause:** `js-yaml@4.2.0` (pulled in by the Dependabot group bump in #2349) added a new default `maxDepth: 100` loader limit — `4.1.1` had no nesting-depth limit at all. js-yaml counts the *YAML node-tree depth*, not subgraph count, and each subgraph level nests ~6 mappings (`implementation → graph → tasks → <task> → componentRef → spec`). So a pipeline only ~16 subgraphs deep already exceeds 100, and `yaml.load` throws `YAMLException: nesting exceeded maxDepth (100)`.

**Symptom:** Loading the editor threw the error **even when the deep component wasn't in the open pipeline**, because `ComponentLibraryProvider` parses *every* stored user component on mount (`populateComponentRefs → parseComponentData → componentSpecFromYaml`). A single deeply nested library entry surfaced a console error on every load. The same limit also broke the v2 spec loader, the URL-fetched component cache, and the component-editor parse paths.

**Fix:** Introduce a shared `PIPELINE_YAML_LOAD_OPTIONS = { maxDepth: 1000 }` in `src/utils/yaml.ts` and pass it to every spec-loading `yaml.load` call. This keeps the `4.2.0` upgrade (and its other security fixes) while lifting the cap to support legitimately deep pipelines. `1000` is bounded (~150 subgraph levels) rather than `Infinity`, so js-yaml's stack-overflow protection still applies to pathological input.

`maxDepth` is a real runtime option but is missing from `@types/js-yaml@4.0.9`, hence the small cast.

### Files
- `src/utils/yaml.ts` — defines `PIPELINE_YAML_LOAD_OPTIONS`; applies it in `componentSpecFromYaml` (the central parser used by the component library, submit, and services).
- `src/utils/cache.ts` — `loadObjectFromYamlData` (URL-fetched components/pipelines).
- `src/routes/v2/pages/Editor/hooks/useLoadSpec.ts` — v2 editor pipeline load.
- `src/components/shared/ComponentEditor/useComponentSpecValidator.tsx`, `utils/preserveComponentName.ts` — component-editor parse paths.
- `src/utils/yaml.test.ts` — new regression test.

## Related Issue and Pull requests

Regression introduced by the `js-yaml` bump in #2349.

## Type of Change

- [x] Bug fix

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

Before: opening any pipeline logged `Error parsing component data: YAMLException: nesting exceeded maxDepth (100)` when a deeply nested component was in the library.

## Test Instructions

1. With a deeply nested (>~16 subgraph levels) pipeline/component in your library, open the editor on `master` → red `nesting exceeded maxDepth (100)` console error on load.
2. On this branch, the same component loads and parses cleanly; no console error.
3. `pnpm test src/utils/yaml.test.ts` — verifies `componentSpecFromYaml` parses a 300-level spec, and asserts the default `yaml.load` throws `/maxDepth/` on the same input while `PIPELINE_YAML_LOAD_OPTIONS` parses it (guards against a future bump or a stray bare `yaml.load`).

## Additional Comments

- This is a behavioral regression from `js-yaml@4.2.0`; worth flagging on the Dependabot bump #2349 so future minor bumps of parsing libs get a closer look.
- The fix is intentionally applied at every spec-loading `yaml.load` site, not just the one that surfaced the error, so the limit can't resurface on the editor/component-editor paths.
