### PR TITLE
feat: Guided Tours Framework (Secrets)

### DIFF
--- a/react-compiler.config.js
+++ b/react-compiler.config.js
@@ -68,6 +68,7 @@ export const REACT_COMPILER_ENABLED_DIRS = [
   "src/components/shared/CodeViewer/CodeEditor.tsx",
   "src/components/shared/Dialogs/MultilineTextInputDialog.tsx",
   "src/components/shared/Dialogs/PipelineNameDialog.tsx",
+  "src/components/shared/SecretsManagement/components/SecretsBackendUnavailable.tsx",
   "src/components/shared/HighlightText.tsx",
   "src/components/shared/AnnouncementBanners.tsx",
   "src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection",

--- a/src/components/Learn/tours/registry.ts
+++ b/src/components/Learn/tours/registry.ts
@@ -6,6 +6,7 @@ import { publicAsset } from "@/utils/publicAsset";
 export type TourStep = StepType &
   TourAction & {
     ringSelectors?: string[];
+    tourPanel?: "secrets-manager";
     resetLibrarySearch?: boolean;
     ensureWindowRestored?: string;
     requiresTaskSelected?: string;

--- a/src/components/Learn/tours/registry.ts
+++ b/src/components/Learn/tours/registry.ts
@@ -18,6 +18,7 @@ export interface TourDefinition {
   displayName?: string;
   requiresEditor?: boolean;
   starterPipelineUrl?: string;
+  mockBackend?: boolean;
   steps: TourStep[];
 }
 

--- a/src/components/shared/SecretsManagement/SelectSecretDialog.tsx
+++ b/src/components/shared/SecretsManagement/SelectSecretDialog.tsx
@@ -16,8 +16,11 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Separator } from "@/components/ui/separator";
 import { Spinner } from "@/components/ui/spinner";
 import { Text } from "@/components/ui/typography";
+import { useBackend } from "@/providers/BackendProvider";
+import { useTourMockBackend } from "@/providers/TourProvider/tourMockBackend";
 
 import { AddSecretForm } from "./components/AddSecretForm";
+import { SecretsBackendUnavailable } from "./components/SecretsBackendUnavailable";
 import { fetchSecretsList } from "./secretsStorage";
 import { type Secret, SecretsQueryKeys } from "./types";
 
@@ -189,6 +192,8 @@ export function SelectSecretDialog({
   onOpenChange,
   onSelect,
 }: SelectSecretDialogProps) {
+  const { available } = useBackend();
+  const mockBackend = useTourMockBackend();
   const handleSelect = (secretName: string) => {
     onSelect(secretName);
     onOpenChange(false);
@@ -198,7 +203,11 @@ export function SelectSecretDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       {open && (
         <DialogContent data-testid="select-secret-dialog">
-          <SelectSecretDialogContent onSelect={handleSelect} />
+          {available || mockBackend ? (
+            <SelectSecretDialogContent onSelect={handleSelect} />
+          ) : (
+            <SecretsBackendUnavailable />
+          )}
         </DialogContent>
       )}
     </Dialog>

--- a/src/components/shared/SecretsManagement/components/SecretsBackendUnavailable.tsx
+++ b/src/components/shared/SecretsManagement/components/SecretsBackendUnavailable.tsx
@@ -1,0 +1,20 @@
+import { Icon } from "@/components/ui/icon";
+import { BlockStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
+
+export function SecretsBackendUnavailable() {
+  return (
+    <BlockStack
+      align="center"
+      className="py-8"
+      data-testid="secrets-backend-unavailable"
+    >
+      <Icon name="DatabaseZap" size="lg" className="text-subdued" />
+      <Text tone="subdued">Backend not connected</Text>
+      <Text size="xs" tone="subdued">
+        Secrets are stored on your Tangle backend. Connect one in Settings to
+        manage secrets.
+      </Text>
+    </BlockStack>
+  );
+}

--- a/src/components/shared/SecretsManagement/components/SecretsList.tsx
+++ b/src/components/shared/SecretsManagement/components/SecretsList.tsx
@@ -10,14 +10,18 @@ import { formatRelativeTime } from "@/utils/date";
 
 import { withSuspenseWrapper } from "../../SuspenseWrapper";
 import { fetchSecretsList } from "../secretsStorage";
-import { SecretsQueryKeys } from "../types";
+import { type Secret, SecretsQueryKeys } from "../types";
 import { RemoveSecretButton } from "./RemoveSecretButton";
 
 interface SecretsListProps {
   onRemoveSuccess?: () => void;
+  onEditSecret?: (secret: Secret) => void;
 }
 
-function SecretsListInternal({ onRemoveSuccess }: SecretsListProps) {
+function SecretsListInternal({
+  onRemoveSuccess,
+  onEditSecret,
+}: SecretsListProps) {
   const { data: secrets } = useSuspenseQuery({
     queryKey: SecretsQueryKeys.All(),
     queryFn: fetchSecretsList,
@@ -67,16 +71,27 @@ function SecretsListInternal({ onRemoveSuccess }: SecretsListProps) {
             </InlineStack>
 
             <InlineStack gap="1">
-              <Link
-                to="/settings/secrets/$secretId/replace"
-                params={{ secretId: secret.id }}
-                replace
-                data-testid="secret-edit-button"
-              >
-                <Button variant="ghost" size="xs">
+              {onEditSecret ? (
+                <Button
+                  variant="ghost"
+                  size="xs"
+                  data-testid="secret-edit-button"
+                  onClick={() => onEditSecret(secret)}
+                >
                   <Icon name="Pencil" size="sm" />
                 </Button>
-              </Link>
+              ) : (
+                <Link
+                  to="/settings/secrets/$secretId/replace"
+                  params={{ secretId: secret.id }}
+                  replace
+                  data-testid="secret-edit-button"
+                >
+                  <Button variant="ghost" size="xs">
+                    <Icon name="Pencil" size="sm" />
+                  </Button>
+                </Link>
+              )}
               <RemoveSecretButton secret={secret} onSuccess={onRemoveSuccess} />
             </InlineStack>
           </InlineStack>

--- a/src/components/shared/SecretsManagement/components/SecretsList.tsx
+++ b/src/components/shared/SecretsManagement/components/SecretsList.tsx
@@ -6,12 +6,15 @@ import { Icon } from "@/components/ui/icon";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Text } from "@/components/ui/typography";
+import { useBackend } from "@/providers/BackendProvider";
+import { useTourMockBackend } from "@/providers/TourProvider/tourMockBackend";
 import { formatRelativeTime } from "@/utils/date";
 
 import { withSuspenseWrapper } from "../../SuspenseWrapper";
 import { fetchSecretsList } from "../secretsStorage";
 import { type Secret, SecretsQueryKeys } from "../types";
 import { RemoveSecretButton } from "./RemoveSecretButton";
+import { SecretsBackendUnavailable } from "./SecretsBackendUnavailable";
 
 interface SecretsListProps {
   onRemoveSuccess?: () => void;
@@ -111,7 +114,16 @@ function SecretsListSkeleton() {
   );
 }
 
-export const SecretsList = withSuspenseWrapper(
+const SecretsListWithSuspense = withSuspenseWrapper(
   SecretsListInternal,
   SecretsListSkeleton,
 );
+
+export function SecretsList(props: SecretsListProps) {
+  const { available } = useBackend();
+  const mockBackend = useTourMockBackend();
+  if (!available && !mockBackend) {
+    return <SecretsBackendUnavailable />;
+  }
+  return <SecretsListWithSuspense {...props} />;
+}

--- a/src/components/shared/SecretsManagement/components/SecretsListView.tsx
+++ b/src/components/shared/SecretsManagement/components/SecretsListView.tsx
@@ -9,9 +9,18 @@ import useToastNotification from "@/hooks/useToastNotification";
 import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { tracking } from "@/utils/tracking";
 
+import type { Secret } from "../types";
 import { SecretsList } from "./SecretsList";
 
-export function SecretsListView() {
+interface SecretsListViewProps {
+  onAddSecret?: () => void;
+  onEditSecret?: (secret: Secret) => void;
+}
+
+export function SecretsListView({
+  onAddSecret,
+  onEditSecret,
+}: SecretsListViewProps = {}) {
   const notify = useToastNotification();
   const { track } = useAnalytics();
 
@@ -32,22 +41,36 @@ export function SecretsListView() {
 
       <Separator />
 
-      <SecretsList onRemoveSuccess={handleRemoveSuccess} />
+      <SecretsList
+        onRemoveSuccess={handleRemoveSuccess}
+        onEditSecret={onEditSecret}
+      />
 
       <Separator />
 
       <InlineStack align="end" fill>
-        <Link
-          to="/settings/secrets/add"
-          replace
-          data-testid="add-secret-link"
-          {...tracking("settings.secrets.add_secret")}
-        >
-          <Button variant="secondary">
+        {onAddSecret ? (
+          <Button
+            variant="secondary"
+            data-testid="add-secret-link"
+            onClick={onAddSecret}
+          >
             <Icon name="Plus" />
             Add Secret
           </Button>
-        </Link>
+        ) : (
+          <Link
+            to="/settings/secrets/add"
+            replace
+            data-testid="add-secret-link"
+            {...tracking("settings.secrets.add_secret")}
+          >
+            <Button variant="secondary">
+              <Icon name="Plus" />
+              Add Secret
+            </Button>
+          </Link>
+        )}
       </InlineStack>
     </BlockStack>
   );

--- a/src/components/shared/SecretsManagement/secretsStorage.ts
+++ b/src/components/shared/SecretsManagement/secretsStorage.ts
@@ -4,6 +4,13 @@ import {
   listSecretsApiSecretsGet,
   updateSecretApiSecretsSecretNamePut,
 } from "@/api/sdk.gen";
+import {
+  isTourMockActive,
+  mockAddSecret,
+  mockListSecrets,
+  mockRemoveSecret,
+  mockUpdateSecret,
+} from "@/providers/TourProvider/tourMockBackend";
 
 import type { Secret } from "./types";
 
@@ -33,6 +40,10 @@ function parseAsUtc(dateString: string): Date {
 }
 
 export async function fetchSecretsList() {
+  if (isTourMockActive()) {
+    return mockListSecrets();
+  }
+
   const response = await listSecretsApiSecretsGet();
 
   if (response.response.status !== 200) {
@@ -60,6 +71,11 @@ export async function updateSecret(
   secretId: string,
   secret: Partial<Secret> & Pick<Secret, "value">,
 ) {
+  if (isTourMockActive()) {
+    mockUpdateSecret(secretId, secret.value);
+    return true;
+  }
+
   const response = await updateSecretApiSecretsSecretNamePut({
     path: {
       secret_name: secretId,
@@ -79,6 +95,11 @@ export async function updateSecret(
 export async function addSecret(
   secret: Partial<Secret> & Pick<Secret, "name" | "value">,
 ) {
+  if (isTourMockActive()) {
+    mockAddSecret(secret.name ?? "", secret.value);
+    return true;
+  }
+
   const response = await createSecretApiSecretsPost({
     query: {
       secret_name: secret.name ?? "",
@@ -96,6 +117,11 @@ export async function addSecret(
 }
 
 export async function removeSecret(secretId: string) {
+  if (isTourMockActive()) {
+    mockRemoveSecret(secretId);
+    return true;
+  }
+
   const response = await deleteSecretApiSecretsSecretNameDelete({
     path: {
       secret_name: secretId,

--- a/src/components/shared/Submitters/Tangle/TangleSubmitter.tsx
+++ b/src/components/shared/Submitters/Tangle/TangleSubmitter.tsx
@@ -12,6 +12,7 @@ import useCooldownTimer from "@/hooks/useCooldownTimer";
 import useToastNotification from "@/hooks/useToastNotification";
 import { cn } from "@/lib/utils";
 import { useBackend } from "@/providers/BackendProvider";
+import { useTourMockBackend } from "@/providers/TourProvider/tourMockBackend";
 import { APP_ROUTES } from "@/routes/router";
 import { updateRunAnnotation } from "@/services/pipelineRunService";
 import type { PipelineRun } from "@/types/pipelineRun";
@@ -102,6 +103,7 @@ const TangleSubmitter = ({
 }: TangleSubmitterProps) => {
   const { isAuthorized } = useAwaitAuthorization();
   const { backendUrl, configured, available } = useBackend();
+  const mockBackend = useTourMockBackend();
   const { mutate: submit, isPending: isSubmitting } = useSubmitPipeline();
   const isAutoRedirect = useFlagValue("redirect-on-new-pipeline-run");
 
@@ -310,7 +312,7 @@ const TangleSubmitter = ({
             size="icon"
             data-testid="run-with-arguments-button"
             onClick={() => setIsArgumentsDialogOpen(true)}
-            disabled={!available}
+            disabled={!available && !mockBackend}
           >
             <Icon name="Split" className="rotate-90" />
           </TooltipButton>

--- a/src/components/shared/Submitters/Tangle/components/SubmitTaskArgumentsDialog.tsx
+++ b/src/components/shared/Submitters/Tangle/components/SubmitTaskArgumentsDialog.tsx
@@ -36,6 +36,7 @@ import { Paragraph } from "@/components/ui/typography";
 import useToastNotification from "@/hooks/useToastNotification";
 import { cn } from "@/lib/utils";
 import { useBackend } from "@/providers/BackendProvider";
+import { useTourMockBackend } from "@/providers/TourProvider/tourMockBackend";
 import { useTourMode } from "@/providers/TourProvider/TourModeContext";
 import {
   fetchExecutionDetails,
@@ -68,6 +69,7 @@ export const SubmitTaskArgumentsDialog = ({
 }: SubmitTaskArgumentsDialogProps) => {
   const notify = useToastNotification();
   const tourMode = useTourMode();
+  const mockBackend = useTourMockBackend();
   const initialArgs = getArgumentsFromInputs(componentSpec);
 
   const [runNotes, setRunNotes] = useState<string>("");
@@ -209,7 +211,10 @@ export const SubmitTaskArgumentsDialog = ({
           <Button variant="outline" onClick={handleCancel}>
             Cancel
           </Button>
-          <Button onClick={handleConfirm} disabled={!isValidToSubmit}>
+          <Button
+            onClick={handleConfirm}
+            disabled={!isValidToSubmit || mockBackend}
+          >
             Submit Run
           </Button>
         </DialogFooter>

--- a/src/components/shared/Submitters/Tangle/components/SubmitTaskArgumentsDialog.tsx
+++ b/src/components/shared/Submitters/Tangle/components/SubmitTaskArgumentsDialog.tsx
@@ -36,6 +36,7 @@ import { Paragraph } from "@/components/ui/typography";
 import useToastNotification from "@/hooks/useToastNotification";
 import { cn } from "@/lib/utils";
 import { useBackend } from "@/providers/BackendProvider";
+import { useTourMode } from "@/providers/TourProvider/TourModeContext";
 import {
   fetchExecutionDetails,
   fetchPipelineRun,
@@ -66,6 +67,7 @@ export const SubmitTaskArgumentsDialog = ({
   componentSpec,
 }: SubmitTaskArgumentsDialogProps) => {
   const notify = useToastNotification();
+  const tourMode = useTourMode();
   const initialArgs = getArgumentsFromInputs(componentSpec);
 
   const [runNotes, setRunNotes] = useState<string>("");
@@ -135,8 +137,16 @@ export const SubmitTaskArgumentsDialog = ({
   const hasInputs = inputs.length > 0;
 
   return (
-    <Dialog open={open} onOpenChange={handleCancel}>
-      <DialogContent className="sm:max-w-lg">
+    <Dialog open={open} onOpenChange={handleCancel} modal={!tourMode}>
+      <DialogContent
+        className="sm:max-w-lg"
+        {...(tourMode
+          ? {
+              onInteractOutside: (event) => event.preventDefault(),
+              onEscapeKeyDown: (event) => event.preventDefault(),
+            }
+          : {})}
+      >
         <DialogHeader>
           <DialogTitle>Submit Run with Arguments</DialogTitle>
           <DialogDescription className="hidden">

--- a/src/providers/TourProvider/TourPopover.tsx
+++ b/src/providers/TourProvider/TourPopover.tsx
@@ -103,6 +103,21 @@ export function computeDefaultPopoverPosition(
     return [props.right + margin, Math.max(props.top + margin, 64)];
   }
 
+  // Tall centered modal/dialog (inset from both side edges): place the popover
+  // to its LEFT, aligned to the dialog's top edge (not vertically centered, as
+  // reactour's "left" would do).
+  if (
+    isTallStrip &&
+    props.left > margin &&
+    props.right < props.windowWidth - margin
+  ) {
+    const popoverWidth = props.width || 380;
+    return [
+      Math.max(margin, props.left - popoverWidth - margin),
+      Math.max(props.top, margin),
+    ];
+  }
+
   return "bottom";
 }
 

--- a/src/providers/TourProvider/TourPopover.tsx
+++ b/src/providers/TourProvider/TourPopover.tsx
@@ -82,9 +82,6 @@ export function computeDefaultPopoverPosition(
   const isTallStrip = targetHeight > props.windowHeight * 0.5;
   const margin = 16;
 
-  // Right-anchored full-height strip (e.g. right sidebar): place popover to
-  // its LEFT. Reactour's "left" fallback can swap to "top"/"bottom" for tall
-  // targets, so we return explicit coords.
   if (isTallStrip && props.right >= props.windowWidth - 4) {
     const popoverWidth = props.width || 380;
     return [
@@ -93,19 +90,10 @@ export function computeDefaultPopoverPosition(
     ];
   }
 
-  // Left-anchored full-height strip (e.g. left dock): place popover to its
-  // RIGHT. Same reason — reactour's "right" fallback drops to "top" for tall
-  // targets even when there's plenty of room horizontally. We test the
-  // target's right edge against the viewport midline rather than its left
-  // edge against zero, so a dock that isn't flush to the window edge still
-  // qualifies.
   if (isTallStrip && props.right < props.windowWidth * 0.5) {
     return [props.right + margin, Math.max(props.top + margin, 64)];
   }
 
-  // Tall centered modal/dialog (inset from both side edges): place the popover
-  // to its LEFT, aligned to the dialog's top edge (not vertically centered, as
-  // reactour's "left" would do).
   if (
     isTallStrip &&
     props.left > margin &&

--- a/src/providers/TourProvider/TourSecretsDialog.tsx
+++ b/src/providers/TourProvider/TourSecretsDialog.tsx
@@ -42,9 +42,7 @@ const SETTINGS_TABS: Array<{ label: string; icon: IconName; active: boolean }> =
   ];
 
 type ManagerMode =
-  | { kind: "list" }
-  | { kind: "add" }
-  | { kind: "replace"; secret: Secret };
+  { kind: "list" } | { kind: "add" } | { kind: "replace"; secret: Secret };
 
 function TourSecretsManager() {
   const [mode, setMode] = useState<ManagerMode>({ kind: "list" });

--- a/src/providers/TourProvider/TourSecretsDialog.tsx
+++ b/src/providers/TourProvider/TourSecretsDialog.tsx
@@ -1,0 +1,167 @@
+import { useTour } from "@reactour/tour";
+import { useEffect, useState } from "react";
+
+import type { TourStep } from "@/components/Learn/tours/registry";
+import { AddSecretForm } from "@/components/shared/SecretsManagement/components/AddSecretForm";
+import { SecretsListView } from "@/components/shared/SecretsManagement/components/SecretsListView";
+import type { Secret } from "@/components/shared/SecretsManagement/types";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Icon, type IconName } from "@/components/ui/icon";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Heading, Text } from "@/components/ui/typography";
+import { cn } from "@/lib/utils";
+import { useTourMode } from "@/providers/TourProvider/TourModeContext";
+
+// The Settings gear (AppMenuActions) calls this in tour mode instead of routing
+// to /settings, which would unmount the tour page and tear the tour down.
+let openSettingsHandler: (() => void) | null = null;
+
+export function openTourSettings() {
+  openSettingsHandler?.();
+}
+
+function registerOpenSettingsHandler(handler: () => void): () => void {
+  openSettingsHandler = handler;
+  return () => {
+    if (openSettingsHandler === handler) openSettingsHandler = null;
+  };
+}
+
+const SETTINGS_TABS: Array<{ label: string; icon: IconName; active: boolean }> =
+  [
+    { label: "Backend", icon: "Database", active: false },
+    { label: "Preferences", icon: "Settings", active: false },
+    { label: "Beta Features", icon: "FlaskConical", active: false },
+    { label: "Secrets", icon: "Lock", active: true },
+  ];
+
+type ManagerMode =
+  | { kind: "list" }
+  | { kind: "add" }
+  | { kind: "replace"; secret: Secret };
+
+function TourSecretsManager() {
+  const [mode, setMode] = useState<ManagerMode>({ kind: "list" });
+
+  if (mode.kind !== "list") {
+    return (
+      <BlockStack gap="3">
+        <InlineStack gap="1" blockAlign="center">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setMode({ kind: "list" })}
+          >
+            <Icon name="ArrowLeft" />
+          </Button>
+          <Text weight="semibold">
+            {mode.kind === "add"
+              ? "Add Secret"
+              : `Replace value for ${mode.secret.name}`}
+          </Text>
+        </InlineStack>
+        <AddSecretForm
+          existingSecret={mode.kind === "replace" ? mode.secret : undefined}
+          onSuccess={() => setMode({ kind: "list" })}
+          onCancel={() => setMode({ kind: "list" })}
+        />
+      </BlockStack>
+    );
+  }
+
+  return (
+    <SecretsListView
+      onAddSecret={() => setMode({ kind: "add" })}
+      onEditSecret={(secret) => setMode({ kind: "replace", secret })}
+    />
+  );
+}
+
+// A tour-safe stand-in for the Settings → Secrets page. It mirrors the real
+// settings shell (sidebar with Secrets active, other tabs disabled) and renders
+// the real SecretsListView, but keeps add/replace in-dialog instead of using the
+// router links the real page relies on, so the tour never navigates away.
+export function TourSecretsDialog() {
+  const tourMode = useTourMode();
+  const { steps, currentStep, isOpen: tourIsOpen } = useTour();
+  const [open, setOpen] = useState(false);
+  const [openKey, setOpenKey] = useState(0);
+
+  useEffect(() => {
+    if (!tourMode) return;
+    return registerOpenSettingsHandler(() => {
+      setOpenKey((key) => key + 1);
+      setOpen(true);
+    });
+  }, [tourMode]);
+
+  const step = steps?.[currentStep] as TourStep | undefined;
+  const onSettingsStep = !!tourIsOpen && step?.tourPanel === "secrets-manager";
+  const isExplainStep = onSettingsStep && !step?.interaction;
+
+  useEffect(() => {
+    if (isExplainStep) setOpen(true);
+    else if (!onSettingsStep) setOpen(false);
+  }, [isExplainStep, onSettingsStep]);
+
+  if (!tourMode) return null;
+
+  return (
+    <Dialog modal={false} open={open}>
+      <DialogContent
+        showCloseButton={false}
+        data-tour="tour-settings-dialog"
+        className="sm:max-w-4xl w-[56rem] h-[80vh] p-0 gap-0 overflow-hidden"
+        onInteractOutside={(event) => event.preventDefault()}
+        onEscapeKeyDown={(event) => event.preventDefault()}
+      >
+        <DialogTitle className="sr-only">Settings</DialogTitle>
+        <DialogDescription className="sr-only">
+          Manage your secrets.
+        </DialogDescription>
+
+        <BlockStack className="h-full">
+          <div className="px-6 py-4 border-b border-border">
+            <Heading level={1}>Settings</Heading>
+          </div>
+
+          <InlineStack
+            className="flex-1 min-h-0"
+            blockAlign="stretch"
+            wrap="nowrap"
+          >
+            <BlockStack
+              gap="1"
+              className="w-48 shrink-0 border-r border-border p-4"
+            >
+              {SETTINGS_TABS.map((tab) => (
+                <Button
+                  key={tab.label}
+                  variant="ghost"
+                  disabled={!tab.active}
+                  className={cn(
+                    "w-full justify-start gap-2",
+                    tab.active && "bg-accent",
+                  )}
+                >
+                  <Icon name={tab.icon} size="sm" />
+                  <Text size="sm">{tab.label}</Text>
+                </Button>
+              ))}
+            </BlockStack>
+
+            <div className="flex-1 min-w-0 overflow-y-auto p-6">
+              <TourSecretsManager key={openKey} />
+            </div>
+          </InlineStack>
+        </BlockStack>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/providers/TourProvider/tourActionLabels.test.ts
+++ b/src/providers/TourProvider/tourActionLabels.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { tourActionLabel } from "./tourActionLabels";
+
+describe("tourActionLabel", () => {
+  it("labels assign-secret-argument with the target argument name", () => {
+    expect(
+      tourActionLabel({
+        interaction: "assign-secret-argument",
+        targetArgumentName: "token",
+      }),
+    ).toBe("Assign a secret to the **token** argument");
+  });
+
+  it("falls back when assign-secret-argument has no target", () => {
+    expect(tourActionLabel({ interaction: "assign-secret-argument" })).toBe(
+      "Assign a secret to the argument",
+    );
+  });
+
+  it("labels assign-secret-submit with the target input name", () => {
+    expect(
+      tourActionLabel({
+        interaction: "assign-secret-submit",
+        targetArgumentName: "API_KEY",
+      }),
+    ).toBe("Bind a secret to **API_KEY** at submit");
+  });
+
+  it("falls back when assign-secret-submit has no target", () => {
+    expect(tourActionLabel({ interaction: "assign-secret-submit" })).toBe(
+      "Bind a secret at submit time",
+    );
+  });
+
+  it("labels open-secret-dialog", () => {
+    expect(tourActionLabel({ interaction: "open-secret-dialog" })).toBe(
+      "Open the secret picker from the ⚡ menu",
+    );
+  });
+
+  it("labels open-settings-panel", () => {
+    expect(tourActionLabel({ interaction: "open-settings-panel" })).toBe(
+      "Open Settings to manage your secrets",
+    );
+  });
+
+  it("labels open-submit-dialog", () => {
+    expect(tourActionLabel({ interaction: "open-submit-dialog" })).toBe(
+      "Open the run arguments dialog",
+    );
+  });
+
+  it("uses the generic label for unknown interactions", () => {
+    expect(tourActionLabel({ interaction: "not-a-real-interaction" })).toBe(
+      "Complete the highlighted action to continue",
+    );
+  });
+});

--- a/src/providers/TourProvider/tourActionLabels.test.ts
+++ b/src/providers/TourProvider/tourActionLabels.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { tourActionLabel } from "./tourActionLabels";
+import type { TourInteraction } from "./tourActions";
 
 describe("tourActionLabel", () => {
   it("labels assign-secret-argument with the target argument name", () => {
@@ -52,8 +53,10 @@ describe("tourActionLabel", () => {
   });
 
   it("uses the generic label for unknown interactions", () => {
-    expect(tourActionLabel({ interaction: "not-a-real-interaction" })).toBe(
-      "Complete the highlighted action to continue",
-    );
+    expect(
+      tourActionLabel({
+        interaction: "not-a-real-interaction" as TourInteraction,
+      }),
+    ).toBe("Complete the highlighted action to continue");
   });
 });

--- a/src/providers/TourProvider/tourActionLabels.ts
+++ b/src/providers/TourProvider/tourActionLabels.ts
@@ -52,6 +52,20 @@ export function tourActionLabel(step: TourAction): string {
       return `Select **${step.targetMinCount ?? 2}** tasks`;
     case "create-subgraph":
       return "Create a subgraph from the selected tasks";
+    case "open-secret-dialog":
+      return "Open the secret picker from the ⚡ menu";
+    case "open-settings-panel":
+      return "Open Settings to manage your secrets";
+    case "open-submit-dialog":
+      return "Open the run arguments dialog";
+    case "assign-secret-argument":
+      return step.targetArgumentName
+        ? `Assign a secret to the **${step.targetArgumentName}** argument`
+        : "Assign a secret to the argument";
+    case "assign-secret-submit":
+      return step.targetArgumentName
+        ? `Bind a secret to **${step.targetArgumentName}** at submit`
+        : "Bind a secret at submit time";
     default:
       return GENERIC_LABEL;
   }

--- a/src/providers/TourProvider/tourActions.ts
+++ b/src/providers/TourProvider/tourActions.ts
@@ -1,4 +1,4 @@
-type TourInteraction =
+export type TourInteraction =
   | "undock-window"
   | "redock-window"
   | "select-task"

--- a/src/providers/TourProvider/tourMockBackend.test.ts
+++ b/src/providers/TourProvider/tourMockBackend.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  addSecret,
+  fetchSecretsList,
+} from "@/components/shared/SecretsManagement/secretsStorage";
+
+import {
+  isTourMockActive,
+  mockAddSecret,
+  mockListSecrets,
+  setTourMockActive,
+} from "./tourMockBackend";
+
+afterEach(() => {
+  // Deactivating clears the in-memory store.
+  setTourMockActive(false);
+});
+
+describe("tourMockBackend store", () => {
+  it("adds and lists secrets while active", () => {
+    setTourMockActive(true);
+    mockAddSecret("API_KEY", "secret-value");
+
+    const names = mockListSecrets().map((s) => s.name);
+    expect(names).toEqual(["API_KEY"]);
+  });
+
+  it("clears the store when deactivated", () => {
+    setTourMockActive(true);
+    mockAddSecret("API_KEY", "secret-value");
+    setTourMockActive(false);
+
+    expect(isTourMockActive()).toBe(false);
+    expect(mockListSecrets()).toEqual([]);
+  });
+});
+
+describe("secretsStorage routes to the mock when active", () => {
+  it("addSecret + fetchSecretsList use the in-memory store", async () => {
+    setTourMockActive(true);
+
+    await addSecret({ name: "TOKEN", value: "v" });
+    const listed = await fetchSecretsList();
+
+    expect(listed.map((s) => s.name)).toEqual(["TOKEN"]);
+  });
+});

--- a/src/providers/TourProvider/tourMockBackend.ts
+++ b/src/providers/TourProvider/tourMockBackend.ts
@@ -1,0 +1,72 @@
+import { useSyncExternalStore } from "react";
+
+import type { Secret } from "@/components/shared/SecretsManagement/types";
+
+/**
+ * In-memory stand-in for the secrets backend, used only while a guided tour
+ * runs without a real backend (see TourMockBackendController). It lets the user
+ * actually perform the secret steps — add, list, pick, assign — against an
+ * ephemeral store that is cleared when the tour ends. Nothing is persisted or
+ * sent anywhere.
+ *
+ * This module is intentionally free of React-provider imports so the leaf
+ * `secretsStorage` util can read `isTourMockActive()` without pulling the
+ * component/provider tree into its import graph.
+ */
+
+let active = false;
+const secrets = new Map<string, Secret>();
+const listeners = new Set<() => void>();
+
+function emit(): void {
+  for (const listener of listeners) listener();
+}
+
+export function setTourMockActive(value: boolean): void {
+  if (active === value) return;
+  active = value;
+  if (!value) secrets.clear();
+  emit();
+}
+
+export function isTourMockActive(): boolean {
+  return active;
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/** Reactively reports whether the tour mock backend is active. */
+export function useTourMockBackend(): boolean {
+  return useSyncExternalStore(subscribe, isTourMockActive, isTourMockActive);
+}
+
+export function mockListSecrets(): Secret[] {
+  return Array.from(secrets.values());
+}
+
+export function mockAddSecret(name: string, value?: string): void {
+  const now = new Date();
+  const existing = secrets.get(name);
+  secrets.set(name, {
+    id: name,
+    name,
+    value,
+    createdAt: existing?.createdAt ?? now,
+    updatedAt: now,
+  });
+}
+
+export function mockUpdateSecret(name: string, value?: string): void {
+  const existing = secrets.get(name);
+  if (!existing) return;
+  secrets.set(name, { ...existing, value, updatedAt: new Date() });
+}
+
+export function mockRemoveSecret(name: string): void {
+  secrets.delete(name);
+}

--- a/src/routes/Dashboard/Learn/Tour.tsx
+++ b/src/routes/Dashboard/Learn/Tour.tsx
@@ -12,10 +12,13 @@ import {
   type TourDefinition,
 } from "@/components/Learn/tours/registry";
 import useToastNotification from "@/hooks/useToastNotification";
+import { useBackend } from "@/providers/BackendProvider";
 import { TourContent } from "@/providers/TourProvider/TourContent";
+import { setTourMockActive } from "@/providers/TourProvider/tourMockBackend";
 import {
   TourModeProvider,
   type TourModeValue,
+  useTourMode,
 } from "@/providers/TourProvider/TourModeContext";
 import {
   buildTourPipelineYaml,
@@ -250,6 +253,7 @@ function TourPageBody({
         promoteToPipeline,
       }}
     >
+      <TourMockBackendController />
       {resolved && (
         <TourReactourBridge
           key={tour.id}
@@ -265,4 +269,18 @@ function TourPageBody({
       />
     </TourModeProvider>
   );
+}
+
+function TourMockBackendController() {
+  const tourMode = useTourMode();
+  const { available } = useBackend();
+  const shouldMock = !!tourMode?.tour.mockBackend && !available;
+
+  useEffect(() => {
+    setTourMockActive(shouldMock);
+  }, [shouldMock]);
+
+  useEffect(() => () => setTourMockActive(false), []);
+
+  return null;
 }

--- a/src/routes/v2/pages/Editor/EditorV2.tsx
+++ b/src/routes/v2/pages/Editor/EditorV2.tsx
@@ -16,6 +16,7 @@ import { ForcedSearchProvider } from "@/providers/ComponentLibraryProvider/Force
 import { DialogProvider } from "@/providers/DialogProvider/DialogProvider";
 import { useTourMode } from "@/providers/TourProvider/TourModeContext";
 import { TourSaveExploreDialog } from "@/providers/TourProvider/TourSaveExploreDialog";
+import { TourSecretsDialog } from "@/providers/TourProvider/TourSecretsDialog";
 import { AiChatStoreProvider } from "@/routes/v2/shared/components/AiChat/AiChatStoreContext";
 import { useDockAreaAccordion } from "@/routes/v2/shared/hooks/useDockAreaAccordion";
 import { useFocusMode } from "@/routes/v2/shared/hooks/useFocusMode";
@@ -169,6 +170,7 @@ function EditorV2Content({ pipelineRef }: { pipelineRef: PipelineRef | null }) {
         <EditorMenuBar />
         <EditorTourBridge />
         <TourSaveExploreDialog />
+        <TourSecretsDialog />
         <ForcedSearchProvider>{body}</ForcedSearchProvider>
       </ReactFlowProvider>
     </ComponentLibraryProvider>

--- a/src/routes/v2/pages/Editor/components/EditorTourBridge.tsx
+++ b/src/routes/v2/pages/Editor/components/EditorTourBridge.tsx
@@ -10,8 +10,6 @@ import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 import type { WindowStoreImpl } from "@/routes/v2/shared/windows/windowStore";
 import { isSecretArgument } from "@/utils/componentSpec";
 
-// PLACEHOLDER FOR EMPTY PR - REMOVE WHEN PR IS POPULATED
-
 type CountInteraction =
   "add-task" | "add-input" | "add-output" | "connect-edge";
 

--- a/src/routes/v2/pages/Editor/components/EditorTourBridge.tsx
+++ b/src/routes/v2/pages/Editor/components/EditorTourBridge.tsx
@@ -8,6 +8,9 @@ import type { ComponentSpec } from "@/models/componentSpec";
 import { useTourProgress } from "@/providers/TourProvider/TourProgressContext";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 import type { WindowStoreImpl } from "@/routes/v2/shared/windows/windowStore";
+import { isSecretArgument } from "@/utils/componentSpec";
+
+// PLACEHOLDER FOR EMPTY PR - REMOVE WHEN PR IS POPULATED
 
 type CountInteraction =
   "add-task" | "add-input" | "add-output" | "connect-edge";
@@ -520,6 +523,135 @@ export function EditorTourBridge() {
       return () => {
         stopFollow();
         dispose();
+      };
+    }
+
+    if (interaction === "assign-secret-argument") {
+      const targetArgumentName = step?.targetArgumentName;
+
+      const hasSecretArgument = () => {
+        const spec = navigation.activeSpec;
+        if (!spec) return false;
+        return spec.tasks.some((task) =>
+          task.arguments.some(
+            (arg) =>
+              (!targetArgumentName || arg.name === targetArgumentName) &&
+              isSecretArgument(arg.value),
+          ),
+        );
+      };
+
+      if (hasSecretArgument()) {
+        skip();
+        return stopFollow;
+      }
+
+      const dispose = reaction(
+        () => hasSecretArgument(),
+        (matches) => {
+          if (matches) {
+            dispose();
+            advance();
+          }
+        },
+      );
+
+      return () => {
+        stopFollow();
+        dispose();
+      };
+    }
+
+    if (interaction === "open-secret-dialog") {
+      const dialogSelector = '[data-testid="select-secret-dialog"]';
+      const isDialogOpen = () => !!document.querySelector(dialogSelector);
+
+      if (isDialogOpen()) {
+        skip();
+        return stopFollow;
+      }
+
+      const observer = new MutationObserver(() => {
+        if (isDialogOpen()) {
+          observer.disconnect();
+          advance();
+        }
+      });
+      observer.observe(document.body, { childList: true, subtree: true });
+
+      return () => {
+        stopFollow();
+        observer.disconnect();
+      };
+    }
+
+    if (interaction === "open-settings-panel") {
+      const panelSelector = '[data-tour="tour-settings-dialog"]';
+      const isPanelOpen = () => !!document.querySelector(panelSelector);
+
+      if (isPanelOpen()) {
+        skip();
+        return stopFollow;
+      }
+
+      const observer = new MutationObserver(() => {
+        if (isPanelOpen()) {
+          observer.disconnect();
+          advance();
+        }
+      });
+      observer.observe(document.body, { childList: true, subtree: true });
+
+      return () => {
+        stopFollow();
+        observer.disconnect();
+      };
+    }
+
+    if (interaction === "open-submit-dialog") {
+      const dialogSelector = '[data-tour="submit-arguments-dialog"]';
+      const isDialogOpen = () => !!document.querySelector(dialogSelector);
+
+      if (isDialogOpen()) {
+        skip();
+        return stopFollow;
+      }
+
+      const observer = new MutationObserver(() => {
+        if (isDialogOpen()) {
+          observer.disconnect();
+          advance();
+        }
+      });
+      observer.observe(document.body, { childList: true, subtree: true });
+
+      return () => {
+        stopFollow();
+        observer.disconnect();
+      };
+    }
+
+    if (interaction === "assign-secret-submit") {
+      const secretSelector =
+        '[data-tour="submit-arguments-dialog"] [data-testid="dynamic-data-argument-input"]';
+      const hasSecret = () => !!document.querySelector(secretSelector);
+
+      if (hasSecret()) {
+        skip();
+        return stopFollow;
+      }
+
+      const observer = new MutationObserver(() => {
+        if (hasSecret()) {
+          observer.disconnect();
+          advance();
+        }
+      });
+      observer.observe(document.body, { childList: true, subtree: true });
+
+      return () => {
+        stopFollow();
+        observer.disconnect();
       };
     }
 

--- a/src/routes/v2/shared/components/AppMenuActions.tsx
+++ b/src/routes/v2/shared/components/AppMenuActions.tsx
@@ -8,11 +8,14 @@ import { EditorVersionToggle } from "@/components/shared/EditorVersionToggle";
 import { Icon } from "@/components/ui/icon";
 import { InlineStack } from "@/components/ui/layout";
 import { Link } from "@/components/ui/link";
+import { useTourMode } from "@/providers/TourProvider/TourModeContext";
+import { openTourSettings } from "@/providers/TourProvider/TourSecretsDialog";
 import { DOCUMENTATION_URL } from "@/utils/constants";
 import { tracking } from "@/utils/tracking";
 
 export function AppMenuActions() {
   const requiresAuthorization = isAuthorizationRequired();
+  const tourMode = useTourMode();
 
   return (
     <InlineStack
@@ -23,11 +26,21 @@ export function AppMenuActions() {
     >
       <AiModelQuickSelect />
       <EditorVersionToggle />
-      <RouterLink to="/settings/backend">
-        <TooltipButton tooltip="Settings" {...tracking("v2.header.settings")}>
+      {tourMode ? (
+        <TooltipButton
+          tooltip="Settings"
+          onClick={openTourSettings}
+          {...tracking("v2.header.settings")}
+        >
           <Icon name="Settings" />
         </TooltipButton>
-      </RouterLink>
+      ) : (
+        <RouterLink to="/settings/backend">
+          <TooltipButton tooltip="Settings" {...tracking("v2.header.settings")}>
+            <Icon name="Settings" />
+          </TooltipButton>
+        </RouterLink>
+      )}
       <Link href={DOCUMENTATION_URL} target="_blank" rel="noopener noreferrer">
         <TooltipButton
           tooltip="Documentation"


### PR DESCRIPTION
## Description

The secret-specific interaction mechanics for the guided-tour framework, layered on the framework stack (#2348 / #2299 / #2347 / #2340) and the subgraphs mechanics (#2365). Foundation for the **Using Secrets** tour (#2406) — this PR adds the interaction *types* and bridge logic that detect them, the in-editor **Settings → Secrets** stand-in the tour opens, an **in-memory mock backend** so the secret steps stay hands-on without a real backend, and small reusability/behavior tweaks that let it all run without leaving the tour page. The tour content and DOM anchors land in #2406.

## What changed

**Interaction vocabulary** (`src/components/Learn/tours/registry.ts`)

Five new `TourStep.interaction` values, plus a `tourPanel` field, plus a tour-level `mockBackend` flag (see below):

- `assign-secret-argument` — a task argument's value becomes a secret (MobX `activeSpec` reaction via `isSecretArgument`; optionally gated to a `targetArgumentName`)
- `assign-secret-submit` — a secret gets bound inside the submit dialog. The value lives in the dialog's local React state (not the spec), so this is detected from the DOM rather than a spec reaction
- `open-secret-dialog` / `open-settings-panel` / `open-submit-dialog` — the respective dialog appears in the DOM
- `tourPanel: "secrets-manager"` — marks the steps during which the in-editor Settings stand-in should be open

**Bridge handlers** (`src/routes/v2/pages/Editor/components/EditorTourBridge.tsx`)

Each interaction marks the step complete in the shared tour-progress state (following #2299; it doesn't advance the tour itself). The three `open-*` handlers are `MutationObserver` DOM-presence checks; `assign-secret-argument` is a spec reaction; `assign-secret-submit` watches for the secret display inside the submit dialog. Already-satisfied-on-entry states are marked complete immediately; gated "Next" / auto-advance (#2340) handle progression.

**Checklist labels** (`src/providers/TourProvider/tourActionLabels.ts` + test)

Copy for the five interactions, e.g. `assign-secret-argument` → "Assign a secret to the **{targetArgumentName}** argument", `open-settings-panel` → "Open Settings to manage your secrets".

**In-editor Settings → Secrets stand-in** (`TourSecretsDialog.tsx`, new)

Navigating to the real `/settings/secrets` route would unmount the tour page and tear the tour down. Instead, a **non-modal** dialog mirrors the real settings shell (sidebar with Secrets active, the other tabs disabled) and renders the **real** `SecretsListView`, keeping add/replace in-dialog rather than using the Settings router links. It opens when the active step is marked `tourPanel: "secrets-manager"` and the user clicks the gear (`openTourSettings`), and closes when the tour leaves those steps.

- `AppMenuActions.tsx` — in tour mode the **Settings** gear calls `openTourSettings()` instead of routing away (keeps its `data-tracking-id` so the tour can anchor to it).
- `EditorV2.tsx` — mounts `<TourSecretsDialog />` alongside the existing tour dialogs.

**No-backend mock backend** (`tourMockBackend.ts` new, `secretsStorage.ts`, `Tour.tsx`, secret/submit gates)

Secrets live on the backend, so without one the secret steps would otherwise trap the user on a step they can't complete. When a tour opts in (`TourDefinition.mockBackend`) **and** there's no real backend, the secrets backend is mocked **in-memory** so the steps stay fully hands-on — the user really opens the picker, adds a secret, picks it, and assigns it, against an ephemeral store that is cleared when the tour ends. Nothing is persisted or sent anywhere; with a real backend this is inert.

- `tourMockBackend.ts` (new) — a provider-free module store: `setTourMockActive`/`isTourMockActive`, a `useTourMockBackend()` hook, and an in-memory `Secret` map (`mockListSecrets`/`mockAddSecret`/`mockUpdateSecret`/`mockRemoveSecret`).
- `secretsStorage.ts` — `fetchSecretsList`/`addSecret`/`updateSecret`/`removeSecret` route to the in-memory store when the mock is active (the existing `SecretsQueryKeys.All()` invalidations keep the list fresh).
- `Tour.tsx` — a `TourMockBackendController` activates the mock while `tour.mockBackend && !available` and clears it (and the store) on tour exit.
- Gates accept the mock: `SelectSecretDialog` / `SecretsList` render the real picker (`available || mock`); the **run-with-arguments** (split-arrows) button enables so the submit dialog can open. The **primary** Submit button and the submit-args **confirm** stay gated on real availability — the secret-to-input assignment is demonstrated, but launching a real run isn't wired in mock mode.

**Friendly no-backend empty state** (`SecretsBackendUnavailable.tsx`, new)

`SelectSecretDialog` / `SecretsList` show a "Backend not connected" state (Lock/DB icon + copy) instead of the generic error-boundary icon when there's genuinely no backend and the mock isn't active — which also improves the real **Settings → Secrets** page for backend-less setups.

**Reusable secrets components** (`SecretsList.tsx`, `SecretsListView.tsx`)

Optional `onAddSecret` / `onEditSecret` callbacks. They default to the existing router links (real Settings page is unchanged), but let the stand-in reuse the *real* list/forms with in-dialog add/replace — so the tour isn't a hand-maintained copy of the secrets UI.

**Popover & dialog behavior**

- `TourPopover.tsx` — `computeDefaultPopoverPosition` gains a branch for a tall, centered modal: anchor the popover to its **left**, aligned to the dialog's **top** edge (rather than vertically centered).
- `SubmitTaskArgumentsDialog.tsx` — renders `modal={!tourMode}`; non-modal during a tour so the portaled tour popover (Next / Finish Tour) stays clickable while the dialog is open. Behavior outside tours is unchanged.

## Related Issue and Pull requests

Progresses https://github.com/Shopify/oasis-frontend/issues/583

Builds on the framework stack (#2348 / #2299 / #2347 / #2340 / #2365); consumed by the Using Secrets tour in #2406.

## Type of Change

- [x] New feature

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

The registry is otherwise inert in this PR — the interactions are exercised end-to-end by the Using Secrets tour in #2406. To verify in isolation:

- **No regressions** in the existing tours and in the real **Settings → Secrets** page (add / replace / delete still navigate and work as before).
- **No backend:** the Using Secrets tour (#2406) runs fully hands-on against the in-memory mock — the secret picker/list show real content (not the error icon), steps gate normally, and no `/api/secrets` calls fire. **Settings → Secrets** with no backend shows the "Backend not connected" state.
- **With a backend:** behavior is unchanged (real secrets, real submit).
- **Submit dialog** outside a tour is still modal (focus trap + scrim) as before.
- `pnpm typecheck`, `pnpm lint`, and the `tourActionLabels` / `tourMockBackend` unit tests pass.
