### PR TITLE
Rename Components V2 to Component Search and replace component library when flag is enabled

### DIFF
--- a/src/flags.ts
+++ b/src/flags.ts
@@ -64,17 +64,17 @@ export const ExistingFlags: ConfigFlags = {
   },
 
   ["component-search-v2"]: {
-    name: "Component Search V2",
+    name: "Component Search",
     description:
-      "Show the experimental Components V2 page that searches across standard, published, registered, and user component sources, with optional AI rerank.",
+      "Show the experimental component search that searches across standard, published, registered, and user component sources, with optional AI rerank.",
     default: false,
     category: "beta",
   },
 
   ["component-search-v2-ai-descriptions"]: {
-    name: "Auto-generate Components V2 AI descriptions",
+    name: "Auto-generate component search AI descriptions",
     description:
-      "Automatically generate an AI description when viewing a component in Components V2.",
+      "Automatically generate an AI description when viewing a component in component search.",
     default: false,
     category: "beta",
   },

--- a/src/routes/Dashboard/DashboardComponentsV2View.tsx
+++ b/src/routes/Dashboard/DashboardComponentsV2View.tsx
@@ -614,7 +614,7 @@ export const DashboardComponentsV2View = () => {
               });
             }
             console.warn(
-              "Components V2: registered library failed to load",
+              "Components: registered library failed to load",
               result.reason,
             );
             continue;
@@ -979,7 +979,7 @@ export const DashboardComponentsV2View = () => {
       <div className="shrink-0 px-8 pt-4 pb-4 border-b border-border">
         <BlockStack gap="3" align="stretch">
           <BlockStack gap="1">
-            <Heading level={2}>Components V2</Heading>
+            <Heading level={2}>Components</Heading>
             <Paragraph size="sm" tone="subdued">
               Type to search across every component source — standard library,
               your published components, registered libraries, and local user

--- a/src/routes/Dashboard/DashboardLayout.tsx
+++ b/src/routes/Dashboard/DashboardLayout.tsx
@@ -9,7 +9,7 @@ import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Link as UILink } from "@/components/ui/link";
 import { Text } from "@/components/ui/typography";
 import { cn } from "@/lib/utils";
