### PR TITLE
Add Sidekick to default view preset and dock layout

### DIFF
--- a/src/routes/v2/pages/Editor/EditorV2.tsx
+++ b/src/routes/v2/pages/Editor/EditorV2.tsx
@@ -105,12 +105,12 @@ const PipelineEditor = withSuspenseWrapper(
     useEditorEscapeShortcut();
     useDebugPanelWindow();
     useTipOfTheDayWindow();
-    useSeedInitialDockLayoutFromPreset(componentSearchV2Enabled);
 
     const aiEnabled = useFlagValue("ai-assistant");
     useAiChatWindow(aiEnabled);
 
     useComponentSearchV2Window(componentSearchV2Enabled);
+    useSeedInitialDockLayoutFromPreset(componentSearchV2Enabled);
 
     const activeSpec = navigation.activeSpec;
 

--- a/src/routes/v2/pages/Editor/hooks/useAiChatWindow.tsx
+++ b/src/routes/v2/pages/Editor/hooks/useAiChatWindow.tsx
@@ -26,11 +26,13 @@ export function useAiChatWindow(enabled: boolean) {
       />,
       {
         id: AI_CHAT_WINDOW_ID,
-        title: "AI Assistant",
+        title: "Sidekick",
         position: { x: 100, y: 80 },
         size: { width: 380, height: 520 },
         disabledActions: ["close"],
+        startVisible: true,
         persisted: true,
+        defaultDockState: "left",
       },
     );
   }, [enabled, windows, editorSession]);

--- a/src/routes/v2/shared/windows/viewPresets.ts
+++ b/src/routes/v2/shared/windows/viewPresets.ts
@@ -12,6 +12,7 @@ export interface ViewPreset {
   dockAreas?: PresetDockAreas;
 }
 
+const AI_ASSISTANT_WINDOW_ID = "ai-assistant-chat";
 const COMPONENT_SEARCH_WINDOW_ID = "component-search-v2";
 const COMPONENT_LIBRARY_WINDOW_ID = "component-library";
 
@@ -21,6 +22,7 @@ export const DEFAULT_DOCK_AREAS: PresetDockAreas = {
     "runs-and-submission",
     COMPONENT_SEARCH_WINDOW_ID,
     COMPONENT_LIBRARY_WINDOW_ID,
+    AI_ASSISTANT_WINDOW_ID,
     "pipeline-tree",
     "history",
     "debug-panel",
@@ -45,12 +47,14 @@ export function dockSideByWindowId(
 
 export const DEFAULT_VIEW_PRESET: ViewPreset = {
   label: "Default",
-  description: "Components, Runs & Submissions, Recent Runs, Pipeline Details",
+  description:
+    "Components, Runs & Submissions, Sidekick, Recent Runs, Pipeline Details",
   visible: new Set([
     "runs-and-submission",
     "recent-runs",
     "component-search-v2",
     "component-library",
+    AI_ASSISTANT_WINDOW_ID,
     "pipeline-details",
     "tip-of-the-day",
   ]),
@@ -62,11 +66,12 @@ export const VIEW_PRESETS: ViewPreset[] = [
   {
     label: "All",
     description:
-      "All windows visible, including Runs & Submissions and Recent Runs",
+      "All windows visible, including Runs & Submissions, Sidekick, and Recent Runs",
     visible: new Set([
       "runs-and-submission",
       COMPONENT_SEARCH_WINDOW_ID,
       COMPONENT_LIBRARY_WINDOW_ID,
+      AI_ASSISTANT_WINDOW_ID,
       "history",
       "pipeline-tree",
       "pipeline-details",

--- a/src/routes/v2/shared/windows/windowStore.viewPreset.test.ts
+++ b/src/routes/v2/shared/windows/windowStore.viewPreset.test.ts
@@ -23,10 +23,16 @@ describe("WindowStoreImpl view preset dock layout", () => {
       title: "Runs",
       defaultDockState: "left",
     });
+    store.openWindow(stubContent, {
+      id: "ai-assistant-chat",
+      title: "Sidekick",
+      defaultDockState: "left",
+    });
 
     expect(store.getDockAreaWindowIds("left")).toEqual([
       "component-library",
       "runs-and-submission",
+      "ai-assistant-chat",
     ]);
 
     store.seedInitialDockLayoutFromPreset(DEFAULT_VIEW_PRESET);


### PR DESCRIPTION
## Description

Renames the AI Assistant window to "Sidekick" and adds it to the default dock layout and view presets. The AI chat window is now visible by default (`startVisible: true`) and docked to the left panel. The `useSeedInitialDockLayoutFromPreset` hook has been moved to run after `useComponentSearchV2Window` to ensure the Sidekick window is registered before the dock layout is seeded.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Open the editor and verify the Sidekick window appears by default in the left dock panel.
2. Confirm the window is titled "Sidekick" rather than "AI Assistant".
3. Apply the "Default" and "All" view presets and verify Sidekick is visible and docked correctly in both.
4. Verify that switching view presets does not cause the Sidekick window to appear in an unexpected position or state.

## Additional Comments

The hook ordering change (`useSeedInitialDockLayoutFromPreset` moved after `useComponentSearchV2Window`) is intentional — the Sidekick window must be registered before the dock layout preset is applied, otherwise it won't be placed correctly in the left dock area.