### PR TITLE
Add remote troubleshoot button to v2 run view task window

### DIFF
--- a/docs/remote-troubleshoot-action.md
+++ b/docs/remote-troubleshoot-action.md
@@ -1,0 +1,124 @@
+# Remote Troubleshoot Execution Action
+
+The Remote Troubleshoot Execution Action is an optional feature that surfaces a button in the task properties panel when a pipeline execution is in a problematic state. Clicking it opens a modal where the user can add context, then submits a structured payload to a configurable endpoint — allowing the deployment operator to integrate with an external troubleshooting or on-call system.
+
+The feature is intentionally OSS-friendly: it renders nothing when unconfigured, and the payload schema is generic enough to adapt to any HTTP-based integration.
+
+## How it works
+
+1. When a task node is selected in the run view, the button appears if:
+   - `window.__TANGLE_REMOTE_TROUBLESHOOT_ACTION__` is set (see [Configuration](#configuration))
+   - The hostname is not `localhost` / `127.0.0.1` / `*.local`
+   - The execution status is immediately eligible (`FAILED`, `CANCELLED`, `SYSTEM_ERROR`), or has been `PENDING` / `QUEUED` for more than 5 minutes
+2. After submission, a localStorage record is written keyed by `(runId, executionId)`. Subsequent views of the same execution show "session opened at [time]" instead of the button, preventing duplicate requests.
+
+## Configuration
+
+Set `window.__TANGLE_REMOTE_TROUBLESHOOT_ACTION__` to a `RemoteTroubleshootActionConfig` object before the React app mounts. Because the config is static deploy-time data, inline it directly in your `index.html` with a synchronous `<script>`. This sets the global at HTML parse time, so it is ready before the app mounts without a render-blocking network round-trip:
+
+```html
+<script>
+  window.__TANGLE_REMOTE_TROUBLESHOOT_ACTION__ = {
+    endpointUrl: "https://your-backend.example.com/api/troubleshoot",
+    buttonText: "Get help with this execution",
+    modalTitle: "Get help with this execution",
+    modalDescription:
+      "Describe the problem or add any context, then submit to notify your support channel.",
+    successTitle: "Request submitted",
+    successMessage:
+      "Your request has been submitted. Someone will follow up shortly.",
+    source: "my-deployment",
+  };
+</script>
+```
+
+Leaving the global unset (the default) disables the feature entirely — the button renders nothing.
+
+### Config shape
+
+```typescript
+interface RemoteTroubleshootActionConfig {
+  /** URL the payload will be POSTed to. */
+  endpointUrl: string;
+
+  /** Label shown on the button and used as the default modal title. */
+  buttonText: string;
+
+  /** Optional modal title (defaults to buttonText). */
+  modalTitle?: string;
+
+  /** Optional modal description shown above the comments textarea. */
+  modalDescription?: string;
+
+  /** Optional heading shown in the success state (defaults to "Request submitted"). */
+  successTitle?: string;
+
+  /** Optional body shown in the success state, and persisted in the task panel after submission. */
+  successMessage?: string;
+
+  /**
+   * Optional source tag included in the payload (defaults to "tangle-ui").
+   * Use this to distinguish requests from different deployments.
+   */
+  source?: string;
+}
+```
+
+### Minimal example
+
+Only `endpointUrl` and `buttonText` are required:
+
+```html
+<script>
+  window.__TANGLE_REMOTE_TROUBLESHOOT_ACTION__ = {
+    endpointUrl:
+      "https://your-backend.example.com/api/remote_troubleshoot/execution",
+    buttonText: "Get help with this execution",
+  };
+</script>
+```
+
+## Payload
+
+The button POSTs the following JSON body to `endpointUrl`:
+
+```json
+{
+  "execution_id": "abc123",
+  "user_email": "user@example.com",
+  "pipeline_run_id": "run-456",
+  "pipeline_run_url": "https://your-deployment.example.com/runs/run-456",
+  "execution_url": "https://your-deployment.example.com/runs/run-456?nodeId=task_MyTask",
+  "additional_comments": "Optional user-provided context.",
+  "source": "tangle-ui"
+}
+```
+
+| Field                 | Description                                                       |
+| --------------------- | ----------------------------------------------------------------- |
+| `execution_id`        | ID of the specific task execution                                 |
+| `user_email`          | Authenticated user's email (empty string if unavailable)          |
+| `pipeline_run_id`     | ID of the parent pipeline run                                     |
+| `pipeline_run_url`    | URL of the run view page                                          |
+| `execution_url`       | Deep-link to the specific task node via `?nodeId=task_<taskName>` |
+| `additional_comments` | Free-text context entered by the user in the modal                |
+| `source`              | Deployment identifier from config (`source` field)                |
+
+The endpoint is expected to return any `2xx` status on success. Any non-`2xx` response causes the modal to return to the input state so the user can retry.
+
+## Visibility logic
+
+| Status         | Visible after |
+| -------------- | ------------- |
+| `FAILED`       | Immediately   |
+| `CANCELLED`    | Immediately   |
+| `SYSTEM_ERROR` | Immediately   |
+| `PENDING`      | 5 minutes     |
+| `QUEUED`       | 5 minutes     |
+| All others     | Never         |
+
+The 5-minute timer measures how long the execution has actually been in its current status. The start time comes from the server: the button fetches the execution's `/details` response and reads the `first_observed_at` of the last `status_history` entry (the current status). This is consistent across reloads and between viewers.
+
+If the server has no status history for the execution yet, the `PENDING` / `QUEUED` button stays hidden — the timer requires the server timestamp rather than falling back to a browser-session clock. Immediately-eligible statuses (`FAILED`, `CANCELLED`, `SYSTEM_ERROR`) are unaffected. Elapsed time is re-checked every 10 seconds.
+
+The `/details` request is re-issued whenever the task's status changes, so a task that transitions while the panel is open (for example `QUEUED` → `PENDING`) picks up the new status's start time and shows the button on its own — the panel does not need to be closed and reopened. Because the timer measures time in the _current_ status, each transition starts a fresh 5-minute clock.

--- a/src/api/types.gen.ts
+++ b/src/api/types.gen.ts
@@ -570,6 +570,20 @@ export type GetExecutionArtifactsResponse = {
 };
 
 /**
+ * ExecutionStatusHistoryEntry
+ */
+export type ExecutionStatusHistoryEntry = {
+    /**
+     * Status
+     */
+    status: string;
+    /**
+     * First Observed At
+     */
+    first_observed_at: string;
+};
+
+/**
  * GetExecutionInfoResponse
  */
 export type GetExecutionInfoResponse = {
@@ -604,6 +618,10 @@ export type GetExecutionInfoResponse = {
     output_artifacts?: {
         [key: string]: ArtifactNodeIdResponse;
     } | null;
+    /**
+     * Status History
+     */
+    status_history?: Array<ExecutionStatusHistoryEntry> | null;
 };
 
 /**

--- a/src/components/shared/RemoteTroubleshootAction/RemoteTroubleshootButton.test.tsx
+++ b/src/components/shared/RemoteTroubleshootAction/RemoteTroubleshootButton.test.tsx
@@ -1,0 +1,200 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import type { GetExecutionInfoResponse } from "@/api/types.gen";
+
+import { RemoteTroubleshootButton } from "./RemoteTroubleshootButton";
+
+const { mockUseFetchExecutionDetails, mockGetRecord } = vi.hoisted(() => ({
+  mockUseFetchExecutionDetails: vi.fn(),
+  mockGetRecord: vi.fn(),
+}));
+
+vi.mock("@/services/executionService", () => ({
+  useFetchExecutionDetails: mockUseFetchExecutionDetails,
+}));
+
+vi.mock("@/utils/remoteTroubleshootStorage", () => ({
+  getRemoteTroubleshootRecord: mockGetRecord,
+  saveRemoteTroubleshootRecord: vi.fn(),
+}));
+
+vi.mock("@/utils/user", () => ({
+  getUserDetails: vi.fn().mockResolvedValue({ id: "user@example.com" }),
+}));
+
+const BUTTON_TEXT = "Get help with this execution";
+
+function statusHistory(status: string, minutesAgo: number) {
+  return {
+    status_history: [
+      {
+        status,
+        first_observed_at: new Date(
+          Date.now() - minutesAgo * 60 * 1000,
+        ).toISOString(),
+      },
+    ],
+  } as GetExecutionInfoResponse;
+}
+
+function renderButton(status: string | undefined) {
+  return render(
+    <RemoteTroubleshootButton
+      runId="run-1"
+      executionId="exec-1"
+      taskName="train"
+      status={status}
+    />,
+  );
+}
+
+describe("RemoteTroubleshootButton", () => {
+  beforeEach(() => {
+    // isLocalEnvironment() returns null on localhost, which is jsdom's default host.
+    vi.stubGlobal("location", {
+      hostname: "app.example.com",
+      origin: "https://app.example.com",
+      pathname: "/runs/run-1",
+      href: "https://app.example.com/runs/run-1",
+      search: "",
+    });
+    window.__TANGLE_REMOTE_TROUBLESHOOT_ACTION__ = {
+      endpointUrl: "https://example.com/troubleshoot",
+      buttonText: BUTTON_TEXT,
+    };
+    mockGetRecord.mockReturnValue(null);
+    mockUseFetchExecutionDetails.mockReturnValue({ data: undefined });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+    delete window.__TANGLE_REMOTE_TROUBLESHOOT_ACTION__;
+    vi.clearAllMocks();
+  });
+
+  test("FAILED is eligible immediately, without status history", () => {
+    renderButton("FAILED");
+    expect(screen.getByText(BUTTON_TEXT)).toBeInTheDocument();
+  });
+
+  test("PENDING is shown once it has been pending for over 5 minutes", async () => {
+    mockUseFetchExecutionDetails.mockReturnValue({
+      data: statusHistory("PENDING", 6),
+    });
+    renderButton("PENDING");
+    await waitFor(() =>
+      expect(screen.getByText(BUTTON_TEXT)).toBeInTheDocument(),
+    );
+  });
+
+  test("PENDING is hidden when it has been pending for under 5 minutes", () => {
+    mockUseFetchExecutionDetails.mockReturnValue({
+      data: statusHistory("PENDING", 1),
+    });
+    renderButton("PENDING");
+    expect(screen.queryByText(BUTTON_TEXT)).not.toBeInTheDocument();
+  });
+
+  test("PENDING is hidden when the server has no status history", () => {
+    mockUseFetchExecutionDetails.mockReturnValue({ data: undefined });
+    renderButton("PENDING");
+    expect(screen.queryByText(BUTTON_TEXT)).not.toBeInTheDocument();
+  });
+
+  test("PENDING is hidden when the latest history entry is a different status", () => {
+    // History says the node most recently entered RUNNING, so the displayed
+    // PENDING has no trustworthy start time and the button stays hidden.
+    mockUseFetchExecutionDetails.mockReturnValue({
+      data: statusHistory("RUNNING", 6),
+    });
+    renderButton("PENDING");
+    expect(screen.queryByText(BUTTON_TEXT)).not.toBeInTheDocument();
+  });
+
+  test("becomes eligible on a QUEUED->PENDING transition without remounting", async () => {
+    // Panel opens while briefly QUEUED: hidden.
+    mockUseFetchExecutionDetails.mockReturnValue({
+      data: statusHistory("QUEUED", 1),
+    });
+    const { rerender } = render(
+      <RemoteTroubleshootButton
+        runId="run-1"
+        executionId="exec-1"
+        taskName="train"
+        status="QUEUED"
+      />,
+    );
+    expect(screen.queryByText(BUTTON_TEXT)).not.toBeInTheDocument();
+
+    // Task transitions to PENDING and has been pending over 5 minutes. Because
+    // status is part of the details query key, the refetch returns fresh
+    // history and the button appears in the same open panel.
+    mockUseFetchExecutionDetails.mockReturnValue({
+      data: statusHistory("PENDING", 6),
+    });
+    rerender(
+      <RemoteTroubleshootButton
+        runId="run-1"
+        executionId="exec-1"
+        taskName="train"
+        status="PENDING"
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.getByText(BUTTON_TEXT)).toBeInTheDocument(),
+    );
+  });
+
+  test("submitted payload deep-links the node with the task name as nodeId", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderButton("FAILED");
+    fireEvent.click(screen.getByText(BUTTON_TEXT));
+    fireEvent.click(await screen.findByRole("button", { name: /submit/i }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.execution_url).toContain("nodeId=train");
+    expect(body.execution_url).not.toContain("nodeId=task_train");
+  });
+
+  test("shows an error message when submission fails", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 500 });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderButton("FAILED");
+    fireEvent.click(screen.getByText(BUTTON_TEXT));
+    fireEvent.click(await screen.findByRole("button", { name: /submit/i }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/Remote troubleshoot request failed/),
+      ).toBeInTheDocument(),
+    );
+    expect(screen.getByRole("button", { name: /submit/i })).toBeInTheDocument();
+  });
+
+  test("persisted confirmation uses the configured success message", () => {
+    window.__TANGLE_REMOTE_TROUBLESHOOT_ACTION__ = {
+      endpointUrl: "https://example.com/troubleshoot",
+      buttonText: BUTTON_TEXT,
+      successMessage:
+        "Your request has been submitted. Follow along in #support.",
+    };
+    mockGetRecord.mockReturnValue({ requestedAt: new Date().toISOString() });
+
+    renderButton("FAILED");
+
+    expect(screen.getByText(/Follow along in #support\./)).toBeInTheDocument();
+    expect(screen.queryByText(/session opened/)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/shared/RemoteTroubleshootAction/RemoteTroubleshootButton.tsx
+++ b/src/components/shared/RemoteTroubleshootAction/RemoteTroubleshootButton.tsx
@@ -1,0 +1,186 @@
+import "@/config/remoteTroubleshootAction";
+
+import { useEffect, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { InlineStack } from "@/components/ui/layout";
+import { Paragraph } from "@/components/ui/typography";
+import type { RemoteTroubleshootActionConfig } from "@/config/remoteTroubleshootAction";
+import { useFetchExecutionDetails } from "@/services/executionService";
+import {
+  getRemoteTroubleshootRecord,
+  saveRemoteTroubleshootRecord,
+} from "@/utils/remoteTroubleshootStorage";
+import { getUserDetails } from "@/utils/user";
+
+import { RemoteTroubleshootDialog } from "./RemoteTroubleshootDialog";
+
+const ALWAYS_ELIGIBLE_STATUSES = new Set([
+  "CANCELLED",
+  "SYSTEM_ERROR",
+  "FAILED",
+]);
+const TIMER_ELIGIBLE_STATUSES = new Set(["PENDING", "QUEUED"]);
+const PENDING_THRESHOLD_MS = 5 * 60 * 1000;
+const POLL_INTERVAL_MS = 10 * 1000;
+
+function isLocalEnvironment(): boolean {
+  const h = window.location.hostname;
+  return h === "localhost" || h === "127.0.0.1" || h.endsWith(".local");
+}
+
+function getConfig(): RemoteTroubleshootActionConfig | null {
+  return window.__TANGLE_REMOTE_TROUBLESHOOT_ACTION__ ?? null;
+}
+
+interface RemoteTroubleshootButtonProps {
+  runId: string;
+  executionId: string | undefined;
+  taskName: string;
+  status: string | undefined;
+}
+
+export function RemoteTroubleshootButton({
+  runId,
+  executionId,
+  taskName,
+  status,
+}: RemoteTroubleshootButtonProps) {
+  const config = getConfig();
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [timerReady, setTimerReady] = useState(false);
+
+  const isTimerStatus =
+    status !== undefined && TIMER_ELIGIBLE_STATUSES.has(status);
+  const isAlwaysEligible =
+    status !== undefined && ALWAYS_ELIGIBLE_STATUSES.has(status);
+
+  const { data: details } = useFetchExecutionDetails(
+    executionId,
+    status,
+    isTimerStatus,
+  );
+  const lastStatusEntry = details?.status_history?.at(-1);
+  const currentStatusSince =
+    lastStatusEntry && lastStatusEntry.status === status
+      ? lastStatusEntry.first_observed_at
+      : undefined;
+
+  useEffect(() => {
+    if (!isTimerStatus || currentStatusSince === undefined) {
+      setTimerReady(false);
+      return;
+    }
+
+    const sinceMs = new Date(currentStatusSince).getTime();
+    const isElapsed = () => Date.now() - sinceMs >= PENDING_THRESHOLD_MS;
+
+    if (isElapsed()) {
+      setTimerReady(true);
+      return;
+    }
+
+    const intervalId = setInterval(() => {
+      if (isElapsed()) {
+        setTimerReady(true);
+        clearInterval(intervalId);
+      }
+    }, POLL_INTERVAL_MS);
+
+    return () => clearInterval(intervalId);
+  }, [isTimerStatus, currentStatusSince]);
+
+  if (
+    !config ||
+    isLocalEnvironment() ||
+    !status ||
+    !executionId ||
+    (!isAlwaysEligible && !(isTimerStatus && timerReady))
+  ) {
+    return null;
+  }
+
+  const existingRecord = getRemoteTroubleshootRecord(runId, executionId);
+
+  if (existingRecord) {
+    const requestedAt = new Date(existingRecord.requestedAt);
+    const formatted = requestedAt.toLocaleString(undefined, {
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+    });
+    return (
+      <InlineStack gap="1" className="px-1 py-1">
+        <Paragraph size="xs" tone="subdued">
+          {config.successMessage
+            ? `${config.successMessage} (${formatted})`
+            : `${config.buttonText} session opened ${formatted}.`}
+        </Paragraph>
+      </InlineStack>
+    );
+  }
+
+  const buildExecutionUrl = () => {
+    const url = new URL(window.location.href);
+    url.search = "";
+    url.searchParams.set("nodeId", taskName);
+    return url.toString();
+  };
+
+  const handleSubmit = async (additionalComments: string) => {
+    let userEmail = "";
+    try {
+      const user = await getUserDetails();
+      userEmail = user.id ?? "";
+    } catch {
+      // leave empty if unavailable
+    }
+
+    const payload = {
+      execution_id: executionId,
+      user_email: userEmail,
+      pipeline_run_id: runId,
+      pipeline_run_url: `${window.location.origin}${window.location.pathname}`,
+      execution_url: buildExecutionUrl(),
+      additional_comments: additionalComments,
+      source: config.source ?? "tangle-ui",
+    };
+
+    const response = await fetch(config.endpointUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Remote troubleshoot request failed: ${response.status}`);
+    }
+
+    saveRemoteTroubleshootRecord(runId, executionId);
+  };
+
+  return (
+    <>
+      <Button
+        variant="outline"
+        className="w-full"
+        onClick={() => setDialogOpen(true)}
+      >
+        {config.buttonText}
+      </Button>
+      <RemoteTroubleshootDialog
+        open={dialogOpen}
+        title={config.modalTitle ?? config.buttonText}
+        description={config.modalDescription}
+        successTitle={config.successTitle ?? "Request submitted"}
+        successMessage={
+          config.successMessage ??
+          "Your request has been submitted successfully."
+        }
+        onSubmit={handleSubmit}
+        onClose={() => setDialogOpen(false)}
+      />
+    </>
+  );
+}

--- a/src/components/shared/RemoteTroubleshootAction/RemoteTroubleshootDialog.tsx
+++ b/src/components/shared/RemoteTroubleshootAction/RemoteTroubleshootDialog.tsx
@@ -1,0 +1,140 @@
+import { CheckCircle2Icon } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { BlockStack } from "@/components/ui/layout";
+import { Spinner } from "@/components/ui/spinner";
+import { Textarea } from "@/components/ui/textarea";
+import { Heading, Paragraph, Text } from "@/components/ui/typography";
+
+interface RemoteTroubleshootDialogProps {
+  open: boolean;
+  title: string;
+  description?: string;
+  successTitle: string;
+  successMessage: string;
+  onSubmit: (additionalComments: string) => Promise<void>;
+  onClose: () => void;
+}
+
+type DialogState = "input" | "submitting" | "success";
+
+export function RemoteTroubleshootDialog({
+  open,
+  title,
+  description,
+  successTitle,
+  successMessage,
+  onSubmit,
+  onClose,
+}: RemoteTroubleshootDialogProps) {
+  const [state, setState] = useState<DialogState>("input");
+  const [comments, setComments] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    if (open) {
+      setState("input");
+      setComments("");
+      setError(null);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (open && state === "input" && textareaRef.current) {
+      textareaRef.current.focus();
+    }
+  }, [open, state]);
+
+  const handleSubmit = async () => {
+    setState("submitting");
+    setError(null);
+    try {
+      await onSubmit(comments);
+      setState("success");
+    } catch (err) {
+      setState("input");
+      setError(
+        err instanceof Error
+          ? err.message
+          : "Something went wrong. Please try again.",
+      );
+    }
+  };
+
+  const canClose = state !== "submitting";
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(isOpen) => {
+        if (!isOpen && canClose) onClose();
+      }}
+    >
+      <DialogContent>
+        {state === "success" ? (
+          <BlockStack gap="4" className="items-center py-4 text-center">
+            <CheckCircle2Icon className="w-12 h-12 text-success animate-in zoom-in-50 duration-300" />
+            <BlockStack gap="2" className="items-center">
+              <DialogTitle asChild>
+                <Heading level={3}>{successTitle}</Heading>
+              </DialogTitle>
+              <DialogDescription asChild>
+                <Paragraph tone="subdued">{successMessage}</Paragraph>
+              </DialogDescription>
+            </BlockStack>
+            <Button onClick={onClose}>Done</Button>
+          </BlockStack>
+        ) : (
+          <>
+            <DialogTitle>{title}</DialogTitle>
+            {description && (
+              <DialogDescription>{description}</DialogDescription>
+            )}
+            <Textarea
+              ref={textareaRef}
+              aria-label="Additional comments"
+              value={comments}
+              onChange={(e) => setComments(e.target.value)}
+              placeholder="Optional: add any context or questions..."
+              className="min-h-28"
+              disabled={state === "submitting"}
+            />
+            {error && (
+              <Text size="sm" tone="critical">
+                {error}
+              </Text>
+            )}
+            <DialogFooter>
+              <Button
+                variant="outline"
+                onClick={onClose}
+                disabled={state === "submitting"}
+              >
+                Cancel
+              </Button>
+              <Button onClick={handleSubmit} disabled={state === "submitting"}>
+                {state === "submitting" ? (
+                  <>
+                    <Spinner size={16} />
+                    Submitting...
+                  </>
+                ) : (
+                  "Submit"
+                )}
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/config/remoteTroubleshootAction.ts
+++ b/src/config/remoteTroubleshootAction.ts
@@ -1,0 +1,15 @@
+export interface RemoteTroubleshootActionConfig {
+  endpointUrl: string;
+  buttonText: string;
+  modalTitle?: string;
+  modalDescription?: string;
+  successTitle?: string;
+  successMessage?: string;
+  source?: string;
+}
+
+declare global {
+  interface Window {
+    __TANGLE_REMOTE_TROUBLESHOOT_ACTION__?: RemoteTroubleshootActionConfig;
+  }
+}

--- a/src/routes/v2/pages/RunView/nodes/TaskNode/context/RunViewTaskDetails.tsx
+++ b/src/routes/v2/pages/RunView/nodes/TaskNode/context/RunViewTaskDetails.tsx
@@ -1,3 +1,4 @@
+import { useParams } from "@tanstack/react-router";
 import { AmphoraIcon, InfoIcon, LogsIcon } from "lucide-react";
 import { observer } from "mobx-react-lite";
 
@@ -7,6 +8,7 @@ import Logs, {
   OpenLogsInNewWindowLink,
 } from "@/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/logs";
 import { LogsEventsOverlaySection } from "@/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/LogsEventsOverlaySection";
+import { RemoteTroubleshootButton } from "@/components/shared/RemoteTroubleshootAction/RemoteTroubleshootButton";
 import { StatusIcon } from "@/components/shared/Status";
 import TaskDetails from "@/components/shared/TaskDetails/Details";
 import { Icon } from "@/components/ui/icon";
@@ -31,6 +33,9 @@ export const RunViewTaskDetails = observer(function RunViewTaskDetails({
   const { track } = useAnalytics();
   const spec = useSpec();
   const executionData = useExecutionDataOptional();
+  const params = useParams({ strict: false });
+  const runId =
+    "id" in params && typeof params.id === "string" ? params.id : undefined;
 
   const task = spec?.tasks.find((t) => t.$id === entityId);
 
@@ -68,6 +73,15 @@ export const RunViewTaskDetails = observer(function RunViewTaskDetails({
       </InlineStack>
 
       <RunViewTaskActions componentRef={componentRef} taskName={task.name} />
+
+      {runId && (
+        <RemoteTroubleshootButton
+          runId={runId}
+          executionId={executionId}
+          taskName={task.name}
+          status={status}
+        />
+      )}
 
       <div className="overflow-y-auto pb-4 h-full w-full">
         <Tabs

--- a/src/services/executionService.ts
+++ b/src/services/executionService.ts
@@ -45,6 +45,22 @@ export const fetchExecutionDetails = async (
   return fetchWithErrorHandling(url);
 };
 
+export const useFetchExecutionDetails = (
+  executionId: string | undefined,
+  status: string | undefined,
+  enabled: boolean,
+) => {
+  const { backendUrl } = useBackend();
+
+  return useQuery<GetExecutionInfoResponse>({
+    queryKey: ["execution-details", executionId, status],
+    queryFn: () => fetchExecutionDetails(executionId!, backendUrl),
+    enabled: !!executionId && enabled,
+    refetchOnWindowFocus: false,
+    retry: retryUnlessAuth,
+  });
+};
+
 export const fetchPipelineRun = async (
   runId: string,
   backendUrl: string,

--- a/src/utils/remoteTroubleshootStorage.ts
+++ b/src/utils/remoteTroubleshootStorage.ts
@@ -1,0 +1,41 @@
+import { getStorage } from "./typedStorage";
+
+interface RemoteTroubleshootRecord {
+  runId: string;
+  executionId: string;
+  requestedAt: string;
+}
+
+interface RemoteTroubleshootStorageMap {
+  "remote-troubleshoot-requests": RemoteTroubleshootRecord[];
+}
+
+const storage = getStorage<
+  keyof RemoteTroubleshootStorageMap,
+  RemoteTroubleshootStorageMap
+>();
+
+export function getRemoteTroubleshootRecord(
+  runId: string,
+  executionId: string,
+): RemoteTroubleshootRecord | undefined {
+  const records = storage.getItem("remote-troubleshoot-requests") ?? [];
+  return records.find(
+    (r) => r.runId === runId && r.executionId === executionId,
+  );
+}
+
+export function saveRemoteTroubleshootRecord(
+  runId: string,
+  executionId: string,
+): void {
+  const records = storage.getItem("remote-troubleshoot-requests") ?? [];
+  const exists = records.some(
+    (r) => r.runId === runId && r.executionId === executionId,
+  );
+  if (exists) return;
+  storage.setItem("remote-troubleshoot-requests", [
+    ...records,
+    { runId, executionId, requestedAt: new Date().toISOString() },
+  ]);
+}


### PR DESCRIPTION
## Summary

- Adds a configurable **execution action button** to the task details panel in the run view.
- Button appears when an execution/task node is selected in the properties panel.
- Status-gated: immediately visible for `CANCELLED`, `SYSTEM_ERROR`, `FAILED`; visible after 5 minutes for `PENDING`/`QUEUED` (polled every 10 s, not on every render).
- Hidden on localhost/local environments. Hidden if `window.__TANGLE_EXECUTION_ACTION__` config is absent.
- Clicking opens a modal for optional additional context; submit POSTs a structured payload to a configurable backend proxy endpoint.
- Animated success checkmark after submit.
- After submit, localStorage (keyed by `runId + executionId`) shows "session opened at [time]" instead of the button — prevents duplicate submissions.
- `execution_url` field in the payload uses existing `?nodeId=<task-name>` deep-link support.
- **OSS-friendly**: button renders nothing if config is absent; Config is set via `window.__TANGLE_EXECUTION_ACTION__` injected from `index.html`.

![image.png](https://app.graphite.com/user-attachments/assets/0c5fecf2-136b-4397-aa46-6ff24bffd233.png)

![image.png](https://app.graphite.com/user-attachments/assets/c4f1e5e7-d02d-4684-bcbb-82aaed9ba14c.png)

![image.png](https://app.graphite.com/user-attachments/assets/3ee91642-898a-489c-be43-49fc05049856.png)

## Config shape (`window.__TANGLE_EXECUTION_ACTION__`)

```typescript
{
  endpointUrl: string;   // proxy endpoint, e.g. "/api/integration/slack_workflow_trigger"
  workflowId: string;    // logical workflow ID, e.g. "inspect_with_river"
  buttonText: string;
  modalTitle?: string;
  modalDescription?: string;
  successTitle?: string;
  successMessage?: string;
  source?: string;
}
```

## Payload sent to `endpointUrl`

```json
{
  "workflow_internal_id": "<workflowId>",
  "webhook_payload": {
    "execution_id": "...",
    "user_email": "...",
    "pipeline_run_id": "...",
    "pipeline_run_url": "...",
    "execution_url": "https://...?nodeId=TaskName",
    "additional_comments": "...",
    "source": "tangle-ui"
  }
}
```

## New files

- `src/config/executionAction.ts` — config type + `Window` augmentation
- `src/utils/executionActionStorage.ts` — localStorage tracking
- `src/components/shared/ExecutionAction/ExecutionActionButton.tsx` — main button with status/timer logic
- `src/components/shared/ExecutionAction/ExecutionActionDialog.tsx` — modal with input/submitting/success states

## Modified files

- `src/routes/v2/pages/RunView/nodes/TaskNode/context/RunViewTaskDetails.tsx` — renders `ExecutionActionButton` above the Tabs

## Test plan

- [ ] Select a FAILED task — button appears immediately
- [ ] Select a PENDING task — button hidden; appears after 5 min threshold
- [ ] Submit with additional context — success animation shown
- [ ] Re-select same task — "session opened at [time]" shown instead of button
- [ ] Open on localhost — button absent
- [ ] No `window.__TANGLE_EXECUTION_ACTION__` set — button absent