### PR TITLE
Add remote troubleshoot button to v1 run view task panel

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/TaskOverview.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/TaskOverview.tsx
@@ -9,6 +9,7 @@ import {
 import type { ContainerExecutionStatus } from "@/api/types.gen";
 import { ComponentDetailsDialog } from "@/components/shared/Dialogs";
 import { ComponentFavoriteToggle } from "@/components/shared/FavoriteComponentToggle";
+import { RemoteTroubleshootButton } from "@/components/shared/RemoteTroubleshootAction/RemoteTroubleshootButton";
 import { StatusIcon } from "@/components/shared/Status";
 import { TaskDetails } from "@/components/shared/TaskDetails";
 import TaskActions from "@/components/shared/TaskDetails/Actions";
@@ -40,6 +41,7 @@ const TaskOverview = ({ taskNode }: TaskOverviewProps) => {
 
   const executionData = useExecutionDataOptional();
   const details = executionData?.details;
+  const runId = executionData?.runId;
 
   const { readOnly, status } = state;
   const disabled = !!status;
@@ -87,6 +89,15 @@ const TaskOverview = ({ taskNode }: TaskOverviewProps) => {
           componentRef={componentRef}
           taskNode={taskNode}
           readOnly={readOnly}
+        />
+      )}
+
+      {runId && (
+        <RemoteTroubleshootButton
+          runId={runId}
+          executionId={executionId}
+          taskName={taskId}
+          status={status}
         />
       )}
 


### PR DESCRIPTION
## Description

Surfaces the optional **Remote Troubleshoot** action button in the **v1** run-view task panel (`TaskOverview`). The button component and all of its behavior are introduced in the parent PR; this change only mounts it in the v1 task overview so both run-view implementations expose the action.

When a task node is selected, the button appears for executions in a problematic state — `FAILED` / `CANCELLED` / `SYSTEM_ERROR` immediately, or `PENDING` / `QUEUED` once the task has been in that status for 5 minutes. Clicking it opens a modal where the user can add context and submit a request to a configurable endpoint.

The feature is opt-in and OSS-friendly: it renders nothing unless `window.__TANGLE_REMOTE_TROUBLESHOOT_ACTION__` is configured (see `docs/remote-troubleshoot-action.md`), so there is no visible change for default deployments.

This is wiring only — no new logic. `TaskOverview` now reads `runId` from the execution data and renders `<RemoteTroubleshootButton>` with the selected task's `runId`, `executionId`, `taskName`, and `status`, guarded on `runId` being present.

## Related Issue and Pull requests

- Stacked on #2455, which introduces the `RemoteTroubleshootButton` component, the server-sourced (`status_history`) timer, and the documentation. This PR adds the same button to the v1 task panel.

## Type of Change

- [x] New feature

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Screenshots (if applicable)

<!-- The button in the v1 task panel for an eligible execution. -->

## Test Instructions

1. Configure the action before the app mounts (e.g. inline in `index.html`):
2. Open a pipeline run in the v1 run view and select a task node.
3. Confirm the button shows for a `FAILED` / `CANCELLED` / `SYSTEM_ERROR` task immediately, and for a `PENDING` / `QUEUED` task once it has been in that status for 5 minutes.
4. Unset the global and confirm no button renders.

## Additional Comments

No secrets or deployment-specific values are introduced — the endpoint URL and labels are entirely deploy-time configuration provided by the operator.