### PR TITLE
fix ai responses compatibility

### DIFF
--- a/src/agent/agents/dispatcherRuntime.ts
+++ b/src/agent/agents/dispatcherRuntime.ts
@@ -7,7 +7,12 @@
  * close over the per-turn `AgentSession` (bridge, recent runs, status
  * emitter).
  */
-import { type Agent, MemorySession, run } from "@openai/agents";
+import {
+  type Agent,
+  type AgentInputItem,
+  MemorySession,
+  run,
+} from "@openai/agents";
 
 import type { AiProviderConfig } from "@/types/aiProvider";
 
@@ -32,6 +37,18 @@ export interface TangleDispatcher {
 
 export type BuildDispatcherAgent = (session: AgentSession) => Promise<Agent>;
 
+// Reasoning items can carry provider-side ids (`rs_...`) that are only valid
+// for the original Responses API turn. OpenAI-compatible proxies that cannot
+// dereference those ids on later turns fail with "Item with id ... not found",
+// so strip them from replayed history while keeping the reasoning content.
+function stripReasoningItemIds(items: AgentInputItem[]): AgentInputItem[] {
+  return items.map((item) => {
+    if (item.type !== "reasoning" || !("id" in item)) return item;
+    const { id: _id, ...itemWithoutId } = item;
+    return itemWithoutId;
+  });
+}
+
 export function createDispatcherRuntime(
   buildAgent: BuildDispatcherAgent,
 ): TangleDispatcher {
@@ -52,6 +69,11 @@ export function createDispatcherRuntime(
       const agent = await buildAgent(params.session);
       const result = await run(agent, params.message, {
         session: sessionMemory,
+        reasoningItemIdPolicy: "omit",
+        sessionInputCallback: (history, newItems) => [
+          ...stripReasoningItemIds(history),
+          ...newItems,
+        ],
       });
       const answer =
         typeof result.finalOutput === "string"

--- a/src/agent/agents/dispatcherRuntime.ts
+++ b/src/agent/agents/dispatcherRuntime.ts
@@ -69,6 +69,11 @@ export function createDispatcherRuntime(
       const agent = await buildAgent(params.session);
       const result = await run(agent, params.message, {
         session: sessionMemory,
+        // `reasoningItemIdPolicy: "omit"` is the primary fix: it stops the SDK
+        // from sending reasoning-item ids on outgoing turns. The callback is
+        // belt-and-suspenders — it scrubs ids the SDK may have already
+        // persisted into replayed session history. Keep both until the SDK
+        // guarantees history is sanitized on read.
         reasoningItemIdPolicy: "omit",
         sessionInputCallback: (history, newItems) => [
           ...stripReasoningItemIds(history),

--- a/src/agent/agents/editorDispatcher.test.ts
+++ b/src/agent/agents/editorDispatcher.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AgentSession } from "../session";
+
+const agentCtor = vi.hoisted(() => vi.fn());
+const memorySessionCtor = vi.hoisted(() => vi.fn());
+const runMock = vi.hoisted(() => vi.fn());
+const attachObservabilityHooks = vi.hoisted(() => vi.fn());
+
+vi.mock("@openai/agents", () => {
+  class FakeAgent {
+    constructor(config: unknown) {
+      agentCtor(config);
+    }
+  }
+
+  class FakeMemorySession {
+    constructor(options: unknown) {
+      memorySessionCtor(options);
+    }
+  }
+
+  return {
+    Agent: FakeAgent,
+    MemorySession: FakeMemorySession,
+    run: (...args: unknown[]) => runMock(...args),
+  };
+});
+
+vi.mock("../middleware/observability", () => ({
+  attachObservabilityHooks: (...args: unknown[]) =>
+    attachObservabilityHooks(...args),
+}));
+
+const fakeSubAgent = {
+  asTool: (config: unknown) => ({ type: "tool", config }),
+};
+
+vi.mock("./subagents/generalHelp", () => ({
+  createGeneralHelpAgent: () => fakeSubAgent,
+}));
+
+vi.mock("./subagents/pipelineRepair", () => ({
+  createPipelineRepairAgent: () => fakeSubAgent,
+}));
+
+vi.mock("./subagents/pipelineArchitect", () => ({
+  createPipelineArchitectAgent: () => Promise.resolve(fakeSubAgent),
+}));
+
+vi.mock("./subagents/debugAssistant", () => ({
+  createDebugAssistantAgent: () => fakeSubAgent,
+}));
+
+const { createEditorDispatcher } = await import("./editorDispatcher");
+
+function makeSession(): AgentSession {
+  const session = {
+    threadId: "thread-1",
+    emitStatus: vi.fn(),
+    proxyClient: {
+      ensureConfigured: vi.fn(),
+      openai: {},
+    },
+    bridge: {},
+    skillsLoader: {},
+    aiConfig: {
+      apiBase: "https://api.example.com/v1",
+      apiKey: "sk-test",
+      model: "gpt-5.5",
+    },
+    recentRuns: [],
+  };
+
+  // ProxyClient has private fields, so a duck-typed test double cannot satisfy
+  // AgentSession structurally without this boundary cast.
+  return session as unknown as AgentSession;
+}
+
+describe("createEditorDispatcher", () => {
+  beforeEach(() => {
+    agentCtor.mockClear();
+    memorySessionCtor.mockClear();
+    runMock.mockReset();
+    attachObservabilityHooks.mockClear();
+    runMock.mockResolvedValue({ finalOutput: "Done" });
+  });
+
+  it("omits Responses reasoning item ids from Sidekick session history", async () => {
+    const dispatcher = createEditorDispatcher();
+    await dispatcher.invoke({
+      message: "add a component",
+      threadId: "thread-1",
+      aiConfig: {
+        apiBase: "https://api.example.com/v1",
+        apiKey: "sk-test",
+        model: "gpt-5.5",
+      },
+      session: makeSession(),
+    });
+
+    const options = runMock.mock.calls[0]?.[2];
+    expect(options).toMatchObject({
+      reasoningItemIdPolicy: "omit",
+    });
+
+    const callback = options.sessionInputCallback;
+    const result = callback(
+      [
+        {
+          type: "reasoning",
+          id: "rs_123",
+          summary: [],
+        },
+        { type: "message", role: "assistant", content: "hello" },
+      ],
+      [{ type: "message", role: "user", content: "next" }],
+    );
+
+    expect(result).toEqual([
+      { type: "reasoning", summary: [] },
+      { type: "message", role: "assistant", content: "hello" },
+      { type: "message", role: "user", content: "next" },
+    ]);
+  });
+});

--- a/src/agent/config.test.ts
+++ b/src/agent/config.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const setDefaultOpenAIClient = vi.fn();
+const setOpenAIAPI = vi.fn();
+const setTracingDisabled = vi.fn();
+const openaiCtor = vi.fn();
+
+vi.mock("@openai/agents", () => ({
+  setDefaultOpenAIClient: (...args: unknown[]) =>
+    setDefaultOpenAIClient(...args),
+  setOpenAIAPI: (...args: unknown[]) => setOpenAIAPI(...args),
+  setTracingDisabled: (...args: unknown[]) => setTracingDisabled(...args),
+}));
+
+vi.mock("openai", () => {
+  class FakeOpenAI {
+    constructor(options: unknown) {
+      openaiCtor(options);
+    }
+  }
+  return { default: FakeOpenAI };
+});
+
+const { getAgentModelConfig, ProxyClient } = await import("./config");
+
+const BASE_CONFIG = {
+  apiBase: "https://api.example.com/v1",
+  apiKey: "sk-test",
+  model: "",
+};
+
+describe("getAgentModelConfig", () => {
+  it("omits the model when the configured model is blank", () => {
+    expect(getAgentModelConfig(BASE_CONFIG)).toEqual({});
+  });
+
+  it("uses the configured model without extra settings", () => {
+    expect(
+      getAgentModelConfig({ ...BASE_CONFIG, model: "gpt-4o-mini" }),
+    ).toEqual({ model: "gpt-4o-mini" });
+  });
+});
+
+describe("ProxyClient", () => {
+  beforeEach(() => {
+    openaiCtor.mockClear();
+    setDefaultOpenAIClient.mockClear();
+    setOpenAIAPI.mockClear();
+    setTracingDisabled.mockClear();
+  });
+
+  it("uses the Responses API for Sidekick", () => {
+    const client = new ProxyClient();
+    client.ensureConfigured({ ...BASE_CONFIG, model: "gpt-5.5" });
+
+    expect(setOpenAIAPI).toHaveBeenLastCalledWith("responses");
+  });
+
+  it("reuses the SDK client when proxy settings are unchanged", () => {
+    const client = new ProxyClient();
+    client.ensureConfigured({ ...BASE_CONFIG, model: "gpt-4o-mini" });
+    client.ensureConfigured({ ...BASE_CONFIG, model: "gpt-5.5" });
+
+    expect(openaiCtor).toHaveBeenCalledTimes(1);
+    expect(setOpenAIAPI).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/agent/config.ts
+++ b/src/agent/config.ts
@@ -9,6 +9,7 @@ import type { AiProviderConfig } from "@/types/aiProvider";
 import { BASE_URL } from "@/utils/constants";
 
 const AI_ASSISTANT_EMBEDDING_MODEL = "text-embedding-3-small";
+const SIDEKICK_OPENAI_API = "responses";
 
 export function getAgentModelConfig(config: AiProviderConfig): {
   model?: string;
@@ -73,7 +74,7 @@ export class ProxyClient implements OpenAIProvider {
       ...(apiKey ? {} : { fetch: stripAuthorizationFetch }),
     });
     setDefaultOpenAIClient(this.#client);
-    setOpenAIAPI("chat_completions");
+    setOpenAIAPI(SIDEKICK_OPENAI_API);
     setTracingDisabled(true);
     this.#lastConfigKey = configKey;
   }

--- a/src/agent/tools/csomTools.test.ts
+++ b/src/agent/tools/csomTools.test.ts
@@ -10,6 +10,7 @@ interface JsonSchemaNode {
   type?: string | string[];
   properties?: Record<string, JsonSchemaNode>;
   anyOf?: JsonSchemaNode[];
+  allOf?: JsonSchemaNode[];
   additionalProperties?: boolean | JsonSchemaNode;
   $ref?: string;
 }
@@ -57,6 +58,19 @@ function getImplementationAnyOf(schema: JsonSchemaNode): JsonSchemaNode[] {
   if (!specObjectSchema) return [];
 
   return specObjectSchema.properties?.implementation?.anyOf ?? [];
+}
+
+function hasAllOf(schema: JsonSchemaNode | undefined): boolean {
+  if (!schema) return false;
+  if (schema.allOf) return true;
+  if (schema.anyOf?.some(hasAllOf)) return true;
+  if (schema.properties && Object.values(schema.properties).some(hasAllOf)) {
+    return true;
+  }
+  const additionalProperties = schema.additionalProperties;
+  return (
+    typeof additionalProperties === "object" && hasAllOf(additionalProperties)
+  );
 }
 
 describe("createCsomTools", () => {
@@ -241,6 +255,44 @@ describe("createCsomTools", () => {
       value: "data.csv",
     });
     expect(setTaskArgument).toHaveBeenCalledWith("task_1", "path", "data.csv");
+  });
+
+  it("set_task_argument accepts graph input and task output argument objects", async () => {
+    const setTaskArgument = vi.fn().mockResolvedValue({ success: true });
+    const { allTools } = createCsomTools(makeBridge({ setTaskArgument }));
+
+    await invoke(findTool(allTools, "set_task_argument"), {
+      taskEntityId: "task_1",
+      inputName: "path",
+      value: { graphInput: { inputName: "dataset" } },
+    });
+    await invoke(findTool(allTools, "set_task_argument"), {
+      taskEntityId: "task_2",
+      inputName: "model",
+      value: { taskOutput: { taskId: "train", outputName: "model" } },
+    });
+
+    expect(setTaskArgument).toHaveBeenNthCalledWith(1, "task_1", "path", {
+      graphInput: { inputName: "dataset" },
+    });
+    expect(setTaskArgument).toHaveBeenNthCalledWith(2, "task_2", "model", {
+      taskOutput: { taskId: "train", outputName: "model" },
+    });
+  });
+
+  it("set_task_argument schema avoids recursive allOf shapes rejected by Responses", () => {
+    const { allTools } = createCsomTools(makeBridge());
+    const setTaskArgumentTool = findTool(allTools, "set_task_argument");
+    const valueSchema = (setTaskArgumentTool.parameters as JsonSchemaNode)
+      .properties?.value;
+
+    expect(valueSchema?.anyOf).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "string" }),
+        expect.objectContaining({ type: "object" }),
+      ]),
+    );
+    expect(hasAllOf(valueSchema)).toBe(false);
   });
 
   it("add_input normalizes null optional fields to undefined", async () => {

--- a/src/agent/tools/csomTools.ts
+++ b/src/agent/tools/csomTools.ts
@@ -45,6 +45,28 @@ const jsonValueSchema: z.ZodType<JsonValue> = z.lazy(() =>
 
 const arbitraryObjectSchema = z.object({}).catchall(jsonValueSchema);
 
+const argumentValueSchema = z.union([
+  z.string(),
+  z.object({
+    graphInput: z.object({
+      inputName: z.string(),
+      type: z.string().nullable().optional(),
+    }),
+  }),
+  z.object({
+    taskOutput: z.object({
+      taskId: z.string(),
+      outputName: z.string(),
+      type: z.string().nullable().optional(),
+    }),
+  }),
+  z.object({
+    dynamicData: z.object({
+      secret: z.object({ name: z.string() }),
+    }),
+  }),
+]);
+
 /**
  * Recursively strips `null` values from an object so the bridge contract
  * (which uses `T?` for optional fields) sees missing keys instead of
@@ -294,12 +316,12 @@ export function createCsomTools(bridge: ToolBridgeApi) {
   const setTaskArgument = tool({
     name: "set_task_argument",
     description:
-      "Set a value for a task input. Removes any existing connection to that port. Accepts a literal string/number/boolean or a structured value (e.g. a graph-input or task-output reference object).",
+      "Set a value for a task input. Removes any existing connection to that port. Accepts a literal string or a graph-input, task-output, or secret reference object.",
     parameters: z.object({
       taskEntityId: z.string().describe("$id of the task"),
       inputName: z.string().describe("Name of the input port"),
-      value: jsonValueSchema.describe(
-        "Literal value (string/number/boolean) or a structured argument value object",
+      value: argumentValueSchema.describe(
+        "Literal string or a graph-input, task-output, or secret reference object",
       ),
     }),
     execute: async ({ taskEntityId, inputName, value }) =>

--- a/src/agent/tools/csomTools.ts
+++ b/src/agent/tools/csomTools.ts
@@ -61,9 +61,16 @@ const argumentValueSchema = z.union([
     }),
   }),
   z.object({
-    dynamicData: z.object({
-      secret: z.object({ name: z.string() }),
-    }),
+    // `DynamicDataValue` is `SecretArgument | SystemDataArgument`. The secret
+    // shape is spelled out so the model has a concrete target; system sources
+    // use arbitrary string keys (e.g. `{ "system/multi_node/node_index": {} }`)
+    // and go through the catchall object. `z.record` is intentionally avoided
+    // here for the same reason as `implementation` below — it emits
+    // `propertyNames`, which OpenAI strict mode rejects at tool registration.
+    dynamicData: z.union([
+      z.object({ secret: z.object({ name: z.string() }) }),
+      arbitraryObjectSchema,
+    ]),
   }),
 ]);
 
@@ -316,12 +323,12 @@ export function createCsomTools(bridge: ToolBridgeApi) {
   const setTaskArgument = tool({
     name: "set_task_argument",
     description:
-      "Set a value for a task input. Removes any existing connection to that port. Accepts a literal string or a graph-input, task-output, or secret reference object.",
+      "Set a value for a task input. Removes any existing connection to that port. Accepts a literal string or a graph-input, task-output, or dynamic-data (secret or system) reference object.",
     parameters: z.object({
       taskEntityId: z.string().describe("$id of the task"),
       inputName: z.string().describe("Name of the input port"),
       value: argumentValueSchema.describe(
-        "Literal string or a graph-input, task-output, or secret reference object",
+        "Literal string or a graph-input, task-output, or dynamic-data (secret or system) reference object",
       ),
     }),
     execute: async ({ taskEntityId, inputName, value }) =>

--- a/src/routes/Dashboard/DashboardComponentsV2View.test.tsx
+++ b/src/routes/Dashboard/DashboardComponentsV2View.test.tsx
@@ -31,8 +31,11 @@ const routeMocks = vi.hoisted(() => {
     navigate: vi.fn(),
     notify: vi.fn(),
     refetchDescription: vi.fn(),
+    rerank: vi.fn(),
+    resetRerank: vi.fn(),
     descriptionErrorState,
     aiDescriptionsEnabled: false,
+    aiSearchConfigured: false,
     search,
   };
 });
@@ -142,12 +145,12 @@ vi.mock("@/hooks/useNaturalLanguageComponentSearch", () => ({
     };
   },
   useNaturalLanguageComponentRerank: () => ({
-    mutate: vi.fn(),
+    mutate: routeMocks.rerank,
     data: undefined,
     isPending: false,
     error: null,
-    reset: vi.fn(),
-    isConfigured: false,
+    reset: routeMocks.resetRerank,
+    isConfigured: routeMocks.aiSearchConfigured,
   }),
 }));
 
@@ -383,6 +386,9 @@ describe("DashboardComponentsV2View", () => {
     routeMocks.descriptionErrorState.current = null;
     routeMocks.search = {};
     routeMocks.refetchDescription.mockClear();
+    routeMocks.rerank.mockClear();
+    routeMocks.resetRerank.mockClear();
+    routeMocks.aiSearchConfigured = false;
   });
 
   it("filters visible component results by source type and restores them", () => {
@@ -405,6 +411,25 @@ describe("DashboardComponentsV2View", () => {
     fireEvent.click(screen.getByRole("button", { name: "Show all" }));
 
     expect(screen.getByText("Registered component")).toBeInTheDocument();
+  });
+
+  it("lets AI search run against a bounded candidate pool when literal search has no matches", () => {
+    routeMocks.aiSearchConfigured = true;
+    render(<DashboardComponentsV2View />);
+
+    fireEvent.change(screen.getByLabelText("Search components"), {
+      target: { value: "find something semantically relevant" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "AI search" }));
+
+    expect(routeMocks.rerank).toHaveBeenCalledWith({
+      query: "find something semantically relevant",
+      candidates: expect.arrayContaining([
+        expect.objectContaining({ id: "standard-digest" }),
+        expect.objectContaining({ id: "registered-digest" }),
+        expect.objectContaining({ id: "user-digest" }),
+      ]),
+    });
   });
 
   it("shows a manual generate button when automatic descriptions are disabled", () => {

--- a/src/routes/Dashboard/DashboardComponentsV2View.tsx
+++ b/src/routes/Dashboard/DashboardComponentsV2View.tsx
@@ -420,6 +420,22 @@ const ComponentDescriptionPanel = ({
  * `standard > published > registered > user` so the most canonical label
  * sticks when the same component appears in multiple places.
  */
+/**
+ * Pick up to `limit` entries spread evenly across `entries`, preserving order.
+ * Used to build a representative browse pool for AI search when literal
+ * matching returns nothing — taking the first N would bias toward names that
+ * sort early in a library larger than the limit.
+ */
+function sampleEvenly<T>(entries: T[], limit: number): T[] {
+  if (entries.length <= limit) return entries;
+  const step = entries.length / limit;
+  const sampled: T[] = [];
+  for (let i = 0; i < limit; i++) {
+    sampled.push(entries[Math.floor(i * step)]);
+  }
+  return sampled;
+}
+
 function collectAllSourcedReferences({
   standardLibrary,
   publishedRefs,
@@ -690,23 +706,31 @@ export const DashboardComponentsV2View = () => {
 
   const trimmedQuery = query.trim();
 
-  const lexicalMatches: LexicalMatch[] = lexicalSearch(filteredIndex, query, {
-    limit: LEXICAL_RESULT_LIMIT,
-  });
+  // One lexical pass at the wider AI-candidate limit; the display list is the
+  // top slice of that same scored result, so we never score and sort the index
+  // twice per render. `lexicalSearch` already orders by score desc then name
+  // asc, so slicing is equivalent to a separate narrower search.
+  const broadLexicalMatches: LexicalMatch[] =
+    trimmedQuery.length === 0
+      ? []
+      : lexicalSearch(filteredIndex, query, { limit: AI_CANDIDATE_LIMIT });
+
+  const lexicalMatches: LexicalMatch[] = broadLexicalMatches.slice(
+    0,
+    LEXICAL_RESULT_LIMIT,
+  );
+
   const aiCandidateMatches: LexicalMatch[] = (() => {
     if (trimmedQuery.length === 0) return [];
-
-    const broadLexicalMatches = lexicalSearch(filteredIndex, query, {
-      limit: AI_CANDIDATE_LIMIT,
-    });
     if (broadLexicalMatches.length > 0) return broadLexicalMatches;
 
     // If literal matching found nothing, AI search can still judge a bounded
-    // browse pool. This keeps natural-language queries useful for small and
-    // medium libraries without sending the entire library to the model.
-    return sortedIndex
-      .slice(0, AI_CANDIDATE_LIMIT)
-      .map(indexEntryToLexicalMatch);
+    // browse pool. Sample evenly across the (alphabetically sorted) library so
+    // the model sees a representative spread instead of only names that sort
+    // early — matters for libraries larger than AI_CANDIDATE_LIMIT.
+    return sampleEvenly(sortedIndex, AI_CANDIDATE_LIMIT).map(
+      indexEntryToLexicalMatch,
+    );
   })();
 
   const {

--- a/src/routes/Dashboard/DashboardComponentsV2View.tsx
+++ b/src/routes/Dashboard/DashboardComponentsV2View.tsx
@@ -42,6 +42,7 @@ import {
   buildSearchIndex,
   type ComponentSearchSource,
   type IndexEntry,
+  indexEntryToLexicalMatch,
   type LexicalMatch,
   lexicalSearch,
   type MatchField,
@@ -102,8 +103,10 @@ const SOURCE_ICON_TONE_BY_KIND: Record<ComponentSearchSource["kind"], string> =
     user: "text-amber-500",
   };
 
-/** How many lexical hits to display (and to feed into rerank). */
+/** How many lexical hits to display before the user asks for AI judgment. */
 const LEXICAL_RESULT_LIMIT = 20;
+/** Bounded pool sent to AI search on click. */
+const AI_CANDIDATE_LIMIT = 80;
 
 const MATCH_FIELD_LABEL: Record<MatchField, string> = {
   name: "name",
@@ -685,9 +688,26 @@ export const DashboardComponentsV2View = () => {
     a.name.localeCompare(b.name),
   );
 
+  const trimmedQuery = query.trim();
+
   const lexicalMatches: LexicalMatch[] = lexicalSearch(filteredIndex, query, {
     limit: LEXICAL_RESULT_LIMIT,
   });
+  const aiCandidateMatches: LexicalMatch[] = (() => {
+    if (trimmedQuery.length === 0) return [];
+
+    const broadLexicalMatches = lexicalSearch(filteredIndex, query, {
+      limit: AI_CANDIDATE_LIMIT,
+    });
+    if (broadLexicalMatches.length > 0) return broadLexicalMatches;
+
+    // If literal matching found nothing, AI search can still judge a bounded
+    // browse pool. This keeps natural-language queries useful for small and
+    // medium libraries without sending the entire library to the model.
+    return sortedIndex
+      .slice(0, AI_CANDIDATE_LIMIT)
+      .map(indexEntryToLexicalMatch);
+  })();
 
   const {
     mutate: rerank,
@@ -702,25 +722,30 @@ export const DashboardComponentsV2View = () => {
   // user types more, we drop the rerank rather than show results for an old
   // query. Tracked here so we can clear on input change.
   const [rerankedFor, setRerankedFor] = useState<string | null>(null);
+  const [rerankBaseMatches, setRerankBaseMatches] = useState<LexicalMatch[]>(
+    [],
+  );
 
   const handleQueryChange = (event: ChangeEvent<HTMLInputElement>) => {
     setQuery(event.target.value);
     if (rerankedFor !== null) {
       setRerankedFor(null);
+      setRerankBaseMatches([]);
       resetRerank();
     }
   };
 
   const handleSmartSearch = () => {
     const trimmed = query.trim();
-    if (trimmed.length === 0 || lexicalMatches.length === 0) return;
+    if (trimmed.length === 0 || aiCandidateMatches.length === 0) return;
 
-    const candidates = lexicalMatches
+    const candidates = aiCandidateMatches
       .map((m) => componentReferenceToCandidate(m.reference))
       .filter((c): c is NonNullable<typeof c> => c !== null);
 
     if (candidates.length === 0) return;
 
+    setRerankBaseMatches(aiCandidateMatches);
     setRerankedFor(trimmed);
     rerank({ query: trimmed, candidates });
   };
@@ -733,6 +758,7 @@ export const DashboardComponentsV2View = () => {
     );
     if (rerankedFor !== null) {
       setRerankedFor(null);
+      setRerankBaseMatches([]);
       resetRerank();
     }
   };
@@ -741,6 +767,7 @@ export const DashboardComponentsV2View = () => {
     setDisabledSourceKeys([]);
     if (rerankedFor !== null) {
       setRerankedFor(null);
+      setRerankBaseMatches([]);
       resetRerank();
     }
   };
@@ -752,7 +779,6 @@ export const DashboardComponentsV2View = () => {
     registeredLoading ||
     hydrating;
   const noLibraryData = !isLoadingLibrary && totalAcrossSources === 0;
-  const trimmedQuery = query.trim();
   const isEmpty = trimmedQuery.length === 0;
   const isConfigError = rerankError instanceof NaturalLanguageSearchConfigError;
   // Only treat rerank as "active" when the model actually returned matches.
@@ -765,11 +791,12 @@ export const DashboardComponentsV2View = () => {
     rerankedFor === trimmedQuery &&
     rerankData !== undefined &&
     rerankData.matches.length > 0 &&
+    rerankBaseMatches.length > 0 &&
     !isReranking;
 
   // What we actually render. Rerank wins when active; otherwise lexical.
   const displayedResults = rerankActive
-    ? mergeRerankIntoLexical(rerankData.matches, lexicalMatches)
+    ? mergeRerankIntoLexical(rerankData.matches, rerankBaseMatches)
     : lexicalMatches.map((m) => ({ ...m, reason: undefined }));
 
   // Resolve the full reference for the selected digest. Prefer the already-
@@ -880,7 +907,7 @@ export const DashboardComponentsV2View = () => {
         </BlockStack>
       );
     }
-    if (lexicalMatches.length === 0) {
+    if (lexicalMatches.length === 0 && !rerankActive) {
       return (
         <Paragraph size="sm" tone="subdued">
           No components matched “{trimmedQuery}”. Try different terms or check
@@ -954,7 +981,7 @@ export const DashboardComponentsV2View = () => {
               disabled={
                 isReranking ||
                 isEmpty ||
-                lexicalMatches.length === 0 ||
+                aiCandidateMatches.length === 0 ||
                 !isConfigured
               }
               aria-label={isReranking ? "AI search in progress" : "AI search"}
@@ -994,14 +1021,14 @@ export const DashboardComponentsV2View = () => {
           {/* AI-search-unavailable banner and rerank error live in the
               results column — they describe what just happened to the
               search the user is looking at. */}
-          {!isConfigured && !isEmpty && lexicalMatches.length > 0 && (
+          {!isConfigured && !isEmpty && aiCandidateMatches.length > 0 && (
             <BlockStack gap="1" className={cn(PANEL_CLASS, "mb-3")}>
               <Text size="sm" weight="semibold">
                 AI search unavailable
               </Text>
               <Paragraph size="sm" tone="subdued">
-                Configure an OpenAI-compatible provider to use AI search.
-                Lexical results above are unaffected.
+                Configure an OpenAI-compatible provider to use AI search. Search
+                results are unaffected.
               </Paragraph>
               <ConfigureInSettingsLink />
             </BlockStack>

--- a/src/routes/Settings/sections/AgentSettings.test.tsx
+++ b/src/routes/Settings/sections/AgentSettings.test.tsx
@@ -30,25 +30,20 @@ describe("AgentSettings", () => {
       target: { value: "   " },
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save and test AI" }));
 
     expect(screen.getByRole("alert")).toHaveTextContent(
       "Enter an API base URL before continuing.",
     );
     expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
     expect(mockNotify).not.toHaveBeenCalledWith(
-      "AI provider settings saved",
+      expect.stringContaining("AI provider settings saved"),
       "success",
     );
   });
 
-  it("validates that the configured model exists when testing connection", async () => {
-    mockFetch.mockResolvedValue(
-      new Response(
-        JSON.stringify({ data: [{ id: "gpt-4o-mini" }, { id: "o3-mini" }] }),
-        { status: 200 },
-      ),
-    );
+  it("saves after testing the Responses API path used by AI generation", async () => {
+    mockFetch.mockResolvedValue(new Response(JSON.stringify({ ok: true })));
     render(<AgentSettings />);
 
     fireEvent.change(screen.getByLabelText("API base URL"), {
@@ -61,20 +56,41 @@ describe("AgentSettings", () => {
       target: { value: "gpt-4o-mini" },
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "Test connection" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save and test AI" }));
 
     await waitFor(() => {
       expect(mockNotify).toHaveBeenCalledWith(
-        "Connected. Model “gpt-4o-mini” is available.",
+        "AI provider settings saved. Model “gpt-4o-mini” works with the Responses API.",
         "success",
       );
     });
+    expect(JSON.parse(window.localStorage.getItem(STORAGE_KEY) ?? "")).toEqual({
+      apiBase: "https://api.example.com/v1",
+      apiKey: "sk-test",
+      model: "gpt-4o-mini",
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://api.example.com/v1/responses",
+      expect.objectContaining({ method: "POST" }),
+    );
+    const init = mockFetch.mock.calls[0]?.[1];
+    if (typeof init !== "object" || init === null || !("body" in init)) {
+      throw new Error("Expected fetch init with a body");
+    }
+    expect(JSON.parse(String(init.body))).toMatchObject({
+      model: "gpt-4o-mini",
+      max_output_tokens: 32,
+      text: { format: { type: "json_object" } },
+    });
+    expect(JSON.stringify(init)).toContain("Bearer sk-test");
   });
 
-  it("reports an error when the configured model is missing from provider models", async () => {
+  it("reports an error and does not save when the Responses API is not supported", async () => {
     mockFetch.mockResolvedValue(
-      new Response(JSON.stringify({ data: [{ id: "gpt-4o-mini" }] }), {
-        status: 200,
+      new Response("Endpoint not supported: /v1/responses", {
+        status: 404,
+        statusText: "Not Found",
       }),
     );
     render(<AgentSettings />);
@@ -82,39 +98,42 @@ describe("AgentSettings", () => {
     fireEvent.change(screen.getByLabelText("API base URL"), {
       target: { value: "https://api.example.com/v1" },
     });
-    fireEvent.change(screen.getByLabelText("API key"), {
-      target: { value: "sk-test" },
-    });
     fireEvent.change(screen.getByLabelText("Model id"), {
-      target: { value: "missing-model" },
+      target: { value: "claude-opus" },
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "Test connection" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save and test AI" }));
 
     await waitFor(() => {
       expect(mockNotify).toHaveBeenCalledWith(
-        "Connected, but model “missing-model” was not found.",
+        "AI test failed: 404 Not Found — Endpoint not supported: /v1/responses",
         "error",
       );
     });
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
   });
 
-  it("saves when API key and model are blank", () => {
+  it("saves after a successful provider-default AI test when API key and model are blank", async () => {
+    mockFetch.mockResolvedValue(new Response(JSON.stringify({ ok: true })));
     render(<AgentSettings />);
 
     fireEvent.change(screen.getByLabelText("API base URL"), {
       target: { value: "https://api.example.com/v1" },
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save and test AI" }));
 
-    expect(JSON.parse(window.localStorage.getItem(STORAGE_KEY) ?? "")).toEqual({
-      apiBase: "https://api.example.com/v1",
-      apiKey: "",
-      model: "",
+    await waitFor(() => {
+      expect(
+        JSON.parse(window.localStorage.getItem(STORAGE_KEY) ?? ""),
+      ).toEqual({
+        apiBase: "https://api.example.com/v1",
+        apiKey: "",
+        model: "",
+      });
     });
     expect(mockNotify).toHaveBeenCalledWith(
-      "AI provider settings saved",
+      "AI provider settings saved. The provider works with the Responses API.",
       "success",
     );
   });

--- a/src/routes/Settings/sections/AgentSettings.tsx
+++ b/src/routes/Settings/sections/AgentSettings.tsx
@@ -9,16 +9,6 @@ import { Separator } from "@/components/ui/separator";
 import { Heading, Paragraph, Text } from "@/components/ui/typography";
 import { useAiProviderSettings } from "@/hooks/useAiProviderSettings";
 import useToastNotification from "@/hooks/useToastNotification";
-import { isRecord } from "@/utils/typeGuards";
-
-function readModelIds(payload: unknown): string[] {
-  if (!isRecord(payload) || !Array.isArray(payload.data)) return [];
-  return payload.data
-    .map((item) =>
-      isRecord(item) && typeof item.id === "string" ? item.id : null,
-    )
-    .filter((id): id is string => id !== null);
-}
 
 /**
  * Shared bring-your-own-provider configuration UI for AI features. Credentials
@@ -53,16 +43,68 @@ export function AgentSettings() {
     return trimmed;
   };
 
-  const handleSave = (event: FormEvent<HTMLFormElement>) => {
+  const handleSave = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+    if (testing) return;
+
     const trimmed = validateRequiredFields();
     if (!trimmed) return;
 
-    setApiBase(trimmed.apiBase);
-    setApiKey(trimmed.apiKey);
-    setModel(trimmed.model);
-    update(trimmed);
-    notify("AI provider settings saved", "success");
+    const testRunId = testRunIdRef.current + 1;
+    testRunIdRef.current = testRunId;
+    const isCurrentTest = () => testRunIdRef.current === testRunId;
+
+    setTesting(true);
+    try {
+      const response = await fetch(`${trimmed.apiBase}/responses`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          ...(trimmed.apiKey
+            ? { authorization: `Bearer ${trimmed.apiKey}` }
+            : {}),
+        },
+        body: JSON.stringify({
+          ...(trimmed.model ? { model: trimmed.model } : {}),
+          max_output_tokens: 32,
+          instructions:
+            "You are testing provider compatibility. Return only JSON.",
+          input: 'Return the JSON object {"ok": true}.',
+          text: { format: { type: "json_object" } },
+        }),
+      });
+      if (!isCurrentTest()) return;
+      if (!response.ok) {
+        const detail = await response.text().catch(() => "");
+        if (!isCurrentTest()) return;
+        notify(
+          `AI test failed: ${response.status} ${response.statusText}${detail ? ` — ${detail.slice(0, 200)}` : ""}`,
+          "error",
+        );
+        return;
+      }
+
+      setApiBase(trimmed.apiBase);
+      setApiKey(trimmed.apiKey);
+      setModel(trimmed.model);
+      update(trimmed);
+      notify(
+        trimmed.model
+          ? `AI provider settings saved. Model “${trimmed.model}” works with the Responses API.`
+          : "AI provider settings saved. The provider works with the Responses API.",
+        "success",
+      );
+    } catch (err) {
+      if (!isCurrentTest()) return;
+      notify(
+        err instanceof Error
+          ? `AI test failed: ${err.message}`
+          : "AI test failed",
+        "error",
+      );
+    } finally {
+      if (isCurrentTest()) setTesting(false);
+    }
   };
 
   const handleClear = () => {
@@ -75,58 +117,6 @@ export function AgentSettings() {
     setShowKey(false);
     setTesting(false);
     notify("AI provider settings cleared", "success");
-  };
-
-  const handleTest = async () => {
-    if (testing) return;
-
-    const trimmed = validateRequiredFields();
-    if (!trimmed) return;
-
-    const testRunId = testRunIdRef.current + 1;
-    testRunIdRef.current = testRunId;
-    const isCurrentTest = () => testRunIdRef.current === testRunId;
-
-    setTesting(true);
-    try {
-      const response = await fetch(`${trimmed.apiBase}/models`, {
-        headers: trimmed.apiKey
-          ? { authorization: `Bearer ${trimmed.apiKey}` }
-          : undefined,
-      });
-      if (!isCurrentTest()) return;
-      if (!response.ok) {
-        notify(
-          `Test failed: ${response.status} ${response.statusText}`,
-          "error",
-        );
-        return;
-      }
-
-      const modelIds = readModelIds(await response.json());
-      if (!isCurrentTest()) return;
-      if (trimmed.model && !modelIds.includes(trimmed.model)) {
-        notify(
-          `Connected, but model “${trimmed.model}” was not found.`,
-          "error",
-        );
-        return;
-      }
-      notify(
-        trimmed.model
-          ? `Connected. Model “${trimmed.model}” is available.`
-          : "Connected. The provider is reachable.",
-        "success",
-      );
-    } catch (err) {
-      if (!isCurrentTest()) return;
-      notify(
-        err instanceof Error ? `Test failed: ${err.message}` : "Test failed",
-        "error",
-      );
-    } finally {
-      if (isCurrentTest()) setTesting(false);
-    }
   };
 
   return (
@@ -166,7 +156,7 @@ export function AgentSettings() {
             />
             <Text id="agent-settings-api-base-hint" size="xs" tone="subdued">
               Any OpenAI-compatible base URL, such as https://api.openai.com/v1.
-              Do not include /chat/completions.
+              Do not include /chat/completions or /responses.
             </Text>
           </BlockStack>
 
@@ -221,8 +211,8 @@ export function AgentSettings() {
               spellCheck={false}
             />
             <Text id="agent-settings-model-hint" size="xs" tone="subdued">
-              Optional. Model id sent to the provider for AI requests. Leave
-              blank to use the default model.
+              Optional. Used by all generation features through the Responses
+              API. Documentation search uses its embedding model separately.
             </Text>
           </BlockStack>
 
@@ -233,14 +223,8 @@ export function AgentSettings() {
           )}
 
           <InlineStack gap="2">
-            <Button type="submit">Save</Button>
-            <Button
-              type="button"
-              variant="secondary"
-              onClick={handleTest}
-              disabled={testing}
-            >
-              {testing ? "Testing…" : "Test connection"}
+            <Button type="submit" disabled={testing}>
+              {testing ? "Testing…" : "Save and test AI"}
             </Button>
             <Button type="button" variant="ghost" onClick={handleClear}>
               Clear

--- a/src/routes/Settings/sections/AgentSettings.tsx
+++ b/src/routes/Settings/sections/AgentSettings.tsx
@@ -75,7 +75,12 @@ export function AgentSettings() {
       });
       if (!isCurrentTest()) return;
       if (!response.ok) {
-        const detail = await response.text().catch(() => "");
+        // Some misconfigured proxies echo request headers back in error bodies.
+        // Redact any bearer token before surfacing the detail in a toast.
+        const detail = (await response.text().catch(() => "")).replace(
+          /Bearer\s+[\w.\-~+/]+=*/gi,
+          "Bearer ***",
+        );
         if (!isCurrentTest()) return;
         notify(
           `AI test failed: ${response.status} ${response.statusText}${detail ? ` — ${detail.slice(0, 200)}` : ""}`,
@@ -156,7 +161,7 @@ export function AgentSettings() {
             />
             <Text id="agent-settings-api-base-hint" size="xs" tone="subdued">
               Any OpenAI-compatible base URL, such as https://api.openai.com/v1.
-              Do not include /chat/completions or /responses.
+              Do not include endpoint paths like /responses.
             </Text>
           </BlockStack>
 

--- a/src/services/componentSearchIndex.test.ts
+++ b/src/services/componentSearchIndex.test.ts
@@ -214,6 +214,51 @@ describe("lexicalSearch", () => {
     expect(results[0]?.digest).toBe("b");
   });
 
+  it("ignores natural-language filler words that would otherwise swamp intent", () => {
+    const index = buildSearchIndex([
+      makeSourced({
+        digest: "target",
+        spec: {
+          name: "upload_to_storage",
+          description: "Upload data to cloud storage.",
+          inputs: [{ name: "dataset" }],
+          outputs: [{ name: "uri" }],
+          implementation: { container: { image: "x" } },
+        },
+      }),
+      makeSourced({
+        digest: "noise",
+        spec: {
+          name: "train_component",
+          description: "A component to train a model.",
+          inputs: [],
+          outputs: [],
+          implementation: { container: { image: "x" } },
+        },
+      }),
+    ]);
+
+    const results = lexicalSearch(index, "I want to upload a component to GCS");
+    expect(results.map((result) => result.digest)).toEqual(["target"]);
+  });
+
+  it("does not special-case single-letter non-stop-word tokens", () => {
+    const index = buildSearchIndex([
+      makeSourced({
+        digest: "x",
+        spec: {
+          name: "x_transform",
+          inputs: [],
+          outputs: [],
+          implementation: { container: { image: "x" } },
+        },
+      }),
+    ]);
+
+    const results = lexicalSearch(index, "x");
+    expect(results[0]?.digest).toBe("x");
+  });
+
   it("matches implementation/command text with the lowest weight", () => {
     const index = buildSearchIndex(fixtures);
     const results = lexicalSearch(index, "pandas");

--- a/src/services/componentSearchIndex.ts
+++ b/src/services/componentSearchIndex.ts
@@ -62,6 +62,16 @@ export interface LexicalMatch {
   matchedFields: MatchField[];
 }
 
+export function indexEntryToLexicalMatch(entry: IndexEntry): LexicalMatch {
+  return {
+    reference: entry.reference,
+    digest: entry.digest,
+    name: entry.name,
+    source: entry.source,
+    matchedFields: [],
+  };
+}
+
 /**
  * Flatten a container implementation's image + command + args into a single
  * lowercase string. Placeholder objects (e.g. `{ inputValue: "Where" }`) are
@@ -176,17 +186,52 @@ export function buildSearchIndex(sourced: SourcedReference[]): IndexEntry[] {
   return entries;
 }
 
+const QUERY_STOP_WORDS = new Set([
+  "a",
+  "an",
+  "and",
+  "are",
+  "component",
+  "for",
+  "from",
+  "i",
+  "in",
+  "into",
+  "me",
+  "my",
+  "of",
+  "on",
+  "please",
+  "that",
+  "the",
+  "to",
+  "want",
+  "with",
+]);
+
 /**
- * Split a query into lowercase alphanumeric tokens. `train_test_split` becomes
- * `["train", "test", "split"]` — users almost always type the parts
- * individually, and exact-string matches are still caught by substring search
- * on the original lowercased text.
+ * Split a query into meaningful lowercase alphanumeric tokens. Natural-language
+ * searches often include filler words ("I want to upload a component to GCS").
+ * Dropping those words prevents common tokens like "a"/"to" from matching
+ * nearly every component and drowning out the useful intent terms.
  */
 function tokenize(text: string): string[] {
-  return text
+  const rawTokens = text
     .toLowerCase()
     .split(/[^a-z0-9]+/)
     .filter((t) => t.length > 0);
+
+  const tokens: string[] = [];
+  const seen = new Set<string>();
+  for (const token of rawTokens) {
+    if (QUERY_STOP_WORDS.has(token)) continue;
+    if (!seen.has(token)) {
+      tokens.push(token);
+      seen.add(token);
+    }
+  }
+
+  return tokens;
 }
 
 /**

--- a/src/services/naturalLanguageComponentSearchService.test.ts
+++ b/src/services/naturalLanguageComponentSearchService.test.ts
@@ -16,10 +16,10 @@ const VALID_OPTIONS = {
   model: "gpt-4o-mini",
 };
 
-function mockChatResponse(content: unknown, status = 200) {
+function mockResponsesResponse(content: unknown, status = 200) {
   return new Response(
     JSON.stringify({
-      choices: [{ message: { content: JSON.stringify(content) } }],
+      output_text: JSON.stringify(content),
     }),
     {
       status,
@@ -152,7 +152,7 @@ describe("rerankComponentsByNaturalLanguage", () => {
 
   it("omits authorization and model when API key and model are blank", async () => {
     vi.mocked(global.fetch).mockResolvedValue(
-      mockChatResponse({ matches: [] }),
+      mockResponsesResponse({ matches: [] }),
     );
 
     await rerankComponentsByNaturalLanguage(
@@ -165,12 +165,13 @@ describe("rerankComponentsByNaturalLanguage", () => {
     const init = call?.[1];
     const body = parseFetchBody(call);
     expect(body.model).toBeUndefined();
+    expect(body.max_output_tokens).toBeDefined();
     expect(JSON.stringify(init)).not.toContain("authorization");
   });
 
   it("filters out hallucinated ids the model returned", async () => {
     vi.mocked(global.fetch).mockResolvedValue(
-      mockChatResponse({
+      mockResponsesResponse({
         matches: [
           { id: "a", score: 0.9, reason: "best fit" },
           { id: "ghost", score: 0.8, reason: "made up" },
@@ -191,7 +192,7 @@ describe("rerankComponentsByNaturalLanguage", () => {
     // serializes to `null`, which never reaches `normalizeScore` because
     // `isValidMatch` rejects it upstream.
     vi.mocked(global.fetch).mockResolvedValue(
-      mockChatResponse({
+      mockResponsesResponse({
         matches: [
           { id: "a", score: 1.5, reason: "over" },
           { id: "b", score: -0.4, reason: "under" },
@@ -214,7 +215,7 @@ describe("rerankComponentsByNaturalLanguage", () => {
 
   it("returns empty matches when the response shape is wrong, but keeps raw content", async () => {
     vi.mocked(global.fetch).mockResolvedValue(
-      mockChatResponse({ matches: "not an array" }),
+      mockResponsesResponse({ matches: "not an array" }),
     );
 
     const result = await rerankComponentsByNaturalLanguage(
@@ -226,27 +227,9 @@ describe("rerankComponentsByNaturalLanguage", () => {
     expect(result.rawContent).toContain("not an array");
   });
 
-  it("uses max_completion_tokens for gpt-5 / o-series models", async () => {
+  it("uses the Responses API for component search generation", async () => {
     vi.mocked(global.fetch).mockResolvedValue(
-      mockChatResponse({ matches: [] }),
-    );
-
-    await rerankComponentsByNaturalLanguage(
-      "train",
-      [{ id: "a", name: "a", description: "" }],
-      { ...VALID_OPTIONS, model: "gpt-5-mini" },
-    );
-
-    const call = vi.mocked(global.fetch).mock.calls[0];
-    const body = parseFetchBody(call);
-    expect(body.max_completion_tokens).toBeDefined();
-    expect(body.max_tokens).toBeUndefined();
-    expect(body.temperature).toBeUndefined();
-  });
-
-  it("uses max_tokens and temperature for non-reasoning models", async () => {
-    vi.mocked(global.fetch).mockResolvedValue(
-      mockChatResponse({ matches: [] }),
+      mockResponsesResponse({ matches: [] }),
     );
 
     await rerankComponentsByNaturalLanguage(
@@ -257,9 +240,31 @@ describe("rerankComponentsByNaturalLanguage", () => {
 
     const call = vi.mocked(global.fetch).mock.calls[0];
     const body = parseFetchBody(call);
-    expect(body.max_tokens).toBeDefined();
+    expect(call?.[0]).toBe("https://api.example.com/v1/responses");
+    expect(body.instructions).toContain("reranker");
+    expect(body.input).toContain("Query: train");
+    expect(body.text).toEqual({ format: { type: "json_object" } });
+    expect(body.max_output_tokens).toBeDefined();
+    expect(body.max_tokens).toBeUndefined();
     expect(body.max_completion_tokens).toBeUndefined();
-    expect(body.temperature).toBe(0);
+    expect(body.temperature).toBeUndefined();
+  });
+
+  it("still bounds Responses output when model is blank", async () => {
+    vi.mocked(global.fetch).mockResolvedValue(
+      mockResponsesResponse({ matches: [] }),
+    );
+
+    await rerankComponentsByNaturalLanguage(
+      "train",
+      [{ id: "a", name: "a", description: "" }],
+      { ...VALID_OPTIONS, model: "" },
+    );
+
+    const call = vi.mocked(global.fetch).mock.calls[0];
+    const body = parseFetchBody(call);
+    expect(body.model).toBeUndefined();
+    expect(body.max_output_tokens).toBeDefined();
   });
 });
 
@@ -290,7 +295,7 @@ describe("generateComponentAiDescription", () => {
 
   it("generates a description from a component spec", async () => {
     vi.mocked(global.fetch).mockResolvedValue(
-      mockChatResponse({
+      mockResponsesResponse({
         description:
           "This component trains a model from the dataset input and writes the trained model output.",
       }),
@@ -304,9 +309,9 @@ describe("generateComponentAiDescription", () => {
     expect(result.description).toContain("trains a model");
     const call = vi.mocked(global.fetch).mock.calls[0];
     const body = parseFetchBody(call);
-    const serializedMessages = JSON.stringify(body.messages);
-    expect(serializedMessages).toContain("train_model");
-    expect(serializedMessages).toContain("dataset");
+    expect(call?.[0]).toBe("https://api.example.com/v1/responses");
+    expect(JSON.stringify(body.input)).toContain("train_model");
+    expect(JSON.stringify(body.input)).toContain("dataset");
   });
 
   it("requires a hydrated component spec", async () => {
@@ -318,7 +323,7 @@ describe("generateComponentAiDescription", () => {
 
   it("throws when the model returns an empty description", async () => {
     vi.mocked(global.fetch).mockResolvedValue(
-      mockChatResponse({ description: "" }),
+      mockResponsesResponse({ description: "" }),
     );
 
     await expect(

--- a/src/services/naturalLanguageComponentSearchService.test.ts
+++ b/src/services/naturalLanguageComponentSearchService.test.ts
@@ -247,6 +247,22 @@ describe("rerankComponentsByNaturalLanguage", () => {
     expect(body.max_output_tokens).toBeDefined();
     expect(body.max_tokens).toBeUndefined();
     expect(body.max_completion_tokens).toBeUndefined();
+    // Non-reasoning model: temperature pinned for deterministic ordering.
+    expect(body.temperature).toBe(0);
+  });
+
+  it("omits temperature for reasoning models that reject it", async () => {
+    vi.mocked(global.fetch).mockResolvedValue(
+      mockResponsesResponse({ matches: [] }),
+    );
+
+    await rerankComponentsByNaturalLanguage(
+      "train",
+      [{ id: "a", name: "a", description: "" }],
+      { ...VALID_OPTIONS, model: "gpt-5-mini" },
+    );
+
+    const body = parseFetchBody(vi.mocked(global.fetch).mock.calls[0]);
     expect(body.temperature).toBeUndefined();
   });
 
@@ -265,6 +281,8 @@ describe("rerankComponentsByNaturalLanguage", () => {
     const body = parseFetchBody(call);
     expect(body.model).toBeUndefined();
     expect(body.max_output_tokens).toBeDefined();
+    // Blank model: proxy owns selection, so we send no temperature.
+    expect(body.temperature).toBeUndefined();
   });
 });
 

--- a/src/services/naturalLanguageComponentSearchService.ts
+++ b/src/services/naturalLanguageComponentSearchService.ts
@@ -1,14 +1,14 @@
 /**
  * LLM reranker for component search.
  *
- * Takes a small candidate set already pre-filtered by the lexical index (see
+ * Takes a small candidate set selected from the component index (see
  * `componentSearchIndex.ts`) and asks an LLM to:
  *   1. Reorder by best fit to the user's query
  *   2. Write a one-sentence reason per result
  *
- * The LLM is intentionally NOT used for retrieval — that's the lexical index's
- * job. Reranking 20 candidates is fast, cheap, and plays to the LLM's actual
- * strength: judgment over a small, well-defined set.
+ * The LLM is intentionally used on a bounded candidate set, not the whole
+ * world. Local indexing keeps search fast and predictable; the LLM adds
+ * judgment over a small, well-defined list when literal matching is not enough.
  */
 
 import type { ComponentReference } from "@/utils/componentSpec";
@@ -67,15 +67,6 @@ interface LlmOptions {
   apiKey: string;
 }
 
-/**
- * gpt-5 / o-series reasoning models reject `max_tokens` and require
- * `max_completion_tokens` instead. Detect by name prefix and use the
- * appropriate field.
- */
-function usesCompletionTokensParam(model: string): boolean {
-  return /^(gpt-5|o\d|openai:gpt-5|openai:o\d)/i.test(model);
-}
-
 /** Clamp score to [0, 1] and reject NaN so the UI/sort never sees garbage. */
 function normalizeScore(value: number): number {
   if (Number.isNaN(value)) return 0;
@@ -93,15 +84,20 @@ function isValidMatch(parsed: unknown): parsed is RerankedMatch {
   );
 }
 
-function readChatCompletionContent(payload: unknown): string {
-  if (!isRecord(payload) || !Array.isArray(payload.choices)) return "";
+function readResponsesContent(payload: unknown): string {
+  if (!isRecord(payload)) return "";
+  if (typeof payload.output_text === "string") return payload.output_text;
+  if (!Array.isArray(payload.output)) return "";
 
-  const [firstChoice] = payload.choices;
-  if (!isRecord(firstChoice) || !isRecord(firstChoice.message)) return "";
+  for (const output of payload.output) {
+    if (!isRecord(output) || !Array.isArray(output.content)) continue;
+    for (const content of output.content) {
+      if (!isRecord(content)) continue;
+      if (typeof content.text === "string") return content.text;
+    }
+  }
 
-  return typeof firstChoice.message.content === "string"
-    ? firstChoice.message.content
-    : "";
+  return "";
 }
 
 function isMatchArray(value: unknown): value is RerankedMatch[] {
@@ -132,7 +128,7 @@ export function componentReferenceToCandidate(
 function buildRerankSystemPrompt(): string {
   return [
     "You are a reranker for an ML pipeline component search.",
-    "The user gives you a natural-language query and a small list of candidate components that were already retrieved by lexical search.",
+    "The user gives you a natural-language query and a small list of candidate components selected from the component library.",
     "Your job: reorder the candidates by how well they fit the query's intent, and write one short reason per match.",
     "Respond with a single JSON object:",
     '{ "matches": [ { "id": "<candidate id>", "score": <0..1>, "reason": "<one short sentence>" } ] }',
@@ -183,32 +179,19 @@ function validateConfig(options: LlmOptions): {
   return { base: base.replace(/\/+$/, ""), key, model };
 }
 
-interface ChatCompletionCallConfig {
+interface ResponsesCallConfig {
   systemPrompt: string;
   userPrompt: string;
-  /**
-   * Token budget for the visible response. Used as `max_tokens` for non-
-   * reasoning models. Reasoning models (gpt-5 / o-series) use a fixed
-   * `max_completion_tokens` of 2000 because they also burn budget on hidden
-   * thinking tokens.
-   */
   maxTokens: number;
 }
 
-/**
- * Shared LLM chat-completion call. Owns the request/response plumbing every
- * AI feature in this service needs: config validation, model-family
- * detection for `max_tokens` vs `max_completion_tokens`, header construction,
- * non-JSON / empty / non-2xx error handling. Callers supply the prompts and
- * parse the returned `rawContent` string themselves.
- */
-async function callLlmChatCompletion(
+async function callLlmResponse(
   options: LlmOptions,
-  config: ChatCompletionCallConfig,
+  config: ResponsesCallConfig,
 ): Promise<string> {
   const { base, key, model } = validateConfig(options);
 
-  const response = await fetch(`${base}/chat/completions`, {
+  const response = await fetch(`${base}/responses`, {
     method: "POST",
     signal: options.signal,
     headers: {
@@ -217,19 +200,10 @@ async function callLlmChatCompletion(
     },
     body: JSON.stringify({
       ...(model ? { model } : {}),
-      // gpt-5 / o-series reject temperature and max_tokens. When the proxy
-      // owns model selection (blank model), omit model-specific tuning entirely.
-      ...(model && !usesCompletionTokensParam(model) ? { temperature: 0 } : {}),
-      ...(model
-        ? usesCompletionTokensParam(model)
-          ? { max_completion_tokens: 2000 }
-          : { max_tokens: config.maxTokens }
-        : {}),
-      response_format: { type: "json_object" },
-      messages: [
-        { role: "system", content: config.systemPrompt },
-        { role: "user", content: config.userPrompt },
-      ],
+      max_output_tokens: config.maxTokens,
+      instructions: config.systemPrompt,
+      input: config.userPrompt,
+      text: { format: { type: "json_object" } },
     }),
   });
 
@@ -246,7 +220,7 @@ async function callLlmChatCompletion(
   } catch {
     throw new Error("LLM proxy returned a non-JSON response");
   }
-  const rawContent = readChatCompletionContent(payload);
+  const rawContent = readResponsesContent(payload);
   if (!rawContent) {
     throw new Error("LLM proxy returned an empty response");
   }
@@ -269,7 +243,7 @@ export async function rerankComponentsByNaturalLanguage(
 
   // Output sizing: at most 20 candidates × roughly {25 id + 30 reason + JSON
   // structure} ≈ 1200-1500 tokens for a full response.
-  const rawContent = await callLlmChatCompletion(options, {
+  const rawContent = await callLlmResponse(options, {
     systemPrompt: buildRerankSystemPrompt(),
     userPrompt: buildRerankUserPrompt(trimmed, candidates),
     maxTokens: 1500,
@@ -398,7 +372,7 @@ export async function generateComponentAiDescription(
     throw new Error("Component details are not loaded yet.");
   }
 
-  const rawContent = await callLlmChatCompletion(options, {
+  const rawContent = await callLlmResponse(options, {
     systemPrompt: buildDescriptionSystemPrompt(),
     userPrompt: buildDescriptionUserPrompt(input),
     maxTokens: 900,

--- a/src/services/naturalLanguageComponentSearchService.ts
+++ b/src/services/naturalLanguageComponentSearchService.ts
@@ -67,6 +67,16 @@ interface LlmOptions {
   apiKey: string;
 }
 
+/**
+ * gpt-5 / o-series reasoning models reject an explicit `temperature`. For every
+ * other configured model we pin `temperature: 0` so the reranker's ordering is
+ * deterministic run-to-run; without it the provider default (often 1.0) makes
+ * the same query reorder differently between runs.
+ */
+function isReasoningModel(model: string): boolean {
+  return /^(openai:)?(gpt-5|o\d)/i.test(model);
+}
+
 /** Clamp score to [0, 1] and reject NaN so the UI/sort never sees garbage. */
 function normalizeScore(value: number): number {
   if (Number.isNaN(value)) return 0;
@@ -200,6 +210,10 @@ async function callLlmResponse(
     },
     body: JSON.stringify({
       ...(model ? { model } : {}),
+      // Deterministic ordering for non-reasoning models; omitted when the proxy
+      // owns model selection (blank model) or for reasoning models that reject
+      // an explicit temperature.
+      ...(model && !isReasoningModel(model) ? { temperature: 0 } : {}),
       max_output_tokens: config.maxTokens,
       instructions: config.systemPrompt,
       input: config.userPrompt,

--- a/src/types/aiProvider.ts
+++ b/src/types/aiProvider.ts
@@ -1,8 +1,8 @@
 export interface AiProviderConfig {
-  /** OpenAI-compatible API base URL. Do not include `/chat/completions`. */
+  /** OpenAI-compatible API base URL. Do not include endpoint paths like `/responses`. */
   apiBase: string;
   /** Optional bearer token. Leave blank when the proxy owns authentication. */
   apiKey: string;
-  /** Optional chat model id. Leave blank to use the default model. */
+  /** Optional generation model id. Leave blank to use the provider default. */
   model: string;
 }


### PR DESCRIPTION
## Summary

This PR makes Tangle's AI features use the same provider path consistently and makes the Settings check reflect what the app actually needs.

The main problem was that some AI paths were still using older request shapes, while Sidekick and newer models need the OpenAI Responses API. This could show up as:

- Sidekick failing on follow-up messages with `Item with id 'rs_...' not found`
- Component Search V2 AI rerank or AI descriptions failing when `/chat/completions` is not supported
- Provider settings passing the old connection check even though Sidekick would later fail on `/responses`
- Tool schemas being rejected before Sidekick could run

## What changed

### Sidekick

- Sidekick now uses the Responses API for generation.
- Sidekick no longer replays temporary provider-side reasoning IDs across turns.
  - This fixes errors like `Item with id 'rs_...' not found`.
- Sidekick tool schemas are stricter and closer to the real values the app supports.
  - `set_task_argument` now accepts explicit supported argument shapes instead of an overly broad JSON schema.

### Component Search V2 AI

- AI rerank and AI-generated component descriptions now use the Responses API.
- Search token cleanup was simplified:
  - common stop words are ignored;
  - hardcoded acronym/synonym expansion was avoided;
  - single-letter tokens are not handled with special cases.

### AI provider settings

- The separate save/test flow is now a single **Save and test AI** action.
- The button sends a small `/responses` request using the entered settings.
- Settings are saved only if that AI test succeeds.
- This makes the Settings check match the same API path used by Sidekick and Component Search V2 AI.

## Provider compatibility note

This PR expects the configured provider to support the OpenAI Responses API for generation.

A provider may list a model or support `/chat/completions` but still not support `/responses`. In that case, **Save and test AI** will fail before saving the settings. That is intentional: it prevents saving a configuration that Sidekick and Component Search V2 AI cannot use.

## What did not change

- No model dropdown was added.
- No model-specific routing was added.
- No separate Sidekick/component-search model setting was added.
- Documentation search embeddings are unchanged.
- The app still uses one provider base URL, one optional API key, and one optional model.

## How to test

### 1. Validate and save AI settings

1. Open Settings → AI Configuration.
2. Enter an API base URL for a provider that supports `/responses`.
3. Enter an API key if needed.
4. Enter a model if needed.
5. Click **Save and test AI**.
6. Confirm the settings are saved and a success message appears.

### 2. Unsupported `/responses` provider

1. Enter a provider/model that is reachable but does not support `/responses`.
2. Click **Save and test AI**.
3. Confirm an error is shown.
4. Confirm the settings are not saved.

### 3. Sidekick follow-up message

1. Open a pipeline canvas.
2. Ask Sidekick a simple question or ask it to make a small edit.
3. Ask a follow-up in the same chat.
4. Confirm the follow-up does not fail with `Item with id 'rs_...' not found`.

### 4. Component Search V2 AI rerank

1. Open Component Search V2.
2. Search for a component.
3. Click the AI search/rerank button.
4. Confirm results are returned, or a normal provider error is shown.
5. Confirm the request no longer fails because `/chat/completions` is unsupported.

### 5. Component AI description

1. Open a component detail panel in Component Search V2.
2. Generate an AI description.
3. Confirm the description is generated successfully.

## Regression checks

```bash
pnpm exec eslint src/agent/agents/tangleDispatcher.ts src/agent/agents/tangleDispatcher.test.ts src/agent/config.ts src/agent/config.test.ts src/agent/tools/csomTools.ts src/agent/tools/csomTools.test.ts src/services/naturalLanguageComponentSearchService.ts src/services/naturalLanguageComponentSearchService.test.ts src/services/componentSearchIndex.ts src/services/componentSearchIndex.test.ts src/routes/Settings/sections/AgentSettings.tsx src/routes/Settings/sections/AgentSettings.test.tsx src/types/aiProvider.ts --config eslint.config.js

pnpm exec vitest run src/agent/agents/tangleDispatcher.test.ts src/agent/config.test.ts src/agent/tools/csomTools.test.ts src/services/naturalLanguageComponentSearchService.test.ts src/services/componentSearchIndex.test.ts src/routes/Settings/sections/AgentSettings.test.tsx

pnpm run typecheck
```

## Notes for reviewers

The main design choice is to keep AI configuration simple while making the requirement explicit: generation features use the Responses API. This avoids provider-specific branching and makes the Settings validation check the same path the app uses at runtime.
