### PR TITLE
fix: component library hanging on hydration when a pipeline is opened

### DIFF
--- a/src/routes/Dashboard/DashboardComponentsV2SourceFilter.tsx
+++ b/src/routes/Dashboard/DashboardComponentsV2SourceFilter.tsx
@@ -52,11 +52,11 @@ function sourceFilterKey(source: ComponentSearchSource): string {
  * as one source category instead of several per-library toggles.
  */
 export function createSourceFilterOptions(
-  index: IndexEntry[],
+  sourced: readonly { source: ComponentSearchSource }[],
 ): SourceFilterOption[] {
   const optionsByKey = new Map<string, SourceFilterOption>();
 
-  for (const entry of index) {
+  for (const entry of sourced) {
     const key = sourceFilterKey(entry.source);
     const option = optionsByKey.get(key);
     if (option) {

--- a/src/routes/v2/pages/Editor/components/ComponentSearchResults.test.tsx
+++ b/src/routes/v2/pages/Editor/components/ComponentSearchResults.test.tsx
@@ -76,6 +76,25 @@ describe("ComponentSearchResults", () => {
     expect(screen.queryByText("Searching")).not.toBeInTheDocument();
   });
 
+  it("browses immediately for an empty query even while sources are loading", () => {
+    render(
+      <ComponentSearchResults
+        {...baseProps}
+        query=""
+        results={[]}
+        browseFolders={[{ name: "Standard library" }]}
+        isLoading
+        isSearching
+      />,
+    );
+
+    expect(
+      screen.queryByTestId("search-results-skeleton"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByTestId("search-results-container")).toBeInTheDocument();
+    expect(screen.getByText("Standard library")).toBeInTheDocument();
+  });
+
   it("shows actionable no-results guidance with clickable suggestions", () => {
     const onSuggestedSearch = vi.fn();
     render(

--- a/src/routes/v2/pages/Editor/components/ComponentSearchResults.tsx
+++ b/src/routes/v2/pages/Editor/components/ComponentSearchResults.tsx
@@ -36,7 +36,7 @@ function ComponentSearchResultsSkeleton() {
       data-testid="search-results-skeleton"
       aria-label="Loading search results"
     >
-      <Text tone="subdued" data-testid="search-results-header">
+      <Text tone="subdued" size="sm" data-testid="search-results-header">
         Search Results
       </Text>
       <Separator />
@@ -82,11 +82,11 @@ export function ComponentSearchResults({
   onClearRerank,
   onSuggestedSearch,
 }: ComponentSearchResultsProps) {
-  if (isLoading || isSearching) {
+  const isEmptyQuery = query.trim().length === 0;
+
+  if (!isEmptyQuery && (isLoading || isSearching)) {
     return <ComponentSearchResultsSkeleton />;
   }
-
-  const isEmptyQuery = query.trim().length === 0;
 
   if (isEmptyQuery) {
     return (
@@ -125,7 +125,7 @@ export function ComponentSearchResults({
       data-testid="search-results-container"
     >
       <InlineStack align="space-between" blockAlign="center" gap="2">
-        <Text tone="subdued" data-testid="search-results-header">
+        <Text tone="subdued" size="sm" data-testid="search-results-header">
           {isRerankActive ? "AI-ranked results" : "Search Results"} (
           {results.length})
         </Text>

--- a/src/routes/v2/pages/Editor/components/componentSearchV2Logic.test.ts
+++ b/src/routes/v2/pages/Editor/components/componentSearchV2Logic.test.ts
@@ -23,6 +23,7 @@ import {
   buildSourcedHydratedReferences,
   collectAllSourcedReferences,
   LEXICAL_RESULT_LIMIT,
+  mergeSearchIndexes,
   PUBLISHED_SOURCE,
   registeredLibrariesFingerprint,
   rerankedMatches,
@@ -164,6 +165,47 @@ describe("buildSourcedHydratedReferences", () => {
       ["b", "user"],
       ["a", "standard"],
     ]);
+  });
+});
+
+describe("mergeSearchIndexes", () => {
+  it("overlays hydrated entries by digest, keeps name-only entries, and appends hydrated-only ones", () => {
+    const base = buildSearchIndex(
+      [
+        {
+          reference: { digest: "a", name: "Alpha" },
+          source: source("standard"),
+        },
+        { reference: { digest: "b", name: "Bravo" }, source: USER_SOURCE },
+      ],
+      { includeNameOnly: true },
+    );
+    const hydrated = buildSearchIndex([
+      { reference: ref("a", "Alpha"), source: source("standard") },
+      { reference: ref("c", "Charlie"), source: PUBLISHED_SOURCE },
+    ]);
+
+    const merged = mergeSearchIndexes(base, hydrated);
+
+    const byDigest = new Map(merged.map((entry) => [entry.digest, entry]));
+    expect([...byDigest.keys()].sort()).toEqual(["a", "b", "c"]);
+    expect(byDigest.get("a")?.searchable.description).toContain("alpha");
+    expect(byDigest.get("b")?.searchable.description).toBe("");
+    expect(byDigest.get("c")?.source.kind).toBe("published");
+  });
+
+  it("returns the base untouched when there is nothing hydrated", () => {
+    const base = buildSearchIndex(
+      [
+        {
+          reference: { digest: "a", name: "Alpha" },
+          source: source("standard"),
+        },
+      ],
+      { includeNameOnly: true },
+    );
+
+    expect(mergeSearchIndexes(base, [])).toBe(base);
   });
 });
 

--- a/src/routes/v2/pages/Editor/components/componentSearchV2Logic.ts
+++ b/src/routes/v2/pages/Editor/components/componentSearchV2Logic.ts
@@ -172,6 +172,33 @@ export function collectAllSourcedReferences({
   return deduped;
 }
 
+/**
+ * Overlay a hydrated index onto an instant name-only base by digest: hydrated
+ * entries win where present, base entries fill in the rest, and hydrated-only
+ * entries are appended. Lets the panel search on names immediately and enrich
+ * as full-text hydration lands.
+ */
+export function mergeSearchIndexes(
+  base: IndexEntry[],
+  hydrated: IndexEntry[],
+): IndexEntry[] {
+  if (hydrated.length === 0) return base;
+
+  const hydratedByDigest = new Map<string, IndexEntry>();
+  for (const entry of hydrated) hydratedByDigest.set(entry.digest, entry);
+
+  const merged = base.map(
+    (entry) => hydratedByDigest.get(entry.digest) ?? entry,
+  );
+
+  const seen = new Set(base.map((entry) => entry.digest));
+  for (const entry of hydrated) {
+    if (!seen.has(entry.digest)) merged.push(entry);
+  }
+
+  return merged;
+}
+
 export function buildSourcedHydratedReferences({
   sourcedReferences,
   hydratedReferences,

--- a/src/routes/v2/pages/Editor/hooks/useComponentSearchV2State.ts
+++ b/src/routes/v2/pages/Editor/hooks/useComponentSearchV2State.ts
@@ -30,6 +30,7 @@ import {
   collectAllSourcedReferences,
   type ComponentSearchV2State,
   LEXICAL_RESULT_LIMIT,
+  mergeSearchIndexes,
   registeredLibrariesFingerprint,
   registeredSource,
   rerankedMatches,
@@ -164,9 +165,12 @@ export function useComponentSearchV2State(
     .sort()
     .join("|");
 
-  const { data: index = [], isLoading: isHydrating } = useQuery({
+  const trimmedQuery = query.trim();
+  const searchableQuery = pauseSearch ? "" : trimmedQuery;
+
+  const { data: hydratedIndex = [] } = useQuery({
     queryKey: ["component-search-v2", "search-index", referencesFingerprint],
-    enabled: sourcedReferences.length > 0,
+    enabled: sourcedReferences.length > 0 && searchableQuery.length > 0,
     staleTime: HOURS,
     queryFn: async (): Promise<IndexEntry[]> => {
       const results = await Promise.all(
@@ -199,16 +203,23 @@ export function useComponentSearchV2State(
     },
   });
 
+  const index = mergeSearchIndexes(
+    buildSearchIndex(sourcedReferences, { includeNameOnly: true }),
+    hydratedIndex,
+  );
+
   const [disabledSourceKeys, setDisabledSourceKeys] = useState<string[]>([]);
-  const sourceFilterOptions = createSourceFilterOptions(index);
+  const sourceFilterOptions = createSourceFilterOptions(sourcedReferences);
   const filteredIndex = filterIndexByDisabledSourceKeys(
     index,
     disabledSourceKeys,
   );
+  const disabled = new Set(disabledSourceKeys);
+  const browseSourcedReferences = sourcedReferences.filter(
+    (item) => !disabled.has(item.source.kind),
+  );
 
   const canUseEmbeddingSearch = aiConfig.apiBase.trim().length > 0;
-  const trimmedQuery = query.trim();
-  const searchableQuery = pauseSearch ? "" : trimmedQuery;
   const lexicalMatches = pauseSearch
     ? []
     : buildLexicalMatches(filteredIndex, searchableQuery);
@@ -377,7 +388,7 @@ export function useComponentSearchV2State(
     browseFolders: pauseSearch
       ? []
       : buildResultFolders({
-          results,
+          results: browseSourcedReferences,
           standardLibrary: disabledSourceKeys.includes("standard")
             ? undefined
             : standardLibrary,
@@ -396,8 +407,7 @@ export function useComponentSearchV2State(
       isLoadingUserComponents ||
       isLoadingPublished ||
       registeredLibraries === undefined ||
-      isLoadingRegistered ||
-      isHydrating,
+      isLoadingRegistered,
     canRerank:
       !pauseSearch &&
       searchableQuery.length > 0 &&

--- a/src/services/componentSearchIndex.test.ts
+++ b/src/services/componentSearchIndex.test.ts
@@ -66,6 +66,26 @@ describe("buildSearchIndex", () => {
     expect(index).toHaveLength(0);
   });
 
+  it("emits a name-only entry for unhydrated refs when includeNameOnly is set", () => {
+    const index = buildSearchIndex(
+      [makeSourced({ digest: "abc", name: "Upload to GCS" })],
+      { includeNameOnly: true },
+    );
+
+    expect(index).toHaveLength(1);
+    expect(index[0].name).toBe("Upload to GCS");
+    expect(index[0].searchable.description).toBe("");
+    expect(lexicalSearch(index, "upload")).toHaveLength(1);
+  });
+
+  it("still skips digest-less refs even with includeNameOnly", () => {
+    const index = buildSearchIndex(
+      [makeSourced({ digest: undefined, name: "no digest" })],
+      { includeNameOnly: true },
+    );
+    expect(index).toHaveLength(0);
+  });
+
   it("preserves the source on each indexed entry", () => {
     const index = buildSearchIndex([
       makeSourced(

--- a/src/services/componentSearchIndex.ts
+++ b/src/services/componentSearchIndex.ts
@@ -306,18 +306,58 @@ export function extractComponentMetadata(
   };
 }
 
+const EMPTY_SEARCHABLE: Record<MatchField, string> = {
+  name: "",
+  description: "",
+  io: "",
+  implementation: "",
+  metadata: "",
+};
+
+export interface BuildSearchIndexOptions {
+  /**
+   * Emit a name-only entry for references that have a digest but no hydrated
+   * spec yet, so the panel can offer instant name search before full text is
+   * fetched. Off by default: callers passing hydrated refs keep the stricter
+   * "skip specs with no useful metadata" behavior.
+   */
+  includeNameOnly?: boolean;
+}
+
 /**
- * Build the searchable index from sourced, hydrated component references.
+ * Build the searchable index from sourced component references.
  * References without a digest are skipped (can't round-trip an LLM rerank
- * without one). References with no useful spec metadata are also skipped —
- * they'd just be noise that ranks below every real result.
+ * without one). References with no useful spec metadata are skipped as noise
+ * that would rank below every real result — unless `includeNameOnly` is set,
+ * in which case they contribute a name-only entry.
  */
-export function buildSearchIndex(sourced: SourcedReference[]): IndexEntry[] {
+export function buildSearchIndex(
+  sourced: SourcedReference[],
+  { includeNameOnly = false }: BuildSearchIndexOptions = {},
+): IndexEntry[] {
   const entries: IndexEntry[] = [];
 
   for (const { reference, source } of sourced) {
     const metadata = extractComponentMetadata(reference);
-    if (!metadata) continue;
+    if (!metadata) {
+      if (!includeNameOnly || !reference.digest) continue;
+
+      const name = reference.name ?? getComponentName(reference);
+      const searchable: Record<MatchField, string> = {
+        ...EMPTY_SEARCHABLE,
+        name: normalizeSearchText(name),
+      };
+      entries.push({
+        reference,
+        digest: reference.digest,
+        name,
+        source,
+        searchable,
+        searchableTokens: buildSearchableTokenCache(searchable),
+        searchablePhrases: buildSearchablePhraseCache(searchable),
+      });
+      continue;
+    }
 
     const searchable: Record<MatchField, string> = {
       name: normalizeSearchText(metadata.name),


### PR DESCRIPTION
## Description

Fixes an issue where the component library could get stuck in loadfing state for a long time while it indexes and hydrates components. This appears to happen when first loading a pipeline - particularly in v2 editor.

The component library browser is now no longer gated by hydration and specific component library search results are lazily loaded when searched for.

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->