### PR TITLE
Add deep AI search to rerank all components in selected sources

### DIFF
--- a/src/components/shared/ReactFlow/FlowSidebar/components/ComponentItem.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/components/ComponentItem.tsx
@@ -29,6 +29,7 @@ interface ComponentMarkupProps {
   error?: string | null;
   className?: string;
   rerankScore?: number;
+  rerankReason?: string;
 }
 
 type ComponentIconProps = {
@@ -87,6 +88,7 @@ const ComponentMarkup = ({
   error,
   className,
   rerankScore,
+  rerankReason,
 }: ComponentMarkupProps) => {
   const isRemoteComponentLibrarySearchEnabled = useFlagValue(
     "remote-component-library-search",
@@ -231,9 +233,18 @@ const ComponentMarkup = ({
                     {author}
                   </span>
                 )}
-                <span className="truncate text-[10px] text-gray-500 font-mono">
-                  Ver: {digest}
-                </span>
+                {rerankReason ? (
+                  <span
+                    className="truncate text-[10px] text-gray-500"
+                    title={rerankReason}
+                  >
+                    Why: {rerankReason}
+                  </span>
+                ) : (
+                  <span className="truncate text-[10px] text-gray-500 font-mono">
+                    Ver: {digest}
+                  </span>
+                )}
               </div>
             </InlineStack>
 

--- a/src/routes/Dashboard/DashboardComponentsV2View.test.tsx
+++ b/src/routes/Dashboard/DashboardComponentsV2View.test.tsx
@@ -430,6 +430,7 @@ describe("DashboardComponentsV2View", () => {
         expect.objectContaining({ id: "registered-digest" }),
         expect.objectContaining({ id: "user-digest" }),
       ]),
+      scoreAllCandidates: true,
     });
   });
 

