### PR TITLE
refactor: optimize outdated components lookup

### DIFF
--- a/src/components/shared/ManageComponent/hooks/useOutdatedComponents.ts
+++ b/src/components/shared/ManageComponent/hooks/useOutdatedComponents.ts
@@ -8,11 +8,14 @@ import {
   type HydratedComponentReference,
   isDiscoverableComponentReference,
 } from "@/utils/componentSpec";
+import { HOURS } from "@/utils/constants";
 
 import { checkComponentUpdates } from "../../GitHubLibrary/utils/checkComponentUpdates";
 import { hasSupersededBy } from "../types";
 import { hydrateAllComponents } from "../utils/hydrateAllComponents";
 import { useAllPublishedComponents } from "./useAllPublishedComponents";
+
+const OUTDATED_COMPONENTS_STALE_TIME = 1 * HOURS;
 
 function usedComponentsQueryKeyDigests(
   usedComponents: ComponentReference[],
@@ -23,6 +26,17 @@ function usedComponentsQueryKeyDigests(
     .sort();
 }
 
+function useMostRecentComponents() {
+  const { data: publishedComponents } = useAllPublishedComponents();
+
+  return useSuspenseQuery({
+    queryKey: ["outdated-components", "most-recent-map"],
+    staleTime: OUTDATED_COMPONENTS_STALE_TIME,
+    queryFn: () =>
+      findMostRecentComponents(publishedComponents.components ?? []),
+  });
+}
+
 /**
  * Hook to get the outdated components in the graph
  *
@@ -30,20 +44,16 @@ function usedComponentsQueryKeyDigests(
  * @returns
  */
 export function useOutdatedComponents(usedComponents: ComponentReference[]) {
-  const { data: publishedComponents } = useAllPublishedComponents();
   const { existingComponentLibraries, getComponentLibrary } =
     useComponentLibrary();
+  const { data: mostRecentComponents } = useMostRecentComponents();
 
   const usedDigestsKey = usedComponentsQueryKeyDigests(usedComponents);
 
   return useSuspenseQuery({
     queryKey: ["outdated-components", usedDigestsKey],
-    staleTime: 1000 * 60 * 5,
+    staleTime: OUTDATED_COMPONENTS_STALE_TIME,
     queryFn: async () => {
-      const mostRecentComponents = await findMostRecentComponents(
-        publishedComponents.components ?? [],
-      );
-
       const hydratedComponents = await hydrateAllComponents(usedComponents);
 
       // check for github components
@@ -63,20 +73,19 @@ export function useOutdatedComponents(usedComponents: ComponentReference[]) {
               .filter((c) => c.library)
           : [];
 
-      if (githubComponents.length > 0) {
-        for (const { component, library } of githubComponents) {
-          if (!library) {
-            continue;
-          }
+      const githubOverrides = new Map<string, HydratedComponentReference>();
+      for (const { component, library } of githubComponents) {
+        if (!library) {
+          continue;
+        }
 
-          const updatedComponent = await checkComponentUpdates(
-            component,
-            library,
-          );
+        const updatedComponent = await checkComponentUpdates(
+          component,
+          library,
+        );
 
-          if (updatedComponent) {
-            mostRecentComponents.set(component.digest, updatedComponent);
-          }
+        if (updatedComponent) {
+          githubOverrides.set(component.digest, updatedComponent);
         }
       }
 
@@ -84,13 +93,17 @@ export function useOutdatedComponents(usedComponents: ComponentReference[]) {
         .filter(
           (c) =>
             isDiscoverableComponentReference(c) &&
-            mostRecentComponents.has(c.digest),
+            (githubOverrides.has(c.digest) ||
+              mostRecentComponents.has(c.digest)),
         )
         .map(
           (c) =>
             [
               c,
-              mostRecentComponents.get(c.digest) as HydratedComponentReference,
+              (githubOverrides.get(c.digest) ??
+                mostRecentComponents.get(
+                  c.digest,
+                )) as HydratedComponentReference,
             ] as const,
         );
     },


### PR DESCRIPTION
## Description

Contributes to https://github.com/Shopify/oasis-frontend/issues/670

Extracts the `findMostRecentComponents` call into its own `useMostRecentComponents` hook with a dedicated query key (`["outdated-components", "most-recent-map"]`), allowing it to be cached independently from the per-component outdated check. This prevents the published components map from being recomputed every time the set of used components changes.

Additionally, GitHub component update overrides are now tracked in a separate `githubOverrides` map rather than mutating `mostRecentComponents` directly. The outdated components filter and mapping logic now checks `githubOverrides` first, falling back to `mostRecentComponents`. The stale time for both queries is unified using a shared `OUTDATED_COMPONENTS_STALE_TIME` constant (1 hour), replacing the previous hardcoded `1000 * 60 * 5` (5 minutes).

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [x] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Open a pipeline that contains outdated components (both registry-published and GitHub-sourced).
2. Verify that the outdated component indicators still appear correctly.
3. Confirm that navigating away and back does not trigger unnecessary refetches of the published components map within the 1-hour stale window.
4. Verify that GitHub component overrides still take precedence over the published components map when determining the most recent version.

## Additional Comments

The removal of the `if (githubComponents.length > 0)` guard is intentional — the loop is now unconditional, which is functionally equivalent and simplifies the control flow.