-import { APP_ROUTES } from "@/routes/router";
+import { APP_ROUTES } from "@/routes/appRoutes";
 import {
   ABOUT_URL,
   DOCUMENTATION_URL,
@@ -37,9 +37,9 @@ const BASE_SIDEBAR_ITEMS: SidebarItem[] = [
   { to: "/learn", label: "Learning Hub", icon: "GraduationCap" },
 ];
 
-const COMPONENTS_V2_ITEM: SidebarItem = {
-  to: "/components-v2",
-  label: "Components V2",
+const COMPONENT_SEARCH_ITEM: SidebarItem = {
+  to: APP_ROUTES.DASHBOARD_COMPONENTS_V2,
+  label: "Components",
   icon: "PackageSearch",
 };
 
@@ -51,22 +51,14 @@ const navItemClass = (isActive: boolean) =>
 
 export function DashboardLayout() {
   const requiresAuthorization = isAuthorizationRequired();
-  const isComponentsV2Enabled = useFlagValue("component-search-v2");
+  const isComponentSearchEnabled = useFlagValue("component-search-v2");
 
-  // Insert the Components V2 entry directly after "Components" when the
-  // beta flag is on. Keeps the nav order intuitive without touching the
-  // base list and stays correct if BASE_SIDEBAR_ITEMS gets reordered.
-  const componentsIndex = BASE_SIDEBAR_ITEMS.findIndex(
-    (item) => item.to === APP_ROUTES.DASHBOARD_COMPONENTS,
-  );
-  const insertAt =
-    componentsIndex >= 0 ? componentsIndex + 1 : BASE_SIDEBAR_ITEMS.length;
-  const sidebarItems = isComponentsV2Enabled
-    ? [
-        ...BASE_SIDEBAR_ITEMS.slice(0, insertAt),
-        COMPONENTS_V2_ITEM,
-        ...BASE_SIDEBAR_ITEMS.slice(insertAt),
-      ]
+  const sidebarItems = isComponentSearchEnabled
+    ? BASE_SIDEBAR_ITEMS.map((item) =>
+        item.to === APP_ROUTES.DASHBOARD_COMPONENTS
+          ? COMPONENT_SEARCH_ITEM
+          : item,
+      )
     : BASE_SIDEBAR_ITEMS;
 
   return (
@@ -130,7 +122,7 @@ export function DashboardLayout() {
               <Text size="sm">Docs</Text>
             </InlineStack>
           </UILink>
-          <Link to="/settings/backend" className="w-full">
+          <Link to={APP_ROUTES.SETTINGS_BACKEND} className="w-full">
             {({ isActive }) => (
               <InlineStack
                 gap="2"

--- a/src/routes/Settings/sections/BetaFeaturesSettings.test.tsx
+++ b/src/routes/Settings/sections/BetaFeaturesSettings.test.tsx
@@ -27,8 +27,8 @@ import { BetaFeaturesSettings } from "./BetaFeaturesSettings";
 
 const componentSearchFlag: Flag = {
   key: "component-search-v2",
-  name: "Component Search V2",
-  description: "Show Components V2.",
+  name: "Component Search",
+  description: "Show component search.",
   default: false,
   enabled: false,
   category: "beta",
@@ -36,7 +36,7 @@ const componentSearchFlag: Flag = {
 
 const aiDescriptionFlag: Flag = {
   key: "component-search-v2-ai-descriptions",
-  name: "Auto-generate Components V2 AI descriptions",
+  name: "Auto-generate component search AI descriptions",
   description: "Automatically generate AI descriptions.",
   default: false,
   enabled: false,
@@ -50,18 +50,18 @@ describe("BetaFeaturesSettings", () => {
     mocks.track.mockClear();
   });
 
-  it("hides the AI descriptions flag when Components V2 is disabled", () => {
+  it("hides the AI descriptions flag when component search is disabled", () => {
     mocks.betaFlags = [componentSearchFlag, aiDescriptionFlag];
 
     render(<BetaFeaturesSettings />);
 
-    expect(screen.getByText("Component Search V2")).toBeInTheDocument();
+    expect(screen.getByText("Component Search")).toBeInTheDocument();
     expect(
-      screen.queryByText("Auto-generate Components V2 AI descriptions"),
+      screen.queryByText("Auto-generate component search AI descriptions"),
     ).not.toBeInTheDocument();
   });
 
-  it("shows the AI descriptions flag when Components V2 is enabled", () => {
+  it("shows the AI descriptions flag when component search is enabled", () => {
     mocks.betaFlags = [
       { ...componentSearchFlag, enabled: true },
       aiDescriptionFlag,
@@ -69,9 +69,9 @@ describe("BetaFeaturesSettings", () => {
 
     render(<BetaFeaturesSettings />);
 
-    expect(screen.getByText("Component Search V2")).toBeInTheDocument();
+    expect(screen.getByText("Component Search")).toBeInTheDocument();
     expect(
-      screen.getByText("Auto-generate Components V2 AI descriptions"),
+      screen.getByText("Auto-generate component search AI descriptions"),
     ).toBeInTheDocument();
   });
 });

--- a/src/routes/appRoutes.ts
+++ b/src/routes/appRoutes.ts
@@ -1,0 +1,45 @@
+export const EDITOR_PATH = "/editor";
+export const RUNS_BASE_PATH = "/runs";
+const LEARN_BASE_PATH = "/learn";
+const EDITOR_V2_BASE_PATH = "/editor-v2";
+const RUNS_V2_BASE_PATH = "/runs-v2";
+const SETTINGS_PATH = "/settings";
+const IMPORT_PATH = "/app/editor/import-pipeline";
+
+export const APP_ROUTES = {
+  HOME: "/",
+  DASHBOARD: "/",
+  DASHBOARD_RUNS: "/runs",
+  DASHBOARD_PIPELINES: "/pipelines",
+  DASHBOARD_COMPONENTS: "/components",
+  DASHBOARD_COMPONENTS_V2: "/components-v2",
+  DASHBOARD_FAVORITES: "/favorites",
+  DASHBOARD_RECENTLY_VIEWED: "/recently-viewed",
+  LEARN: LEARN_BASE_PATH,
+  LEARN_EXAMPLES: `${LEARN_BASE_PATH}/examples`,
+  LEARN_TIPS: `${LEARN_BASE_PATH}/tips`,
+  LEARN_TOURS: `${LEARN_BASE_PATH}/tours`,
+  IMPORT: IMPORT_PATH,
+  PIPELINE_EDITOR: `${EDITOR_PATH}/$name`,
+  RUN_DETAIL: `${RUNS_BASE_PATH}/$id`,
+  RUN_DETAIL_WITH_SUBGRAPH: `${RUNS_BASE_PATH}/$id/$subgraphExecutionId`,
+  RUNS: RUNS_BASE_PATH,
+  SETTINGS: SETTINGS_PATH,
+  SETTINGS_BACKEND: `${SETTINGS_PATH}/backend`,
+  SETTINGS_PREFERENCES: `${SETTINGS_PATH}/preferences`,
+  SETTINGS_BETA_FEATURES: `${SETTINGS_PATH}/beta-features`,
+  SETTINGS_AGENT: `${SETTINGS_PATH}/agent`,
+  SETTINGS_SECRETS: `${SETTINGS_PATH}/secrets`,
+  SETTINGS_SECRETS_ADD: `${SETTINGS_PATH}/secrets/add`,
+  SETTINGS_SECRETS_REPLACE: `${SETTINGS_PATH}/secrets/$secretId/replace`,
+  GITHUB_AUTH_CALLBACK: "/authorize/github",
+  HUGGINGFACE_AUTH_CALLBACK: "/authorize/huggingface",
+  EDITOR_V2: EDITOR_V2_BASE_PATH,
+  EDITOR_V2_PIPELINE: `${EDITOR_V2_BASE_PATH}/$pipelineName`,
+  RUNS_V2: RUNS_V2_BASE_PATH,
+  RUN_DETAIL_V2: `${RUNS_V2_BASE_PATH}/$id`,
+  RUN_DETAIL_V2_WITH_SUBGRAPH: `${RUNS_V2_BASE_PATH}/$id/$subgraphExecutionId`,
+  PIPELINE_FOLDERS: "/pipeline-folders",
+  PLAYGROUND: "/playground",
+  ARTIFACT_PREVIEW: "/artifact/$artifactId",
+} as const;

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -16,7 +16,6 @@ import { SecretsListView } from "@/components/shared/SecretsManagement/component
 import { isFlagEnabled } from "@/components/shared/Settings/useFlags";
 import { BASE_URL, IS_GITHUB_PAGES } from "@/utils/constants";
 
-export { APP_ROUTES, EDITOR_PATH, RUNS_BASE_PATH } from "./appRoutes";
 import RootLayout from "../components/layout/RootLayout";
 import { APP_ROUTES } from "./appRoutes";
 import { DashboardComponentsV2View } from "./Dashboard/DashboardComponentsV2View";
@@ -45,6 +44,10 @@ import { SettingsLayout } from "./Settings/SettingsLayout";
 import { EditorV2 } from "./v2/pages/Editor/EditorV2";
 import { PipelineFoldersPage } from "./v2/pages/PipelineFolders/PipelineFoldersPage";
 import { RunViewV2 } from "./v2/pages/RunView/RunViewV2";
+
+// Re-exported so existing `@/routes/router` import paths keep working after the
+// constants moved to the dependency-free `./appRoutes` leaf module.
+export { APP_ROUTES, EDITOR_PATH, RUNS_BASE_PATH } from "./appRoutes";
 
 declare module "@tanstack/react-router" {
   interface Register {

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -16,7 +16,9 @@ import { SecretsListView } from "@/components/shared/SecretsManagement/component
 import { isFlagEnabled } from "@/components/shared/Settings/useFlags";
 import { BASE_URL, IS_GITHUB_PAGES } from "@/utils/constants";
 
+export { APP_ROUTES, EDITOR_PATH, RUNS_BASE_PATH } from "./appRoutes";
 import RootLayout from "../components/layout/RootLayout";
+import { APP_ROUTES } from "./appRoutes";
 import { DashboardComponentsV2View } from "./Dashboard/DashboardComponentsV2View";
 import { DashboardComponentsView } from "./Dashboard/DashboardComponentsView";
 import { DashboardFavoritesView } from "./Dashboard/DashboardFavoritesView";
@@ -49,51 +51,6 @@ declare module "@tanstack/react-router" {
     router: typeof router;
   }
 }
-
-export const EDITOR_PATH = "/editor";
-export const RUNS_BASE_PATH = "/runs";
-const LEARN_BASE_PATH = "/learn";
-const EDITOR_V2_BASE_PATH = "/editor-v2";
-const RUNS_V2_BASE_PATH = "/runs-v2";
-const SETTINGS_PATH = "/settings";
-const IMPORT_PATH = "/app/editor/import-pipeline";
-export const APP_ROUTES = {
-  HOME: "/",
-  DASHBOARD: "/",
-  DASHBOARD_RUNS: "/runs",
-  DASHBOARD_PIPELINES: "/pipelines",
-  DASHBOARD_COMPONENTS: "/components",
-  DASHBOARD_COMPONENTS_V2: "/components-v2",
-  DASHBOARD_FAVORITES: "/favorites",
-  DASHBOARD_RECENTLY_VIEWED: "/recently-viewed",
-  LEARN: LEARN_BASE_PATH,
-  LEARN_EXAMPLES: `${LEARN_BASE_PATH}/examples`,
-  LEARN_TIPS: `${LEARN_BASE_PATH}/tips`,
-  LEARN_TOURS: `${LEARN_BASE_PATH}/tours`,
-  IMPORT: IMPORT_PATH,
-  PIPELINE_EDITOR: `${EDITOR_PATH}/$name`,
-  RUN_DETAIL: `${RUNS_BASE_PATH}/$id`,
-  RUN_DETAIL_WITH_SUBGRAPH: `${RUNS_BASE_PATH}/$id/$subgraphExecutionId`,
-  RUNS: RUNS_BASE_PATH,
-  SETTINGS: SETTINGS_PATH,
-  SETTINGS_BACKEND: `${SETTINGS_PATH}/backend`,
-  SETTINGS_PREFERENCES: `${SETTINGS_PATH}/preferences`,
-  SETTINGS_BETA_FEATURES: `${SETTINGS_PATH}/beta-features`,
-  SETTINGS_AGENT: `${SETTINGS_PATH}/agent`,
-  SETTINGS_SECRETS: `${SETTINGS_PATH}/secrets`,
-  SETTINGS_SECRETS_ADD: `${SETTINGS_PATH}/secrets/add`,
-  SETTINGS_SECRETS_REPLACE: `${SETTINGS_PATH}/secrets/$secretId/replace`,
-  GITHUB_AUTH_CALLBACK: "/authorize/github",
-  HUGGINGFACE_AUTH_CALLBACK: "/authorize/huggingface",
-  EDITOR_V2: EDITOR_V2_BASE_PATH,
-  EDITOR_V2_PIPELINE: `${EDITOR_V2_BASE_PATH}/$pipelineName`,
-  RUNS_V2: RUNS_V2_BASE_PATH,
-  RUN_DETAIL_V2: `${RUNS_V2_BASE_PATH}/$id`,
-  RUN_DETAIL_V2_WITH_SUBGRAPH: `${RUNS_V2_BASE_PATH}/$id/$subgraphExecutionId`,
-  PIPELINE_FOLDERS: "/pipeline-folders",
-  PLAYGROUND: "/playground",
-  ARTIFACT_PREVIEW: "/artifact/$artifactId",
-} as const;
 
 const rootRoute = createRootRoute({
   component: Outlet,
@@ -137,6 +94,11 @@ const dashboardComponentsRoute = createRoute({
   getParentRoute: () => dashboardRoute,
   path: "/components",
   component: DashboardComponentsView,
+  beforeLoad: () => {
+    if (isFlagEnabled("component-search-v2")) {
+      throw redirect({ to: APP_ROUTES.DASHBOARD_COMPONENTS_V2 });
+    }
+  },
 });
 
 const dashboardComponentsV2Route = createRoute({
@@ -164,7 +126,7 @@ const dashboardRecentlyViewedRoute = createRoute({
 
 const learnIndexRoute = createRoute({
   getParentRoute: () => dashboardRoute,
-  path: LEARN_BASE_PATH,
+  path: APP_ROUTES.LEARN,
   component: LearnHomeView,
 });
 
@@ -196,7 +158,7 @@ const quickStartRoute = createRoute({
 
 const settingsLayoutRoute = createRoute({
   getParentRoute: () => mainLayout,
-  path: SETTINGS_PATH,
+  path: APP_ROUTES.SETTINGS,
   component: SettingsLayout,
 });
 

--- a/src/routes/v2/pages/Editor/EditorV2.tsx
+++ b/src/routes/v2/pages/Editor/EditorV2.tsx
@@ -83,7 +83,9 @@ const PipelineEditor = withSuspenseWrapper(
     useSelectionWindowSync();
     usePropertiesWindowPositioning();
     useLinkedWindowCleanup();
-    useComponentLibraryWindow();
+
+    const componentSearchV2Enabled = useFlagValue("component-search-v2");
+    useComponentLibraryWindow(!componentSearchV2Enabled);
     usePipelineDetailsWindow();
     usePipelineTreeWindow();
     useHistoryWindow();
@@ -95,12 +97,11 @@ const PipelineEditor = withSuspenseWrapper(
     useEditorEscapeShortcut();
     useDebugPanelWindow();
     useTipOfTheDayWindow();
-    useSeedInitialDockLayoutFromPreset();
+    useSeedInitialDockLayoutFromPreset(componentSearchV2Enabled);
 
     const aiEnabled = useFlagValue("ai-assistant");
     useAiChatWindow(aiEnabled);
 
-    const componentSearchV2Enabled = useFlagValue("component-search-v2");
     useComponentSearchV2Window(componentSearchV2Enabled);
 
     const activeSpec = navigation.activeSpec;

--- a/src/routes/v2/pages/Editor/components/EditorMenuBar/components/WindowsMenu.tsx
+++ b/src/routes/v2/pages/Editor/components/EditorMenuBar/components/WindowsMenu.tsx
@@ -1,5 +1,6 @@
 import { observer } from "mobx-react-lite";
 
+import { useFlagValue } from "@/components/shared/Settings/useFlags";
 import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
@@ -16,13 +17,15 @@ import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { MenuTriggerButton } from "@/routes/v2/shared/components/MenuTriggerButton";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 import {
-  VIEW_PRESETS,
   type ViewPreset,
+  viewPresetForComponentSearchMode,
+  viewPresetsForComponentSearchMode,
 } from "@/routes/v2/shared/windows/viewPresets";
 import { tracking } from "@/utils/tracking";
 
 export const WindowsMenu = observer(function WindowsMenu() {
   const { track } = useAnalytics();
+  const componentSearchV2Enabled = useFlagValue("component-search-v2");
   const { windows } = useSharedStores();
   const sortedWindows = [...windows.getAllWindows()]
     .filter((window) => window.persisted)
@@ -32,7 +35,9 @@ export const WindowsMenu = observer(function WindowsMenu() {
     track("v2.pipeline_editor.windows_menu.view_preset.click", {
       preset_label: preset.label,
     });
-    windows.applyViewPreset(preset);
+    windows.applyViewPreset(
+      viewPresetForComponentSearchMode(preset, componentSearchV2Enabled),
+    );
   };
 
   return (
@@ -73,14 +78,16 @@ export const WindowsMenu = observer(function WindowsMenu() {
             Views
           </DropdownMenuSubTrigger>
           <DropdownMenuSubContent>
-            {VIEW_PRESETS.map((preset) => (
-              <DropdownMenuItem
-                key={preset.label}
-                onSelect={() => applyPreset(preset)}
-              >
-                {preset.label}
-              </DropdownMenuItem>
-            ))}
+            {viewPresetsForComponentSearchMode(componentSearchV2Enabled).map(
+              (preset) => (
+                <DropdownMenuItem
+                  key={preset.label}
+                  onSelect={() => applyPreset(preset)}
+                >
+                  {preset.label}
+                </DropdownMenuItem>
+              ),
+            )}
           </DropdownMenuSubContent>
         </DropdownMenuSub>
       </DropdownMenuContent>

--- a/src/routes/v2/pages/Editor/hooks/useComponentLibraryWindow.tsx
+++ b/src/routes/v2/pages/Editor/hooks/useComponentLibraryWindow.tsx
@@ -6,10 +6,15 @@ import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 
 const COMPONENT_LIBRARY_WINDOW_ID = "component-library";
 
-export function useComponentLibraryWindow() {
+export function useComponentLibraryWindow(enabled: boolean) {
   const { windows } = useSharedStores();
   useEffect(() => {
-    if (windows.getWindowById(COMPONENT_LIBRARY_WINDOW_ID)) return;
+    const existing = windows.getWindowById(COMPONENT_LIBRARY_WINDOW_ID);
+    if (!enabled) {
+      existing?.hide();
+      return;
+    }
+    if (existing) return;
     windows.openWindow(<ComponentLibraryContent />, {
       id: COMPONENT_LIBRARY_WINDOW_ID,
       title: "Components",
@@ -20,5 +25,5 @@ export function useComponentLibraryWindow() {
       defaultDockState: "left",
       miniContent: <ComponentLibraryWindowMiniContent />,
     });
-  }, [windows]);
+  }, [enabled, windows]);
 }

--- a/src/routes/v2/pages/Editor/hooks/useSeedInitialDockLayoutFromPreset.ts
+++ b/src/routes/v2/pages/Editor/hooks/useSeedInitialDockLayoutFromPreset.ts
@@ -1,7 +1,10 @@
 import { useEffect } from "react";
 
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
-import { DEFAULT_VIEW_PRESET } from "@/routes/v2/shared/windows/viewPresets";
+import {
+  DEFAULT_VIEW_PRESET,
+  viewPresetForComponentSearchMode,
+} from "@/routes/v2/shared/windows/viewPresets";
 import { hasPersistedLayout } from "@/routes/v2/shared/windows/windowPersistence";
 
 /**
@@ -12,12 +15,19 @@ import { hasPersistedLayout } from "@/routes/v2/shared/windows/windowPersistence
  * `PipelineEditor` so those hooks’ effects have already opened windows in the
  * store. Only runs when `hasPersistedLayout()` is false.
  */
-export function useSeedInitialDockLayoutFromPreset(): void {
+export function useSeedInitialDockLayoutFromPreset(
+  componentSearchV2Enabled: boolean,
+): void {
   const { windows } = useSharedStores();
 
   useEffect(() => {
     if (!hasPersistedLayout()) {
-      windows.seedInitialDockLayoutFromPreset(DEFAULT_VIEW_PRESET);
+      windows.seedInitialDockLayoutFromPreset(
+        viewPresetForComponentSearchMode(
+          DEFAULT_VIEW_PRESET,
+          componentSearchV2Enabled,
+        ),
+      );
     }
-  }, [windows]);
+  }, [componentSearchV2Enabled, windows]);
 }

--- a/src/routes/v2/shared/windows/viewPresets.ts
+++ b/src/routes/v2/shared/windows/viewPresets.ts
@@ -12,12 +12,15 @@ export interface ViewPreset {
   dockAreas?: PresetDockAreas;
 }
 
+const COMPONENT_SEARCH_WINDOW_ID = "component-search-v2";
+const COMPONENT_LIBRARY_WINDOW_ID = "component-library";
+
 export const DEFAULT_DOCK_AREAS: PresetDockAreas = {
   left: [
     "tip-of-the-day",
     "runs-and-submission",
-    "component-search-v2",
-    "component-library",
+    COMPONENT_SEARCH_WINDOW_ID,
+    COMPONENT_LIBRARY_WINDOW_ID,
     "pipeline-tree",
     "history",
     "debug-panel",
@@ -62,8 +65,8 @@ export const VIEW_PRESETS: ViewPreset[] = [
       "All windows visible, including Runs & Submissions and Recent Runs",
     visible: new Set([
       "runs-and-submission",
-      "component-search-v2",
-      "component-library",
+      COMPONENT_SEARCH_WINDOW_ID,
+      COMPONENT_LIBRARY_WINDOW_ID,
       "history",
       "pipeline-tree",
       "pipeline-details",
@@ -79,3 +82,48 @@ export const VIEW_PRESETS: ViewPreset[] = [
     visible: new Set<string>(),
   },
 ];
+
+function filterWindowIdsForComponentSearchMode(
+  ids: string[],
+  componentSearchV2Enabled: boolean,
+): string[] {
+  const hiddenWindowId = componentSearchV2Enabled
+    ? COMPONENT_LIBRARY_WINDOW_ID
+    : COMPONENT_SEARCH_WINDOW_ID;
+  return ids.filter((id) => id !== hiddenWindowId);
+}
+
+export function viewPresetForComponentSearchMode(
+  preset: ViewPreset,
+  componentSearchV2Enabled: boolean,
+): ViewPreset {
+  const visible = new Set(
+    filterWindowIdsForComponentSearchMode(
+      [...preset.visible],
+      componentSearchV2Enabled,
+    ),
+  );
+
+  const dockAreas = preset.dockAreas
+    ? {
+        left: filterWindowIdsForComponentSearchMode(
+          preset.dockAreas.left,
+          componentSearchV2Enabled,
+        ),
+        right: filterWindowIdsForComponentSearchMode(
+          preset.dockAreas.right,
+          componentSearchV2Enabled,
+        ),
+      }
+    : undefined;
+
+  return { ...preset, visible, dockAreas };
+}
+
+export function viewPresetsForComponentSearchMode(
+  componentSearchV2Enabled: boolean,
+): ViewPreset[] {
+  return VIEW_PRESETS.map((preset) =>
+    viewPresetForComponentSearchMode(preset, componentSearchV2Enabled),
+  );
+}


### PR DESCRIPTION
## Description

Renames "Components V2" to "Components" across all user-facing labels, flag names, log messages, and test descriptions to reflect that the component search feature is no longer considered a secondary/experimental variant but the canonical component experience.

When the `component-search-v2` flag is enabled, the sidebar now replaces the existing "Components" entry with the "Components" (search) entry instead of inserting a second item alongside it. Navigating to `/components` while the flag is on redirects automatically to `/components-v2`.

The `APP_ROUTES` constant and related path/constant definitions have been extracted from `router.ts` into a dedicated `appRoutes.ts` module, with `router.ts` re-exporting from it to preserve existing import paths.

View preset logic now accounts for the component search mode: `viewPresetForComponentSearchMode` and `viewPresetsForComponentSearchMode` helpers filter out the appropriate window (`component-library` or `component-search-v2`) depending on whether the flag is enabled. The `useComponentLibraryWindow` hook accepts an `enabled` flag and hides the window when disabled. `useSeedInitialDockLayoutFromPreset` and `WindowsMenu` both apply the correct preset variant based on the flag state.

The rerank exclusion logic in component search has been updated so that candidates scoring at or below the threshold are pushed below unscored lexical matches rather than simply being left in place without a badge. A `fallbackRerankScore` function assigns a position-based score to unscored items when reranking is active.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] Improvement
- [x] Cleanup/Refactor

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Enable the `component-search-v2` beta flag in Settings → Beta Features.
2. Confirm the sidebar shows a single "Components" entry (not two entries).
3. Navigate to `/components` and confirm it redirects to `/components-v2`.
4. Open the editor and verify the component search window appears while the component library window is hidden.
5. Open the Windows menu and apply each view preset; confirm the correct windows are shown or hidden based on the flag state.
6. Disable the flag and confirm the original "Components" library window is restored and the sidebar reverts to the standard entry.

## Additional Comments

The `component-search-v2` flag key is intentionally unchanged to avoid a migration; only the display name and descriptions have been updated.