### PR TITLE
feat: Guided Tour - Secrets

### DIFF
--- a/public/tour-pipelines/Secrets.pipeline.component.yaml
+++ b/public/tour-pipelines/Secrets.pipeline.component.yaml
@@ -1,0 +1,155 @@
+name: Secrets
+description: |
+  A tiny authenticated pipeline used by the "Using Secrets" guided tour. The
+  Authenticated Request task reads a bearer token and an API key, sends them as
+  headers to https://httpbin.org/headers, and prints a masked response. Neither
+  credential is ever written into the pipeline definition: assign a secret to the
+  task's `token` argument with the lightning-bolt menu, and bind a secret to the
+  `API_KEY` input when you submit.
+metadata:
+  annotations:
+    editor.flow-direction: left-to-right
+inputs:
+  - name: API_KEY
+    description: |
+      API key for the request. Left empty here so you can bind a secret to it at
+      submit time via run arguments.
+    optional: true
+    annotations:
+      editor.position: '{"x": -180, "y": 120}'
+outputs:
+  - name: HTTP Response
+    annotations:
+      editor.position: '{"x": 920, "y": 80}'
+implementation:
+  graph:
+    tasks:
+      Authenticated Request:
+        componentRef:
+          name: Authenticated Request
+          spec:
+            name: Authenticated Request
+            description: |
+              Reads a bearer token and an API key (each injected from a Tangle
+              secret as a file), sends them as request headers to
+              https://httpbin.org/headers, masks the sensitive headers, and writes
+              the response body to its output. Credential values are never logged.
+            inputs:
+              - name: token
+                description: Bearer token, injected from a Tangle secret.
+                optional: true
+              - name: api_key
+                description: API key, injected from a Tangle secret.
+                optional: true
+            outputs:
+              - name: response
+                type: String
+                description: httpbin's JSON response body, with secrets masked.
+            implementation:
+              container:
+                image: python:3.12-slim
+                command:
+                  - python3
+                  - '-u'
+                  - '-c'
+                  - |
+                    import argparse, json, os, urllib.request
+
+                    parser = argparse.ArgumentParser()
+                    parser.add_argument("--token")
+                    parser.add_argument("--api-key", dest="api_key")
+                    parser.add_argument("--output", required=True)
+                    args = parser.parse_args()
+
+                    headers = {}
+                    if args.token:
+                        with open(args.token) as f:
+                            token = f.read().strip()
+                        headers["Authorization"] = f"Bearer {token}"
+                        print(f"loaded token: length={len(token)} (value not logged)")
+                    if args.api_key:
+                        with open(args.api_key) as f:
+                            api_key = f.read().strip()
+                        headers["X-Api-Key"] = api_key
+                        print(f"loaded api_key: length={len(api_key)} (value not logged)")
+
+                    req = urllib.request.Request(
+                        "https://httpbin.org/headers", headers=headers
+                    )
+                    with urllib.request.urlopen(req, timeout=30) as resp:
+                        print(f"http status: {resp.status}")
+                        body = resp.read().decode("utf-8")
+
+                    parsed = json.loads(body)
+                    # httpbin echoes the request headers back, so mask the sensitive
+                    # ones before writing them to the pipeline output.
+                    echoed = parsed.get("headers", {})
+                    if "Authorization" in echoed:
+                        echoed["Authorization"] = "Bearer <redacted>"
+                    if "X-Api-Key" in echoed:
+                        echoed["X-Api-Key"] = "<redacted>"
+                    masked = json.dumps(parsed, indent=2)
+                    print(masked)
+
+                    os.makedirs(os.path.dirname(args.output), exist_ok=True)
+                    with open(args.output, "w") as f:
+                        f.write(masked + "\n")
+                args:
+                  - if:
+                      cond:
+                        isPresent: token
+                      then:
+                        - '--token'
+                        - inputPath: token
+                  - if:
+                      cond:
+                        isPresent: api_key
+                      then:
+                        - '--api-key'
+                        - inputPath: api_key
+                  - '--output'
+                  - outputPath: response
+        arguments:
+          api_key:
+            graphInput:
+              inputName: API_KEY
+        annotations:
+          editor.position: '{"x": 160, "y": 80}'
+          cloud-pipelines.net/launchers/generic/resources.cpu: '1'
+          cloud-pipelines.net/launchers/generic/resources.memory: 512Mi
+      Show Response:
+        componentRef:
+          name: Show Response
+          spec:
+            name: Show Response
+            description: Echoes the masked HTTP response to stdout and to the pipeline output.
+            inputs:
+              - name: response
+                type: String
+            outputs:
+              - name: echoed
+                type: String
+            implementation:
+              container:
+                image: python:3.12-slim
+                command:
+                  - sh
+                  - '-ec'
+                  - |
+                    cat "$0"
+                    mkdir -p "$(dirname "$1")"
+                    cp "$0" "$1"
+                  - inputPath: response
+                  - outputPath: echoed
+        arguments:
+          response:
+            taskOutput:
+              outputName: response
+              taskId: Authenticated Request
+        annotations:
+          editor.position: '{"x": 560, "y": 80}'
+    outputValues:
+      HTTP Response:
+        taskOutput:
+          outputName: echoed
+          taskId: Show Response

