### PR TITLE
Add component search URL state

### DIFF
--- a/src/hooks/useDebouncedSearchValue.ts
+++ b/src/hooks/useDebouncedSearchValue.ts
@@ -11,23 +11,44 @@ const SEARCH_QUERY_DEBOUNCE_MS = 200;
  *
  * Returns `[localValue, setLocalValue]` for the input to bind to. The commit is
  * skipped while the value still matches what was last committed, so it never
- * fires a no-op commit on mount.
+ * fires a no-op commit on mount. `shouldSyncExternalValue` can block URL echo
+ * updates while the input is focused, keeping typing independent from routing.
  */
 export function useDebouncedSearchValue(
   onCommit: (value: string) => void,
   delayMs: number = SEARCH_QUERY_DEBOUNCE_MS,
+  initialValue: string = "",
+  shouldSyncExternalValue: () => boolean = () => true,
 ): readonly [string, (value: string) => void] {
-  const [localValue, setLocalValue] = useState("");
+  const [localValue, setLocalValue] = useState(initialValue);
   // Keep the latest callback without re-running the debounce effect when the
   // parent passes a new function identity on each render.
   const onCommitRef = useRef(onCommit);
-  const lastCommittedRef = useRef(localValue);
+  const shouldSyncExternalValueRef = useRef(shouldSyncExternalValue);
+  const lastCommittedRef = useRef(initialValue);
+  const skipNextCommitRef = useRef(false);
 
   useEffect(() => {
     onCommitRef.current = onCommit;
   }, [onCommit]);
 
   useEffect(() => {
+    shouldSyncExternalValueRef.current = shouldSyncExternalValue;
+  }, [shouldSyncExternalValue]);
+
+  useEffect(() => {
+    if (initialValue === lastCommittedRef.current) return;
+    lastCommittedRef.current = initialValue;
+    if (!shouldSyncExternalValueRef.current()) return;
+    skipNextCommitRef.current = true;
+    setLocalValue(initialValue);
+  }, [initialValue]);
+
+  useEffect(() => {
+    if (skipNextCommitRef.current) {
+      skipNextCommitRef.current = false;
+      return;
+    }
     if (localValue === lastCommittedRef.current) return;
     const timeout = window.setTimeout(() => {
       lastCommittedRef.current = localValue;

--- a/src/routes/Dashboard/DashboardComponentsV2View.test.tsx
+++ b/src/routes/Dashboard/DashboardComponentsV2View.test.tsx
@@ -7,6 +7,8 @@ import type { ComponentReference } from "@/utils/componentSpec";
 
 interface DashboardComponentsV2Search {
   component?: string;
+  q?: string;
+  disabled_sources?: string;
 }
 
 const routeMocks = vi.hoisted(() => {
@@ -409,6 +411,8 @@ describe("DashboardComponentsV2View", () => {
     routeMocks.aiDescriptionsEnabled = false;
     routeMocks.descriptionErrorState.current = null;
     routeMocks.search = {};
+    routeMocks.navigate.mockClear();
+    routeMocks.notify.mockClear();
     routeMocks.refetchDescription.mockClear();
     routeMocks.rerank.mockClear();
     routeMocks.resetRerank.mockClear();
@@ -432,10 +436,109 @@ describe("DashboardComponentsV2View", () => {
     expect(screen.queryByText("Registered component")).not.toBeInTheDocument();
     expect(screen.getByText("Standard component")).toBeInTheDocument();
     expect(screen.getByText("User component")).toBeInTheDocument();
+    expect(routeMocks.navigate).toHaveBeenLastCalledWith({
+      to: "/dashboard/components-v2",
+      search: { disabled_sources: "registered" },
+    });
 
     fireEvent.click(screen.getByRole("button", { name: "Show all" }));
 
     expect(screen.getByText("Registered component")).toBeInTheDocument();
+    expect(routeMocks.navigate).toHaveBeenLastCalledWith({
+      to: "/dashboard/components-v2",
+      search: {},
+    });
+  });
+
+  it("initializes search state from URL params", () => {
+    routeMocks.search = {
+      q: "registered",
+      disabled_sources: "standard,user",
+    };
+
+    render(<DashboardComponentsV2View />);
+
+    expect(screen.getByLabelText("Search components")).toHaveValue(
+      "registered",
+    );
+    expect(screen.getByText("Registered component")).toBeInTheDocument();
+    expect(screen.queryByText("Standard component")).not.toBeInTheDocument();
+    expect(screen.queryByText("User component")).not.toBeInTheDocument();
+  });
+
+  it("writes search text into URL params after debounce without trimming active input whitespace", async () => {
+    render(<DashboardComponentsV2View />);
+
+    fireEvent.change(screen.getByLabelText("Search components"), {
+      target: { value: "standard " },
+    });
+
+    await waitFor(() => {
+      expect(routeMocks.navigate).toHaveBeenCalledWith({
+        to: "/dashboard/components-v2",
+        search: { q: "standard " },
+      });
+    });
+    expect(screen.getByLabelText("Search components")).toHaveValue("standard ");
+  });
+
+  it("does not let URL echo updates rewrite the focused search input", async () => {
+    const { rerender } = render(<DashboardComponentsV2View />);
+    const input = screen.getByLabelText("Search components");
+
+    input.focus();
+    fireEvent.change(input, { target: { value: "standard " } });
+
+    await waitFor(() => {
+      expect(routeMocks.navigate).toHaveBeenCalled();
+    });
+
+    routeMocks.search = { q: "standard" };
+    rerender(<DashboardComponentsV2View />);
+
+    expect(input).toHaveValue("standard ");
+  });
+
+  it("copies a shareable link for a selected component", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    routeMocks.search = { component: "standard-digest", q: "standard" };
+
+    render(<DashboardComponentsV2View />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Copy component link" }),
+    );
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith(window.location.href);
+    });
+    expect(routeMocks.notify).toHaveBeenCalledWith(
+      "Component link copied to clipboard",
+      "success",
+    );
+  });
+
+  it("clears only the selected component when closing details", () => {
+    routeMocks.search = {
+      component: "standard-digest",
+      q: "standard",
+      disabled_sources: "registered",
+    };
+
+    render(<DashboardComponentsV2View />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Close component details" }),
+    );
+
+    expect(routeMocks.navigate).toHaveBeenCalledWith({
+      to: "/dashboard/components-v2",
+      search: { q: "standard", disabled_sources: "registered" },
+    });
   });
 
   it("does not run AI search when literal search has no matches", async () => {

--- a/src/routes/Dashboard/DashboardComponentsV2View.tsx
+++ b/src/routes/Dashboard/DashboardComponentsV2View.tsx
@@ -2,7 +2,13 @@ import Bugsnag from "@bugsnag/js";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useNavigate, useSearch } from "@tanstack/react-router";
 import { useLiveQuery } from "dexie-react-hooks";
-import { useEffect, useState } from "react";
+import {
+  useDeferredValue,
+  useEffect,
+  useRef,
+  useState,
+  useTransition,
+} from "react";
 
 import { listApiPublishedComponentsGet } from "@/api/sdk.gen";
 import {
@@ -77,7 +83,12 @@ import {
   filterIndexByDisabledSourceKeys,
   SourceFilterBar,
 } from "./DashboardComponentsV2SourceFilter";
-import { readSelectedComponentDigest } from "./searchParams";
+import {
+  createDashboardComponentsV2SearchParams,
+  readComponentSearchQuery,
+  readDisabledSourceKeys,
+  readSelectedComponentDigest,
+} from "./searchParams";
 
 // Repeated Tailwind combos extracted as named constants.
 const PANEL_CLASS = "p-3 rounded-lg bg-card border border-border";
@@ -109,6 +120,7 @@ const SOURCE_ICON_TONE_BY_KIND: Record<ComponentSearchSource["kind"], string> =
 const LEXICAL_RESULT_LIMIT = 20;
 /** Bounded pool sent to AI search on click. */
 const AI_CANDIDATE_LIMIT = 80;
+const DASHBOARD_SEARCH_RESULT_DEBOUNCE_MS = 500;
 
 const MATCH_FIELD_LABEL: Record<MatchField, string> = {
   name: "name",
@@ -454,14 +466,23 @@ function mergeUniqueMatches(
 function DebouncedComponentSearchInput({
   onCommit,
   disabled,
+  initialValue,
 }: {
   onCommit: (value: string) => void;
   disabled: boolean;
+  initialValue: string;
 }) {
-  const [localValue, setLocalValue] = useDebouncedSearchValue(onCommit);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [localValue, setLocalValue] = useDebouncedSearchValue(
+    onCommit,
+    DASHBOARD_SEARCH_RESULT_DEBOUNCE_MS,
+    initialValue,
+    () => document.activeElement !== inputRef.current,
+  );
 
   return (
     <Input
+      ref={inputRef}
       type="search"
       placeholder="e.g. train_test_split, pandas, clean up my data"
       value={localValue}
@@ -522,38 +543,71 @@ export const DashboardComponentsV2View = () => {
   );
   const { backendUrl, configured, available } = useBackend();
   const { config: aiConfig } = useAiProviderSettings();
-  const [query, setQuery] = useState("");
-  const [disabledSourceKeys, setDisabledSourceKeys] = useState<string[]>([]);
+  const dashboardSearch = useSearch({ strict: false });
+  const queryFromUrl = readComponentSearchQuery(dashboardSearch);
+  const disabledSourceKeysFromUrl = readDisabledSourceKeys(dashboardSearch);
+  const disabledSourceKeysParam = disabledSourceKeysFromUrl.join(",");
+  const [query, setQuery] = useState(queryFromUrl);
+  const deferredQuery = useDeferredValue(query);
+  const [, startSearchTransition] = useTransition();
+  const [disabledSourceKeys, setDisabledSourceKeys] = useState<string[]>(
+    disabledSourceKeysFromUrl,
+  );
 
   // Detail-pane selection lives in the URL so refreshes preserve it and the
   // selection can be linked-to. The V2 route has no validateSearch defined.
   const navigate = useNavigate();
-  const selectedDigest = readSelectedComponentDigest(
-    useSearch({ strict: false }),
-  );
+  const selectedDigest = readSelectedComponentDigest(dashboardSearch);
+  const buildSearch = ({
+    component = selectedDigest,
+    q = query,
+    sourceKeys = disabledSourceKeys,
+  }: {
+    component?: string | null;
+    q?: string;
+    sourceKeys?: string[];
+  }) =>
+    createDashboardComponentsV2SearchParams({
+      component: component ?? undefined,
+      q,
+      disabledSourceKeys: sourceKeys,
+    });
   const selectComponent = (reference: ComponentReference) => {
     navigate({
       to: APP_ROUTES.DASHBOARD_COMPONENTS_V2,
-      search: { component: reference.digest },
+      search: buildSearch({ component: reference.digest }),
     });
   };
   const closeDetail = () => {
-    navigate({ to: APP_ROUTES.DASHBOARD_COMPONENTS_V2, search: {} });
+    navigate({
+      to: APP_ROUTES.DASHBOARD_COMPONENTS_V2,
+      search: buildSearch({ component: null }),
+    });
   };
 
+  useEffect(() => {
+    startSearchTransition(() => setQuery(queryFromUrl));
+  }, [queryFromUrl, startSearchTransition]);
+
+  useEffect(() => {
+    setDisabledSourceKeys(disabledSourceKeysFromUrl);
+  }, [disabledSourceKeysParam]);
+
   // Close detail on Escape — only when something is open, so we don't fight
-  // other Esc handlers (e.g. inside Inputs). Navigate inline so the effect has
-  // no callback dep that would re-bind on every render.
+  // other Esc handlers (e.g. inside Inputs).
   useEffect(() => {
     if (!selectedDigest) return;
     const onKey = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
-        navigate({ to: APP_ROUTES.DASHBOARD_COMPONENTS_V2, search: {} });
+        navigate({
+          to: APP_ROUTES.DASHBOARD_COMPONENTS_V2,
+          search: buildSearch({ component: null }),
+        });
       }
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [selectedDigest, navigate]);
+  }, [selectedDigest, navigate, buildSearch]);
 
   // The dashboard search page doesn't mount `ComponentLibraryProvider` (which
   // is editor-scoped), so the GitHub library factory isn't auto-registered.
@@ -742,7 +796,7 @@ export const DashboardComponentsV2View = () => {
     a.name.localeCompare(b.name),
   );
 
-  const trimmedQuery = query.trim();
+  const trimmedQuery = deferredQuery.trim();
 
   // One lexical pass at the wider AI-candidate limit; the display list is the
   // top slice of that same scored result, so we never score and sort the index
@@ -751,7 +805,7 @@ export const DashboardComponentsV2View = () => {
   const broadLexicalMatches: LexicalMatch[] =
     trimmedQuery.length === 0
       ? []
-      : lexicalSearch(filteredIndex, query, {
+      : lexicalSearch(filteredIndex, deferredQuery, {
           limit: AI_CANDIDATE_LIMIT,
         });
 
@@ -759,7 +813,6 @@ export const DashboardComponentsV2View = () => {
     0,
     LEXICAL_RESULT_LIMIT,
   );
-
   const aiCandidateMatches: LexicalMatch[] = (() => {
     if (trimmedQuery.length === 0) return [];
     return broadLexicalMatches;
@@ -792,10 +845,12 @@ export const DashboardComponentsV2View = () => {
   };
 
   const handleQueryCommit = (value: string) => {
-    setQuery(value);
-    if (rerankedFor !== null) {
-      clearRerank();
-    }
+    startSearchTransition(() => {
+      setQuery(value);
+      if (rerankedFor !== null) {
+        clearRerank();
+      }
+    });
   };
 
   const buildEmbeddingMatches = async (
@@ -857,12 +912,30 @@ export const DashboardComponentsV2View = () => {
     });
   };
 
+  useEffect(() => {
+    if (query === queryFromUrl) return;
+    const timeout = window.setTimeout(() => {
+      navigate({
+        to: APP_ROUTES.DASHBOARD_COMPONENTS_V2,
+        search: createDashboardComponentsV2SearchParams({
+          component: selectedDigest,
+          q: query,
+          disabledSourceKeys,
+        }),
+      });
+    }, 400);
+    return () => window.clearTimeout(timeout);
+  }, [query, queryFromUrl, selectedDigest, disabledSourceKeys, navigate]);
+
   const handleSourceToggle = (sourceKey: string) => {
-    setDisabledSourceKeys((current) =>
-      current.includes(sourceKey)
-        ? current.filter((key) => key !== sourceKey)
-        : [...current, sourceKey],
-    );
+    const nextDisabledSourceKeys = disabledSourceKeys.includes(sourceKey)
+      ? disabledSourceKeys.filter((key) => key !== sourceKey)
+      : [...disabledSourceKeys, sourceKey];
+    setDisabledSourceKeys(nextDisabledSourceKeys);
+    navigate({
+      to: APP_ROUTES.DASHBOARD_COMPONENTS_V2,
+      search: buildSearch({ sourceKeys: nextDisabledSourceKeys }),
+    });
     if (rerankedFor !== null) {
       clearRerank();
     }
@@ -870,6 +943,10 @@ export const DashboardComponentsV2View = () => {
 
   const handleEnableAllSources = () => {
     setDisabledSourceKeys([]);
+    navigate({
+      to: APP_ROUTES.DASHBOARD_COMPONENTS_V2,
+      search: buildSearch({ sourceKeys: [] }),
+    });
     if (rerankedFor !== null) {
       clearRerank();
     }
@@ -952,6 +1029,26 @@ export const DashboardComponentsV2View = () => {
     if (!selectedReference?.digest || !selectedReference.spec) return;
     if (!canGenerateDescription) return;
     refetchDescription();
+  };
+
+  const handleCopyLink = async () => {
+    if (!selectedDigest) return;
+    if (!navigator.clipboard) {
+      notify(
+        "Couldn't copy link. Check browser permissions and try again.",
+        "error",
+      );
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(window.location.href);
+      notify("Component link copied to clipboard", "success");
+    } catch {
+      notify(
+        "Couldn't copy link. Check browser permissions and try again.",
+        "error",
+      );
+    }
   };
 
   const handleCopyToPipeline = async () => {
@@ -1092,6 +1189,7 @@ export const DashboardComponentsV2View = () => {
             <DebouncedComponentSearchInput
               onCommit={handleQueryCommit}
               disabled={isLoadingLibrary || noLibraryData}
+              initialValue={queryFromUrl}
             />
             <Button
               variant="secondary"
@@ -1185,6 +1283,22 @@ export const DashboardComponentsV2View = () => {
                 InlineStack handles the button row's layout. */}
             <div className="sticky top-0 float-right z-10 bg-background/80 backdrop-blur-sm rounded-md">
               <InlineStack gap="1">
+                <QuickTooltip content="Copy link" side="bottom">
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={handleCopyLink}
+                    aria-label="Copy component link"
+                    {...tracking(
+                      "component_library.result_detail_v2.copy_link_button",
+                      {
+                        surface: "dashboard_v2",
+                      },
+                    )}
+                  >
+                    <Icon name="Link" />
+                  </Button>
+                </QuickTooltip>
                 <QuickTooltip content="Copy to clipboard" side="bottom">
                   <Button
                     variant="ghost"

--- a/src/routes/Dashboard/searchParams.test.ts
+++ b/src/routes/Dashboard/searchParams.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { readSelectedComponentDigest } from "./searchParams";
+import {
+  createDashboardComponentsV2SearchParams,
+  readComponentSearchQuery,
+  readDisabledSourceKeys,
+  readSelectedComponentDigest,
+} from "./searchParams";
 
 describe("readSelectedComponentDigest", () => {
   it("returns the digest from a search record with a string `component`", () => {
@@ -23,5 +28,64 @@ describe("readSelectedComponentDigest", () => {
     expect(readSelectedComponentDigest(null)).toBeUndefined();
     expect(readSelectedComponentDigest("abc")).toBeUndefined();
     expect(readSelectedComponentDigest(["abc"])).toBeUndefined();
+  });
+});
+
+describe("readComponentSearchQuery", () => {
+  it("returns the query from a string `q` param", () => {
+    expect(readComponentSearchQuery({ q: "train model" })).toBe("train model");
+  });
+
+  it("returns an empty string when `q` is missing or invalid", () => {
+    expect(readComponentSearchQuery({})).toBe("");
+    expect(readComponentSearchQuery({ q: 42 })).toBe("");
+    expect(readComponentSearchQuery(undefined)).toBe("");
+  });
+});
+
+describe("readDisabledSourceKeys", () => {
+  it("reads valid comma-separated source keys", () => {
+    expect(
+      readDisabledSourceKeys({ disabled_sources: "registered,user" }),
+    ).toEqual(["registered", "user"]);
+  });
+
+  it("drops unknown source keys", () => {
+    expect(
+      readDisabledSourceKeys({
+        disabled_sources: "registered,unknown,standard",
+      }),
+    ).toEqual(["registered", "standard"]);
+  });
+
+  it("returns an empty list when source keys are missing or invalid", () => {
+    expect(readDisabledSourceKeys({})).toEqual([]);
+    expect(readDisabledSourceKeys({ disabled_sources: 42 })).toEqual([]);
+    expect(readDisabledSourceKeys(undefined)).toEqual([]);
+  });
+});
+
+describe("createDashboardComponentsV2SearchParams", () => {
+  it("omits empty values", () => {
+    expect(
+      createDashboardComponentsV2SearchParams({
+        q: "  ",
+        disabledSourceKeys: [],
+      }),
+    ).toEqual({});
+  });
+
+  it("preserves search query whitespace so URL sync does not rewrite active input", () => {
+    expect(
+      createDashboardComponentsV2SearchParams({
+        component: "abc123",
+        q: "  train model  ",
+        disabledSourceKeys: ["registered", "unknown"],
+      }),
+    ).toEqual({
+      component: "abc123",
+      q: "  train model  ",
+      disabled_sources: "registered",
+    });
   });
 });

--- a/src/routes/Dashboard/searchParams.ts
+++ b/src/routes/Dashboard/searchParams.ts
@@ -1,5 +1,18 @@
 import { isRecord } from "@/utils/typeGuards";
 
+export interface DashboardComponentsV2SearchParams {
+  component?: string;
+  q?: string;
+  disabled_sources?: string;
+}
+
+const VALID_SOURCE_KEYS = new Set([
+  "standard",
+  "published",
+  "registered",
+  "user",
+]);
+
 /**
  * Read the `?component=<digest>` search param from a TanStack Router search
  * object. Shared between the V1 and V2 dashboard views so both surfaces parse
@@ -10,4 +23,42 @@ export function readSelectedComponentDigest(
 ): string | undefined {
   if (!isRecord(search)) return undefined;
   return typeof search.component === "string" ? search.component : undefined;
+}
+
+export function readComponentSearchQuery(search: unknown): string {
+  if (!isRecord(search)) return "";
+  return typeof search.q === "string" ? search.q : "";
+}
+
+export function readDisabledSourceKeys(search: unknown): string[] {
+  if (!isRecord(search) || typeof search.disabled_sources !== "string") {
+    return [];
+  }
+
+  return search.disabled_sources
+    .split(",")
+    .filter((key) => VALID_SOURCE_KEYS.has(key));
+}
+
+export function createDashboardComponentsV2SearchParams({
+  component,
+  q,
+  disabledSourceKeys,
+}: {
+  component?: string;
+  q: string;
+  disabledSourceKeys: string[];
+}): DashboardComponentsV2SearchParams {
+  const hasNonWhitespaceQuery = q.trim().length > 0;
+  const validDisabledKeys = disabledSourceKeys.filter((key) =>
+    VALID_SOURCE_KEYS.has(key),
+  );
+
+  return {
+    ...(component ? { component } : {}),
+    ...(hasNonWhitespaceQuery ? { q } : {}),
+    ...(validDisabledKeys.length > 0
+      ? { disabled_sources: validDisabledKeys.join(",") }
+      : {}),
+  };
 }


### PR DESCRIPTION
## Description

The component search state (`q` and `disabled_sources`) is now persisted in the URL, making searches shareable and preserving state across page refreshes. A "Copy component link" button has been added to the detail pane so users can copy a URL that includes the selected component, active search query, and source filters.

Key behaviors:
- The search input initializes from the `q` URL param on mount and syncs back to the URL after a debounce, without trimming whitespace while the input is focused.
- Focused input is protected from URL echo updates — navigating back to the same page with a slightly different URL (e.g. trimmed query) will not overwrite what the user is actively typing.
- Source filter toggles immediately write `disabled_sources` into the URL.
- Closing the detail pane preserves the active search query and source filters rather than clearing all search params.
- `useDebouncedSearchValue` now accepts an `initialValue` and a `shouldSyncExternalValue` guard so external value changes can be blocked while the input is focused.
- New helpers `readComponentSearchQuery`, `readDisabledSourceKeys`, and `createDashboardComponentsV2SearchParams` centralize URL param parsing and serialization, with unknown source keys silently dropped.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Navigate to the Components V2 dashboard page.
2. Type a search query and verify the `q` param appears in the URL after the debounce delay.
3. Reload the page and confirm the search input and filtered results are restored from the URL.
4. Toggle source filters and confirm `disabled_sources` updates in the URL immediately.
5. Open a component detail pane, then close it and confirm the search query and source filters remain in the URL.
6. With a component selected, click "Copy component link" and paste the URL — confirm it includes the selected component, query, and filters.
7. Type in the search input rapidly and confirm the URL does not rewrite the input value while it is focused.

## Additional Comments

The `disabled_sources` param only accepts the known source keys (`standard`, `published`, `registered`, `user`); unrecognized values are silently dropped during parsing and serialization.