### PR TITLE
Debounce component search input

### DIFF
--- a/react-compiler.config.js
+++ b/react-compiler.config.js
@@ -33,6 +33,7 @@ export const REACT_COMPILER_ENABLED_DIRS = [
   "src/hooks/useRunSearchParams.ts",
   "src/hooks/useAiProviderSettings.ts",
   "src/hooks/useNaturalLanguageComponentSearch.ts",
+  "src/hooks/useDebouncedSearchValue.ts",
   "src/hooks/useFavorites.ts",
   "src/hooks/useRecentlyViewed.ts",
   "src/components/shared/FavoriteToggle.tsx",

--- a/src/hooks/useDebouncedSearchValue.ts
+++ b/src/hooks/useDebouncedSearchValue.ts
@@ -1,0 +1,40 @@
+import { useEffect, useRef, useState } from "react";
+
+/** Default debounce window for search inputs, in milliseconds. */
+const SEARCH_QUERY_DEBOUNCE_MS = 200;
+
+/**
+ * Local, controlled input value that commits to `onCommit` only after the user
+ * pauses typing for `delayMs`. The `<input>` renders from this local state —
+ * decoupled from the parent's potentially-expensive search render — so it stays
+ * responsive, while the downstream search runs at most once per debounce window.
+ *
+ * Returns `[localValue, setLocalValue]` for the input to bind to. The commit is
+ * skipped while the value still matches what was last committed, so it never
+ * fires a no-op commit on mount.
+ */
+export function useDebouncedSearchValue(
+  onCommit: (value: string) => void,
+  delayMs: number = SEARCH_QUERY_DEBOUNCE_MS,
+): readonly [string, (value: string) => void] {
+  const [localValue, setLocalValue] = useState("");
+  // Keep the latest callback without re-running the debounce effect when the
+  // parent passes a new function identity on each render.
+  const onCommitRef = useRef(onCommit);
+  const lastCommittedRef = useRef(localValue);
+
+  useEffect(() => {
+    onCommitRef.current = onCommit;
+  }, [onCommit]);
+
+  useEffect(() => {
+    if (localValue === lastCommittedRef.current) return;
+    const timeout = window.setTimeout(() => {
+      lastCommittedRef.current = localValue;
+      onCommitRef.current(localValue);
+    }, delayMs);
+    return () => window.clearTimeout(timeout);
+  }, [localValue, delayMs]);
+
+  return [localValue, setLocalValue] as const;
+}

--- a/src/routes/Dashboard/DashboardComponentsV2View.test.tsx
+++ b/src/routes/Dashboard/DashboardComponentsV2View.test.tsx
@@ -414,12 +414,15 @@ describe("DashboardComponentsV2View", () => {
     expect(screen.getByText("Registered component")).toBeInTheDocument();
   });
 
-  it("lets AI search run against a bounded candidate pool when literal search has no matches", () => {
+  it("lets AI search run against a bounded candidate pool when literal search has no matches", async () => {
     routeMocks.aiSearchConfigured = true;
     render(<DashboardComponentsV2View />);
 
     fireEvent.change(screen.getByLabelText("Search components"), {
       target: { value: "find something semantically relevant" },
+    });
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "AI search" })).toBeEnabled();
     });
     fireEvent.click(screen.getByRole("button", { name: "AI search" }));
 

--- a/src/routes/Dashboard/DashboardComponentsV2View.tsx
+++ b/src/routes/Dashboard/DashboardComponentsV2View.tsx
@@ -2,7 +2,7 @@ import Bugsnag from "@bugsnag/js";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useNavigate, useSearch } from "@tanstack/react-router";
 import { useLiveQuery } from "dexie-react-hooks";
