### PR TITLE
Expand component search indexing fields

### DIFF
--- a/src/routes/Dashboard/DashboardComponentsV2View.test.tsx
+++ b/src/routes/Dashboard/DashboardComponentsV2View.test.tsx
@@ -228,6 +228,7 @@ function createIndexEntry(
       description: "",
       io: "",
       implementation: "",
+      metadata: "",
     },
   };
 }

--- a/src/routes/Dashboard/DashboardComponentsV2View.tsx
+++ b/src/routes/Dashboard/DashboardComponentsV2View.tsx
@@ -113,6 +113,7 @@ const MATCH_FIELD_LABEL: Record<MatchField, string> = {
   description: "description",
   io: "inputs/outputs",
   implementation: "command",
+  metadata: "metadata",
 };
 
 // Built-in sources are constants — only registered libraries vary per row.

--- a/src/routes/v2/pages/Editor/components/componentSearchV2Logic.test.ts
+++ b/src/routes/v2/pages/Editor/components/componentSearchV2Logic.test.ts
@@ -94,6 +94,23 @@ describe("registeredLibrariesFingerprint", () => {
     ]);
     expect(before).not.toBe(after);
   });
+
+  it("changes when non-secret configuration fields change", () => {
+    const before = registeredLibrariesFingerprint([
+      {
+        ...library("lib-a", ["d1"]),
+        configuration: { repo_name: "old/repo", token: "secret" },
+      },
+    ]);
+    const after = registeredLibrariesFingerprint([
+      {
+        ...library("lib-a", ["d1"]),
+        configuration: { repo_name: "new/repo", token: "secret" },
+      },
+    ]);
+    expect(before).not.toBe(after);
+    expect(before).not.toContain("secret");
+  });
 });
 
 describe("collectAllSourcedReferences", () => {

--- a/src/routes/v2/pages/Editor/components/componentSearchV2Logic.ts
+++ b/src/routes/v2/pages/Editor/components/componentSearchV2Logic.ts
@@ -79,6 +79,22 @@ export function registeredSource(
   return { kind: "registered", label: library.name, id: library.id };
 }
 
+function registeredLibraryConfigurationFingerprint(
+  configuration: StoredLibrary["configuration"],
+): string {
+  if (!configuration) return "";
+
+  const repoName = configuration.repo_name;
+  const lastUpdatedAt = configuration.last_updated_at;
+  const autoUpdate = configuration.auto_update;
+
+  return JSON.stringify({
+    repoName: typeof repoName === "string" ? repoName : "",
+    lastUpdatedAt: typeof lastUpdatedAt === "string" ? lastUpdatedAt : "",
+    autoUpdate: typeof autoUpdate === "boolean" ? autoUpdate : "",
+  });
+}
+
 export function registeredLibrariesFingerprint(
   libraries: StoredLibrary[] | undefined,
 ): string {
@@ -91,6 +107,9 @@ export function registeredLibrariesFingerprint(
         name: library.name,
         type: library.type,
         knownDigests: [...library.knownDigests].sort(),
+        configuration: registeredLibraryConfigurationFingerprint(
+          library.configuration,
+        ),
       }))
       .sort((a, b) => a.id.localeCompare(b.id)),
   );

