### PR TITLE
Wire `search_components` tool into dispatcher and subagents

### DIFF
--- a/src/agent/agents/editorDispatcher.test.ts
+++ b/src/agent/agents/editorDispatcher.test.ts
@@ -24,6 +24,7 @@ vi.mock("@openai/agents", () => {
     Agent: FakeAgent,
     MemorySession: FakeMemorySession,
     run: (...args: unknown[]) => runMock(...args),
+    tool: (config: unknown) => ({ type: "tool", config }),
   };
 });
 

--- a/src/agent/agents/editorDispatcher.ts
+++ b/src/agent/agents/editorDispatcher.ts
@@ -19,6 +19,7 @@ import { getAgentModelConfig } from "../config";
 import { attachObservabilityHooks } from "../middleware/observability";
 import dispatcherPrompt from "../prompts/dispatcher.md?raw";
 import type { AgentSession } from "../session";
+import { createComponentSearchTools } from "../tools/componentSearchTools";
 import {
   createDispatcherRuntime,
   type TangleDispatcher,
@@ -33,12 +34,14 @@ async function buildEditorAgent(session: AgentSession): Promise<Agent> {
   const pipelineRepair = createPipelineRepairAgent(session);
   const pipelineArchitect = await createPipelineArchitectAgent(session);
   const debugAssistant = createDebugAssistantAgent(session);
+  const componentSearch = createComponentSearchTools(session);
 
   const agent = new Agent({
     name: "tangle-dispatcher",
     ...getAgentModelConfig(session.aiConfig),
     instructions: dispatcherPrompt,
     tools: [
+      componentSearch.searchComponents,
       generalHelp.asTool({
         toolName: "ask_general_help",
         toolDescription:

--- a/src/agent/agents/subagents/pipelineArchitect.ts
+++ b/src/agent/agents/subagents/pipelineArchitect.ts
@@ -14,6 +14,7 @@ import { getAgentModelConfig } from "../../config";
 import { attachObservabilityHooks } from "../../middleware/observability";
 import architectPrompt from "../../prompts/architect.md?raw";
 import type { AgentSession } from "../../session";
+import { createComponentSearchTools } from "../../tools/componentSearchTools";
 import { createCsomTools } from "../../tools/csomTools";
 import { createRunTools } from "../../tools/runTools";
 
@@ -36,6 +37,7 @@ export async function createPipelineArchitectAgent(
   session: AgentSession,
 ): Promise<Agent> {
   const csom = createCsomTools(session.bridge);
+  const componentSearch = createComponentSearchTools(session);
   const runTools = createRunTools(session.bridge);
   const agent = new Agent({
     name: "pipeline-architect",
@@ -44,7 +46,11 @@ export async function createPipelineArchitectAgent(
       after a successful build when the user asks. Asks the user for input when design choices
       are ambiguous.`,
     instructions: await buildInstructions(session),
-    tools: [...csom.allTools, runTools.submitPipelineRun],
+    tools: [
+      componentSearch.searchComponents,
+      ...csom.allTools,
+      runTools.submitPipelineRun,
+    ],
     ...getAgentModelConfig(session.aiConfig),
   });
   attachObservabilityHooks(agent, session.emitStatus);

--- a/src/agent/agents/subagents/pipelineRepair.ts
+++ b/src/agent/agents/subagents/pipelineRepair.ts
@@ -10,11 +10,13 @@ import { getAgentModelConfig } from "../../config";
 import { attachObservabilityHooks } from "../../middleware/observability";
 import pipelineRepairPrompt from "../../prompts/pipelineRepair.md?raw";
 import type { AgentSession } from "../../session";
+import { createComponentSearchTools } from "../../tools/componentSearchTools";
 import { createCsomTools } from "../../tools/csomTools";
 import { createRunTools } from "../../tools/runTools";
 
 export function createPipelineRepairAgent(session: AgentSession): Agent {
   const csom = createCsomTools(session.bridge);
+  const componentSearch = createComponentSearchTools(session);
   const runTools = createRunTools(session.bridge);
   const agent = new Agent({
     name: "pipeline-repair",
@@ -22,7 +24,11 @@ export function createPipelineRepairAgent(session: AgentSession): Agent {
       structural problems in existing pipelines. Can mutate the pipeline via CSOM tools and submit a run
       after a successful fix when the user asks. Asks the user for input when fixes are ambiguous.`,
     instructions: pipelineRepairPrompt,
-    tools: [...csom.allTools, runTools.submitPipelineRun],
+    tools: [
+      componentSearch.searchComponents,
+      ...csom.allTools,
+      runTools.submitPipelineRun,
+    ],
     ...getAgentModelConfig(session.aiConfig),
   });
   attachObservabilityHooks(agent, session.emitStatus);

--- a/src/agent/createWorkerApi.ts
+++ b/src/agent/createWorkerApi.ts
@@ -93,14 +93,10 @@ export function createWorkerApi(
         session,
       });
 
-      // TODO: populate from session.componentReferences once the
-      // search_components tool is wired.
-      const componentReferences: AgentResponse["componentReferences"] = {};
-
       return {
         answer: result.answer,
         threadId: result.threadId,
-        componentReferences,
+        componentReferences: session.componentReferences,
       };
     },
   };

--- a/src/agent/prompts/architect.md
+++ b/src/agent/prompts/architect.md
@@ -1,6 +1,6 @@
 # Pipeline Architect — System Prompt
 
-You are the **Pipeline Architect** specialist for Tangle Pipeline Studio. Your job is to design and build new pipelines — or new stages within an existing pipeline — from a high-level user goal. You translate intent into a concrete graph of tasks, bindings, inputs, and outputs.
+You are the **Pipeline Architect** specialist for Tangle. Your job is to design and build new pipelines — or new stages within an existing pipeline — from a high-level user goal. You translate intent into a concrete graph of tasks, bindings, inputs, and outputs.
 
 ## Your Workflow
 
@@ -13,13 +13,13 @@ You are the **Pipeline Architect** specialist for Tangle Pipeline Studio. Your j
 4. For ambiguous decisions (which dataset format? which evaluation metric? which output to expose?), ask the user one clear question instead of guessing. Do not invent component names, IDs, or input/output ports.
 5. When the design is structurally sound, summarize what you built using the entity-link summary format below.
 
-## Component-availability constraint (beta)
+## Component lookup
 
-Component lookup is not yet wired into the architect (it lands in a later release alongside `search_components`). Until then:
+Use `search_components` whenever the user asks for a new stage that is not already present in the pipeline, or when you need to choose a component by intent. Search results include a `componentRef`; pass that exact `componentRef` to `add_task`.
 
-- You can freely **add, rename, delete, connect, and configure** tasks whose components are already referenced somewhere in the current pipeline spec — those `componentRef` payloads are visible in `get_pipeline_state`.
-- You cannot conjure brand-new components from thin air. If the user asks for a stage that needs a component the spec does not already reference, say so plainly, suggest the closest existing component, and ask whether the user wants to add the component manually first.
-- For an empty canvas, ask the user which components they want to start from (or which template), rather than fabricating tasks the system cannot resolve.
+- Do not invent component names, ids, ports, or component refs.
+- If search returns multiple plausible components, choose the best fit when the user's intent is clear, or ask one clarifying question when the choice changes the pipeline design.
+- When mentioning found components in your response, use the returned `componentLink` markdown exactly so the UI can render it as an interactive component chip.
 
 ## Subgraph design
 

--- a/src/agent/prompts/dispatcher.md
+++ b/src/agent/prompts/dispatcher.md
@@ -1,6 +1,6 @@
 # Tangle Dispatcher — System Prompt
 
-You are the **Tangle Dispatcher**, the entry point for the Tangle Pipeline Studio AI assistant. Your job is to route the user's request to the right specialist(s) and relay their responses back. You do not answer Tangle questions yourself unless the user is asking about your capabilities or the request is off-topic.
+You are the **Tangle Dispatcher**, the entry point for the Tangle AI assistant. Your job is to route the user's request to the right specialist(s) and relay their responses back. You do not answer Tangle questions yourself unless the user is asking about your capabilities, component search, or the request is off-topic.
 
 ## Available specialist tools
 
@@ -8,6 +8,7 @@ Each specialist is exposed to you as a tool. Calling a tool runs the specialist'
 
 | Tool                     | When to call it                                                                                                                                                                                                                                                                                                       |
 | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `search_components`      | Any request to find, list, compare, choose, or look up available components by intent or keywords (e.g. "find components that upload a file", "what components can read CSV?"). Return matching components as component links.                                                                                        |
 | `ask_general_help`       | Any question about Tangle concepts, features, how things work, best practices, getting started, or documentation lookups (e.g. "what is a pipeline?", "how do I connect tasks?", "what are subgraphs?").                                                                                                              |
 | `ask_pipeline_repair`    | Any request to inspect, validate, or fix the user's current pipeline — broken connections, validation errors, dangling bindings, missing arguments, structural cleanup — and "fix it and run it". Also call this with a specific directive when `ask_debug_assistant` has already identified a concrete fix to apply. |
 | `ask_pipeline_architect` | Any request to **design or build new pipeline structure** — a whole pipeline from scratch ("build me a pipeline that…"), a new stage in an existing pipeline ("add a training stage"), or a multi-task subgraph. Can also "build it and run it". NOT for fixing validation errors or single-task tweaks.              |
@@ -39,6 +40,8 @@ Some user requests need more than one specialist in a single turn. Chain tool ca
 - Genuinely ambiguous (e.g. "make this pipeline work") → prefer `ask_pipeline_repair` and let it ask the user a clarifying question if needed.
 
 ## Returning tool output
+
+When `search_components` returns, list the strongest matches using the `componentLink` values exactly as returned. Add at most one short reason per component.
 
 When a specialist tool returns, **relay its response** to the user. Specialists emit interactive entity links the UI renders as chips:
 

--- a/src/agent/prompts/pipelineRepair.md
+++ b/src/agent/prompts/pipelineRepair.md
@@ -1,6 +1,6 @@
 # Pipeline Repair — System Prompt
 
-You are the **Pipeline Repair** specialist for Tangle Pipeline Studio. Your job is to diagnose and fix validation issues, broken connections, missing inputs, and other structural problems in existing pipelines.
+You are the **Pipeline Repair** specialist for Tangle. Your job is to diagnose and fix validation issues, broken connections, missing inputs, and other structural problems in existing pipelines.
 
 ## Invoked with a fix directive
 
@@ -41,9 +41,9 @@ Use the validation-driven workflow below for every other input ("Validate and fi
 
 ### Out of scope (explain and defer)
 
-- Building new pipeline stages from scratch (that's the architect's job — coming in a later release)
+- Building new pipeline stages from scratch (that's the architect's job)
 - Diagnosing why a previous run failed (that's the **debug-assistant**'s job — defer back to the dispatcher). When the dispatcher invokes you with an already-identified fix directive, follow the **Invoked with a fix directive** rules instead of re-diagnosing.
-- Adding tasks for components you don't already have access to. Component lookup will land in a future release; until then, only operate on tasks and components already present in the pipeline spec.
+- Choosing among multiple new components when the user's intent is ambiguous. Use `search_components` for targeted single-task additions, but ask a clarifying question when several results would change the fix meaningfully.
 
 ## Submitting runs
 

--- a/src/agent/session.ts
+++ b/src/agent/session.ts
@@ -6,7 +6,7 @@ import type { AiProviderConfig } from "@/types/aiProvider";
 import type { ProxyClient } from "./config";
 import type { SkillsLoader } from "./skills/loader";
 import type { ToolBridgeApi } from "./toolBridgeApi";
-import type { AgentContext, StatusCallback } from "./types";
+import type { AgentContext, AgentResponse, StatusCallback } from "./types";
 
 export interface RecentPipelineRun {
   id: number;
@@ -25,6 +25,7 @@ export interface AgentSession {
   aiConfig: AiProviderConfig;
   recentRuns: RecentPipelineRun[];
   context: AgentContext;
+  componentReferences: AgentResponse["componentReferences"];
 }
 
 export function createSession(params: {
@@ -46,5 +47,6 @@ export function createSession(params: {
     aiConfig: params.aiConfig,
     recentRuns: params.recentRuns ?? [],
     context: params.context,
+    componentReferences: {},
   };
 }

--- a/src/agent/toolBridgeApi.ts
+++ b/src/agent/toolBridgeApi.ts
@@ -75,6 +75,29 @@ export interface RunDebugSnapshot {
   error?: string;
 }
 
+interface SearchComponentsArgs {
+  query: string;
+  limit?: number;
+}
+
+interface ComponentSearchBridgeResult {
+  id: string;
+  name: string;
+  description: string;
+  source: string;
+  matchedFields: string[];
+  inputs: string[];
+  outputs: string[];
+  componentRef: Pick<ComponentReference, "name" | "url" | "spec">;
+  yamlText: string | null;
+}
+
+interface SearchComponentsResult {
+  success: boolean;
+  results: ComponentSearchBridgeResult[];
+  error?: string;
+}
+
 export type RunDetails = PipelineRunResponse;
 export type ExecutionDetails = GetExecutionInfoResponse;
 export type ExecutionState = GetGraphExecutionStateResponse;
@@ -134,6 +157,8 @@ export interface ToolBridgeApi {
   unpackSubgraph(taskEntityId: string): Promise<{ success: boolean }>;
 
   validatePipeline(): Promise<ValidationResult>;
+
+  searchComponents(args: SearchComponentsArgs): Promise<SearchComponentsResult>;
 
   submitPipelineRun(): Promise<RunSubmissionResult>;
   getRunDetails(runId: string): Promise<RunDetails>;

--- a/src/agent/tools/componentSearchTools.ts
+++ b/src/agent/tools/componentSearchTools.ts
@@ -1,0 +1,57 @@
+import { tool } from "@openai/agents";
+import { z } from "zod";
+
+import type { AgentSession } from "../session";
+
+function asJson(value: unknown): string {
+  return JSON.stringify(value);
+}
+
+export function createComponentSearchTools(session: AgentSession) {
+  const searchComponents = tool({
+    name: "search_components",
+    description:
+      "Search the available Tangle component library by natural-language intent or keywords. Use this when the user asks to find, list, choose, add, or build with components that may not already be on the canvas.",
+    parameters: z.object({
+      query: z
+        .string()
+        .describe(
+          "The user's component intent, e.g. 'upload a file', 'train xgboost', or 'read csv'.",
+        ),
+      limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(20)
+        .nullable()
+        .optional()
+        .describe("Maximum results to return. Defaults to 8."),
+    }),
+    execute: async ({ query, limit }) => {
+      const searchResult = await session.bridge.searchComponents({
+        query,
+        limit: limit ?? undefined,
+      });
+
+      for (const result of searchResult.results) {
+        if (!result.yamlText) continue;
+        session.componentReferences[result.id] = {
+          name: result.name,
+          yamlText: result.yamlText,
+        };
+      }
+
+      return asJson({
+        ...searchResult,
+        results: searchResult.results.map(
+          ({ yamlText: _yamlText, ...result }) => ({
+            ...result,
+            componentLink: `[${result.name}](component://${result.id})`,
+          }),
+        ),
+      });
+    },
+  });
+
+  return { searchComponents };
+}

--- a/src/routes/v2/pages/Editor/components/AiChat/toolBridge/index.ts
+++ b/src/routes/v2/pages/Editor/components/AiChat/toolBridge/index.ts
@@ -13,6 +13,7 @@
  * changes are picked up without rebuilding the bridge.
  */
 import type { ToolBridgeApi } from "@/agent/toolBridgeApi";
+import { createComponentSearchBridgeHandlers } from "@/routes/v2/shared/components/AiChat/toolBridge/componentSearchBridge";
 import { createDebugBridgeHandlers } from "@/routes/v2/shared/components/AiChat/toolBridge/debugBridge";
 import { createRunBridgeHandlers } from "@/routes/v2/shared/components/AiChat/toolBridge/runBridge";
 
@@ -30,6 +31,7 @@ export function createEditorToolBridge(
 ): ToolBridgeApi {
   return {
     ...createCsomBridgeHandlers(deps),
+    ...createComponentSearchBridgeHandlers(deps),
     ...createRunBridgeHandlers(deps),
     ...createDebugBridgeHandlers(deps),
   };

--- a/src/routes/v2/pages/RunView/toolBridge/runViewToolBridge.ts
+++ b/src/routes/v2/pages/RunView/toolBridge/runViewToolBridge.ts
@@ -39,6 +39,7 @@ type ReadOnlyCsomHandlers = Pick<
   | "createSubgraph"
   | "unpackSubgraph"
   | "validatePipeline"
+  | "searchComponents"
 >;
 
 function createReadOnlyCsomHandlers(deps: BridgeDeps): ReadOnlyCsomHandlers {
@@ -61,6 +62,14 @@ function createReadOnlyCsomHandlers(deps: BridgeDeps): ReadOnlyCsomHandlers {
           entityId: i.entityId,
           issueCode: i.issueCode,
         })),
+      };
+    },
+
+    async searchComponents() {
+      return {
+        success: false,
+        results: [],
+        error: "Component search is only available in the editor.",
       };
     },
 

--- a/src/routes/v2/shared/components/AiChat/agentThread.ts
+++ b/src/routes/v2/shared/components/AiChat/agentThread.ts
@@ -97,12 +97,16 @@ export class AgentThread {
 
       runInAction(() => {
         this.thinkingText = null;
+        const componentReferences = response.componentReferences;
         this.messages = [
           ...this.messages,
           {
             id: generateMessageId(),
             role: "assistant",
             content: response.answer,
+            ...(Object.keys(componentReferences).length > 0
+              ? { componentReferences }
+              : {}),
           },
         ];
       });

--- a/src/routes/v2/shared/components/AiChat/toolBridge/componentSearchBridge.ts
+++ b/src/routes/v2/shared/components/AiChat/toolBridge/componentSearchBridge.ts
@@ -1,0 +1,240 @@
+import type { ToolBridgeApi } from "@/agent/toolBridgeApi";
+import { listApiPublishedComponentsGet } from "@/api/sdk.gen";
+import {
+  fetchUserComponents,
+  flattenFolders,
+} from "@/providers/ComponentLibraryProvider/componentLibrary";
+import { createLibraryObject } from "@/providers/ComponentLibraryProvider/libraries/factory";
+import { ensureLibraryFactoriesRegistered } from "@/providers/ComponentLibraryProvider/libraries/setup";
+import { LibraryDB } from "@/providers/ComponentLibraryProvider/libraries/storage";
+import {
+  buildSearchIndex,
+  type ComponentSearchSource,
+  lexicalSearch,
+  type SourcedReference,
+} from "@/services/componentSearchIndex";
+import {
+  fetchAndStoreComponentLibrary,
+  hydrateComponentReference,
+} from "@/services/componentService";
+import type { ComponentFolder } from "@/types/componentLibrary";
+import type { ComponentReference } from "@/utils/componentSpec";
+import { componentSpecToYaml } from "@/utils/yaml";
+
+import type { BridgeDeps } from "./utils";
+
+const SEARCH_STALE_TIME = 1000 * 60 * 60;
+const DEFAULT_LIMIT = 8;
+const MAX_LIMIT = 20;
+
+const STANDARD_SOURCE: ComponentSearchSource = {
+  kind: "standard",
+  label: "Standard",
+  id: "standard",
+};
+
+const PUBLISHED_SOURCE: ComponentSearchSource = {
+  kind: "published",
+  label: "Published",
+  id: "published",
+};
+
+const USER_SOURCE: ComponentSearchSource = {
+  kind: "user",
+  label: "User",
+  id: "user",
+};
+
+type ComponentSearchHandlers = Pick<ToolBridgeApi, "searchComponents">;
+
+async function ensureData<T>(
+  deps: BridgeDeps,
+  queryKey: readonly unknown[],
+  queryFn: () => Promise<T>,
+): Promise<T> {
+  if (!deps.queryClient) return queryFn();
+  return deps.queryClient.ensureQueryData({
+    queryKey,
+    queryFn,
+    staleTime: SEARCH_STALE_TIME,
+  });
+}
+
+async function collectPublishedReferences(
+  deps: BridgeDeps,
+): Promise<ComponentReference[]> {
+  const backendUrl = deps.getBackendUrl?.().replace(/\/+$/, "");
+  if (!backendUrl) return [];
+
+  try {
+    const result = await listApiPublishedComponentsGet({});
+    if (result.response.status !== 200 || !result.data) return [];
+
+    return (result.data.published_components ?? [])
+      .filter((component) => !component.deprecated)
+      .map((component) => ({
+        digest: component.digest,
+        name: component.name ?? undefined,
+        url:
+          component.url ?? `${backendUrl}/api/components/${component.digest}`,
+        published_by: component.published_by,
+      }));
+  } catch {
+    return [];
+  }
+}
+
+async function collectRegisteredReferences(): Promise<SourcedReference[]> {
+  ensureLibraryFactoriesRegistered();
+  const libraries = await LibraryDB.component_libraries.toArray();
+  if (libraries.length === 0) return [];
+
+  const results = await Promise.allSettled(
+    libraries.map(async (library) => {
+      const componentLibrary = createLibraryObject(library);
+      const folder: ComponentFolder = await componentLibrary.getComponents({});
+      return { library, folder };
+    }),
+  );
+
+  const sourced: SourcedReference[] = [];
+  for (const result of results) {
+    if (result.status !== "fulfilled") continue;
+    const source: ComponentSearchSource = {
+      kind: "registered",
+      label: result.value.library.name,
+      id: result.value.library.id,
+    };
+    for (const reference of flattenFolders(result.value.folder)) {
+      sourced.push({ reference, source });
+    }
+  }
+  return sourced;
+}
+
+function dedupeByDigest(sourcedReferences: SourcedReference[]) {
+  const seen = new Set<string>();
+  return sourcedReferences.filter((item) => {
+    const digest = item.reference.digest;
+    if (!digest || seen.has(digest)) return false;
+    seen.add(digest);
+    return true;
+  });
+}
+
+async function buildSourcedReferences(
+  deps: BridgeDeps,
+): Promise<SourcedReference[]> {
+  const [standardLibrary, userFolder, publishedRefs, registeredRefs] =
+    await Promise.all([
+      ensureData(deps, ["componentLibrary"], fetchAndStoreComponentLibrary),
+      ensureData(deps, ["userComponents"], fetchUserComponents),
+      ensureData(
+        deps,
+        ["component-search-v2", "published", deps.getBackendUrl?.() ?? ""],
+        () => collectPublishedReferences(deps),
+      ),
+      ensureData(
+        deps,
+        ["component-search-v2", "registered-libraries"],
+        collectRegisteredReferences,
+      ),
+    ]);
+
+  return dedupeByDigest([
+    ...flattenFolders(standardLibrary).map((reference) => ({
+      reference,
+      source: STANDARD_SOURCE,
+    })),
+    ...publishedRefs.map((reference) => ({
+      reference,
+      source: PUBLISHED_SOURCE,
+    })),
+    ...registeredRefs,
+    ...(userFolder.components ?? []).map((reference) => ({
+      reference,
+      source: USER_SOURCE,
+    })),
+  ]);
+}
+
+function componentReferenceForTool(reference: ComponentReference) {
+  return {
+    name: reference.name ?? reference.spec?.name ?? "Component",
+    ...(reference.url ? { url: reference.url } : {}),
+    ...(!reference.url && reference.spec ? { spec: reference.spec } : {}),
+  };
+}
+
+function yamlTextForReference(reference: ComponentReference): string | null {
+  if (reference.text) return reference.text;
+  if (reference.spec) return componentSpecToYaml(reference.spec);
+  return null;
+}
+
+export function createComponentSearchBridgeHandlers(
+  deps: BridgeDeps,
+): ComponentSearchHandlers {
+  return {
+    async searchComponents({ query, limit }) {
+      const trimmedQuery = query.trim();
+      if (trimmedQuery.length === 0) {
+        return { success: false, results: [], error: "Search query is empty." };
+      }
+
+      const resultLimit = Math.min(
+        Math.max(limit ?? DEFAULT_LIMIT, 1),
+        MAX_LIMIT,
+      );
+      const sourcedReferences = await buildSourcedReferences(deps);
+      const hydratedResults = await Promise.all(
+        sourcedReferences.map(async (item) => {
+          const reference = await ensureData(
+            deps,
+            [
+              "component",
+              "hydrate",
+              item.reference.digest ?? item.reference.url,
+            ],
+            () => hydrateComponentReference(item.reference),
+          ).catch(() => null);
+          return reference ? { reference, source: item.source } : null;
+        }),
+      );
+      const hydratedReferences: SourcedReference[] = hydratedResults.filter(
+        (item): item is NonNullable<(typeof hydratedResults)[number]> =>
+          item !== null,
+      );
+
+      const index = buildSearchIndex(hydratedReferences);
+      const matches = lexicalSearch(index, trimmedQuery, {
+        limit: resultLimit,
+        minLength: 1,
+      });
+
+      return {
+        success: true,
+        results: matches.map((match) => {
+          const spec = match.reference.spec;
+          return {
+            id: match.digest,
+            name: match.name,
+            description: spec?.description ?? "",
+            source: match.source.label,
+            matchedFields: match.matchedFields,
+            inputs:
+              spec?.inputs
+                ?.map((input) => input.name)
+                .filter((name): name is string => Boolean(name)) ?? [],
+            outputs:
+              spec?.outputs
+                ?.map((output) => output.name)
+                .filter((name): name is string => Boolean(name)) ?? [],
+            componentRef: componentReferenceForTool(match.reference),
+            yamlText: yamlTextForReference(match.reference),
+          };
+        }),
+      };
+    },
+  };
+}


### PR DESCRIPTION
## Description

Wires up the `search_components` tool end-to-end, allowing agents to search the full component library by natural-language intent and return results as interactive component links.

A new `createComponentSearchTools` factory creates a `search_components` tool that calls `session.bridge.searchComponents`, accumulates `componentReferences` (including YAML text) into the session, and strips the raw YAML before returning results to the model — replacing it with a `componentLink` markdown string the UI can render as a component chip.

The tool is now registered on the dispatcher, pipeline architect, and pipeline repair agents. The `AgentSession` gains a `componentReferences` map that is populated during a run and returned directly in the worker API response, removing the previous TODO placeholder.

On the bridge side, `createComponentSearchBridgeHandlers` collects references from the standard library, published components, registered libraries, and user components, deduplicates by digest, hydrates each reference, builds a lexical search index, and returns ranked matches with inputs, outputs, and a `componentRef` suitable for passing directly to `add_task`. The run-view bridge returns a graceful "only available in the editor" error for this method.

The architect and repair prompts are updated to instruct agents to use `search_components` instead of the previous "component lookup not yet wired" placeholder guidance.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)



![image.png](https://app.graphite.com/user-attachments/assets/1352470e-4a23-4e40-a666-28e918586037.png)



## Test Instructions

1. Open the editor and start a chat session.
2. Ask the assistant to find a component by intent, e.g. "find components that read a CSV file".
3. Verify the response lists matching components as clickable component chips.
4. Ask the architect to add a new stage using a component not already on the canvas and confirm it uses `search_components` rather than refusing or fabricating a component ref.
5. Confirm the run-view chat returns a graceful error when `search_components` is invoked.

## Additional Comments

The `yamlText` field is collected into `session.componentReferences` for UI hydration but is stripped from the payload sent back to the model to avoid bloating the context window.