### PR TITLE
add client-side embeddings cached in IndexedDB

### DIFF
--- a/src/routes/Dashboard/DashboardComponentsV2View.tsx
+++ b/src/routes/Dashboard/DashboardComponentsV2View.tsx
@@ -20,6 +20,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { QuickTooltip } from "@/components/ui/tooltip";
 import { Heading, Paragraph, Text } from "@/components/ui/typography";
+import { useAiProviderSettings } from "@/hooks/useAiProviderSettings";
 import { getComponentQueryKey } from "@/hooks/useHydrateComponentReference";
 import {
   useComponentAiDescription,
@@ -38,6 +39,7 @@ import {
   LibraryDB,
   type StoredLibrary,
 } from "@/providers/ComponentLibraryProvider/libraries/storage";
+import { rankComponentMatchesByEmbeddings } from "@/services/componentSearchEmbeddings";
 import {
   buildSearchIndex,
   type ComponentSearchSource,
@@ -448,6 +450,23 @@ function sampleEvenly<T>(entries: T[], limit: number): T[] {
   return sampled;
 }
 
+function mergeUniqueMatches(
+  primary: LexicalMatch[],
+  secondary: LexicalMatch[],
+  fallback: LexicalMatch[],
+  limit: number,
+): LexicalMatch[] {
+  const merged: LexicalMatch[] = [];
+  const seen = new Set<string>();
+  for (const match of [...primary, ...secondary, ...fallback]) {
+    if (seen.has(match.digest)) continue;
+    seen.add(match.digest);
+    merged.push(match);
+    if (merged.length >= limit) return merged;
+  }
+  return merged;
+}
+
 function collectAllSourcedReferences({
   standardLibrary,
   publishedRefs,
@@ -496,6 +515,7 @@ export const DashboardComponentsV2View = () => {
     "component-search-v2-ai-descriptions",
   );
   const { backendUrl, configured, available } = useBackend();
+  const { config: aiConfig } = useAiProviderSettings();
   const [query, setQuery] = useState("");
   const [disabledSourceKeys, setDisabledSourceKeys] = useState<string[]>([]);
 
@@ -761,6 +781,8 @@ export const DashboardComponentsV2View = () => {
   const [rerankBaseMatches, setRerankBaseMatches] = useState<LexicalMatch[]>(
     [],
   );
+  const [isEmbeddingSearchPending, setIsEmbeddingSearchPending] =
+    useState(false);
 
   const clearRerank = () => {
     setRerankedFor(null);
@@ -775,27 +797,61 @@ export const DashboardComponentsV2View = () => {
     }
   };
 
-  const startAiSearch = (
+  const buildEmbeddingMatches = async (
+    trimmed: string,
+    limit: number,
+  ): Promise<LexicalMatch[]> => {
+    if (!aiConfig.apiBase.trim()) return [];
+    setIsEmbeddingSearchPending(true);
+    try {
+      return await rankComponentMatchesByEmbeddings(
+        filteredIndex,
+        trimmed,
+        { apiBase: aiConfig.apiBase, apiKey: aiConfig.apiKey },
+        { limit },
+      );
+    } catch {
+      return [];
+    } finally {
+      setIsEmbeddingSearchPending(false);
+    }
+  };
+
+  const startAiSearch = async (
     matches: LexicalMatch[],
-    { scoreAllCandidates }: { scoreAllCandidates: boolean },
+    {
+      scoreAllCandidates,
+      limit,
+    }: { scoreAllCandidates: boolean; limit: number },
   ) => {
     const trimmed = query.trim();
     if (trimmed.length === 0 || matches.length === 0) return;
 
-    const candidates = matches
+    const embeddingMatches = aiConfig.apiBase.trim()
+      ? await buildEmbeddingMatches(trimmed, limit)
+      : [];
+    const rerankMatches = mergeUniqueMatches(
+      matches.slice(0, 60),
+      embeddingMatches,
+      matches,
+      limit,
+    );
+
+    const candidates = rerankMatches
       .map((m) => componentReferenceToCandidate(m.reference, m.source))
       .filter((c): c is NonNullable<typeof c> => c !== null);
 
     if (candidates.length === 0) return;
 
-    setRerankBaseMatches(matches);
+    setRerankBaseMatches(rerankMatches);
     setRerankedFor(trimmed);
     rerank({ query: trimmed, candidates, scoreAllCandidates });
   };
 
   const handleSmartSearch = () => {
-    startAiSearch(aiCandidateMatches, {
+    void startAiSearch(aiCandidateMatches, {
       scoreAllCandidates: true,
+      limit: aiCandidateMatches.length,
     });
   };
 
@@ -837,7 +893,8 @@ export const DashboardComponentsV2View = () => {
     rerankData !== undefined &&
     rerankData.matches.length > 0 &&
     rerankBaseMatches.length > 0 &&
-    !isReranking;
+    !isReranking &&
+    !isEmbeddingSearchPending;
 
   // What we actually render. Rerank wins when active; otherwise lexical.
   const displayedResults: Array<
@@ -1045,14 +1102,23 @@ export const DashboardComponentsV2View = () => {
               onClick={handleSmartSearch}
               disabled={
                 isReranking ||
+                isEmbeddingSearchPending ||
                 isEmpty ||
                 aiCandidateMatches.length === 0 ||
                 !isConfigured
               }
-              aria-label={isReranking ? "AI search in progress" : "AI search"}
+              aria-label={
+                isReranking || isEmbeddingSearchPending
+                  ? "AI search in progress"
+                  : "AI search"
+              }
               title="AI search — rerank a bounded set of top candidates with an LLM"
             >
-              {isReranking ? <Spinner size={16} /> : <Icon name="Sparkles" />}
+              {isReranking || isEmbeddingSearchPending ? (
+                <Spinner size={16} />
+              ) : (
+                <Icon name="Sparkles" />
+              )}
             </Button>
           </InlineStack>
           <SourceFilterBar

--- a/src/routes/v2/pages/Editor/hooks/useComponentSearchV2State.ts
+++ b/src/routes/v2/pages/Editor/hooks/useComponentSearchV2State.ts
@@ -1,8 +1,9 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useLiveQuery } from "dexie-react-hooks";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { listApiPublishedComponentsGet } from "@/api/sdk.gen";
+import { useAiProviderSettings } from "@/hooks/useAiProviderSettings";
 import { getComponentQueryKey } from "@/hooks/useHydrateComponentReference";
 import { useNaturalLanguageComponentRerank } from "@/hooks/useNaturalLanguageComponentSearch";
 import { useBackend } from "@/providers/BackendProvider";
@@ -25,12 +26,15 @@ import {
   buildSourcedHydratedReferences,
   collectAllSourcedReferences,
   type ComponentSearchV2State,
+  LEXICAL_RESULT_LIMIT,
   registeredLibrariesFingerprint,
   registeredSource,
   rerankedMatches,
 } from "@/routes/v2/pages/Editor/components/componentSearchV2Logic";
+import { rankComponentMatchesByEmbeddings } from "@/services/componentSearchEmbeddings";
 import {
   buildSearchIndex,
+  type IndexEntry,
   type LexicalMatch,
   type SourcedReference,
 } from "@/services/componentSearchIndex";
@@ -46,11 +50,29 @@ import type {
 } from "@/utils/componentSpec";
 import { HOURS } from "@/utils/constants";
 
+function mergeUniqueMatches(
+  primary: LexicalMatch[],
+  secondary: LexicalMatch[],
+  fallback: LexicalMatch[],
+  limit: number,
+): LexicalMatch[] {
+  const merged: LexicalMatch[] = [];
+  const seen = new Set<string>();
+  for (const match of [...primary, ...secondary, ...fallback]) {
+    if (seen.has(match.digest)) continue;
+    seen.add(match.digest);
+    merged.push(match);
+    if (merged.length >= limit) return merged;
+  }
+  return merged;
+}
+
 export function useComponentSearchV2State(
   query: string,
 ): ComponentSearchV2State {
   const queryClient = useQueryClient();
   const { backendUrl, configured, available } = useBackend();
+  const { config: aiConfig } = useAiProviderSettings();
 
   const { data: standardLibrary, isLoading: isLoadingStandardLibrary } =
     useQuery({
@@ -185,6 +207,9 @@ export function useComponentSearchV2State(
   const [rerankBaseMatches, setRerankBaseMatches] = useState<LexicalMatch[]>(
     [],
   );
+  const [isEmbeddingSearchPending, setIsEmbeddingSearchPending] =
+    useState(false);
+  const embeddingAbortControllerRef = useRef<AbortController | null>(null);
 
   const clearRerank = () => {
     setRerankedFor(null);
@@ -194,26 +219,93 @@ export function useComponentSearchV2State(
   useEffect(() => {
     setRerankedFor(null);
     setRerankBaseMatches([]);
+    embeddingAbortControllerRef.current?.abort();
   }, [query]);
+
+  useEffect(() => {
+    return () => embeddingAbortControllerRef.current?.abort();
+  }, []);
 
   const isRerankActive =
     rerankedFor === trimmedQuery &&
     rerankBaseMatches.length > 0 &&
     !isReranking &&
+    !isEmbeddingSearchPending &&
     (rerankData?.matches.length ?? 0) > 0;
 
   const displayedMatches = isRerankActive
     ? rerankedMatches(rerankData, rerankBaseMatches)
     : lexicalMatches;
 
-  const startRerank = (
-    matches: LexicalMatch[],
-    { scoreAllCandidates }: { scoreAllCandidates: boolean },
-  ) => {
-    if (!trimmedQuery || matches.length === 0 || !isConfigured) return;
+  const buildEmbeddingMatches = async ({
+    sourceIndex,
+    limit,
+  }: {
+    sourceIndex: IndexEntry[];
+    limit: number;
+  }): Promise<LexicalMatch[]> => {
+    if (!aiConfig.apiBase.trim()) return [];
+    embeddingAbortControllerRef.current?.abort();
+    const abortController = new AbortController();
+    embeddingAbortControllerRef.current = abortController;
+    setIsEmbeddingSearchPending(true);
+    try {
+      return await rankComponentMatchesByEmbeddings(
+        sourceIndex,
+        trimmedQuery,
+        {
+          apiBase: aiConfig.apiBase,
+          apiKey: aiConfig.apiKey,
+          signal: abortController.signal,
+        },
+        { limit },
+      );
+    } catch {
+      return [];
+    } finally {
+      if (embeddingAbortControllerRef.current === abortController) {
+        embeddingAbortControllerRef.current = null;
+        setIsEmbeddingSearchPending(false);
+      }
+    }
+  };
 
-    const rerankBase = matches;
-    const candidates = rerankBase
+  const startRerank = async (
+    matches: LexicalMatch[],
+    {
+      scoreAllCandidates,
+      useEmbeddings,
+      limit,
+    }: {
+      scoreAllCandidates: boolean;
+      useEmbeddings: boolean;
+      limit: number;
+    },
+  ) => {
+    if (!trimmedQuery || !isConfigured) return;
+
+    const canUseEmbeddings =
+      useEmbeddings && aiConfig.apiBase.trim().length > 0;
+    if (matches.length === 0 && !canUseEmbeddings) return;
+
+    const effectiveLimit = limit || LEXICAL_RESULT_LIMIT;
+    const embeddingMatches = canUseEmbeddings
+      ? await buildEmbeddingMatches({
+          sourceIndex: index,
+          limit: effectiveLimit,
+        })
+      : [];
+    const lexicalMatchesToKeep = useEmbeddings
+      ? matches.slice(0, Math.min(60, effectiveLimit))
+      : matches;
+    const rerankMatches = mergeUniqueMatches(
+      lexicalMatchesToKeep,
+      embeddingMatches,
+      matches,
+      effectiveLimit,
+    );
+
+    const candidates = rerankMatches
       .map((match) =>
         componentReferenceToCandidate(match.reference, match.source),
       )
@@ -223,14 +315,16 @@ export function useComponentSearchV2State(
 
     if (candidates.length === 0) return;
 
-    setRerankBaseMatches(rerankBase);
+    setRerankBaseMatches(rerankMatches);
     setRerankedFor(trimmedQuery);
     mutate({ query: trimmedQuery, candidates, scoreAllCandidates });
   };
 
   const rerank = () => {
-    startRerank(aiCandidateMatches, {
+    void startRerank(aiCandidateMatches, {
       scoreAllCandidates: true,
+      useEmbeddings: true,
+      limit: aiCandidateMatches.length,
     });
   };
 
@@ -255,8 +349,10 @@ export function useComponentSearchV2State(
       isLoadingRegistered ||
       isHydrating,
     canRerank:
-      trimmedQuery.length > 0 && aiCandidateMatches.length > 0 && isConfigured,
-    isReranking,
+      trimmedQuery.length > 0 &&
+      (aiCandidateMatches.length > 0 || aiConfig.apiBase.trim().length > 0) &&
+      isConfigured,
+    isReranking: isReranking || isEmbeddingSearchPending,
     isRerankActive,
     rerank,
     clearRerank,

--- a/src/services/componentSearchEmbeddings.test.ts
+++ b/src/services/componentSearchEmbeddings.test.ts
@@ -1,0 +1,233 @@
+import "fake-indexeddb/auto";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  buildSearchIndex,
+  type ComponentSearchSource,
+  type SourcedReference,
+} from "@/services/componentSearchIndex";
+import type { ComponentReference } from "@/utils/componentSpec";
+import { isRecord } from "@/utils/typeGuards";
+
+import {
+  buildComponentEmbeddingText,
+  clearComponentSearchEmbeddingCache,
+  rankComponentMatchesByEmbeddings,
+} from "./componentSearchEmbeddings";
+
+const STANDARD: ComponentSearchSource = {
+  kind: "standard",
+  label: "Standard",
+  id: "standard",
+};
+
+const OPTIONS = {
+  apiBase: "https://api.example.com/v1",
+  apiKey: "sk-test",
+};
+
+function makeSourced(reference: ComponentReference): SourcedReference {
+  return { reference, source: STANDARD };
+}
+
+function embeddingForText(text: string): number[] {
+  if (/spreadsheet|csv|tabular|dataframe/i.test(text)) return [1, 0, 0];
+  if (/train|model|classifier/i.test(text)) return [0, 1, 0];
+  return [0, 0, 1];
+}
+
+function readFetchInput(init: RequestInit | undefined): string[] {
+  if (!init || typeof init.body !== "string") {
+    throw new Error("Expected fetch body");
+  }
+  const body: unknown = JSON.parse(init.body);
+  if (!isRecord(body) || !Array.isArray(body.input)) {
+    throw new Error("Expected embeddings input array");
+  }
+  return body.input.filter(
+    (value): value is string => typeof value === "string",
+  );
+}
+
+describe("component search embeddings", () => {
+  beforeEach(() => {
+    global.fetch = vi.fn(
+      async (_url: string | URL | Request, init?: RequestInit) => {
+        const input = readFetchInput(init);
+        return new Response(
+          JSON.stringify({
+            data: input.map((text, index) => ({
+              index,
+              embedding: embeddingForText(text),
+            })),
+          }),
+          { status: 200, statusText: "OK" },
+        );
+      },
+    );
+  });
+
+  afterEach(async () => {
+    await clearComponentSearchEmbeddingCache();
+    vi.restoreAllMocks();
+  });
+
+  it("builds embedding text from component metadata", () => {
+    const index = buildSearchIndex([
+      makeSourced({
+        digest: "csv",
+        published_by: "publisher@example.com",
+        spec: {
+          name: "load_csv_file",
+          description: "Read a CSV file.",
+          inputs: [{ name: "path", type: "String", description: "File path" }],
+          outputs: [{ name: "table", type: "Dataset" }],
+          implementation: { container: { image: "x" } },
+        },
+      }),
+    ]);
+
+    const text = buildComponentEmbeddingText(index[0]);
+
+    expect(text).toContain("load_csv_file");
+    expect(text).toContain("Read a CSV file");
+    expect(text).toContain("File path");
+    expect(text).toContain("Dataset");
+    expect(text).toContain("Standard");
+    expect(text).toContain("publisher@example.com");
+  });
+
+  it("ranks components by cosine similarity", async () => {
+    const index = buildSearchIndex([
+      makeSourced({
+        digest: "train",
+        spec: {
+          name: "train_model",
+          description: "Train a classifier.",
+          inputs: [],
+          outputs: [],
+          implementation: { container: { image: "x" } },
+        },
+      }),
+      makeSourced({
+        digest: "csv",
+        spec: {
+          name: "load_csv_file",
+          description: "Read a CSV file into a tabular dataframe.",
+          inputs: [],
+          outputs: [],
+          implementation: { container: { image: "x" } },
+        },
+      }),
+    ]);
+
+    const results = await rankComponentMatchesByEmbeddings(
+      index,
+      "open a spreadsheet",
+      OPTIONS,
+      { limit: 2 },
+    );
+
+    expect(results[0]?.digest).toBe("csv");
+  });
+
+  it("requests cache misses in batches", async () => {
+    const index = buildSearchIndex(
+      Array.from({ length: 257 }, (_, index) =>
+        makeSourced({
+          digest: `component-${index}`,
+          spec: {
+            name: `component_${index}`,
+            description: "Read a CSV file into a tabular dataframe.",
+            inputs: [],
+            outputs: [],
+            implementation: { container: { image: "x" } },
+          },
+        }),
+      ),
+    );
+
+    await rankComponentMatchesByEmbeddings(index, "open a spreadsheet", OPTIONS, {
+      limit: 1,
+    });
+
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("invalidates a cached component embedding when its text changes", async () => {
+    const initialIndex = buildSearchIndex([
+      makeSourced({
+        digest: "component",
+        spec: {
+          name: "load_csv_file",
+          description: "Read a CSV file into a tabular dataframe.",
+          inputs: [],
+          outputs: [],
+          implementation: { container: { image: "x" } },
+        },
+      }),
+    ]);
+    const updatedIndex = buildSearchIndex([
+      makeSourced({
+        digest: "component",
+        spec: {
+          name: "load_csv_file",
+          description: "Train a classifier.",
+          inputs: [],
+          outputs: [],
+          implementation: { container: { image: "x" } },
+        },
+      }),
+    ]);
+
+    await rankComponentMatchesByEmbeddings(
+      initialIndex,
+      "open a spreadsheet",
+      OPTIONS,
+      { limit: 1 },
+    );
+    await rankComponentMatchesByEmbeddings(
+      updatedIndex,
+      "open a spreadsheet",
+      OPTIONS,
+      { limit: 1 },
+    );
+
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("caches query and component embeddings in IndexedDB", async () => {
+    const index = buildSearchIndex([
+      makeSourced({
+        digest: "csv",
+        spec: {
+          name: "load_csv_file",
+          description: "Read a CSV file into a tabular dataframe.",
+          inputs: [],
+          outputs: [],
+          implementation: { container: { image: "x" } },
+        },
+      }),
+    ]);
+
+    await rankComponentMatchesByEmbeddings(
+      index,
+      "open a spreadsheet",
+      OPTIONS,
+      {
+        limit: 1,
+      },
+    );
+    await rankComponentMatchesByEmbeddings(
+      index,
+      "open a spreadsheet",
+      OPTIONS,
+      {
+        limit: 1,
+      },
+    );
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/services/componentSearchEmbeddings.ts
+++ b/src/services/componentSearchEmbeddings.ts
@@ -1,0 +1,305 @@
+import { Dexie, type EntityTable } from "dexie";
+
+import {
+  type IndexEntry,
+  indexEntryToLexicalMatch,
+  type LexicalMatch,
+} from "@/services/componentSearchIndex";
+import { isRecord } from "@/utils/typeGuards";
+
+const COMPONENT_SEARCH_EMBEDDING_MODEL = "text-embedding-3-small";
+const DB_NAME = "tangle_component_search_embeddings";
+const CACHE_SCHEMA_VERSION = 1;
+// The embeddings endpoint caps a single request at 2048 inputs (plus a token
+// budget), so batch well under that — otherwise a large cold-cache library
+// sends the whole index in one request and 400s, silently disabling the layer.
+const EMBEDDING_BATCH_SIZE = 256;
+const CACHE_MAX_ENTRIES = 2_000;
+const CACHE_TTL_MS = 30 * 24 * 60 * 60 * 1_000;
+
+interface ComponentSearchEmbeddingCacheEntry {
+  cacheKey: string;
+  embeddingModel: string;
+  textHash: string;
+  // Stored alongside the hash so a 32-bit-hash collision is caught as a cache
+  // miss: a matching key must agree on both the hash and the text length.
+  textLength: number;
+  embedding: number[];
+  updatedAt: number;
+}
+
+const componentSearchEmbeddingDb = new Dexie(DB_NAME) as Dexie & {
+  embeddings: EntityTable<ComponentSearchEmbeddingCacheEntry, "cacheKey">;
+};
+
+componentSearchEmbeddingDb.version(1).stores({
+  embeddings: "cacheKey, embeddingModel, textHash, updatedAt",
+});
+
+interface EmbeddingOptions {
+  apiBase: string;
+  apiKey: string;
+  signal?: AbortSignal;
+}
+
+interface RankOptions {
+  limit: number;
+}
+
+function hashText(text: string): string {
+  let hash = 2166136261;
+  for (let i = 0; i < text.length; i++) {
+    hash ^= text.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0).toString(16);
+}
+
+function cacheKey(text: string): string {
+  return `${CACHE_SCHEMA_VERSION}:${COMPONENT_SEARCH_EMBEDDING_MODEL}:${hashText(text)}`;
+}
+
+function stringifyEmbeddingField(value: unknown): string {
+  if (typeof value === "string") return value.trim();
+  if (value === null || value === undefined) return "";
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return "";
+  }
+}
+
+function isNumberArray(value: unknown): value is number[] {
+  return (
+    Array.isArray(value) && value.every((item) => typeof item === "number")
+  );
+}
+
+function readEmbeddingResponse(
+  payload: unknown,
+  expectedCount: number,
+): number[][] {
+  if (!isRecord(payload) || !Array.isArray(payload.data)) return [];
+
+  const rows = payload.data
+    .map((row, fallbackIndex) => {
+      if (!isRecord(row) || !isNumberArray(row.embedding)) return null;
+      const index = typeof row.index === "number" ? row.index : fallbackIndex;
+      return { index, embedding: row.embedding };
+    })
+    .filter(
+      (row): row is { index: number; embedding: number[] } => row !== null,
+    )
+    .sort((a, b) => a.index - b.index);
+
+  if (rows.length !== expectedCount) return [];
+  return rows.map((row) => row.embedding);
+}
+
+async function fetchEmbeddings(
+  texts: string[],
+  options: EmbeddingOptions,
+): Promise<number[][]> {
+  const base = options.apiBase.trim().replace(/\/+$/, "");
+  if (!base) return [];
+
+  const response = await fetch(`${base}/embeddings`, {
+    method: "POST",
+    signal: options.signal,
+    headers: {
+      "content-type": "application/json",
+      ...(options.apiKey.trim()
+        ? { authorization: `Bearer ${options.apiKey.trim()}` }
+        : {}),
+    },
+    body: JSON.stringify({
+      model: COMPONENT_SEARCH_EMBEDDING_MODEL,
+      input: texts,
+    }),
+  });
+
+  if (!response.ok) {
+    const detail = await response.text().catch(() => "");
+    throw new Error(
+      `Embeddings API returned ${response.status}: ${detail.slice(0, 200) || response.statusText}`,
+    );
+  }
+
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch {
+    throw new Error("Embeddings API returned a non-JSON response");
+  }
+
+  const embeddings = readEmbeddingResponse(payload, texts.length);
+  if (embeddings.length === 0) {
+    throw new Error("Embeddings API returned no usable embeddings");
+  }
+  return embeddings;
+}
+
+async function embedTextsWithCache(
+  texts: string[],
+  options: EmbeddingOptions,
+): Promise<Map<string, number[]>> {
+  const uniqueTexts = [
+    ...new Set(texts.map((text) => text.trim()).filter(Boolean)),
+  ];
+  const keys = uniqueTexts.map(cacheKey);
+  const cachedRows = await componentSearchEmbeddingDb.embeddings.bulkGet(keys);
+  const now = Date.now();
+  const expiresBefore = now - CACHE_TTL_MS;
+
+  const result = new Map<string, number[]>();
+  const missingTexts: string[] = [];
+  for (let i = 0; i < uniqueTexts.length; i++) {
+    const cached = cachedRows[i];
+    if (
+      cached &&
+      cached.embeddingModel === COMPONENT_SEARCH_EMBEDDING_MODEL &&
+      cached.textHash === hashText(uniqueTexts[i]) &&
+      cached.textLength === uniqueTexts[i].length &&
+      cached.updatedAt >= expiresBefore
+    ) {
+      result.set(uniqueTexts[i], cached.embedding);
+    } else {
+      missingTexts.push(uniqueTexts[i]);
+    }
+  }
+
+  if (missingTexts.length === 0) return result;
+
+  // Batch the cache-missing texts: a single request over the whole index can
+  // exceed the embeddings endpoint's input/token limits and 400.
+  const embeddings: number[][] = [];
+  for (
+    let start = 0;
+    start < missingTexts.length;
+    start += EMBEDDING_BATCH_SIZE
+  ) {
+    const batch = missingTexts.slice(start, start + EMBEDDING_BATCH_SIZE);
+    embeddings.push(...(await fetchEmbeddings(batch, options)));
+  }
+
+  try {
+    await componentSearchEmbeddingDb.embeddings.bulkPut(
+      missingTexts.map((text, index) => ({
+        cacheKey: cacheKey(text),
+        embeddingModel: COMPONENT_SEARCH_EMBEDDING_MODEL,
+        textHash: hashText(text),
+        textLength: text.length,
+        embedding: embeddings[index],
+        updatedAt: now,
+      })),
+    );
+    await pruneEmbeddingCache(now);
+  } catch {
+    // Persisting to IndexedDB failed (e.g. QuotaExceededError). The embeddings
+    // are still returned below — only the cache write is skipped — so search
+    // degrades to "recompute next time" rather than silently returning nothing.
+  }
+  for (let i = 0; i < missingTexts.length; i++) {
+    result.set(missingTexts[i], embeddings[i]);
+  }
+
+  return result;
+}
+
+async function pruneEmbeddingCache(now: number): Promise<void> {
+  const expiresBefore = now - CACHE_TTL_MS;
+  await componentSearchEmbeddingDb.embeddings
+    .where("updatedAt")
+    .below(expiresBefore)
+    .delete();
+
+  const count = await componentSearchEmbeddingDb.embeddings.count();
+  if (count <= CACHE_MAX_ENTRIES) return;
+
+  const staleRows = await componentSearchEmbeddingDb.embeddings
+    .orderBy("updatedAt")
+    .limit(count - CACHE_MAX_ENTRIES)
+    .primaryKeys();
+  await componentSearchEmbeddingDb.embeddings.bulkDelete(staleRows);
+}
+
+function cosineSimilarity(a: number[], b: number[]): number {
+  if (a.length !== b.length) return 0;
+  let dot = 0;
+  let normA = 0;
+  let normB = 0;
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i] * b[i];
+    normA += a[i] * a[i];
+    normB += b[i] * b[i];
+  }
+  const denominator = Math.sqrt(normA) * Math.sqrt(normB);
+  return denominator === 0 ? 0 : dot / denominator;
+}
+
+export function buildComponentEmbeddingText(entry: IndexEntry): string {
+  const spec = entry.reference.spec;
+  const ioParts = [...(spec?.inputs ?? []), ...(spec?.outputs ?? [])].flatMap(
+    (ioSpec) => [
+      ioSpec.name,
+      ioSpec.description,
+      stringifyEmbeddingField(ioSpec.type),
+    ],
+  );
+
+  return [
+    entry.name,
+    spec?.description,
+    ...ioParts,
+    entry.source.label,
+    entry.reference.published_by,
+  ]
+    .filter(
+      (part): part is string =>
+        typeof part === "string" && part.trim().length > 0,
+    )
+    .join("\n");
+}
+
+export async function rankComponentMatchesByEmbeddings(
+  index: IndexEntry[],
+  query: string,
+  options: EmbeddingOptions,
+  { limit }: RankOptions,
+): Promise<LexicalMatch[]> {
+  const trimmedQuery = query.trim();
+  if (trimmedQuery.length === 0 || index.length === 0 || limit <= 0) return [];
+
+  const textByDigest = new Map<string, string>();
+  const texts = [trimmedQuery];
+  for (const entry of index) {
+    const text = buildComponentEmbeddingText(entry);
+    if (!text) continue;
+    textByDigest.set(entry.digest, text);
+    texts.push(text);
+  }
+
+  const embeddings = await embedTextsWithCache(texts, options);
+  const queryEmbedding = embeddings.get(trimmedQuery);
+  if (!queryEmbedding) return [];
+
+  return index
+    .map((entry) => {
+      const text = textByDigest.get(entry.digest);
+      const embedding = text ? embeddings.get(text) : undefined;
+      return {
+        entry,
+        score: embedding ? cosineSimilarity(queryEmbedding, embedding) : 0,
+      };
+    })
+    .filter((item) => item.score > 0)
+    .sort(
+      (a, b) => b.score - a.score || a.entry.name.localeCompare(b.entry.name),
+    )
+    .slice(0, limit)
+    .map((item) => indexEntryToLexicalMatch(item.entry));
+}
+
+export async function clearComponentSearchEmbeddingCache(): Promise<void> {
+  await componentSearchEmbeddingDb.embeddings.clear();
+}


### PR DESCRIPTION
## Description

Adds embedding-based semantic search as a pre-processing step before LLM reranking. When an AI provider API base is configured, the component search now fetches text embeddings for both the search query and all indexed components, ranks them by cosine similarity, and merges those results with the top lexical matches before passing candidates to the LLM reranker. This improves the quality of candidates surfaced to the reranker, particularly for queries that don't share keywords with component names or descriptions.

A new `componentSearchEmbeddings` service handles embedding generation, cosine similarity scoring, and persistent caching of embeddings in IndexedDB (keyed by a FNV-1a hash of the text and model name) to avoid redundant API calls across searches. A `mergeUniqueMatches` helper deduplicates and merges lexical and embedding results by digest before reranking.

The embedding fetch is tracked with an `isEmbeddingSearchPending` flag, which gates the rerank active state and disables the AI search buttons while in progress, keeping the spinner and disabled states consistent with the existing reranking UX.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Configure an OpenAI-compatible API base (e.g. `https://api.openai.com/v1`) in AI provider settings.
2. Open the component search panel and enter a query that is semantically related to a component but does not share exact keywords.
3. Click the AI search (Sparkles) button and verify the spinner appears during both the embedding fetch and reranking phases.
4. Confirm that results are ranked by semantic relevance.
5. Repeat the same search and verify via network tooling that no additional embedding API calls are made (cache hit).
6. Verify that searches still work correctly when no API base is configured (embedding step is skipped gracefully).

## Additional Comments

The embedding model is hardcoded to `text-embedding-3-small`. If no `apiBase` is set, the embedding step is skipped entirely and behaviour is identical to before this change.