### PR TITLE
Normalize component search tokens for better matching

### DIFF
--- a/src/services/componentSearchIndex.test.ts
+++ b/src/services/componentSearchIndex.test.ts
@@ -236,10 +236,59 @@ describe("lexicalSearch", () => {
     expect(results[0]?.digest).toBe("contiguous");
   });
 
-  it("tokenizes snake_case queries so each segment matches independently", () => {
-    const index = buildSearchIndex(fixtures);
-    const results = lexicalSearch(index, "drop nulls");
-    expect(results[0]?.digest).toBe("b");
+  it("normalizes snake_case, kebab-case, and camelCase text", () => {
+    const index = buildSearchIndex([
+      makeSourced({
+        digest: "snake",
+        spec: {
+          name: "drop_nulls",
+          inputs: [],
+          outputs: [],
+          implementation: { container: { image: "x" } },
+        },
+      }),
+      makeSourced({
+        digest: "kebab",
+        spec: {
+          name: "train-model",
+          inputs: [],
+          outputs: [],
+          implementation: { container: { image: "x" } },
+        },
+      }),
+      makeSourced({
+        digest: "camel",
+        spec: {
+          name: "loadCSVFile",
+          inputs: [],
+          outputs: [],
+          implementation: { container: { image: "x" } },
+        },
+      }),
+    ]);
+
+    expect(lexicalSearch(index, "drop nulls")[0]?.digest).toBe("snake");
+    expect(lexicalSearch(index, "train model")[0]?.digest).toBe("kebab");
+    expect(lexicalSearch(index, "load csv file")[0]?.digest).toBe("camel");
+  });
+
+  it("normalizes plurals and simple stemmed terms", () => {
+    const index = buildSearchIndex([
+      makeSourced({
+        digest: "normalize",
+        spec: {
+          name: "train_model",
+          description: "Train models on a dataset with labeled batches.",
+          inputs: [],
+          outputs: [],
+          implementation: { container: { image: "x" } },
+        },
+      }),
+    ]);
+
+    expect(lexicalSearch(index, "training")[0]?.digest).toBe("normalize");
+    expect(lexicalSearch(index, "datasets")[0]?.digest).toBe("normalize");
+    expect(lexicalSearch(index, "batch")[0]?.digest).toBe("normalize");
   });
 
   it("ignores natural-language filler words that would otherwise swamp intent", () => {

--- a/src/services/componentSearchIndex.test.ts
+++ b/src/services/componentSearchIndex.test.ts
@@ -291,6 +291,33 @@ describe("lexicalSearch", () => {
     expect(lexicalSearch(index, "batch")[0]?.digest).toBe("normalize");
   });
 
+  it("scores surface tokens and stems as one concept", () => {
+    const index = buildSearchIndex([
+      makeSourced({
+        digest: "inflected-only",
+        spec: {
+          name: "training_metadata",
+          inputs: [],
+          outputs: [],
+          implementation: { container: { image: "x" } },
+        },
+      }),
+      makeSourced({
+        digest: "stronger-concept-match",
+        spec: {
+          name: "train_model",
+          description: "Training classifier.",
+          inputs: [],
+          outputs: [],
+          implementation: { container: { image: "x" } },
+        },
+      }),
+    ]);
+
+    const results = lexicalSearch(index, "training");
+    expect(results[0]?.digest).toBe("stronger-concept-match");
+  });
+
   it("ignores natural-language filler words that would otherwise swamp intent", () => {
     const index = buildSearchIndex([
       makeSourced({

--- a/src/services/componentSearchIndex.ts
+++ b/src/services/componentSearchIndex.ts
@@ -115,7 +115,7 @@ function stringifySearchValue(value: unknown): string {
 
 function splitIdentifierText(text: string): string {
   return text
-    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1 $2")
+    .replace(/([A-Z])([A-Z][a-z])/g, "$1 $2")
     .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
     .replace(/[_-]+/g, " ");
 }
@@ -132,6 +132,7 @@ function removeSuffixAndCollapseDoubleFinal(
   return last && last === previous ? stemmed.slice(0, -1) : stemmed;
 }
 
+// Deliberately lossy search heuristic, not a full Porter stemmer.
 function stemToken(token: string): string {
   if (token.length <= 3) return token;
   if (token.endsWith("ies") && token.length > 4) {
@@ -146,7 +147,13 @@ function stemToken(token: string): string {
   if (/(ches|shes|xes|zes|ses)$/.test(token) && token.length > 4) {
     return token.slice(0, -2);
   }
-  if (token.endsWith("s") && !token.endsWith("ss") && token.length > 3) {
+  if (
+    token.endsWith("s") &&
+    !token.endsWith("ss") &&
+    !token.endsWith("is") &&
+    !token.endsWith("us") &&
+    token.length > 3
+  ) {
     return token.slice(0, -1);
   }
   return token;
@@ -352,22 +359,28 @@ const QUERY_STOP_WORDS = new Set([
  * Dropping those words prevents common tokens like "a"/"to" from matching
  * nearly every component and drowning out the useful intent terms.
  */
-function tokenize(text: string): string[] {
-  const rawTokens = normalizeSearchText(text)
-    .split(/[^a-z0-9]+/)
-    .filter(isNonEmptyString);
+function tokenizeConcepts(text: string): string[][] {
+  const splitText = splitIdentifierText(text).toLowerCase();
+  const rawTokens = splitText.split(/[^a-z0-9]+/).filter(isNonEmptyString);
 
-  const tokens: string[] = [];
+  const concepts: string[][] = [];
   const seen = new Set<string>();
   for (const token of rawTokens) {
     if (QUERY_STOP_WORDS.has(token)) continue;
-    if (!seen.has(token)) {
-      tokens.push(token);
-      seen.add(token);
-    }
+
+    const variants = Array.from(new Set([token, stemToken(token)])).filter(
+      (variant) => !QUERY_STOP_WORDS.has(variant),
+    );
+    if (variants.length === 0) continue;
+
+    const conceptKey = variants.join("\0");
+    if (seen.has(conceptKey)) continue;
+
+    concepts.push(variants);
+    seen.add(conceptKey);
   }
 
-  return tokens;
+  return concepts;
 }
 
 /**
@@ -405,7 +418,8 @@ interface SearchOptions {
  * Score one entry against the tokenized query. Returns 0 if no field matched.
  *
  * Scoring model:
- * - Per query token: each field that contains the token contributes its weight.
+ * - Per query concept: each field that contains any token variant contributes
+ *   its weight once.
  * - Bonus: full multi-token query as a substring of the name (+10). Catches
  *   "train test split" matching `train_test_split` strongly even though we
  *   tokenized.
@@ -415,14 +429,14 @@ interface SearchOptions {
  */
 function scoreEntry(
   entry: IndexEntry,
-  tokens: string[],
+  concepts: string[][],
 ): { score: number; matchedFields: MatchField[] } {
   const matched = new Set<MatchField>();
   let score = 0;
 
-  for (const token of tokens) {
+  for (const concept of concepts) {
     for (const field of SEARCH_FIELDS) {
-      if (entry.searchable[field].includes(token)) {
+      if (concept.some((token) => entry.searchable[field].includes(token))) {
         score += FIELD_WEIGHTS[field];
         matched.add(field);
       }
@@ -433,9 +447,9 @@ function scoreEntry(
   // sides are normalized so the bonus also fires for snake_case names —
   // query "train test split" should match `train_test_split`, not just
   // names that happen to contain literal spaces.
-  if (tokens.length > 1) {
+  if (concepts.length > 1) {
     const normalizedName = entry.searchable.name.replace(/[^a-z0-9]+/g, " ");
-    const normalizedQuery = tokens.join(" ");
+    const normalizedQuery = concepts.map((concept) => concept[0]).join(" ");
     if (normalizedName.includes(normalizedQuery)) {
       score += 10;
       matched.add("name");
@@ -459,12 +473,12 @@ export function lexicalSearch(
   const trimmed = query.trim().toLowerCase();
   if (trimmed.length < minLength) return [];
 
-  const tokens = tokenize(trimmed);
-  if (tokens.length === 0) return [];
+  const concepts = tokenizeConcepts(trimmed);
+  if (concepts.length === 0) return [];
 
   const scored: Array<LexicalMatch & { score: number }> = [];
   for (const entry of index) {
-    const { score, matchedFields } = scoreEntry(entry, tokens);
+    const { score, matchedFields } = scoreEntry(entry, concepts);
     if (score === 0) continue;
     scored.push({
       reference: entry.reference,

--- a/src/services/componentSearchIndex.ts
+++ b/src/services/componentSearchIndex.ts
@@ -54,7 +54,7 @@ export interface IndexEntry {
   name: string;
   /** Where this component came from. */
   source: ComponentSearchSource;
-  /** Pre-lowercased searchable text, one per logical field. */
+  /** Normalized searchable text, one per logical field. */
   searchable: Record<MatchField, string>;
 }
 
@@ -111,6 +111,62 @@ function stringifySearchValue(value: unknown): string {
         return "";
       }
   }
+}
+
+function splitIdentifierText(text: string): string {
+  return text
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1 $2")
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/[_-]+/g, " ");
+}
+
+function removeSuffixAndCollapseDoubleFinal(
+  token: string,
+  suffixLength: number,
+): string {
+  const stemmed = token.slice(0, -suffixLength);
+  if (stemmed.length < 3) return stemmed;
+
+  const last = stemmed.at(-1);
+  const previous = stemmed.at(-2);
+  return last && last === previous ? stemmed.slice(0, -1) : stemmed;
+}
+
+function stemToken(token: string): string {
+  if (token.length <= 3) return token;
+  if (token.endsWith("ies") && token.length > 4) {
+    return `${token.slice(0, -3)}y`;
+  }
+  if (token.endsWith("ing") && token.length > 5) {
+    return removeSuffixAndCollapseDoubleFinal(token, 3);
+  }
+  if (token.endsWith("ed") && token.length > 4) {
+    return removeSuffixAndCollapseDoubleFinal(token, 2);
+  }
+  if (/(ches|shes|xes|zes|ses)$/.test(token) && token.length > 4) {
+    return token.slice(0, -2);
+  }
+  if (token.endsWith("s") && !token.endsWith("ss") && token.length > 3) {
+    return token.slice(0, -1);
+  }
+  return token;
+}
+
+function normalizeSearchText(text: string): string {
+  const splitText = splitIdentifierText(text).toLowerCase();
+  const tokens = splitText.split(/[^a-z0-9]+/).filter(isNonEmptyString);
+  const expandedTokens: string[] = [];
+  const seen = new Set<string>();
+
+  for (const token of tokens) {
+    for (const variant of [token, stemToken(token)]) {
+      if (seen.has(variant)) continue;
+      seen.add(variant);
+      expandedTokens.push(variant);
+    }
+  }
+
+  return [text.toLowerCase(), splitText, expandedTokens.join(" ")].join(" ");
 }
 
 function extractAnnotationsText(
@@ -250,11 +306,16 @@ export function buildSearchIndex(sourced: SourcedReference[]): IndexEntry[] {
       name: metadata.name,
       source,
       searchable: {
-        name: metadata.name.toLowerCase(),
-        description: metadata.description.toLowerCase(),
-        io: metadata.ioText.toLowerCase(),
-        implementation: extractImplementationText(reference),
-        metadata: metadata.metadataText.toLowerCase(),
+        name: normalizeSearchText(metadata.name),
+        description: normalizeSearchText(metadata.description),
+        io: normalizeSearchText(metadata.ioText),
+        implementation: normalizeSearchText(
+          extractImplementationText(reference),
+        ),
+        metadata: normalizeSearchText(metadata.metadataText).slice(
+          0,
+          MAX_ANNOTATION_TOTAL_TEXT_LENGTH,
+        ),
       },
     });
   }
@@ -292,10 +353,9 @@ const QUERY_STOP_WORDS = new Set([
  * nearly every component and drowning out the useful intent terms.
  */
 function tokenize(text: string): string[] {
-  const rawTokens = text
-    .toLowerCase()
+  const rawTokens = normalizeSearchText(text)
     .split(/[^a-z0-9]+/)
-    .filter((t) => t.length > 0);
+    .filter(isNonEmptyString);
 
   const tokens: string[] = [];
   const seen = new Set<string>();
@@ -350,7 +410,8 @@ interface SearchOptions {
  *   "train test split" matching `train_test_split` strongly even though we
  *   tokenized.
  *
- * We deliberately do not normalize — raw scores are only used for ordering.
+ * Indexed text and query text are normalized before scoring; raw scores are
+ * only used for ordering.
  */
 function scoreEntry(
   entry: IndexEntry,


### PR DESCRIPTION
## Description

Improves the component search index by normalizing indexed and query text beyond simple lowercasing. Specifically:

- **Identifier splitting**: `snake_case`, `kebab-case`, and `camelCase` component names are split into individual words before indexing, so a query like `"train model"` matches a component named `train-model` or `train_model`, and `"load csv file"` matches `loadCSVFile`.
- **Lightweight stemming**: A `stemToken` function reduces common English inflections (plurals via `-s`/`-ies`, gerunds via `-ing`, past tense via `-ed`, sibilant plurals) to their base forms. Both the original token and its stem are stored in the index, so queries like `"training"`, `"datasets"`, or `"batch"` match components described with `"train"`, `"dataset"`, or `"batches"`.
- **Normalized query tokenization**: The same `normalizeSearchText` pipeline is applied to query text before scoring, ensuring query tokens and indexed tokens are in the same form.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Run the existing test suite (`componentSearchIndex.test.ts`) to verify the new normalization cases pass:
   - Snake/kebab/camelCase names matched by space-separated queries.
   - Stemmed query terms (`training`, `datasets`, `batch`) matching indexed descriptions.
2. Manually search for components using inflected or hyphenated terms in the UI and confirm relevant results surface.

## Additional Comments

The stemmer is intentionally minimal — it handles the most common English suffixes without introducing a full NLP dependency. Both the raw token and its stem are stored so that exact matches are never lost.