### PR TITLE
chore: change task annotation tab icon to NotebookPen

### DIFF
--- a/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/TaskDetails.tsx
+++ b/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/TaskDetails.tsx
@@ -196,7 +196,7 @@ export const TaskDetails = observer(function TaskDetails({
             className="flex-none w-8 px-0"
             {...tracking("v2.pipeline_editor.task_details.tab_annotations")}
           >
-            <Icon name="EllipsisVertical" size="xs" className="shrink-0" />
+            <Icon name="Tag" size="xs" className="shrink-0" />
           </TabsTrigger>
         </TabsList>
 


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

![image.png](https://app.graphite.com/user-attachments/assets/0e8a401c-af31-46c6-a566-343a0961afd0.png)



<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->