### PR TITLE
feat: Onboarding Welcome Page

### DIFF
--- a/src/components/Onboarding/IndexRedirect.test.tsx
+++ b/src/components/Onboarding/IndexRedirect.test.tsx
@@ -7,7 +7,7 @@ vi.mock("@tanstack/react-router", () => ({
   Navigate: ({ to }: { to: string }) => <div data-testid="navigate">{to}</div>,
 }));
 
-let onboarding = { isReady: true, isComplete: false, dismissed: false };
+let onboarding = { isResolved: true, shouldShowOnboarding: true };
 vi.mock("@/providers/OnboardingProvider/OnboardingProvider", () => ({
   useOnboarding: () => onboarding,
 }));
@@ -17,26 +17,20 @@ afterEach(cleanup);
 const target = () => screen.queryByTestId("navigate");
 
 describe("IndexRedirect", () => {
-  it("waits (no redirect) until onboarding state is ready", () => {
-    onboarding = { isReady: false, isComplete: false, dismissed: false };
+  it("waits (no redirect) until onboarding state is resolved", () => {
+    onboarding = { isResolved: false, shouldShowOnboarding: false };
     render(<IndexRedirect />);
     expect(target()).toBeNull();
   });
 
-  it("redirects to /welcome while onboarding is active", () => {
-    onboarding = { isReady: true, isComplete: false, dismissed: false };
+  it("redirects to /welcome while onboarding should show", () => {
+    onboarding = { isResolved: true, shouldShowOnboarding: true };
     render(<IndexRedirect />);
     expect(target()).toHaveTextContent("/welcome");
   });
 
-  it("redirects to /dashboard once complete", () => {
-    onboarding = { isReady: true, isComplete: true, dismissed: false };
-    render(<IndexRedirect />);
-    expect(target()).toHaveTextContent("/dashboard");
-  });
-
-  it("redirects to /dashboard once dismissed", () => {
-    onboarding = { isReady: true, isComplete: false, dismissed: true };
+  it("redirects to /dashboard when onboarding should not show", () => {
+    onboarding = { isResolved: true, shouldShowOnboarding: false };
     render(<IndexRedirect />);
     expect(target()).toHaveTextContent("/dashboard");
   });

--- a/src/components/Onboarding/IndexRedirect.test.tsx
+++ b/src/components/Onboarding/IndexRedirect.test.tsx
@@ -1,0 +1,43 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { IndexRedirect } from "./IndexRedirect";
+
+vi.mock("@tanstack/react-router", () => ({
+  Navigate: ({ to }: { to: string }) => <div data-testid="navigate">{to}</div>,
+}));
+
+let onboarding = { isReady: true, isComplete: false, dismissed: false };
+vi.mock("@/providers/OnboardingProvider/OnboardingProvider", () => ({
+  useOnboarding: () => onboarding,
+}));
+
+afterEach(cleanup);
+
+const target = () => screen.queryByTestId("navigate");
+
+describe("IndexRedirect", () => {
+  it("waits (no redirect) until onboarding state is ready", () => {
+    onboarding = { isReady: false, isComplete: false, dismissed: false };
+    render(<IndexRedirect />);
+    expect(target()).toBeNull();
+  });
+
+  it("redirects to /welcome while onboarding is active", () => {
+    onboarding = { isReady: true, isComplete: false, dismissed: false };
+    render(<IndexRedirect />);
+    expect(target()).toHaveTextContent("/welcome");
+  });
+
+  it("redirects to /dashboard once complete", () => {
+    onboarding = { isReady: true, isComplete: true, dismissed: false };
+    render(<IndexRedirect />);
+    expect(target()).toHaveTextContent("/dashboard");
+  });
+
+  it("redirects to /dashboard once dismissed", () => {
+    onboarding = { isReady: true, isComplete: false, dismissed: true };
+    render(<IndexRedirect />);
+    expect(target()).toHaveTextContent("/dashboard");
+  });
+});

--- a/src/components/Onboarding/IndexRedirect.tsx
+++ b/src/components/Onboarding/IndexRedirect.tsx
@@ -1,0 +1,26 @@
+import { Navigate } from "@tanstack/react-router";
+
+import { BlockStack } from "@/components/ui/layout";
+import { Spinner } from "@/components/ui/spinner";
+import { useOnboarding } from "@/providers/OnboardingProvider/OnboardingProvider";
+import { APP_ROUTES } from "@/routes/appRoutes";
+
+export function IndexRedirect() {
+  const { isReady, isComplete, dismissed } = useOnboarding();
+
+  if (!isReady) {
+    return (
+      <BlockStack align="center" inlineAlign="center" className="h-full">
+        <Spinner />
+      </BlockStack>
+    );
+  }
+
+  const showOnboarding = !isComplete && !dismissed;
+  return (
+    <Navigate
+      replace
+      to={showOnboarding ? APP_ROUTES.WELCOME : APP_ROUTES.DASHBOARD}
+    />
+  );
+}

--- a/src/components/Onboarding/IndexRedirect.tsx
+++ b/src/components/Onboarding/IndexRedirect.tsx
@@ -6,9 +6,9 @@ import { useOnboarding } from "@/providers/OnboardingProvider/OnboardingProvider
 import { APP_ROUTES } from "@/routes/appRoutes";
 
 export function IndexRedirect() {
-  const { isReady, isComplete, dismissed } = useOnboarding();
+  const { isResolved, shouldShowOnboarding } = useOnboarding();
 
-  if (!isReady) {
+  if (!isResolved) {
     return (
       <BlockStack align="center" inlineAlign="center" className="h-full">
         <Spinner />
@@ -16,11 +16,10 @@ export function IndexRedirect() {
     );
   }
 
-  const showOnboarding = !isComplete && !dismissed;
   return (
     <Navigate
       replace
-      to={showOnboarding ? APP_ROUTES.WELCOME : APP_ROUTES.DASHBOARD}
+      to={shouldShowOnboarding ? APP_ROUTES.WELCOME : APP_ROUTES.DASHBOARD}
     />
   );
 }

--- a/src/components/Onboarding/OnboardingNavPill.test.tsx
+++ b/src/components/Onboarding/OnboardingNavPill.test.tsx
@@ -12,9 +12,7 @@ let onboarding = {
   steps: [],
   completedCount: 1,
   total: 4,
-  isComplete: false,
-  dismissed: false,
-  isResolved: true,
+  shouldShowOnboarding: true,
   markDocsRead: vi.fn(),
 };
 vi.mock("@/providers/OnboardingProvider/OnboardingProvider", () => ({
@@ -26,9 +24,7 @@ function resetState() {
     steps: [],
     completedCount: 1,
     total: 4,
-    isComplete: false,
-    dismissed: false,
-    isResolved: true,
+    shouldShowOnboarding: true,
     markDocsRead: vi.fn(),
   };
 }
@@ -39,19 +35,13 @@ afterEach(cleanup);
 const pill = () => screen.queryByText(/Onboarding/);
 
 describe("OnboardingNavPill", () => {
-  it("shows progress while onboarding is in progress", () => {
+  it("shows progress while onboarding should show", () => {
     render(<OnboardingNavPill />);
     expect(pill()).toHaveTextContent("Onboarding · 1/4");
   });
 
-  it("is hidden once onboarding is complete", () => {
-    onboarding.isComplete = true;
-    render(<OnboardingNavPill />);
-    expect(pill()).toBeNull();
-  });
-
-  it("is hidden once onboarding is dismissed", () => {
-    onboarding.dismissed = true;
+  it("is hidden when onboarding should not show", () => {
+    onboarding.shouldShowOnboarding = false;
     render(<OnboardingNavPill />);
     expect(pill()).toBeNull();
   });

--- a/src/components/Onboarding/OnboardingNavPill.tsx
+++ b/src/components/Onboarding/OnboardingNavPill.tsx
@@ -12,10 +12,9 @@ import { useOnboarding } from "@/providers/OnboardingProvider/OnboardingProvider
 import { tracking } from "@/utils/tracking";
 
 export function OnboardingNavPill() {
-  const { completedCount, total, isComplete, dismissed, isResolved } =
-    useOnboarding();
+  const { completedCount, total, shouldShowOnboarding } = useOnboarding();
 
-  if (!isResolved || isComplete || dismissed) {
+  if (!shouldShowOnboarding) {
     return null;
   }
 

--- a/src/components/Onboarding/OnboardingWelcome.test.tsx
+++ b/src/components/Onboarding/OnboardingWelcome.test.tsx
@@ -1,0 +1,41 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { OnboardingWelcome } from "./OnboardingWelcome";
+
+vi.mock("@tanstack/react-router", () => ({
+  Navigate: ({ to }: { to: string }) => <div data-testid="navigate">{to}</div>,
+  Link: ({ children }: { children: React.ReactNode }) => <a>{children}</a>,
+}));
+
+vi.mock("@/components/Learn/OnboardingHero", () => ({
+  OnboardingHero: () => <div data-testid="hero" />,
+}));
+
+let onboarding = { isResolved: true, shouldShowOnboarding: true };
+vi.mock("@/providers/OnboardingProvider/OnboardingProvider", () => ({
+  useOnboarding: () => onboarding,
+}));
+
+afterEach(cleanup);
+
+describe("OnboardingWelcome", () => {
+  it("shows a spinner until onboarding state is resolved", () => {
+    onboarding = { isResolved: false, shouldShowOnboarding: false };
+    render(<OnboardingWelcome />);
+    expect(screen.queryByTestId("hero")).toBeNull();
+    expect(screen.queryByTestId("navigate")).toBeNull();
+  });
+
+  it("renders the welcome hero when onboarding should show", () => {
+    onboarding = { isResolved: true, shouldShowOnboarding: true };
+    render(<OnboardingWelcome />);
+    expect(screen.getByTestId("hero")).toBeInTheDocument();
+  });
+
+  it("redirects to /dashboard when onboarding should not show", () => {
+    onboarding = { isResolved: true, shouldShowOnboarding: false };
+    render(<OnboardingWelcome />);
+    expect(screen.getByTestId("navigate")).toHaveTextContent("/dashboard");
+  });
+});

--- a/src/components/Onboarding/OnboardingWelcome.tsx
+++ b/src/components/Onboarding/OnboardingWelcome.tsx
@@ -2,14 +2,23 @@ import { Link, Navigate } from "@tanstack/react-router";
 
 import { OnboardingHero } from "@/components/Learn/OnboardingHero";
 import { BlockStack } from "@/components/ui/layout";
+import { Spinner } from "@/components/ui/spinner";
 import { useOnboarding } from "@/providers/OnboardingProvider/OnboardingProvider";
-import { APP_ROUTES } from "@/routes/router";
+import { APP_ROUTES } from "@/routes/appRoutes";
 import { tracking } from "@/utils/tracking";
 
 export function OnboardingWelcome() {
-  const { isReady, isComplete, dismissed } = useOnboarding();
+  const { isResolved, shouldShowOnboarding } = useOnboarding();
 
-  if (isReady && (isComplete || dismissed)) {
+  if (!isResolved) {
+    return (
+      <BlockStack align="center" inlineAlign="center" className="h-full">
+        <Spinner />
+      </BlockStack>
+    );
+  }
+
+  if (!shouldShowOnboarding) {
     return <Navigate to={APP_ROUTES.DASHBOARD} replace />;
   }
 

--- a/src/components/Onboarding/OnboardingWelcome.tsx
+++ b/src/components/Onboarding/OnboardingWelcome.tsx
@@ -1,0 +1,35 @@
+import { Link, Navigate } from "@tanstack/react-router";
+
+import { OnboardingHero } from "@/components/Learn/OnboardingHero";
+import { BlockStack } from "@/components/ui/layout";
+import { useOnboarding } from "@/providers/OnboardingProvider/OnboardingProvider";
+import { APP_ROUTES } from "@/routes/router";
+import { tracking } from "@/utils/tracking";
+
+export function OnboardingWelcome() {
+  const { isReady, isComplete, dismissed } = useOnboarding();
+
+  if (isReady && (isComplete || dismissed)) {
+    return <Navigate to={APP_ROUTES.DASHBOARD} replace />;
+  }
+
+  return (
+    <BlockStack
+      gap="4"
+      align="center"
+      inlineAlign="center"
+      className="h-full w-full"
+    >
+      <div className="w-full max-w-2xl">
+        <OnboardingHero />
+      </div>
+      <Link
+        to={APP_ROUTES.LEARN}
+        className="text-sm text-muted-foreground hover:text-foreground"
+        {...tracking("homepage.onboarding.learning_hub")}
+      >
+        Explore the Learning Hub →
+      </Link>
+    </BlockStack>
+  );
+}

--- a/src/providers/BackendProvider.tsx
+++ b/src/providers/BackendProvider.tsx
@@ -105,6 +105,7 @@ export const BackendProvider = ({ children }: { children: ReactNode }) => {
       if (!normalizedUrl) {
         if (notifyResult) notify("Backend is not configured", "error");
         if (saveAvailability) setAvailable(false);
+        setReady(true);
         return Promise.resolve(false);
       }
       return fetch(`${normalizedUrl}/services/ping`)
@@ -126,6 +127,7 @@ export const BackendProvider = ({ children }: { children: ReactNode }) => {
         .catch(() => {
           if (notifyResult) notify("Backend unavailable", "error");
           if (saveAvailability) setAvailable(false);
+          setReady(true);
           return false;
         });
     },

--- a/src/providers/OnboardingProvider/OnboardingProvider.test.tsx
+++ b/src/providers/OnboardingProvider/OnboardingProvider.test.tsx
@@ -111,6 +111,17 @@ describe("OnboardingProvider", () => {
     expect(patched()).toBe(false);
   });
 
+  it("does not show onboarding when the backend is unavailable", async () => {
+    backend = { available: false, backendUrl: "https://backend.example" };
+
+    const { result } = render();
+
+    await waitFor(() => expect(result.current.isReady).toBe(true));
+    expect(result.current.isOnboardingAvailable).toBe(false);
+    expect(result.current.shouldShowOnboarding).toBe(false);
+    expect(patched()).toBe(false);
+  });
+
   it("derives tour and run completion live without persisting them", async () => {
     tourCompletions = { "first-pipeline": { completedAt: "x" } };
     runsPayload = { pipeline_runs: [{ id: "run-1" }] };

--- a/src/providers/OnboardingProvider/OnboardingProvider.tsx
+++ b/src/providers/OnboardingProvider/OnboardingProvider.tsx
@@ -51,6 +51,8 @@ interface OnboardingContextValue {
   dismissed: boolean;
   isReady: boolean;
   isResolved: boolean;
+  isOnboardingAvailable: boolean;
+  shouldShowOnboarding: boolean;
   markDocsRead: () => void;
   dismiss: () => void;
   reopen: () => void;
@@ -84,7 +86,13 @@ function useHasMyRun(): {
 export function OnboardingProvider({ children }: { children: ReactNode }) {
   const { track } = useAnalytics();
   const notify = useToastNotification();
-  const { ready: backendReady, configured } = useBackend();
+  const {
+    ready: backendReady,
+    configured,
+    available,
+    backendUrl,
+  } = useBackend();
+  const hasBackend = available && Boolean(backendUrl);
   const { data: progress, isLoading: progressLoading } =
     useOnboardingProgress();
   const persist = usePersistOnboardingProgress();
@@ -105,8 +113,12 @@ export function OnboardingProvider({ children }: { children: ReactNode }) {
   };
 
   const isComplete = ONBOARDING_STEP_IDS.every((id) => desiredSteps[id]);
+  const dismissed = progress?.dismissed ?? false;
   const isReady = !progressLoading && !toursLoading && !runsLoading;
   const isResolved = (backendReady || !configured) && isReady;
+  const isOnboardingAvailable = isResolved && hasBackend;
+  const shouldShowOnboarding =
+    isOnboardingAvailable && !isComplete && !dismissed;
 
   const [pipelineWriteCount, setPipelineWriteCount] = useState(0);
 
@@ -166,9 +178,11 @@ export function OnboardingProvider({ children }: { children: ReactNode }) {
     completedCount: steps.filter((step) => step.completed).length,
     total: steps.length,
     isComplete,
-    dismissed: progress?.dismissed ?? false,
+    dismissed,
     isReady,
     isResolved,
+    isOnboardingAvailable,
+    shouldShowOnboarding,
     markDocsRead,
     dismiss,
     reopen,

--- a/src/providers/TourProvider/tourCompletion.ts
+++ b/src/providers/TourProvider/tourCompletion.ts
@@ -95,9 +95,6 @@ export function useRecordTourCompletion() {
   const { mutate } = useMutation({
     mutationFn: async (tourId: string) => {
       const key = queryKey(backendUrl);
-      // Merge against the authoritative server map — fetching it when the query
-      // hasn't loaded yet or previously failed — so the PATCH can never replace
-      // saved completions with only the current tour.
       const current = await queryClient.ensureQueryData({
         queryKey: key,
         queryFn: () => fetchCompletions(backendUrl),
@@ -122,7 +119,6 @@ export function useRecordTourCompletion() {
       queryClient.setQueryData(queryKey(backendUrl), next);
     },
     onError: () => {
-      // Our optimistic value may be wrong; re-sync from the server.
       void queryClient.invalidateQueries({ queryKey: queryKey(backendUrl) });
     },
   });
@@ -136,8 +132,6 @@ export function useRecordTourCompletion() {
     if (available && backendUrl) {
       mutate(tourId);
     } else {
-      // No backend: nothing to clobber, so keep the optimistic local cache
-      // update so the completion is reflected for the rest of the session.
       queryClient.setQueryData<TourCompletionMap>(key, {
         ...current,
         [tourId]: { completedAt: new Date().toISOString(), completionCount },

--- a/src/routes/Dashboard/DashboardLayout.tsx
+++ b/src/routes/Dashboard/DashboardLayout.tsx
@@ -9,6 +9,7 @@ import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Link as UILink } from "@/components/ui/link";
 import { Text } from "@/components/ui/typography";
 import { cn } from "@/lib/utils";
+import { useOnboarding } from "@/providers/OnboardingProvider/OnboardingProvider";
 import { APP_ROUTES } from "@/routes/appRoutes";
 import {
   ABOUT_URL,
@@ -28,7 +29,12 @@ interface SidebarItem {
 }
 
 const BASE_SIDEBAR_ITEMS: SidebarItem[] = [
-  { to: "/", label: "My Dashboard", icon: "LayoutDashboard", exact: true },
+  {
+    to: APP_ROUTES.DASHBOARD,
+    label: "My Dashboard",
+    icon: "LayoutDashboard",
+    exact: true,
+  },
   { to: "/pipelines", label: "My Pipelines", icon: "GitBranch" },
   { to: "/runs", label: "All Runs", icon: "Play" },
   { to: "/components", label: "Components", icon: "Package" },
@@ -53,13 +59,28 @@ export function DashboardLayout() {
   const requiresAuthorization = isAuthorizationRequired();
   const isComponentSearchEnabled = useFlagValue("component-search-v2");
 
-  const sidebarItems = isComponentSearchEnabled
+  const { isComplete, dismissed, isResolved } = useOnboarding();
+  const showOnboarding = isResolved && !isComplete && !dismissed;
+
+  const baseItems = isComponentSearchEnabled
     ? BASE_SIDEBAR_ITEMS.map((item) =>
         item.to === APP_ROUTES.DASHBOARD_COMPONENTS
           ? COMPONENT_SEARCH_ITEM
           : item,
       )
     : BASE_SIDEBAR_ITEMS;
+
+  const sidebarItems: SidebarItem[] = showOnboarding
+    ? [
+        {
+          to: APP_ROUTES.WELCOME,
+          label: "Get started",
+          icon: "Rocket",
+          exact: true,
+        },
+        ...baseItems,
+      ]
+    : baseItems;
 
   return (
     <div

--- a/src/routes/Dashboard/DashboardLayout.tsx
+++ b/src/routes/Dashboard/DashboardLayout.tsx
@@ -59,8 +59,7 @@ export function DashboardLayout() {
   const requiresAuthorization = isAuthorizationRequired();
   const isComponentSearchEnabled = useFlagValue("component-search-v2");
 
-  const { isComplete, dismissed, isResolved } = useOnboarding();
-  const showOnboarding = isResolved && !isComplete && !dismissed;
+  const { shouldShowOnboarding } = useOnboarding();
 
   const baseItems = isComponentSearchEnabled
     ? BASE_SIDEBAR_ITEMS.map((item) =>
@@ -70,11 +69,11 @@ export function DashboardLayout() {
       )
     : BASE_SIDEBAR_ITEMS;
 
-  const sidebarItems: SidebarItem[] = showOnboarding
+  const sidebarItems: SidebarItem[] = shouldShowOnboarding
     ? [
         {
           to: APP_ROUTES.WELCOME,
-          label: "Get started",
+          label: "Get Started",
           icon: "Rocket",
           exact: true,
         },

--- a/src/routes/Dashboard/Learn/LearnHomeView.test.tsx
+++ b/src/routes/Dashboard/Learn/LearnHomeView.test.tsx
@@ -68,14 +68,14 @@ describe("<LearnHomeView/>", () => {
     ).toBeInTheDocument();
   });
 
-  test("renders the onboarding hero with progress", () => {
+  test("hides the onboarding hero when no backend is available", () => {
     renderWithClient(<LearnHomeView />);
     expect(
-      screen.getByRole("heading", { level: 2, name: /welcome to tangle/i }),
-    ).toBeInTheDocument();
+      screen.queryByRole("heading", { level: 2, name: /welcome to tangle/i }),
+    ).not.toBeInTheDocument();
     expect(
-      screen.getByRole("progressbar", { name: /onboarding progress/i }),
-    ).toBeInTheDocument();
+      screen.queryByRole("progressbar", { name: /onboarding progress/i }),
+    ).not.toBeInTheDocument();
   });
 
   test("renders the docs quicklinks and full-docs link at the top", () => {

--- a/src/routes/Dashboard/Learn/LearnHomeView.tsx
+++ b/src/routes/Dashboard/Learn/LearnHomeView.tsx
@@ -11,7 +11,7 @@ import { BlockStack } from "@/components/ui/layout";
 import { useOnboarding } from "@/providers/OnboardingProvider/OnboardingProvider";
 
 export function LearnHomeView() {
-  const { dismissed } = useOnboarding();
+  const { dismissed, isOnboardingAvailable } = useOnboarding();
   return (
     <BlockStack gap="6">
       <BlockStack gap="4">
@@ -26,7 +26,9 @@ export function LearnHomeView() {
         </BlockStack>
       </BlockStack>
 
-      <OnboardingHero className={dismissed ? "order-last" : undefined} />
+      {isOnboardingAvailable && (
+        <OnboardingHero className={dismissed ? "order-last" : undefined} />
+      )}
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
         <TipOfTheDay />

--- a/src/routes/appRoutes.ts
+++ b/src/routes/appRoutes.ts
@@ -9,7 +9,8 @@ const TOUR_BASE_PATH = "/tour";
 
 export const APP_ROUTES = {
   HOME: "/",
-  DASHBOARD: "/",
+  DASHBOARD: "/dashboard",
+  WELCOME: "/welcome",
   DASHBOARD_RUNS: "/runs",
   DASHBOARD_PIPELINES: "/pipelines",
   DASHBOARD_COMPONENTS: "/components",

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -7,6 +7,8 @@ import {
   redirect,
 } from "@tanstack/react-router";
 
+import { IndexRedirect } from "@/components/Onboarding/IndexRedirect";
+import { OnboardingWelcome } from "@/components/Onboarding/OnboardingWelcome";
 import { ErrorPage } from "@/components/shared/ErrorPage";
 import { AuthorizationResultScreen as GitHubAuthorizationResultScreen } from "@/components/shared/GitHubAuth/AuthorizationResultScreen";
 import { AuthorizationResultScreen as HuggingFaceAuthorizationResultScreen } from "@/components/shared/HuggingFaceAuth/AuthorizationResultScreen";
@@ -79,7 +81,19 @@ const dashboardRoute = createRoute({
 const dashboardIndexRoute = createRoute({
   getParentRoute: () => dashboardRoute,
   path: "/",
+  component: IndexRedirect,
+});
+
+const dashboardHomeRoute = createRoute({
+  getParentRoute: () => dashboardRoute,
+  path: APP_ROUTES.DASHBOARD,
   component: DashboardHomeView,
+});
+
+const welcomeRoute = createRoute({
+  getParentRoute: () => dashboardRoute,
+  path: APP_ROUTES.WELCOME,
+  component: OnboardingWelcome,
 });
 
 const dashboardRunsRoute = createRoute({
@@ -329,6 +343,8 @@ const artifactPreviewRoute = createRoute({
 
 const dashboardRouteTree = dashboardRoute.addChildren([
   dashboardIndexRoute,
+  dashboardHomeRoute,
+  welcomeRoute,
   dashboardRunsRoute,
   dashboardPipelinesRoute,
   dashboardComponentsRoute,

--- a/tests/e2e/navigation-tracking.spec.ts
+++ b/tests/e2e/navigation-tracking.spec.ts
@@ -5,12 +5,10 @@ test.describe("Navigation tracking", () => {
     page,
   }) => {
     await page.addInitScript(() => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (window as any).__analyticsEvents = [];
       window.addEventListener("tangle.analytics.track", (e) => {
         const detail = (e as CustomEvent).detail;
         if (detail.actionType === "page_view") {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (window as any).__analyticsEvents.push(detail);
         }
       });
@@ -24,26 +22,28 @@ test.describe("Navigation tracking", () => {
     await page.getByRole("link", { name: "Settings" }).click();
     await expect(page).toHaveURL(/\/settings/);
 
-    const events = await page.evaluate(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      () => (window as any).__analyticsEvents,
-    );
+    const events = await page.evaluate(() => (window as any).__analyticsEvents);
 
     expect(events.length).toBeGreaterThanOrEqual(2);
 
-    const [initial, navigation] = events;
-
-    // First page_view from landing on /
-    expect(initial.actionType).toBe("page_view");
-    expect(initial.metadata).toMatchObject({
-      to: "/",
+    const landing = events.find(
+      (e: { metadata?: { to?: string } }) =>
+        e.metadata?.to === "/welcome" || e.metadata?.to === "/dashboard",
+    );
+    expect(landing).toBeTruthy();
+    expect(landing.metadata).toMatchObject({
+      to: expect.stringMatching(/^\/(welcome|dashboard)$/),
       route_pattern: expect.any(String),
     });
 
-    // Second page_view from navigating to settings
-    expect(navigation.actionType).toBe("page_view");
+    // Navigating to settings emits a page_view.
+    const navigation = events.find(
+      (e: { metadata?: { to?: string } }) =>
+        typeof e.metadata?.to === "string" &&
+        e.metadata.to.includes("/settings"),
+    );
+    expect(navigation).toBeTruthy();
     expect(navigation.metadata).toMatchObject({
-      from: "/",
       to: expect.stringContaining("/settings"),
       route_pattern: expect.any(String),
     });
@@ -51,12 +51,10 @@ test.describe("Navigation tracking", () => {
 
   test("captures search params in page_view metadata", async ({ page }) => {
     await page.addInitScript(() => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (window as any).__analyticsEvents = [];
       window.addEventListener("tangle.analytics.track", (e) => {
         const detail = (e as CustomEvent).detail;
         if (detail.actionType === "page_view") {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (window as any).__analyticsEvents.push(detail);
         }
       });
@@ -67,10 +65,7 @@ test.describe("Navigation tracking", () => {
       page.locator("[data-testid='app-menu-actions']"),
     ).toBeVisible();
 
-    const events = await page.evaluate(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      () => (window as any).__analyticsEvents,
-    );
+    const events = await page.evaluate(() => (window as any).__analyticsEvents);
 
     expect(events.length).toBeGreaterThanOrEqual(1);
 


### PR DESCRIPTION
## Description

Final PR in the onboarding series (stacked on #2440). Gives new users a dedicated landing experience instead of dropping them into an empty dashboard.

- **Dedicated** **`/welcome`** **route** — a focused, centered welcome page hosting the onboarding card, so onboarding doesn't take over the "My Dashboard" view.
- **Index routing (`IndexRedirect`)** — `/` now resolves based on onboarding state: new users (onboarding not complete and not dismissed) go to `/welcome`; everyone else goes to `/dashboard`. The dashboard is moved off `/` to its own route so manual navigation to either still works.
- **Sidebar "Get started" entry** — shown in the dashboard sidebar while onboarding is active, gated on `isResolved` to avoid flicker.
- Updates the navigation-tracking e2e spec for the new routes.

> **Stacked PR** — base: Onboarding Pill (#2440), which is stacked on the Onboarding Checklist (#2421). Closes the issue.

## Related Issue and Pull requests

Closes https://github.com/Shopify/oasis-frontend/issues/622

Stacked on #2421 → #2440

## Type of Change

- [x] New feature

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

![image.png](https://app.graphite.com/user-attachments/assets/62a062c7-6988-4d81-b581-a9d8ca246186.png)



## Test Instructions

1. As a fresh user, navigate to `/` — you should be redirected to `/welcome` with the onboarding card centered in the available space.
2. As a user who has completed or dismissed onboarding, navigate to `/` — you should land on `/dashboard`.
3. Manually navigate directly to `/welcome` and `/dashboard` — both should be reachable regardless of redirect logic.
4. While onboarding is active, confirm the **Get started** item appears in the dashboard sidebar (and does not flash before backend state resolves).
5. Complete onboarding from `/welcome` and confirm subsequent visits to `/` land on the dashboard.

## Additional Comments

Routing decisions wait on `isReady` (queries settled, valid even with no backend) while the sidebar entry gates on `isResolved`, matching the provider contract introduced earlier in the stack.