### PR TITLE
feat: Support Pre-Submit Hooks

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -6,6 +6,7 @@
     "src/api/**",
     "src/components/ui/**",
     "src/config/announcements.ts",
+    "src/config/preSubmitHooks.ts",
     "src/components/shared/BetaFeatureWrapper/BetaFeatureWrapper.tsx"
   ],
   "ignoreDependencies": [

--- a/src/components/layout/RootLayout.tsx
+++ b/src/components/layout/RootLayout.tsx
@@ -2,6 +2,7 @@ import { Outlet } from "@tanstack/react-router";
 import { TanStackRouterDevtools } from "@tanstack/router-devtools";
 import { ToastContainer } from "react-toastify";
 
+import { ConfirmDialogBridge } from "@/components/shared/ConfirmDialogBridge/ConfirmDialogBridge";
 import { useClickTracking } from "@/hooks/useClickTracking";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 import { usePageViewTracking } from "@/hooks/usePageViewTracking";
@@ -28,6 +29,7 @@ function RootLayoutContent() {
         <PipelineStorageProvider>
           <SessionPipelineStatsTracker />
           <ToastContainer />
+          <ConfirmDialogBridge />
 
           <div className="App flex flex-col min-h-screen w-full">
             <AppMenu />

--- a/src/components/shared/ConfirmDialogBridge/ConfirmDialogBridge.test.tsx
+++ b/src/components/shared/ConfirmDialogBridge/ConfirmDialogBridge.test.tsx
@@ -1,0 +1,121 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { ConfirmPayload, ConfirmResult } from "@/config/preSubmitHooks";
+
+import { ConfirmDialogBridge } from "./ConfirmDialogBridge";
+
+const invokeConfirm = (payload: ConfirmPayload) => {
+  let result!: Promise<ConfirmResult>;
+  act(() => {
+    result = window.__TANGLE_CONFIRM__!(payload);
+  });
+  return result;
+};
+
+describe("ConfirmDialogBridge", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    delete window.__TANGLE_CONFIRM__;
+  });
+
+  it("installs window.__TANGLE_CONFIRM__ on mount and removes it on unmount", () => {
+    const { unmount } = render(<ConfirmDialogBridge />);
+    expect(typeof window.__TANGLE_CONFIRM__).toBe("function");
+
+    unmount();
+    expect(window.__TANGLE_CONFIRM__).toBeUndefined();
+  });
+
+  it("renders a dialog with the payload content when invoked", async () => {
+    render(<ConfirmDialogBridge />);
+
+    invokeConfirm({ title: "Are you sure?", body: "This may fail." });
+
+    expect(await screen.findByText("Are you sure?")).toBeInTheDocument();
+    expect(screen.getByText("This may fail.")).toBeInTheDocument();
+  });
+
+  it("resolves with confirmed: true when the confirm button is clicked", async () => {
+    const user = userEvent.setup();
+    render(<ConfirmDialogBridge />);
+
+    const result = invokeConfirm({
+      title: "T",
+      body: "B",
+      confirmLabel: "Proceed",
+    });
+
+    await user.click(await screen.findByRole("button", { name: "Proceed" }));
+
+    await expect(result).resolves.toEqual({
+      confirmed: true,
+      dismissForever: false,
+    });
+  });
+
+  it("resolves with confirmed: false when the cancel button is clicked", async () => {
+    const user = userEvent.setup();
+    render(<ConfirmDialogBridge />);
+
+    const result = invokeConfirm({
+      title: "T",
+      body: "B",
+      cancelLabel: "Go back",
+    });
+
+    await user.click(await screen.findByRole("button", { name: "Go back" }));
+
+    await expect(result).resolves.toEqual({
+      confirmed: false,
+      dismissForever: false,
+    });
+  });
+
+  it("closes the dialog after resolving", async () => {
+    const user = userEvent.setup();
+    render(<ConfirmDialogBridge />);
+
+    invokeConfirm({ title: "Closing", body: "B", confirmLabel: "OK" });
+
+    await user.click(await screen.findByRole("button", { name: "OK" }));
+
+    await waitFor(() => {
+      expect(screen.queryByText("Closing")).not.toBeInTheDocument();
+    });
+  });
+
+  it("writes localStorage when dismissForever is checked and confirmed", async () => {
+    const user = userEvent.setup();
+    render(<ConfirmDialogBridge />);
+
+    const result = invokeConfirm({
+      title: "T",
+      body: "B",
+      confirmLabel: "OK",
+      dismissForeverKey: "dismiss-csa-warning",
+    });
+
+    await user.click(await screen.findByRole("checkbox"));
+    await user.click(screen.getByRole("button", { name: "OK" }));
+
+    await expect(result).resolves.toEqual({
+      confirmed: true,
+      dismissForever: true,
+    });
+    expect(localStorage.getItem("dismiss-csa-warning")).toBe("true");
+  });
+
+  it("does not render the checkbox when dismissForeverKey is absent", async () => {
+    render(<ConfirmDialogBridge />);
+
+    invokeConfirm({ title: "No checkbox", body: "B" });
+
+    await screen.findByText("No checkbox");
+    expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/shared/ConfirmDialogBridge/ConfirmDialogBridge.tsx
+++ b/src/components/shared/ConfirmDialogBridge/ConfirmDialogBridge.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useState } from "react";
+
+import type { ConfirmPayload, ConfirmResult } from "@/config/preSubmitHooks";
+
+import { ConfirmDialogContent } from "./ConfirmDialogContent";
+
+interface ActiveDialog {
+  payload: ConfirmPayload;
+  resolve: (result: ConfirmResult) => void;
+}
+
+export function ConfirmDialogBridge() {
+  const [active, setActive] = useState<ActiveDialog | null>(null);
+
+  useEffect(() => {
+    const confirm = (payload: ConfirmPayload) =>
+      new Promise<ConfirmResult>((resolve) => {
+        setActive({ payload, resolve });
+      });
+
+    window.__TANGLE_CONFIRM__ = confirm;
+
+    return () => {
+      if (window.__TANGLE_CONFIRM__ === confirm) {
+        delete window.__TANGLE_CONFIRM__;
+      }
+    };
+  }, []);
+
+  if (!active) {
+    return null;
+  }
+
+  const handleResolve = (result: ConfirmResult) => {
+    active.resolve(result);
+    setActive(null);
+  };
+
+  return (
+    <ConfirmDialogContent payload={active.payload} onResolve={handleResolve} />
+  );
+}

--- a/src/components/shared/ConfirmDialogBridge/ConfirmDialogContent.tsx
+++ b/src/components/shared/ConfirmDialogBridge/ConfirmDialogContent.tsx
@@ -1,0 +1,76 @@
+import { useState } from "react";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+import { InlineStack } from "@/components/ui/layout";
+import type { ConfirmPayload, ConfirmResult } from "@/config/preSubmitHooks";
+
+interface ConfirmDialogContentProps {
+  payload: ConfirmPayload;
+  onResolve: (result: ConfirmResult) => void;
+}
+
+export function ConfirmDialogContent({
+  payload,
+  onResolve,
+}: ConfirmDialogContentProps) {
+  const [dismissForever, setDismissForever] = useState(false);
+
+  const handleConfirm = () => {
+    if (payload.dismissForeverKey && dismissForever) {
+      try {
+        localStorage.setItem(payload.dismissForeverKey, "true");
+      } catch {
+        // Ignore storage restriction errors.
+      }
+    }
+    onResolve({ confirmed: true, dismissForever });
+  };
+
+  const handleCancel = () => {
+    onResolve({ confirmed: false, dismissForever: false });
+  };
+
+  return (
+    <AlertDialog open>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{payload.title}</AlertDialogTitle>
+          <AlertDialogDescription>{payload.body}</AlertDialogDescription>
+        </AlertDialogHeader>
+
+        {payload.dismissForeverKey && (
+          <InlineStack gap="2" blockAlign="center">
+            <Checkbox
+              id="confirm-dialog-dismiss-forever"
+              checked={dismissForever}
+              onCheckedChange={(checked) => setDismissForever(checked === true)}
+            />
+            <Label htmlFor="confirm-dialog-dismiss-forever">
+              Don&apos;t show this again
+            </Label>
+          </InlineStack>
+        )}
+
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={handleCancel}>
+            {payload.cancelLabel ?? "Cancel"}
+          </AlertDialogCancel>
+          <AlertDialogAction onClick={handleConfirm}>
+            {payload.confirmLabel ?? "Confirm"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/config/preSubmitHooks.ts
+++ b/src/config/preSubmitHooks.ts
@@ -1,0 +1,32 @@
+import type { ArgumentType, ComponentSpec } from "@/utils/componentSpec";
+
+export interface PreSubmitContext {
+  componentSpec: ComponentSpec;
+  taskArguments?: Record<string, ArgumentType>;
+}
+
+export interface PreSubmitResult {
+  proceed: boolean;
+}
+
+export type PreSubmitHook = (ctx: PreSubmitContext) => Promise<PreSubmitResult>;
+
+export interface ConfirmPayload {
+  title: string;
+  body: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  dismissForeverKey?: string;
+}
+
+export interface ConfirmResult {
+  confirmed: boolean;
+  dismissForever: boolean;
+}
+
+declare global {
+  interface Window {
+    __TANGLE_PRE_SUBMIT_HOOKS__?: PreSubmitHook[];
+    __TANGLE_CONFIRM__?: (payload: ConfirmPayload) => Promise<ConfirmResult>;
+  }
+}

--- a/src/utils/runPreSubmitHooks.test.ts
+++ b/src/utils/runPreSubmitHooks.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { PreSubmitContext, PreSubmitHook } from "@/config/preSubmitHooks";
+
+import { runPreSubmitHooks } from "./runPreSubmitHooks";
+
+const ctx: PreSubmitContext = {
+  componentSpec: { implementation: { container: { image: "test:latest" } } },
+};
+
+describe("runPreSubmitHooks", () => {
+  afterEach(() => {
+    delete window.__TANGLE_PRE_SUBMIT_HOOKS__;
+    vi.restoreAllMocks();
+  });
+
+  it("proceeds when no hooks are registered", async () => {
+    await expect(runPreSubmitHooks(ctx)).resolves.toBe(true);
+  });
+
+  it("proceeds when all hooks return proceed: true", async () => {
+    window.__TANGLE_PRE_SUBMIT_HOOKS__ = [
+      vi.fn(async () => ({ proceed: true })),
+      vi.fn(async () => ({ proceed: true })),
+    ];
+
+    await expect(runPreSubmitHooks(ctx)).resolves.toBe(true);
+  });
+
+  it("halts when a hook returns proceed: false", async () => {
+    const second = vi.fn(async () => ({ proceed: true }));
+    window.__TANGLE_PRE_SUBMIT_HOOKS__ = [
+      vi.fn(async () => ({ proceed: false })),
+      second,
+    ];
+
+    await expect(runPreSubmitHooks(ctx)).resolves.toBe(false);
+    expect(second).not.toHaveBeenCalled();
+  });
+
+  it("halts and warns when a hook throws", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    window.__TANGLE_PRE_SUBMIT_HOOKS__ = [
+      vi.fn(async () => {
+        throw new Error("boom");
+      }),
+    ];
+
+    await expect(runPreSubmitHooks(ctx)).resolves.toBe(false);
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it("awaits hooks sequentially in registration order", async () => {
+    const calls: string[] = [];
+    const makeHook =
+      (name: string): PreSubmitHook =>
+      async () => {
+        calls.push(`${name}:start`);
+        await Promise.resolve();
+        calls.push(`${name}:end`);
+        return { proceed: true };
+      };
+
+    window.__TANGLE_PRE_SUBMIT_HOOKS__ = [makeHook("a"), makeHook("b")];
+
+    await runPreSubmitHooks(ctx);
+
+    expect(calls).toEqual(["a:start", "a:end", "b:start", "b:end"]);
+  });
+
+  it("passes the context through to each hook", async () => {
+    const hook = vi.fn(async () => ({ proceed: true }));
+    window.__TANGLE_PRE_SUBMIT_HOOKS__ = [hook];
+
+    await runPreSubmitHooks(ctx);
+
+    expect(hook).toHaveBeenCalledWith(ctx);
+  });
+});

--- a/src/utils/runPreSubmitHooks.ts
+++ b/src/utils/runPreSubmitHooks.ts
@@ -1,0 +1,22 @@
+import type { PreSubmitContext } from "@/config/preSubmitHooks";
+
+export async function runPreSubmitHooks(
+  ctx: PreSubmitContext,
+): Promise<boolean> {
+  const hooks = window.__TANGLE_PRE_SUBMIT_HOOKS__ ?? [];
+  for (const hook of hooks) {
+    try {
+      const result = await hook(ctx);
+      if (!result.proceed) {
+        return false;
+      }
+    } catch (err) {
+      console.warn(
+        "[Tangle] Pre-submit hook threw, cancelling submission",
+        err,
+      );
+      return false;
+    }
+  }
+  return true;
+}

--- a/src/utils/submitPipeline.test.ts
+++ b/src/utils/submitPipeline.test.ts
@@ -48,6 +48,71 @@ describe("submitPipelineRun", () => {
     vi.restoreAllMocks();
   });
 
+  describe("pre-submit hooks", () => {
+    afterEach(() => {
+      delete window.__TANGLE_PRE_SUBMIT_HOOKS__;
+    });
+
+    const componentSpec: ComponentSpec = {
+      name: "hooked-component",
+      implementation: { container: { image: "test:latest" } },
+    };
+
+    it("awaits a registered hook before submitting", async () => {
+      const order: string[] = [];
+      const hook = vi.fn(async () => {
+        order.push("hook");
+        return { proceed: true };
+      });
+      vi.mocked(pipelineRunService.createPipelineRun).mockImplementation(
+        async () => {
+          order.push("create");
+          return mockPipelineRun;
+        },
+      );
+      window.__TANGLE_PRE_SUBMIT_HOOKS__ = [hook];
+
+      await submitPipelineRun(componentSpec, mockBackendUrl);
+
+      expect(hook).toHaveBeenCalledWith({
+        componentSpec,
+        taskArguments: undefined,
+      });
+      expect(order).toEqual(["hook", "create"]);
+    });
+
+    it("skips submission and does not call onError when a hook declines", async () => {
+      const mockOnError = vi.fn();
+      const mockOnSuccess = vi.fn();
+      window.__TANGLE_PRE_SUBMIT_HOOKS__ = [
+        vi.fn(async () => ({ proceed: false })),
+      ];
+
+      await submitPipelineRun(componentSpec, mockBackendUrl, {
+        onSuccess: mockOnSuccess,
+        onError: mockOnError,
+      });
+
+      expect(pipelineRunService.createPipelineRun).not.toHaveBeenCalled();
+      expect(mockOnError).not.toHaveBeenCalled();
+      expect(mockOnSuccess).not.toHaveBeenCalled();
+    });
+
+    it("forwards taskArguments to the hook context", async () => {
+      const hook = vi.fn(async () => ({ proceed: true }));
+      window.__TANGLE_PRE_SUBMIT_HOOKS__ = [hook];
+
+      await submitPipelineRun(componentSpec, mockBackendUrl, {
+        taskArguments: { param1: "value1" },
+      });
+
+      expect(hook).toHaveBeenCalledWith({
+        componentSpec,
+        taskArguments: { param1: "value1" },
+      });
+    });
+  });
+
   describe("basic functionality", () => {
     it("should successfully submit a simple component spec", async () => {
       // Arrange

--- a/src/utils/submitPipeline.ts
+++ b/src/utils/submitPipeline.ts
@@ -19,6 +19,7 @@ import type {
   ComponentReference,
   ComponentSpec,
 } from "./componentSpec";
+import { runPreSubmitHooks } from "./runPreSubmitHooks";
 import { componentSpecFromYaml } from "./yaml";
 
 export async function submitPipelineRun(
@@ -35,6 +36,16 @@ export async function submitPipelineRun(
 ) {
   const pipelineName =
     options?.canonicalName ?? componentSpec.name ?? "Pipeline";
+
+  const proceed = await runPreSubmitHooks({
+    componentSpec,
+    taskArguments: options?.taskArguments,
+  });
+  if (!proceed) {
+    // User declined via a pre-submit hook. This is a successful cancel, not an
+    // error, so we don't invoke onError.
+    return;
+  }
 
   try {
     const specCopy = structuredClone(componentSpec);


### PR DESCRIPTION
## Description

Adds support for inject pre-submit hooks at pipeline submission time. Any registered hooks will be executed upon submitting a run and prior to any communication with the backend.

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

To be shipped in conjunction with https://github.com/Shopify/oasis-frontend/pull/645

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->