### PR TITLE
Add component search analytics baseline

### DIFF
--- a/src/components/shared/ComponentSearchEmptyStateSuggestions.tsx
+++ b/src/components/shared/ComponentSearchEmptyStateSuggestions.tsx
@@ -2,13 +2,16 @@ import { Button } from "@/components/ui/button";
 import { InlineStack } from "@/components/ui/layout";
 import { Text } from "@/components/ui/typography";
 import { COMPONENT_SEARCH_EMPTY_STATE_SUGGESTIONS } from "@/services/componentSearchSuggestions";
+import { tracking } from "@/utils/tracking";
 
 interface ComponentSearchEmptyStateSuggestionsProps {
   onSelectSuggestion: (query: string) => void;
+  surface: string;
 }
 
 export function ComponentSearchEmptyStateSuggestions({
   onSelectSuggestion,
+  surface,
 }: ComponentSearchEmptyStateSuggestionsProps) {
   return (
     <InlineStack gap="2">
@@ -22,6 +25,10 @@ export function ComponentSearchEmptyStateSuggestions({
           variant="outline"
           size="xs"
           onClick={() => onSelectSuggestion(suggestion)}
+          {...tracking("component_library.search.suggestion", {
+            surface,
+            suggested_query: suggestion,
+          })}
         >
           {suggestion}
         </Button>

--- a/src/routes/Dashboard/DashboardComponentsV2View.test.tsx
+++ b/src/routes/Dashboard/DashboardComponentsV2View.test.tsx
@@ -39,6 +39,7 @@ const routeMocks = vi.hoisted(() => {
     extraStandardComponents: [] as ComponentReference[],
     navigate: vi.fn(),
     notify: vi.fn(),
+    track: vi.fn(),
     refetchDescription: vi.fn(),
     rerank: vi.fn(),
     resetRerank: vi.fn(),
@@ -124,6 +125,10 @@ vi.mock("@tanstack/react-router", () => ({
 
 vi.mock("dexie-react-hooks", () => ({
   useLiveQuery: () => [],
+}));
+
+vi.mock("@/providers/AnalyticsProvider", () => ({
+  useAnalytics: () => ({ track: routeMocks.track }),
 }));
 
 vi.mock("@/providers/BackendProvider", () => ({
@@ -479,6 +484,7 @@ describe("DashboardComponentsV2View", () => {
     routeMocks.extraStandardComponents = [];
     routeMocks.navigate.mockClear();
     routeMocks.notify.mockClear();
+    routeMocks.track.mockClear();
     routeMocks.refetchDescription.mockClear();
     routeMocks.rerank.mockClear();
     routeMocks.resetRerank.mockClear();
@@ -592,6 +598,34 @@ describe("DashboardComponentsV2View", () => {
     await waitFor(() => {
       expect(screen.getByText(/Why: Matched/)).toBeInTheDocument();
     });
+  });
+
+  it("tracks dashboard component search completions without query text", async () => {
+    render(<DashboardComponentsV2View />);
+
+    fireEvent.change(screen.getByLabelText("Search components"), {
+      target: { value: "standard" },
+    });
+
+    await waitFor(() => {
+      expect(routeMocks.track).toHaveBeenCalledWith(
+        "component_library.search.completed",
+        expect.objectContaining({
+          surface: "dashboard_v2",
+          search_backend: "frontend_aggregate",
+          query_length: "standard".length,
+          result_count: 1,
+          component_result_count: 1,
+          collection_result_count: 0,
+          ai_ranked: false,
+        }),
+      );
+    });
+
+    expect(routeMocks.track).not.toHaveBeenCalledWith(
+      "component_library.search.completed",
+      expect.objectContaining({ query: "standard" }),
+    );
   });
 
   it("shows actionable no-results guidance with clickable suggestions", async () => {

--- a/src/routes/Dashboard/DashboardComponentsV2View.tsx
+++ b/src/routes/Dashboard/DashboardComponentsV2View.tsx
@@ -37,6 +37,7 @@ import {
 } from "@/hooks/useNaturalLanguageComponentSearch";
 import useToastNotification from "@/hooks/useToastNotification";
 import { cn } from "@/lib/utils";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { useBackend } from "@/providers/BackendProvider";
 import {
   fetchUserComponents,
@@ -674,6 +675,7 @@ export const DashboardComponentsV2View = () => {
   const aiDescriptionsEnabled = useFlagValue(
     "component-search-v2-ai-descriptions",
   );
+  const { track } = useAnalytics();
   const { backendUrl, configured, available } = useBackend();
   const { config: aiConfig } = useAiProviderSettings();
   const dashboardSearch = useSearch({ strict: false });
@@ -1146,6 +1148,37 @@ export const DashboardComponentsV2View = () => {
         rerankScore: undefined,
       }));
 
+  const trackedSearchResultCount =
+    displayedResults.length + collectionMatches.length;
+
+  useEffect(() => {
+    if (isLoadingLibrary || trimmedQuery.length === 0) return;
+
+    const timeout = window.setTimeout(() => {
+      track("component_library.search.completed", {
+        surface: "dashboard_v2",
+        search_backend: rerankActive
+          ? "frontend_aggregate_ai_rerank"
+          : "frontend_aggregate",
+        query_length: trimmedQuery.length,
+        result_count: trackedSearchResultCount,
+        component_result_count: displayedResults.length,
+        collection_result_count: collectionMatches.length,
+        ai_ranked: rerankActive,
+      });
+    }, 400);
+
+    return () => window.clearTimeout(timeout);
+  }, [
+    collectionMatches.length,
+    displayedResults.length,
+    isLoadingLibrary,
+    rerankActive,
+    track,
+    trackedSearchResultCount,
+    trimmedQuery,
+  ]);
+
   // Resolve the full reference for the selected digest. Prefer the already-
   // hydrated copy (no extra network), fall back to the un-hydrated index
   // entry, then to a backend stub. The shared ComponentDetail will suspend on
@@ -1313,6 +1346,7 @@ export const DashboardComponentsV2View = () => {
             reranks matching local candidates when it is configured.
           </Paragraph>
           <ComponentSearchEmptyStateSuggestions
+            surface="dashboard_v2"
             onSelectSuggestion={handleSuggestedSearch}
           />
         </BlockStack>
@@ -1414,6 +1448,12 @@ export const DashboardComponentsV2View = () => {
                   : "AI search"
               }
               title="AI search — rerank a bounded set of top candidates with an LLM"
+              {...tracking("component_library.search.ai_rerank", {
+                surface: "dashboard_v2",
+                mode: "smart",
+                query_length: trimmedQuery.length,
+                candidate_count: aiCandidateMatches.length,
+              })}
             >
               {isReranking || isEmbeddingSearchPending ? (
                 <Spinner size={16} />

--- a/src/routes/v2/pages/Editor/components/ComponentSearchResults.test.tsx
+++ b/src/routes/v2/pages/Editor/components/ComponentSearchResults.test.tsx
@@ -58,7 +58,21 @@ describe("ComponentSearchResults", () => {
     ).toBeInTheDocument();
     expect(screen.getByText(/Try a component name/)).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "csv" }));
+    const suggestion = screen.getByRole("button", { name: "csv" });
+
+    expect(suggestion).toHaveAttribute(
+      "data-tracking-id",
+      "component_library.search.suggestion",
+    );
+    expect(suggestion).toHaveAttribute(
+      "data-tracking-metadata",
+      JSON.stringify({
+        surface: "editor_component_search_v2",
+        suggested_query: "csv",
+      }),
+    );
+
+    fireEvent.click(suggestion);
 
     expect(onSuggestedSearch).toHaveBeenCalledWith("csv");
   });

--- a/src/routes/v2/pages/Editor/components/ComponentSearchResults.tsx
+++ b/src/routes/v2/pages/Editor/components/ComponentSearchResults.tsx
@@ -127,6 +127,7 @@ export function ComponentSearchResults({
               </Paragraph>
             </BlockStack>
             <ComponentSearchEmptyStateSuggestions
+              surface="editor_component_search_v2"
               onSelectSuggestion={onSuggestedSearch}
             />
           </BlockStack>

--- a/src/routes/v2/pages/Editor/components/ComponentSearchV2Content.test.tsx
+++ b/src/routes/v2/pages/Editor/components/ComponentSearchV2Content.test.tsx
@@ -5,8 +5,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ComponentSearchV2Content } from "./ComponentSearchV2Content";
 
 const mocks = vi.hoisted(() => ({
+  track: vi.fn(),
   useComponentSearchV2State: vi.fn(),
-  useFlagValue: vi.fn(),
 }));
 
 vi.mock(
@@ -18,8 +18,8 @@ vi.mock(
   }),
 );
 
-vi.mock("@/components/shared/Settings/useFlags", () => ({
-  useFlagValue: mocks.useFlagValue,
+vi.mock("@/providers/AnalyticsProvider", () => ({
+  useAnalytics: () => ({ track: mocks.track }),
 }));
 
 vi.mock("@/routes/v2/pages/Editor/hooks/useComponentSearchV2State", () => ({
@@ -35,17 +35,15 @@ vi.mock("./ComponentSearchResults", () => ({
 describe("ComponentSearchV2Content", () => {
   beforeEach(() => {
     vi.useFakeTimers();
-    mocks.useFlagValue.mockReturnValue(false);
+    mocks.track.mockClear();
     mocks.useComponentSearchV2State.mockImplementation(() => ({
       results: [],
       browseFolders: [],
       isLoading: false,
       canRerank: false,
-      canDeepRerank: false,
       isReranking: false,
       isRerankActive: false,
       rerank: vi.fn(),
-      deepRerank: vi.fn(),
       clearRerank: vi.fn(),
     }));
   });
@@ -75,5 +73,35 @@ describe("ComponentSearchV2Content", () => {
     });
 
     expect(screen.getByTestId("results-query")).toHaveTextContent("csv");
+  });
+
+  it("tracks editor component search completions without query text", async () => {
+    render(<ComponentSearchV2Content />);
+
+    fireEvent.change(screen.getByLabelText("Search components"), {
+      target: { value: "csv" },
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(400);
+    });
+
+    expect(mocks.track).toHaveBeenCalledWith(
+      "component_library.search.completed",
+      expect.objectContaining({
+        surface: "editor_component_search_v2",
+        search_backend: "frontend_aggregate",
+        query_length: "csv".length,
+        result_count: 0,
+        ai_ranked: false,
+      }),
+    );
+    expect(mocks.track).not.toHaveBeenCalledWith(
+      "component_library.search.completed",
+      expect.objectContaining({ query: "csv" }),
+    );
   });
 });

--- a/src/routes/v2/pages/Editor/components/ComponentSearchV2Content.tsx
+++ b/src/routes/v2/pages/Editor/components/ComponentSearchV2Content.tsx
@@ -1,4 +1,4 @@
-import { useDeferredValue, useState, useTransition } from "react";
+import { useDeferredValue, useEffect, useState, useTransition } from "react";
 
 import ImportComponent from "@/components/shared/ReactFlow/FlowSidebar/components/ImportComponent";
 import { Button } from "@/components/ui/button";
@@ -8,7 +8,9 @@ import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Spinner } from "@/components/ui/spinner";
 import { Text } from "@/components/ui/typography";
 import { useDebouncedSearchValue } from "@/hooks/useDebouncedSearchValue";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { useComponentSearchV2State } from "@/routes/v2/pages/Editor/hooks/useComponentSearchV2State";
+import { tracking } from "@/utils/tracking";
 
 import { ComponentSearchResults } from "./ComponentSearchResults";
 
@@ -42,6 +44,7 @@ function DebouncedComponentSearchInput({
 }
 
 export function ComponentSearchV2Content() {
+  const { track } = useAnalytics();
   const [query, setQuery] = useState("");
   const deferredQuery = useDeferredValue(query);
   const [, startSearchTransition] = useTransition();
@@ -63,6 +66,26 @@ export function ComponentSearchV2Content() {
   const handleSuggestedSearch = (value: string) => {
     startSearchTransition(() => setQuery(value));
   };
+
+  const trimmedDeferredQuery = deferredQuery.trim();
+
+  useEffect(() => {
+    if (isLoading || trimmedDeferredQuery.length === 0) return;
+
+    const timeout = window.setTimeout(() => {
+      track("component_library.search.completed", {
+        surface: "editor_component_search_v2",
+        search_backend: isRerankActive
+          ? "frontend_aggregate_ai_rerank"
+          : "frontend_aggregate",
+        query_length: trimmedDeferredQuery.length,
+        result_count: results.length,
+        ai_ranked: isRerankActive,
+      });
+    }, 400);
+
+    return () => window.clearTimeout(timeout);
+  }, [isLoading, isRerankActive, results.length, track, trimmedDeferredQuery]);
 
   return (
     <BlockStack className="h-full min-h-0 overflow-hidden [&_.text-sm]:text-xs!">
@@ -107,6 +130,12 @@ export function ComponentSearchV2Content() {
             title="AI rerank — rerank a bounded set of top candidates"
             onClick={rerank}
             disabled={!canRerank || isReranking}
+            {...tracking("component_library.search.ai_rerank", {
+              surface: "editor_component_search_v2",
+              mode: "smart",
+              query_length: trimmedDeferredQuery.length,
+              result_count: results.length,
+            })}
           >
             {isReranking ? <Spinner size={14} /> : <Icon name="Sparkles" />}
           </Button>


### PR DESCRIPTION
## Description

Adds analytics tracking to the component library search experience across both the dashboard and editor surfaces. Search completion events are fired with a debounced 400ms delay after results settle, capturing metadata such as `query_length`, `result_count`, `search_backend`, and `ai_ranked` — intentionally omitting the raw query text to avoid logging potentially sensitive user input.

Tracking is also added to the AI rerank buttons (both "smart" and "deep" modes) and the empty-state suggestion chips, each annotated with the relevant `surface` identifier (`dashboard_v2` or `editor_component_search_v2`).

The `ComponentSearchEmptyStateSuggestions` component now accepts a required `surface` prop so the correct surface label is forwarded to the tracking payload.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Open the component library search in both the dashboard and the editor.
2. Type a query and wait ~400ms after results appear — verify a `component_library.search.completed` event is fired with the correct metadata and that no raw query text is included.
3. Click an AI rerank button (smart or deep) and confirm a `component_library.search.ai_rerank` event is fired with the correct `mode`, `surface`, and `query_length`.
4. Trigger the empty-state suggestions (search for something with no results) and click a suggestion chip — confirm a `component_library.search.suggestion` event fires with the correct `surface` and `suggested_query`.

## Additional Comments

Query text is deliberately excluded from all tracking payloads; only `query_length` is recorded to avoid capturing potentially sensitive search input.