--- a/src/components/Learn/tours/usingSecrets.tour.json
+++ b/src/components/Learn/tours/usingSecrets.tour.json
@@ -1,0 +1,139 @@
+{
+  "id": "using-secrets",
+  "displayName": "Guided Tour: Using Secrets",
+  "requiresEditor": true,
+  "starterPipelineUrl": "tour-pipelines/Secrets.pipeline.component.yaml",
+  "steps": [
+    {
+      "selector": "[data-tour-anchor=\"no-spotlight\"]",
+      "content": "Let's talk about **Secrets**.\n\nEverything you put in a pipeline (argument values, input defaults, run settings) is saved with it and visible to anyone who can access your Tangle instance. If they can open this pipeline or one of its runs, they can read those values.\n\nSo typing an API key or token straight into an argument quietly shares it with everyone, and writes it into the pipeline YAML too.",
+      "position": "center"
+    },
+    {
+      "selector": "[data-tour-anchor=\"no-spotlight\"]",
+      "content": "That's where **secrets** come in.\n\nA secret keeps its value on the backend under a name you choose. Tangle only ever stores and sends the **name**. The value gets injected into the running container when the pipeline runs, and it never shows up anywhere in the app.",
+      "position": "center"
+    },
+    {
+      "selector": "[data-tour-card=\"task\"][data-tour-card-name=\"Authenticated Request\"]",
+      "highlightedSelectors": [
+        "[data-tour-card=\"task\"][data-tour-card-name=\"Authenticated Request\"]"
+      ],
+      "resizeObservables": ["[data-tour=\"editor-canvas\"]"],
+      "content": "Let's create a secret and put it to use right in the **argument editor**.\n\nStart by selecting the **Authenticated Request** task. Its inputs show up in the **Task Properties** panel on the right.",
+      "position": "top",
+      "stepInteraction": true,
+      "interaction": "select-task",
+      "targetTaskName": "Authenticated Request"
+    },
+    {
+      "selector": "[data-dock-window-content=\"context-panel\"]",
+      "highlightedSelectors": [
+        "[data-dock-window-content=\"context-panel\"]",
+        "[data-tour=\"thunder-menu-content\"]",
+        "[data-tour=\"thunder-menu-submenu-content\"]"
+      ],
+      "mutationObservables": [
+        "[data-dock-window-content=\"context-panel\"]",
+        "[data-tour=\"thunder-menu-content\"]",
+        "[data-tour=\"thunder-menu-submenu-content\"]"
+      ],
+      "resizeObservables": ["[data-dock-window-content=\"context-panel\"]"],
+      "requiresTaskSelected": "Authenticated Request",
+      "content": "Now open the secret picker for the `token` argument.\n\nHover its row to reveal the **⚡** button, click it, then choose **Dynamic Data → Select Secret**.",
+      "position": "left",
+      "stepInteraction": true,
+      "interaction": "open-secret-dialog"
+    },
+    {
+      "selector": "[data-testid=\"select-secret-dialog\"]",
+      "highlightedSelectors": ["[data-testid=\"select-secret-dialog\"]"],
+      "mutationObservables": ["[data-testid=\"select-secret-dialog\"]"],
+      "resizeObservables": ["[data-testid=\"select-secret-dialog\"]"],
+      "content": "Click **Add Secret** and give it a name and a value. The value is write only, so Tangle won't ever show it back to you. Save it, then pick it from the list to attach it to the argument.\n\nOnly the secret's **name** ends up in the pipeline.",
+      "position": "left",
+      "stepInteraction": true,
+      "interaction": "assign-secret-argument",
+      "targetArgumentName": "token"
+    },
+    {
+      "selector": "[data-dock-window-content=\"context-panel\"]",
+      "highlightedSelectors": ["[data-dock-window-content=\"context-panel\"]"],
+      "mutationObservables": ["[data-dock-window-content=\"context-panel\"]"],
+      "resizeObservables": ["[data-dock-window-content=\"context-panel\"]"],
+      "content": "Nice. The `token` argument now shows your secret **by name**, with a little lock icon, instead of its value.\n\nThe value stays on the backend and the pipeline only points at the name. Anyone you share this with sees the reference, never the credential.",
+      "position": "left"
+    },
+    {
+      "selector": "[data-tracking-id=\"v2.header.settings\"]",
+      "highlightedSelectors": ["[data-tour=\"editor-top-bar-actions\"]"],
+      "ringSelectors": ["[data-tracking-id=\"v2.header.settings\"]"],
+      "tourPanel": "secrets-manager",
+      "content": "Tangle has a dedicated **secrets manager**.\n\nOpen it by clicking the **Settings** gear in the top right.",
+      "position": "bottom",
+      "stepInteraction": true,
+      "interaction": "open-settings-panel"
+    },
+    {
+      "selector": "[data-tour=\"tour-settings-dialog\"]",
+      "highlightedSelectors": ["[data-tour=\"tour-settings-dialog\"]"],
+      "mutationObservables": ["[data-tour=\"tour-settings-dialog\"]"],
+      "resizeObservables": ["[data-tour=\"tour-settings-dialog\"]"],
+      "tourPanel": "secrets-manager",
+      "content": "This is **Settings → Secrets**, where all your secrets live. They're listed by name only, never by value.\n\nYou can **replace** a secret's value here (the change reaches every pipeline that uses it, and the value still never appears) or **delete** one you no longer need. Take a look, then carry on."
+    },
+    {
+      "selector": "[data-tour-card=\"input\"][data-tour-card-name=\"API_KEY\"]",
+      "highlightedSelectors": [
+        "[data-tour-card=\"input\"][data-tour-card-name=\"API_KEY\"]"
+      ],
+      "resizeObservables": ["[data-tour=\"editor-canvas\"]"],
+      "content": "There's a second way to hand a secret to a pipeline, and it keeps the pipeline itself generic.\n\nInstead of baking a specific secret into a task, you can leave a pipeline **input** empty and choose a secret for it **when you submit a run**. The pipeline definition then mentions no secret at all, and everyone can run it with their own.\n\nThis pipeline's **API_KEY** input was left blank for exactly that.",
+      "position": "top"
+    },
+    {
+      "selector": "[data-dock-window-content=\"runs-and-submission\"]",
+      "highlightedSelectors": [
+        "[data-dock-window-content=\"runs-and-submission\"]"
+      ],
+      "ringSelectors": ["[data-testid=\"run-with-arguments-button\"]"],
+      "mutationObservables": [
+        "[data-dock-window-content=\"runs-and-submission\"]"
+      ],
+      "resizeObservables": [
+        "[data-dock-window-content=\"runs-and-submission\"]"
+      ],
+      "ensureWindowRestored": "runs-and-submission",
+      "content": "In **Runs and submission**, click the **split-arrows** icon next to Submit to open the run arguments dialog.",
+      "position": "right",
+      "stepInteraction": true,
+      "interaction": "open-submit-dialog"
+    },
+    {
+      "selector": "[data-tour=\"submit-arguments-dialog\"]",
+      "highlightedSelectors": [
+        "[data-tour=\"submit-arguments-dialog\"]",
+        "[data-testid=\"select-secret-dialog\"]"
+      ],
+      "mutationObservables": [
+        "[data-tour=\"submit-arguments-dialog\"]",
+        "[data-testid=\"select-secret-dialog\"]"
+      ],
+      "resizeObservables": ["[data-tour=\"submit-arguments-dialog\"]"],
+      "content": "Find the **API_KEY** input, hover it, and click the **lock** (\"Use Secret\") button. Pick your secret to set it for this run. The value is supplied only at submit time and never saved into the pipeline.",
+      "position": "left",
+      "stepInteraction": true,
+      "interaction": "assign-secret-submit",
+      "targetArgumentName": "API_KEY"
+    },
+    {
+      "selector": "[data-tour=\"submit-arguments-dialog\"]",
+      "highlightedSelectors": ["[data-tour=\"submit-arguments-dialog\"]"],
+      "ringSelectors": ["[data-tour=\"submit-arguments-confirm\"]"],
+      "mutationObservables": ["[data-tour=\"submit-arguments-dialog\"]"],
+      "resizeObservables": ["[data-tour=\"submit-arguments-dialog\"]"],
+      "content": "Great! Now the pipeline will use the selected secret for the **API_KEY** input at runtime and the value will never be recorded in the pipeline definition.\n\nClick **Submit Run** to launch the pipeline with your secret, then wrap up the tour.",
+      "position": "left"
+    }
+  ]
+}

