### PR TITLE
fix: onboarding redirect

### DIFF
--- a/src/providers/BackendProvider.tsx
+++ b/src/providers/BackendProvider.tsx
@@ -41,6 +41,8 @@ type BackendContextType = {
   }) => Promise<boolean>;
 };
 
+const PING_TIMEOUT_MS = 5000;
+
 const BackendContext =
   createRequiredContext<BackendContextType>("BackendProvider");
 
@@ -108,7 +110,11 @@ export const BackendProvider = ({ children }: { children: ReactNode }) => {
         setReady(true);
         return Promise.resolve(false);
       }
-      return fetch(`${normalizedUrl}/services/ping`)
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), PING_TIMEOUT_MS);
+      return fetch(`${normalizedUrl}/services/ping`, {
+        signal: controller.signal,
+      })
         .then((res) => {
           if (notifyResult) {
             if (res.ok) notify("Backend available", "success");
@@ -129,7 +135,8 @@ export const BackendProvider = ({ children }: { children: ReactNode }) => {
           if (saveAvailability) setAvailable(false);
           setReady(true);
           return false;
-        });
+        })
+        .finally(() => clearTimeout(timeout));
     },
     [backendUrl],
   );

--- a/src/providers/OnboardingProvider/OnboardingProvider.test.tsx
+++ b/src/providers/OnboardingProvider/OnboardingProvider.test.tsx
@@ -18,7 +18,11 @@ vi.mock("@/utils/fetchWithErrorHandling", () => ({
     fetchWithErrorHandling(url, options),
 }));
 
-let backend = { available: true, backendUrl: "https://backend.example" };
+let backend = {
+  available: true,
+  backendUrl: "https://backend.example",
+  ready: true,
+};
 vi.mock("@/providers/BackendProvider", () => ({
   useBackend: () => backend,
 }));
@@ -86,7 +90,11 @@ function patched() {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  backend = { available: true, backendUrl: "https://backend.example" };
+  backend = {
+    available: true,
+    backendUrl: "https://backend.example",
+    ready: true,
+  };
   tourCompletions = {};
   settingsPayload = {};
   runsPayload = { pipeline_runs: [] };
@@ -112,7 +120,11 @@ describe("OnboardingProvider", () => {
   });
 
   it("does not show onboarding when the backend is unavailable", async () => {
-    backend = { available: false, backendUrl: "https://backend.example" };
+    backend = {
+      available: false,
+      backendUrl: "https://backend.example",
+      ready: true,
+    };
 
     const { result } = render();
 
@@ -120,6 +132,16 @@ describe("OnboardingProvider", () => {
     expect(result.current.isOnboardingAvailable).toBe(false);
     expect(result.current.shouldShowOnboarding).toBe(false);
     expect(patched()).toBe(false);
+  });
+
+  it("stays unresolved until the backend is ready so the index route does not prematurely redirect", async () => {
+    backend = { available: false, backendUrl: "", ready: false };
+
+    const { result } = render();
+
+    await waitFor(() => expect(result.current.isReady).toBe(true));
+    expect(result.current.isResolved).toBe(false);
+    expect(result.current.shouldShowOnboarding).toBe(false);
   });
 
   it("derives tour and run completion live without persisting them", async () => {

--- a/src/providers/OnboardingProvider/OnboardingProvider.tsx
+++ b/src/providers/OnboardingProvider/OnboardingProvider.tsx
@@ -86,12 +86,7 @@ function useHasMyRun(): {
 export function OnboardingProvider({ children }: { children: ReactNode }) {
   const { track } = useAnalytics();
   const notify = useToastNotification();
-  const {
-    ready: backendReady,
-    configured,
-    available,
-    backendUrl,
-  } = useBackend();
+  const { ready: backendReady, available, backendUrl } = useBackend();
   const hasBackend = available && Boolean(backendUrl);
   const { data: progress, isLoading: progressLoading } =
     useOnboardingProgress();
@@ -115,7 +110,7 @@ export function OnboardingProvider({ children }: { children: ReactNode }) {
   const isComplete = ONBOARDING_STEP_IDS.every((id) => desiredSteps[id]);
   const dismissed = progress?.dismissed ?? false;
   const isReady = !progressLoading && !toursLoading && !runsLoading;
-  const isResolved = (backendReady || !configured) && isReady;
+  const isResolved = backendReady && isReady;
   const isOnboardingAvailable = isResolved && hasBackend;
   const shouldShowOnboarding =
     isOnboardingAvailable && !isComplete && !dismissed;


### PR DESCRIPTION
## Description

Fixes an issue where onboarding could get stuck when the backend is unavailable (added a 5s ping timeout), and a second issue where onboarding may incorrectly redirect an onboarding user to `/dashboard` instead of `/welcome` due to an async race condition when reading backend configuration.

Onboarding is now hidden when the backend is unavailable. This is because onboarding steps are not complete or readable without a backend.

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

Open app with new/onboarding users. Confirm you get redirected to `/welcome` not `/dashboard`. Detach and unconfigure the backend and cnfirm that onboarding is no longer available.

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->