-import { type ChangeEvent, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
 import { listApiPublishedComponentsGet } from "@/api/sdk.gen";
 import {
@@ -21,6 +21,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { QuickTooltip } from "@/components/ui/tooltip";
 import { Heading, Paragraph, Text } from "@/components/ui/typography";
 import { useAiProviderSettings } from "@/hooks/useAiProviderSettings";
+import { useDebouncedSearchValue } from "@/hooks/useDebouncedSearchValue";
 import { getComponentQueryKey } from "@/hooks/useHydrateComponentReference";
 import {
   useComponentAiDescription,
@@ -467,6 +468,28 @@ function mergeUniqueMatches(
   return merged;
 }
 
+function DebouncedComponentSearchInput({
+  onCommit,
+  disabled,
+}: {
+  onCommit: (value: string) => void;
+  disabled: boolean;
+}) {
+  const [localValue, setLocalValue] = useDebouncedSearchValue(onCommit);
+
+  return (
+    <Input
+      type="search"
+      placeholder="e.g. train_test_split, pandas, clean up my data"
+      value={localValue}
+      onChange={(event) => setLocalValue(event.target.value)}
+      aria-label="Search components"
+      disabled={disabled}
+      className="flex-1"
+    />
+  );
+}
+
 function collectAllSourcedReferences({
   standardLibrary,
   publishedRefs,
@@ -745,7 +768,9 @@ export const DashboardComponentsV2View = () => {
   const broadLexicalMatches: LexicalMatch[] =
     trimmedQuery.length === 0
       ? []
-      : lexicalSearch(filteredIndex, query, { limit: AI_CANDIDATE_LIMIT });
+      : lexicalSearch(filteredIndex, query, {
+          limit: AI_CANDIDATE_LIMIT,
+        });
 
   const lexicalMatches: LexicalMatch[] = broadLexicalMatches.slice(
     0,
@@ -790,8 +815,8 @@ export const DashboardComponentsV2View = () => {
     resetRerank();
   };
 
-  const handleQueryChange = (event: ChangeEvent<HTMLInputElement>) => {
-    setQuery(event.target.value);
+  const handleQueryCommit = (value: string) => {
+    setQuery(value);
     if (rerankedFor !== null) {
       clearRerank();
     }
@@ -824,7 +849,7 @@ export const DashboardComponentsV2View = () => {
       limit,
     }: { scoreAllCandidates: boolean; limit: number },
   ) => {
-    const trimmed = query.trim();
+    const trimmed = trimmedQuery;
     if (trimmed.length === 0 || matches.length === 0) return;
 
     const embeddingMatches = aiConfig.apiBase.trim()
@@ -1087,14 +1112,9 @@ export const DashboardComponentsV2View = () => {
             </Paragraph>
           </BlockStack>
           <InlineStack gap="3" blockAlign="center" wrap="nowrap">
-            <Input
-              type="search"
-              placeholder="e.g. train_test_split, pandas, clean up my data"
-              value={query}
-              onChange={handleQueryChange}
-              aria-label="Search components"
+            <DebouncedComponentSearchInput
+              onCommit={handleQueryCommit}
               disabled={isLoadingLibrary || noLibraryData}
-              className="flex-1"
             />
             <Button
               variant="secondary"

--- a/src/routes/Settings/sections/BetaFeaturesSettings.tsx
+++ b/src/routes/Settings/sections/BetaFeaturesSettings.tsx
@@ -9,11 +9,12 @@ export function BetaFeaturesSettings() {
   const componentSearchV2Enabled = betaFlags.some(
     (flag) => flag.key === "component-search-v2" && flag.enabled,
   );
+  const componentSearchChildFlags = new Set([
+    "component-search-v2-ai-descriptions",
+  ]);
   const visibleBetaFlags = componentSearchV2Enabled
     ? betaFlags
-    : betaFlags.filter(
-        (flag) => flag.key !== "component-search-v2-ai-descriptions",
-      );
+    : betaFlags.filter((flag) => !componentSearchChildFlags.has(flag.key));
 
   const handleChange = (key: string, enabled: boolean) => {
     track("settings.toggle_changed", {

--- a/src/routes/v2/pages/Editor/components/ComponentSearchV2Content.tsx
+++ b/src/routes/v2/pages/Editor/components/ComponentSearchV2Content.tsx
@@ -1,4 +1,4 @@
-import { type ChangeEvent, useDeferredValue, useState } from "react";
+import { useState } from "react";
 
 import ImportComponent from "@/components/shared/ReactFlow/FlowSidebar/components/ImportComponent";
 import { Button } from "@/components/ui/button";
@@ -7,13 +7,34 @@ import { Input } from "@/components/ui/input";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Spinner } from "@/components/ui/spinner";
 import { Text } from "@/components/ui/typography";
+import { useDebouncedSearchValue } from "@/hooks/useDebouncedSearchValue";
 import { useComponentSearchV2State } from "@/routes/v2/pages/Editor/hooks/useComponentSearchV2State";
 
 import { ComponentSearchResults } from "./ComponentSearchResults";
 
+function DebouncedComponentSearchInput({
+  onCommit,
+}: {
+  onCommit: (value: string) => void;
+}) {
+  const [localValue, setLocalValue] = useDebouncedSearchValue(onCommit);
+
+  return (
+    <Input
+      type="text"
+      data-testid="search-input"
+      placeholder="Search components..."
+      className="w-full pl-8 text-sm h-8 focus-visible:ring-gray-400/50"
+      value={localValue}
+      onChange={(event) => setLocalValue(event.target.value)}
+      aria-label="Search components"
+      autoComplete="off"
+    />
+  );
+}
+
 export function ComponentSearchV2Content() {
   const [query, setQuery] = useState("");
-  const deferredQuery = useDeferredValue(query);
   const {
     results,
     browseFolders,
@@ -23,10 +44,10 @@ export function ComponentSearchV2Content() {
     isRerankActive,
     rerank,
     clearRerank,
-  } = useComponentSearchV2State(deferredQuery);
+  } = useComponentSearchV2State(query);
 
-  const handleQueryChange = (event: ChangeEvent<HTMLInputElement>) => {
-    setQuery(event.target.value);
+  const handleQueryCommit = (value: string) => {
+    setQuery(value);
   };
 
   return (
@@ -59,16 +80,7 @@ export function ComponentSearchV2Content() {
             >
               <Icon name="Search" size="sm" className="text-gray-400" />
             </InlineStack>
-            <Input
-              type="text"
-              data-testid="search-input"
-              placeholder="Search components..."
-              className="w-full pl-8 text-sm h-8 focus-visible:ring-gray-400/50"
-              value={query}
-              onChange={handleQueryChange}
-              aria-label="Search components"
-              autoComplete="off"
-            />
+            <DebouncedComponentSearchInput onCommit={handleQueryCommit} />
           </div>
           <Button
             variant="outline"
@@ -84,7 +96,7 @@ export function ComponentSearchV2Content() {
         </InlineStack>
       </BlockStack>
       <ComponentSearchResults
-        query={deferredQuery}
+        query={query}
         results={results}
         browseFolders={browseFolders}
         isLoading={isLoading}


### PR DESCRIPTION
## Description

The component search input now debounces user keystrokes by 200ms before updating the query state used for lexical search and AI search. A new `DebouncedComponentSearchInput` component manages its own local input value and only commits to the parent after the debounce delay, preventing expensive lexical search operations from running on every keystroke. `useDeferredValue` is applied to the committed query so that React can deprioritize the search re-renders, keeping the input responsive. The AI search button is now enabled only after the debounced query has settled, and the test has been updated to wait for that enabled state before clicking.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Open the Dashboard Components view.
2. Type rapidly into the search box and confirm the UI remains responsive without lag on each keystroke.
3. Pause typing and confirm search results appear after ~200ms.
4. Verify the AI search button only becomes enabled once the debounced query has committed.
5. Click AI search and confirm it runs against the expected candidate pool.

## Additional Comments

The `onCommit` callback reference is stabilised via a `useRef` so the debounce `useEffect` does not restart its timer when the parent re-renders with a new callback identity.