--- a/src/components/Learn/tours/usingSecrets.tour.json
+++ b/src/components/Learn/tours/usingSecrets.tour.json
@@ -3,6 +3,7 @@
   "displayName": "Guided Tour: Using Secrets",
   "requiresEditor": true,
   "starterPipelineUrl": "tour-pipelines/Secrets.pipeline.component.yaml",
+  "mockBackend": true,
   "steps": [
     {
       "selector": "[data-tour-anchor=\"no-spotlight\"]",
@@ -132,7 +133,7 @@
       "ringSelectors": ["[data-tour=\"submit-arguments-confirm\"]"],
       "mutationObservables": ["[data-tour=\"submit-arguments-dialog\"]"],
       "resizeObservables": ["[data-tour=\"submit-arguments-dialog\"]"],
-      "content": "Great! Now the pipeline will use the selected secret for the **API_KEY** input at runtime and the value will never be recorded in the pipeline definition.\n\nClick **Submit Run** to launch the pipeline with your secret, then wrap up the tour.",
+      "content": "Done! The **API_KEY** input is now backed by your secret. At submit time the value is supplied to the run and never recorded in the pipeline definition.\n\nWith a backend connected you can **Submit Run** to launch it with your secret. Either way, wrap up the tour below.",
       "position": "left"
     }
   ]

