### PR TITLE
Add component lifecycle badges

### DIFF
--- a/react-compiler.config.js
+++ b/react-compiler.config.js
@@ -37,6 +37,7 @@ export const REACT_COMPILER_ENABLED_DIRS = [
   "src/hooks/useFavorites.ts",
   "src/hooks/useRecentlyViewed.ts",
   "src/components/shared/FavoriteToggle.tsx",
+  "src/components/shared/ComponentLifecycleBadges.tsx",
 
   "src/components/shared/Tags",
   "src/components/shared/Submitters/Tangle/components",

--- a/src/components/shared/ComponentDetail/ComponentDetail.tsx
+++ b/src/components/shared/ComponentDetail/ComponentDetail.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 
 import { CodeViewer } from "@/components/shared/CodeViewer";
+import { ComponentLifecycleBadges } from "@/components/shared/ComponentLifecycleBadges";
 import { CopyText } from "@/components/shared/CopyText/CopyText";
 import { GithubDetails } from "@/components/shared/TaskDetails/GithubDetails";
 import { Badge } from "@/components/ui/badge";
@@ -9,6 +10,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Heading, Paragraph, Text } from "@/components/ui/typography";
 import { useHydrateComponentReference } from "@/hooks/useHydrateComponentReference";
 import { cn } from "@/lib/utils";
