### PR TITLE
Limit dashboard component browse rendering

### DIFF
--- a/src/routes/Dashboard/DashboardComponentsV2View.test.tsx
+++ b/src/routes/Dashboard/DashboardComponentsV2View.test.tsx
@@ -36,6 +36,7 @@ const routeMocks = vi.hoisted(() => {
     standard: makeComponent("standard-digest", "Standard component"),
     registered: makeComponent("registered-digest", "Registered component"),
     user: makeComponent("user-digest", "User component"),
+    extraStandardComponents: [] as ComponentReference[],
     navigate: vi.fn(),
     notify: vi.fn(),
     refetchDescription: vi.fn(),
@@ -59,7 +60,10 @@ vi.mock("@tanstack/react-query", () => ({
       return {
         data: {
           name: "Standard",
-          components: [routeMocks.standard],
+          components: [
+            routeMocks.standard,
+            ...routeMocks.extraStandardComponents,
+          ],
           folders: [],
         },
         isLoading: false,
@@ -98,7 +102,12 @@ vi.mock("@tanstack/react-query", () => ({
 
     if (key === "component-search-v2" && queryKey[1] === "hydrate-library") {
       return {
-        data: [routeMocks.standard, routeMocks.registered, routeMocks.user],
+        data: [
+          routeMocks.standard,
+          routeMocks.registered,
+          routeMocks.user,
+          ...routeMocks.extraStandardComponents,
+        ],
         isLoading: false,
       };
     }
@@ -467,6 +476,7 @@ describe("DashboardComponentsV2View", () => {
     routeMocks.search = {};
     routeMocks.standard.deprecated = false;
     routeMocks.standard.superseded_by = undefined;
+    routeMocks.extraStandardComponents = [];
     routeMocks.navigate.mockClear();
     routeMocks.notify.mockClear();
     routeMocks.refetchDescription.mockClear();
@@ -474,6 +484,43 @@ describe("DashboardComponentsV2View", () => {
     routeMocks.resetRerank.mockClear();
     routeMocks.aiSearchConfigured = false;
     routeMocks.aiApiBase = "";
+  });
+
+  it("limits browse rendering and lets users show more results", async () => {
+    routeMocks.extraStandardComponents = Array.from(
+      { length: 105 },
+      (_, idx) => {
+        const paddedIndex = String(idx).padStart(3, "0");
+        return {
+          digest: `browse-${paddedIndex}`,
+          name: `Browse component ${paddedIndex}`,
+          text: "component yaml",
+          spec: {
+            name: `Browse component ${paddedIndex}`,
+            description: `Browse component ${paddedIndex} description`,
+            inputs: [],
+            outputs: [],
+            implementation: { container: { image: "python:3.11" } },
+          },
+        };
+      },
+    );
+
+    render(<DashboardComponentsV2View />);
+
+    expect(
+      screen.getByText(
+        "Showing 100 of 108 components in selected sources. Start typing to search.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Browse component 099")).toBeInTheDocument();
+    expect(screen.queryByText("Browse component 100")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Show 8 more" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Browse component 104")).toBeInTheDocument();
+    });
   });
 
   it("filters visible component results by source type and restores them", () => {

--- a/src/routes/Dashboard/DashboardComponentsV2View.tsx
+++ b/src/routes/Dashboard/DashboardComponentsV2View.tsx
@@ -128,6 +128,8 @@ const LEXICAL_RESULT_LIMIT = 20;
 /** Bounded pool sent to AI search on click. */
 const AI_CANDIDATE_LIMIT = 80;
 const DASHBOARD_SEARCH_RESULT_DEBOUNCE_MS = 500;
+const BROWSE_RESULT_INITIAL_LIMIT = 100;
+const BROWSE_RESULT_INCREMENT = 100;
 
 // Built-in sources are constants — only registered libraries vary per row.
 const STANDARD_SOURCE: ComponentSearchSource = {
@@ -684,6 +686,9 @@ export const DashboardComponentsV2View = () => {
   const [disabledSourceKeys, setDisabledSourceKeys] = useState<string[]>(
     disabledSourceKeysFromUrl,
   );
+  const [browseResultLimit, setBrowseResultLimit] = useState(
+    BROWSE_RESULT_INITIAL_LIMIT,
+  );
 
   // Detail-pane selection lives in the URL so refreshes preserve it and the
   // selection can be linked-to. The V2 route has no validateSearch defined.
@@ -927,6 +932,10 @@ export const DashboardComponentsV2View = () => {
     a.name.localeCompare(b.name),
   );
 
+  useEffect(() => {
+    setBrowseResultLimit(BROWSE_RESULT_INITIAL_LIMIT);
+  }, [deferredQuery, disabledSourceKeysParam, total]);
+
   const trimmedQuery = deferredQuery.trim();
 
   // One lexical pass at the wider AI-candidate limit; the display list is the
@@ -1097,6 +1106,12 @@ export const DashboardComponentsV2View = () => {
     }
   };
 
+  const handleShowMoreBrowseResults = () => {
+    setBrowseResultLimit((currentLimit) =>
+      Math.min(currentLimit + BROWSE_RESULT_INCREMENT, sortedIndex.length),
+    );
+  };
+
   const isLoadingLibrary =
     libraryLoading ||
     userLoading ||
@@ -1243,13 +1258,18 @@ export const DashboardComponentsV2View = () => {
       );
     }
     if (isEmpty) {
+      const visibleBrowseEntries = sortedIndex.slice(0, browseResultLimit);
+      const hasMoreBrowseResults =
+        visibleBrowseEntries.length < sortedIndex.length;
+
       return (
         <BlockStack gap="2" align="stretch">
           <Paragraph size="xs" tone="subdued">
-            {total} component{total === 1 ? "" : "s"} in selected sources. Start
-            typing to search.
+            Showing {visibleBrowseEntries.length} of {total} component
+            {total === 1 ? "" : "s"} in selected sources. Start typing to
+            search.
           </Paragraph>
-          {sortedIndex.map((entry, idx) => (
+          {visibleBrowseEntries.map((entry, idx) => (
             <ComponentCard
               key={entry.digest}
               reference={entry.reference}
@@ -1260,6 +1280,20 @@ export const DashboardComponentsV2View = () => {
               onSelect={selectComponent}
             />
           ))}
+          {hasMoreBrowseResults && (
+            <Button
+              type="button"
+              variant="outline"
+              onClick={handleShowMoreBrowseResults}
+            >
+              Show{" "}
+              {Math.min(
+                BROWSE_RESULT_INCREMENT,
+                sortedIndex.length - visibleBrowseEntries.length,
+              )}{" "}
+              more
+            </Button>
+          )}
         </BlockStack>
       );
     }


### PR DESCRIPTION
## Description

When browsing components without an active search query, the component list is now paginated. The initial render is capped at 100 components, with a "Show N more" button that loads the next batch of up to 100 results. The status text also now reads "Showing X of Y components in selected sources" to reflect the partial display. The limit resets to 100 whenever the query, source filters, or total component count changes.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Open the component browser with no search query active.
2. Ensure a source with more than 100 components is enabled.
3. Verify the status bar reads "Showing 100 of N components in selected sources. Start typing to search."
4. Verify that only 100 component cards are rendered initially.
5. Click the "Show N more" button and confirm the next batch of components appears.
6. Apply or change a source filter and confirm the visible count resets back to 100.

## Additional Comments