### PR TITLE
Add source-diverse AI rerank candidate pool

### DIFF
--- a/src/routes/v2/pages/Editor/components/componentSearchV2Logic.test.ts
+++ b/src/routes/v2/pages/Editor/components/componentSearchV2Logic.test.ts
@@ -262,10 +262,28 @@ describe("buildLexicalMatches / buildAiCandidateMatches", () => {
     expect(buildAiCandidateMatches(index, "")).toEqual([]);
   });
 
-  it("falls back to a browse pool when literal search finds nothing", () => {
-    // A query with no token overlap returns no lexical hits, so the AI
-    // candidate pool falls back to the (alphabetical) browse slice.
+  it("returns no AI candidates when literal search finds nothing", () => {
     const candidates = buildAiCandidateMatches(index, "qqzznomatch");
-    expect(candidates.map((m) => m.digest)).toEqual(["alpha", "zebra"]);
+    expect(candidates).toEqual([]);
+  });
+
+  it("adds source-diverse lexical candidates beyond the top lexical hits", () => {
+    const broadIndex = buildSearchIndex([
+      ...Array.from({ length: 100 }, (_, i) => ({
+        reference: ref(`train-${i}`, `train_${i}`),
+        source: source("standard"),
+      })),
+      {
+        reference: ref("user-upload", "train_user_upload"),
+        source: USER_SOURCE,
+      },
+    ]);
+
+    const candidates = buildAiCandidateMatches(broadIndex, "train");
+
+    expect(candidates.length).toBeLessThanOrEqual(80);
+    expect(candidates.map((candidate) => candidate.digest)).toContain(
+      "user-upload",
+    );
   });
 });

--- a/src/routes/v2/pages/Editor/components/componentSearchV2Logic.ts
+++ b/src/routes/v2/pages/Editor/components/componentSearchV2Logic.ts
@@ -28,10 +28,10 @@ import type {
 } from "@/utils/componentSpec";
 
 /** How many lexical hits to display before the user asks for AI judgment. */
-const LEXICAL_RESULT_LIMIT = 50;
-// Candidate pool sent to AI rerank on click. Matches LEXICAL_RESULT_LIMIT so
-// every displayed result is scored and can show a relevance percentage.
-const AI_CANDIDATE_LIMIT = 50;
+export const LEXICAL_RESULT_LIMIT = 50;
+const AI_CANDIDATE_LIMIT = 80;
+const AI_LEXICAL_CANDIDATE_LIMIT = 60;
+const AI_SOURCE_DIVERSITY_CANDIDATES_PER_SOURCE = 8;
 // Scores at or below this are treated as the model excluding a candidate: such
 // items keep their place in the list but are not badged as relevance matches.
 const RERANK_EXCLUSION_THRESHOLD = 0.01;
@@ -252,10 +252,9 @@ export function buildResultFolders({
     } else if (result.source.kind === "published") {
       published.push(result.reference);
     } else if (result.source.kind === "registered") {
-      connectedByName.set(name, [
-        ...(connectedByName.get(name) ?? []),
-        result.reference,
-      ]);
+      const components = connectedByName.get(name) ?? [];
+      components.push(result.reference);
+      connectedByName.set(name, components);
     }
   }
 
@@ -300,10 +299,53 @@ export function buildLexicalMatches(
   });
 }
 
