### PR TITLE
Add per-query field boost directives to lexical search

### DIFF
--- a/src/services/componentSearchIndex.test.ts
+++ b/src/services/componentSearchIndex.test.ts
@@ -691,6 +691,53 @@ describe("lexicalSearch", () => {
     expect(results).not.toContain("plural");
   });
 
+  it("supports per-query field boosts in bracket directives", () => {
+    const index = buildSearchIndex([
+      makeSourced({
+        digest: "title-match",
+        spec: {
+          name: "upload_file",
+          inputs: [],
+          outputs: [],
+          implementation: { container: { image: "x" } },
+        },
+      }),
+      makeSourced({
+        digest: "metadata-match",
+        spec: {
+          name: "generic_component",
+          inputs: [],
+          outputs: [],
+          implementation: { container: { image: "x" } },
+          metadata: { annotations: { intent: "upload" } },
+        },
+      }),
+      makeSourced({
+        digest: "directive-noise",
+        spec: {
+          name: "metadata_helper",
+          inputs: [],
+          outputs: [],
+          implementation: { container: { image: "x" } },
+        },
+      }),
+    ]);
+
+    expect(lexicalSearch(index, "upload [metadata^20]")[0]?.digest).toBe(
+      "metadata-match",
+    );
+    expect(
+      lexicalSearch(index, "upload [metadata+10, title-5]").map(
+        (result) => result.digest,
+      ),
+    ).toEqual(["metadata-match"]);
+    expect(
+      lexicalSearch(index, "upload [metadata^20]").map(
+        (result) => result.digest,
+      ),
+    ).not.toContain("directive-noise");
+  });
+
   it("ignores natural-language filler words that would otherwise swamp intent", () => {
     const index = buildSearchIndex([
       makeSourced({

--- a/src/services/componentSearchIndex.ts
+++ b/src/services/componentSearchIndex.ts
@@ -433,6 +433,8 @@ function tokenizeQuery(text: string): {
 interface ParsedSearchQuery {
   positiveText: string;
   negativeText: string;
+  fieldWeights: Record<MatchField, number>;
+  fieldPhraseBonuses: Record<MatchField, number>;
 }
 
 // Bind a negation to its term(s): capture consecutive words but stop at a
@@ -442,10 +444,81 @@ interface ParsedSearchQuery {
 const NEGATIVE_CONSTRAINT_PATTERN =
   /\b(?:without|excluding|exclude|not|no)\b\s+(?:(?:to|use|using)\s+)?([a-z0-9][a-z0-9-]*(?:\s+(?!(?:and|or|but|then|also|plus|with)\b)[a-z0-9][a-z0-9-]*)*)/gi;
 const NEGATIVE_LEADING_FILLER_PATTERN = /^(?:(?:to|use|using)\s+)+/i;
+const FIELD_BOOST_BLOCK_PATTERN = /\[([^\]]+)\]/g;
+const FIELD_BOOST_DIRECTIVE_PATTERN =
+  /^([a-z]+)(\+{1,}|-{1,}|[+-]\d+(?:\.\d+)?|\^\d+(?:\.\d+)?|=\d+(?:\.\d+)?)$/;
+
+function cloneFieldWeights(): Record<MatchField, number> {
+  return { ...FIELD_WEIGHTS };
+}
+
+function buildFieldPhraseBonuses(
+  fieldWeights: Record<MatchField, number>,
+): Record<MatchField, number> {
+  return Object.fromEntries(
+    SEARCH_FIELDS.map((field) => {
+      const baseWeight = FIELD_WEIGHTS[field];
+      const ratio = baseWeight > 0 ? fieldWeights[field] / baseWeight : 0;
+      return [field, FIELD_PHRASE_BONUS[field] * ratio];
+    }),
+  ) as Record<MatchField, number>;
+}
+
+function applyFieldBoostDirective(
+  fieldWeights: Record<MatchField, number>,
+  directive: string,
+): void {
+  const match = FIELD_BOOST_DIRECTIVE_PATTERN.exec(directive.trim());
+  if (!match) return;
+
+  const fieldName = match[1];
+  const operator = match[2];
+  if (!fieldName || !operator) return;
+
+  const field = FIELD_ALIASES[fieldName];
+  if (!field) return;
+
+  const currentWeight = fieldWeights[field];
+  let nextWeight = currentWeight;
+  if (operator.startsWith("^")) {
+    nextWeight = currentWeight * Number(operator.slice(1));
+  } else if (operator.startsWith("=")) {
+    nextWeight = Number(operator.slice(1));
+  } else if (/^\++$/.test(operator)) {
+    nextWeight = currentWeight + operator.length;
+  } else if (/^-+$/.test(operator)) {
+    nextWeight = currentWeight - operator.length;
+  } else {
+    nextWeight = currentWeight + Number(operator);
+  }
+
+  fieldWeights[field] = Number.isFinite(nextWeight)
+    ? Math.max(0, nextWeight)
+    : currentWeight;
+}
+
+function extractFieldBoosts(text: string): {
+  textWithoutBoosts: string;
+  fieldWeights: Record<MatchField, number>;
+} {
+  const fieldWeights = cloneFieldWeights();
+  const textWithoutBoosts = text.replace(
+    FIELD_BOOST_BLOCK_PATTERN,
+    (_match, block: string) => {
+      for (const directive of block.split(/[\s,]+/)) {
+        applyFieldBoostDirective(fieldWeights, directive);
+      }
+      return " ";
+    },
+  );
+
+  return { textWithoutBoosts, fieldWeights };
+}
 
 function parseSearchQuery(text: string): ParsedSearchQuery {
+  const { textWithoutBoosts, fieldWeights } = extractFieldBoosts(text);
   const negativeParts: string[] = [];
-  const positiveText = text.replace(
+  const positiveText = textWithoutBoosts.replace(
     NEGATIVE_CONSTRAINT_PATTERN,
     (_match, negativePart: string) => {
       negativeParts.push(
@@ -458,6 +531,8 @@ function parseSearchQuery(text: string): ParsedSearchQuery {
   return {
     positiveText,
     negativeText: negativeParts.join(" "),
+    fieldWeights,
+    fieldPhraseBonuses: buildFieldPhraseBonuses(fieldWeights),
   };
 }
 
@@ -493,6 +568,24 @@ const FIELD_PHRASE_BONUS: Record<MatchField, number> = {
   io: 4,
   implementation: 0.5,
   metadata: 1,
+};
+
+const FIELD_ALIASES: Record<string, MatchField> = {
+  command: "implementation",
+  commands: "implementation",
+  desc: "description",
+  description: "description",
+  implementation: "implementation",
+  impl: "implementation",
+  input: "io",
+  inputs: "io",
+  io: "io",
+  metadata: "metadata",
+  meta: "metadata",
+  name: "name",
+  output: "io",
+  outputs: "io",
+  title: "name",
 };
 
 const PREFIX_MATCH_BONUS_MULTIPLIER = 0.5;
@@ -666,6 +759,8 @@ function scoreEntry(
   phraseTokenSequences: string[][],
   negativeTokens: string[],
   tokenWeights: Map<string, number>,
+  fieldWeights: Record<MatchField, number>,
+  fieldPhraseBonuses: Record<MatchField, number>,
 ): { score: number; matchedFields: MatchField[] } {
   const matched = new Set<MatchField>();
   let score = 0;
@@ -686,7 +781,7 @@ function scoreEntry(
   for (const concept of concepts) {
     for (const field of SEARCH_FIELDS) {
       const fieldText = entry.searchable[field];
-      const fieldWeight = FIELD_WEIGHTS[field];
+      const fieldWeight = fieldWeights[field];
       const matchingTokens = concept.filter((token) =>
         fieldText.includes(token),
       );
@@ -739,7 +834,7 @@ function scoreEntry(
       ) {
         continue;
       }
-      score += FIELD_PHRASE_BONUS[field];
+      score += fieldPhraseBonuses[field];
       matched.add(field);
     }
   }
@@ -789,6 +884,8 @@ export function lexicalSearch(
       phraseTokenSequences,
       negativeTokens,
       tokenWeights,
+      parsedQuery.fieldWeights,
+      parsedQuery.fieldPhraseBonuses,
     );
     if (score === 0) continue;
     scored.push({


### PR DESCRIPTION
## Description

Adds support for per-query field boost directives in the lexical search syntax. Users can now include bracket expressions (e.g., `upload [metadata^20]` or `upload [metadata+10, title-5]`) in their search queries to dynamically adjust how much weight individual fields contribute to scoring for that specific query.

Supported operator formats within `[...]` blocks:
- `^N` — multiply the field's base weight by N
- `=N` — set the field weight to an absolute value
- `+` / `++` / `+++` — increment weight by the number of `+` characters
- `-` / `--` / `---` — decrement weight by the number of `-` characters
- `+N` / `-N` — add or subtract a numeric value

Field aliases are supported (e.g., `title` → `name`, `desc` → `description`, `impl` → `implementation`, `input`/`output` → `io`, `meta` → `metadata`).

Phrase bonuses are scaled proportionally to the adjusted field weights, keeping scoring consistent. Boost blocks are stripped from the query text before token parsing so they do not interfere with term matching.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Run the test suite with `npm test` (or equivalent) and confirm the new `"supports per-query field boosts in bracket directives"` test passes alongside existing lexical search tests.
2. Perform a manual search using a query like `upload [metadata^20]` and verify that results with matching metadata rank above results that only match on name/title.
3. Confirm that the bracket directive text itself does not appear as a matched token or affect unrelated results.

## Additional Comments

The field weight overrides are scoped entirely to the parsed query and do not mutate the global `FIELD_WEIGHTS` constant.