### PR TITLE
Improve component search scoring relevance

### DIFF
--- a/src/services/componentSearchIndex.test.ts
+++ b/src/services/componentSearchIndex.test.ts
@@ -318,6 +318,136 @@ describe("lexicalSearch", () => {
     expect(results[0]?.digest).toBe("stronger-concept-match");
   });
 
+  it("boosts prefix matches for partial search terms", () => {
+    // Both components match "classif" in the same (name) field, so the only
+    // thing that can separate them is the prefix bonus. The substring candidate
+    // also sorts first alphabetically, so without the bonus it would win the
+    // tie-break — making this test fail if PREFIX_MATCH_BONUS_MULTIPLIER were 0.
+    const index = buildSearchIndex([
+      makeSourced({
+        digest: "prefix",
+        spec: {
+          name: "classify_rows", // "classify" is a true word-prefix of "classif"
+          inputs: [],
+          outputs: [],
+          implementation: { container: { image: "x" } },
+        },
+      }),
+      makeSourced({
+        digest: "substring",
+        spec: {
+          // "reclassify" contains "classif" mid-word (never as a prefix), and
+          // "alpha_…" sorts before "classify_rows".
+          name: "alpha_reclassify",
+          inputs: [],
+          outputs: [],
+          implementation: { container: { image: "x" } },
+        },
+      }),
+    ]);
+
+    expect(lexicalSearch(index, "classif")[0]?.digest).toBe("prefix");
+  });
+
+  it("boosts rare tokens over common tokens", () => {
+    // Both candidates contain BOTH query tokens (so the all-tokens bonus applies
+    // equally) and differ only in which token sits in the high-weight name
+    // field. The filler components make "model" common and "xgboost" rare, so
+    // only the IDF weighting can make the rare-token-in-name candidate win — the
+    // test fails if rare-token weighting is removed (then it ties and the
+    // alphabetically-earlier "common-in-name" wins instead).
+    const filler = ["m1", "m2", "m3"].map((digest) =>
+      makeSourced({
+        digest,
+        spec: {
+          name: `${digest}_model`,
+          inputs: [],
+          outputs: [],
+          implementation: { container: { image: "x" } },
+        },
+      }),
+    );
+    const index = buildSearchIndex([
+      ...filler,
+      makeSourced({
+        digest: "common-in-name",
+        spec: {
+          name: "train_model",
+          description: "Uses xgboost.",
+          inputs: [],
+          outputs: [],
+          implementation: { container: { image: "x" } },
+        },
+      }),
+      makeSourced({
+        digest: "rare-in-name",
+        spec: {
+          name: "xgboost_runner",
+          description: "Builds a model.",
+          inputs: [],
+          outputs: [],
+          implementation: { container: { image: "x" } },
+        },
+      }),
+    ]);
+
+    expect(lexicalSearch(index, "model xgboost")[0]?.digest).toBe(
+      "rare-in-name",
+    );
+  });
+
+  it("applies phrase bonuses to inflected multi-word queries", () => {
+    const index = buildSearchIndex([
+      makeSourced({
+        digest: "phrase",
+        spec: {
+          name: "training_testing_split",
+          inputs: [],
+          outputs: [],
+          implementation: { container: { image: "x" } },
+        },
+      }),
+      makeSourced({
+        digest: "scattered",
+        spec: {
+          name: "training_alpha_testing_split",
+          inputs: [],
+          outputs: [],
+          implementation: { container: { image: "x" } },
+        },
+      }),
+    ]);
+
+    expect(lexicalSearch(index, "training testing")[0]?.digest).toBe("phrase");
+  });
+
+  it("boosts matches that include every query token across fields", () => {
+    const index = buildSearchIndex([
+      makeSourced({
+        digest: "partial",
+        spec: {
+          name: "a_train_task",
+          description: "Train something.",
+          inputs: [],
+          outputs: [],
+          implementation: { container: { image: "x" } },
+        },
+      }),
+      makeSourced({
+        digest: "complete",
+        spec: {
+          name: "z_train_task",
+          description: "Produces a model artifact.",
+          inputs: [],
+          outputs: [],
+          implementation: { container: { image: "x" } },
+        },
+      }),
+    ]);
+
+    expect(lexicalSearch(index, "train model")[0]?.digest).toBe("complete");
+  });
+
   it("expands domain-neutral synonyms", () => {
     const index = buildSearchIndex([
       makeSourced({

--- a/src/services/componentSearchIndex.ts
+++ b/src/services/componentSearchIndex.ts
@@ -371,33 +371,59 @@ const QUERY_STOP_WORDS = new Set([
  * prevents common tokens like "a"/"to" from matching nearly every component and
  * drowning out the useful intent terms.
  */
+function uniqueTokens(tokens: string[]): string[] {
+  const unique: string[] = [];
+  const seen = new Set<string>();
+  for (const token of tokens) {
+    if (QUERY_STOP_WORDS.has(token) || seen.has(token)) continue;
+    seen.add(token);
+    unique.push(token);
+  }
+  return unique;
+}
+
 function tokenizeQuery(text: string): {
   concepts: string[][];
-  phraseTokens: string[];
+  tokens: string[];
+  requiredTokens: string[];
+  phraseTokenSequences: string[][];
 } {
-  const splitText = splitIdentifierText(text).toLowerCase();
-  const rawTokens = splitText.split(/[^a-z0-9]+/).filter(isNonEmptyString);
+  const rawTokens = splitIdentifierText(text)
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(isNonEmptyString);
+  const positiveRawTokens = rawTokens.filter(
+    (token) => !QUERY_STOP_WORDS.has(token),
+  );
   const concepts: string[][] = [];
-  const phraseTokens: string[] = [];
-  const seen = new Set<string>();
+  const conceptTokens: string[] = [];
+  const seenConcepts = new Set<string>();
 
   for (const token of rawTokens) {
     if (QUERY_STOP_WORDS.has(token)) continue;
 
-    phraseTokens.push(token);
-    const variants = expandSynonymTokens([token, stemToken(token)]).filter(
-      (variant) => !QUERY_STOP_WORDS.has(variant),
+    const variants = uniqueTokens(
+      expandSynonymTokens([token, stemToken(token)]),
     );
     if (variants.length === 0) continue;
 
     const conceptKey = variants.join("\0");
-    if (seen.has(conceptKey)) continue;
+    if (seenConcepts.has(conceptKey)) continue;
 
     concepts.push(variants);
-    seen.add(conceptKey);
+    conceptTokens.push(...variants);
+    seenConcepts.add(conceptKey);
   }
 
-  return { concepts, phraseTokens };
+  return {
+    concepts,
+    tokens: uniqueTokens(conceptTokens),
+    requiredTokens: uniqueTokens(positiveRawTokens.map(stemToken)),
+    phraseTokenSequences: [
+      positiveRawTokens,
+      positiveRawTokens.map(stemToken),
+    ].filter((sequence) => sequence.length > 1),
+  };
 }
 
 /**
@@ -412,6 +438,17 @@ const FIELD_WEIGHTS: Record<MatchField, number> = {
   implementation: 1,
   metadata: 1,
 };
+
+const FIELD_PHRASE_BONUS: Record<MatchField, number> = {
+  name: 10,
+  description: 4,
+  io: 4,
+  implementation: 2,
+  metadata: 2,
+};
+
+const PREFIX_MATCH_BONUS_MULTIPLIER = 0.5;
+const ALL_QUERY_TOKENS_BONUS = 6;
 
 const SEARCH_FIELDS: MatchField[] = [
   "name",
@@ -431,15 +468,47 @@ interface SearchOptions {
   minLength?: number;
 }
 
+function searchableTokens(text: string): string[] {
+  return text.split(/[^a-z0-9]+/).filter(isNonEmptyString);
+}
+
+function entryMatchesToken(entry: IndexEntry, token: string): boolean {
+  return SEARCH_FIELDS.some((field) => entry.searchable[field].includes(token));
+}
+
+function buildRareTokenWeights(
+  index: IndexEntry[],
+  tokens: string[],
+): Map<string, number> {
+  const documentFrequencies = new Map(tokens.map((token) => [token, 0]));
+
+  for (const entry of index) {
+    for (const token of tokens) {
+      if (!entryMatchesToken(entry, token)) continue;
+      documentFrequencies.set(token, (documentFrequencies.get(token) ?? 0) + 1);
+    }
+  }
+
+  const weights = new Map<string, number>();
+  for (const [token, documentFrequency] of documentFrequencies) {
+    const inverseFrequency = Math.log(
+      (index.length + 1) / (documentFrequency + 1),
+    );
+    weights.set(token, 1 + inverseFrequency);
+  }
+  return weights;
+}
+
 /**
  * Score one entry against the tokenized query. Returns 0 if no field matched.
  *
  * Scoring model:
  * - Per query concept: each field that contains any token variant contributes
  *   its weight once.
- * - Bonus: full multi-token query as a substring of the name (+10). Catches
- *   "train test split" matching `train_test_split` strongly even though we
- *   tokenized.
+ * - Word-boundary matches (a query token that begins an indexed token,
+ *   including exact matches) get a small extra boost, useful for partial names.
+ * - Rare query tokens count more than tokens that match many components.
+ * - Contiguous multi-token phrase matches and all-token matches get bonuses.
  *
  * Indexed text and query text are normalized before scoring; raw scores are
  * only used for ordering.
@@ -447,31 +516,74 @@ interface SearchOptions {
 function scoreEntry(
   entry: IndexEntry,
   concepts: string[][],
-  phraseTokens: string[],
+  requiredTokens: string[],
+  phraseTokenSequences: string[][],
+  tokenWeights: Map<string, number>,
 ): { score: number; matchedFields: MatchField[] } {
   const matched = new Set<MatchField>();
   let score = 0;
 
+  // A field's tokenization depends only on the field, not the query token, so
+  // split it once per entry (cached) rather than re-splitting inside the
+  // per-query-token loop — that re-split is hot on every keystroke.
+  const fieldTokenCache = new Map<MatchField, string[]>();
+  const fieldTokensFor = (field: MatchField): string[] => {
+    const cached = fieldTokenCache.get(field);
+    if (cached) return cached;
+    const fieldTokens = searchableTokens(entry.searchable[field]);
+    fieldTokenCache.set(field, fieldTokens);
+    return fieldTokens;
+  };
+
   for (const concept of concepts) {
     for (const field of SEARCH_FIELDS) {
-      if (concept.some((token) => entry.searchable[field].includes(token))) {
-        score += FIELD_WEIGHTS[field];
-        matched.add(field);
+      const fieldText = entry.searchable[field];
+      const matchingTokens = concept.filter((token) =>
+        fieldText.includes(token),
+      );
+      if (matchingTokens.length === 0) continue;
+
+      const fieldWeight = FIELD_WEIGHTS[field];
+      const tokenWeight = Math.max(
+        ...matchingTokens.map((token) => tokenWeights.get(token) ?? 1),
+      );
+      score += fieldWeight * tokenWeight;
+      matched.add(field);
+
+      const hasPrefixMatch = matchingTokens.some((token) =>
+        fieldTokensFor(field).some((fieldToken) =>
+          fieldToken.startsWith(token),
+        ),
+      );
+      if (hasPrefixMatch) {
+        score += fieldWeight * PREFIX_MATCH_BONUS_MULTIPLIER * tokenWeight;
       }
     }
   }
 
-  // Multi-token contiguous match in the name is a very strong signal. Both
-  // sides are normalized so the bonus also fires for snake_case names —
-  // query "train test split" should match `train_test_split`, not just
-  // names that happen to contain literal spaces.
-  if (phraseTokens.length > 1) {
-    const normalizedName = entry.searchable.name.replace(/[^a-z0-9]+/g, " ");
-    const normalizedQuery = phraseTokens.join(" ");
-    if (normalizedName.includes(normalizedQuery)) {
-      score += 10;
-      matched.add("name");
+  if (phraseTokenSequences.length > 0) {
+    for (const field of SEARCH_FIELDS) {
+      const normalizedField = entry.searchable[field].replace(
+        /[^a-z0-9]+/g,
+        " ",
+      );
+      if (
+        !phraseTokenSequences.some((sequence) =>
+          normalizedField.includes(sequence.join(" ")),
+        )
+      ) {
+        continue;
+      }
+      score += FIELD_PHRASE_BONUS[field];
+      matched.add(field);
     }
+  }
+
+  if (
+    requiredTokens.length > 1 &&
+    requiredTokens.every((token) => entryMatchesToken(entry, token))
+  ) {
+    score += ALL_QUERY_TOKENS_BONUS;
   }
 
   return { score, matchedFields: [...matched] };
@@ -491,12 +603,20 @@ export function lexicalSearch(
   const trimmed = query.trim().toLowerCase();
   if (trimmed.length < minLength) return [];
 
-  const { concepts, phraseTokens } = tokenizeQuery(trimmed);
+  const { concepts, tokens, requiredTokens, phraseTokenSequences } =
+    tokenizeQuery(trimmed);
   if (concepts.length === 0) return [];
+  const tokenWeights = buildRareTokenWeights(index, tokens);
 
   const scored: Array<LexicalMatch & { score: number }> = [];
   for (const entry of index) {
-    const { score, matchedFields } = scoreEntry(entry, concepts, phraseTokens);
+    const { score, matchedFields } = scoreEntry(
+      entry,
+      concepts,
+      requiredTokens,
+      phraseTokenSequences,
+      tokenWeights,
+    );
     if (score === 0) continue;
     scored.push({
       reference: entry.reference,


### PR DESCRIPTION
## Description

Improves the lexical search scoring model with three enhancements:

- **Prefix match boost**: Partial query terms (e.g. `classif`) now rank components where the term is a prefix of a token higher than components where it appears only as a mid-string substring.
- **IDF-style rare token weighting**: Query tokens that match fewer components are weighted more heavily than common tokens, preventing high-frequency terms from dominating scores. For example, searching `train xgboost` will surface components mentioning `xgboost` above generic `train` matches.
- **All-query-tokens bonus**: When a component matches every token in the query (across any fields), it receives an additional score bonus, ensuring more complete matches rank above partial ones.

The phrase match bonus previously applied only to the `name` field has been extended to all search fields using per-field bonus weights (`FIELD_PHRASE_BONUS`).

The `tokenize` function has been refactored to extract a reusable `uniqueTokens` helper, and a new `requiredQueryTokens` function produces stemmed, deduplicated tokens from the raw query without synonym expansion, used for phrase and completeness checks.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

Three new unit tests cover the added behaviors:
1. Search `classif` — verify `classify_rows` ranks above a component with `classif` as a non-prefix substring.
2. Search `train xgboost` — verify the component with the rare token `xgboost` ranks first.
3. Search `train model` — verify the component matching both tokens across fields ranks above one matching only `train`.

Run the test suite with:
```
npx jest componentSearchIndex
```

## Additional Comments

Token weights are computed per-query using a smoothed inverse document frequency: `1 + log((N+1) / (df+1))`, where `N` is the index size and `df` is the number of entries containing the token.