### PR TITLE
Remove Vertex AI AutoML and TFX example pipelines

### DIFF
--- a/src/components/Learn/examplePipelines.json
+++ b/src/components/Learn/examplePipelines.json
@@ -62,21 +62,5 @@
     "url": "example-pipelines/Pytorch pipeline.pipeline.component.yaml",
     "previewImage": "example-pipelines/Pytorch pipeline.pipeline.component.png",
     "tags": ["PyTorch", "Deep Learning", "Neural Network"]
-  },
-  {
-    "id": "vertex-automl",
-    "name": "Vertex AI AutoML Tables",
-    "description": "Leverage Google Cloud's Vertex AI AutoML to automatically build and deploy tabular models. No coding required for model training.",
-    "url": "example-pipelines/Vertex AI AutoML Tables pipeline.pipeline.component.yaml",
-    "previewImage": "example-pipelines/Vertex AI AutoML Tables pipeline.pipeline.component.png",
-    "tags": ["AutoML", "Google Cloud", "Vertex AI"]
-  },
-  {
-    "id": "tfx",
-    "name": "TFX Pipeline",
-    "description": "Production-ready TensorFlow Extended (TFX) pipeline for end-to-end ML workflows. Includes data validation, transformation, training, and model serving.",
-    "url": "example-pipelines/Tfx pipeline.pipeline.component.yaml",
-    "previewImage": "example-pipelines/Tfx pipeline.pipeline.component.png",
-    "tags": ["TensorFlow", "TFX", "Production"]
   }
 ]


### PR DESCRIPTION
## Description



closes: https://github.com/TangleML/tangle-ui/issues/2410  
  
Removes the "Vertex AI AutoML Tables" and "TFX Pipeline" example pipelines from the example pipelines list.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [x] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Navigate to the Learn section of the application.
2. Verify that the "Vertex AI AutoML Tables" and "TFX Pipeline" example pipelines no longer appear in the list.
3. Confirm that all remaining example pipelines load and display correctly.

## Additional Comments

The removed pipelines were the Vertex AI AutoML Tables pipeline (tagged with AutoML, Google Cloud, Vertex AI) and the TFX Pipeline (tagged with TensorFlow, TFX, Production).