### PR TITLE
Add compatible component suggestions

### DIFF
--- a/src/routes/Dashboard/DashboardComponentsV2View.test.tsx
+++ b/src/routes/Dashboard/DashboardComponentsV2View.test.tsx
@@ -19,6 +19,12 @@ const routeMocks = vi.hoisted(() => {
     spec: {
       name,
       description: `${name} description`,
+      inputs:
+        digest === "registered-digest"
+          ? [{ name: "data", type: "Dataset" }]
+          : [],
+      outputs:
+        digest === "standard-digest" ? [{ name: "data", type: "Dataset" }] : [],
       implementation: { container: { image: "python:3.11" } },
     },
   });
@@ -599,6 +605,17 @@ describe("DashboardComponentsV2View", () => {
       "Component link copied to clipboard",
       "success",
     );
+  });
+
+  it("shows compatible component suggestions in details", () => {
+    routeMocks.search = { component: "standard-digest" };
+
+    render(<DashboardComponentsV2View />);
+
+    expect(screen.getByText("Compatible components")).toBeInTheDocument();
+    expect(screen.getAllByText("Registered component")).not.toHaveLength(0);
+    expect(screen.getByText("Can use outputs")).toBeInTheDocument();
+    expect(screen.getByText("Matching type: dataset")).toBeInTheDocument();
   });
 
   it("clears only the selected component when closing details", () => {

--- a/src/routes/Dashboard/DashboardComponentsV2View.tsx
+++ b/src/routes/Dashboard/DashboardComponentsV2View.tsx
@@ -47,6 +47,7 @@ import {
   LibraryDB,
   type StoredLibrary,
 } from "@/providers/ComponentLibraryProvider/libraries/storage";
+import { buildCompatibleComponentSuggestions } from "@/services/componentCompatibility";
 import { rankComponentMatchesByEmbeddings } from "@/services/componentSearchEmbeddings";
 import {
   buildSearchIndex,
@@ -373,6 +374,73 @@ const CollectionCard = ({ collection }: CollectionCardProps) => (
     )}
   </BlockStack>
 );
+
+interface CompatibleComponentsPanelProps {
+  suggestions: ReturnType<typeof buildCompatibleComponentSuggestions>;
+  onSelect: (reference: ComponentReference) => void;
+}
+
+const CompatibleComponentsPanel = ({
+  suggestions,
+  onSelect,
+}: CompatibleComponentsPanelProps) => {
+  if (suggestions.length === 0) return null;
+
+  return (
+    <BlockStack gap="2" align="stretch">
+      <Text
+        size="xs"
+        tone="subdued"
+        weight="semibold"
+        className="uppercase tracking-wide"
+      >
+        Compatible components
+      </Text>
+      <BlockStack gap="2" align="stretch">
+        {suggestions.map((suggestion) => {
+          const name = getComponentName(suggestion.reference);
+          return (
+            <button
+              key={`${suggestion.direction}:${suggestion.reference.digest}`}
+              type="button"
+              onClick={() => onSelect(suggestion.reference)}
+              aria-label={`View details for compatible component ${name}`}
+              className={cn(
+                PANEL_CLASS,
+                "w-full text-left cursor-pointer hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:border-ring",
+              )}
+            >
+              <BlockStack gap="1">
+                <InlineStack gap="2" blockAlign="center" wrap="wrap">
+                  <Icon
+                    name={
+                      suggestion.direction === "downstream"
+                        ? "ArrowRight"
+                        : "ArrowLeft"
+                    }
+                    size="sm"
+                  />
+                  <Text size="sm" weight="semibold">
+                    {name}
+                  </Text>
+                  <Badge variant="secondary">
+                    {suggestion.direction === "downstream"
+                      ? "Can use outputs"
+                      : "Can provide inputs"}
+                  </Badge>
+                </InlineStack>
+                <Paragraph size="xs" tone="subdued">
+                  Matching type{suggestion.matchedTypes.length === 1 ? "" : "s"}
+                  : {suggestion.matchedTypes.join(", ")}
+                </Paragraph>
+              </BlockStack>
+            </button>
+          );
+        })}
+      </BlockStack>
+    </BlockStack>
+  );
+};
 
 interface ComponentDescriptionPanelProps {
   prefilledDescription?: string;
@@ -1075,6 +1143,10 @@ export const DashboardComponentsV2View = () => {
     };
   })();
   const isDetailOpen = Boolean(selectedDigest);
