### PR TITLE
Add analytics tracking and thumbs feedback to AI sidekick (V2 editor)

### DIFF
--- a/src/routes/v2/shared/components/AiChat/AiChatContent.tsx
+++ b/src/routes/v2/shared/components/AiChat/AiChatContent.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { useAiProviderSettings } from "@/hooks/useAiProviderSettings";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { useBackend } from "@/providers/BackendProvider";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 import { fetchPipelineRuns } from "@/services/pipelineRunService";
@@ -48,6 +49,7 @@ export const AiChatContent = observer(function AiChatContent({
   createBridge,
 }: AiChatContentProps) {
   const aiChat = useAiChatStore();
+  const { track } = useAnalytics();
   const { navigation } = useSharedStores();
   const { backendUrl } = useBackend();
   const authStorage = useAuthLocalStorage();
@@ -101,16 +103,31 @@ export const AiChatContent = observer(function AiChatContent({
 
   const thread = aiChat.activeThread;
 
-  function handleSend(prompt: string) {
+  async function handleSend(prompt: string) {
     if (!thread) return;
     const recentRuns = recentRunsData
       ? projectRecentRuns(recentRunsData)
       : undefined;
-    thread.sendMessage(prompt, {
+
+    track("ai_assistant.message.submitted", {
+      prompt,
+      thread_message_count: thread.messages.length,
+    });
+
+    await thread.sendMessage(prompt, {
       bridge,
       aiConfig,
       ...(recentRuns && { recentRuns }),
     });
+
+    const lastMessage = thread.messages[thread.messages.length - 1];
+    if (lastMessage?.role === "assistant") {
+      track("ai_assistant.response.received", {
+        prompt,
+        response: lastMessage.content,
+        thread_message_count: thread.messages.length,
+      });
+    }
   }
 
   if (!isAiConfigured) {

--- a/src/routes/v2/shared/components/AiChat/agentThread.ts
+++ b/src/routes/v2/shared/components/AiChat/agentThread.ts
@@ -120,6 +120,7 @@ export class AgentThread {
             id: generateMessageId(),
             role: "assistant",
             content: response.answer,
+            prompt,
             ...(Object.keys(componentReferences).length > 0
               ? { componentReferences }
               : {}),
@@ -135,6 +136,7 @@ export class AgentThread {
             id: generateMessageId(),
             role: "assistant",
             content: formatAssistantError(error),
+            prompt,
           },
         ];
       });

--- a/src/routes/v2/shared/components/AiChat/components/ChatMessage.tsx
+++ b/src/routes/v2/shared/components/AiChat/components/ChatMessage.tsx
@@ -3,6 +3,7 @@ import type { ChatMessage as ChatMessageType } from "@/routes/v2/shared/componen
 
 import { MessageBubble } from "./MessageBubble";
 import { renderMarkdown } from "./renderMarkdown";
+import { ResponseFeedback } from "./ResponseFeedback";
 
 interface ChatMessageProps {
   message: ChatMessageType;
@@ -18,9 +19,15 @@ export function ChatMessage({ message }: ChatMessageProps) {
           {message.content}
         </Text>
       ) : (
-        <div className="text-sm break-words min-w-0 overflow-x-auto">
-          {renderMarkdown(message.content, message.componentReferences)}
-        </div>
+        <>
+          <div className="text-sm break-words min-w-0 overflow-x-auto">
+            {renderMarkdown(message.content, message.componentReferences)}
+          </div>
+          <ResponseFeedback
+            prompt={message.prompt}
+            response={message.content}
+          />
+        </>
       )}
     </MessageBubble>
   );

--- a/src/routes/v2/shared/components/AiChat/components/ResponseFeedback.tsx
+++ b/src/routes/v2/shared/components/AiChat/components/ResponseFeedback.tsx
@@ -1,0 +1,74 @@
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icon";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
+import { cn } from "@/lib/utils";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
+
+interface ResponseFeedbackProps {
+  prompt: string;
+  response: string;
+}
+
+type FeedbackState = "idle" | "submitted";
+
+export function ResponseFeedback({ prompt, response }: ResponseFeedbackProps) {
+  const { track } = useAnalytics();
+  const [state, setState] = useState<FeedbackState>("idle");
+
+  function handleFeedback(rating: "positive" | "negative") {
+    if (state !== "idle") return;
+    setState("submitted");
+    track("ai_assistant.response.feedback", { rating, prompt, response });
+  }
+
+  return (
+    <BlockStack className="relative h-5 mt-1.5">
+      <InlineStack
+        gap="0"
+        className={cn(
+          "transition-opacity duration-200",
+          state === "submitted" ? "opacity-0" : "opacity-100",
+        )}
+        aria-hidden={state === "submitted"}
+      >
+        <Button
+          type="button"
+          variant="ghost"
+          size="min"
+          onClick={() => handleFeedback("positive")}
+          disabled={state !== "idle"}
+          aria-label="Helpful response"
+          className="text-muted-foreground/30 hover:text-info transition-colors duration-150"
+        >
+          <Icon name="ThumbsUp" size="xs" />
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="min"
+          onClick={() => handleFeedback("negative")}
+          disabled={state !== "idle"}
+          aria-label="Not helpful response"
+          className="text-muted-foreground/30 hover:text-info transition-colors duration-150"
+        >
+          <Icon name="ThumbsDown" size="xs" />
+        </Button>
+      </InlineStack>
+      <Text
+        size="xs"
+        tone="subdued"
+        className={cn(
+          "absolute left-0 top-0 transition-opacity duration-300 delay-200",
+          state === "submitted"
+            ? "opacity-100"
+            : "opacity-0 pointer-events-none",
+        )}
+      >
+        Thank you for sharing your feedback
+      </Text>
+    </BlockStack>
+  );
+}

--- a/src/routes/v2/shared/components/AiChat/types.ts
+++ b/src/routes/v2/shared/components/AiChat/types.ts
@@ -3,9 +3,19 @@ export interface ComponentRefData {
   yamlText: string;
 }
 
-export interface ChatMessage {
+interface BaseChatMessage {
   id: string;
-  role: "user" | "assistant";
   content: string;
   componentReferences?: Record<string, ComponentRefData>;
 }
+
+interface UserChatMessage extends BaseChatMessage {
+  role: "user";
+}
+
+interface AssistantChatMessage extends BaseChatMessage {
+  role: "assistant";
+  prompt: string;
+}
+
+export type ChatMessage = UserChatMessage | AssistantChatMessage;


### PR DESCRIPTION
## Description

Adds analytics tracking and thumbs up/down feedback UI to the AI chat assistant.

When a user sends a message, an `ai_assistant.message.submitted` event is tracked with the prompt and current thread message count. Once the assistant responds, an `ai_assistant.response.received` event is tracked with the prompt, response content, and updated message count.

A new `ResponseFeedback` component is rendered below each assistant message, showing thumbs up and thumbs down buttons. Clicking either fires an `ai_assistant.response.feedback` event with the rating, prompt, and response, then fades out the buttons and displays a "Thank you for sharing your feedback" confirmation. The prompt for each assistant message is resolved by looking at the preceding user message in the thread.

## Analytics events added

- ai_assistant.message.submitted
- ai_assistant.response.received
- ai_assistant.response.feedback

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Screenshots (if applicable)

![image.png](https://app.graphite.com/user-attachments/assets/a80152ca-2004-496c-bb8c-6310f641b57f.png)

## Test Instructions

1. Open the AI chat assistant and send a message.
2. Verify that `ai_assistant.message.submitted` and `ai_assistant.response.received` events are fired in your analytics provider after the assistant replies.
3. Confirm that thumbs up and thumbs down buttons appear below each assistant response.
4. Click either button and verify the buttons fade out, the "Thank you for sharing your feedback" message appears, and an `ai_assistant.response.feedback` event is tracked with the correct rating, prompt, and response.
5. Confirm that clicking a feedback button a second time has no effect.

## Additional Comments