### PR TITLE
Reduce lexical search result limit and field weights

### DIFF
--- a/src/routes/v2/pages/Editor/components/componentSearchV2Logic.test.ts
+++ b/src/routes/v2/pages/Editor/components/componentSearchV2Logic.test.ts
@@ -22,6 +22,7 @@ import {
   buildResults,
   buildSourcedHydratedReferences,
   collectAllSourcedReferences,
+  LEXICAL_RESULT_LIMIT,
   PUBLISHED_SOURCE,
   registeredLibrariesFingerprint,
   rerankedMatches,
@@ -285,6 +286,22 @@ describe("buildLexicalMatches / buildAiCandidateMatches", () => {
 
   it("returns no AI candidates for an empty query", () => {
     expect(buildAiCandidateMatches(index, "")).toEqual([]);
+  });
+
+  it("caps displayed lexical results below the AI candidate pool", () => {
+    const broadIndex = buildSearchIndex(
+      Array.from({ length: 20 }, (_, i) => ({
+        reference: ref(`train-${i}`, `train_${i}`),
+        source: source("standard"),
+      })),
+    );
+
+    expect(buildLexicalMatches(broadIndex, "train")).toHaveLength(
+      LEXICAL_RESULT_LIMIT,
+    );
+    expect(buildAiCandidateMatches(broadIndex, "train").length).toBeGreaterThan(
+      LEXICAL_RESULT_LIMIT,
+    );
   });
 
   it("returns no AI candidates when literal search finds nothing", () => {

--- a/src/routes/v2/pages/Editor/components/componentSearchV2Logic.ts
+++ b/src/routes/v2/pages/Editor/components/componentSearchV2Logic.ts
@@ -29,8 +29,8 @@ import type {
   HydratedComponentReference,
 } from "@/utils/componentSpec";
 
-/** How many lexical hits to display before the user asks for AI judgment. */
-export const LEXICAL_RESULT_LIMIT = 50;
+/** How many hits to show by default before the user asks for AI judgment. */
+export const LEXICAL_RESULT_LIMIT = 10;
 const AI_CANDIDATE_LIMIT = 80;
 const AI_LEXICAL_CANDIDATE_LIMIT = 60;
 const AI_SOURCE_DIVERSITY_CANDIDATES_PER_SOURCE = 8;

--- a/src/routes/v2/pages/Editor/hooks/useComponentSearchV2State.ts
+++ b/src/routes/v2/pages/Editor/hooks/useComponentSearchV2State.ts
@@ -238,9 +238,11 @@ export function useComponentSearchV2State(
     !isEmbeddingSearchPending &&
     (rerankData?.matches.length ?? 0) > 0;
 
-  const displayedMatches = isRerankActive
-    ? rerankedMatches(rerankData, rerankBaseMatches)
-    : lexicalMatches;
+  const displayedMatches = (
+    isRerankActive
+      ? rerankedMatches(rerankData, rerankBaseMatches)
+      : lexicalMatches
+  ).slice(0, LEXICAL_RESULT_LIMIT);
 
   const buildEmbeddingMatches = async ({
     sourceIndex,

--- a/src/services/componentSearchIndex.test.ts
+++ b/src/services/componentSearchIndex.test.ts
@@ -1012,6 +1012,41 @@ describe("lexicalSearch", () => {
     expect(results[0]?.matchedFields).toContain("implementation");
   });
 
+  it("keeps implementation-only matches below intent-field matches", () => {
+    const index = buildSearchIndex([
+      makeSourced({
+        digest: "name-match",
+        spec: {
+          name: "word_counter",
+          inputs: [],
+          outputs: [],
+          implementation: { container: { image: "x" } },
+        },
+      }),
+      makeSourced({
+        digest: "command-comment-match",
+        spec: {
+          name: "binarize_column",
+          inputs: [],
+          outputs: [],
+          implementation: {
+            container: {
+              image: "python:3.11",
+              args: ["# exec() takes no keyword arguments"],
+            },
+          },
+        },
+      }),
+    ]);
+
+    const results = lexicalSearch(index, "word");
+    expect(results.map((result) => result.digest)).toEqual([
+      "name-match",
+      "command-comment-match",
+    ]);
+    expect(results[1]?.matchedFields).toContain("implementation");
+  });
+
   it("preserves the source on each returned match", () => {
     const index = buildSearchIndex(fixtures);
     const results = lexicalSearch(index, "my_custom_train");

--- a/src/services/componentSearchIndex.ts
+++ b/src/services/componentSearchIndex.ts
@@ -477,16 +477,20 @@ const FIELD_WEIGHTS: Record<MatchField, number> = {
   name: 5,
   description: 2,
   io: 2,
-  implementation: 1,
-  metadata: 1,
+  // Keep implementation/metadata searchable for recall, but make matches there
+  // much weaker than user-facing component intent fields. A common word in a
+  // command comment should not look as relevant as the same word in a name,
+  // description, or input/output.
+  implementation: 0.25,
+  metadata: 0.5,
 };
 
 const FIELD_PHRASE_BONUS: Record<MatchField, number> = {
   name: 10,
   description: 4,
   io: 4,
-  implementation: 2,
-  metadata: 2,
+  implementation: 0.5,
+  metadata: 1,
 };
 
 const PREFIX_MATCH_BONUS_MULTIPLIER = 0.5;


### PR DESCRIPTION
## Description

Reduces the default number of displayed search results from 50 to 10, applying the `LEXICAL_RESULT_LIMIT` cap to both lexical and reranked match lists so users see a focused set of results before opting into AI judgment.

Additionally, lowers the scoring weights for `implementation` and `metadata` fields significantly — `implementation` base weight drops from 1 to 0.25 and its phrase bonus from 2 to 0.5 — so that incidental keyword matches in command comments or container args no longer surface above results where the word appears in a component's name, description, or inputs/outputs.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Open the component search panel and type a broad term (e.g. `train`). Confirm no more than 10 results are shown before triggering AI search.
2. Search for a term that appears only inside a container command comment. Confirm that any component whose name or description contains the same term ranks above the implementation-only match.
3. Run the test suite and confirm the new tests in `componentSearchV2Logic.test.ts` and `componentSearchIndex.test.ts` pass.

## Additional Comments

The `LEXICAL_RESULT_LIMIT` constant is now exported from `componentSearchV2Logic.ts` so it can be referenced directly in tests to keep the cap assertion resilient to future value changes.