### PR TITLE
Add AI model quick-select to app menu and injectable model config

### DIFF
--- a/src/components/layout/AiModelQuickSelect.test.tsx
+++ b/src/components/layout/AiModelQuickSelect.test.tsx
@@ -1,0 +1,88 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { AiModelQuickSelect } from "./AiModelQuickSelect";
+
+const STORAGE_KEY = "tangle.aiProvider.config";
+const FLAGS_STORAGE_KEY = "betaFlags";
+
+function enableFlags(flags: Record<string, boolean>) {
+  window.localStorage.setItem(FLAGS_STORAGE_KEY, JSON.stringify(flags));
+}
+
+describe("AiModelQuickSelect", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    delete window.__TANGLE_AI_MODELS__;
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+    delete window.__TANGLE_AI_MODELS__;
+  });
+
+  it("does not render until AI provider settings are configured", () => {
+    enableFlags({ "ai-assistant": true });
+
+    render(<AiModelQuickSelect />);
+
+    expect(screen.queryByRole("combobox", { name: "AI model" })).toBeNull();
+  });
+
+  it("does not render when both AI features are disabled", () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        apiBase: "https://api.example.com/v1",
+        apiKey: "",
+        model: "gpt-4.1-mini",
+      }),
+    );
+
+    render(<AiModelQuickSelect />);
+
+    expect(screen.queryByRole("combobox", { name: "AI model" })).toBeNull();
+  });
+
+  it("shows configured model choices when component search is enabled", () => {
+    enableFlags({ "component-search-v2": true });
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        apiBase: "https://api.example.com/v1",
+        apiKey: "",
+        model: "gpt-4.1-mini",
+      }),
+    );
+
+    render(<AiModelQuickSelect />);
+
+    fireEvent.click(screen.getByRole("combobox", { name: "AI model" }));
+
+    expect(
+      screen.queryByRole("option", { name: "Provider default" }),
+    ).toBeNull();
+    expect(screen.getByRole("option", { name: "GPT-5.5" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("option", { name: "GPT-4.1 mini" }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows configured model choices when the AI assistant is enabled", () => {
+    enableFlags({ "ai-assistant": true });
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        apiBase: "https://api.example.com/v1",
+        apiKey: "",
+        model: "gpt-4.1-mini",
+      }),
+    );
+
+    render(<AiModelQuickSelect />);
+
+    expect(
+      screen.getByRole("combobox", { name: "AI model" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/layout/AiModelQuickSelect.tsx
+++ b/src/components/layout/AiModelQuickSelect.tsx
@@ -1,0 +1,59 @@
+import { useFlagValue } from "@/components/shared/Settings/useFlags";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  getAiModelLabel,
+  getAiModelOptions,
+  getDefaultAiModelId,
+} from "@/config/aiModels";
+import { useAiProviderSettings } from "@/hooks/useAiProviderSettings";
+
+export function AiModelQuickSelect() {
+  const componentSearchEnabled = useFlagValue("component-search-v2");
+  const aiAssistantEnabled = useFlagValue("ai-assistant");
+  const { config, update, isConfigured } = useAiProviderSettings();
+  const configuredModel = config.model.trim();
+  const options = getAiModelOptions();
+  const selectedValue = configuredModel || getDefaultAiModelId();
+  const hasCustomModel = options.every((option) => option.id !== selectedValue);
+
+  const handleValueChange = (value: string) => {
+    update({ model: value });
+  };
+
+  if ((!componentSearchEnabled && !aiAssistantEnabled) || !isConfigured) {
+    return null;
+  }
+
+  return (
+    <Select value={selectedValue} onValueChange={handleValueChange}>
+      <SelectTrigger
+        aria-label="AI model"
+        title={`AI model: ${getAiModelLabel(configuredModel)}`}
+        className="hidden h-8 max-w-48 border-0 bg-transparent px-1 text-xs text-white shadow-none hover:bg-stone-800/70 focus-visible:ring-white/30 lg:flex [&_svg]:text-stone-300"
+      >
+        <SelectValue placeholder="AI model" />
+      </SelectTrigger>
+      <SelectContent align="end">
+        <SelectGroup>
+          <SelectLabel>AI model</SelectLabel>
+          {hasCustomModel && (
+            <SelectItem value={selectedValue}>{selectedValue}</SelectItem>
+          )}
+          {options.map((option) => (
+            <SelectItem key={option.id} value={option.id}>
+              {option.label ?? option.id}
+            </SelectItem>
+          ))}
+        </SelectGroup>
+      </SelectContent>
+    </Select>
+  );
+}

--- a/src/components/layout/AppMenu.tsx
+++ b/src/components/layout/AppMenu.tsx
@@ -35,6 +35,7 @@ import { tracking } from "@/utils/tracking";
 
 import TooltipButton from "../shared/Buttons/TooltipButton";
 import NewPipelineButton from "../shared/NewPipelineButton";
+import { AiModelQuickSelect } from "./AiModelQuickSelect";
 
 const DefaultAppMenu = () => {
   const router = useRouter();
@@ -50,6 +51,11 @@ const DefaultAppMenu = () => {
   };
 
   const isOnSettingsRoute = location.pathname.startsWith("/settings");
+  const showAiModelQuickSelect =
+    location.pathname.startsWith(APP_ROUTES.DASHBOARD_COMPONENTS) ||
+    location.pathname.startsWith(APP_ROUTES.DASHBOARD_COMPONENTS_V2) ||
+    location.pathname.startsWith(APP_ROUTES.EDITOR_V2) ||
+    location.pathname.startsWith(APP_ROUTES.SETTINGS_AGENT);
 
   return (
     <div
@@ -110,6 +116,7 @@ const DefaultAppMenu = () => {
             <div className="w-px h-5 bg-stone-700" />
           </div>
 
+          {showAiModelQuickSelect && <AiModelQuickSelect />}
           <EditorVersionToggle />
 
           {/* Settings & status */}

--- a/src/config/aiModels.test.ts
+++ b/src/config/aiModels.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { getAiModelOptions, getDefaultAiModelId } from "./aiModels";
+
+describe("aiModels", () => {
+  afterEach(() => {
+    delete window.__TANGLE_AI_MODELS__;
+  });
+
+  it("uses built-in model suggestions by default", () => {
+    expect(getAiModelOptions().map((option) => option.id)).toContain("gpt-5.5");
+    expect(getDefaultAiModelId()).toBe("gpt-5.5");
+  });
+
+  it("allows host pages to replace model suggestions and the suggested default", () => {
+    window.__TANGLE_AI_MODELS__ = {
+      defaultModel: "proxy-frontier",
+      models: [
+        {
+          id: "proxy-frontier",
+          label: "Proxy frontier",
+          description: "Default proxy model",
+        },
+        { id: "proxy-fast" },
+      ],
+    };
+
+    expect(getDefaultAiModelId()).toBe("proxy-frontier");
+    expect(getAiModelOptions()).toEqual([
+      {
+        id: "proxy-frontier",
+        label: "Proxy frontier",
+        description: "Default proxy model",
+      },
+      { id: "proxy-fast" },
+    ]);
+  });
+});

--- a/src/config/aiModels.ts
+++ b/src/config/aiModels.ts
@@ -1,0 +1,113 @@
+import { isRecord } from "@/utils/typeGuards";
+
+export interface AiModelOption {
+  id: string;
+  label?: string;
+  description?: string;
+}
+
+interface AiModelOptionsConfig {
+  /** Replaces the built-in model suggestions when provided by the host page. */
+  models?: AiModelOption[];
+  /** Suggested model shown first in blank model inputs. */
+  defaultModel?: string;
+}
+
+const BUILT_IN_AI_MODEL_OPTIONS: AiModelOption[] = [
+  {
+    id: "gpt-5.5",
+    label: "GPT-5.5",
+    description: "Latest frontier model",
+  },
+  {
+    id: "gpt-5",
+    label: "GPT-5",
+    description: "Frontier model",
+  },
+  {
+    id: "gpt-5-mini",
+    label: "GPT-5 mini",
+    description: "Fast frontier model",
+  },
+  {
+    id: "gpt-4.1",
+    label: "GPT-4.1",
+    description: "General-purpose model",
+  },
+  {
+    id: "gpt-4.1-mini",
+    label: "GPT-4.1 mini",
+    description: "Fast general-purpose model",
+  },
+  {
+    id: "gpt-4o",
+    label: "GPT-4o",
+    description: "OpenAI-compatible model",
+  },
+  {
+    id: "gpt-4o-mini",
+    label: "GPT-4o mini",
+    description: "Small OpenAI-compatible model",
+  },
+];
+
+const BUILT_IN_DEFAULT_MODEL = BUILT_IN_AI_MODEL_OPTIONS[0]?.id ?? "gpt-5.5";
+
+declare global {
+  interface Window {
+    __TANGLE_AI_MODELS__?: AiModelOptionsConfig;
+  }
+}
+
+function readModelOption(value: unknown): AiModelOption | null {
+  if (!isRecord(value) || typeof value.id !== "string") return null;
+
+  const id = value.id.trim();
+  if (!id) return null;
+
+  return {
+    id,
+    ...(typeof value.label === "string" && value.label.trim()
+      ? { label: value.label.trim() }
+      : {}),
+    ...(typeof value.description === "string" && value.description.trim()
+      ? { description: value.description.trim() }
+      : {}),
+  };
+}
+
+function readInjectedModelOptions(): AiModelOptionsConfig | null {
+  if (typeof window === "undefined") return null;
+  const config = window.__TANGLE_AI_MODELS__;
+  if (!isRecord(config)) return null;
+
+  return {
+    ...(Array.isArray(config.models)
+      ? { models: config.models.map(readModelOption).filter((v) => v !== null) }
+      : {}),
+    ...(typeof config.defaultModel === "string" && config.defaultModel.trim()
+      ? { defaultModel: config.defaultModel.trim() }
+      : {}),
+  };
+}
+
+export function getAiModelOptions(): AiModelOption[] {
+  const injected = readInjectedModelOptions();
+  return injected?.models && injected.models.length > 0
+    ? injected.models
+    : BUILT_IN_AI_MODEL_OPTIONS;
+}
+
+export function getDefaultAiModelId(): string {
+  const injected = readInjectedModelOptions();
+  return injected?.defaultModel ?? BUILT_IN_DEFAULT_MODEL;
+}
+
+export function getAiModelLabel(modelId: string): string {
+  const trimmed = modelId.trim();
+  if (!trimmed) return "Provider default";
+  return (
+    getAiModelOptions().find((option) => option.id === trimmed)?.label ??
+    trimmed
+  );
+}

--- a/src/routes/Dashboard/DashboardComponentsV2View.test.tsx
+++ b/src/routes/Dashboard/DashboardComponentsV2View.test.tsx
@@ -46,7 +46,9 @@ const routeMocks = vi.hoisted(() => {
     descriptionErrorState,
     aiDescriptionsEnabled: false,
     aiSearchConfigured: false,
+    aiRerankPending: false,
     aiApiBase: "",
+    aiModel: "",
     search,
   };
 });
@@ -170,7 +172,7 @@ vi.mock("@/hooks/useNaturalLanguageComponentSearch", () => ({
   useNaturalLanguageComponentRerank: () => ({
     mutate: routeMocks.rerank,
     data: undefined,
-    isPending: false,
+    isPending: routeMocks.aiRerankPending,
     error: null,
     reset: routeMocks.resetRerank,
     isConfigured: routeMocks.aiSearchConfigured,
@@ -183,7 +185,11 @@ vi.mock("@/hooks/useToastNotification", () => ({
 
 vi.mock("@/hooks/useAiProviderSettings", () => ({
   useAiProviderSettings: () => ({
-    config: { apiBase: routeMocks.aiApiBase, apiKey: "" },
+    config: {
+      apiBase: routeMocks.aiApiBase,
+      apiKey: "",
+      model: routeMocks.aiModel,
+    },
   }),
 }));
 
@@ -489,7 +495,21 @@ describe("DashboardComponentsV2View", () => {
     routeMocks.rerank.mockClear();
     routeMocks.resetRerank.mockClear();
     routeMocks.aiSearchConfigured = false;
+    routeMocks.aiRerankPending = false;
     routeMocks.aiApiBase = "";
+    routeMocks.aiModel = "";
+  });
+
+  it("shows active AI search progress below the search box", () => {
+    routeMocks.aiSearchConfigured = true;
+    routeMocks.aiRerankPending = true;
+    routeMocks.aiModel = "gpt-4o-mini";
+
+    render(<DashboardComponentsV2View />);
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "component candidates with GPT-4o mini",
+    );
   });
 
   it("limits browse rendering and lets users show more results", async () => {

--- a/src/routes/Dashboard/DashboardComponentsV2View.tsx
+++ b/src/routes/Dashboard/DashboardComponentsV2View.tsx
@@ -28,6 +28,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { QuickTooltip } from "@/components/ui/tooltip";
 import { Heading, Paragraph, Text } from "@/components/ui/typography";
+import { getAiModelLabel } from "@/config/aiModels";
 import { useAiProviderSettings } from "@/hooks/useAiProviderSettings";
 import { useDebouncedSearchValue } from "@/hooks/useDebouncedSearchValue";
 import { getComponentQueryKey } from "@/hooks/useHydrateComponentReference";
@@ -659,6 +660,51 @@ function mergeUniqueMatches(
   return merged;
 }
 
+const AI_SEARCH_PROGRESS_VERBS = [
+  "Scanning",
+  "Comparing",
+  "Scoring",
+  "Ranking",
+];
+
+function AiSearchProgress({
+  mode,
+  modelLabel,
+}: {
+  mode: "embedding" | "smart";
+  modelLabel: string;
+}) {
+  const [verbIndex, setVerbIndex] = useState(0);
+
+  useEffect(() => {
+    const intervalId = window.setInterval(() => {
+      setVerbIndex(
+        (current) => (current + 1) % AI_SEARCH_PROGRESS_VERBS.length,
+      );
+    }, 1200);
+    return () => window.clearInterval(intervalId);
+  }, []);
+
+  const verb = AI_SEARCH_PROGRESS_VERBS[verbIndex];
+  const message =
+    mode === "embedding"
+      ? "Finding semantic matches in local embeddings…"
+      : `${verb} component candidates with ${modelLabel}…`;
+
+  return (
+    <InlineStack
+      gap="2"
+      blockAlign="center"
+      className="rounded-md bg-muted/50 px-3 py-2 text-muted-foreground"
+    >
+      <Spinner size={14} />
+      <Text size="xs" tone="subdued" role="status" aria-live="polite">
+        {message}
+      </Text>
+    </InlineStack>
+  );
+}
+
 function DebouncedComponentSearchInput({
   onCommit,
   disabled,
@@ -1188,6 +1234,10 @@ export const DashboardComponentsV2View = () => {
   const noLibraryData = !isLoadingLibrary && totalAcrossSources === 0;
   const isEmpty = trimmedQuery.length === 0;
   const isConfigError = rerankError instanceof NaturalLanguageSearchConfigError;
+  const aiSearchProgressMode = isEmbeddingSearchPending ? "embedding" : "smart";
+  const aiSearchModelLabel = aiConfig.model.trim()
+    ? getAiModelLabel(aiConfig.model)
+    : "the configured model";
   // Only treat rerank as "active" when the model actually returned matches.
   // An empty result set (model decided nothing fit, or the response was
   // malformed and the service degraded it to `{ matches: [] }`) means the
@@ -1549,6 +1599,12 @@ export const DashboardComponentsV2View = () => {
               )}
             </Button>
           </InlineStack>
+          {(isReranking || isEmbeddingSearchPending) && (
+            <AiSearchProgress
+              mode={aiSearchProgressMode}
+              modelLabel={aiSearchModelLabel}
+            />
+          )}
           <SourceFilterBar
             options={sourceFilterOptions}
             disabledSourceKeys={disabledSourceKeys}

--- a/src/routes/Settings/sections/AgentSettings.test.tsx
+++ b/src/routes/Settings/sections/AgentSettings.test.tsx
@@ -1,4 +1,10 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { AgentSettings } from "./AgentSettings";
@@ -14,6 +20,7 @@ vi.mock("@/hooks/useToastNotification", () => ({
 describe("AgentSettings", () => {
   beforeEach(() => {
     window.localStorage.clear();
+    delete window.__TANGLE_AI_MODELS__;
     mockNotify.mockClear();
     mockFetch.mockReset();
     global.fetch = mockFetch;
@@ -21,6 +28,7 @@ describe("AgentSettings", () => {
 
   afterEach(() => {
     window.localStorage.clear();
+    delete window.__TANGLE_AI_MODELS__;
   });
 
   it("shows inline feedback instead of saving when API base URL is blank", () => {
@@ -86,7 +94,87 @@ describe("AgentSettings", () => {
     expect(JSON.stringify(init)).toContain("Bearer sk-test");
   });
 
-  it("reports an error and does not save when the Responses API is not supported", async () => {
+  it("renders injectable model suggestions for the freeform model input", () => {
+    window.__TANGLE_AI_MODELS__ = {
+      defaultModel: "proxy-frontier",
+      models: [
+        {
+          id: "proxy-frontier",
+          label: "Proxy frontier",
+          description: "Default proxy model",
+        },
+      ],
+    };
+
+    render(<AgentSettings />);
+
+    expect(screen.getByLabelText("Model id")).toHaveAttribute(
+      "placeholder",
+      "e.g. proxy-frontier",
+    );
+
+    fireEvent.click(screen.getByRole("combobox", { name: "Select a model" }));
+
+    expect(
+      screen.getByRole("option", { name: "Proxy frontier" }),
+    ).toBeInTheDocument();
+  });
+
+  it("updates saved model settings as the model field changes", () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        apiBase: "https://api.example.com/v1",
+        apiKey: "",
+        model: "gpt-5",
+      }),
+    );
+
+    render(<AgentSettings />);
+
+    fireEvent.change(screen.getByLabelText("Model id"), {
+      target: { value: "gpt-5.5" },
+    });
+
+    expect(JSON.parse(window.localStorage.getItem(STORAGE_KEY) ?? "")).toEqual({
+      apiBase: "https://api.example.com/v1",
+      apiKey: "",
+      model: "gpt-5.5",
+    });
+  });
+
+  it("syncs the model field when another control updates saved AI settings", async () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        apiBase: "https://api.example.com/v1",
+        apiKey: "",
+        model: "gpt-5",
+      }),
+    );
+
+    render(<AgentSettings />);
+
+    expect(screen.getByLabelText("Model id")).toHaveValue("gpt-5");
+
+    act(() => {
+      window.localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          apiBase: "https://api.example.com/v1",
+          apiKey: "",
+          model: "gpt-5.5",
+        }),
+      );
+      window.dispatchEvent(new StorageEvent("storage", { key: STORAGE_KEY }));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Model id")).toHaveValue("gpt-5.5");
+    });
+  });
+
+  it("reports an error and does not save provider details when the Responses API is not supported", async () => {
     mockFetch.mockResolvedValue(
       new Response("Endpoint not supported: /v1/responses", {
         status: 404,
@@ -110,7 +198,11 @@ describe("AgentSettings", () => {
         "error",
       );
     });
-    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+    expect(JSON.parse(window.localStorage.getItem(STORAGE_KEY) ?? "")).toEqual({
+      apiBase: "",
+      apiKey: "",
+      model: "claude-opus",
+    });
   });
 
   it("saves after a successful provider-default AI test when API key and model are blank", async () => {

--- a/src/routes/Settings/sections/AgentSettings.tsx
+++ b/src/routes/Settings/sections/AgentSettings.tsx
@@ -1,12 +1,22 @@
-import { type FormEvent, useRef, useState } from "react";
+import { type FormEvent, useEffect, useRef, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Separator } from "@/components/ui/separator";
 import { Heading, Paragraph, Text } from "@/components/ui/typography";
+import { getAiModelOptions, getDefaultAiModelId } from "@/config/aiModels";
 import { useAiProviderSettings } from "@/hooks/useAiProviderSettings";
 import useToastNotification from "@/hooks/useToastNotification";
 
@@ -26,12 +36,24 @@ export function AgentSettings() {
   const [showKey, setShowKey] = useState(false);
   const [testing, setTesting] = useState(false);
   const testRunIdRef = useRef(0);
+  const modelOptions = getAiModelOptions();
+  const defaultModelId = getDefaultAiModelId();
+
+  useEffect(() => {
+    setModel(config.model);
+  }, [config.model]);
 
   const getTrimmedConfig = () => ({
     apiBase: apiBase.trim().replace(/\/+$/, ""),
     apiKey: apiKey.trim(),
     model: model.trim(),
   });
+
+  const handleModelChange = (nextModel: string) => {
+    setModel(nextModel);
+    setValidationError(null);
+    update({ model: nextModel.trim() });
+  };
 
   const validateRequiredFields = () => {
     const trimmed = getTrimmedConfig();
@@ -194,30 +216,49 @@ export function AgentSettings() {
               </Button>
             </InlineStack>
             <Text id="agent-settings-api-key-hint" size="xs" tone="subdued">
-              Optional. Stored in browser localStorage. Leave blank when your
-              proxy handles authentication.
+              Optional if your proxy already handles authentication. Stored in
+              this browser only when provided.
             </Text>
           </BlockStack>
 
           <BlockStack gap="1">
             <Label htmlFor="agent-settings-model">Model</Label>
-            <Input
-              id="agent-settings-model"
-              type="text"
-              placeholder="e.g. gpt-4o-mini, gemini-2.5-flash, claude-3-5-haiku"
-              value={model}
-              onChange={(e) => {
-                setModel(e.target.value);
-                setValidationError(null);
-              }}
-              aria-label="Model id"
-              aria-describedby="agent-settings-model-hint"
-              autoComplete="off"
-              spellCheck={false}
-            />
+            <InlineStack gap="0" wrap="nowrap">
+              <Input
+                id="agent-settings-model"
+                type="text"
+                placeholder={`e.g. ${defaultModelId}`}
+                value={model}
+                onChange={(e) => handleModelChange(e.target.value)}
+                aria-label="Model id"
+                aria-describedby="agent-settings-model-hint"
+                autoComplete="off"
+                spellCheck={false}
+                className="rounded-r-none"
+              />
+              <Select onValueChange={handleModelChange}>
+                <SelectTrigger
+                  aria-label="Select a model"
+                  className="w-11 rounded-l-none border-l-0 px-2 [&_[data-slot=select-value]]:hidden"
+                >
+                  <SelectValue placeholder="Model suggestions" />
+                </SelectTrigger>
+                <SelectContent align="end">
+                  <SelectGroup>
+                    <SelectLabel>Common models</SelectLabel>
+                    {modelOptions.map((option) => (
+                      <SelectItem key={option.id} value={option.id}>
+                        {option.label ?? option.id}
+                      </SelectItem>
+                    ))}
+                  </SelectGroup>
+                </SelectContent>
+              </Select>
+            </InlineStack>
             <Text id="agent-settings-model-hint" size="xs" tone="subdued">
-              Optional. Used by all generation features through the Responses
-              API. Documentation search uses its embedding model separately.
+              Optional if your proxy selects a model. Choose a common
+              OpenAI-compatible model or enter any model id supported by your
+              provider.
             </Text>
           </BlockStack>
 

--- a/src/routes/v2/shared/components/AppMenuActions.tsx
+++ b/src/routes/v2/shared/components/AppMenuActions.tsx
@@ -1,5 +1,6 @@
 import { Link as RouterLink } from "@tanstack/react-router";
 
+import { AiModelQuickSelect } from "@/components/layout/AiModelQuickSelect";
 import { isAuthorizationRequired } from "@/components/shared/Authentication/helpers";
 import { TopBarAuthentication } from "@/components/shared/Authentication/TopBarAuthentication";
 import TooltipButton from "@/components/shared/Buttons/TooltipButton";
@@ -20,6 +21,7 @@ export function AppMenuActions() {
       className="shrink-0"
       data-testid="app-menu-actions"
     >
+      <AiModelQuickSelect />
       <EditorVersionToggle />
       <RouterLink to="/settings/backend">
         <TooltipButton tooltip="Settings" {...tracking("v2.header.settings")}>


### PR DESCRIPTION
## Description

Adds an AI model quick-select dropdown to the app header that appears once AI provider settings are configured. The selector lets users switch between models without navigating to the settings page.

A new `aiModels` config module centralises the list of available model options and the default model ID. Host pages can override both by setting `window.__TANGLE_AI_MODELS__` before the app loads, allowing proxy deployments to expose their own model catalogue instead of the built-in OpenAI model list.

The Agent Settings model field is also improved: the freeform text input now sits alongside a dropdown populated from the same model options list, the placeholder reflects the configured default model ID, and the field stays in sync when the stored config is updated from another control (e.g. the new header selector).

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Open the app without any AI provider configured — confirm no model selector appears in the header.
2. Navigate to Settings → Agent and configure an API base URL, then return to the main view — confirm the model selector now appears in the header.
3. Use the header selector to switch models and verify the change is reflected in the Agent Settings model field.
4. In Agent Settings, click the dropdown chevron next to the model input and confirm the list of common models appears and selecting one populates the text field.
5. To test host-page injection, set `window.__TANGLE_AI_MODELS__ = { defaultModel: "proxy-frontier", models: [{ id: "proxy-frontier", label: "Proxy frontier" }] }` in the browser console before loading the page and confirm the custom model list appears in both the header selector and the settings dropdown.

## Additional Comments

The `window.__TANGLE_AI_MODELS__` injection point is intentionally read at call time rather than cached, so tests can set and clear it between cases without module-level side effects.