+  const compatibleComponentSuggestions = buildCompatibleComponentSuggestions(
+    selectedReference,
+    sourcedHydrated.map((sourced) => sourced.reference),
+  );
 
   // AI description query. Keyed by digest so each component gets its own
   // cached result, isolated error/pending, and an AbortSignal that fires
@@ -1434,6 +1506,10 @@ export const DashboardComponentsV2View = () => {
                   hideDescription
                 />
               </SuspenseWrapper>
+              <CompatibleComponentsPanel
+                suggestions={compatibleComponentSuggestions}
+                onSelect={selectComponent}
+              />
             </BlockStack>
           </div>
         )}

--- a/src/services/componentCompatibility.test.ts
+++ b/src/services/componentCompatibility.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+
+import type { ComponentReference, TypeSpecType } from "@/utils/componentSpec";
+
+import { buildCompatibleComponentSuggestions } from "./componentCompatibility";
+
+function component({
+  digest,
+  inputs = [],
+  outputs = [],
+}: {
+  digest: string;
+  inputs?: Array<{ name: string; type?: TypeSpecType }>;
+  outputs?: Array<{ name: string; type?: TypeSpecType }>;
+}): ComponentReference {
+  return {
+    digest,
+    name: digest,
+    spec: {
+      name: digest,
+      inputs,
+      outputs,
+      implementation: { container: { image: "python:3.11" } },
+    },
+  };
+}
+
+describe("buildCompatibleComponentSuggestions", () => {
+  it("finds downstream components whose inputs match selected outputs", () => {
+    const selected = component({
+      digest: "load-data",
+      outputs: [{ name: "dataset", type: "Dataset" }],
+    });
+    const downstream = component({
+      digest: "train-model",
+      inputs: [{ name: "dataset", type: "dataset" }],
+    });
+
+    expect(buildCompatibleComponentSuggestions(selected, [downstream])).toEqual(
+      [
+        {
+          direction: "downstream",
+          reference: downstream,
+          matchedTypes: ["dataset"],
+        },
+      ],
+    );
+  });
+
+  it("finds upstream components whose outputs match selected inputs", () => {
+    const selected = component({
+      digest: "train-model",
+      inputs: [{ name: "dataset", type: "Dataset" }],
+    });
+    const upstream = component({
+      digest: "load-data",
+      outputs: [{ name: "dataset", type: "dataset" }],
+    });
+
+    expect(buildCompatibleComponentSuggestions(selected, [upstream])).toEqual([
+      {
+        direction: "upstream",
+        reference: upstream,
+        matchedTypes: ["dataset"],
+      },
+    ]);
+  });
+
+  it("matches object types regardless of key order", () => {
+    const selected = component({
+      digest: "load-data",
+      outputs: [
+        {
+          name: "dataset",
+          type: { schema: "Dataset", format: "parquet" },
+        },
+      ],
+    });
+    const downstream = component({
+      digest: "train-model",
+      inputs: [
+        {
+          name: "dataset",
+          type: { format: "parquet", schema: "Dataset" },
+        },
+      ],
+    });
+
+    expect(buildCompatibleComponentSuggestions(selected, [downstream])).toEqual(
+      [
+        {
+          direction: "downstream",
+          reference: downstream,
+          matchedTypes: ['{"format":"parquet","schema":"dataset"}'],
+        },
+      ],
+    );
+  });
+
+  it("ignores self, any, missing specs, and unmatched types", () => {
+    const selected = component({
+      digest: "selected",
+      inputs: [{ name: "input", type: "Any" }],
+      outputs: [{ name: "output", type: "Dataset" }],
+    });
+
+    expect(
+      buildCompatibleComponentSuggestions(selected, [
+        selected,
+        { digest: "stub" },
+        component({
+          digest: "metrics",
+          inputs: [{ name: "metrics", type: "Metrics" }],
+        }),
+      ]),
+    ).toEqual([]);
+  });
+});

