### PR TITLE
Cache search index in query and show skeleton while typing

### DIFF
--- a/src/routes/Dashboard/DashboardComponentsV2View.test.tsx
+++ b/src/routes/Dashboard/DashboardComponentsV2View.test.tsx
@@ -12,6 +12,23 @@ interface DashboardComponentsV2Search {
 }
 
 const routeMocks = vi.hoisted(() => {
+  const standardSource = {
+    kind: "standard",
+    label: "Standard",
+    id: "standard",
+  } as const;
+  const registeredSource = {
+    kind: "registered",
+    label: "GitHub library",
+    id: "github-lib",
+  } as const;
+  const publishedSource = {
+    kind: "published",
+    label: "Published",
+    id: "published",
+  } as const;
+  const userSource = { kind: "user", label: "User", id: "user" } as const;
+
   const makeComponent = (digest: string, name: string): ComponentReference => ({
     digest,
     name,
@@ -32,8 +49,40 @@ const routeMocks = vi.hoisted(() => {
   const search: DashboardComponentsV2Search = {};
   const descriptionErrorState: { current: Error | null } = { current: null };
 
+  const toIndexEntry = (
+    reference: ComponentReference,
+    source:
+      | typeof standardSource
+      | typeof registeredSource
+      | typeof publishedSource
+      | typeof userSource,
+  ): IndexEntry => ({
+    reference,
+    digest: reference.digest!,
+    name: reference.name!,
+    source,
+    searchable: {
+      name: reference.name!.toLowerCase(),
+      description: reference.spec?.description?.toLowerCase() ?? "",
+      io: [
+        ...(reference.spec?.inputs ?? []),
+        ...(reference.spec?.outputs ?? []),
+      ]
+        .map((io) => io.name)
+        .join(" ")
+        .toLowerCase(),
+      implementation: "",
+      metadata: "",
+    },
+  });
+
   return {
     standard: makeComponent("standard-digest", "Standard component"),
+    standardSource,
+    registeredSource,
+    publishedSource,
+    userSource,
+    toIndexEntry,
     registered: makeComponent("registered-digest", "Registered component"),
     published: {
       ...makeComponent("published-digest", "Published component"),
@@ -108,14 +157,29 @@ vi.mock("@tanstack/react-query", () => ({
     }
 
     if (key === "component-search-v2" && queryKey[1] === "hydrate-library") {
+      const standardSourced = [
+        routeMocks.standard,
+        ...routeMocks.extraStandardComponents,
+      ].map((reference) => ({
+        reference,
+        source: routeMocks.standardSource,
+      }));
+      const sourcedHydrated = [
+        ...standardSourced,
+        {
+          reference: routeMocks.registered,
+          source: routeMocks.registeredSource,
+        },
+        { reference: routeMocks.published, source: routeMocks.publishedSource },
+        { reference: routeMocks.user, source: routeMocks.userSource },
+      ];
       return {
-        data: [
-          routeMocks.standard,
-          routeMocks.registered,
-          routeMocks.published,
-          routeMocks.user,
-          ...routeMocks.extraStandardComponents,
-        ],
+        data: {
+          sourcedHydrated,
+          index: sourcedHydrated.map((item) =>
+            routeMocks.toIndexEntry(item.reference, item.source),
+          ),
+        },
         isLoading: false,
       };
     }

--- a/src/routes/Dashboard/DashboardComponentsV2View.tsx
+++ b/src/routes/Dashboard/DashboardComponentsV2View.tsx
@@ -77,10 +77,7 @@ import {
   type RerankedMatch,
 } from "@/services/naturalLanguageComponentSearchService";
 import type { ComponentFolder } from "@/types/componentLibrary";
-import type {
-  ComponentReference,
-  HydratedComponentReference,
-} from "@/utils/componentSpec";
+import type { ComponentReference } from "@/utils/componentSpec";
 import { componentMetadata } from "@/utils/componentTracking";
 import { HOURS, TOP_NAV_HEIGHT } from "@/utils/constants";
 import { getComponentName } from "@/utils/getComponentName";
@@ -200,6 +197,11 @@ export function createRegisteredLibrariesFingerprint(
 
 type ComponentLibraryFolder = Parameters<typeof flattenFolders>[0];
 type UserFolder = { components?: ComponentReference[] };
+
+interface HydratedComponentSearchData {
+  sourcedHydrated: SourcedReference[];
+  index: IndexEntry[];
+}
 
 interface ComponentCollectionMatch {
   id: string;
@@ -714,10 +716,12 @@ function DebouncedComponentSearchInput({
   onCommit,
   disabled,
   initialValue,
+  onLocalChange,
 }: {
   onCommit: (value: string) => void;
   disabled: boolean;
   initialValue: string;
+  onLocalChange?: (value: string) => void;
 }) {
   const inputRef = useRef<HTMLInputElement>(null);
   const [localValue, setLocalValue] = useDebouncedSearchValue(
@@ -733,7 +737,10 @@ function DebouncedComponentSearchInput({
       type="search"
       placeholder="e.g. train_test_split, pandas, clean up my data"
       value={localValue}
-      onChange={(event) => setLocalValue(event.target.value)}
+      onChange={(event) => {
+        setLocalValue(event.target.value);
+        onLocalChange?.(event.target.value);
+      }}
       aria-label="Search components"
       disabled={disabled}
       className="flex-1"
@@ -796,8 +803,9 @@ export const DashboardComponentsV2View = () => {
   const disabledSourceKeysFromUrl = readDisabledSourceKeys(dashboardSearch);
   const disabledSourceKeysParam = disabledSourceKeysFromUrl.join(",");
   const [query, setQuery] = useState(queryFromUrl);
+  const [isSearching, setIsSearching] = useState(false);
   const deferredQuery = useDeferredValue(query);
-  const [, startSearchTransition] = useTransition();
+  const [isSearchPending, startSearchTransition] = useTransition();
   const [disabledSourceKeys, setDisabledSourceKeys] = useState<string[]>(
     disabledSourceKeysFromUrl,
   );
@@ -984,17 +992,23 @@ export const DashboardComponentsV2View = () => {
   // Fingerprint of which refs are in play. Changes when the library set
   // changes, so the hydration cache invalidates appropriately.
   const referencesFingerprint = allSourced
-    .map((s) => s.reference.digest ?? s.reference.url ?? "")
+    .map(
+      (s) =>
+        `${s.source.kind}:${s.source.id}:${s.source.label}:${s.reference.digest ?? s.reference.url ?? ""}`,
+    )
     .sort()
     .join("|");
 
   // Use `isLoading` (first fetch only), not `isFetching` (any fetch). A
-  // background refetch shouldn't flip the page back to a skeleton state.
-  const { data: hydratedReferences, isLoading: hydrating } = useQuery({
+  // background refetch shouldn't flip the page back to a skeleton state. Build
+  // the pure search index inside the query as well so expensive hydration/index
+  // derivation is cached by the component fingerprint instead of repeated on
+  // every search render.
+  const { data: searchData, isLoading: hydrating } = useQuery({
     queryKey: ["component-search-v2", "hydrate-library", referencesFingerprint],
     enabled: allSourced.length > 0,
     staleTime: HOURS,
-    queryFn: async () => {
+    queryFn: async (): Promise<HydratedComponentSearchData> => {
       const results = await Promise.all(
         allSourced.map((sourced) =>
           // Reuse the same cache key as useHydrateComponentReference so
@@ -1009,30 +1023,29 @@ export const DashboardComponentsV2View = () => {
               staleTime: HOURS,
               queryFn: () => hydrateComponentReference(sourced.reference),
             })
+            .then((reference) => ({ reference, source: sourced.source }))
             .catch(() => null),
         ),
       );
-      return results.filter((r): r is HydratedComponentReference => r !== null);
+
+      const sourcedHydrated: SourcedReference[] = [];
+      for (const item of results) {
+        if (!item?.reference) continue;
+        sourcedHydrated.push({
+          reference: item.reference,
+          source: item.source,
+        });
+      }
+
+      return {
+        sourcedHydrated,
+        index: buildSearchIndex(sourcedHydrated),
+      };
     },
   });
 
-  // Pair hydrated refs back with their source by digest. Hydration preserves
-  // digests, so this is a straightforward join.
-  const sourceByDigest = new Map<string, ComponentSearchSource>();
-  for (const sourced of allSourced) {
-    if (sourced.reference.digest) {
-      sourceByDigest.set(sourced.reference.digest, sourced.source);
-    }
-  }
-  const sourcedHydrated: SourcedReference[] = [];
-  for (const reference of hydratedReferences ?? []) {
-    const source = sourceByDigest.get(reference.digest);
-    if (!source) continue;
-    sourcedHydrated.push({ reference, source });
-  }
-
-  // The search index is a pure derivation. React Compiler will memoize this.
-  const index: IndexEntry[] = buildSearchIndex(sourcedHydrated);
+  const sourcedHydrated = searchData?.sourcedHydrated ?? [];
+  const index = searchData?.index ?? [];
   const sourceFilterOptions = createSourceFilterOptions(index);
   const filteredIndex = filterIndexByDisabledSourceKeys(
     index,
@@ -1040,18 +1053,22 @@ export const DashboardComponentsV2View = () => {
   );
   const total = filteredIndex.length;
   const totalAcrossSources = index.length;
+  const isSearchUiPending = isSearching || isSearchPending;
+  const activeQuery = isSearchUiPending ? "" : deferredQuery;
 
   // Alphabetical order for the browse-all view. Predictable scrolling beats
-  // "whatever order the library happened to load in."
-  const sortedIndex = [...filteredIndex].sort((a, b) =>
-    a.name.localeCompare(b.name),
-  );
+  // "whatever order the library happened to load in." Skip it while search is
+  // pending because the skeleton is showing and sorting the full index can steal
+  // the keystroke that should reveal the skeleton.
+  const sortedIndex = isSearchUiPending
+    ? []
+    : [...filteredIndex].sort((a, b) => a.name.localeCompare(b.name));
 
   useEffect(() => {
     setBrowseResultLimit(BROWSE_RESULT_INITIAL_LIMIT);
   }, [deferredQuery, disabledSourceKeysParam, total]);
 
-  const trimmedQuery = deferredQuery.trim();
+  const trimmedQuery = activeQuery.trim();
 
   // One lexical pass at the wider AI-candidate limit; the display list is the
   // top slice of that same scored result, so we never score and sort the index
@@ -1060,7 +1077,7 @@ export const DashboardComponentsV2View = () => {
   const broadLexicalMatches: LexicalMatch[] =
     trimmedQuery.length === 0
       ? []
-      : lexicalSearch(filteredIndex, deferredQuery, {
+      : lexicalSearch(filteredIndex, activeQuery, {
           limit: AI_CANDIDATE_LIMIT,
         });
 
@@ -1070,12 +1087,8 @@ export const DashboardComponentsV2View = () => {
   );
   const collectionMatches = buildComponentCollectionMatches(
     filteredIndex,
-    deferredQuery,
+    activeQuery,
   );
-  const searchSuggestions = buildComponentSearchSuggestions(filteredIndex, {
-    query: trimmedQuery,
-  });
-
   const aiCandidateMatches: LexicalMatch[] = (() => {
     if (trimmedQuery.length === 0) return [];
     return broadLexicalMatches;
@@ -1110,6 +1123,7 @@ export const DashboardComponentsV2View = () => {
   const handleQueryCommit = (value: string) => {
     startSearchTransition(() => {
       setQuery(value);
+      setIsSearching(false);
       if (rerankedFor !== null) {
         clearRerank();
       }
@@ -1119,10 +1133,15 @@ export const DashboardComponentsV2View = () => {
   const handleSuggestedSearch = (value: string) => {
     startSearchTransition(() => {
       setQuery(value);
+      setIsSearching(false);
       if (rerankedFor !== null) {
         clearRerank();
       }
     });
+  };
+
+  const handleLocalQueryChange = (value: string) => {
+    setIsSearching(value.trim() !== query.trim());
   };
 
   const buildEmbeddingMatches = async (
@@ -1268,6 +1287,15 @@ export const DashboardComponentsV2View = () => {
         rerankScore: undefined,
       }));
 
+  const searchSuggestions =
+    lexicalMatches.length === 0 &&
+    collectionMatches.length === 0 &&
+    !rerankActive
+      ? buildComponentSearchSuggestions(filteredIndex, {
+          query: trimmedQuery,
+        })
+      : [];
+
   const trackedSearchResultCount =
     displayedResults.length + collectionMatches.length;
 
@@ -1387,7 +1415,7 @@ export const DashboardComponentsV2View = () => {
   // Render helpers — keeps the JSX below tidy. These read the closed-over
   // state from the surrounding component; React Compiler memoises them.
   const renderResults = () => {
-    if (isLoadingLibrary) {
+    if (isLoadingLibrary || isSearchUiPending) {
       return (
         <BlockStack gap="2">
           <Skeleton className="h-20 w-full" />
@@ -1572,6 +1600,7 @@ export const DashboardComponentsV2View = () => {
               onCommit={handleQueryCommit}
               disabled={isLoadingLibrary || noLibraryData}
               initialValue={query}
+              onLocalChange={handleLocalQueryChange}
             />
             <Button
               variant="secondary"

--- a/src/routes/v2/pages/Editor/components/ComponentSearchV2Content.tsx
+++ b/src/routes/v2/pages/Editor/components/ComponentSearchV2Content.tsx
@@ -1,4 +1,10 @@
-import { useDeferredValue, useEffect, useState, useTransition } from "react";
+import {
+  useDeferredValue,
+  useEffect,
+  useRef,
+  useState,
+  useTransition,
+} from "react";
 
 import ImportComponent from "@/components/shared/ReactFlow/FlowSidebar/components/ImportComponent";
 import { Button } from "@/components/ui/button";
@@ -84,9 +90,12 @@ function DebouncedComponentSearchInput({
 export function ComponentSearchV2Content() {
   const { track } = useAnalytics();
   const [query, setQuery] = useState("");
-  const [localQuery, setLocalQuery] = useState("");
+  const [isSearching, setIsSearching] = useState(false);
+  const latestLocalQueryRef = useRef(query);
+  const latestCommittedQueryRef = useRef(query);
   const deferredQuery = useDeferredValue(query);
-  const [, startSearchTransition] = useTransition();
+  const [isSearchPending, startSearchTransition] = useTransition();
+  const isSearchUiPending = isSearching || isSearchPending;
   const {
     results,
     browseFolders,
@@ -101,22 +110,39 @@ export function ComponentSearchV2Content() {
     disabledSourceKeys,
     toggleSourceFilter,
     enableAllSources,
-  } = useComponentSearchV2State(deferredQuery);
+  } = useComponentSearchV2State(deferredQuery, {
+    pauseSearch: isSearchUiPending,
+  });
 
   const handleQueryCommit = (value: string) => {
-    startSearchTransition(() => setQuery(value));
+    latestCommittedQueryRef.current = value;
+    startSearchTransition(() => {
+      setQuery(value);
+    });
+    if (latestLocalQueryRef.current.trim() === value.trim()) {
+      setIsSearching(false);
+    }
   };
 
   const handleSuggestedSearch = (value: string) => {
-    setLocalQuery(value);
-    startSearchTransition(() => setQuery(value));
+    latestLocalQueryRef.current = value;
+    latestCommittedQueryRef.current = value;
+    startSearchTransition(() => {
+      setQuery(value);
+    });
+    setIsSearching(false);
+  };
+
+  const handleLocalQueryChange = (value: string) => {
+    latestLocalQueryRef.current = value;
+    setIsSearching(value.trim() !== latestCommittedQueryRef.current.trim());
   };
 
   const trimmedDeferredQuery = deferredQuery.trim();
-  const isSearching = localQuery.trim() !== trimmedDeferredQuery;
 
   useEffect(() => {
-    if (isLoading || trimmedDeferredQuery.length === 0) return;
+    if (isLoading || isSearchUiPending || trimmedDeferredQuery.length === 0)
+      return;
 
     const timeout = window.setTimeout(() => {
       track("component_library.search.completed", {
@@ -131,7 +157,14 @@ export function ComponentSearchV2Content() {
     }, 400);
 
     return () => window.clearTimeout(timeout);
-  }, [isLoading, isRerankActive, results.length, track, trimmedDeferredQuery]);
+  }, [
+    isLoading,
+    isSearchUiPending,
+    isRerankActive,
+    results.length,
+    track,
+    trimmedDeferredQuery,
+  ]);
 
   return (
     <BlockStack className="h-full min-h-0 overflow-hidden [&_.text-sm]:text-xs!">
@@ -166,7 +199,7 @@ export function ComponentSearchV2Content() {
             <DebouncedComponentSearchInput
               initialValue={query}
               onCommit={handleQueryCommit}
-              onLocalChange={setLocalQuery}
+              onLocalChange={handleLocalQueryChange}
             />
           </div>
           <Button
@@ -202,7 +235,7 @@ export function ComponentSearchV2Content() {
         browseFolders={browseFolders}
         searchSuggestions={searchSuggestions}
         isLoading={isLoading}
-        isSearching={isSearching}
+        isSearching={isSearchUiPending}
         isRerankActive={isRerankActive}
         onClearRerank={clearRerank}
         onSuggestedSearch={handleSuggestedSearch}

--- a/src/routes/v2/pages/Editor/hooks/useComponentSearchV2State.ts
+++ b/src/routes/v2/pages/Editor/hooks/useComponentSearchV2State.ts
@@ -27,7 +27,6 @@ import {
   buildRerankMatchByDigest,
   buildResultFolders,
   buildResults,
-  buildSourcedHydratedReferences,
   collectAllSourcedReferences,
   type ComponentSearchV2State,
   LEXICAL_RESULT_LIMIT,
@@ -49,10 +48,7 @@ import {
 } from "@/services/componentService";
 import { componentReferenceToCandidate } from "@/services/naturalLanguageComponentSearchService";
 import type { ComponentFolder } from "@/types/componentLibrary";
-import type {
-  ComponentReference,
-  HydratedComponentReference,
-} from "@/utils/componentSpec";
+import type { ComponentReference } from "@/utils/componentSpec";
 import { HOURS } from "@/utils/constants";
 
 function mergeUniqueMatches(
@@ -74,6 +70,7 @@ function mergeUniqueMatches(
 
 export function useComponentSearchV2State(
   query: string,
+  { pauseSearch = false }: { pauseSearch?: boolean } = {},
 ): ComponentSearchV2State {
   const queryClient = useQueryClient();
   const { backendUrl, configured, available } = useBackend();
@@ -160,15 +157,18 @@ export function useComponentSearchV2State(
   });
 
   const referencesFingerprint = sourcedReferences
-    .map((item) => item.reference.digest ?? item.reference.url ?? "")
+    .map(
+      (item) =>
+        `${item.source.kind}:${item.source.id}:${item.source.label}:${item.reference.digest ?? item.reference.url ?? ""}`,
+    )
     .sort()
     .join("|");
 
-  const { data: hydratedReferences = [], isLoading: isHydrating } = useQuery({
-    queryKey: ["component-search-v2", "hydrate-library", referencesFingerprint],
+  const { data: index = [], isLoading: isHydrating } = useQuery({
+    queryKey: ["component-search-v2", "search-index", referencesFingerprint],
     enabled: sourcedReferences.length > 0,
     staleTime: HOURS,
-    queryFn: async (): Promise<HydratedComponentReference[]> => {
+    queryFn: async (): Promise<IndexEntry[]> => {
       const results = await Promise.all(
         sourcedReferences.map((item) =>
           queryClient
@@ -181,23 +181,23 @@ export function useComponentSearchV2State(
               staleTime: HOURS,
               queryFn: () => hydrateComponentReference(item.reference),
             })
+            .then((reference) => ({ reference, source: item.source }))
             .catch(() => null),
         ),
       );
 
-      return results.filter(
-        (reference): reference is HydratedComponentReference =>
-          reference !== null,
-      );
+      const hydratedSourced: SourcedReference[] = [];
+      for (const item of results) {
+        if (!item?.reference) continue;
+        hydratedSourced.push({
+          reference: item.reference,
+          source: item.source,
+        });
+      }
+
+      return buildSearchIndex(hydratedSourced);
     },
   });
-
-  const index = buildSearchIndex(
-    buildSourcedHydratedReferences({
-      sourcedReferences,
-      hydratedReferences,
-    }),
-  );
 
   const [disabledSourceKeys, setDisabledSourceKeys] = useState<string[]>([]);
   const sourceFilterOptions = createSourceFilterOptions(index);
@@ -208,11 +208,10 @@ export function useComponentSearchV2State(
 
   const canUseEmbeddingSearch = aiConfig.apiBase.trim().length > 0;
   const trimmedQuery = query.trim();
-  const lexicalMatches = buildLexicalMatches(filteredIndex, trimmedQuery);
-  const aiCandidateMatches = buildAiCandidateMatches(
-    filteredIndex,
-    trimmedQuery,
-  );
+  const searchableQuery = pauseSearch ? "" : trimmedQuery;
+  const lexicalMatches = pauseSearch
+    ? []
+    : buildLexicalMatches(filteredIndex, searchableQuery);
   const {
     mutate,
     reset: resetRerank,
@@ -246,7 +245,7 @@ export function useComponentSearchV2State(
   }, []);
 
   const isRerankActive =
-    rerankedFor === trimmedQuery &&
+    rerankedFor === searchableQuery &&
     rerankBaseMatches.length > 0 &&
     !isReranking &&
     !isEmbeddingSearchPending &&
@@ -273,7 +272,7 @@ export function useComponentSearchV2State(
     try {
       return await rankComponentMatchesByEmbeddings(
         sourceIndex,
-        trimmedQuery,
+        searchableQuery,
         {
           apiBase: aiConfig.apiBase,
           apiKey: aiConfig.apiKey,
@@ -303,7 +302,7 @@ export function useComponentSearchV2State(
       limit: number;
     },
   ) => {
-    if (!trimmedQuery || !isConfigured) return;
+    if (!searchableQuery || !isConfigured) return;
 
     const canUseEmbeddings = useEmbeddings && canUseEmbeddingSearch;
     if (matches.length === 0 && !canUseEmbeddings) return;
@@ -337,11 +336,15 @@ export function useComponentSearchV2State(
 
     resetRerank();
     setRerankBaseMatches(rerankMatches);
-    setRerankedFor(trimmedQuery);
-    mutate({ query: trimmedQuery, candidates, scoreAllCandidates });
+    setRerankedFor(searchableQuery);
+    mutate({ query: searchableQuery, candidates, scoreAllCandidates });
   };
 
   const rerank = () => {
+    const aiCandidateMatches = buildAiCandidateMatches(
+      filteredIndex,
+      searchableQuery,
+    );
     void startRerank(aiCandidateMatches, {
       scoreAllCandidates: true,
       useEmbeddings: true,
@@ -371,16 +374,21 @@ export function useComponentSearchV2State(
 
   return {
     results,
-    browseFolders: buildResultFolders({
-      results,
-      standardLibrary: disabledSourceKeys.includes("standard")
-        ? undefined
-        : standardLibrary,
-    }),
-    searchSuggestions: buildComponentSearchSuggestions(filteredIndex, {
-      includeSources: false,
-      query: trimmedQuery,
-    }),
+    browseFolders: pauseSearch
+      ? []
+      : buildResultFolders({
+          results,
+          standardLibrary: disabledSourceKeys.includes("standard")
+            ? undefined
+            : standardLibrary,
+        }),
+    searchSuggestions:
+      !pauseSearch && results.length === 0
+        ? buildComponentSearchSuggestions(filteredIndex, {
+            includeSources: false,
+            query: searchableQuery,
+          })
+        : [],
     sourceFilterOptions,
     disabledSourceKeys,
     isLoading:
@@ -391,8 +399,9 @@ export function useComponentSearchV2State(
       isLoadingRegistered ||
       isHydrating,
     canRerank:
-      trimmedQuery.length > 0 &&
-      (aiCandidateMatches.length > 0 || canUseEmbeddingSearch) &&
+      !pauseSearch &&
+      searchableQuery.length > 0 &&
+      (lexicalMatches.length > 0 || canUseEmbeddingSearch) &&
       isConfigured,
     isReranking: isReranking || isEmbeddingSearchPending,
     isRerankActive,

--- a/src/services/componentSearchIndex.ts
+++ b/src/services/componentSearchIndex.ts
@@ -54,6 +54,10 @@ export interface IndexEntry {
   source: ComponentSearchSource;
   /** Normalized searchable text, one per logical field. */
   searchable: Record<MatchField, string>;
+  /** Pre-split searchable text, built once with the index to avoid per-keystroke tokenization. */
+  searchableTokens?: Record<MatchField, string[]>;
+  /** Phrase-normalized searchable text, built once with the index to avoid per-keystroke regex work. */
+  searchablePhrases?: Record<MatchField, string>;
 }
 
 export interface LexicalMatch {
@@ -315,23 +319,25 @@ export function buildSearchIndex(sourced: SourcedReference[]): IndexEntry[] {
     const metadata = extractComponentMetadata(reference);
     if (!metadata) continue;
 
+    const searchable: Record<MatchField, string> = {
+      name: normalizeSearchText(metadata.name),
+      description: normalizeSearchText(metadata.description),
+      io: normalizeSearchText(metadata.ioText),
+      implementation: normalizeSearchText(extractImplementationText(reference)),
+      metadata: normalizeSearchText(metadata.metadataText).slice(
+        0,
+        MAX_ANNOTATION_TOTAL_TEXT_LENGTH,
+      ),
+    };
+
     entries.push({
       reference,
       digest: metadata.digest,
       name: metadata.name,
       source,
-      searchable: {
-        name: normalizeSearchText(metadata.name),
-        description: normalizeSearchText(metadata.description),
-        io: normalizeSearchText(metadata.ioText),
-        implementation: normalizeSearchText(
-          extractImplementationText(reference),
-        ),
-        metadata: normalizeSearchText(metadata.metadataText).slice(
-          0,
-          MAX_ANNOTATION_TOTAL_TEXT_LENGTH,
-        ),
-      },
+      searchable,
+      searchableTokens: buildSearchableTokenCache(searchable),
+      searchablePhrases: buildSearchablePhraseCache(searchable),
     });
   }
 
@@ -517,6 +523,42 @@ function searchableTokens(text: string): string[] {
   return text.split(/[^a-z0-9]+/).filter(isNonEmptyString);
 }
 
+function normalizePhraseSearchText(text: string): string {
+  return text.replace(/[^a-z0-9]+/g, " ");
+}
+
+function buildSearchableTokenCache(
+  searchable: Record<MatchField, string>,
+): Record<MatchField, string[]> {
+  return Object.fromEntries(
+    SEARCH_FIELDS.map((field) => [field, searchableTokens(searchable[field])]),
+  ) as Record<MatchField, string[]>;
+}
+
+function buildSearchablePhraseCache(
+  searchable: Record<MatchField, string>,
+): Record<MatchField, string> {
+  return Object.fromEntries(
+    SEARCH_FIELDS.map((field) => [
+      field,
+      normalizePhraseSearchText(searchable[field]),
+    ]),
+  ) as Record<MatchField, string>;
+}
+
+function fieldTokensFor(entry: IndexEntry, field: MatchField): string[] {
+  return (
+    entry.searchableTokens?.[field] ?? searchableTokens(entry.searchable[field])
+  );
+}
+
+function phraseTextFor(entry: IndexEntry, field: MatchField): string {
+  return (
+    entry.searchablePhrases?.[field] ??
+    normalizePhraseSearchText(entry.searchable[field])
+  );
+}
+
 function maxTypoDistance(field: MatchField, token: string): number {
   // Require length >= 5 before allowing any edits: 4-char tokens are too short
   // for distance-1 fuzziness without false positives on generic IO names
@@ -628,25 +670,13 @@ function scoreEntry(
   const matched = new Set<MatchField>();
   let score = 0;
 
-  // A field's tokenization depends only on the field, not the query token, so
-  // split it once per entry (cached) rather than re-splitting inside the
-  // per-query-token loop — that re-split is hot on every keystroke.
-  const fieldTokenCache = new Map<MatchField, string[]>();
-  const fieldTokensFor = (field: MatchField): string[] => {
-    const cached = fieldTokenCache.get(field);
-    if (cached) return cached;
-    const fieldTokens = searchableTokens(entry.searchable[field]);
-    fieldTokenCache.set(field, fieldTokens);
-    return fieldTokens;
-  };
-
   // Hard exclusion uses a whole-token match (not substring): a zero-score
   // filter removes the entire component, so a short negated token must not
   // knock one out by incidentally appearing inside an unrelated word.
   if (
     negativeTokens.some((token) =>
       NEGATIVE_SEARCH_FIELDS.some((field) =>
-        fieldTokensFor(field).includes(token),
+        fieldTokensFor(entry, field).includes(token),
       ),
     )
   ) {
@@ -669,7 +699,7 @@ function scoreEntry(
         matched.add(field);
 
         const hasPrefixMatch = matchingTokens.some((token) =>
-          fieldTokensFor(field).some((fieldToken) =>
+          fieldTokensFor(entry, field).some((fieldToken) =>
             fieldToken.startsWith(token),
           ),
         );
@@ -684,7 +714,7 @@ function scoreEntry(
       const literalToken = concept[0];
       const fuzzyTokens = hasFuzzyTokenMatch(
         field,
-        fieldTokensFor(field),
+        fieldTokensFor(entry, field),
         literalToken,
       )
         ? [literalToken]
@@ -701,10 +731,7 @@ function scoreEntry(
 
   if (phraseTokenSequences.length > 0) {
     for (const field of SEARCH_FIELDS) {
-      const normalizedField = entry.searchable[field].replace(
-        /[^a-z0-9]+/g,
-        " ",
-      );
+      const normalizedField = phraseTextFor(entry, field);
       if (
         !phraseTokenSequences.some((sequence) =>
           normalizedField.includes(sequence.join(" ")),


### PR DESCRIPTION
## Description

Improves search responsiveness by showing a skeleton loading state immediately when the user starts typing, preventing the UI from performing expensive sorting and searching operations on keystrokes that haven't yet committed to a query transition.

A new `isSearching` flag is set as soon as the local input value diverges from the committed query. While `isSearching` is true, the active query is treated as empty, sorted index computation is skipped, and the results area renders a skeleton. Once the debounced commit fires, `isSearching` is cleared and the real results appear.

The `pauseSearch` option is threaded into `useComponentSearchV2State` so the editor-side component search panel gets the same behaviour.

The hydration query now builds and caches the search index (`IndexEntry[]`) alongside the hydrated references, so expensive index derivation is tied to the library fingerprint cache rather than recomputed on every render. The library fingerprint now includes source kind, id, and label so cache entries correctly invalidate when the source set changes.

Pre-computed token and phrase caches (`searchableTokens`, `searchablePhrases`) are stored on each `IndexEntry` at index-build time, eliminating repeated tokenization and regex work on every keystroke inside `scoreEntry`.

Search suggestions are now only computed when there are no lexical or collection matches and rerank is not active, avoiding unnecessary work when results are already present.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Improvement
- [x] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Open the component search panel or dashboard components view.
2. Begin typing a search query and observe that a skeleton loading state appears immediately while typing.
3. Stop typing and confirm that results appear correctly after the debounce period.
4. Verify that source filter toggles still correctly filter results.
5. Confirm that AI rerank and embedding search continue to function as expected.

## Additional Comments

The `buildSourcedHydratedReferences` helper is no longer needed and has been removed. The hydration query now pairs each hydrated reference with its source directly, making the post-hydration join step unnecessary.