--- a/src/components/shared/Submitters/Tangle/components/SubmitTaskArgumentsDialog.tsx
+++ b/src/components/shared/Submitters/Tangle/components/SubmitTaskArgumentsDialog.tsx
@@ -142,6 +142,7 @@ export const SubmitTaskArgumentsDialog = ({
     <Dialog open={open} onOpenChange={handleCancel} modal={!tourMode}>
       <DialogContent
         className="sm:max-w-lg"
+        data-tour="submit-arguments-dialog"
         {...(tourMode
           ? {
               onInteractOutside: (event) => event.preventDefault(),
@@ -214,6 +215,7 @@ export const SubmitTaskArgumentsDialog = ({
           <Button
             onClick={handleConfirm}
             disabled={!isValidToSubmit || mockBackend}
+            data-tour="submit-arguments-confirm"
           >
             Submit Run
           </Button>

--- a/src/routes/v2/pages/Editor/components/ArgumentRow/components/ThunderMenu/ThunderMenu.tsx
+++ b/src/routes/v2/pages/Editor/components/ArgumentRow/components/ThunderMenu/ThunderMenu.tsx
@@ -115,6 +115,7 @@ export const ThunderMenu = observer(function ThunderMenu({
           side="bottom"
           sideOffset={4}
           className="w-56 z-[9999]"
+          data-tour="thunder-menu-content"
         >
           <DropdownMenuItem
             disabled={!canReset}

--- a/src/routes/v2/pages/Editor/components/ArgumentRow/components/ThunderMenu/components/DynamicDataSubmenu.tsx
+++ b/src/routes/v2/pages/Editor/components/ArgumentRow/components/ThunderMenu/components/DynamicDataSubmenu.tsx
@@ -31,7 +31,10 @@ export function DynamicDataSubmenu({
         <Icon name="Zap" size="sm" className="text-purple-600" />
         Dynamic Data
       </DropdownMenuSubTrigger>
-      <DropdownMenuSubContent className="w-52 z-[9999]">
+      <DropdownMenuSubContent
+        className="w-52 z-[9999]"
+        data-tour="thunder-menu-submenu-content"
+      >
         {groups.map((group, index) => (
           <DropdownMenuGroup key={group.id}>
             {index > 0 && <DropdownMenuSeparator />}


### PR DESCRIPTION
## Description

The registered **Using Secrets** guided tour — a 12-step walkthrough of why credentials don't belong in a pipeline, what secrets are, and the two ways to attach one. Uses the secret interaction mechanics, the in-editor Settings stand-in, and the in-memory mock backend from #2405, and boots into a small `Secrets` tour pipeline that makes an authenticated HTTP request.

The tour covers the whole lifecycle: the problem → what a secret is → create one and bind it to a task argument → manage secrets in an in-editor **Settings → Secrets** stand-in → then the alternative: bind a secret to a pipeline input at submit time.

It runs hands-on **with or without a backend**: it sets `mockBackend: true`, so when no real backend is available the secret steps work against the in-memory mock from #2405 (ephemeral, never leaves the browser); with a backend they use the real secrets API. Either way the steps gate normally.

## What's in the tour

1. The problem — everything in a pipeline is shared and visible (centered, no spotlight)
2. What a secret is — value stays on the backend, only the name travels (centered)
3. **Interactive** — select the **Authenticated Request** task (`select-task`)
4. **Interactive** — open the `token` argument's **⚡** menu → **Dynamic Data → Select Secret** (`open-secret-dialog`)
5. **Interactive** — **Add Secret**, then pick it to bind it to the argument (`assign-secret-argument`)
6. Outcome — the `token` argument now shows the secret by name, with a lock icon (context panel)
7. **Interactive** — click the **Settings** gear to open the secrets manager (`open-settings-panel`)
8. Settings → Secrets — replace a value or delete a secret here (the in-editor stand-in)
9. The second way — leave a pipeline **input** empty and bind at submit time (rings the **API_KEY** input node)
10. **Interactive** — open the run arguments dialog from **Runs and submission** (`open-submit-dialog`)
11. **Interactive** — bind a secret to **API_KEY** via the **Use Secret** lock button (`assign-secret-submit`)
12. Wrap-up — the `API_KEY` input is now backed by the secret; with a backend you can **Submit Run**, then finish (the copy reads correctly whether or not a real run is launched)

![image.png](https://app.graphite.com/user-attachments/assets/f838e773-c68f-495d-99bc-997c90357d42.png)

## DOM anchors & assets added in this PR

Following the convention that tour-specific anchors ship with the tour:

- **`mockBackend: true`** on the tour definition — opts the Secrets tour into the in-memory mock backend (from #2405) when no real backend is available.
- **Seed pipeline** — `public/tour-pipelines/Secrets.pipeline.component.yaml` (`Secrets`: an `Authenticated Request` task taking a `token` and an `api_key`, wired to an empty `API_KEY` input, plus a `Show Response` echo task).
- **`ThunderMenu`** — `data-tour="thunder-menu-content"`; **`DynamicDataSubmenu`** — `data-tour="thunder-menu-submenu-content"` (so the ⚡ menu and its submenu can be spotlit together).
- **`SubmitTaskArgumentsDialog`** — `data-tour="submit-arguments-dialog"` and `data-tour="submit-arguments-confirm"`.

Interactions consumed (defined in #2405): `select-task`, `open-secret-dialog`, `assign-secret-argument`, `open-settings-panel`, `open-submit-dialog`, `assign-secret-submit`. The `using-secrets` Learning Hub entry was already registered lower in the stack, so no `tours.json` / `FeaturedTours` change is needed here.

## Related Issue and Pull requests

Progresses https://github.com/Shopify/oasis-frontend/issues/583

Depends on #2405 (secret interaction mechanics, in-editor Settings stand-in, and the in-memory mock backend) and the framework stack below it.

## Type of Change

- [x] New feature

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

Start the **Using Secrets** tour from the Learning Hub and walk all 12 steps.

**With a backend** (configured + authorized for the secrets API):
- Steps 3–5 create and bind a secret through the ⚡ menu; the `token` argument should end up showing the secret name, not a value.
- Step 7 opens the in-editor Settings stand-in (the gear does **not** navigate away); step 8 shows the real secrets list with working replace/delete.
- Steps 10–11 bind a secret to `API_KEY` in the submit dialog; step 12's **Submit Run** is enabled and **Finish Tour** is clickable while the dialog is open.

**Without a backend** (mock path):
- The same steps are fully hands-on against the in-memory mock — the picker/list show real content (not the error icon) and no `/api/secrets` calls fire.
- Steps gate normally (Next stays disabled until the action is done).
- In the submit dialog the secret-to-input assignment works; **Submit Run** is disabled (no real run to launch) and the tour wraps up via **Finish Tour**.

## Screenshots

<!-- add a short capture of the tour if helpful -->
