### PR TITLE
Polish component search explanations

### DIFF
--- a/src/components/shared/ReactFlow/FlowSidebar/components/ComponentItem.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/components/ComponentItem.tsx
@@ -13,6 +13,8 @@ import { Spinner } from "@/components/ui/spinner";
 import { Text } from "@/components/ui/typography";
 import { useHydrateComponentReference } from "@/hooks/useHydrateComponentReference";
 import { cn } from "@/lib/utils";
+import { formatMatchedFieldsExplanation } from "@/services/componentSearchExplanations";
+import type { MatchField } from "@/services/componentSearchIndex";
 import { type ComponentReference, type TaskSpec } from "@/utils/componentSpec";
 import { getComponentName } from "@/utils/getComponentName";
 import { isSubgraph } from "@/utils/subgraphUtils";
@@ -28,6 +30,7 @@ interface ComponentMarkupProps {
   isLoading?: boolean;
   error?: string | null;
   className?: string;
+  matchedFields?: MatchField[];
   rerankScore?: number;
   rerankReason?: string;
 }
@@ -87,6 +90,7 @@ const ComponentMarkup = ({
   isLoading,
   error,
   className,
+  matchedFields,
   rerankScore,
   rerankReason,
 }: ComponentMarkupProps) => {
@@ -173,6 +177,8 @@ const ComponentMarkup = ({
   }, []);
 
   const iconName = isSubgraphSpec ? "Workflow" : owned ? "FileBadge" : "File";
+  const matchExplanation =
+    rerankReason ?? formatMatchedFieldsExplanation(matchedFields);
 
   const iconClass = cn(
     "shrink-0",
@@ -233,12 +239,12 @@ const ComponentMarkup = ({
                     {author}
                   </span>
                 )}
-                {rerankReason ? (
+                {matchExplanation ? (
                   <span
                     className="truncate text-[10px] text-gray-500"
-                    title={rerankReason}
+                    title={matchExplanation}
                   >
-                    Why: {rerankReason}
+                    Why: {matchExplanation}
                   </span>
                 ) : (
                   <span className="truncate text-[10px] text-gray-500 font-mono">

--- a/src/routes/Dashboard/DashboardComponentsV2View.test.tsx
+++ b/src/routes/Dashboard/DashboardComponentsV2View.test.tsx
@@ -535,6 +535,33 @@ describe("DashboardComponentsV2View", () => {
     });
   });
 
+  it("explains why lexical component results matched", async () => {
+    render(<DashboardComponentsV2View />);
+
+    fireEvent.change(screen.getByLabelText("Search components"), {
+      target: { value: "standard" },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Why: Matched/)).toBeInTheDocument();
+    });
+  });
+
+  it("shows actionable no-results guidance", async () => {
+    render(<DashboardComponentsV2View />);
+
+    fireEvent.change(screen.getByLabelText("Search components"), {
+      target: { value: "no-such-component" },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("No components matched “no-such-component”."),
+      ).toBeInTheDocument();
+    });
+    expect(screen.getByText(/Try a component name/)).toBeInTheDocument();
+  });
+
   it("initializes search state from URL params", () => {
     routeMocks.search = {
       q: "registered",

--- a/src/routes/Dashboard/DashboardComponentsV2View.tsx
+++ b/src/routes/Dashboard/DashboardComponentsV2View.tsx
@@ -50,6 +50,10 @@ import {
 import { buildCompatibleComponentSuggestions } from "@/services/componentCompatibility";
 import { rankComponentMatchesByEmbeddings } from "@/services/componentSearchEmbeddings";
 import {
+  COMPONENT_SEARCH_MATCH_FIELD_LABEL,
+  formatMatchedFieldsExplanation,
+} from "@/services/componentSearchExplanations";
+import {
   buildSearchIndex,
   type ComponentSearchSource,
   type IndexEntry,
@@ -123,14 +127,6 @@ const LEXICAL_RESULT_LIMIT = 20;
 /** Bounded pool sent to AI search on click. */
 const AI_CANDIDATE_LIMIT = 80;
 const DASHBOARD_SEARCH_RESULT_DEBOUNCE_MS = 500;
-
-const MATCH_FIELD_LABEL: Record<MatchField, string> = {
-  name: "name",
-  description: "description",
-  io: "inputs/outputs",
-  implementation: "command",
-  metadata: "metadata",
-};
 
 // Built-in sources are constants — only registered libraries vary per row.
 const STANDARD_SOURCE: ComponentSearchSource = {
@@ -266,6 +262,8 @@ const ComponentCard = ({
     : "unknown";
   const showLexicalMatchBadges = isAiRanked ? undefined : matchedFields;
   const showDescription = description;
+  const matchExplanation =
+    reason ?? formatMatchedFieldsExplanation(showLexicalMatchBadges);
 
   return (
     // Raw <button> rather than the <Button> primitive: the primitive's variants
@@ -324,7 +322,7 @@ const ComponentCard = ({
           )}
           {showLexicalMatchBadges?.map((field) => (
             <Badge key={field} variant="secondary">
-              matched: {MATCH_FIELD_LABEL[field]}
+              matched: {COMPONENT_SEARCH_MATCH_FIELD_LABEL[field]}
             </Badge>
           ))}
         </InlineStack>
@@ -342,9 +340,9 @@ const ComponentCard = ({
             {description}
           </Paragraph>
         )}
-        {reason && (
+        {matchExplanation && (
           <Paragraph size="xs" tone="subdued">
-            Why: {reason}
+            Why: {matchExplanation}
           </Paragraph>
         )}
       </BlockStack>
@@ -1261,10 +1259,16 @@ export const DashboardComponentsV2View = () => {
       !rerankActive
     ) {
       return (
-        <Paragraph size="sm" tone="subdued">
-          No components matched “{trimmedQuery}”. Try different terms or check
-          for typos.
-        </Paragraph>
+        <BlockStack gap="2">
+          <Paragraph size="sm" tone="subdued">
+            No components matched “{trimmedQuery}”.
+          </Paragraph>
+          <Paragraph size="xs" tone="subdued">
+            Try a component name, input/output type, source term, or task intent
+            like “csv”, “train model”, “predict”, or “dataframe”. AI search
+            reranks matching local candidates when it is configured.
+          </Paragraph>
+        </BlockStack>
       );
     }
     return (
@@ -1335,9 +1339,9 @@ export const DashboardComponentsV2View = () => {
             <Paragraph size="sm" tone="subdued">
               Type to search across every component source — standard library,
               your published components, registered libraries, and local user
-              components. Results match on name, description, inputs/outputs,
-              and container command. Use AI search to rerank with an LLM when
-              literal matching isn&apos;t enough.
+              components. Local results match on name, description,
+              inputs/outputs, metadata, and container command. Optional AI
+              search reranks matching local candidates when configured.
             </Paragraph>
           </BlockStack>
           <InlineStack gap="3" blockAlign="center" wrap="nowrap">

--- a/src/routes/v2/pages/Editor/components/ComponentSearchResults.test.tsx
+++ b/src/routes/v2/pages/Editor/components/ComponentSearchResults.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { ComponentSearchResults } from "./ComponentSearchResults";
+import type { ComponentSearchV2Result } from "./componentSearchV2Logic";
+
+vi.mock(
+  "@/components/shared/ReactFlow/FlowSidebar/components/ComponentItem",
+  () => ({
+    ComponentMarkup: ({
+      component,
+      matchedFields,
+    }: {
+      component: { name?: string };
+      matchedFields?: string[];
+    }) => (
+      <li>
+        {component.name}
+        {matchedFields && <span>matched {matchedFields.join(",")}</span>}
+      </li>
+    ),
+    IONodeSidebarItem: () => <li>IO node</li>,
+    StickyNoteSidebarItem: () => <li>Sticky note</li>,
+  }),
+);
+
+vi.mock(
+  "@/components/shared/ReactFlow/FlowSidebar/components/FolderItem",
+  () => ({
+    default: ({ folder }: { folder: { name: string } }) => (
+      <div>{folder.name}</div>
+    ),
+  }),
+);
+
+const baseProps = {
+  browseFolders: [],
+  isLoading: false,
+  isRerankActive: false,
+  onClearRerank: vi.fn(),
+};
+
+describe("ComponentSearchResults", () => {
+  it("shows actionable no-results guidance", () => {
+    render(
+      <ComponentSearchResults {...baseProps} query="missing" results={[]} />,
+    );
+
+    expect(
+      screen.getByText("No components matched “missing”."),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Try a component name/)).toBeInTheDocument();
+  });
+
+  it("passes matched fields through for result explanations", () => {
+    const results: ComponentSearchV2Result[] = [
+      {
+        reference: { digest: "digest", name: "Load CSV" },
+        source: { kind: "standard", id: "standard", label: "Standard" },
+        matchedFields: ["name", "io"],
+      },
+    ];
+
+    render(
+      <ComponentSearchResults {...baseProps} query="csv" results={results} />,
+    );
+
+    expect(screen.getByText("matched name,io")).toBeInTheDocument();
+  });
+});

--- a/src/routes/v2/pages/Editor/components/ComponentSearchResults.tsx
+++ b/src/routes/v2/pages/Editor/components/ComponentSearchResults.tsx
@@ -106,15 +106,22 @@ export function ComponentSearchResults({
               <ComponentMarkup
                 key={`${result.reference.digest}-${result.reference.name ?? result.reference.url ?? "component"}`}
                 component={result.reference}
+                matchedFields={result.matchedFields}
                 rerankScore={result.rerankScore}
                 rerankReason={result.rerankReason}
               />
             ))}
           </BlockStack>
         ) : (
-          <Paragraph size="sm" tone="subdued">
-            No results found
-          </Paragraph>
+          <BlockStack gap="1">
+            <Paragraph size="sm" tone="subdued">
+              No components matched “{query.trim()}”.
+            </Paragraph>
+            <Paragraph size="xs" tone="subdued">
+              Try a component name, input/output type, or task intent like
+              “csv”, “train”, “predict”, or “dataframe”.
+            </Paragraph>
+          </BlockStack>
         )}
       </div>
     </BlockStack>

--- a/src/routes/v2/pages/Editor/components/componentSearchV2Logic.test.ts
+++ b/src/routes/v2/pages/Editor/components/componentSearchV2Logic.test.ts
@@ -57,13 +57,14 @@ function source(
 function match(
   digest: string,
   src: ComponentSearchSource = source("standard"),
+  matchedFields: LexicalMatch["matchedFields"] = [],
 ): LexicalMatch {
   return {
     reference: ref(digest),
     digest,
     name: digest,
     source: src,
-    matchedFields: [],
+    matchedFields,
   };
 }
 
@@ -192,6 +193,16 @@ describe("rerankedMatches", () => {
 
 describe("buildResults", () => {
   const displayed = [match("a"), match("b"), match("c")];
+
+  it("carries matched fields for lexical explanations", () => {
+    const results = buildResults(
+      [match("a", source("standard"), ["name", "io"])],
+      new Map(),
+      false,
+    );
+
+    expect(results[0]?.matchedFields).toEqual(["name", "io"]);
+  });
 
   it("badges only items scored above the exclusion threshold", () => {
     const rerankMatches = buildRerankMatchByDigest(

--- a/src/routes/v2/pages/Editor/components/componentSearchV2Logic.ts
+++ b/src/routes/v2/pages/Editor/components/componentSearchV2Logic.ts
@@ -14,6 +14,7 @@ import {
   indexEntryToLexicalMatch,
   type LexicalMatch,
   lexicalSearch,
+  type MatchField,
   type SourcedReference,
 } from "@/services/componentSearchIndex";
 import type { RerankResult } from "@/services/naturalLanguageComponentSearchService";
@@ -61,6 +62,7 @@ export interface UserFolder {
 export interface ComponentSearchV2Result {
   reference: ComponentReference;
   source: ComponentSearchSource;
+  matchedFields?: MatchField[];
   rerankScore?: number;
   rerankReason?: string;
 }
@@ -417,6 +419,7 @@ export function buildResults(
     return {
       reference: match.reference,
       source: match.source,
+      matchedFields: match.matchedFields,
       ...(hasRerankMatch
         ? { rerankScore, rerankReason: rerankMatch.reason }
         : {}),

--- a/src/services/componentSearchExplanations.test.ts
+++ b/src/services/componentSearchExplanations.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { formatMatchedFieldsExplanation } from "./componentSearchExplanations";
+
+describe("formatMatchedFieldsExplanation", () => {
+  it("returns undefined when there are no matched fields", () => {
+    expect(formatMatchedFieldsExplanation(undefined)).toBeUndefined();
+    expect(formatMatchedFieldsExplanation([])).toBeUndefined();
+  });
+
+  it("formats one matched field", () => {
+    expect(formatMatchedFieldsExplanation(["name"])).toBe("Matched name.");
+  });
+
+  it("formats multiple matched fields as readable copy", () => {
+    expect(formatMatchedFieldsExplanation(["name", "io", "metadata"])).toBe(
+      "Matched name, inputs/outputs, and metadata.",
+    );
+  });
+
+  it("deduplicates matched fields", () => {
+    expect(formatMatchedFieldsExplanation(["name", "name", "io"])).toBe(
+      "Matched name and inputs/outputs.",
+    );
+  });
+});

--- a/src/services/componentSearchExplanations.ts
+++ b/src/services/componentSearchExplanations.ts
@@ -1,0 +1,27 @@
+import type { MatchField } from "@/services/componentSearchIndex";
+
+export const COMPONENT_SEARCH_MATCH_FIELD_LABEL: Record<MatchField, string> = {
+  name: "name",
+  description: "description",
+  io: "inputs/outputs",
+  implementation: "command",
+  metadata: "metadata",
+};
+
+function joinReadableList(values: string[]): string {
+  if (values.length === 1) return values[0];
+  if (values.length === 2) return `${values[0]} and ${values[1]}`;
+
+  return `${values.slice(0, -1).join(", ")}, and ${values.at(-1)}`;
+}
+
+export function formatMatchedFieldsExplanation(
+  fields: MatchField[] | undefined,
+): string | undefined {
+  if (!fields || fields.length === 0) return undefined;
+
+  const labels = Array.from(
+    new Set(fields.map((field) => COMPONENT_SEARCH_MATCH_FIELD_LABEL[field])),
+  );
+  return `Matched ${joinReadableList(labels)}.`;
+}


### PR DESCRIPTION
## Description

Introduces a dedicated `componentSearchExplanations` service that centralises the human-readable labels for matched search fields and a `formatMatchedFieldsExplanation` helper that converts a list of `MatchField` values into a natural-language sentence (e.g. "Matched name, inputs/outputs, and metadata."). The `MATCH_FIELD_LABEL` map that previously lived inline in `DashboardComponentsV2View` has been removed in favour of the shared `COMPONENT_SEARCH_MATCH_FIELD_LABEL` export.

Both `ComponentCard` (dashboard) and `ComponentMarkup` (sidebar) now show a "Why: …" explanation for lexical matches, falling back to the AI rerank reason when one is present. Previously only AI-reranked results showed this explanation.

The no-results message in both the dashboard and the editor sidebar has been split into two lines: a concise "No components matched …" sentence followed by actionable guidance on what kinds of terms to try.

`matchedFields` is now threaded through `ComponentSearchV2Result` and `ComponentSearchResults` so the sidebar can render per-field match explanations alongside rerank metadata.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Open the component search in the dashboard or editor sidebar and type a query that matches components lexically (e.g. "standard" or "csv").
2. Confirm that each result shows a "Why: Matched …" line describing which fields matched.
3. Type a query that returns no results (e.g. "no-such-component") and confirm the two-line no-results guidance appears.
4. Configure AI search and confirm that AI rerank reasons still take precedence over the lexical explanation.

## Additional Comments

The `formatMatchedFieldsExplanation` helper deduplicates field labels before joining them, so repeated entries in `matchedFields` do not produce malformed output.