### PR TITLE
Add negative constraint parsing to lexical search

### DIFF
--- a/src/services/componentSearchIndex.test.ts
+++ b/src/services/componentSearchIndex.test.ts
@@ -569,6 +569,128 @@ describe("lexicalSearch", () => {
     expect(lexicalSearch(index, "df")[0]?.digest).toBe("table");
   });
 
+  it("parses negative constraints and excludes matching components", () => {
+    const index = buildSearchIndex([
+      makeSourced({
+        digest: "local-upload",
+        spec: {
+          name: "upload_file",
+          description: "Upload a file to a local directory.",
+          inputs: [],
+          outputs: [],
+          implementation: { container: { image: "x" } },
+        },
+      }),
+      makeSourced({
+        digest: "gcs-upload",
+        spec: {
+          name: "upload_to_gcs",
+          description: "Upload a file to GCS.",
+          inputs: [],
+          outputs: [],
+          implementation: { container: { image: "x" } },
+        },
+      }),
+    ]);
+
+    expect(
+      lexicalSearch(index, "I want to upload a file but not to GCS").map(
+        (result) => result.digest,
+      ),
+    ).toEqual(["local-upload"]);
+    expect(
+      lexicalSearch(index, "I want to upload a file excluding GCS").map(
+        (result) => result.digest,
+      ),
+    ).toEqual(["local-upload"]);
+    expect(
+      lexicalSearch(index, "upload not to use GCS").map(
+        (result) => result.digest,
+      ),
+    ).toEqual(["local-upload"]);
+  });
+
+  it("excludes only the literal negated term, not its synonyms", () => {
+    const index = buildSearchIndex([
+      makeSourced({
+        digest: "gcs-uploader",
+        spec: {
+          name: "upload_to_gcs",
+          description: "Upload to GCS.",
+          inputs: [],
+          outputs: [],
+          implementation: { container: { image: "x" } },
+        },
+      }),
+      makeSourced({
+        digest: "storage-uploader",
+        spec: {
+          name: "upload_to_storage",
+          description: "Upload to a storage bucket.",
+          inputs: [],
+          outputs: [],
+          implementation: { container: { image: "x" } },
+        },
+      }),
+    ]);
+
+    // "gcs" is a synonym of "storage"/"bucket", but negation is literal: only
+    // the gcs component is dropped, the storage one survives.
+    const results = lexicalSearch(index, "upload not gcs").map((r) => r.digest);
+    expect(results).toContain("storage-uploader");
+    expect(results).not.toContain("gcs-uploader");
+  });
+
+  it("does not exclude implementation-only negated matches", () => {
+    const index = buildSearchIndex([
+      makeSourced({
+        digest: "implementation-match",
+        spec: {
+          name: "upload_file",
+          description: "Upload a file.",
+          inputs: [],
+          outputs: [],
+          implementation: { container: { image: "gcs-upload:latest" } },
+        },
+      }),
+    ]);
+
+    expect(lexicalSearch(index, "upload not gcs")[0]?.digest).toBe(
+      "implementation-match",
+    );
+  });
+
+  it("does not stem negated terms", () => {
+    const index = buildSearchIndex([
+      makeSourced({
+        digest: "singular",
+        spec: {
+          name: "train_model",
+          description: "Train one model.",
+          inputs: [],
+          outputs: [],
+          implementation: { container: { image: "x" } },
+        },
+      }),
+      makeSourced({
+        digest: "plural",
+        spec: {
+          name: "train_models",
+          description: "Train many models.",
+          inputs: [],
+          outputs: [],
+          implementation: { container: { image: "x" } },
+        },
+      }),
+    ]);
+
+    const results = lexicalSearch(index, "train no models").map(
+      (result) => result.digest,
+    );
+    expect(results).toContain("singular");
+    expect(results).not.toContain("plural");
+  });
+
   it("ignores natural-language filler words that would otherwise swamp intent", () => {
     const index = buildSearchIndex([
       makeSourced({

--- a/src/services/componentSearchIndex.ts
+++ b/src/services/componentSearchIndex.ts
@@ -347,6 +347,7 @@ const QUERY_STOP_WORDS = new Set([
   "an",
   "and",
   "are",
+  "but",
   "component",
   "for",
   "from",
@@ -355,6 +356,7 @@ const QUERY_STOP_WORDS = new Set([
   "into",
   "me",
   "my",
+  "no",
   "of",
   "on",
   "please",
@@ -426,6 +428,46 @@ function tokenizeQuery(text: string): {
   };
 }
 
+interface ParsedSearchQuery {
+  positiveText: string;
+  negativeText: string;
+}
+
+// Bind a negation to its term(s): capture consecutive words but stop at a
+// conjunction/filler word (and punctuation), so "not gcs and also train"
+// excludes only "gcs" and leaves "and also train" for positive matching
+// instead of swallowing the whole tail.
+const NEGATIVE_CONSTRAINT_PATTERN =
+  /\b(?:without|excluding|exclude|not|no)\b\s+(?:(?:to|use|using)\s+)?([a-z0-9][a-z0-9-]*(?:\s+(?!(?:and|or|but|then|also|plus|with)\b)[a-z0-9][a-z0-9-]*)*)/gi;
+const NEGATIVE_LEADING_FILLER_PATTERN = /^(?:(?:to|use|using)\s+)+/i;
+
+function parseSearchQuery(text: string): ParsedSearchQuery {
+  const negativeParts: string[] = [];
+  const positiveText = text.replace(
+    NEGATIVE_CONSTRAINT_PATTERN,
+    (_match, negativePart: string) => {
+      negativeParts.push(
+        negativePart.replace(NEGATIVE_LEADING_FILLER_PATTERN, ""),
+      );
+      return " ";
+    },
+  );
+
+  return {
+    positiveText,
+    negativeText: negativeParts.join(" "),
+  };
+}
+
+function literalSearchTokens(text: string): string[] {
+  return uniqueTokens(
+    splitIdentifierText(text)
+      .toLowerCase()
+      .split(/[^a-z0-9]+/)
+      .filter(isNonEmptyString),
+  );
+}
+
 /**
  * Per-field weights. Name matches are by far the most signal: `train` in the
  * name means the component is *about* training. The same word in implementation
@@ -459,6 +501,7 @@ const SEARCH_FIELDS: MatchField[] = [
   "metadata",
 ];
 const FUZZY_SEARCH_FIELDS: MatchField[] = ["name", "io"];
+const NEGATIVE_SEARCH_FIELDS: MatchField[] = ["name", "description", "io"];
 
 interface SearchOptions {
   /** Max results to return. Default 20. */
@@ -579,6 +622,7 @@ function scoreEntry(
   concepts: string[][],
   requiredTokens: string[],
   phraseTokenSequences: string[][],
+  negativeTokens: string[],
   tokenWeights: Map<string, number>,
 ): { score: number; matchedFields: MatchField[] } {
   const matched = new Set<MatchField>();
@@ -595,6 +639,19 @@ function scoreEntry(
     fieldTokenCache.set(field, fieldTokens);
     return fieldTokens;
   };
+
+  // Hard exclusion uses a whole-token match (not substring): a zero-score
+  // filter removes the entire component, so a short negated token must not
+  // knock one out by incidentally appearing inside an unrelated word.
+  if (
+    negativeTokens.some((token) =>
+      NEGATIVE_SEARCH_FIELDS.some((field) =>
+        fieldTokensFor(field).includes(token),
+      ),
+    )
+  ) {
+    return { score: 0, matchedFields: [] };
+  }
 
   for (const concept of concepts) {
     for (const field of SEARCH_FIELDS) {
@@ -684,9 +741,16 @@ export function lexicalSearch(
   const trimmed = query.trim().toLowerCase();
   if (trimmed.length < minLength) return [];
 
+  const parsedQuery = parseSearchQuery(trimmed);
   const { concepts, tokens, requiredTokens, phraseTokenSequences } =
-    tokenizeQuery(trimmed);
+    tokenizeQuery(parsedQuery.positiveText);
+  // An all-negative query (e.g. "not gcs") has no positive intent to rank.
+  // Exclusion only filters positive matches — it doesn't enumerate the whole
+  // library — so there's nothing to return.
   if (concepts.length === 0) return [];
+  // Literal exclusion: don't synonym-expand the negated term, so "not gcs"
+  // removes gcs components without also dropping storage/bucket/etc.
+  const negativeTokens = literalSearchTokens(parsedQuery.negativeText);
   const tokenWeights = buildRareTokenWeights(index, tokens);
 
   const scored: Array<LexicalMatch & { score: number }> = [];
@@ -696,6 +760,7 @@ export function lexicalSearch(
       concepts,
       requiredTokens,
       phraseTokenSequences,
+      negativeTokens,
       tokenWeights,
     );
     if (score === 0) continue;


### PR DESCRIPTION
## Description

Adds support for negative constraints in lexical search queries. When a user includes phrases like "not GCS", "excluding GCS", or "without GCS" in their search, components matching those excluded terms are filtered out of the results. This allows users to express intent more naturally, such as "I want to upload a file but not to GCS", and receive only the relevant components.

This is implemented by parsing the query text before tokenization, extracting negative constraint phrases using a regex pattern, and scoring any index entry that matches a negative token as zero. The word `"but"` has also been added to the stop words list to avoid it interfering with scoring.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Build the search index with components that have overlapping keywords (e.g., two upload components, one for local and one for GCS).
2. Run a search query containing a negative constraint such as `"upload a file but not to GCS"` or `"upload a file excluding GCS"`.
3. Verify that only the component not matching the excluded term is returned.

## Additional Comments

The negative constraint pattern currently recognises the trigger words `without`, `excluding`, `exclude`, `not`, and `no`, optionally followed by prepositions like `to`, `use`, or `using`.