--- a/src/services/componentSearchIndex.test.ts
+++ b/src/services/componentSearchIndex.test.ts
@@ -134,7 +134,7 @@ describe("buildSearchIndex", () => {
     expect(index[0].searchable.io).toContain("serialized classifier");
     expect(index[0].searchable.io).toContain("artifact");
     expect(index[0].searchable.metadata).toContain("sklearn");
-    expect(index[0].searchable.metadata).toContain("publisher@example.com");
+    expect(index[0].searchable.metadata).not.toContain("publisher@example.com");
     expect(index[0].searchable.metadata).not.toContain("source blob");
     expect(index[0].searchable.implementation).toContain("pandas.train");
     expect(index[0].searchable.implementation).toContain("--epochs");
@@ -318,7 +318,7 @@ describe("lexicalSearch", () => {
     expect(typeResults[0]?.matchedFields).toContain("io");
   });
 
-  it("matches component metadata and source information", () => {
+  it("matches component metadata without treating source labels or author emails as free text", () => {
     const index = buildSearchIndex([
       makeSourced(
         {
@@ -339,8 +339,56 @@ describe("lexicalSearch", () => {
     expect(lexicalSearch(index, "lightgbm")[0]?.matchedFields).toContain(
       "metadata",
     );
-    expect(lexicalSearch(index, "publisher@example")[0]?.digest).toBe("meta");
-    expect(lexicalSearch(index, "user")[0]?.digest).toBe("meta");
+    expect(lexicalSearch(index, "publisher@example")).toHaveLength(0);
+    expect(lexicalSearch(index, "user")).toHaveLength(0);
+  });
+
+  it("matches dependency annotations after filtering noisy annotation keys", () => {
+    const index = buildSearchIndex([
+      makeSourced({
+        digest: "deps",
+        spec: {
+          name: "dependency_component",
+          inputs: [],
+          outputs: [],
+          implementation: { container: { image: "x" } },
+          metadata: {
+            annotations: {
+              python_dependencies: ["tensorflow", "lightgbm"],
+              python_original_code: "import noisy_private_blob",
+            },
+          },
+        },
+      }),
+    ]);
+
+    expect(lexicalSearch(index, "tensorflow")[0]?.digest).toBe("deps");
+    expect(lexicalSearch(index, "noisy_private_blob")).toHaveLength(0);
+  });
+
+  it("caps aggregate annotation text indexed per component", () => {
+    const annotations = Object.fromEntries(
+      Array.from({ length: 20 }, (_, index) => [
+        `annotation_${index}`,
+        `${index}`.padEnd(200, "x"),
+      ]),
+    );
+    const index = buildSearchIndex([
+      makeSourced({
+        digest: "capped",
+        spec: {
+          name: "capped_component",
+          inputs: [],
+          outputs: [],
+          implementation: { container: { image: "x" } },
+          metadata: { annotations },
+        },
+      }),
+    ]);
+
+    expect(index[0].searchable.metadata.length).toBeLessThanOrEqual(2_000);
+    expect(index[0].searchable.metadata).toContain("annotation_0");
+    expect(index[0].searchable.metadata).not.toContain("annotation_19");
   });
 
   it("matches implementation/command text with the lowest weight", () => {

--- a/src/services/componentSearchIndex.test.ts
+++ b/src/services/componentSearchIndex.test.ts
@@ -23,6 +23,7 @@ function makeRef(
     digest: partial.digest,
     url: partial.url,
     name: partial.name,
+    published_by: partial.published_by,
     spec: partial.spec,
   };
 }
@@ -84,20 +85,40 @@ describe("buildSearchIndex", () => {
     expect(index[0].source).toEqual(USER);
   });
 
-  it("indexes name, description, io, and container command text", () => {
+  it("indexes name, description, io details, metadata, and container command text", () => {
     const index = buildSearchIndex([
       makeSourced({
         digest: "a",
+        published_by: "publisher@example.com",
         spec: {
           name: "train_model",
           description: "Train a regression model on a dataset.",
-          inputs: [{ name: "dataset" }],
-          outputs: [{ name: "model" }],
+          inputs: [
+            {
+              name: "dataset",
+              type: "Dataset",
+              description: "Training table with labeled rows.",
+              annotations: { format: "parquet" },
+            },
+          ],
+          outputs: [
+            {
+              name: "model",
+              type: { artifact: "Model" },
+              description: "Serialized classifier artifact.",
+            },
+          ],
           implementation: {
             container: {
               image: "python:3.11",
               command: ["python", "-m", "pandas.train"],
               args: ["--epochs", "10"],
+            },
+          },
+          metadata: {
+            annotations: {
+              framework: "sklearn",
+              python_original_code: "do not index this large source blob",
             },
           },
         },
@@ -107,7 +128,14 @@ describe("buildSearchIndex", () => {
     expect(index[0].searchable.name).toContain("train_model");
     expect(index[0].searchable.description).toContain("regression");
     expect(index[0].searchable.io).toContain("dataset");
+    expect(index[0].searchable.io).toContain("training table");
+    expect(index[0].searchable.io).toContain("parquet");
     expect(index[0].searchable.io).toContain("model");
+    expect(index[0].searchable.io).toContain("serialized classifier");
+    expect(index[0].searchable.io).toContain("artifact");
+    expect(index[0].searchable.metadata).toContain("sklearn");
+    expect(index[0].searchable.metadata).toContain("publisher@example.com");
+    expect(index[0].searchable.metadata).not.toContain("source blob");
     expect(index[0].searchable.implementation).toContain("pandas.train");
     expect(index[0].searchable.implementation).toContain("--epochs");
   });
@@ -257,6 +285,62 @@ describe("lexicalSearch", () => {
 
     const results = lexicalSearch(index, "x");
     expect(results[0]?.digest).toBe("x");
+  });
+
+  it("matches input/output descriptions and types", () => {
+    const index = buildSearchIndex([
+      makeSourced({
+        digest: "typed-io",
+        spec: {
+          name: "generic_processor",
+          inputs: [
+            {
+              name: "data",
+              type: "Dataset",
+              description: "Tabular dataframe rows to clean.",
+            },
+          ],
+          outputs: [
+            {
+              name: "result",
+              type: { artifact: "Model" },
+              description: "Trained classifier artifact.",
+            },
+          ],
+          implementation: { container: { image: "x" } },
+        },
+      }),
+    ]);
+
+    expect(lexicalSearch(index, "dataframe")[0]?.digest).toBe("typed-io");
+    const typeResults = lexicalSearch(index, "artifact");
+    expect(typeResults[0]?.digest).toBe("typed-io");
+    expect(typeResults[0]?.matchedFields).toContain("io");
+  });
+
+  it("matches component metadata and source information", () => {
+    const index = buildSearchIndex([
+      makeSourced(
+        {
+          digest: "meta",
+          published_by: "publisher@example.com",
+          spec: {
+            name: "generic_processor",
+            inputs: [],
+            outputs: [],
+            implementation: { container: { image: "x" } },
+            metadata: { annotations: { framework: "lightgbm" } },
+          },
+        },
+        USER,
+      ),
+    ]);
+
+    expect(lexicalSearch(index, "lightgbm")[0]?.matchedFields).toContain(
+      "metadata",
+    );
+    expect(lexicalSearch(index, "publisher@example")[0]?.digest).toBe("meta");
+    expect(lexicalSearch(index, "user")[0]?.digest).toBe("meta");
   });
 
   it("matches implementation/command text with the lowest weight", () => {

--- a/src/services/componentSearchIndex.ts
+++ b/src/services/componentSearchIndex.ts
@@ -82,7 +82,6 @@ const ANNOTATION_KEYS_EXCLUDED_FROM_SEARCH = new Set([
   "editor.collapsed",
   "editor.flow-direction",
   "flex-nodes",
-  "python_dependencies",
   "python_original_code",
   "tangleml.com/editor/task-color",
   "tangleml.com/editor/edge-conduits",
@@ -90,6 +89,7 @@ const ANNOTATION_KEYS_EXCLUDED_FROM_SEARCH = new Set([
 ]);
 
 const MAX_ANNOTATION_TEXT_LENGTH = 500;
+const MAX_ANNOTATION_TOTAL_TEXT_LENGTH = 2_000;
 
 function isNonEmptyString(value: unknown): value is string {
   return typeof value === "string" && value.trim().length > 0;
@@ -119,12 +119,19 @@ function extractAnnotationsText(
   if (!annotations) return "";
 
   const parts: string[] = [];
+  let textLength = 0;
   for (const [key, value] of Object.entries(annotations)) {
     if (ANNOTATION_KEYS_EXCLUDED_FROM_SEARCH.has(key)) continue;
 
     const valueText = stringifySearchValue(value).trim();
     if (!valueText || valueText.length > MAX_ANNOTATION_TEXT_LENGTH) continue;
-    parts.push(key, valueText);
+
+    const part = `${key} ${valueText}`;
+    const nextLength = textLength + (parts.length > 0 ? 1 : 0) + part.length;
+    if (nextLength > MAX_ANNOTATION_TOTAL_TEXT_LENGTH) break;
+
+    parts.push(part);
+    textLength = nextLength;
   }
 
   return parts.join(" ");
@@ -247,10 +254,7 @@ export function buildSearchIndex(sourced: SourcedReference[]): IndexEntry[] {
         description: metadata.description.toLowerCase(),
         io: metadata.ioText.toLowerCase(),
         implementation: extractImplementationText(reference),
-        metadata: [metadata.metadataText, source.label, reference.published_by]
-          .filter(isNonEmptyString)
-          .join(" ")
-          .toLowerCase(),
+        metadata: metadata.metadataText.toLowerCase(),
       },
     });
   }

--- a/src/services/componentSearchIndex.ts
+++ b/src/services/componentSearchIndex.ts
@@ -16,7 +16,12 @@ import type { ComponentReference } from "@/utils/componentSpec";
 import { getComponentName } from "@/utils/getComponentName";
 
 /** Which field of a component matched the query. Surfaced in the UI. */
-export type MatchField = "name" | "description" | "io" | "implementation";
+export type MatchField =
+  | "name"
+  | "description"
+  | "io"
+  | "implementation"
+  | "metadata";
 
 /**
  * Where a component came from. Attached to every index entry and threaded
@@ -72,6 +77,59 @@ export function indexEntryToLexicalMatch(entry: IndexEntry): LexicalMatch {
   };
 }
 
+const ANNOTATION_KEYS_EXCLUDED_FROM_SEARCH = new Set([
+  "editor.position",
+  "editor.collapsed",
+  "editor.flow-direction",
+  "flex-nodes",
+  "python_dependencies",
+  "python_original_code",
+  "tangleml.com/editor/task-color",
+  "tangleml.com/editor/edge-conduits",
+  "zIndex",
+]);
+
+const MAX_ANNOTATION_TEXT_LENGTH = 500;
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function stringifySearchValue(value: unknown): string {
+  switch (typeof value) {
+    case "string":
+    case "number":
+    case "boolean":
+      return String(value);
+    case "undefined":
+      return "";
+    default:
+      if (value === null) return "";
+      try {
+        return JSON.stringify(value);
+      } catch {
+        return "";
+      }
+  }
+}
+
+function extractAnnotationsText(
+  annotations: Record<string, unknown> | undefined,
+): string {
+  if (!annotations) return "";
+
+  const parts: string[] = [];
+  for (const [key, value] of Object.entries(annotations)) {
+    if (ANNOTATION_KEYS_EXCLUDED_FROM_SEARCH.has(key)) continue;
+
+    const valueText = stringifySearchValue(value).trim();
+    if (!valueText || valueText.length > MAX_ANNOTATION_TEXT_LENGTH) continue;
+    parts.push(key, valueText);
+  }
+
+  return parts.join(" ");
+}
+
 /**
  * Flatten a container implementation's image + command + args into a single
  * lowercase string. Placeholder objects (e.g. `{ inputValue: "Where" }`) are
@@ -123,6 +181,10 @@ export interface ComponentMetadata {
   description: string;
   inputNames: string[];
   outputNames: string[];
+  /** Names, descriptions, types, and annotations for inputs/outputs. */
+  ioText: string;
+  /** Searchable component-level metadata annotations. */
+  metadataText: string;
 }
 
 export function extractComponentMetadata(
@@ -132,18 +194,24 @@ export function extractComponentMetadata(
   const spec = reference.spec;
   const description = spec?.description?.trim() ?? "";
   const inputNames =
-    spec?.inputs
-      ?.map((i) => i.name)
-      .filter((n): n is string => typeof n === "string" && n.length > 0) ?? [];
+    spec?.inputs?.map((input) => input.name).filter(isNonEmptyString) ?? [];
   const outputNames =
-    spec?.outputs
-      ?.map((o) => o.name)
-      .filter((n): n is string => typeof n === "string" && n.length > 0) ?? [];
+    spec?.outputs?.map((output) => output.name).filter(isNonEmptyString) ?? [];
+  const ioText = [...(spec?.inputs ?? []), ...(spec?.outputs ?? [])]
+    .flatMap((ioSpec) => [
+      ioSpec.name,
+      ioSpec.description,
+      stringifySearchValue(ioSpec.type),
+      extractAnnotationsText(ioSpec.annotations),
+    ])
+    .filter(isNonEmptyString)
+    .join(" ");
+  const metadataText = extractAnnotationsText(spec?.metadata?.annotations);
   const hasUsefulMetadata =
     Boolean(spec?.name) ||
     description.length > 0 ||
-    inputNames.length > 0 ||
-    outputNames.length > 0;
+    ioText.length > 0 ||
+    metadataText.length > 0;
   if (!hasUsefulMetadata) return null;
   return {
     digest: reference.digest,
@@ -151,6 +219,8 @@ export function extractComponentMetadata(
     description,
     inputNames,
     outputNames,
+    ioText,
+    metadataText,
   };
 }
 
@@ -175,10 +245,12 @@ export function buildSearchIndex(sourced: SourcedReference[]): IndexEntry[] {
       searchable: {
         name: metadata.name.toLowerCase(),
         description: metadata.description.toLowerCase(),
-        io: [...metadata.inputNames, ...metadata.outputNames]
+        io: metadata.ioText.toLowerCase(),
+        implementation: extractImplementationText(reference),
+        metadata: [metadata.metadataText, source.label, reference.published_by]
+          .filter(isNonEmptyString)
           .join(" ")
           .toLowerCase(),
-        implementation: extractImplementationText(reference),
       },
     });
   }
@@ -244,7 +316,16 @@ const FIELD_WEIGHTS: Record<MatchField, number> = {
   description: 2,
   io: 2,
   implementation: 1,
+  metadata: 1,
 };
+
+const SEARCH_FIELDS: MatchField[] = [
+  "name",
+  "description",
+  "io",
+  "implementation",
+  "metadata",
+];
 
 interface SearchOptions {
   /** Max results to return. Default 20. */
@@ -271,12 +352,11 @@ function scoreEntry(
   entry: IndexEntry,
   tokens: string[],
 ): { score: number; matchedFields: MatchField[] } {
-  const fields: MatchField[] = ["name", "description", "io", "implementation"];
   const matched = new Set<MatchField>();
   let score = 0;
 
   for (const token of tokens) {
-    for (const field of fields) {
+    for (const field of SEARCH_FIELDS) {
       if (entry.searchable[field].includes(token)) {
         score += FIELD_WEIGHTS[field];
         matched.add(field);


### PR DESCRIPTION
## Description

Expands the component search index to include richer input/output details and a new `metadata` match field.

Previously, the `io` searchable field only contained input and output names. It now includes descriptions, types, and annotations for each input and output spec. A new `metadata` field has been added that indexes component-level metadata annotations (with a blocklist for noisy keys like `python_original_code`, editor state, and similar large/irrelevant blobs) as well as the source label and `published_by` value from the component reference.

The `MatchField` type and all related scoring, labeling, and UI display logic have been updated to include `metadata` alongside the existing fields. Annotation values longer than 500 characters are excluded from indexing to avoid polluting search with large blobs.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Open the component dashboard and search for a term that appears in a component's metadata annotations (e.g. a framework name like `sklearn` or `lightgbm`).
2. Verify the result surfaces with `metadata` listed as a matched field.
3. Search for a publisher email address and confirm the matching component appears.
4. Search for a term that exists only in `python_original_code` or other excluded annotation keys and confirm it does **not** return results.
5. Search for an input/output description or type (e.g. `parquet`, `artifact`) and confirm results appear with `io` as the matched field.

## Additional Comments

The annotation exclusion list (`ANNOTATION_KEYS_EXCLUDED_FROM_SEARCH`) and the 500-character value length cap are the primary mechanisms for keeping the metadata index clean. These can be extended as new noisy annotation keys are identified.