+import { getComponentLifecycleInfo } from "@/services/componentLifecycle";
 import type {
   ComponentReference,
   InputSpec,
@@ -257,11 +259,15 @@ export const ComponentDetail = ({
   const hasIO =
     (spec.inputs && spec.inputs.length > 0) ||
     (spec.outputs && spec.outputs.length > 0);
+  const lifecycle = getComponentLifecycleInfo(hydrated);
 
   // ── Shared sub-blocks ──────────────────────────────────────────────────
   const header = (
     <BlockStack gap="2">
-      <Heading level={2}>{getComponentName(hydrated)}</Heading>
+      <InlineStack gap="2" blockAlign="center" wrap="wrap">
+        <Heading level={2}>{getComponentName(hydrated)}</Heading>
+        <ComponentLifecycleBadges reference={hydrated} />
+      </InlineStack>
       {author && (
         <Text size="sm" tone="subdued">
           {author}
@@ -278,6 +284,14 @@ export const ComponentDetail = ({
         </Badge>
       )}
     </BlockStack>
+  );
+
+  const lifecycleWarning = lifecycle && (
+    <Paragraph size="sm" tone="subdued">
+      {lifecycle.state === "superseded"
+        ? "This component has been superseded. Prefer the replacement when possible."
+        : "This component is deprecated. Prefer an active replacement when possible."}
+    </Paragraph>
   );
 
   const description = spec.description && (
@@ -308,6 +322,7 @@ export const ComponentDetail = ({
     return (
       <BlockStack gap="6" align="stretch">
         {header}
+        {lifecycleWarning}
         {!hideDescription && description}
         {githubLinks}
         {io}
@@ -334,6 +349,7 @@ export const ComponentDetail = ({
     <InlineStack gap="6" blockAlign="start">
       <BlockStack gap="4" className="flex-2 min-w-0">
         {header}
+        {lifecycleWarning}
         {!hideDescription && description}
         {githubLinks}
         {io}

--- a/src/components/shared/ComponentLifecycleBadges.tsx
+++ b/src/components/shared/ComponentLifecycleBadges.tsx
@@ -1,0 +1,45 @@
+import { Badge } from "@/components/ui/badge";
+import { InlineStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
+import {
+  type ComponentLifecycleInfo,
+  getComponentLifecycleInfo,
+} from "@/services/componentLifecycle";
+import type { ComponentReference } from "@/utils/componentSpec";
+
+interface ComponentLifecycleBadgesProps {
+  reference: ComponentReference;
+}
+
+function lifecycleLabel(lifecycle: ComponentLifecycleInfo): string {
+  if (lifecycle.state === "superseded") return "Superseded";
+  return "Deprecated";
+}
+
+export function ComponentLifecycleBadges({
+  reference,
+}: ComponentLifecycleBadgesProps) {
+  const lifecycle = getComponentLifecycleInfo(reference);
+  if (!lifecycle) return null;
+
+  return (
+    <InlineStack gap="1">
+      <Badge
+        variant={lifecycle.state === "superseded" ? "secondary" : "destructive"}
+      >
+        {lifecycleLabel(lifecycle)}
+      </Badge>
+      {lifecycle.replacementDigest && (
+        <Badge
+          variant="outline"
+          title={`Replaced by ${lifecycle.replacementDigest}`}
+        >
+          Replaced by
+          <Text as="span" font="mono">
+            {lifecycle.replacementDigest}
+          </Text>
+        </Badge>
+      )}
+    </InlineStack>
+  );
+}

--- a/src/routes/Dashboard/DashboardComponentsV2View.test.tsx
+++ b/src/routes/Dashboard/DashboardComponentsV2View.test.tsx
@@ -411,6 +411,8 @@ describe("DashboardComponentsV2View", () => {
     routeMocks.aiDescriptionsEnabled = false;
     routeMocks.descriptionErrorState.current = null;
     routeMocks.search = {};
+    routeMocks.standard.deprecated = false;
+    routeMocks.standard.superseded_by = undefined;
     routeMocks.navigate.mockClear();
     routeMocks.notify.mockClear();
     routeMocks.refetchDescription.mockClear();
@@ -539,6 +541,14 @@ describe("DashboardComponentsV2View", () => {
       to: "/dashboard/components-v2",
       search: { q: "standard", disabled_sources: "registered" },
     });
+  });
+
+  it("shows lifecycle badges from component metadata", () => {
+    routeMocks.standard.deprecated = true;
+
+    render(<DashboardComponentsV2View />);
+
+    expect(screen.getByText("Deprecated")).toBeInTheDocument();
   });
 
   it("does not run AI search when literal search has no matches", async () => {

--- a/src/routes/Dashboard/DashboardComponentsV2View.tsx
+++ b/src/routes/Dashboard/DashboardComponentsV2View.tsx
@@ -15,6 +15,7 @@ import {
   ComponentDetail,
   ComponentDetailSkeleton,
 } from "@/components/shared/ComponentDetail/ComponentDetail";
+import { ComponentLifecycleBadges } from "@/components/shared/ComponentLifecycleBadges";
 import { useFlagValue } from "@/components/shared/Settings/useFlags";
 import { SuspenseWrapper } from "@/components/shared/SuspenseWrapper";
 import { Badge } from "@/components/ui/badge";
@@ -275,6 +276,7 @@ const ComponentCard = ({
           <Text size="sm" weight="semibold">
             {name}
           </Text>
+          <ComponentLifecycleBadges reference={reference} />
           {rerankScore !== undefined && (
             <Badge variant="secondary">
               Relevance: {Math.round(rerankScore * 100)}%

--- a/src/services/componentLifecycle.test.ts
+++ b/src/services/componentLifecycle.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import type { ComponentReference } from "@/utils/componentSpec";
+
+import { getComponentLifecycleInfo } from "./componentLifecycle";
+
+function reference(
+  overrides: Partial<ComponentReference> = {},
+): ComponentReference {
+  return {
+    digest: "component-digest",
+    name: "Component",
+    spec: {
+      name: "Component",
+      implementation: { container: { image: "python:3.11" } },
+    },
+    ...overrides,
+  };
+}
+
+describe("getComponentLifecycleInfo", () => {
+  it("returns undefined when no lifecycle metadata is present", () => {
+    expect(getComponentLifecycleInfo(reference())).toBeUndefined();
+  });
+
+  it("reads deprecated state from component references", () => {
+    expect(getComponentLifecycleInfo(reference({ deprecated: true }))).toEqual({
+      state: "deprecated",
+    });
+  });
+
+  it("reads superseded state from component references", () => {
+    expect(
+      getComponentLifecycleInfo(reference({ superseded_by: "next-digest" })),
+    ).toEqual({ state: "superseded", replacementDigest: "next-digest" });
+  });
+
+  it("reads lifecycle state from annotations", () => {
+    expect(
+      getComponentLifecycleInfo(
+        reference({
+          spec: {
+            name: "Component",
+            implementation: { container: { image: "python:3.11" } },
+            metadata: {
+              annotations: { "lifecycle.state": "deprecated" },
+            },
+          },
+        }),
+      ),
+    ).toEqual({ state: "deprecated" });
+  });
+
+  it("prefers superseded state when replacement metadata exists", () => {
+    expect(
+      getComponentLifecycleInfo(
+        reference({
+          deprecated: true,
+          spec: {
+            name: "Component",
+            implementation: { container: { image: "python:3.11" } },
+            metadata: {
+              annotations: { superseded_by: "replacement-digest" },
+            },
+          },
+        }),
+      ),
+    ).toEqual({
+      state: "superseded",
+      replacementDigest: "replacement-digest",
+    });
+  });
+});

--- a/src/services/componentLifecycle.ts
+++ b/src/services/componentLifecycle.ts
@@ -1,0 +1,70 @@
+import type { ComponentReference } from "@/utils/componentSpec";
+import { isRecord } from "@/utils/typeGuards";
+
+type ComponentLifecycleState = "deprecated" | "superseded";
+
+export interface ComponentLifecycleInfo {
+  state: ComponentLifecycleState;
+  replacementDigest?: string;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : undefined;
+}
+
+function readBoolean(value: unknown): boolean | undefined {
+  if (typeof value === "boolean") return value;
+  if (typeof value !== "string") return undefined;
+
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "true") return true;
+  if (normalized === "false") return false;
+  return undefined;
+}
+
+function readLifecycleState(
+  value: unknown,
+): ComponentLifecycleState | undefined {
+  if (typeof value !== "string") return undefined;
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "deprecated") return "deprecated";
+  if (normalized === "superseded") return "superseded";
+  return undefined;
+}
+
+export function getComponentLifecycleInfo(
+  reference: ComponentReference,
+): ComponentLifecycleInfo | undefined {
+  const annotations = reference.spec?.metadata?.annotations;
+  const annotationLifecycleState = isRecord(annotations)
+    ? readLifecycleState(
+        annotations["lifecycle.state"] ??
+          annotations["tangleml.com/lifecycle-state"],
+      )
+    : undefined;
+  const replacementDigest = isRecord(annotations)
+    ? (readString(annotations.superseded_by) ??
+      readString(annotations.supersededBy) ??
+      readString(annotations["tangleml.com/superseded-by"]) ??
+      readString(reference.superseded_by))
+    : readString(reference.superseded_by);
+
+  if (replacementDigest) {
+    return { state: "superseded", replacementDigest };
+  }
+
+  if (annotationLifecycleState === "superseded") {
+    return { state: "superseded" };
+  }
+
+  const deprecated = isRecord(annotations)
+    ? (readBoolean(annotations.deprecated) ?? reference.deprecated)
+    : reference.deprecated;
+  if (deprecated || annotationLifecycleState === "deprecated") {
+    return { state: "deprecated" };
+  }
+
+  return undefined;
+}


### PR DESCRIPTION
## Description

Adds visual indicators for deprecated and superseded components throughout the component browser. A new `ComponentLifecycleBadges` component renders "Deprecated" or "Superseded" badges next to component names, and a warning message is shown in the component detail pane advising users to prefer active replacements. When a replacement digest is available, it is shown inline within the badge.

Lifecycle state is resolved via a new `getComponentLifecycleInfo` service that reads from multiple sources: top-level `deprecated` and `superseded_by` fields on the component reference, as well as `lifecycle.state`, `superseded_by`, `supersededBy`, and their `tangleml.com/`-prefixed annotation equivalents. Superseded state takes priority over deprecated state when a replacement digest is present.

Badges appear both on component cards in the list view and in the component detail header.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Open the component browser and select a component that has `deprecated: true` set on its reference — confirm a "Deprecated" badge appears next to the component name in both the card and the detail pane, along with a warning message.
2. Set `superseded_by` to a digest on a component reference — confirm a "Superseded" badge and a "Replaced by `<digest>`" badge appear, and the detail pane shows the superseded warning.
3. Confirm components with no lifecycle metadata show no badges or warnings.
4. Run the unit tests in `src/services/componentLifecycle.test.ts` to verify all annotation and field resolution paths.

## Additional Comments

The annotation keys checked are `lifecycle.state`, `tangleml.com/lifecycle-state`, `superseded_by`, `supersededBy`, and `tangleml.com/superseded-by`, providing flexibility across different annotation conventions.