+function sampleEvenly<T>(items: T[], limit: number): T[] {
+  if (items.length <= limit) return items;
+  const step = items.length / limit;
+  return Array.from(
+    { length: limit },
+    (_, index) => items[Math.floor(index * step)],
+  );
+}
+
+function appendUniqueMatches(
+  target: LexicalMatch[],
+  seenDigests: Set<string>,
+  matches: LexicalMatch[],
+) {
+  for (const match of matches) {
+    if (seenDigests.has(match.digest)) continue;
+    seenDigests.add(match.digest);
+    target.push(match);
+    if (target.length >= AI_CANDIDATE_LIMIT) return;
+  }
+}
+
+function buildSourceDiverseLexicalMatches(
+  index: IndexEntry[],
+  trimmedQuery: string,
+): LexicalMatch[] {
+  const lexicalMatches = lexicalSearch(index, trimmedQuery, {
+    limit: index.length,
+    minLength: 1,
+  });
+  const bySource = new Map<string, LexicalMatch[]>();
+  for (const match of lexicalMatches) {
+    const key = `${match.source.kind}:${match.source.id}`;
+    const matches = bySource.get(key) ?? [];
+    matches.push(match);
+    bySource.set(key, matches);
+  }
+
+  return [...bySource.values()].flatMap((matches) =>
+    sampleEvenly(matches, AI_SOURCE_DIVERSITY_CANDIDATES_PER_SOURCE),
+  );
+}
+
 /**
- * Bounded candidate pool for AI rerank. Prefers broad lexical hits; when
- * literal matching finds nothing it falls back to an alphabetical browse slice
- * so natural-language queries stay useful.
+ * Bounded candidate pool for AI rerank. Starts with the strongest lexical hits,
+ * then adds a source-diverse lexical sample so AI can rescue plausible matches
+ * from lower-ranked sources without falling back to query-independent browse.
  */
 export function buildAiCandidateMatches(
   index: IndexEntry[],
@@ -311,16 +353,25 @@ export function buildAiCandidateMatches(
 ): LexicalMatch[] {
   if (trimmedQuery.length === 0) return [];
 
-  const broadMatches = lexicalSearch(index, trimmedQuery, {
-    limit: AI_CANDIDATE_LIMIT,
-    minLength: 1,
-  });
-  if (broadMatches.length > 0) return broadMatches;
+  const candidates: LexicalMatch[] = [];
+  const seenDigests = new Set<string>();
 
-  return [...index]
-    .sort((a, b) => a.name.localeCompare(b.name))
-    .slice(0, AI_CANDIDATE_LIMIT)
-    .map(indexEntryToLexicalMatch);
+  appendUniqueMatches(
+    candidates,
+    seenDigests,
+    lexicalSearch(index, trimmedQuery, {
+      limit: AI_LEXICAL_CANDIDATE_LIMIT,
+      minLength: 1,
+    }),
+  );
+
+  appendUniqueMatches(
+    candidates,
+    seenDigests,
+    buildSourceDiverseLexicalMatches(index, trimmedQuery),
+  );
+
+  return candidates;
 }
 
 export function buildRerankScoreByDigest(

--- a/src/routes/v2/pages/Editor/hooks/useComponentSearchV2State.ts
+++ b/src/routes/v2/pages/Editor/hooks/useComponentSearchV2State.ts
@@ -207,7 +207,8 @@ export function useComponentSearchV2State(
       return;
     }
 
-    const candidates = aiCandidateMatches
+    const rerankBase = aiCandidateMatches;
+    const candidates = rerankBase
       .map((match) => componentReferenceToCandidate(match.reference))
       .filter((candidate): candidate is NonNullable<typeof candidate> =>
         Boolean(candidate),
@@ -215,9 +216,7 @@ export function useComponentSearchV2State(
 
     if (candidates.length === 0) return;
 
-    setRerankBaseMatches(
-      lexicalMatches.length > 0 ? lexicalMatches : aiCandidateMatches,
-    );
+    setRerankBaseMatches(rerankBase);
     setRerankedFor(trimmedQuery);
     // Score every candidate so each displayed result shows a relevance %.
     mutate({ query: trimmedQuery, candidates, scoreAllCandidates: true });


### PR DESCRIPTION
## Description

The AI rerank candidate pool now uses a source-diverse selection strategy instead of relying purely on lexical hits. Previously, the candidate pool was capped at 50 results drawn entirely from lexical matches, falling back to a plain alphabetical slice when no matches were found. This meant components from underrepresented sources (e.g. user uploads) could be crowded out entirely when a query produced many strong lexical hits from a single source.

The new approach builds the candidate pool in three layers:
1. Up to 60 of the strongest lexical hits for the query
2. An evenly-sampled set of up to 8 candidates per source (source-diverse browse)
3. An evenly-sampled alphabetical slice of the full index to fill remaining slots up to the new cap of 80

The rerank base is now always set to `aiCandidateMatches` rather than switching between lexical and AI candidate lists depending on whether lexical results existed.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Open the component search panel in the editor.
2. Enter a query that matches many components from a single source (e.g. a library with 100+ entries).
3. Click the AI rerank button and verify that components from other sources (e.g. user-uploaded files) still appear in the ranked results.
4. Verify that the total candidate count sent to the reranker does not exceed 80.
5. Run the unit tests in `componentSearchV2Logic.test.ts` to confirm the new source-diversity test passes.

## Additional Comments

The new `sampleEvenly` helper picks items at uniform intervals so that the browse sample is representative of the full sorted list rather than just the top entries.