### PR TITLE
Decouple editor component search input

### DIFF
--- a/src/routes/v2/pages/Editor/components/ComponentSearchV2Content.test.tsx
+++ b/src/routes/v2/pages/Editor/components/ComponentSearchV2Content.test.tsx
@@ -1,0 +1,79 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ComponentSearchV2Content } from "./ComponentSearchV2Content";
+
+const mocks = vi.hoisted(() => ({
+  useComponentSearchV2State: vi.fn(),
+  useFlagValue: vi.fn(),
+}));
+
+vi.mock(
+  "@/components/shared/ReactFlow/FlowSidebar/components/ImportComponent",
+  () => ({
+    default: ({ triggerComponent }: { triggerComponent: ReactNode }) => (
+      <>{triggerComponent}</>
+    ),
+  }),
+);
+
+vi.mock("@/components/shared/Settings/useFlags", () => ({
+  useFlagValue: mocks.useFlagValue,
+}));
+
+vi.mock("@/routes/v2/pages/Editor/hooks/useComponentSearchV2State", () => ({
+  useComponentSearchV2State: mocks.useComponentSearchV2State,
+}));
+
+vi.mock("./ComponentSearchResults", () => ({
+  ComponentSearchResults: ({ query }: { query: string }) => (
+    <div data-testid="results-query">{query}</div>
+  ),
+}));
+
+describe("ComponentSearchV2Content", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mocks.useFlagValue.mockReturnValue(false);
+    mocks.useComponentSearchV2State.mockImplementation(() => ({
+      results: [],
+      browseFolders: [],
+      isLoading: false,
+      canRerank: false,
+      canDeepRerank: false,
+      isReranking: false,
+      isRerankActive: false,
+      rerank: vi.fn(),
+      deepRerank: vi.fn(),
+      clearRerank: vi.fn(),
+    }));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("keeps typing local while delaying result query updates", async () => {
+    render(<ComponentSearchV2Content />);
+
+    const input = screen.getByLabelText("Search components");
+
+    fireEvent.change(input, { target: { value: "csv" } });
+
+    expect(input).toHaveValue("csv");
+    expect(screen.getByTestId("results-query")).toHaveTextContent("");
+
+    await act(async () => {
+      vi.advanceTimersByTime(499);
+    });
+
+    expect(screen.getByTestId("results-query")).toHaveTextContent("");
+
+    await act(async () => {
+      vi.advanceTimersByTime(1);
+    });
+
+    expect(screen.getByTestId("results-query")).toHaveTextContent("csv");
+  });
+});

--- a/src/routes/v2/pages/Editor/components/ComponentSearchV2Content.tsx
+++ b/src/routes/v2/pages/Editor/components/ComponentSearchV2Content.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useDeferredValue, useState, useTransition } from "react";
 
 import ImportComponent from "@/components/shared/ReactFlow/FlowSidebar/components/ImportComponent";
 import { Button } from "@/components/ui/button";
@@ -12,12 +12,17 @@ import { useComponentSearchV2State } from "@/routes/v2/pages/Editor/hooks/useCom
 
 import { ComponentSearchResults } from "./ComponentSearchResults";
 
+const EDITOR_SEARCH_RESULT_DEBOUNCE_MS = 500;
+
 function DebouncedComponentSearchInput({
   onCommit,
 }: {
   onCommit: (value: string) => void;
 }) {
-  const [localValue, setLocalValue] = useDebouncedSearchValue(onCommit);
+  const [localValue, setLocalValue] = useDebouncedSearchValue(
+    onCommit,
+    EDITOR_SEARCH_RESULT_DEBOUNCE_MS,
+  );
 
   return (
     <Input
@@ -35,6 +40,8 @@ function DebouncedComponentSearchInput({
 
 export function ComponentSearchV2Content() {
   const [query, setQuery] = useState("");
+  const deferredQuery = useDeferredValue(query);
+  const [, startSearchTransition] = useTransition();
   const {
     results,
     browseFolders,
@@ -44,10 +51,10 @@ export function ComponentSearchV2Content() {
     isRerankActive,
     rerank,
     clearRerank,
-  } = useComponentSearchV2State(query);
+  } = useComponentSearchV2State(deferredQuery);
 
   const handleQueryCommit = (value: string) => {
-    setQuery(value);
+    startSearchTransition(() => setQuery(value));
   };
 
   return (
@@ -96,7 +103,7 @@ export function ComponentSearchV2Content() {
         </InlineStack>
       </BlockStack>
       <ComponentSearchResults
-        query={query}
+        query={deferredQuery}
         results={results}
         browseFolders={browseFolders}
         isLoading={isLoading}


### PR DESCRIPTION
## Description

Improves the responsiveness of the component search by introducing a debounced query update with `useDeferredValue` and `useTransition`. The input field now reflects typing immediately while search results only update after a 500ms debounce delay, preventing unnecessary queries on every keystroke. The deferred query is passed to both `useComponentSearchV2State` and `ComponentSearchResults` to ensure consistent behavior.

Also corrects the Deep AI search tooltip to accurately reflect a limit of 100 matching components (previously stated 200).

A test is added to verify that the input value updates immediately while the results query remains unchanged until the debounce period has elapsed.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Open the component search panel in the editor.
2. Type a query and verify the input updates immediately.
3. Confirm that search results do not update until 500ms after the last keystroke.
4. Run the new `ComponentSearchV2Content.test.tsx` test to validate debounce timing behavior.

## Additional Comments

The 500ms debounce constant (`EDITOR_SEARCH_RESULT_DEBOUNCE_MS`) is defined at the module level for easy adjustment if the delay needs tuning in the future.