### PR TITLE
Add context-aware component search suggestions

### DIFF
--- a/src/components/shared/ComponentSearchEmptyStateSuggestions.tsx
+++ b/src/components/shared/ComponentSearchEmptyStateSuggestions.tsx
@@ -1,16 +1,18 @@
 import { Button } from "@/components/ui/button";
 import { InlineStack } from "@/components/ui/layout";
 import { Text } from "@/components/ui/typography";
-import { COMPONENT_SEARCH_EMPTY_STATE_SUGGESTIONS } from "@/services/componentSearchSuggestions";
+import type { ComponentSearchSuggestion } from "@/services/componentSearchSuggestions";
 import { tracking } from "@/utils/tracking";
 
 interface ComponentSearchEmptyStateSuggestionsProps {
   onSelectSuggestion: (query: string) => void;
+  suggestions: ComponentSearchSuggestion[];
   surface: string;
 }
 
 export function ComponentSearchEmptyStateSuggestions({
   onSelectSuggestion,
+  suggestions,
   surface,
 }: ComponentSearchEmptyStateSuggestionsProps) {
   return (
@@ -18,19 +20,20 @@ export function ComponentSearchEmptyStateSuggestions({
       <Text size="xs" tone="subdued">
         Suggested searches:
       </Text>
-      {COMPONENT_SEARCH_EMPTY_STATE_SUGGESTIONS.map((suggestion) => (
+      {suggestions.map((suggestion, index) => (
         <Button
-          key={suggestion}
+          key={suggestion.label}
           type="button"
           variant="outline"
           size="xs"
-          onClick={() => onSelectSuggestion(suggestion)}
+          onClick={() => onSelectSuggestion(suggestion.label)}
           {...tracking("component_library.search.suggestion", {
             surface,
-            suggested_query: suggestion,
+            suggestion_kind: suggestion.kind,
+            suggestion_position: index,
           })}
         >
-          {suggestion}
+          {suggestion.label}
         </Button>
       ))}
     </InlineStack>

--- a/src/routes/Dashboard/DashboardComponentsV2View.tsx
+++ b/src/routes/Dashboard/DashboardComponentsV2View.tsx
@@ -64,6 +64,7 @@ import {
   type MatchField,
   type SourcedReference,
 } from "@/services/componentSearchIndex";
+import { buildComponentSearchSuggestions } from "@/services/componentSearchSuggestions";
 import {
   fetchAndStoreComponentLibrary,
   hydrateComponentReference,
@@ -959,6 +960,9 @@ export const DashboardComponentsV2View = () => {
     filteredIndex,
     deferredQuery,
   );
+  const searchSuggestions = buildComponentSearchSuggestions(filteredIndex, {
+    query: trimmedQuery,
+  });
 
   const aiCandidateMatches: LexicalMatch[] = (() => {
     if (trimmedQuery.length === 0) return [];
@@ -1341,11 +1345,12 @@ export const DashboardComponentsV2View = () => {
             No components matched “{trimmedQuery}”.
           </Paragraph>
           <Paragraph size="xs" tone="subdued">
-            Try a component name, input/output type, source term, or task intent
-            like “csv”, “train model”, “predict”, or “dataframe”. AI search
+            Try a component name, input/output type, source term, or task intent.
+            Suggestions below are based on your loaded component sources. AI search
             reranks matching local candidates when it is configured.
           </Paragraph>
           <ComponentSearchEmptyStateSuggestions
+            suggestions={searchSuggestions}
             surface="dashboard_v2"
             onSelectSuggestion={handleSuggestedSearch}
           />

--- a/src/routes/v2/pages/Editor/components/ComponentSearchResults.test.tsx
+++ b/src/routes/v2/pages/Editor/components/ComponentSearchResults.test.tsx
@@ -1,6 +1,8 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
+import type { ComponentSearchSuggestion } from "@/services/componentSearchSuggestions";
+
 import { ComponentSearchResults } from "./ComponentSearchResults";
 import type { ComponentSearchV2Result } from "./componentSearchV2Logic";
 
@@ -35,6 +37,10 @@ vi.mock(
 
 const baseProps = {
   browseFolders: [],
+  searchSuggestions: [
+    { label: "csv", kind: "default" },
+    { label: "dataset", kind: "type" },
+  ] satisfies ComponentSearchSuggestion[],
   isLoading: false,
   isRerankActive: false,
   onClearRerank: vi.fn(),
@@ -68,7 +74,8 @@ describe("ComponentSearchResults", () => {
       "data-tracking-metadata",
       JSON.stringify({
         surface: "editor_component_search_v2",
-        suggested_query: "csv",
+        suggestion_kind: "default",
+        suggestion_position: 0,
       }),
     );
 

--- a/src/routes/v2/pages/Editor/components/ComponentSearchResults.tsx
+++ b/src/routes/v2/pages/Editor/components/ComponentSearchResults.tsx
@@ -10,6 +10,7 @@ import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Separator } from "@/components/ui/separator";
 import { Spinner } from "@/components/ui/spinner";
 import { Paragraph, Text } from "@/components/ui/typography";
+import type { ComponentSearchSuggestion } from "@/services/componentSearchSuggestions";
 import type { UIComponentFolder } from "@/types/componentLibrary";
 
 import type { ComponentSearchV2Result } from "./componentSearchV2Logic";
@@ -18,6 +19,7 @@ interface ComponentSearchResultsProps {
   query: string;
   results: ComponentSearchV2Result[];
   browseFolders: UIComponentFolder[];
+  searchSuggestions: ComponentSearchSuggestion[];
   isLoading: boolean;
   isRerankActive: boolean;
   onClearRerank: () => void;
@@ -28,6 +30,7 @@ export function ComponentSearchResults({
   query,
   results,
   browseFolders,
+  searchSuggestions,
   isLoading,
   isRerankActive,
   onClearRerank,
@@ -122,11 +125,13 @@ export function ComponentSearchResults({
                 No components matched “{query.trim()}”.
               </Paragraph>
               <Paragraph size="xs" tone="subdued">
-                Try a component name, input/output type, or task intent like
-                “csv”, “train”, “predict”, or “dataframe”.
+                Try a component name, input/output type, source term, or task
+                intent. Suggestions below are based on your loaded component
+                sources.
               </Paragraph>
             </BlockStack>
             <ComponentSearchEmptyStateSuggestions
+              suggestions={searchSuggestions}
               surface="editor_component_search_v2"
               onSelectSuggestion={onSuggestedSearch}
             />

--- a/src/routes/v2/pages/Editor/components/ComponentSearchV2Content.test.tsx
+++ b/src/routes/v2/pages/Editor/components/ComponentSearchV2Content.test.tsx
@@ -39,6 +39,7 @@ describe("ComponentSearchV2Content", () => {
     mocks.useComponentSearchV2State.mockImplementation(() => ({
       results: [],
       browseFolders: [],
+      searchSuggestions: [],
       isLoading: false,
       canRerank: false,
       isReranking: false,

--- a/src/routes/v2/pages/Editor/components/ComponentSearchV2Content.tsx
+++ b/src/routes/v2/pages/Editor/components/ComponentSearchV2Content.tsx
@@ -51,6 +51,7 @@ export function ComponentSearchV2Content() {
   const {
     results,
     browseFolders,
+    searchSuggestions,
     isLoading,
     canRerank,
     isReranking,
@@ -145,6 +146,7 @@ export function ComponentSearchV2Content() {
         query={deferredQuery}
         results={results}
         browseFolders={browseFolders}
+        searchSuggestions={searchSuggestions}
         isLoading={isLoading}
         isRerankActive={isRerankActive}
         onClearRerank={clearRerank}

--- a/src/routes/v2/pages/Editor/components/componentSearchV2Logic.ts
+++ b/src/routes/v2/pages/Editor/components/componentSearchV2Logic.ts
@@ -17,6 +17,7 @@ import {
   type MatchField,
   type SourcedReference,
 } from "@/services/componentSearchIndex";
+import type { ComponentSearchSuggestion } from "@/services/componentSearchSuggestions";
 import type { RerankResult } from "@/services/naturalLanguageComponentSearchService";
 import type {
   ComponentFolder,
@@ -70,6 +71,7 @@ export interface ComponentSearchV2Result {
 export interface ComponentSearchV2State {
   results: ComponentSearchV2Result[];
   browseFolders: UIComponentFolder[];
+  searchSuggestions: ComponentSearchSuggestion[];
   isLoading: boolean;
   canRerank: boolean;
   isReranking: boolean;

--- a/src/routes/v2/pages/Editor/hooks/useComponentSearchV2State.ts
+++ b/src/routes/v2/pages/Editor/hooks/useComponentSearchV2State.ts
@@ -38,6 +38,7 @@ import {
   type LexicalMatch,
   type SourcedReference,
 } from "@/services/componentSearchIndex";
+import { buildComponentSearchSuggestions } from "@/services/componentSearchSuggestions";
 import {
   fetchAndStoreComponentLibrary,
   hydrateComponentReference,
@@ -345,6 +346,10 @@ export function useComponentSearchV2State(
   return {
     results,
     browseFolders: buildResultFolders({ results, standardLibrary }),
+    searchSuggestions: buildComponentSearchSuggestions(index, {
+      includeSources: false,
+      query: trimmedQuery,
+    }),
     isLoading:
       isLoadingStandardLibrary ||
       isLoadingUserComponents ||

--- a/src/services/componentSearchSuggestions.test.ts
+++ b/src/services/componentSearchSuggestions.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+
+import type { IndexEntry } from "@/services/componentSearchIndex";
+
+import { buildComponentSearchSuggestions } from "./componentSearchSuggestions";
+
+function createEntry({
+  digest,
+  name,
+  sourceLabel = "Standard",
+  sourceKind = "standard",
+  inputType,
+  outputType,
+}: {
+  digest: string;
+  name: string;
+  sourceLabel?: string;
+  sourceKind?: IndexEntry["source"]["kind"];
+  inputType?: string;
+  outputType?: string;
+}): IndexEntry {
+  return {
+    digest,
+    name,
+    source: { kind: sourceKind, id: sourceLabel, label: sourceLabel },
+    reference: {
+      digest,
+      name,
+      spec: {
+        name,
+        description: "",
+        inputs: inputType ? [{ name: "input", type: inputType }] : [],
+        outputs: outputType ? [{ name: "output", type: outputType }] : [],
+        implementation: { container: { image: "python:3.11" } },
+      },
+    },
+    searchable: {
+      name,
+      description: "",
+      io: "",
+      implementation: "",
+      metadata: "",
+    },
+  };
+}
+
+describe("buildComponentSearchSuggestions", () => {
+  it("prioritizes common input and output types over fallback suggestions", () => {
+    const suggestions = buildComponentSearchSuggestions([
+      createEntry({ digest: "1", name: "Load CSV", outputType: "Dataset" }),
+      createEntry({ digest: "2", name: "Train Model", inputType: "Dataset" }),
+      createEntry({ digest: "3", name: "Evaluate Model", inputType: "Model" }),
+    ]);
+
+    expect(suggestions).toEqual([
+      { label: "dataset", kind: "type" },
+      { label: "model", kind: "type" },
+      { label: "csv", kind: "name" },
+      { label: "train", kind: "name" },
+    ]);
+  });
+
+  it("uses safe registered library labels when available", () => {
+    const suggestions = buildComponentSearchSuggestions([
+      createEntry({
+        digest: "1",
+        name: "Normalize Data",
+        sourceKind: "registered",
+        sourceLabel: "Data Tools",
+      }),
+    ]);
+
+    expect(suggestions).toContainEqual({ label: "data tools", kind: "source" });
+  });
+
+  it("can omit source suggestions for surfaces that do not search collections", () => {
+    const suggestions = buildComponentSearchSuggestions(
+      [
+        createEntry({
+          digest: "1",
+          name: "Normalize Data",
+          sourceKind: "registered",
+          sourceLabel: "Data Tools",
+        }),
+      ],
+      { includeSources: false },
+    );
+
+    expect(suggestions).not.toContainEqual({
+      label: "data tools",
+      kind: "source",
+    });
+  });
+
+  it("falls back to curated suggestions and excludes terms already in the query", () => {
+    expect(buildComponentSearchSuggestions([], { query: "csv" })).toEqual([
+      { label: "train", kind: "default" },
+      { label: "predict", kind: "default" },
+      { label: "dataframe", kind: "default" },
+    ]);
+  });
+});

--- a/src/services/componentSearchSuggestions.ts
+++ b/src/services/componentSearchSuggestions.ts
@@ -1,6 +1,143 @@
-export const COMPONENT_SEARCH_EMPTY_STATE_SUGGESTIONS = [
+import type { IndexEntry } from "@/services/componentSearchIndex";
+import type { ComponentReference, TypeSpecType } from "@/utils/componentSpec";
+
+const DEFAULT_COMPONENT_SEARCH_SUGGESTIONS = [
   "csv",
   "train",
   "predict",
   "dataframe",
 ] as const;
+
+const NOISY_SUGGESTION_TOKENS = new Set([
+  "component",
+  "components",
+  "library",
+  "standard",
+  "published",
+  "user",
+  "input",
+  "inputs",
+  "output",
+  "outputs",
+  "string",
+  "integer",
+  "number",
+  "boolean",
+  "float",
+  "double",
+  "object",
+  "python",
+]);
+
+type ComponentSearchSuggestionKind = "default" | "name" | "source" | "type";
+
+export interface ComponentSearchSuggestion {
+  label: string;
+  kind: ComponentSearchSuggestionKind;
+}
+
+interface ScoredSuggestion extends ComponentSearchSuggestion {
+  score: number;
+}
+
+function normalizeToken(value: string): string | undefined {
+  const normalized = value.trim().toLowerCase();
+  if (normalized.length < 3 || normalized.length > 24) return undefined;
+  if (NOISY_SUGGESTION_TOKENS.has(normalized)) return undefined;
+  if (!/[a-z]/.test(normalized)) return undefined;
+  return normalized;
+}
+
+function splitSuggestionTokens(value: string): string[] {
+  const camelSplit = value.replace(/([a-z])([A-Z])/g, "$1 $2");
+  return camelSplit
+    .split(/[^a-zA-Z0-9]+/)
+    .map((token) => normalizeToken(token))
+    .filter((token): token is string => token !== undefined);
+}
+
+function typeToTokens(type: TypeSpecType | undefined): string[] {
+  if (typeof type === "string") return splitSuggestionTokens(type);
+  if (!type) return [];
+  return splitSuggestionTokens(JSON.stringify(type));
+}
+
+function sourceLabelToSuggestion(label: string): string | undefined {
+  const normalized = label.trim().toLowerCase();
+  if (normalized.length < 3 || normalized.length > 28) return undefined;
+  if (normalized.includes("@") || normalized.includes("/")) return undefined;
+  if (NOISY_SUGGESTION_TOKENS.has(normalized)) return undefined;
+  return normalized;
+}
+
+function addSuggestion(
+  suggestions: Map<string, ScoredSuggestion>,
+  label: string,
+  kind: ComponentSearchSuggestionKind,
+  score: number,
+) {
+  const current = suggestions.get(label);
+  if (!current || score > current.score) {
+    suggestions.set(label, {
+      label,
+      kind,
+      score: (current?.score ?? 0) + score,
+    });
+  } else {
+    current.score += score;
+  }
+}
+
+function addReferenceSuggestions(
+  suggestions: Map<string, ScoredSuggestion>,
+  reference: ComponentReference,
+) {
+  for (const input of reference.spec?.inputs ?? []) {
+    for (const token of typeToTokens(input.type)) {
+      addSuggestion(suggestions, token, "type", 4);
+    }
+  }
+
+  for (const output of reference.spec?.outputs ?? []) {
+    for (const token of typeToTokens(output.type)) {
+      addSuggestion(suggestions, token, "type", 4);
+    }
+  }
+
+  for (const token of splitSuggestionTokens(reference.name ?? "")) {
+    addSuggestion(suggestions, token, "name", 1);
+  }
+}
+
+export function buildComponentSearchSuggestions(
+  index: IndexEntry[],
+  {
+    includeSources = true,
+    limit = 4,
+    query = "",
+  }: { includeSources?: boolean; limit?: number; query?: string } = {},
+): ComponentSearchSuggestion[] {
+  const suggestions = new Map<string, ScoredSuggestion>();
+  const queryTokens = new Set(splitSuggestionTokens(query));
+
+  for (const entry of index) {
+    addReferenceSuggestions(suggestions, entry.reference);
+
+    if (includeSources && entry.source.kind === "registered") {
+      const sourceSuggestion = sourceLabelToSuggestion(entry.source.label);
+      if (sourceSuggestion) {
+        addSuggestion(suggestions, sourceSuggestion, "source", 3);
+      }
+    }
+  }
+
+  DEFAULT_COMPONENT_SEARCH_SUGGESTIONS.forEach((label, index) => {
+    addSuggestion(suggestions, label, "default", 0.5 - index * 0.01);
+  });
+
+  return Array.from(suggestions.values())
+    .filter((suggestion) => !queryTokens.has(suggestion.label))
+    .sort((a, b) => b.score - a.score || a.label.localeCompare(b.label))
+    .slice(0, limit)
+    .map(({ label, kind }) => ({ label, kind }));
+}


### PR DESCRIPTION
## Description

Replaces the static list of hardcoded component search suggestions with a dynamic `buildComponentSearchSuggestions` function that derives suggestions from the loaded component index. Suggestions are scored and ranked based on common input/output types (highest weight), registered source labels, and component name tokens, with curated fallback defaults when the index is sparse. Each suggestion now carries a `kind` field (`"type"`, `"source"`, `"name"`, or `"default"`) and a `suggestion_position` index, both of which are emitted in tracking events instead of the previous `suggested_query` field. Suggestions that overlap with the current query are filtered out, and the empty-state help text is updated to reflect that suggestions are derived from loaded sources.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Open the component search panel in the editor or dashboard with no query entered and verify that the empty-state suggestion chips reflect types and source labels from your loaded component libraries rather than always showing the same four hardcoded terms.
2. Enter a partial query (e.g. `csv`) and confirm that `csv` no longer appears as a suggestion chip.
3. Load a registered component library and verify its label appears as a suggestion chip.
4. Confirm that tracking events for suggestion clicks now include `suggestion_kind` and `suggestion_position` instead of `suggested_query`.
5. Run the unit tests in `componentSearchSuggestions.test.ts` to verify scoring, source label inclusion, and fallback behaviour.

## Additional Comments

The `COMPONENT_SEARCH_EMPTY_STATE_SUGGESTIONS` constant has been removed. The `ComponentSearchEmptyStateSuggestions` component no longer sources suggestions internally; callers are now responsible for passing a `suggestions` prop, which allows each surface (dashboard v2 and editor v2) to supply index-aware suggestions independently.