### PR TITLE
Add source filter bar to editor component search

### DIFF
--- a/src/routes/Dashboard/DashboardComponentsV2SourceFilter.tsx
+++ b/src/routes/Dashboard/DashboardComponentsV2SourceFilter.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { QuickTooltip } from "@/components/ui/tooltip";
 import { Paragraph, Text } from "@/components/ui/typography";
 import { cn } from "@/lib/utils";
 import type {
@@ -25,6 +26,16 @@ const SOURCE_FILTER_LABEL_BY_KIND: Record<
   published: "Published",
   registered: "Registered libraries",
   user: "User generated",
+};
+
+const SOURCE_FILTER_TOOLTIP_BY_KIND: Record<
+  ComponentSearchSource["kind"],
+  string
+> = {
+  standard: "Standard",
+  published: "Published",
+  registered: "Registered",
+  user: "User",
 };
 
 export interface SourceFilterOption {
@@ -79,6 +90,7 @@ interface SourceFilterBarProps {
   disabledSourceKeys: string[];
   onToggle: (sourceKey: string) => void;
   onEnableAll: () => void;
+  display?: "full" | "icons";
 }
 
 export const SourceFilterBar = ({
@@ -86,6 +98,7 @@ export const SourceFilterBar = ({
   disabledSourceKeys,
   onToggle,
   onEnableAll,
+  display = "full",
 }: SourceFilterBarProps) => {
   const disabled = new Set(disabledSourceKeys);
   const activeCount = options.filter(
@@ -103,16 +116,20 @@ export const SourceFilterBar = ({
         {options.map(({ source, count }) => {
           const key = sourceFilterKey(source);
           const active = !disabled.has(key);
-          return (
+          const label = `${source.label} source (${count} component${count === 1 ? "" : "s"})`;
+          const button = (
             <Button
               key={key}
               type="button"
-              size="xs"
+              size={display === "icons" ? "min" : "xs"}
               variant={active ? "secondary" : "outline"}
               aria-pressed={active}
-              aria-label={`${source.label} source (${count} component${count === 1 ? "" : "s"})`}
+              aria-label={label}
               onClick={() => onToggle(key)}
-              className={cn(!active && "opacity-60")}
+              className={cn(
+                display === "icons" && "h-7 w-7 rounded-full p-1.5",
+                !active && "opacity-60",
+              )}
               {...tracking("component_library.source_filter", {
                 source_kind: source.kind,
                 enabled_after_click: !active,
@@ -123,12 +140,30 @@ export const SourceFilterBar = ({
                 size="sm"
                 className={SOURCE_ICON_TONE_BY_KIND[source.kind]}
               />
-              {source.label}
-              <Text as="span" size="xs" tone="subdued">
-                {count}
-              </Text>
+              {display === "full" && (
+                <>
+                  {source.label}
+                  <Text as="span" size="xs" tone="subdued">
+                    {count}
+                  </Text>
+                </>
+              )}
             </Button>
           );
+
+          if (display === "icons") {
+            return (
+              <QuickTooltip
+                key={key}
+                content={SOURCE_FILTER_TOOLTIP_BY_KIND[source.kind]}
+                side="bottom"
+              >
+                {button}
+              </QuickTooltip>
+            );
+          }
+
+          return button;
         })}
         {activeCount < options.length && (
           <Button

--- a/src/routes/v2/pages/Editor/components/ComponentSearchV2Content.test.tsx
+++ b/src/routes/v2/pages/Editor/components/ComponentSearchV2Content.test.tsx
@@ -55,6 +55,10 @@ describe("ComponentSearchV2Content", () => {
       isRerankActive: false,
       rerank: vi.fn(),
       clearRerank: vi.fn(),
+      sourceFilterOptions: [],
+      disabledSourceKeys: [],
+      toggleSourceFilter: vi.fn(),
+      enableAllSources: vi.fn(),
     }));
   });
 
@@ -98,6 +102,10 @@ describe("ComponentSearchV2Content", () => {
       isRerankActive: false,
       rerank: vi.fn(),
       clearRerank: vi.fn(),
+      sourceFilterOptions: [],
+      disabledSourceKeys: [],
+      toggleSourceFilter: vi.fn(),
+      enableAllSources: vi.fn(),
     }));
 
     render(<ComponentSearchV2Content />);
@@ -113,6 +121,47 @@ describe("ComponentSearchV2Content", () => {
     expect(screen.getByRole("status")).toHaveTextContent(
       "Comparing component candidates with AI…",
     );
+  });
+
+  it("shows source filters and toggles them from editor search", () => {
+    const toggleSourceFilter = vi.fn();
+    const enableAllSources = vi.fn();
+    mocks.useComponentSearchV2State.mockImplementation(() => ({
+      results: [],
+      browseFolders: [],
+      searchSuggestions: [],
+      isLoading: false,
+      canRerank: false,
+      isReranking: false,
+      isRerankActive: false,
+      rerank: vi.fn(),
+      clearRerank: vi.fn(),
+      sourceFilterOptions: [
+        {
+          source: { kind: "standard", id: "standard", label: "Standard" },
+          count: 2,
+        },
+        {
+          source: { kind: "user", id: "user", label: "User generated" },
+          count: 1,
+        },
+      ],
+      disabledSourceKeys: ["user"],
+      toggleSourceFilter,
+      enableAllSources,
+    }));
+
+    render(<ComponentSearchV2Content />);
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "User generated source (1 component)",
+      }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Show all" }));
+
+    expect(toggleSourceFilter).toHaveBeenCalledWith("user");
+    expect(enableAllSources).toHaveBeenCalled();
   });
 
   it("tracks editor component search completions without query text", async () => {

--- a/src/routes/v2/pages/Editor/components/ComponentSearchV2Content.tsx
+++ b/src/routes/v2/pages/Editor/components/ComponentSearchV2Content.tsx
@@ -9,6 +9,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { Text } from "@/components/ui/typography";
 import { useDebouncedSearchValue } from "@/hooks/useDebouncedSearchValue";
 import { useAnalytics } from "@/providers/AnalyticsProvider";
+import { SourceFilterBar } from "@/routes/Dashboard/DashboardComponentsV2SourceFilter";
 import { useComponentSearchV2State } from "@/routes/v2/pages/Editor/hooks/useComponentSearchV2State";
 import { tracking } from "@/utils/tracking";
 
@@ -96,6 +97,10 @@ export function ComponentSearchV2Content() {
     isRerankActive,
     rerank,
     clearRerank,
+    sourceFilterOptions,
+    disabledSourceKeys,
+    toggleSourceFilter,
+    enableAllSources,
   } = useComponentSearchV2State(deferredQuery);
 
   const handleQueryCommit = (value: string) => {
@@ -183,6 +188,13 @@ export function ComponentSearchV2Content() {
           </Button>
         </InlineStack>
         {isReranking && <AiRerankProgress />}
+        <SourceFilterBar
+          options={sourceFilterOptions}
+          disabledSourceKeys={disabledSourceKeys}
+          onToggle={toggleSourceFilter}
+          onEnableAll={enableAllSources}
+          display="icons"
+        />
       </BlockStack>
       <ComponentSearchResults
         query={deferredQuery}

--- a/src/routes/v2/pages/Editor/components/componentSearchV2Logic.ts
+++ b/src/routes/v2/pages/Editor/components/componentSearchV2Logic.ts
@@ -68,16 +68,25 @@ export interface ComponentSearchV2Result {
   rerankReason?: string;
 }
 
+interface ComponentSearchV2SourceFilterOption {
+  source: ComponentSearchSource;
+  count: number;
+}
+
 export interface ComponentSearchV2State {
   results: ComponentSearchV2Result[];
   browseFolders: UIComponentFolder[];
   searchSuggestions: ComponentSearchSuggestion[];
+  sourceFilterOptions: ComponentSearchV2SourceFilterOption[];
+  disabledSourceKeys: string[];
   isLoading: boolean;
   canRerank: boolean;
   isReranking: boolean;
   isRerankActive: boolean;
   rerank: () => void;
   clearRerank: () => void;
+  toggleSourceFilter: (sourceKey: string) => void;
+  enableAllSources: () => void;
 }
 
 export function registeredSource(

--- a/src/routes/v2/pages/Editor/hooks/useComponentSearchV2State.ts
+++ b/src/routes/v2/pages/Editor/hooks/useComponentSearchV2State.ts
@@ -18,6 +18,10 @@ import {
   type StoredLibrary,
 } from "@/providers/ComponentLibraryProvider/libraries/storage";
 import {
+  createSourceFilterOptions,
+  filterIndexByDisabledSourceKeys,
+} from "@/routes/Dashboard/DashboardComponentsV2SourceFilter";
+import {
   buildAiCandidateMatches,
   buildLexicalMatches,
   buildRerankMatchByDigest,
@@ -195,10 +199,20 @@ export function useComponentSearchV2State(
     }),
   );
 
+  const [disabledSourceKeys, setDisabledSourceKeys] = useState<string[]>([]);
+  const sourceFilterOptions = createSourceFilterOptions(index);
+  const filteredIndex = filterIndexByDisabledSourceKeys(
+    index,
+    disabledSourceKeys,
+  );
+
   const canUseEmbeddingSearch = aiConfig.apiBase.trim().length > 0;
   const trimmedQuery = query.trim();
-  const lexicalMatches = buildLexicalMatches(index, trimmedQuery);
-  const aiCandidateMatches = buildAiCandidateMatches(index, trimmedQuery);
+  const lexicalMatches = buildLexicalMatches(filteredIndex, trimmedQuery);
+  const aiCandidateMatches = buildAiCandidateMatches(
+    filteredIndex,
+    trimmedQuery,
+  );
   const {
     mutate,
     reset: resetRerank,
@@ -225,7 +239,7 @@ export function useComponentSearchV2State(
     setRerankedFor(null);
     setRerankBaseMatches([]);
     embeddingAbortControllerRef.current?.abort();
-  }, [query, resetRerank]);
+  }, [query, disabledSourceKeys, resetRerank]);
 
   useEffect(() => {
     return () => embeddingAbortControllerRef.current?.abort();
@@ -297,7 +311,7 @@ export function useComponentSearchV2State(
     const effectiveLimit = limit || LEXICAL_RESULT_LIMIT;
     const embeddingMatches = canUseEmbeddings
       ? await buildEmbeddingMatches({
-          sourceIndex: index,
+          sourceIndex: filteredIndex,
           limit: effectiveLimit,
         })
       : [];
@@ -335,6 +349,16 @@ export function useComponentSearchV2State(
     });
   };
 
+  const toggleSourceFilter = (sourceKey: string) => {
+    setDisabledSourceKeys((current) =>
+      current.includes(sourceKey)
+        ? current.filter((key) => key !== sourceKey)
+        : [...current, sourceKey],
+    );
+  };
+
+  const enableAllSources = () => setDisabledSourceKeys([]);
+
   const rerankMatchByDigest = buildRerankMatchByDigest(
     rerankData,
     isRerankActive,
@@ -347,11 +371,18 @@ export function useComponentSearchV2State(
 
   return {
     results,
-    browseFolders: buildResultFolders({ results, standardLibrary }),
-    searchSuggestions: buildComponentSearchSuggestions(index, {
+    browseFolders: buildResultFolders({
+      results,
+      standardLibrary: disabledSourceKeys.includes("standard")
+        ? undefined
+        : standardLibrary,
+    }),
+    searchSuggestions: buildComponentSearchSuggestions(filteredIndex, {
       includeSources: false,
       query: trimmedQuery,
     }),
+    sourceFilterOptions,
+    disabledSourceKeys,
     isLoading:
       isLoadingStandardLibrary ||
       isLoadingUserComponents ||
@@ -367,5 +398,7 @@ export function useComponentSearchV2State(
     isRerankActive,
     rerank,
     clearRerank,
+    toggleSourceFilter,
+    enableAllSources,
   };
 }


### PR DESCRIPTION
## Description

Adds source filtering to the editor's component search panel. The `SourceFilterBar` component now supports an `"icons"` display mode that renders compact circular icon-only buttons (instead of full label + count buttons), with tooltips showing the source name, component count, and toggle hint on hover.

The editor's `ComponentSearchV2Content` renders the `SourceFilterBar` in `"icons"` mode, wired up to new state (`sourceFilterOptions`, `disabledSourceKeys`, `toggleSourceFilter`, `enableAllSources`) exposed by `useComponentSearchV2State`. Filtering by disabled source keys is applied to lexical matches, AI candidate matches, embedding matches, browse folders, and search suggestions. Resetting the rerank state is also triggered when the source filter changes.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Open the editor and expand the component search panel.
2. Verify that source filter icons appear below the search/rerank controls.
3. Hover over an icon to confirm the tooltip shows the source name, component count, and click hint.
4. Click an icon to hide that source and confirm results update accordingly.
5. Click "Show all" to re-enable all sources.
6. Confirm that switching sources resets any active rerank state.

## Additional Comments

The `SourceFilterBar` `display="icons"` mode intentionally omits the label and count from the button itself, relying on the `QuickTooltip` to surface that information, keeping the toolbar compact in the constrained editor sidebar layout.