### PR TITLE
Simplify component search result cards

### DIFF
--- a/src/components/shared/ReactFlow/FlowSidebar/components/ComponentItem.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/components/ComponentItem.tsx
@@ -13,7 +13,10 @@ import { Spinner } from "@/components/ui/spinner";
 import { Text } from "@/components/ui/typography";
 import { useHydrateComponentReference } from "@/hooks/useHydrateComponentReference";
 import { cn } from "@/lib/utils";
-import { formatMatchedFieldsExplanation } from "@/services/componentSearchExplanations";
+import {
+  formatComponentSearchMatchSummary,
+  formatMatchedFieldsExplanation,
+} from "@/services/componentSearchExplanations";
 import type { MatchField } from "@/services/componentSearchIndex";
 import { type ComponentReference, type TaskSpec } from "@/utils/componentSpec";
 import { getComponentName } from "@/utils/getComponentName";
@@ -104,7 +107,7 @@ const ComponentMarkup = ({
   const carousel = useRef(0);
   const { notifyNode, getNodeIdsByDigest, fitNodeIntoView } = useNodesOverlay();
 
-  const { spec, digest, url, name, published_by: author, owned } = component;
+  const { spec, digest, url, name, owned } = component;
 
   const displayName = useMemo(
     () => name ?? getComponentName({ spec, url }),
@@ -176,22 +179,27 @@ const ComponentMarkup = ({
     }
   }, []);
 
-  const iconName = isSubgraphSpec ? "Workflow" : owned ? "FileBadge" : "File";
-  const matchExplanation =
-    rerankReason ?? formatMatchedFieldsExplanation(matchedFields);
+  const iconName = isSubgraphSpec ? "Workflow" : "Package";
+  const matchExplanation = formatComponentSearchMatchSummary(
+    rerankReason ?? formatMatchedFieldsExplanation(matchedFields),
+  );
 
   const iconClass = cn(
     "shrink-0",
-    isSubgraphSpec ? "text-blue-400" : "text-gray-400",
+    isSubgraphSpec
+      ? "text-violet-500"
+      : owned
+        ? "text-orange-500"
+        : "text-blue-500",
   );
 
   return (
     <li
       className={cn(
-        "pl-2 py-1.5 w-full",
+        "group w-full px-3 py-2 text-left transition-colors",
         error
           ? "cursor-not-allowed opacity-60"
-          : "cursor-grab hover:bg-gray-100 active:bg-gray-200",
+          : "cursor-grab hover:bg-muted/40 active:bg-muted/60",
         className,
       )}
       draggable={!error && !isLoading}
@@ -207,54 +215,62 @@ const ComponentMarkup = ({
         ) : (
           <InlineStack
             wrap="nowrap"
+            gap="3"
             className="w-full"
             data-testid="component-item"
             data-component-name={displayName}
           >
-            <InlineStack gap="2" className="flex-1 min-w-0" wrap="nowrap">
+            <InlineStack
+              gap="2"
+              className="flex-1 min-w-0"
+              wrap="nowrap"
+              blockAlign="start"
+            >
               {isRemoteComponentLibrarySearchEnabled ? (
                 <ComponentIcon
                   name={iconName}
                   className={iconClass}
                   component={component}
+                  size="sm"
                 />
               ) : (
-                <Icon name={iconName} className={iconClass} />
+                <Icon name={iconName} className={iconClass} size="sm" />
               )}
 
               <div
-                className="flex flex-col flex-1 min-w-0"
+                className="flex flex-col flex-1 min-w-0 gap-1"
                 onMouseEnter={onMouseEnter}
                 onMouseLeave={onMouseLeave}
                 onClick={onMouseClick}
               >
-                <span
-                  className="truncate text-xs text-gray-800"
+                <Text
+                  size="sm"
+                  weight="semibold"
+                  className="min-w-0 truncate"
                   title={displayName}
                 >
                   {displayName}
-                </span>
-                {author && author.length > 0 && (
-                  <span className="truncate text-[10px] text-gray-500 font-mono">
-                    {author}
-                  </span>
-                )}
-                {matchExplanation ? (
-                  <span
-                    className="truncate text-[10px] text-gray-500"
+                </Text>
+                {matchExplanation && (
+                  <Text
+                    size="xs"
+                    tone="subdued"
+                    className="min-w-0 line-clamp-1"
                     title={matchExplanation}
                   >
                     Why: {matchExplanation}
-                  </span>
-                ) : (
-                  <span className="truncate text-[10px] text-gray-500 font-mono">
-                    Ver: {digest}
-                  </span>
+                  </Text>
                 )}
               </div>
             </InlineStack>
 
-            <InlineStack align="end" blockAlign="center" gap="1" wrap="nowrap">
+            <InlineStack
+              align="end"
+              blockAlign="center"
+              gap="1"
+              wrap="nowrap"
+              className="shrink-0 self-center opacity-70 transition-opacity group-hover:opacity-100"
+            >
               {rerankScore !== undefined && (
                 <Text
                   size="xs"

--- a/src/routes/Dashboard/DashboardComponentsV2View.test.tsx
+++ b/src/routes/Dashboard/DashboardComponentsV2View.test.tsx
@@ -529,6 +529,33 @@ describe("DashboardComponentsV2View", () => {
     });
   });
 
+  it("allows long component result titles to wrap inside cards", () => {
+    const longName =
+      "Train regression model using Vowpal Wabbit on VowpalWabbitJsonDatasetWithAnExtremelyLongName";
+    routeMocks.extraStandardComponents = [
+      {
+        digest: "long-title-component",
+        name: longName,
+        text: "component yaml",
+        spec: {
+          name: longName,
+          description: "Long title component description",
+          inputs: [],
+          outputs: [],
+          implementation: { container: { image: "python:3.11" } },
+        },
+      },
+    ];
+
+    render(<DashboardComponentsV2View />);
+
+    expect(screen.getByText(longName)).toHaveClass(
+      "whitespace-normal",
+      "[overflow-wrap:anywhere]",
+      "line-clamp-2",
+    );
+  });
+
   it("filters visible component results by source type and restores them", () => {
     render(<DashboardComponentsV2View />);
 
@@ -596,8 +623,24 @@ describe("DashboardComponentsV2View", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText(/Why: Matched/)).toBeInTheDocument();
+      expect(screen.getByText(/Why: name/)).toBeInTheDocument();
     });
+  });
+
+  it("keeps dashboard search result cards summary-only", async () => {
+    render(<DashboardComponentsV2View />);
+
+    fireEvent.change(screen.getByLabelText("Search components"), {
+      target: { value: "registered" },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Why: name/)).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText("Inputs")).not.toBeInTheDocument();
+    expect(screen.queryByText("1 required")).not.toBeInTheDocument();
+    expect(screen.queryByText(/data: Dataset/)).not.toBeInTheDocument();
   });
 
   it("tracks dashboard component search completions without query text", async () => {

--- a/src/routes/Dashboard/DashboardComponentsV2View.tsx
+++ b/src/routes/Dashboard/DashboardComponentsV2View.tsx
@@ -52,7 +52,7 @@ import {
 import { buildCompatibleComponentSuggestions } from "@/services/componentCompatibility";
 import { rankComponentMatchesByEmbeddings } from "@/services/componentSearchEmbeddings";
 import {
-  COMPONENT_SEARCH_MATCH_FIELD_LABEL,
+  formatComponentSearchMatchSummary,
   formatMatchedFieldsExplanation,
 } from "@/services/componentSearchExplanations";
 import {
@@ -124,6 +124,13 @@ const SOURCE_ICON_TONE_BY_KIND: Record<ComponentSearchSource["kind"], string> =
     registered: "text-violet-500",
     user: "text-amber-500",
   };
+
+function rerankScoreClass(score: number): string {
+  if (score >= 0.9) return "text-emerald-700 bg-emerald-50 border-emerald-200";
+  if (score >= 0.75)
+    return "text-emerald-600 bg-emerald-50/70 border-emerald-100";
+  return "text-emerald-500 bg-white border-emerald-100";
+}
 
 /** How many lexical hits to display before the user asks for AI judgment. */
 const LEXICAL_RESULT_LIMIT = 20;
@@ -244,7 +251,17 @@ interface ComponentCardProps {
   position?: number;
   /** Whether the user had typed a query when this card was rendered. */
   hadQuery?: boolean;
+  /** Whether the detail pane is open, forcing the results list into compact rows. */
+  isDetailOpen?: boolean;
   onSelect: (reference: ComponentReference) => void;
+}
+
+function cleanComponentCardDescription(
+  description: string | undefined,
+): string | undefined {
+  const cleaned = description?.replace(/\s*Annotations:.*$/i, "").trim();
+
+  return cleaned || description;
 }
 
 const ComponentCard = ({
@@ -257,18 +274,22 @@ const ComponentCard = ({
   isSelected,
   position,
   hadQuery,
+  isDetailOpen,
   onSelect,
 }: ComponentCardProps) => {
   const name = getComponentName(reference);
-  const description = reference.spec?.description;
+  const description = cleanComponentCardDescription(
+    reference.spec?.description,
+  );
   const publishedBy = reference.published_by;
   const trackingSource = source
     ? TRACKING_SOURCE_BY_KIND[source.kind]
     : "unknown";
-  const showLexicalMatchBadges = isAiRanked ? undefined : matchedFields;
-  const showDescription = description;
-  const matchExplanation =
-    reason ?? formatMatchedFieldsExplanation(showLexicalMatchBadges);
+  const showLexicalMatchFields = isAiRanked ? undefined : matchedFields;
+  const showDescription = !isDetailOpen ? description : undefined;
+  const matchSummary = formatComponentSearchMatchSummary(
+    reason ?? formatMatchedFieldsExplanation(showLexicalMatchFields),
+  );
 
   return (
     // Raw <button> rather than the <Button> primitive: the primitive's variants
@@ -285,11 +306,15 @@ const ComponentCard = ({
         PANEL_CLASS,
         // Card is a button: align text, full width, subtle hover, focus ring.
         "w-full text-left cursor-pointer transition-colors",
+        isDetailOpen ? "p-3" : "p-4",
         "hover:bg-muted/40",
         "focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:border-ring",
         // Selected state: left accent bar + tinted background.
         isSelected &&
-          "bg-muted/60 border-l-4 border-l-primary pl-[calc(0.75rem-3px)]",
+          cn(
+            "bg-[#5B35F5]/5 border-l-4 border-l-[#5B35F5]",
+            isDetailOpen ? "pl-[calc(0.75rem-3px)]" : "pl-[calc(1rem-3px)]",
+          ),
       )}
       {...tracking("component_library.result_card_v2", {
         ...componentMetadata(reference, trackingSource),
@@ -302,52 +327,75 @@ const ComponentCard = ({
       {/* min-w-0 so the flex column can shrink below its content width;
           without this, long unbroken URLs in the description force the
           card to grow horizontally. */}
-      <BlockStack gap="2" className="min-w-0">
-        <InlineStack gap="2" blockAlign="center" wrap="wrap">
+      <BlockStack gap={isDetailOpen ? "1" : "2"} className="min-w-0">
+        <InlineStack
+          gap="2"
+          blockAlign="center"
+          wrap="wrap"
+          className="min-w-0"
+        >
           {source ? (
             <QuickTooltip content={source.label}>
               <Icon
                 name="Package"
                 size="sm"
-                className={SOURCE_ICON_TONE_BY_KIND[source.kind]}
+                className={cn(
+                  "shrink-0",
+                  SOURCE_ICON_TONE_BY_KIND[source.kind],
+                )}
                 aria-label={`Source: ${source.label}`}
               />
             </QuickTooltip>
           ) : (
-            <Icon name="Package" size="sm" />
+            <Icon name="Package" size="sm" className="shrink-0" />
           )}
-          <Text size="sm" weight="semibold">
+          <Text
+            size="sm"
+            weight="semibold"
+            className="block min-w-0 flex-1 basis-0 whitespace-normal [overflow-wrap:anywhere] line-clamp-2"
+          >
             {name}
           </Text>
-          <ComponentLifecycleBadges reference={reference} />
-          {rerankScore !== undefined && (
-            <Badge variant="secondary">
-              Relevance: {Math.round(rerankScore * 100)}%
+          {!isDetailOpen && <ComponentLifecycleBadges reference={reference} />}
+          {rerankScore !== undefined && !isDetailOpen && (
+            <Badge
+              variant="secondary"
+              className={cn(
+                "shrink-0 whitespace-nowrap rounded-full px-1.5 py-0.5 font-semibold leading-none",
+                rerankScoreClass(rerankScore),
+              )}
+              aria-label={`${Math.round(rerankScore * 100)} percent relevance`}
+              title={`${Math.round(rerankScore * 100)}% relevance`}
+            >
+              {Math.round(rerankScore * 100)}%
             </Badge>
           )}
-          {showLexicalMatchBadges?.map((field) => (
-            <Badge key={field} variant="secondary">
-              matched: {COMPONENT_SEARCH_MATCH_FIELD_LABEL[field]}
-            </Badge>
-          ))}
         </InlineStack>
-        {publishedBy && (
+        {publishedBy && !isDetailOpen && (
           <Text size="xs" tone="subdued">
             by {publishedBy}
           </Text>
+        )}
+        {matchSummary && (
+          <Paragraph
+            size="xs"
+            tone="subdued"
+            className={cn("line-clamp-1", isDetailOpen ? "pl-6" : undefined)}
+          >
+            Why: {matchSummary}
+          </Paragraph>
         )}
         {showDescription && (
           // `[overflow-wrap:anywhere]` breaks at any character if needed —
           // `break-words` only breaks at word boundaries, which doesn't help
           // for long URLs without spaces. Pair with `min-w-0` on the parent
           // so the flex container actually allows shrinking.
-          <Paragraph size="sm" className="[overflow-wrap:anywhere] min-w-0">
+          <Paragraph
+            size="sm"
+            tone="subdued"
+            className="[overflow-wrap:anywhere] min-w-0 line-clamp-2"
+          >
             {description}
-          </Paragraph>
-        )}
-        {matchExplanation && (
-          <Paragraph size="xs" tone="subdued">
-            Why: {matchExplanation}
           </Paragraph>
         )}
       </BlockStack>
@@ -542,9 +590,22 @@ const ComponentDescriptionPanel = ({
         );
       case "idle":
         return (
-          <Button type="button" size="sm" onClick={onGenerate}>
-            Generate AI description
-          </Button>
+          <InlineStack gap="2" blockAlign="center" wrap="wrap">
+            <Button
+              type="button"
+              variant="outline"
+              size="xs"
+              onClick={onGenerate}
+              aria-label="Generate AI description"
+              className="border-border/60 bg-background/60 text-muted-foreground shadow-none hover:bg-muted/50 hover:text-foreground"
+            >
+              <Icon name="Sparkles" size="xs" />
+              Generate with AI
+            </Button>
+            <Text size="xs" tone="subdued">
+              Optional
+            </Text>
+          </InlineStack>
         );
     }
   };
@@ -1306,17 +1367,27 @@ export const DashboardComponentsV2View = () => {
             {total === 1 ? "" : "s"} in selected sources. Start typing to
             search.
           </Paragraph>
-          {visibleBrowseEntries.map((entry, idx) => (
-            <ComponentCard
-              key={entry.digest}
-              reference={entry.reference}
-              source={entry.source}
-              isSelected={entry.digest === selectedDigest}
-              position={idx}
-              hadQuery={false}
-              onSelect={selectComponent}
-            />
-          ))}
+          <div
+            className={cn(
+              "grid gap-2",
+              isDetailOpen
+                ? "grid-cols-1"
+                : "grid-cols-[repeat(auto-fit,minmax(420px,1fr))]",
+            )}
+          >
+            {visibleBrowseEntries.map((entry, idx) => (
+              <ComponentCard
+                key={entry.digest}
+                reference={entry.reference}
+                source={entry.source}
+                isSelected={entry.digest === selectedDigest}
+                position={idx}
+                hadQuery={false}
+                isDetailOpen={isDetailOpen}
+                onSelect={selectComponent}
+              />
+            ))}
+          </div>
           {hasMoreBrowseResults && (
             <Button
               type="button"
@@ -1345,9 +1416,10 @@ export const DashboardComponentsV2View = () => {
             No components matched “{trimmedQuery}”.
           </Paragraph>
           <Paragraph size="xs" tone="subdued">
-            Try a component name, input/output type, source term, or task intent.
-            Suggestions below are based on your loaded component sources. AI search
-            reranks matching local candidates when it is configured.
+            Try a component name, input/output type, source term, or task
+            intent. Suggestions below are based on your loaded component
+            sources. AI search reranks matching local candidates when it is
+            configured.
           </Paragraph>
           <ComponentSearchEmptyStateSuggestions
             suggestions={searchSuggestions}
@@ -1386,21 +1458,31 @@ export const DashboardComponentsV2View = () => {
             </Button>
           )}
         </InlineStack>
-        {displayedResults.map((result, idx) => (
-          <ComponentCard
-            key={result.digest}
-            reference={result.reference}
-            source={result.source}
-            matchedFields={result.matchedFields}
-            reason={result.reason}
-            rerankScore={result.rerankScore}
-            isAiRanked={rerankActive}
-            isSelected={result.digest === selectedDigest}
-            position={idx}
-            hadQuery={true}
-            onSelect={selectComponent}
-          />
-        ))}
+        <div
+          className={cn(
+            "grid gap-2",
+            isDetailOpen
+              ? "grid-cols-1"
+              : "grid-cols-[repeat(auto-fit,minmax(420px,1fr))]",
+          )}
+        >
+          {displayedResults.map((result, idx) => (
+            <ComponentCard
+              key={result.digest}
+              reference={result.reference}
+              source={result.source}
+              matchedFields={result.matchedFields}
+              reason={result.reason}
+              rerankScore={result.rerankScore}
+              isAiRanked={rerankActive}
+              isSelected={result.digest === selectedDigest}
+              position={idx}
+              hadQuery={true}
+              isDetailOpen={isDetailOpen}
+              onSelect={selectComponent}
+            />
+          ))}
+        </div>
       </BlockStack>
     );
   };
@@ -1491,7 +1573,7 @@ export const DashboardComponentsV2View = () => {
           className={cn(
             "min-h-0 min-w-0 overflow-y-auto px-8 py-4",
             isDetailOpen
-              ? "w-[360px] shrink-0 border-r border-border"
+              ? "w-[420px] shrink-0 border-r border-border"
               : "flex-1",
           )}
         >

--- a/src/services/componentSearchExplanations.ts
+++ b/src/services/componentSearchExplanations.ts
@@ -1,6 +1,6 @@
 import type { MatchField } from "@/services/componentSearchIndex";
 
-export const COMPONENT_SEARCH_MATCH_FIELD_LABEL: Record<MatchField, string> = {
+const COMPONENT_SEARCH_MATCH_FIELD_LABEL: Record<MatchField, string> = {
   name: "name",
   description: "description",
   io: "inputs/outputs",
@@ -24,4 +24,12 @@ export function formatMatchedFieldsExplanation(
     new Set(fields.map((field) => COMPONENT_SEARCH_MATCH_FIELD_LABEL[field])),
   );
   return `Matched ${joinReadableList(labels)}.`;
+}
+
+export function formatComponentSearchMatchSummary(
+  explanation: string | undefined,
+): string | undefined {
+  if (!explanation) return undefined;
+
+  return explanation.replace(/^Matched /, "").replace(/\.$/, "");
 }


### PR DESCRIPTION
## Description

Refreshes the component search result UI in both the Flow sidebar and the Dashboard components view for a cleaner, more compact presentation.

**Flow sidebar (`ComponentItem`):**
- Replaces the `File`/`FileBadge` icon with `Package` and updates icon colors: violet for subgraphs, orange for owned components, blue for others.
- Removes the `published_by` author line and the digest fallback line from each row.
- Strips the leading "Matched " prefix and trailing period from match explanations via a new `formatComponentItemMatchSummary` helper.
- Tightens hover/active background tokens and adjusts padding.
- Action buttons now fade in on hover via a `group-hover` opacity transition.

**Dashboard components view (`DashboardComponentsV2View`):**
- Adds an `isDetailOpen` prop to `ComponentCard` that switches the card into a compact single-column row when the detail pane is open, and expands to a responsive multi-column grid otherwise.
- Strips trailing `Annotations: …` noise from component descriptions via `cleanComponentCardDescription`.
- Replaces the "matched: field" badge list with a single inline "Why: …" summary line using the new `formatComponentCardMatchSummary` helper (same prefix/suffix trimming as the sidebar).
- Hides `published_by`, lifecycle badges, and relevance score badges in compact mode.
- Widens the detail-open sidebar column from 360 px to 420 px.
- Converts the "Generate AI description" button to a smaller outline style with a Sparkles icon and an "Optional" label.
- Wraps browse and search result lists in a CSS grid for the responsive two-column layout.

**Internals:**
- `COMPONENT_SEARCH_MATCH_FIELD_LABEL` is now module-private (no longer exported).
- Adds a test asserting that search result cards in compact mode do not render the full input/output detail pane content.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [x] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Open the Flow sidebar and search for a component — confirm the row shows the "Why: …" explanation without "Matched " prefix, no author line, and no digest fallback.
2. Open the Dashboard components view and search — confirm results render in a two-column grid when the detail pane is closed and a single column when it is open.
3. Select a result with the detail pane open and confirm the card switches to compact mode (no description, no badges, smaller padding).
4. Verify the "Generate AI description" button renders as a small outline button with a Sparkles icon.

## Additional Comments

The `COMPONENT_SEARCH_MATCH_FIELD_LABEL` export removal is a non-breaking internal change; the constant is only consumed within `componentSearchExplanations.ts`.