### PR TITLE
Add editor v2 welcome spotlight and default path routing

### DIFF
--- a/react-compiler.config.js
+++ b/react-compiler.config.js
@@ -41,6 +41,7 @@ export const REACT_COMPILER_ENABLED_DIRS = [
   "src/components/shared/FavoriteToggle.tsx",
   "src/components/shared/ComponentLifecycleBadges.tsx",
   "src/components/shared/ComponentSearchEmptyStateSuggestions.tsx",
+  "src/components/shared/EditorV2WelcomeSpotlight.tsx",
 
   "src/components/shared/Tags",
   "src/components/shared/Submitters/Tangle/components",

--- a/src/components/Home/PipelineSection/PipelineRow.tsx
+++ b/src/components/Home/PipelineSection/PipelineRow.tsx
@@ -30,7 +30,7 @@ import {
 import { Paragraph } from "@/components/ui/typography";
 import { cn } from "@/lib/utils";
 import { useAnalytics } from "@/providers/AnalyticsProvider";
-import { EDITOR_PATH } from "@/routes/router";
+import { getDefaultEditorPath } from "@/routes/editorRoutes";
 import { deletePipeline } from "@/services/pipelineService";
 import { getPipelineTagsFromSpec } from "@/utils/annotations";
 import type { ComponentReferenceWithSpec } from "@/utils/componentStore";
@@ -107,17 +107,15 @@ const PipelineRow = withSuspenseWrapper(
         return;
       }
 
+      if (!name) return;
+
       if (e.ctrlKey || e.metaKey) {
-        if (name) {
-          rowTrack("pipeline_opened", { open_mode: "editor_new_tab" });
-        }
-        window.open(`${EDITOR_PATH}/${name}`, "_blank");
+        rowTrack("pipeline_opened", { open_mode: "editor_new_tab" });
+        window.open(getDefaultEditorPath(name), "_blank");
         return;
       }
-      if (name) {
-        rowTrack("pipeline_opened", { open_mode: "editor_same_tab" });
-      }
-      navigate({ to: `${EDITOR_PATH}/${name}` });
+      rowTrack("pipeline_opened", { open_mode: "editor_same_tab" });
+      navigate({ to: getDefaultEditorPath(name) });
     };
 
     const handleCheckboxChange = (checked: boolean | "indeterminate") => {

--- a/src/components/Learn/useImportPipeline.ts
+++ b/src/components/Learn/useImportPipeline.ts
@@ -2,7 +2,7 @@ import { useMutation } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 
 import useToastNotification from "@/hooks/useToastNotification";
-import { EDITOR_PATH } from "@/routes/router";
+import { getDefaultEditorPath } from "@/routes/editorRoutes";
 
 import { importPipelineFromUrl } from "./importPipelineFromUrl";
 
@@ -15,7 +15,7 @@ export function useImportPipeline() {
     onSuccess: (result) => {
       notify(`Pipeline "${result.name}" created successfully`, "success");
       navigate({
-        to: `${EDITOR_PATH}/${encodeURIComponent(result.name)}`,
+        to: getDefaultEditorPath(result.name),
       });
     },
   });

--- a/src/components/PipelineRun/RunToolbar.tsx
+++ b/src/components/PipelineRun/RunToolbar.tsx
@@ -5,6 +5,7 @@ import { useUserDetails } from "@/hooks/useUserDetails";
 import { cn } from "@/lib/utils";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 import { useExecutionData } from "@/providers/ExecutionDataProvider";
+import { getDefaultEditorPath } from "@/routes/editorRoutes";
 import { extractCanonicalName } from "@/utils/canonicalPipelineName";
 import {
   countInProgressFromStats,
@@ -30,7 +31,7 @@ export const RunToolbar = () => {
   const { data: currentUserDetails } = useUserDetails();
 
   const editorRoute = componentSpec.name
-    ? `/editor/${encodeURIComponent(componentSpec.name)}`
+    ? getDefaultEditorPath(componentSpec.name)
     : "";
 
   const canAccessEditorSpec = useCheckComponentSpecFromPath(

--- a/src/components/PipelineRun/components/InspectPipelineButton.test.tsx
+++ b/src/components/PipelineRun/components/InspectPipelineButton.test.tsx
@@ -16,6 +16,6 @@ describe("<InspectPipelineButton/>", () => {
     render(<InspectPipelineButton pipelineName="foo" />);
     const inspectButton = screen.getByTestId("inspect-pipeline-button");
     act(() => fireEvent.click(inspectButton));
-    expect(mockNavigate).toHaveBeenCalledWith({ to: "/editor/foo" });
+    expect(mockNavigate).toHaveBeenCalledWith({ to: "/editor-v2/foo" });
   });
 });

--- a/src/components/PipelineRun/components/InspectPipelineButton.tsx
+++ b/src/components/PipelineRun/components/InspectPipelineButton.tsx
@@ -7,6 +7,7 @@ import {
 
 import TooltipButton from "@/components/shared/Buttons/TooltipButton";
 import { Icon } from "@/components/ui/icon";
+import { getDefaultEditorPath } from "@/routes/editorRoutes";
 
 type InspectPipelineButtonProps = {
   pipelineName: string;
@@ -25,7 +26,7 @@ export const InspectPipelineButton = ({
 
   const handleInspect = useCallback(
     (e: MouseEvent<HTMLButtonElement>) => {
-      const clickThroughUrl = `/editor/${encodeURIComponent(pipelineName)}`;
+      const clickThroughUrl = getDefaultEditorPath(pipelineName);
 
       if (e.ctrlKey || e.metaKey) {
         window.open(clickThroughUrl, "_blank");

--- a/src/components/layout/AiModelQuickSelect.test.tsx
+++ b/src/components/layout/AiModelQuickSelect.test.tsx
@@ -30,6 +30,7 @@ describe("AiModelQuickSelect", () => {
   });
 
   it("does not render when both AI features are disabled", () => {
+    enableFlags({ "ai-assistant": false, "component-search-v2": false });
     window.localStorage.setItem(
       STORAGE_KEY,
       JSON.stringify({

--- a/src/components/shared/EditorV2WelcomeSpotlight.tsx
+++ b/src/components/shared/EditorV2WelcomeSpotlight.tsx
@@ -1,0 +1,210 @@
+import {
+  type RefObject,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+import { createPortal } from "react-dom";
+
+import { Button } from "@/components/ui/button";
+import { BlockStack } from "@/components/ui/layout";
+import { Paragraph, Text } from "@/components/ui/typography";
+import { getStorage } from "@/utils/typedStorage";
+
+interface EditorV2WelcomeStorage {
+  "seen-editor-v2-welcome": boolean;
+}
+
+const storage = getStorage<
+  keyof EditorV2WelcomeStorage,
+  EditorV2WelcomeStorage
+>();
+const STORAGE_KEY = "seen-editor-v2-welcome";
+const SPOTLIGHT_PADDING = 16;
+const CARD_WIDTH = 320;
+const SPOTLIGHT_COLOR = "#5B35F5";
+const SPOTLIGHT_HALO_COLOR = "rgba(91, 53, 245, 0.35)";
+
+interface SpotlightRect {
+  centerX: number;
+  centerY: number;
+  radius: number;
+}
+
+export function hasSeenEditorV2Welcome(): boolean {
+  return storage.getItem(STORAGE_KEY) === true;
+}
+
+export function markEditorV2WelcomeSeen() {
+  storage.setItem(STORAGE_KEY, true);
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+function getSpotlightRect(target: HTMLElement): SpotlightRect {
+  const rect = target.getBoundingClientRect();
+  return {
+    centerX: rect.left + rect.width / 2,
+    centerY: rect.top + rect.height / 2,
+    radius: Math.max(rect.width, rect.height) / 2 + SPOTLIGHT_PADDING,
+  };
+}
+
+interface ClickBlockersProps {
+  spotlight: SpotlightRect;
+  onDismiss: () => void;
+}
+
+function ClickBlockers({ spotlight, onDismiss }: ClickBlockersProps) {
+  const { centerX, centerY, radius } = spotlight;
+  const top = Math.max(centerY - radius, 0);
+  const bottom = Math.min(centerY + radius, window.innerHeight);
+  const left = Math.max(centerX - radius, 0);
+  const right = Math.min(centerX + radius, window.innerWidth);
+
+  return (
+    <>
+      <button
+        type="button"
+        aria-label="Dismiss new editor welcome"
+        className="fixed left-0 right-0 top-0 z-[1000] cursor-default bg-transparent"
+        style={{ height: top }}
+        onClick={onDismiss}
+      />
+      <button
+        type="button"
+        aria-label="Dismiss new editor welcome"
+        className="fixed bottom-0 left-0 right-0 z-[1000] cursor-default bg-transparent"
+        style={{ top: bottom }}
+        onClick={onDismiss}
+      />
+      <button
+        type="button"
+        aria-label="Dismiss new editor welcome"
+        className="fixed z-[1000] cursor-default bg-transparent"
+        style={{ top, left: 0, width: left, height: bottom - top }}
+        onClick={onDismiss}
+      />
+      <button
+        type="button"
+        aria-label="Dismiss new editor welcome"
+        className="fixed z-[1000] cursor-default bg-transparent"
+        style={{ top, left: right, right: 0, height: bottom - top }}
+        onClick={onDismiss}
+      />
+    </>
+  );
+}
+
+interface EditorV2WelcomeSpotlightProps {
+  targetRef: RefObject<HTMLElement | null>;
+  onDismiss: () => void;
+}
+
+export function EditorV2WelcomeSpotlight({
+  targetRef,
+  onDismiss,
+}: EditorV2WelcomeSpotlightProps) {
+  const [spotlight, setSpotlight] = useState<SpotlightRect | null>(null);
+  const gotItRef = useRef<HTMLButtonElement>(null);
+
+  useLayoutEffect(() => {
+    const update = () => {
+      if (!targetRef.current) return;
+      setSpotlight(getSpotlightRect(targetRef.current));
+    };
+
+    update();
+    const animationFrame = window.requestAnimationFrame(update);
+    window.addEventListener("resize", update);
+    window.addEventListener("scroll", update, true);
+
+    return () => {
+      window.cancelAnimationFrame(animationFrame);
+      window.removeEventListener("resize", update);
+      window.removeEventListener("scroll", update, true);
+    };
+  }, [targetRef]);
+
+  useEffect(() => {
+    gotItRef.current?.focus();
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onDismiss();
+        return;
+      }
+      if (event.key === "Tab") {
+        event.preventDefault();
+        gotItRef.current?.focus();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [onDismiss]);
+
+  if (!spotlight) return null;
+
+  const cardTop = clamp(
+    spotlight.centerY + spotlight.radius + 16,
+    16,
+    window.innerHeight - 180,
+  );
+  const cardLeft = clamp(
+    spotlight.centerX - CARD_WIDTH / 2,
+    16,
+    window.innerWidth - CARD_WIDTH - 16,
+  );
+
+  return createPortal(
+    <>
+      <div
+        aria-hidden="true"
+        className="fixed inset-0 z-[999] bg-black/75 pointer-events-none"
+        style={{
+          WebkitMaskImage: `radial-gradient(circle ${spotlight.radius}px at ${spotlight.centerX}px ${spotlight.centerY}px, transparent 0, transparent ${spotlight.radius}px, black ${spotlight.radius + 1}px)`,
+          maskImage: `radial-gradient(circle ${spotlight.radius}px at ${spotlight.centerX}px ${spotlight.centerY}px, transparent 0, transparent ${spotlight.radius}px, black ${spotlight.radius + 1}px)`,
+        }}
+      />
+      <div
+        aria-hidden="true"
+        className="fixed z-[1001] rounded-full border-2 pointer-events-none"
+        style={{
+          left: spotlight.centerX - spotlight.radius,
+          top: spotlight.centerY - spotlight.radius,
+          width: spotlight.radius * 2,
+          height: spotlight.radius * 2,
+          borderColor: SPOTLIGHT_COLOR,
+          boxShadow: `0 0 0 4px ${SPOTLIGHT_HALO_COLOR}`,
+        }}
+      />
+      <ClickBlockers spotlight={spotlight} onDismiss={onDismiss} />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="editor-v2-welcome-title"
+        className="fixed z-[1002] rounded-lg border border-border bg-card p-4 text-card-foreground shadow-lg"
+        style={{ top: cardTop, left: cardLeft, width: CARD_WIDTH }}
+      >
+        <BlockStack gap="3">
+          <BlockStack gap="1">
+            <Text id="editor-v2-welcome-title" weight="semibold">
+              Welcome to the new editor
+            </Text>
+            <Paragraph size="sm" tone="subdued">
+              You can easily switch between the new and old editor here.
+            </Paragraph>
+          </BlockStack>
+          <Button ref={gotItRef} size="sm" onClick={onDismiss}>
+            Got it
+          </Button>
+        </BlockStack>
+      </div>
+    </>,
+    document.body,
+  );
+}

--- a/src/components/shared/EditorVersionToggle.tsx
+++ b/src/components/shared/EditorVersionToggle.tsx
@@ -1,7 +1,14 @@
 import { useLocation, useNavigate } from "@tanstack/react-router";
+import { useCallback, useRef, useState } from "react";
 
 import TooltipButton from "@/components/shared/Buttons/TooltipButton";
+import {
+  EditorV2WelcomeSpotlight,
+  hasSeenEditorV2Welcome,
+  markEditorV2WelcomeSeen,
+} from "@/components/shared/EditorV2WelcomeSpotlight";
 import { Icon } from "@/components/ui/icon";
+import { cn } from "@/lib/utils";
 import { APP_ROUTES, EDITOR_PATH } from "@/routes/router";
 
 import { useFlagValue } from "./Settings/useFlags";
@@ -14,10 +21,23 @@ const detectEditorVersion = (pathname: string): EditorVersion | null => {
   return null;
 };
 
-export const EditorVersionToggle = () => {
+interface EditorVersionToggleProps {
+  showWelcomeSpotlight?: boolean;
+}
+
+export const EditorVersionToggle = ({
+  showWelcomeSpotlight = false,
+}: EditorVersionToggleProps) => {
   const location = useLocation();
   const navigate = useNavigate();
   const isEnabled = useFlagValue("v2_editor");
+  const toggleRef = useRef<HTMLButtonElement>(null);
+  const [welcomeSeen, setWelcomeSeen] = useState(hasSeenEditorV2Welcome);
+
+  const dismissWelcome = useCallback(() => {
+    markEditorV2WelcomeSeen();
+    setWelcomeSeen(true);
+  }, []);
 
   if (!isEnabled) return null;
 
@@ -35,14 +55,28 @@ export const EditorVersionToggle = () => {
       : `${EDITOR_PATH}/${encodeURIComponent(pipelineName)}`;
   const tooltip =
     targetVersion === "v2" ? "Switch to new editor" : "Switch to legacy editor";
+  const showWelcome = showWelcomeSpotlight && version === "v2" && !welcomeSeen;
 
   return (
-    <TooltipButton
-      tooltip={tooltip}
-      onClick={() => navigate({ to: targetPath })}
-      aria-label={tooltip}
-    >
-      <Icon name={targetVersion === "v2" ? "Sparkles" : "History"} />
-    </TooltipButton>
+    <>
+      <TooltipButton
+        ref={toggleRef}
+        tooltip={tooltip}
+        className={cn(showWelcome && "relative z-[1001]")}
+        onClick={() => {
+          if (showWelcome) dismissWelcome();
+          navigate({ to: targetPath });
+        }}
+        aria-label={tooltip}
+      >
+        <Icon name={targetVersion === "v2" ? "Zap" : "Snail"} />
+      </TooltipButton>
+      {showWelcome && (
+        <EditorV2WelcomeSpotlight
+          targetRef={toggleRef}
+          onDismiss={dismissWelcome}
+        />
+      )}
+    </>
   );
 };

--- a/src/components/shared/ImportPipeline.tsx
+++ b/src/components/shared/ImportPipeline.tsx
@@ -19,7 +19,7 @@ import { Label } from "@/components/ui/label";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
 import { useAnalytics } from "@/providers/AnalyticsProvider";
-import { EDITOR_PATH } from "@/routes/router";
+import { getDefaultEditorPath } from "@/routes/editorRoutes";
 import {
   importPipelineFromFile,
   importPipelineFromYaml,
@@ -63,7 +63,7 @@ const ImportPipeline = ({
       onImportComplete(importedPipeline);
     } else {
       navigate({
-        to: `${EDITOR_PATH}/${encodeURIComponent(importedPipeline.name)}`,
+        to: getDefaultEditorPath(importedPipeline.name),
       });
     }
   };

--- a/src/components/shared/NewPipelineButton.tsx
+++ b/src/components/shared/NewPipelineButton.tsx
@@ -3,7 +3,7 @@ import { generate } from "random-words";
 import type { MouseEvent, ReactNode } from "react";
 
 import { Button, type ButtonProps } from "@/components/ui/button";
-import { EDITOR_PATH } from "@/routes/router";
+import { getDefaultEditorPath } from "@/routes/editorRoutes";
 import { writeComponentToFileListFromText } from "@/utils/componentStore";
 import {
   defaultPipelineYamlWithName,
@@ -32,7 +32,7 @@ const NewPipelineButton = ({
       componentText,
     );
 
-    const clickThroughUrl = `${EDITOR_PATH}/${encodeURIComponent(name)}`;
+    const clickThroughUrl = getDefaultEditorPath(name);
 
     if (e.ctrlKey || e.metaKey) {
       window.open(clickThroughUrl, "_blank");

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -67,7 +67,7 @@ export const ExistingFlags: ConfigFlags = {
     name: "Component Search",
     description:
       "Show the experimental component search that searches across standard, published, registered, and user component sources, with optional AI rerank.",
-    default: false,
+    default: true,
     category: "beta",
   },
 

--- a/src/routes/Dashboard/TypePill.tsx
+++ b/src/routes/Dashboard/TypePill.tsx
@@ -2,7 +2,8 @@ import { Icon, type IconName } from "@/components/ui/icon";
 import type { FavoriteItem } from "@/hooks/useFavorites";
 import type { RecentlyViewedItem } from "@/hooks/useRecentlyViewed";
 import { cn } from "@/lib/utils";
-import { APP_ROUTES, EDITOR_PATH, RUNS_BASE_PATH } from "@/routes/router";
+import { getDefaultEditorPath } from "@/routes/editorRoutes";
+import { APP_ROUTES, RUNS_BASE_PATH } from "@/routes/router";
 
 type ItemType = "pipeline" | "run" | "component";
 
@@ -50,12 +51,12 @@ export const TypePill = ({
 };
 
 export function getFavoriteUrl(item: FavoriteItem): string {
-  if (item.type === "pipeline") return `${EDITOR_PATH}/${item.id}`;
+  if (item.type === "pipeline") return getDefaultEditorPath(item.id);
   return `${RUNS_BASE_PATH}/${item.id}`;
 }
 
 export function getRecentlyViewedUrl(item: RecentlyViewedItem): string {
-  if (item.type === "pipeline") return `${EDITOR_PATH}/${item.id}`;
+  if (item.type === "pipeline") return getDefaultEditorPath(item.id);
   if (item.type === "run") return `${RUNS_BASE_PATH}/${item.id}`;
   return APP_ROUTES.DASHBOARD_COMPONENTS;
 }

--- a/src/routes/Import/Import.test.tsx
+++ b/src/routes/Import/Import.test.tsx
@@ -142,7 +142,7 @@ describe("ImportPage", () => {
 
     await waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith({
-        to: "/editor/Test%20Pipeline",
+        to: "/editor-v2/Test%20Pipeline",
       });
     });
   });

--- a/src/routes/Import/index.tsx
+++ b/src/routes/Import/index.tsx
@@ -6,7 +6,7 @@ import { Button } from "@/components/ui/button";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Spinner } from "@/components/ui/spinner";
 import { Paragraph, Text } from "@/components/ui/typography";
-import { EDITOR_PATH } from "@/routes/router";
+import { getDefaultEditorPath } from "@/routes/editorRoutes";
 import { importPipelineFromYaml } from "@/services/pipelineService";
 
 /**
@@ -202,7 +202,7 @@ export const ImportPage = () => {
         setPipelineName(result.name);
         setStep(Step.Done);
         navigate({
-          to: `${EDITOR_PATH}/${encodeURIComponent(result.name)}`,
+          to: getDefaultEditorPath(result.name),
         });
       } else {
         setError(result.errorMessage || "Failed to import pipeline from URL.");

--- a/src/routes/editorRoutes.ts
+++ b/src/routes/editorRoutes.ts
@@ -1,0 +1,17 @@
+import { isFlagEnabled } from "@/components/shared/Settings/useFlags";
+
+import { APP_ROUTES, EDITOR_PATH } from "./appRoutes";
+
+function getLegacyEditorPath(pipelineName: string): string {
+  return `${EDITOR_PATH}/${encodeURIComponent(pipelineName)}`;
+}
+
+function getEditorV2Path(pipelineName: string): string {
+  return `${APP_ROUTES.EDITOR_V2}/${encodeURIComponent(pipelineName)}`;
+}
+
+export function getDefaultEditorPath(pipelineName: string): string {
+  return isFlagEnabled("v2_editor")
+    ? getEditorV2Path(pipelineName)
+    : getLegacyEditorPath(pipelineName);
+}

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -309,12 +309,25 @@ const editorV2Route = createRoute({
   getParentRoute: () => mainLayout,
   path: APP_ROUTES.EDITOR_V2,
   component: EditorV2,
+  beforeLoad: () => {
+    if (!isFlagEnabled("v2_editor")) {
+      throw redirect({ to: APP_ROUTES.DASHBOARD_PIPELINES });
+    }
+  },
 });
 
 const editorV2PipelineRoute = createRoute({
   getParentRoute: () => mainLayout,
   path: APP_ROUTES.EDITOR_V2_PIPELINE,
   component: EditorV2,
+  beforeLoad: ({ params }) => {
+    if (!isFlagEnabled("v2_editor")) {
+      throw redirect({
+        to: APP_ROUTES.PIPELINE_EDITOR,
+        params: { name: params.pipelineName },
+      });
+    }
+  },
 });
 
 const runV2Route = createRoute({

--- a/src/routes/v2/pages/RunView/components/RunViewMenuBar/components/RunMenu.tsx
+++ b/src/routes/v2/pages/RunView/components/RunViewMenuBar/components/RunMenu.tsx
@@ -8,6 +8,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Icon } from "@/components/ui/icon";
+import { getDefaultEditorPath } from "@/routes/editorRoutes";
 import { useRunViewActions } from "@/routes/v2/pages/RunView/hooks/useRunViewActions";
 import { MenuTriggerButton } from "@/routes/v2/shared/components/MenuTriggerButton";
 import { tracking } from "@/utils/tracking";
@@ -41,7 +42,7 @@ export function RunMenu() {
 
   const handleInspect = () => {
     if (pipelineName) {
-      navigate({ to: `/editor/${encodeURIComponent(pipelineName)}` });
+      navigate({ to: getDefaultEditorPath(pipelineName) });
     }
   };
 

--- a/src/routes/v2/pages/RunView/hooks/useRunViewActions.ts
+++ b/src/routes/v2/pages/RunView/hooks/useRunViewActions.ts
@@ -8,6 +8,7 @@ import { useCheckComponentSpecFromPath } from "@/hooks/useCheckComponentSpecFrom
 import { useUserDetails } from "@/hooks/useUserDetails";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 import { useExecutionData } from "@/providers/ExecutionDataProvider";
+import { getDefaultEditorPath } from "@/routes/editorRoutes";
 import { extractCanonicalName } from "@/utils/canonicalPipelineName";
 import type { ComponentSpec } from "@/utils/componentSpec";
 import {
@@ -80,7 +81,7 @@ export function useRunViewActions(): RunViewActions {
   const { data: currentUserDetails } = useUserDetails();
 
   const editorRoute = componentSpec?.name
-    ? `/editor/${encodeURIComponent(componentSpec.name)}`
+    ? getDefaultEditorPath(componentSpec.name)
     : "";
 
   const canAccessEditorSpec = useCheckComponentSpecFromPath(

--- a/src/routes/v2/shared/components/AppMenuActions.tsx
+++ b/src/routes/v2/shared/components/AppMenuActions.tsx
@@ -27,7 +27,7 @@ export function AppMenuActions() {
     >
       {!tourMode && <OnboardingNavPill />}
       <AiModelQuickSelect />
-      <EditorVersionToggle />
+      <EditorVersionToggle showWelcomeSpotlight />
       {tourMode ? (
         <TooltipButton
           tooltip="Settings"

--- a/src/services/pipelineRunService.ts
+++ b/src/services/pipelineRunService.ts
@@ -4,7 +4,7 @@ import type {
   BodyCreateApiPipelineRunsPost,
   ListAnnotationsApiPipelineRunsIdAnnotationsGetResponse,
 } from "@/api/types.gen";
-import { APP_ROUTES } from "@/routes/router";
+import { getDefaultEditorPath } from "@/routes/editorRoutes";
 import type { PipelineRun } from "@/types/pipelineRun";
 import { EDITOR_FLOW_DIRECTION_ANNOTATION } from "@/utils/annotations";
 import { removeCachingStrategyFromSpec } from "@/utils/cache";
@@ -161,10 +161,8 @@ export const copyRunToPipeline = async (
       componentText,
     );
 
-    const urlName = encodeURIComponent(newName);
-
     return {
-      url: APP_ROUTES.PIPELINE_EDITOR.replace("$name", urlName),
+      url: getDefaultEditorPath(newName),
       name: newName,
     };
   } catch (error) {

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -5,6 +5,19 @@ import { expect, type Locator, type Page } from "@playwright/test";
  * Waits for the React Flow canvas to be fully loaded (past Suspense loading state).
  */
 export async function createNewPipeline(page: Page): Promise<void> {
+  // These shared E2E helpers cover the legacy editor until v2 has matching coverage.
+  await page.addInitScript(() => {
+    const flags = JSON.parse(
+      window.localStorage.getItem("betaFlags") ?? "{}",
+    ) as Record<string, boolean>;
+
+    window.localStorage.setItem(
+      "betaFlags",
+      JSON.stringify({ ...flags, v2_editor: false }),
+    );
+    window.localStorage.setItem("seen-editor-v2-welcome", JSON.stringify(true));
+  });
+
   await page.goto("/");
   await page.getByTestId("new-pipeline-button").click();
   await waitForFlowCanvas(page);

--- a/tests/e2e/tours/tourDriver.ts
+++ b/tests/e2e/tours/tourDriver.ts
@@ -7,6 +7,11 @@ import type {
   TourDefinition,
   TourStep,
 } from "@/components/Learn/tours/registry";
+import { ExistingFlags } from "@/flags";
+import {
+  componentWindowIdForFlag,
+  LEGACY_COMPONENT_WINDOW_ID,
+} from "@/providers/TourProvider/resolveComponentWindowSteps";
 import type { TourInteraction } from "@/providers/TourProvider/tourActions";
 
 import { fitToView, locateFlowCanvas } from "../helpers";
@@ -110,7 +115,19 @@ export function loadTour(fileName: string): TourDef {
     readFileSync(join(TOURS_DIR, fileName), "utf8"),
   );
   assertTourDef(parsed, fileName);
-  return parsed;
+
+  const componentWindowId = componentWindowIdForFlag(
+    ExistingFlags["component-search-v2"].default,
+  );
+  if (componentWindowId === LEGACY_COMPONENT_WINDOW_ID) return parsed;
+
+  return {
+    ...parsed,
+    steps: resolveTourDriverComponentWindowSteps(
+      parsed.steps,
+      componentWindowId,
+    ),
+  };
 }
 
 /**
@@ -158,6 +175,27 @@ type TourStepDef = Pick<
 export type TourDef = Pick<TourDefinition, "id" | "displayName"> & {
   steps: TourStepDef[];
 };
+
+function resolveTourDriverComponentWindowSteps(
+  steps: TourStepDef[],
+  activeWindowId: string,
+): TourStepDef[] {
+  if (activeWindowId === LEGACY_COMPONENT_WINDOW_ID) return steps;
+
+  const rewrite = (value: string) =>
+    value.replaceAll(LEGACY_COMPONENT_WINDOW_ID, activeWindowId);
+  const rewriteList = (list: string[] | undefined) => list?.map(rewrite);
+
+  return steps.map((step) => ({
+    ...step,
+    selector: rewrite(step.selector),
+    highlightedSelectors: rewriteList(step.highlightedSelectors),
+    targetWindowId:
+      typeof step.targetWindowId === "string"
+        ? rewrite(step.targetWindowId)
+        : step.targetWindowId,
+  }));
+}
 
 // Sentinel selector tours use to mean "no spotlight, center the popover". No
 // such element exists in the DOM, so anchor assertions skip it.
@@ -370,6 +408,9 @@ async function pickDropPoint(page: Page): Promise<{ x: number; y: number }> {
   if (!canvas) throw new Error("Unable to locate canvas bounding box for drop");
 
   const popover = await page.locator(POPOVER).boundingBox();
+  const minimap = await page
+    .locator('[data-testid="rf__minimap"]')
+    .boundingBox();
   const nodes = page.locator(".react-flow__node");
   const nodeCount = await nodes.count();
   const nodeBoxes: Box[] = [];
@@ -380,7 +421,7 @@ async function pickDropPoint(page: Page): Promise<{ x: number; y: number }> {
 
   const cols = [0.12, 0.32, 0.52, 0.72, 0.9];
   const rows = [0.14, 0.34, 0.54, 0.76];
-  const footprint = { w: 120, h: 90 };
+  const footprint = { w: 360, h: 180 };
 
   let best: { x: number; y: number; clear: boolean; margin: number } | null =
     null;
@@ -396,8 +437,9 @@ async function pickDropPoint(page: Page): Promise<{ x: number; y: number }> {
       };
 
       const hitsPopover = popover ? boxesIntersect(rect, popover) : false;
+      const hitsMinimap = minimap ? boxesIntersect(rect, minimap) : false;
       const hitsNode = nodeBoxes.some((n) => boxesIntersect(rect, n));
-      const clear = !hitsPopover && !hitsNode;
+      const clear = !hitsPopover && !hitsMinimap && !hitsNode;
 
       // Margin: distance to the popover edge (bigger is safer).
       const margin = popover


### PR DESCRIPTION
## Description

Introduces a `getDefaultEditorPath` helper in a new `src/routes/editorRoutes.ts` module that resolves the correct editor path based on whether the `v2_editor` feature flag is enabled. When the flag is on, navigation targets `/editor-v2/<pipelineName>`; otherwise it falls back to `/editor/<pipelineName>`. All hardcoded editor path constructions across the codebase have been replaced with this helper.

Additionally, the `editorV2Route` and `editorV2PipelineRoute` routes now include a `beforeLoad` guard that redirects users to the legacy editor (or pipelines dashboard) if the `v2_editor` flag is disabled, preventing direct access to the v2 editor without the flag.

A first-time welcome spotlight (`EditorV2WelcomeSpotlight`) has been added. When a user lands on the v2 editor for the first time, a spotlight overlay highlights the editor version toggle button with a brief explanatory card. Dismissal is persisted to local storage so the spotlight is only shown once.

The `component_search` feature flag default has been changed from `false` to `true`, enabling the experimental component search by default.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Improvement
- [x] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Enable the `v2_editor` feature flag and verify that all navigation entry points (pipeline row clicks, new pipeline button, import, run toolbar, favorites, recently viewed) route to `/editor-v2/<name>`.
2. Disable the `v2_editor` flag and confirm all the same entry points route to `/editor/<name>` and that direct navigation to `/editor-v2/<name>` redirects appropriately.
3. With the `v2_editor` flag enabled, open the v2 editor for the first time and confirm the welcome spotlight appears over the version toggle button, can be dismissed via the "Got it" button, Escape key, or clicking outside, and does not reappear after dismissal.
4. Confirm the component search panel is now visible by default without manually enabling the flag.

## Additional Comments

The `getDefaultEditorPath` utility centralises all editor URL construction, making future editor version routing changes a single-file update.