### PR TITLE
feat: move tip of the day banner to sidebar

### DIFF
--- a/src/components/Learn/TipOfTheDay.tsx
+++ b/src/components/Learn/TipOfTheDay.tsx
@@ -23,13 +23,18 @@ function getDayOfYear(date: Date) {
 
 interface TipOfTheDayProps {
   variant?: "card" | "compact";
+  showHeader?: boolean;
 }
 
-export function TipOfTheDay({ variant = "card" }: TipOfTheDayProps = {}) {
+export function TipOfTheDay({
+  variant = "card",
+  showHeader,
+}: TipOfTheDayProps = {}) {
   const index = getDayOfYear(new Date()) % tips.length;
   const tip = tips[index];
   const isCompact = variant === "compact";
   const textSize = isCompact ? "xs" : "sm";
+  const headerVisible = showHeader ?? !isCompact;
 
   const badge = (
     <Badge size="sm" variant="secondary">
@@ -46,16 +51,22 @@ export function TipOfTheDay({ variant = "card" }: TipOfTheDayProps = {}) {
       }
     >
       <BlockStack gap={isCompact ? "2" : "3"} className="h-full">
-        {!isCompact && (
+        {headerVisible && (
           <InlineStack gap="2" blockAlign="center" align="space-between">
             <InlineStack gap="2" blockAlign="center">
               <Icon
                 name="Lightbulb"
-                size="md"
+                size={isCompact ? "sm" : "md"}
                 className="text-amber-500"
                 aria-hidden="true"
               />
-              <Heading level={3}>Tip of the day</Heading>
+              {isCompact ? (
+                <Text size="xs" weight="semibold" tone="subdued">
+                  Tip of the day
+                </Text>
+              ) : (
+                <Heading level={3}>Tip of the day</Heading>
+              )}
             </InlineStack>
             {badge}
           </InlineStack>
@@ -66,9 +77,14 @@ export function TipOfTheDay({ variant = "card" }: TipOfTheDayProps = {}) {
             <Text as="p" size={textSize} weight="semibold">
               {tip.title}
             </Text>
-            {isCompact && badge}
+            {!headerVisible && badge}
           </InlineStack>
-          <Text as="p" size={textSize} tone="subdued">
+          <Text
+            as="p"
+            size={textSize}
+            tone="subdued"
+            className={isCompact ? "line-clamp-3" : undefined}
+          >
             {tip.body}
           </Text>
         </BlockStack>

--- a/src/routes/Dashboard/DashboardHomeView.tsx
+++ b/src/routes/Dashboard/DashboardHomeView.tsx
@@ -1,7 +1,6 @@
 import { Link } from "@tanstack/react-router";
 
 import { RunSection } from "@/components/Home/RunSection/RunSection";
-import { TipOfTheDay } from "@/components/Learn/TipOfTheDay";
 import { AnnouncementBanners } from "@/components/shared/AnnouncementBanners";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import {
@@ -171,13 +170,10 @@ export function DashboardHomeView() {
     <BlockStack gap="6">
       <AnnouncementBanners />
 
-      <div className="w-full grid grid-cols-3 xl:grid-cols-6 gap-6 overflow-hidden">
+      <div className="w-full grid grid-cols-3 gap-6 overflow-hidden">
         <FavoritesPreview />
         <RecentlyViewedPreview />
         <RecentComponentsPreview />
-        <div className="col-span-3 max-w-4xl mx-auto">
-          <TipOfTheDay />
-        </div>
       </div>
 
       <BlockStack gap="3">

--- a/src/routes/Dashboard/DashboardLayout.tsx
+++ b/src/routes/Dashboard/DashboardLayout.tsx
@@ -1,5 +1,6 @@
 import { Link, Outlet } from "@tanstack/react-router";
 
+import { TipOfTheDay } from "@/components/Learn/TipOfTheDay";
 import { isAuthorizationRequired } from "@/components/shared/Authentication/helpers";
 import { TopBarAuthentication } from "@/components/shared/Authentication/TopBarAuthentication";
 import { Icon, type IconName } from "@/components/ui/icon";
@@ -82,6 +83,13 @@ export function DashboardLayout() {
 
         {/* Spacer */}
         <div className="flex-1 min-h-4" />
+
+        {/* Tip of the day */}
+        <div className="px-3 pb-2">
+          <div className="rounded-lg border border-border bg-card">
+            <TipOfTheDay variant="compact" showHeader />
+          </div>
+        </div>
 
         {/* Bottom utilities */}
         <BlockStack gap="1" className="px-3 border-t border-border pt-3 pb-3">


### PR DESCRIPTION
## Description

The "Tip of the Day" banner was squishing the existing components on the homepage. It has now been moved to the dahsboard sidebar, above Documentation / Settings.

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

Related: https://github.com/Shopify/oasis-frontend/issues/581

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

![image.png](https://app.graphite.com/user-attachments/assets/8c665105-8e6c-4ac4-aa6f-fc025687aba1.png)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->