### PR TITLE
Add component search empty state suggestions

### DIFF
--- a/react-compiler.config.js
+++ b/react-compiler.config.js
@@ -38,6 +38,7 @@ export const REACT_COMPILER_ENABLED_DIRS = [
   "src/hooks/useRecentlyViewed.ts",
   "src/components/shared/FavoriteToggle.tsx",
   "src/components/shared/ComponentLifecycleBadges.tsx",
+  "src/components/shared/ComponentSearchEmptyStateSuggestions.tsx",
 
   "src/components/shared/Tags",
   "src/components/shared/Submitters/Tangle/components",

--- a/src/components/shared/ComponentSearchEmptyStateSuggestions.tsx
+++ b/src/components/shared/ComponentSearchEmptyStateSuggestions.tsx
@@ -1,0 +1,31 @@
+import { Button } from "@/components/ui/button";
+import { InlineStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
+import { COMPONENT_SEARCH_EMPTY_STATE_SUGGESTIONS } from "@/services/componentSearchSuggestions";
+
+interface ComponentSearchEmptyStateSuggestionsProps {
+  onSelectSuggestion: (query: string) => void;
+}
+
+export function ComponentSearchEmptyStateSuggestions({
+  onSelectSuggestion,
+}: ComponentSearchEmptyStateSuggestionsProps) {
+  return (
+    <InlineStack gap="2">
+      <Text size="xs" tone="subdued">
+        Suggested searches:
+      </Text>
+      {COMPONENT_SEARCH_EMPTY_STATE_SUGGESTIONS.map((suggestion) => (
+        <Button
+          key={suggestion}
+          type="button"
+          variant="outline"
+          size="xs"
+          onClick={() => onSelectSuggestion(suggestion)}
+        >
+          {suggestion}
+        </Button>
+      ))}
+    </InlineStack>
+  );
+}

--- a/src/routes/Dashboard/DashboardComponentsV2View.test.tsx
+++ b/src/routes/Dashboard/DashboardComponentsV2View.test.tsx
@@ -547,10 +547,11 @@ describe("DashboardComponentsV2View", () => {
     });
   });
 