--- a/src/routes/Dashboard/DashboardComponentsV2View.tsx
+++ b/src/routes/Dashboard/DashboardComponentsV2View.tsx
@@ -181,6 +181,8 @@ interface ComponentCardProps {
   source?: ComponentSearchSource;
   matchedFields?: MatchField[];
   reason?: string;
+  rerankScore?: number;
+  isAiRanked?: boolean;
   isSelected?: boolean;
   /** Position within the current result list — passed to analytics. */
   position?: number;
@@ -194,6 +196,8 @@ const ComponentCard = ({
   source,
   matchedFields,
   reason,
+  rerankScore,
+  isAiRanked,
   isSelected,
   position,
   hadQuery,
@@ -205,6 +209,8 @@ const ComponentCard = ({
   const trackingSource = source
     ? TRACKING_SOURCE_BY_KIND[source.kind]
     : "unknown";
+  const showLexicalMatchBadges = isAiRanked ? undefined : matchedFields;
+  const showDescription = description;
 
   return (
     // Raw <button> rather than the <Button> primitive: the primitive's variants
@@ -255,7 +261,12 @@ const ComponentCard = ({
           <Text size="sm" weight="semibold">
             {name}
           </Text>
-          {matchedFields?.map((field) => (
+          {rerankScore !== undefined && (
+            <Badge variant="secondary">
+              Relevance: {Math.round(rerankScore * 100)}%
+            </Badge>
+          )}
+          {showLexicalMatchBadges?.map((field) => (
             <Badge key={field} variant="secondary">
               matched: {MATCH_FIELD_LABEL[field]}
             </Badge>
@@ -266,7 +277,7 @@ const ComponentCard = ({
             by {publishedBy}
           </Text>
         )}
-        {description && (
+        {showDescription && (
           // `[overflow-wrap:anywhere]` breaks at any character if needed —
           // `break-words` only breaks at word boundaries, which doesn't help
           // for long URLs without spaces. Pair with `min-w-0` on the parent
@@ -751,28 +762,41 @@ export const DashboardComponentsV2View = () => {
     [],
   );
 
+  const clearRerank = () => {
+    setRerankedFor(null);
+    setRerankBaseMatches([]);
+    resetRerank();
+  };
+
   const handleQueryChange = (event: ChangeEvent<HTMLInputElement>) => {
     setQuery(event.target.value);
     if (rerankedFor !== null) {
-      setRerankedFor(null);
-      setRerankBaseMatches([]);
-      resetRerank();
+      clearRerank();
     }
   };
 
-  const handleSmartSearch = () => {
+  const startAiSearch = (
+    matches: LexicalMatch[],
+    { scoreAllCandidates }: { scoreAllCandidates: boolean },
+  ) => {
     const trimmed = query.trim();
-    if (trimmed.length === 0 || aiCandidateMatches.length === 0) return;
+    if (trimmed.length === 0 || matches.length === 0) return;
 
-    const candidates = aiCandidateMatches
-      .map((m) => componentReferenceToCandidate(m.reference))
+    const candidates = matches
+      .map((m) => componentReferenceToCandidate(m.reference, m.source))
       .filter((c): c is NonNullable<typeof c> => c !== null);
 
     if (candidates.length === 0) return;
 
-    setRerankBaseMatches(aiCandidateMatches);
+    setRerankBaseMatches(matches);
     setRerankedFor(trimmed);
-    rerank({ query: trimmed, candidates });
+    rerank({ query: trimmed, candidates, scoreAllCandidates });
+  };
+
+  const handleSmartSearch = () => {
+    startAiSearch(aiCandidateMatches, {
+      scoreAllCandidates: true,
+    });
   };
 
   const handleSourceToggle = (sourceKey: string) => {
@@ -782,18 +806,14 @@ export const DashboardComponentsV2View = () => {
         : [...current, sourceKey],
     );
     if (rerankedFor !== null) {
-      setRerankedFor(null);
-      setRerankBaseMatches([]);
-      resetRerank();
+      clearRerank();
     }
   };
 
   const handleEnableAllSources = () => {
     setDisabledSourceKeys([]);
     if (rerankedFor !== null) {
-      setRerankedFor(null);
-      setRerankBaseMatches([]);
-      resetRerank();
+      clearRerank();
     }
   };
 
@@ -820,9 +840,15 @@ export const DashboardComponentsV2View = () => {
     !isReranking;
 
   // What we actually render. Rerank wins when active; otherwise lexical.
-  const displayedResults = rerankActive
+  const displayedResults: Array<
+    LexicalMatch & { reason?: string; rerankScore?: number }
+  > = rerankActive
     ? mergeRerankIntoLexical(rerankData.matches, rerankBaseMatches)
-    : lexicalMatches.map((m) => ({ ...m, reason: undefined }));
+    : lexicalMatches.map((m) => ({
+        ...m,
+        reason: undefined,
+        rerankScore: undefined,
+      }));
 
   // Resolve the full reference for the selected digest. Prefer the already-
   // hydrated copy (no extra network), fall back to the un-hydrated index
@@ -942,11 +968,23 @@ export const DashboardComponentsV2View = () => {
     }
     return (
       <BlockStack gap="2" align="stretch">
-        <Paragraph size="xs" tone="subdued">
-          {rerankActive
-            ? `AI-reranked ${displayedResults.length} result${displayedResults.length === 1 ? "" : "s"} for “${trimmedQuery}”`
-            : `${displayedResults.length} result${displayedResults.length === 1 ? "" : "s"} for “${trimmedQuery}”`}
-        </Paragraph>
+        <InlineStack align="space-between" blockAlign="center" gap="2">
+          <Paragraph size="xs" tone="subdued">
+            {rerankActive
+              ? `AI-ranked ${displayedResults.length} result${displayedResults.length === 1 ? "" : "s"} for “${trimmedQuery}”`
+              : `${displayedResults.length} result${displayedResults.length === 1 ? "" : "s"} for “${trimmedQuery}”`}
+          </Paragraph>
+          {rerankActive && (
+            <Button
+              type="button"
+              variant="link"
+              size="inline-xs"
+              onClick={clearRerank}
+            >
+              Use lexical ranking
+            </Button>
+          )}
+        </InlineStack>
         {displayedResults.map((result, idx) => (
           <ComponentCard
             key={result.digest}
@@ -954,6 +992,8 @@ export const DashboardComponentsV2View = () => {
             source={result.source}
             matchedFields={result.matchedFields}
             reason={result.reason}
+            rerankScore={result.rerankScore}
+            isAiRanked={rerankActive}
             isSelected={result.digest === selectedDigest}
             position={idx}
             hadQuery={true}
@@ -1010,7 +1050,7 @@ export const DashboardComponentsV2View = () => {
                 !isConfigured
               }
               aria-label={isReranking ? "AI search in progress" : "AI search"}
-              title="AI search — rerank these results with an LLM"
+              title="AI search — rerank a bounded set of top candidates with an LLM"
             >
               {isReranking ? <Spinner size={16} /> : <Icon name="Sparkles" />}
             </Button>
@@ -1143,26 +1183,23 @@ export const DashboardComponentsV2View = () => {
 };
 
 /**
- * Merge LLM rerank results back into the lexical match metadata so the UI
- * can still show "matched: name" badges alongside the rerank reason. Items
- * the LLM dropped are appended after the reranked ones (the lexical layer
- * thought they were relevant, even if the LLM disagreed — surfacing them
- * builds trust by not silently hiding lexical hits).
+ * Merge LLM rerank results back into the lexical match metadata. AI search
+ * keeps unranked lexical matches after the model-ranked set.
  */
 function mergeRerankIntoLexical(
   reranked: RerankedMatch[],
   lexical: LexicalMatch[],
-): Array<LexicalMatch & { reason?: string }> {
+): Array<LexicalMatch & { reason?: string; rerankScore?: number }> {
   const lexicalByDigest = new Map(lexical.map((m) => [m.digest, m]));
-  const out: Array<LexicalMatch & { reason?: string }> = [];
+  const out: Array<LexicalMatch & { reason?: string; rerankScore?: number }> =
+    [];
 
   for (const r of reranked) {
     const lex = lexicalByDigest.get(r.id);
     if (!lex) continue;
-    out.push({ ...lex, reason: r.reason });
+    out.push({ ...lex, reason: r.reason, rerankScore: r.score });
     lexicalByDigest.delete(r.id);
   }
-  // Tail: lexical hits the LLM didn't rank.
   for (const lex of lexicalByDigest.values()) {
     out.push({ ...lex });
   }

--- a/src/routes/v2/pages/Editor/components/ComponentSearchResults.tsx
+++ b/src/routes/v2/pages/Editor/components/ComponentSearchResults.tsx
@@ -4,6 +4,7 @@ import {
   StickyNoteSidebarItem,
 } from "@/components/shared/ReactFlow/FlowSidebar/components/ComponentItem";
 import FolderItem from "@/components/shared/ReactFlow/FlowSidebar/components/FolderItem";
+import { Button } from "@/components/ui/button";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Separator } from "@/components/ui/separator";
 import { Spinner } from "@/components/ui/spinner";
@@ -17,6 +18,8 @@ interface ComponentSearchResultsProps {
   results: ComponentSearchV2Result[];
   browseFolders: UIComponentFolder[];
   isLoading: boolean;
+  isRerankActive: boolean;
+  onClearRerank: () => void;
 }
 
 export function ComponentSearchResults({
@@ -24,6 +27,8 @@ export function ComponentSearchResults({
   results,
   browseFolders,
   isLoading,
+  isRerankActive,
+  onClearRerank,
 }: ComponentSearchResultsProps) {
   if (isLoading) {
     return (
@@ -74,9 +79,22 @@ export function ComponentSearchResults({
       className="px-2 min-h-0 flex-1"
       data-testid="search-results-container"
     >
-      <Text tone="subdued" data-testid="search-results-header">
-        Search Results ({results.length})
-      </Text>
+      <InlineStack align="space-between" blockAlign="center" gap="2">
+        <Text tone="subdued" data-testid="search-results-header">
+          {isRerankActive ? "AI-ranked results" : "Search Results"} (
+          {results.length})
+        </Text>
+        {isRerankActive && (
+          <Button
+            type="button"
+            variant="link"
+            size="inline-xs"
+            onClick={onClearRerank}
+          >
+            Use lexical ranking
+          </Button>
+        )}
+      </InlineStack>
       <Separator />
       <div className="min-h-0 w-full flex-1 overflow-y-auto overflow-x-hidden scrollbar-thin">
         {results.length > 0 ? (
@@ -89,6 +107,7 @@ export function ComponentSearchResults({
                 key={`${result.reference.digest}-${result.reference.name ?? result.reference.url ?? "component"}`}
                 component={result.reference}
                 rerankScore={result.rerankScore}
+                rerankReason={result.rerankReason}
               />
             ))}
           </BlockStack>

--- a/src/routes/v2/pages/Editor/components/ComponentSearchV2Content.tsx
+++ b/src/routes/v2/pages/Editor/components/ComponentSearchV2Content.tsx
@@ -14,8 +14,16 @@ import { ComponentSearchResults } from "./ComponentSearchResults";
 export function ComponentSearchV2Content() {
   const [query, setQuery] = useState("");
   const deferredQuery = useDeferredValue(query);
-  const { results, browseFolders, isLoading, canRerank, isReranking, rerank } =
-    useComponentSearchV2State(deferredQuery);
+  const {
+    results,
+    browseFolders,
+    isLoading,
+    canRerank,
+    isReranking,
+    isRerankActive,
+    rerank,
+    clearRerank,
+  } = useComponentSearchV2State(deferredQuery);
 
   const handleQueryChange = (event: ChangeEvent<HTMLInputElement>) => {
     setQuery(event.target.value);
@@ -67,7 +75,7 @@ export function ComponentSearchV2Content() {
             size="icon"
             className="h-8 w-8 p-0 shrink-0"
             aria-label={isReranking ? "AI reranking in progress" : "AI rerank"}
-            title="AI rerank"
+            title="AI rerank — rerank a bounded set of top candidates"
             onClick={rerank}
             disabled={!canRerank || isReranking}
           >
@@ -80,6 +88,8 @@ export function ComponentSearchV2Content() {
         results={results}
         browseFolders={browseFolders}
         isLoading={isLoading}
+        isRerankActive={isRerankActive}
+        onClearRerank={clearRerank}
       />
     </BlockStack>
   );

--- a/src/routes/v2/pages/Editor/components/componentSearchV2Logic.test.ts
+++ b/src/routes/v2/pages/Editor/components/componentSearchV2Logic.test.ts
@@ -17,6 +17,7 @@ import type {
 import {
   buildAiCandidateMatches,
   buildLexicalMatches,
+  buildRerankMatchByDigest,
   buildResultFolders,
   buildResults,
   buildSourcedHydratedReferences,
@@ -193,22 +194,35 @@ describe("buildResults", () => {
   const displayed = [match("a"), match("b"), match("c")];
 
   it("badges only items scored above the exclusion threshold", () => {
-    const scores = new Map([
-      ["a", 0.9],
-      ["b", 0.0], // model-excluded
-      // "c" was never scored
-    ]);
-    const results = buildResults(displayed, scores, true);
+    const rerankMatches = buildRerankMatchByDigest(
+      {
+        matches: [
+          { id: "a", score: 0.9, reason: "Strong match" },
+          { id: "b", score: 0.0, reason: "Weak match" }, // model-excluded
+          // "c" was never scored
+        ],
+      },
+      true,
+    );
+    const results = buildResults(displayed, rerankMatches, true);
     expect(results.map((r) => r.rerankScore)).toEqual([
       0.9,
+      undefined,
+      undefined,
+    ]);
+    expect(results.map((r) => r.rerankReason)).toEqual([
+      "Strong match",
       undefined,
       undefined,
     ]);
   });
 
   it("never badges when rerank is not active", () => {
-    const scores = new Map([["a", 0.9]]);
-    const results = buildResults(displayed, scores, false);
+    const rerankMatches = buildRerankMatchByDigest(
+      { matches: [{ id: "a", score: 0.9, reason: "Strong match" }] },
+      true,
+    );
+    const results = buildResults(displayed, rerankMatches, false);
     expect(results.every((r) => r.rerankScore === undefined)).toBe(true);
   });
 });

--- a/src/routes/v2/pages/Editor/components/componentSearchV2Logic.ts
+++ b/src/routes/v2/pages/Editor/components/componentSearchV2Logic.ts
@@ -62,6 +62,7 @@ export interface ComponentSearchV2Result {
   reference: ComponentReference;
   source: ComponentSearchSource;
   rerankScore?: number;
+  rerankReason?: string;
 }
 
 export interface ComponentSearchV2State {
@@ -70,7 +71,9 @@ export interface ComponentSearchV2State {
   isLoading: boolean;
   canRerank: boolean;
   isReranking: boolean;
+  isRerankActive: boolean;
   rerank: () => void;
+  clearRerank: () => void;
 }
 
 export function registeredSource(
@@ -208,7 +211,8 @@ export function rerankedMatches(
     baseByDigest.delete(match.id);
   }
 
-  ordered.push(...baseByDigest.values(), ...excluded);
+  ordered.push(...baseByDigest.values());
+  ordered.push(...excluded);
   return ordered;
 }
 
@@ -312,12 +316,13 @@ function appendUniqueMatches(
   target: LexicalMatch[],
   seenDigests: Set<string>,
   matches: LexicalMatch[],
+  limit: number,
 ) {
   for (const match of matches) {
     if (seenDigests.has(match.digest)) continue;
     seenDigests.add(match.digest);
     target.push(match);
-    if (target.length >= AI_CANDIDATE_LIMIT) return;
+    if (target.length >= limit) return;
   }
 }
 
@@ -363,25 +368,26 @@ export function buildAiCandidateMatches(
       limit: AI_LEXICAL_CANDIDATE_LIMIT,
       minLength: 1,
     }),
+    AI_CANDIDATE_LIMIT,
   );
 
   appendUniqueMatches(
     candidates,
     seenDigests,
     buildSourceDiverseLexicalMatches(index, trimmedQuery),
+    AI_CANDIDATE_LIMIT,
   );
 
   return candidates;
 }
 
-export function buildRerankScoreByDigest(
+export function buildRerankMatchByDigest(
   rerankData: RerankResult | undefined,
   isRerankActive: boolean,
-): Map<string, number> {
+): Map<string, RerankResult["matches"][number]> {
   return new Map(
     isRerankActive
-      ? (rerankData?.matches.map((match) => [match.id, match.score] as const) ??
-          [])
+      ? (rerankData?.matches.map((match) => [match.id, match] as const) ?? [])
       : [],
   );
 }
@@ -393,18 +399,23 @@ export function buildRerankScoreByDigest(
  */
 export function buildResults(
   displayedMatches: LexicalMatch[],
-  rerankScoreByDigest: Map<string, number>,
+  rerankMatchByDigest: Map<string, RerankResult["matches"][number]>,
   isRerankActive: boolean,
 ): ComponentSearchV2Result[] {
   return displayedMatches.map((match) => {
-    const rerankScore = isRerankActive
-      ? rerankScoreByDigest.get(match.digest)
+    const rerankMatch = isRerankActive
+      ? rerankMatchByDigest.get(match.digest)
       : undefined;
+    const rerankScore = rerankMatch?.score;
+    const hasRerankMatch =
+      rerankMatch !== undefined &&
+      rerankScore !== undefined &&
+      rerankScore > RERANK_EXCLUSION_THRESHOLD;
     return {
       reference: match.reference,
       source: match.source,
-      ...(rerankScore !== undefined && rerankScore > RERANK_EXCLUSION_THRESHOLD
-        ? { rerankScore }
+      ...(hasRerankMatch
+        ? { rerankScore, rerankReason: rerankMatch.reason }
         : {}),
     };
   });

--- a/src/routes/v2/pages/Editor/hooks/useComponentSearchV2State.ts
+++ b/src/routes/v2/pages/Editor/hooks/useComponentSearchV2State.ts
@@ -19,7 +19,7 @@ import {
 import {
   buildAiCandidateMatches,
   buildLexicalMatches,
-  buildRerankScoreByDigest,
+  buildRerankMatchByDigest,
   buildResultFolders,
   buildResults,
   buildSourcedHydratedReferences,
@@ -175,7 +175,6 @@ export function useComponentSearchV2State(
   const trimmedQuery = query.trim();
   const lexicalMatches = buildLexicalMatches(index, trimmedQuery);
   const aiCandidateMatches = buildAiCandidateMatches(index, trimmedQuery);
-
   const {
     mutate,
     data: rerankData,
@@ -187,6 +186,11 @@ export function useComponentSearchV2State(
     [],
   );
 
+  const clearRerank = () => {
+    setRerankedFor(null);
+    setRerankBaseMatches([]);
+  };
+
   useEffect(() => {
     setRerankedFor(null);
     setRerankBaseMatches([]);
@@ -196,20 +200,23 @@ export function useComponentSearchV2State(
     rerankedFor === trimmedQuery &&
     rerankBaseMatches.length > 0 &&
     !isReranking &&
-    rerankData !== undefined;
+    (rerankData?.matches.length ?? 0) > 0;
 
   const displayedMatches = isRerankActive
     ? rerankedMatches(rerankData, rerankBaseMatches)
     : lexicalMatches;
 
-  const rerank = () => {
-    if (!trimmedQuery || aiCandidateMatches.length === 0 || !isConfigured) {
-      return;
-    }
+  const startRerank = (
+    matches: LexicalMatch[],
+    { scoreAllCandidates }: { scoreAllCandidates: boolean },
+  ) => {
+    if (!trimmedQuery || matches.length === 0 || !isConfigured) return;
 
-    const rerankBase = aiCandidateMatches;
+    const rerankBase = matches;
     const candidates = rerankBase
-      .map((match) => componentReferenceToCandidate(match.reference))
+      .map((match) =>
+        componentReferenceToCandidate(match.reference, match.source),
+      )
       .filter((candidate): candidate is NonNullable<typeof candidate> =>
         Boolean(candidate),
       );
@@ -218,17 +225,22 @@ export function useComponentSearchV2State(
 
     setRerankBaseMatches(rerankBase);
     setRerankedFor(trimmedQuery);
-    // Score every candidate so each displayed result shows a relevance %.
-    mutate({ query: trimmedQuery, candidates, scoreAllCandidates: true });
+    mutate({ query: trimmedQuery, candidates, scoreAllCandidates });
   };
 
-  const rerankScoreByDigest = buildRerankScoreByDigest(
+  const rerank = () => {
+    startRerank(aiCandidateMatches, {
+      scoreAllCandidates: true,
+    });
+  };
+
+  const rerankMatchByDigest = buildRerankMatchByDigest(
     rerankData,
     isRerankActive,
   );
   const results = buildResults(
     displayedMatches,
-    rerankScoreByDigest,
+    rerankMatchByDigest,
     isRerankActive,
   );
 
@@ -245,6 +257,8 @@ export function useComponentSearchV2State(
     canRerank:
       trimmedQuery.length > 0 && aiCandidateMatches.length > 0 && isConfigured,
     isReranking,
+    isRerankActive,
     rerank,
+    clearRerank,
   };
 }

--- a/src/services/naturalLanguageComponentSearchService.test.ts
+++ b/src/services/naturalLanguageComponentSearchService.test.ts
@@ -90,23 +90,54 @@ describe("componentReferenceToCandidate", () => {
     });
   });
 
-  it("includes input/output names when present", () => {
+  it("includes input/output types, descriptions, and source when present", () => {
     const ref: ComponentReference = {
       digest: "abc",
       spec: {
         name: "train",
         description: "",
-        inputs: [{ name: "dataset" }],
-        outputs: [{ name: "model" }],
+        inputs: [
+          {
+            name: "dataset",
+            type: "Dataset",
+            description: "Training data",
+          },
+        ],
+        outputs: [
+          {
+            name: "model",
+            type: { Model: { format: "xgboost" } },
+            description: "Trained model",
+          },
+        ],
         implementation: { container: { image: "x" } },
       },
     };
-    expect(componentReferenceToCandidate(ref)).toEqual({
+    expect(
+      componentReferenceToCandidate(ref, {
+        kind: "published",
+        label: "Published",
+        id: "published",
+      }),
+    ).toEqual({
       id: "abc",
       name: "train",
       description: "",
-      inputs: ["dataset"],
-      outputs: ["model"],
+      source: { kind: "published", label: "Published" },
+      inputs: [
+        {
+          name: "dataset",
+          type: "Dataset",
+          description: "Training data",
+        },
+      ],
+      outputs: [
+        {
+          name: "model",
+          type: '{"Model":{"format":"xgboost"}}',
+          description: "Trained model",
+        },
+      ],
     });
   });
 });

--- a/src/services/naturalLanguageComponentSearchService.ts
+++ b/src/services/naturalLanguageComponentSearchService.ts
@@ -11,24 +11,42 @@
  * judgment over a small, well-defined list when literal matching is not enough.
  */
 
-import type { ComponentReference } from "@/utils/componentSpec";
+import type {
+  ComponentReference,
+  InputSpec,
+  OutputSpec,
+} from "@/utils/componentSpec";
 import { getComponentName } from "@/utils/getComponentName";
 import { isRecord } from "@/utils/typeGuards";
 
-import { extractComponentMetadata } from "./componentSearchIndex";
+import {
+  type ComponentSearchSource,
+  extractComponentMetadata,
+} from "./componentSearchIndex";
 
 /**
  * Compact candidate shape sent to the model. Only the fields that inform
- * judgment: name, description, i/o names. Implementation/command text is
- * already covered by the lexical layer and would just inflate the prompt.
+ * judgment: name, description, source, and i/o summaries. Implementation/
+ * command text is already covered by the lexical layer and would just inflate
+ * the prompt.
  */
+interface RerankCandidateIO {
+  name: string;
+  type?: string;
+  description?: string;
+}
+
 export interface RerankCandidate {
   /** Component digest. Used to round-trip the model's response to references. */
   id: string;
   name: string;
   description: string;
-  inputs?: string[];
-  outputs?: string[];
+  source?: {
+    kind: ComponentSearchSource["kind"];
+    label: string;
+  };
+  inputs?: RerankCandidateIO[];
+  outputs?: RerankCandidateIO[];
 }
 
 export interface RerankedMatch {
@@ -119,19 +137,44 @@ function isMatchArray(value: unknown): value is RerankedMatch[] {
  * the model. Returns null when the reference has no usable metadata — those
  * would just waste tokens.
  */
+function stringifyCandidateField(value: unknown): string {
+  if (typeof value === "string") return value.trim();
+  if (value === null || value === undefined) return "";
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return "";
+  }
+}
+
+function componentIoToCandidateIo(
+  ioSpec: InputSpec | OutputSpec,
+): RerankCandidateIO {
+  const type = stringifyCandidateField(ioSpec.type);
+  const description = ioSpec.description?.trim() ?? "";
+  return {
+    name: ioSpec.name,
+    ...(type ? { type } : {}),
+    ...(description ? { description } : {}),
+  };
+}
+
 export function componentReferenceToCandidate(
   reference: ComponentReference,
+  source?: ComponentSearchSource,
 ): RerankCandidate | null {
   const metadata = extractComponentMetadata(reference);
   if (!metadata) return null;
+  const inputs = reference.spec?.inputs?.map(componentIoToCandidateIo) ?? [];
+  const outputs = reference.spec?.outputs?.map(componentIoToCandidateIo) ?? [];
+
   return {
     id: metadata.digest,
     name: metadata.name,
     description: metadata.description,
-    ...(metadata.inputNames.length > 0 ? { inputs: metadata.inputNames } : {}),
-    ...(metadata.outputNames.length > 0
-      ? { outputs: metadata.outputNames }
-      : {}),
+    ...(source ? { source: { kind: source.kind, label: source.label } } : {}),
+    ...(inputs.length > 0 ? { inputs } : {}),
+    ...(outputs.length > 0 ? { outputs } : {}),
   };
 }
 


### PR DESCRIPTION
## Description

Adds a **Deep AI search** button alongside the existing AI (smart) search button. While the standard AI search sends a limited, curated set of candidate components to the reranker, Deep AI search sends the entire searchable index — lexical hits first so truncating providers still see the most likely matches early — allowing the model to rerank across every available component in the selected sources.

Key changes:
- Introduces `buildDeepAiCandidateMatches`, which builds a candidate pool from all indexed components (no cap), ordered with lexical matches first and remaining components appended alphabetically.
- Exposes `canDeepRerank` and `deepRerank` from `useComponentSearchV2State` and wires them into both the Dashboard and Editor search UIs.
- Enriches `RerankCandidate` with richer I/O metadata (type and description, not just names) and a `source` field, giving the model more signal when ranking.
- Refactors the shared `startAiSearch` / `startRerank` helpers to accept an arbitrary candidate list, removing duplication between the standard and deep paths.
- Updates `componentReferenceToCandidate` to accept an optional `source` argument and serialize I/O types (including complex object types) via `JSON.stringify`.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Open the component search panel (Dashboard or Editor).
2. Enter a non-empty query.
3. Confirm the **Deep AI search** button appears and is enabled when an AI provider is configured.
4. Click **Deep AI search** and verify that results are reranked across all components in the selected sources, not just the top lexical candidates.
5. Confirm the existing **AI search** (sparkles) button still behaves as before.
6. Verify the button is disabled when the query is empty or no AI provider is configured.

## Additional Comments

`scoreAllCandidates` is intentionally set to `false` for deep rerank to avoid scoring overhead across the full index on every result row. The standard AI search retains `scoreAllCandidates: true` so relevance percentages continue to appear on displayed results.