### PR TITLE
fix: disable upgraded components lookup in search results

### DIFF
--- a/src/components/shared/ReactFlow/FlowSidebar/components/ComponentItem.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/components/ComponentItem.tsx
@@ -39,6 +39,7 @@ interface ComponentMarkupProps {
   matchedFields?: MatchField[];
   rerankScore?: number;
   rerankReason?: string;
+  showOutdatedBadge?: boolean;
   source?: ComponentSearchSource;
 }
 
@@ -100,11 +101,14 @@ const ComponentMarkup = ({
   matchedFields,
   rerankScore,
   rerankReason,
+  showOutdatedBadge = true,
   source,
 }: ComponentMarkupProps) => {
   const isRemoteComponentLibrarySearchEnabled = useFlagValue(
     "remote-component-library-search",
   );
+  const shouldShowOutdatedBadge =
+    isRemoteComponentLibrarySearchEnabled && showOutdatedBadge;
 
   const popoverRef = useRef<ComponentHoverPopoverHandle>(null);
 
@@ -247,7 +251,7 @@ const ComponentMarkup = ({
               wrap="nowrap"
               blockAlign="start"
             >
-              {isRemoteComponentLibrarySearchEnabled ? (
+              {shouldShowOutdatedBadge ? (
                 <ComponentIcon
                   name={iconName}
                   className={iconClass}

--- a/src/routes/v2/pages/Editor/components/ComponentSearchResults.tsx
+++ b/src/routes/v2/pages/Editor/components/ComponentSearchResults.tsx
@@ -154,6 +154,7 @@ export function ComponentSearchResults({
                 matchedFields={result.matchedFields}
                 rerankScore={result.rerankScore}
                 rerankReason={result.rerankReason}
+                showOutdatedBadge={false}
                 source={result.source}
               />
             ))}


### PR DESCRIPTION
## Description

Contributes to https://github.com/Shopify/oasis-frontend/issues/670

The outdated badge in `ComponentItem` is now hidden when rendering results in the `ComponentSearchResults` view. A new `showOutdatedBadge` prop has been added to `ComponentMarkup`, which defaults to `true` but is passed as `false` from `ComponentSearchResults`. The badge visibility also continues to respect the `remote-component-library-search` feature flag.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Enable the `remote-component-library-search` feature flag.
2. Open the component search panel and perform a search.
3. Verify that the outdated badge does not appear on results rendered in the `ComponentSearchResults` view.
4. Verify that the outdated badge still appears as expected in other contexts where `showOutdatedBadge` is not explicitly set to `false`.

## Additional Comments

The default value of `showOutdatedBadge` is `true`, so existing usages of `ComponentMarkup` are unaffected unless explicitly opted out.