-  it("shows actionable no-results guidance", async () => {
+  it("shows actionable no-results guidance with clickable suggestions", async () => {
     render(<DashboardComponentsV2View />);
 
-    fireEvent.change(screen.getByLabelText("Search components"), {
+    const input = screen.getByLabelText("Search components");
+    fireEvent.change(input, {
       target: { value: "no-such-component" },
     });
 
@@ -560,6 +561,12 @@ describe("DashboardComponentsV2View", () => {
       ).toBeInTheDocument();
     });
     expect(screen.getByText(/Try a component name/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "csv" }));
+
+    await waitFor(() => {
+      expect(input).toHaveValue("csv");
+    });
   });
 
   it("initializes search state from URL params", () => {

--- a/src/routes/Dashboard/DashboardComponentsV2View.tsx
+++ b/src/routes/Dashboard/DashboardComponentsV2View.tsx
@@ -16,6 +16,7 @@ import {
   ComponentDetailSkeleton,
 } from "@/components/shared/ComponentDetail/ComponentDetail";
 import { ComponentLifecycleBadges } from "@/components/shared/ComponentLifecycleBadges";
+import { ComponentSearchEmptyStateSuggestions } from "@/components/shared/ComponentSearchEmptyStateSuggestions";
 import { useFlagValue } from "@/components/shared/Settings/useFlags";
 import { SuspenseWrapper } from "@/components/shared/SuspenseWrapper";
 import { Badge } from "@/components/ui/badge";
@@ -988,6 +989,15 @@ export const DashboardComponentsV2View = () => {
     });
   };
 
+  const handleSuggestedSearch = (value: string) => {
+    startSearchTransition(() => {
+      setQuery(value);
+      if (rerankedFor !== null) {
+        clearRerank();
+      }
+    });
+  };
+
   const buildEmbeddingMatches = async (
     trimmed: string,
     limit: number,
@@ -1268,6 +1278,9 @@ export const DashboardComponentsV2View = () => {
             like “csv”, “train model”, “predict”, or “dataframe”. AI search
             reranks matching local candidates when it is configured.
           </Paragraph>
+          <ComponentSearchEmptyStateSuggestions
+            onSelectSuggestion={handleSuggestedSearch}
+          />
         </BlockStack>
       );
     }
@@ -1348,7 +1361,7 @@ export const DashboardComponentsV2View = () => {
             <DebouncedComponentSearchInput
               onCommit={handleQueryCommit}
               disabled={isLoadingLibrary || noLibraryData}
-              initialValue={queryFromUrl}
+              initialValue={query}
             />
             <Button
               variant="secondary"

--- a/src/routes/v2/pages/Editor/components/ComponentSearchResults.test.tsx
+++ b/src/routes/v2/pages/Editor/components/ComponentSearchResults.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import { ComponentSearchResults } from "./ComponentSearchResults";
@@ -38,18 +38,29 @@ const baseProps = {
   isLoading: false,
   isRerankActive: false,
   onClearRerank: vi.fn(),
+  onSuggestedSearch: vi.fn(),
 };
 
 describe("ComponentSearchResults", () => {
-  it("shows actionable no-results guidance", () => {
+  it("shows actionable no-results guidance with clickable suggestions", () => {
+    const onSuggestedSearch = vi.fn();
     render(
-      <ComponentSearchResults {...baseProps} query="missing" results={[]} />,
+      <ComponentSearchResults
+        {...baseProps}
+        query="missing"
+        results={[]}
+        onSuggestedSearch={onSuggestedSearch}
+      />,
     );
 
     expect(
       screen.getByText("No components matched “missing”."),
     ).toBeInTheDocument();
     expect(screen.getByText(/Try a component name/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "csv" }));
+
+    expect(onSuggestedSearch).toHaveBeenCalledWith("csv");
   });
 
   it("passes matched fields through for result explanations", () => {

--- a/src/routes/v2/pages/Editor/components/ComponentSearchResults.tsx
+++ b/src/routes/v2/pages/Editor/components/ComponentSearchResults.tsx
@@ -1,3 +1,4 @@
+import { ComponentSearchEmptyStateSuggestions } from "@/components/shared/ComponentSearchEmptyStateSuggestions";
 import {
   ComponentMarkup,
   IONodeSidebarItem,
@@ -20,6 +21,7 @@ interface ComponentSearchResultsProps {
   isLoading: boolean;
   isRerankActive: boolean;
   onClearRerank: () => void;
+  onSuggestedSearch: (query: string) => void;
 }
 
 export function ComponentSearchResults({
@@ -29,6 +31,7 @@ export function ComponentSearchResults({
   isLoading,
   isRerankActive,
   onClearRerank,
+  onSuggestedSearch,
 }: ComponentSearchResultsProps) {
   if (isLoading) {
     return (
@@ -113,14 +116,19 @@ export function ComponentSearchResults({
             ))}
           </BlockStack>
         ) : (
-          <BlockStack gap="1">
-            <Paragraph size="sm" tone="subdued">
-              No components matched “{query.trim()}”.
-            </Paragraph>
-            <Paragraph size="xs" tone="subdued">
-              Try a component name, input/output type, or task intent like
-              “csv”, “train”, “predict”, or “dataframe”.
-            </Paragraph>
+          <BlockStack gap="2">
+            <BlockStack gap="1">
+              <Paragraph size="sm" tone="subdued">
+                No components matched “{query.trim()}”.
+              </Paragraph>
+              <Paragraph size="xs" tone="subdued">
+                Try a component name, input/output type, or task intent like
+                “csv”, “train”, “predict”, or “dataframe”.
+              </Paragraph>
+            </BlockStack>
+            <ComponentSearchEmptyStateSuggestions
+              onSelectSuggestion={onSuggestedSearch}
+            />
           </BlockStack>
         )}
       </div>

--- a/src/routes/v2/pages/Editor/components/ComponentSearchV2Content.tsx
+++ b/src/routes/v2/pages/Editor/components/ComponentSearchV2Content.tsx
@@ -15,13 +15,16 @@ import { ComponentSearchResults } from "./ComponentSearchResults";
 const EDITOR_SEARCH_RESULT_DEBOUNCE_MS = 500;
 
 function DebouncedComponentSearchInput({
+  initialValue,
   onCommit,
 }: {
+  initialValue: string;
   onCommit: (value: string) => void;
 }) {
   const [localValue, setLocalValue] = useDebouncedSearchValue(
     onCommit,
     EDITOR_SEARCH_RESULT_DEBOUNCE_MS,
+    initialValue,
   );
 
   return (
@@ -57,6 +60,10 @@ export function ComponentSearchV2Content() {
     startSearchTransition(() => setQuery(value));
   };
 
+  const handleSuggestedSearch = (value: string) => {
+    startSearchTransition(() => setQuery(value));
+  };
+
   return (
     <BlockStack className="h-full min-h-0 overflow-hidden [&_.text-sm]:text-xs!">
       <BlockStack gap="2" className="px-2 py-2">
@@ -87,7 +94,10 @@ export function ComponentSearchV2Content() {
             >
               <Icon name="Search" size="sm" className="text-gray-400" />
             </InlineStack>
-            <DebouncedComponentSearchInput onCommit={handleQueryCommit} />
+            <DebouncedComponentSearchInput
+              initialValue={query}
+              onCommit={handleQueryCommit}
+            />
           </div>
           <Button
             variant="outline"
@@ -109,6 +119,7 @@ export function ComponentSearchV2Content() {
         isLoading={isLoading}
         isRerankActive={isRerankActive}
         onClearRerank={clearRerank}
+        onSuggestedSearch={handleSuggestedSearch}
       />
     </BlockStack>
   );

--- a/src/services/componentSearchSuggestions.ts
+++ b/src/services/componentSearchSuggestions.ts
@@ -1,0 +1,6 @@
+export const COMPONENT_SEARCH_EMPTY_STATE_SUGGESTIONS = [
+  "csv",
+  "train",
+  "predict",
+  "dataframe",
+] as const;


### PR DESCRIPTION
## Description

Adds clickable suggested search terms ("csv", "train", "predict", "dataframe") to the component search empty state. When a search returns no results, users now see these suggestions as clickable buttons that populate the search input and trigger a new search. The suggestions are rendered via a new shared `ComponentSearchEmptyStateSuggestions` component, and the list of suggestions is centralized in `componentSearchSuggestions.ts`.

The `DebouncedComponentSearchInput` in the editor now accepts an `initialValue` prop so that clicking a suggestion correctly reflects the new query in the input field.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Open the component search in either the Dashboard or Editor view.
2. Enter a search term that returns no results (e.g., "no-such-component").
3. Verify that the empty state displays suggested search buttons: "csv", "train", "predict", "dataframe".
4. Click one of the suggestion buttons and confirm the search input updates to that value and a new search is triggered.

## Additional Comments

The suggestions are defined as a `const` array in `src/services/componentSearchSuggestions.ts`, making it straightforward to add or remove suggestions in one place.