### PR TITLE
Fix reasoning continuity and inline agent errors in chat

### DIFF
--- a/src/agent/agents/dispatcherRuntime.ts
+++ b/src/agent/agents/dispatcherRuntime.ts
@@ -7,12 +7,7 @@
  * close over the per-turn `AgentSession` (bridge, recent runs, status
  * emitter).
  */
-import {
-  type Agent,
-  type AgentInputItem,
-  MemorySession,
-  run,
-} from "@openai/agents";
+import { type Agent, MemorySession, run } from "@openai/agents";
 
 import type { AiProviderConfig } from "@/types/aiProvider";
 
@@ -37,18 +32,6 @@ export interface TangleDispatcher {
 
 export type BuildDispatcherAgent = (session: AgentSession) => Promise<Agent>;
 
-// Reasoning items can carry provider-side ids (`rs_...`) that are only valid
-// for the original Responses API turn. OpenAI-compatible proxies that cannot
-// dereference those ids on later turns fail with "Item with id ... not found",
-// so strip them from replayed history while keeping the reasoning content.
-function stripReasoningItemIds(items: AgentInputItem[]): AgentInputItem[] {
-  return items.map((item) => {
-    if (item.type !== "reasoning" || !("id" in item)) return item;
-    const { id: _id, ...itemWithoutId } = item;
-    return itemWithoutId;
-  });
-}
-
 export function createDispatcherRuntime(
   buildAgent: BuildDispatcherAgent,
 ): TangleDispatcher {
@@ -69,16 +52,6 @@ export function createDispatcherRuntime(
       const agent = await buildAgent(params.session);
       const result = await run(agent, params.message, {
         session: sessionMemory,
-        // `reasoningItemIdPolicy: "omit"` is the primary fix: it stops the SDK
-        // from sending reasoning-item ids on outgoing turns. The callback is
-        // belt-and-suspenders — it scrubs ids the SDK may have already
-        // persisted into replayed session history. Keep both until the SDK
-        // guarantees history is sanitized on read.
-        reasoningItemIdPolicy: "omit",
-        sessionInputCallback: (history, newItems) => [
-          ...stripReasoningItemIds(history),
-          ...newItems,
-        ],
       });
       const answer =
         typeof result.finalOutput === "string"

--- a/src/agent/agents/editorDispatcher.test.ts
+++ b/src/agent/agents/editorDispatcher.test.ts
@@ -87,7 +87,7 @@ describe("createEditorDispatcher", () => {
     runMock.mockResolvedValue({ finalOutput: "Done" });
   });
 
-  it("omits Responses reasoning item ids from Sidekick session history", async () => {
+  it("preserves Responses reasoning continuity for Sidekick runs", async () => {
     const dispatcher = createEditorDispatcher();
     await dispatcher.invoke({
       message: "add a component",
@@ -100,28 +100,19 @@ describe("createEditorDispatcher", () => {
       session: makeSession(),
     });
 
-    const options = runMock.mock.calls[0]?.[2];
-    expect(options).toMatchObject({
-      reasoningItemIdPolicy: "omit",
+    const agentConfig = agentCtor.mock.calls.at(-1)?.[0];
+    expect(agentConfig).toMatchObject({
+      model: "gpt-5.5",
+      modelSettings: {
+        providerData: {
+          include: ["reasoning.encrypted_content"],
+        },
+      },
     });
 
-    const callback = options.sessionInputCallback;
-    const result = callback(
-      [
-        {
-          type: "reasoning",
-          id: "rs_123",
-          summary: [],
-        },
-        { type: "message", role: "assistant", content: "hello" },
-      ],
-      [{ type: "message", role: "user", content: "next" }],
-    );
-
-    expect(result).toEqual([
-      { type: "reasoning", summary: [] },
-      { type: "message", role: "assistant", content: "hello" },
-      { type: "message", role: "user", content: "next" },
-    ]);
+    const options = runMock.mock.calls[0]?.[2];
+    expect(options).toEqual({
+      session: expect.any(Object),
+    });
   });
 });

--- a/src/agent/config.test.ts
+++ b/src/agent/config.test.ts
@@ -31,13 +31,24 @@ const BASE_CONFIG = {
 
 describe("getAgentModelConfig", () => {
   it("omits the model when the configured model is blank", () => {
-    expect(getAgentModelConfig(BASE_CONFIG)).toEqual({});
+    expect(getAgentModelConfig(BASE_CONFIG)).toEqual({
+      modelSettings: {
+        providerData: {
+          include: ["reasoning.encrypted_content"],
+        },
+      },
+    });
   });
 
-  it("uses the configured model without extra settings", () => {
-    expect(
-      getAgentModelConfig({ ...BASE_CONFIG, model: "gpt-4o-mini" }),
-    ).toEqual({ model: "gpt-4o-mini" });
+  it("uses the configured model with Responses reasoning continuity", () => {
+    expect(getAgentModelConfig({ ...BASE_CONFIG, model: "gpt-5.5" })).toEqual({
+      model: "gpt-5.5",
+      modelSettings: {
+        providerData: {
+          include: ["reasoning.encrypted_content"],
+        },
+      },
+    });
   });
 });
 

--- a/src/agent/config.ts
+++ b/src/agent/config.ts
@@ -11,11 +11,21 @@ import { BASE_URL } from "@/utils/constants";
 const AI_ASSISTANT_EMBEDDING_MODEL = "text-embedding-3-small";
 const SIDEKICK_OPENAI_API = "responses";
 
+const RESPONSES_REASONING_INCLUDE = ["reasoning.encrypted_content"];
+
 export function getAgentModelConfig(config: AiProviderConfig): {
   model?: string;
+  modelSettings: { providerData: { include: string[] } };
 } {
   const model = config.model.trim();
-  return model ? { model } : {};
+  return {
+    ...(model ? { model } : {}),
+    modelSettings: {
+      providerData: {
+        include: RESPONSES_REASONING_INCLUDE,
+      },
+    },
+  };
 }
 
 export function requireEmbeddingModel(): string {

--- a/src/routes/v2/shared/components/AiChat/AiChatContent.tsx
+++ b/src/routes/v2/shared/components/AiChat/AiChatContent.tsx
@@ -9,7 +9,6 @@ import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { useAiProviderSettings } from "@/hooks/useAiProviderSettings";
-import useToastNotification from "@/hooks/useToastNotification";
 import { useBackend } from "@/providers/BackendProvider";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 import { fetchPipelineRuns } from "@/services/pipelineRunService";
@@ -49,7 +48,6 @@ export const AiChatContent = observer(function AiChatContent({
   createBridge,
 }: AiChatContentProps) {
   const aiChat = useAiChatStore();
-  const notify = useToastNotification();
   const { navigation } = useSharedStores();
   const { backendUrl } = useBackend();
   const authStorage = useAuthLocalStorage();
@@ -109,7 +107,6 @@ export const AiChatContent = observer(function AiChatContent({
       ? projectRecentRuns(recentRunsData)
       : undefined;
     thread.sendMessage(prompt, {
-      onError: (msg) => notify(msg, "error"),
       bridge,
       aiConfig,
       ...(recentRuns && { recentRuns }),

--- a/src/routes/v2/shared/components/AiChat/agentThread.test.ts
+++ b/src/routes/v2/shared/components/AiChat/agentThread.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { ToolBridgeApi } from "@/agent/toolBridgeApi";
+
+const askMock = vi.hoisted(() => vi.fn());
+const terminateMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./agentClient", () => {
+  class FakeAgentClient {
+    ask = askMock;
+    terminate = terminateMock;
+  }
+
+  return { AgentClient: FakeAgentClient };
+});
+
+const { AgentThread } = await import("./agentThread");
+
+const aiConfig = {
+  apiBase: "https://api.example.com/v1",
+  apiKey: "sk-test",
+  model: "gpt-5.5",
+};
+
+function createThread(): InstanceType<typeof AgentThread> {
+  return new AgentThread({
+    createWorker: () => ({ terminate: vi.fn() }) as unknown as Worker,
+    context: { mode: "editor" },
+  });
+}
+
+describe("AgentThread", () => {
+  it("renders provider conversation-state errors in the chat", async () => {
+    askMock.mockRejectedValueOnce(
+      new Error(
+        "400 Item 'fc_123' of type 'function_call' was provided without its required 'reasoning' item: 'rs_123'.",
+      ),
+    );
+    const thread = createThread();
+
+    await thread.sendMessage("Fix validation", {
+      bridge: {} as ToolBridgeApi,
+      aiConfig,
+    });
+
+    expect(thread.messages).toHaveLength(2);
+    expect(thread.messages[0]).toMatchObject({
+      role: "user",
+      content: "Fix validation",
+    });
+    expect(thread.messages[1]).toMatchObject({
+      role: "assistant",
+      content:
+        "I ran into a model conversation-state error while processing that request. Please try again in this chat, or start a new chat if it keeps happening.",
+    });
+    expect(thread.isPending).toBe(false);
+  });
+});

--- a/src/routes/v2/shared/components/AiChat/agentThread.ts
+++ b/src/routes/v2/shared/components/AiChat/agentThread.ts
@@ -17,8 +17,24 @@ function generateThreadId(): string {
   return `thread-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 }
 
+function formatAssistantError(error: unknown): string {
+  const message = getErrorMessage(error);
+  if (isProviderConversationStateError(message)) {
+    return "I ran into a model conversation-state error while processing that request. Please try again in this chat, or start a new chat if it keeps happening.";
+  }
+
+  return `I couldn't complete that request: ${message}`;
+}
+
+function isProviderConversationStateError(message: string): boolean {
+  return (
+    /\brs_[a-zA-Z0-9]+\b/.test(message) ||
+    /required ['"]reasoning['"] item/i.test(message) ||
+    /Item with id .* not found/i.test(message)
+  );
+}
+
 interface SendMessageOptions {
-  onError: (message: string) => void;
   bridge: ToolBridgeApi;
   aiConfig: AiProviderConfig;
   recentRuns?: RecentPipelineRun[];
@@ -111,7 +127,17 @@ export class AgentThread {
         ];
       });
     } catch (error) {
-      options.onError(`AI request failed: ${getErrorMessage(error)}`);
+      runInAction(() => {
+        this.thinkingText = null;
+        this.messages = [
+          ...this.messages,
+          {
+            id: generateMessageId(),
+            role: "assistant",
+            content: formatAssistantError(error),
+          },
+        ];
+      });
     } finally {
       this.abortController = null;
       runInAction(() => {


### PR DESCRIPTION
## Description

Replaces the `reasoningItemIdPolicy: "omit"` + `sessionInputCallback` workaround for OpenAI Responses API reasoning continuity with the proper fix: passing `reasoning.encrypted_content` in `providerData.include` on every agent's model settings. This allows the Responses API to carry encrypted reasoning state across turns natively, eliminating the need to strip `rs_...` ids from session history at the SDK level.

Error handling for agent failures has also been moved inline into the chat thread itself. Instead of surfacing errors via a toast notification callback passed through `sendMessage`, errors are now appended directly as assistant messages in the conversation. Provider conversation-state errors (identified by patterns like `rs_` item ids or "required reasoning item" messages) receive a specific, user-friendly message guiding the user to retry or start a new chat.

## Related Issue and Pull requests

## Type of Change

- [x] Bug fix
- [x] Improvement
- [x] Cleanup/Refactor

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Configure an AI provider using a model that supports reasoning (e.g. `gpt-5.5`).
2. Send a multi-turn conversation in the Sidekick chat and confirm reasoning continuity works across turns without "Item with id ... not found" errors.
3. Simulate a provider conversation-state error and confirm the error appears as an assistant message in the chat rather than a toast notification.
4. Confirm that no toast notifications are shown for agent errors.

## Additional Comments

The `stripReasoningItemIds` helper and the `sessionInputCallback` override have been fully removed. The `onError` callback parameter has been removed from `sendMessage` options, and `useToastNotification` is no longer imported in `AiChatContent`.