--- a/src/services/componentCompatibility.ts
+++ b/src/services/componentCompatibility.ts
@@ -1,0 +1,104 @@
+import type { ComponentReference, TypeSpecType } from "@/utils/componentSpec";
+
+type ComponentCompatibilityDirection = "upstream" | "downstream";
+
+export interface CompatibleComponentSuggestion {
+  direction: ComponentCompatibilityDirection;
+  reference: ComponentReference;
+  matchedTypes: string[];
+}
+
+function sortTypeObject(type: TypeSpecType): TypeSpecType {
+  if (typeof type === "string") return type;
+
+  return Object.fromEntries(
+    Object.entries(type)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, value]) => [key, sortTypeObject(value)]),
+  );
+}
+
+function stableStringifyType(type: TypeSpecType): string {
+  return JSON.stringify(sortTypeObject(type));
+}
+
+function normalizeType(type: TypeSpecType | undefined): string | undefined {
+  if (typeof type === "string") {
+    const normalized = type.trim().toLowerCase();
+    return normalized && normalized !== "any" ? normalized : undefined;
+  }
+  if (!type) return undefined;
+
+  const normalized = stableStringifyType(type).toLowerCase();
+  return normalized === "{}" ? undefined : normalized;
+}
+
+function uniqueTypes(types: Array<string | undefined>): string[] {
+  return [...new Set(types.filter((type): type is string => Boolean(type)))];
+}
+
+function intersectTypes(a: string[], b: string[]): string[] {
+  const bSet = new Set(b);
+  return a.filter((type) => bSet.has(type));
+}
+
+export function buildCompatibleComponentSuggestions(
+  selected: ComponentReference | undefined,
+  candidates: ComponentReference[],
+  { limit = 6 }: { limit?: number } = {},
+): CompatibleComponentSuggestion[] {
+  const selectedSpec = selected?.spec;
+  if (!selected?.digest || !selectedSpec) return [];
+
+  const selectedInputTypes = uniqueTypes(
+    selectedSpec.inputs?.map((input) => normalizeType(input.type)) ?? [],
+  );
+  const selectedOutputTypes = uniqueTypes(
+    selectedSpec.outputs?.map((output) => normalizeType(output.type)) ?? [],
+  );
+  if (selectedInputTypes.length === 0 && selectedOutputTypes.length === 0) {
+    return [];
+  }
+
+  const suggestions: CompatibleComponentSuggestion[] = [];
+  for (const candidate of candidates) {
+    if (!candidate.digest || candidate.digest === selected.digest) continue;
+    const candidateSpec = candidate.spec;
+    if (!candidateSpec) continue;
+
+    const candidateInputTypes = uniqueTypes(
+      candidateSpec.inputs?.map((input) => normalizeType(input.type)) ?? [],
+    );
+    const candidateOutputTypes = uniqueTypes(
+      candidateSpec.outputs?.map((output) => normalizeType(output.type)) ?? [],
+    );
+
+    const downstreamTypes = intersectTypes(
+      selectedOutputTypes,
+      candidateInputTypes,
+    );
+    if (downstreamTypes.length > 0) {
+      suggestions.push({
+        direction: "downstream",
+        reference: candidate,
+        matchedTypes: downstreamTypes,
+      });
+    }
+
+    const upstreamTypes = intersectTypes(
+      candidateOutputTypes,
+      selectedInputTypes,
+    );
+    if (upstreamTypes.length > 0) {
+      suggestions.push({
+        direction: "upstream",
+        reference: candidate,
+        matchedTypes: upstreamTypes,
+      });
+    }
+
+    if (suggestions.length >= limit) break;
+  }
+
+  return suggestions.slice(0, limit);
+}


### PR DESCRIPTION
## Description

Adds a "Compatible components" panel to the component details view that surfaces other components in the library whose input/output types are compatible with the currently selected component.

A new `buildCompatibleComponentSuggestions` service compares the selected component's inputs and outputs against all other loaded components. It normalizes types to lowercase, ignores `Any` and empty types, and handles both string and object type definitions (sorting object keys for stable comparison). Each suggestion is labelled as either `"downstream"` (can consume the selected component's outputs) or `"upstream"` (can provide inputs to the selected component), with the matched types listed. Results are capped at 6 suggestions.

The panel renders each suggestion as a clickable button that navigates to that component's detail view, showing the direction badge ("Can use outputs" / "Can provide inputs") and the matching type names.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Open the component library and select a component that has typed inputs or outputs.
2. Verify that a "Compatible components" section appears in the details panel.
3. Confirm that listed components show the correct direction badge ("Can use outputs" or "Can provide inputs") and matching type labels.
4. Click a suggestion and confirm the detail view navigates to that component.
5. Select a component with no typed inputs or outputs and confirm the section does not appear.

## Additional Comments

Type matching is case-insensitive and `Any` types are excluded from matching to avoid false positives. Object types are compared by serialising their keys in sorted order.