### PR TITLE
Disable AI search when literal search finds no matches

### DIFF
--- a/src/routes/Dashboard/DashboardComponentsV2View.test.tsx
+++ b/src/routes/Dashboard/DashboardComponentsV2View.test.tsx
@@ -36,6 +36,7 @@ const routeMocks = vi.hoisted(() => {
     descriptionErrorState,
     aiDescriptionsEnabled: false,
     aiSearchConfigured: false,
+    aiApiBase: "",
     search,
   };
 });
@@ -156,6 +157,28 @@ vi.mock("@/hooks/useNaturalLanguageComponentSearch", () => ({
 
 vi.mock("@/hooks/useToastNotification", () => ({
   default: () => routeMocks.notify,
+}));
+
+vi.mock("@/hooks/useAiProviderSettings", () => ({
+  useAiProviderSettings: () => ({
+    config: { apiBase: routeMocks.aiApiBase, apiKey: "" },
+  }),
+}));
+
+vi.mock("@/services/componentSearchEmbeddings", () => ({
+  rankComponentMatchesByEmbeddings: vi.fn(async (index: IndexEntry[]) =>
+    index.length > 0
+      ? [
+          {
+            reference: index[0].reference,
+            digest: index[0].digest,
+            name: index[0].name,
+            source: index[0].source,
+            matchedFields: [],
+          },
+        ]
+      : [],
+  ),
 }));
 
 vi.mock("@/components/shared/ComponentDetail/ComponentDetail", () => ({
@@ -390,6 +413,7 @@ describe("DashboardComponentsV2View", () => {
     routeMocks.rerank.mockClear();
     routeMocks.resetRerank.mockClear();
     routeMocks.aiSearchConfigured = false;
+    routeMocks.aiApiBase = "";
   });
 
   it("filters visible component results by source type and restores them", () => {
@@ -414,8 +438,24 @@ describe("DashboardComponentsV2View", () => {
     expect(screen.getByText("Registered component")).toBeInTheDocument();
   });
 
-  it("lets AI search run against a bounded candidate pool when literal search has no matches", async () => {
+  it("does not run AI search when literal search has no matches", async () => {
     routeMocks.aiSearchConfigured = true;
+    render(<DashboardComponentsV2View />);
+
+    fireEvent.change(screen.getByLabelText("Search components"), {
+      target: { value: "find something semantically relevant" },
+    });
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "AI search" })).toBeDisabled();
+    });
+    fireEvent.click(screen.getByRole("button", { name: "AI search" }));
+
+    expect(routeMocks.rerank).not.toHaveBeenCalled();
+  });
+
+  it("allows AI search with embeddings when literal search has no matches", async () => {
+    routeMocks.aiSearchConfigured = true;
+    routeMocks.aiApiBase = "https://api.example.com/v1";
     render(<DashboardComponentsV2View />);
 
     fireEvent.change(screen.getByLabelText("Search components"), {
@@ -426,15 +466,7 @@ describe("DashboardComponentsV2View", () => {
     });
     fireEvent.click(screen.getByRole("button", { name: "AI search" }));
 
-    expect(routeMocks.rerank).toHaveBeenCalledWith({
-      query: "find something semantically relevant",
-      candidates: expect.arrayContaining([
-        expect.objectContaining({ id: "standard-digest" }),
-        expect.objectContaining({ id: "registered-digest" }),
-        expect.objectContaining({ id: "user-digest" }),
-      ]),
-      scoreAllCandidates: true,
-    });
+    await waitFor(() => expect(routeMocks.rerank).toHaveBeenCalled());
   });
 
   it("shows a manual generate button when automatic descriptions are disabled", () => {

--- a/src/routes/Dashboard/DashboardComponentsV2View.tsx
+++ b/src/routes/Dashboard/DashboardComponentsV2View.tsx
@@ -45,7 +45,6 @@ import {
   buildSearchIndex,
   type ComponentSearchSource,
   type IndexEntry,
-  indexEntryToLexicalMatch,
   type LexicalMatch,
   lexicalSearch,
   type MatchField,
@@ -435,22 +434,6 @@ const ComponentDescriptionPanel = ({
  * `standard > published > registered > user` so the most canonical label
  * sticks when the same component appears in multiple places.
  */
-/**
- * Pick up to `limit` entries spread evenly across `entries`, preserving order.
- * Used to build a representative browse pool for AI search when literal
- * matching returns nothing — taking the first N would bias toward names that
- * sort early in a library larger than the limit.
- */
-function sampleEvenly<T>(entries: T[], limit: number): T[] {
-  if (entries.length <= limit) return entries;
-  const step = entries.length / limit;
-  const sampled: T[] = [];
-  for (let i = 0; i < limit; i++) {
-    sampled.push(entries[Math.floor(i * step)]);
-  }
-  return sampled;
-}
-
 function mergeUniqueMatches(
   primary: LexicalMatch[],
   secondary: LexicalMatch[],
@@ -779,16 +762,9 @@ export const DashboardComponentsV2View = () => {
 
   const aiCandidateMatches: LexicalMatch[] = (() => {
     if (trimmedQuery.length === 0) return [];
-    if (broadLexicalMatches.length > 0) return broadLexicalMatches;
-
-    // If literal matching found nothing, AI search can still judge a bounded
-    // browse pool. Sample evenly across the (alphabetically sorted) library so
-    // the model sees a representative spread instead of only names that sort
-    // early — matters for libraries larger than AI_CANDIDATE_LIMIT.
-    return sampleEvenly(sortedIndex, AI_CANDIDATE_LIMIT).map(
-      indexEntryToLexicalMatch,
-    );
+    return broadLexicalMatches;
   })();
+  const canUseEmbeddingSearch = aiConfig.apiBase.trim().length > 0;
 
   const {
     mutate: rerank,
@@ -826,7 +802,7 @@ export const DashboardComponentsV2View = () => {
     trimmed: string,
     limit: number,
   ): Promise<LexicalMatch[]> => {
-    if (!aiConfig.apiBase.trim()) return [];
+    if (!canUseEmbeddingSearch) return [];
     setIsEmbeddingSearchPending(true);
     try {
       return await rankComponentMatchesByEmbeddings(
@@ -850,9 +826,10 @@ export const DashboardComponentsV2View = () => {
     }: { scoreAllCandidates: boolean; limit: number },
   ) => {
     const trimmed = trimmedQuery;
-    if (trimmed.length === 0 || matches.length === 0) return;
+    if (trimmed.length === 0) return;
+    if (matches.length === 0 && !canUseEmbeddingSearch) return;
 
-    const embeddingMatches = aiConfig.apiBase.trim()
+    const embeddingMatches = canUseEmbeddingSearch
       ? await buildEmbeddingMatches(trimmed, limit)
       : [];
     const rerankMatches = mergeUniqueMatches(
@@ -876,7 +853,7 @@ export const DashboardComponentsV2View = () => {
   const handleSmartSearch = () => {
     void startAiSearch(aiCandidateMatches, {
       scoreAllCandidates: true,
-      limit: aiCandidateMatches.length,
+      limit: aiCandidateMatches.length || LEXICAL_RESULT_LIMIT,
     });
   };
 
@@ -1124,7 +1101,7 @@ export const DashboardComponentsV2View = () => {
                 isReranking ||
                 isEmbeddingSearchPending ||
                 isEmpty ||
-                aiCandidateMatches.length === 0 ||
+                (aiCandidateMatches.length === 0 && !canUseEmbeddingSearch) ||
                 !isConfigured
               }
               aria-label={

--- a/src/routes/v2/pages/Editor/components/componentSearchV2Logic.test.ts
+++ b/src/routes/v2/pages/Editor/components/componentSearchV2Logic.test.ts
@@ -277,8 +277,7 @@ describe("buildLexicalMatches / buildAiCandidateMatches", () => {
   });
 
   it("returns no AI candidates when literal search finds nothing", () => {
-    const candidates = buildAiCandidateMatches(index, "qqzznomatch");
-    expect(candidates).toEqual([]);
+    expect(buildAiCandidateMatches(index, "qqzznomatch")).toEqual([]);
   });
 
   it("adds source-diverse lexical candidates beyond the top lexical hits", () => {

--- a/src/routes/v2/pages/Editor/components/componentSearchV2Logic.ts
+++ b/src/routes/v2/pages/Editor/components/componentSearchV2Logic.ts
@@ -358,16 +358,19 @@ export function buildAiCandidateMatches(
 ): LexicalMatch[] {
   if (trimmedQuery.length === 0) return [];
 
+  const lexicalMatches = lexicalSearch(index, trimmedQuery, {
+    limit: AI_LEXICAL_CANDIDATE_LIMIT,
+    minLength: 1,
+  });
+  if (lexicalMatches.length === 0) return [];
+
   const candidates: LexicalMatch[] = [];
   const seenDigests = new Set<string>();
 
   appendUniqueMatches(
     candidates,
     seenDigests,
-    lexicalSearch(index, trimmedQuery, {
-      limit: AI_LEXICAL_CANDIDATE_LIMIT,
-      minLength: 1,
-    }),
+    lexicalMatches,
     AI_CANDIDATE_LIMIT,
   );
 

--- a/src/routes/v2/pages/Editor/hooks/useComponentSearchV2State.ts
+++ b/src/routes/v2/pages/Editor/hooks/useComponentSearchV2State.ts
@@ -194,11 +194,13 @@ export function useComponentSearchV2State(
     }),
   );
 
+  const canUseEmbeddingSearch = aiConfig.apiBase.trim().length > 0;
   const trimmedQuery = query.trim();
   const lexicalMatches = buildLexicalMatches(index, trimmedQuery);
   const aiCandidateMatches = buildAiCandidateMatches(index, trimmedQuery);
   const {
     mutate,
+    reset: resetRerank,
     data: rerankData,
     isPending: isReranking,
     isConfigured,
@@ -212,15 +214,17 @@ export function useComponentSearchV2State(
   const embeddingAbortControllerRef = useRef<AbortController | null>(null);
 
   const clearRerank = () => {
+    resetRerank();
     setRerankedFor(null);
     setRerankBaseMatches([]);
   };
 
   useEffect(() => {
+    resetRerank();
     setRerankedFor(null);
     setRerankBaseMatches([]);
     embeddingAbortControllerRef.current?.abort();
-  }, [query]);
+  }, [query, resetRerank]);
 
   useEffect(() => {
     return () => embeddingAbortControllerRef.current?.abort();
@@ -244,7 +248,7 @@ export function useComponentSearchV2State(
     sourceIndex: IndexEntry[];
     limit: number;
   }): Promise<LexicalMatch[]> => {
-    if (!aiConfig.apiBase.trim()) return [];
+    if (!canUseEmbeddingSearch) return [];
     embeddingAbortControllerRef.current?.abort();
     const abortController = new AbortController();
     embeddingAbortControllerRef.current = abortController;
@@ -284,8 +288,7 @@ export function useComponentSearchV2State(
   ) => {
     if (!trimmedQuery || !isConfigured) return;
 
-    const canUseEmbeddings =
-      useEmbeddings && aiConfig.apiBase.trim().length > 0;
+    const canUseEmbeddings = useEmbeddings && canUseEmbeddingSearch;
     if (matches.length === 0 && !canUseEmbeddings) return;
 
     const effectiveLimit = limit || LEXICAL_RESULT_LIMIT;
@@ -315,6 +318,7 @@ export function useComponentSearchV2State(
 
     if (candidates.length === 0) return;
 
+    resetRerank();
     setRerankBaseMatches(rerankMatches);
     setRerankedFor(trimmedQuery);
     mutate({ query: trimmedQuery, candidates, scoreAllCandidates });
@@ -324,7 +328,7 @@ export function useComponentSearchV2State(
     void startRerank(aiCandidateMatches, {
       scoreAllCandidates: true,
       useEmbeddings: true,
-      limit: aiCandidateMatches.length,
+      limit: aiCandidateMatches.length || LEXICAL_RESULT_LIMIT,
     });
   };
 
@@ -350,7 +354,7 @@ export function useComponentSearchV2State(
       isHydrating,
     canRerank:
       trimmedQuery.length > 0 &&
-      (aiCandidateMatches.length > 0 || aiConfig.apiBase.trim().length > 0) &&
+      (aiCandidateMatches.length > 0 || canUseEmbeddingSearch) &&
       isConfigured,
     isReranking: isReranking || isEmbeddingSearchPending,
     isRerankActive,

--- a/src/services/componentSearchEmbeddings.test.ts
+++ b/src/services/componentSearchEmbeddings.test.ts
@@ -148,9 +148,14 @@ describe("component search embeddings", () => {
       ),
     );
 
-    await rankComponentMatchesByEmbeddings(index, "open a spreadsheet", OPTIONS, {
-      limit: 1,
-    });
+    await rankComponentMatchesByEmbeddings(
+      index,
+      "open a spreadsheet",
+      OPTIONS,
+      {
+        limit: 1,
+      },
+    );
 
     expect(global.fetch).toHaveBeenCalledTimes(2);
   });


### PR DESCRIPTION
## Description

AI search is now disabled when a literal (lexical) search returns no matches. Previously, when no lexical hits were found, AI search would fall back to a sampled "browse pool" built by evenly sampling the full component index, allowing the AI reranker to run against a representative spread of components. This behavior has been removed — if the query doesn't match anything lexically, the AI search button is disabled and the reranker is not called.

This removes the `sampleEvenly` utility function and the `indexEntryToLexicalMatch` fallback path from the Dashboard view, and updates `buildAiCandidateMatches` to return an empty array immediately when lexical search finds nothing.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [x] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Open the Dashboard components view with AI search configured.
2. Enter a query that has no lexical matches (e.g., a nonsense string like `qqzznomatch`).
3. Confirm the "AI search" button is disabled and clicking it does not trigger a rerank call.
4. Enter a query that does have lexical matches and confirm AI search remains functional.

## Additional Comments

The previous browse-pool fallback was intended to give the AI model a representative sample when literal search found nothing. This PR removes that behavior, meaning AI search is only available as a refinement step when there are already some lexical candidates to rerank.