### PR TITLE
feat: Add Tours and Components to Recently Viewed

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
@@ -29,7 +29,7 @@ import { useCopyPaste } from "@/hooks/useCopyPaste";
 import { useGhostNode } from "@/hooks/useGhostNode";
 import { useIOSelectionPersistence } from "@/hooks/useIOSelectionPersistence";
 import { useNodeCallbacks } from "@/hooks/useNodeCallbacks";
-import { addRecentlyViewed } from "@/hooks/useRecentlyViewed";
+import { addRecentlyUsed } from "@/hooks/useRecentlyViewed";
 import { useSubgraphKeyboardNavigation } from "@/hooks/useSubgraphKeyboardNavigation";
 import useToastNotification from "@/hooks/useToastNotification";
 import { useUserDetails } from "@/hooks/useUserDetails";
@@ -680,7 +680,7 @@ const FlowCanvasContent = ({
 
           const ref = hydratedComponentRef;
           if (ref.digest && ref.spec?.name) {
-            addRecentlyViewed({
+            addRecentlyUsed({
               type: "component",
               id: ref.digest,
               name: ref.spec.name,
@@ -824,7 +824,7 @@ const FlowCanvasContent = ({
 
       const ref = droppedTask?.componentRef;
       if (ref?.digest && ref.spec?.name) {
-        addRecentlyViewed({
+        addRecentlyUsed({
           type: "component",
           id: ref.digest,
           name: ref.spec.name,

--- a/src/hooks/useRecentlyViewed.test.ts
+++ b/src/hooks/useRecentlyViewed.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import { parseRecent, type RecentItem } from "./useRecentlyViewed";
+
+describe("parseRecent", () => {
+  it("keeps well-formed items", () => {
+    const items: RecentItem[] = [
+      { type: "pipeline", id: "p1", name: "Pipeline", timestamp: 1 },
+      { type: "component", id: "c1", name: "Component", timestamp: 2 },
+      { type: "tour", id: "t1", name: "Tour", timestamp: 3 },
+    ];
+    expect(parseRecent(JSON.stringify(items))).toEqual(items);
+  });
+
+  it("drops entries with an unsupported type", () => {
+    const json = JSON.stringify([
+      { type: "other", id: "x", name: "X", timestamp: 1 },
+    ]);
+    expect(parseRecent(json)).toEqual([]);
+  });
+
+  it("drops entries with non-string id or name", () => {
+    const json = JSON.stringify([
+      { type: "run", id: null, name: {}, timestamp: 1 },
+    ]);
+    expect(parseRecent(json)).toEqual([]);
+  });
+
+  it("drops entries with a non-finite or non-numeric timestamp", () => {
+    const json = JSON.stringify([
+      { type: "run", id: "r1", name: "Run", timestamp: "bad" },
+      { type: "run", id: "r2", name: "Run", timestamp: null },
+    ]);
+    expect(parseRecent(json)).toEqual([]);
+  });
+
+  it("drops legacy entries that use viewedAt instead of timestamp", () => {
+    const json = JSON.stringify([
+      { type: "run", id: "r1", name: "Run", viewedAt: 1 },
+    ]);
+    expect(parseRecent(json)).toEqual([]);
+  });
+
+  it("returns an empty array for invalid JSON or non-array data", () => {
+    expect(parseRecent("not json")).toEqual([]);
+    expect(parseRecent(JSON.stringify({ not: "an array" }))).toEqual([]);
+  });
+});

--- a/src/hooks/useRecentlyViewed.ts
+++ b/src/hooks/useRecentlyViewed.ts
@@ -3,77 +3,95 @@ import { useEffect, useState } from "react";
 import { getStorage } from "@/utils/typedStorage";
 
 const RECENTLY_VIEWED_KEY = "Home/recently_viewed";
+const RECENTLY_USED_KEY = "Home/recently_used";
 const MAX_ITEMS = 100;
 
-type RecentlyViewedType = "pipeline" | "run" | "component";
+type RecentKey = typeof RECENTLY_VIEWED_KEY | typeof RECENTLY_USED_KEY;
 
-export interface RecentlyViewedItem {
-  type: RecentlyViewedType;
+const RECENT_ITEM_TYPES = ["pipeline", "run", "component", "tour"] as const;
+
+type RecentItemType = (typeof RECENT_ITEM_TYPES)[number];
+
+export interface RecentItem {
+  type: RecentItemType;
   id: string;
   name: string;
-  viewedAt: number;
+  timestamp: number;
 }
 
-type RecentlyViewedStorageMapping = {
-  [RECENTLY_VIEWED_KEY]: RecentlyViewedItem[];
+type RecentStorageMapping = {
+  [RECENTLY_VIEWED_KEY]: RecentItem[];
+  [RECENTLY_USED_KEY]: RecentItem[];
 };
 
-const storage = getStorage<
-  typeof RECENTLY_VIEWED_KEY,
-  RecentlyViewedStorageMapping
->();
+const storage = getStorage<RecentKey, RecentStorageMapping>();
 
-function isRecentlyViewedItem(item: unknown): item is RecentlyViewedItem {
+function isRecentItem(item: unknown): item is RecentItem {
+  if (typeof item !== "object" || item === null) return false;
+  const candidate = item as Record<string, unknown>;
   return (
-    typeof item === "object" &&
-    item !== null &&
-    "type" in item &&
-    "id" in item &&
-    "name" in item &&
-    "viewedAt" in item
+    RECENT_ITEM_TYPES.includes(candidate.type as RecentItemType) &&
+    typeof candidate.id === "string" &&
+    typeof candidate.name === "string" &&
+    typeof candidate.timestamp === "number" &&
+    Number.isFinite(candidate.timestamp)
   );
 }
 
-function parseRecentlyViewed(json: string): RecentlyViewedItem[] {
+export function parseRecent(json: string): RecentItem[] {
   try {
     const parsed: unknown = JSON.parse(json);
-    return Array.isArray(parsed) ? parsed.filter(isRecentlyViewedItem) : [];
+    return Array.isArray(parsed) ? parsed.filter(isRecentItem) : [];
   } catch {
     return [];
   }
 }
 
-function readRecentlyViewed(): RecentlyViewedItem[] {
-  const json = localStorage.getItem(RECENTLY_VIEWED_KEY);
-  return json ? parseRecentlyViewed(json) : [];
+function readRecent(key: RecentKey): RecentItem[] {
+  const json = localStorage.getItem(key);
+  return json ? parseRecent(json) : [];
 }
 
-export function useRecentlyViewed() {
-  const [recentlyViewed, setRecentlyViewed] =
-    useState<RecentlyViewedItem[]>(readRecentlyViewed);
+function addRecent(key: RecentKey, item: Omit<RecentItem, "timestamp">) {
+  const current = readRecent(key);
+  const deduped = current.filter(
+    (existing) => !(existing.type === item.type && existing.id === item.id),
+  );
+  const updated = [{ ...item, timestamp: Date.now() }, ...deduped].slice(
+    0,
+    MAX_ITEMS,
+  );
+  storage.setItem(key, updated);
+}
+
+function useRecent(key: RecentKey): RecentItem[] {
+  const [items, setItems] = useState<RecentItem[]>(() => readRecent(key));
 
   useEffect(() => {
     const handleStorage = (e: StorageEvent) => {
-      if (e.key === RECENTLY_VIEWED_KEY) {
-        setRecentlyViewed(readRecentlyViewed());
+      if (e.key === key) {
+        setItems(readRecent(key));
       }
     };
     window.addEventListener("storage", handleStorage);
     return () => window.removeEventListener("storage", handleStorage);
-  }, []);
+  }, [key]);
 
-  return { recentlyViewed };
+  return items;
 }
 
-export function addRecentlyViewed(item: Omit<RecentlyViewedItem, "viewedAt">) {
-  const current = readRecentlyViewed();
-  // Remove any existing entry for the same item, then prepend the fresh one
-  const deduped = current.filter(
-    (existing) => !(existing.type === item.type && existing.id === item.id),
-  );
-  const updated = [{ ...item, viewedAt: Date.now() }, ...deduped].slice(
-    0,
-    MAX_ITEMS,
-  );
-  storage.setItem(RECENTLY_VIEWED_KEY, updated);
+export function useRecentlyViewed() {
+  return { recentlyViewed: useRecent(RECENTLY_VIEWED_KEY) };
+}
+
+export function addRecentlyViewed(item: Omit<RecentItem, "timestamp">) {
+  addRecent(RECENTLY_VIEWED_KEY, item);
+}
+
+export function useRecentlyUsed() {
+  return { recentlyUsed: useRecent(RECENTLY_USED_KEY) };
+}
+
+export function addRecentlyUsed(item: Omit<RecentItem, "timestamp">) {
+  addRecent(RECENTLY_USED_KEY, item);
 }

--- a/src/routes/Dashboard/DashboardComponentsV2View.tsx
+++ b/src/routes/Dashboard/DashboardComponentsV2View.tsx
@@ -36,6 +36,7 @@ import {
   useComponentAiDescription,
   useNaturalLanguageComponentRerank,
 } from "@/hooks/useNaturalLanguageComponentSearch";
+import { addRecentlyViewed } from "@/hooks/useRecentlyViewed";
 import useToastNotification from "@/hooks/useToastNotification";
 import { cn } from "@/lib/utils";
 import { useAnalytics } from "@/providers/AnalyticsProvider";
@@ -833,6 +834,13 @@ export const DashboardComponentsV2View = () => {
       disabledSourceKeys: sourceKeys,
     });
   const selectComponent = (reference: ComponentReference) => {
+    if (reference.digest) {
+      addRecentlyViewed({
+        type: "component",
+        id: reference.digest,
+        name: getComponentName(reference),
+      });
+    }
     navigate({
       to: APP_ROUTES.DASHBOARD_COMPONENTS_V2,
       search: buildSearch({ component: reference.digest }),

--- a/src/routes/Dashboard/DashboardComponentsView.tsx
+++ b/src/routes/Dashboard/DashboardComponentsView.tsx
@@ -18,6 +18,7 @@ import { Input } from "@/components/ui/input";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Paragraph, Text } from "@/components/ui/typography";
+import { addRecentlyViewed } from "@/hooks/useRecentlyViewed";
 import { cn } from "@/lib/utils";
 import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { useBackend } from "@/providers/BackendProvider";
@@ -371,6 +372,13 @@ export function DashboardComponentsView() {
     useSearch({ strict: false }),
   );
   const handleSelect = (component: ComponentReference) => {
+    if (component.digest) {
+      addRecentlyViewed({
+        type: "component",
+        id: component.digest,
+        name: component.name ?? getComponentName(component),
+      });
+    }
     navigate({
       to: APP_ROUTES.DASHBOARD_COMPONENTS,
       search: { component: component.digest },

--- a/src/routes/Dashboard/DashboardHomeView.tsx
+++ b/src/routes/Dashboard/DashboardHomeView.tsx
@@ -10,7 +10,8 @@ import {
 } from "@/components/ui/tooltip";
 import { Heading, Paragraph, Text } from "@/components/ui/typography";
 import {
-  type RecentlyViewedItem,
+  type RecentItem,
+  useRecentlyUsed,
   useRecentlyViewed,
 } from "@/hooks/useRecentlyViewed";
 import { useAnalytics } from "@/providers/AnalyticsProvider";
@@ -45,7 +46,7 @@ const SectionHeader = ({
   </InlineStack>
 );
 
-const RecentlyViewedPreviewRow = ({ item }: { item: RecentlyViewedItem }) => (
+const RecentlyViewedPreviewRow = ({ item }: { item: RecentItem }) => (
   <InlineStack gap="2" className="min-w-0 overflow-hidden">
     <Link
       to={getRecentlyViewedUrl(item)}
@@ -62,7 +63,7 @@ const RecentlyViewedPreviewRow = ({ item }: { item: RecentlyViewedItem }) => (
         <TooltipContent>{item.name}</TooltipContent>
       </Tooltip>
       <Text size="xs" className="text-muted-foreground shrink-0">
-        {formatRelativeTime(new Date(item.viewedAt))}
+        {formatRelativeTime(new Date(item.timestamp))}
       </Text>
     </Link>
   </InlineStack>
@@ -70,9 +71,7 @@ const RecentlyViewedPreviewRow = ({ item }: { item: RecentlyViewedItem }) => (
 
 const RecentlyViewedPreview = () => {
   const { recentlyViewed } = useRecentlyViewed();
-  const preview = recentlyViewed
-    .filter((item) => item.type !== "component")
-    .slice(0, PREVIEW_COUNT);
+  const preview = recentlyViewed.slice(0, PREVIEW_COUNT);
 
   return (
     <BlockStack gap="4" className="min-w-0">
@@ -84,36 +83,54 @@ const RecentlyViewedPreview = () => {
         {preview.length === 0 ? (
           <div className="px-4 py-3">
             <Paragraph tone="subdued" size="sm">
-              Nothing viewed yet. Open a pipeline or run to see it here.
+              Nothing viewed yet. Open a pipeline, run, component, or tour to
+              see it here.
             </Paragraph>
           </div>
         ) : (
-          preview.map((item) => (
-            <RecentlyViewedPreviewRow
-              key={`${item.type}-${item.id}`}
-              item={item}
-            />
-          ))
+          preview.map((item) =>
+            item.type === "component" ? (
+              <RecentComponentPreviewRow
+                key={`${item.type}-${item.id}`}
+                item={item}
+                actionType="homepage.recently_viewed_pipelines.item"
+                surface="homepage_recently_viewed"
+              />
+            ) : (
+              <RecentlyViewedPreviewRow
+                key={`${item.type}-${item.id}`}
+                item={item}
+              />
+            ),
+          )
         )}
       </div>
     </BlockStack>
   );
 };
 
-const RecentComponentPreviewRow = ({ item }: { item: RecentlyViewedItem }) => {
+const RecentComponentPreviewRow = ({
+  item,
+  actionType = "homepage.recently_used_components.item",
+  surface = "homepage_recent",
+}: {
+  item: RecentItem;
+  actionType?: string;
+  surface?: string;
+}) => {
   const { track } = useAnalytics();
   return (
     <InlineStack gap="2" className="min-w-0 overflow-hidden">
       <Link
         to={APP_ROUTES.DASHBOARD_COMPONENTS}
         search={{ component: item.id }}
-        {...tracking("homepage.recently_used_components.item")}
+        {...tracking(actionType)}
         onClick={() => {
           track("component_library.row.click", {
             component_id: item.id,
             component_name: item.name,
             component_source: "unknown",
-            surface: "homepage_recent",
+            surface,
           });
         }}
         className="flex w-full items-center gap-3 px-4 py-3 hover:bg-muted/50 no-underline"
@@ -128,7 +145,7 @@ const RecentComponentPreviewRow = ({ item }: { item: RecentlyViewedItem }) => {
           <TooltipContent>{item.name}</TooltipContent>
         </Tooltip>
         <Text size="xs" className="text-muted-foreground shrink-0">
-          {formatRelativeTime(new Date(item.viewedAt))}
+          {formatRelativeTime(new Date(item.timestamp))}
         </Text>
       </Link>
     </InlineStack>
@@ -136,10 +153,8 @@ const RecentComponentPreviewRow = ({ item }: { item: RecentlyViewedItem }) => {
 };
 
 const RecentComponentsPreview = () => {
-  const { recentlyViewed } = useRecentlyViewed();
-  const preview = recentlyViewed
-    .filter((item) => item.type === "component")
-    .slice(0, PREVIEW_COUNT);
+  const { recentlyUsed } = useRecentlyUsed();
+  const preview = recentlyUsed.slice(0, PREVIEW_COUNT);
 
   return (
     <BlockStack gap="4" className="min-w-0">
@@ -152,7 +167,8 @@ const RecentComponentsPreview = () => {
         {preview.length === 0 ? (
           <div className="px-4 py-3">
             <Paragraph tone="subdued" size="sm">
-              No components viewed yet. Open a component to see it here.
+              No components used yet. Add a component to a pipeline to see it
+              here.
             </Paragraph>
           </div>
         ) : (

--- a/src/routes/Dashboard/DashboardRecentlyViewedView.tsx
+++ b/src/routes/Dashboard/DashboardRecentlyViewedView.tsx
@@ -5,45 +5,61 @@ import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Heading, Paragraph, Text } from "@/components/ui/typography";
-import {
-  type RecentlyViewedItem,
-  useRecentlyViewed,
-} from "@/hooks/useRecentlyViewed";
+import { type RecentItem, useRecentlyViewed } from "@/hooks/useRecentlyViewed";
+import { APP_ROUTES } from "@/routes/router";
 import { formatRelativeTime } from "@/utils/date";
 
 import { getRecentlyViewedUrl, TypePill } from "./TypePill";
 
 const PAGE_SIZE = 20;
 
-const RecentlyViewedCard = ({ item }: { item: RecentlyViewedItem }) => (
-  <Link to={getRecentlyViewedUrl(item)} className="no-underline block">
-    <BlockStack
-      gap="2"
-      className="p-3 rounded-lg transition-all shadow-sm hover:shadow-md bg-card border border-border hover:border-foreground/20 overflow-hidden"
+const RecentlyViewedCardBody = ({ item }: { item: RecentItem }) => (
+  <BlockStack
+    gap="2"
+    className="p-3 rounded-lg transition-all shadow-sm hover:shadow-md bg-card border border-border hover:border-foreground/20 overflow-hidden"
+  >
+    <InlineStack blockAlign="center" align="space-between" gap="2">
+      <TypePill type={item.type} />
+      <Text size="xs" className="text-muted-foreground">
+        {formatRelativeTime(new Date(item.timestamp))}
+      </Text>
+    </InlineStack>
+
+    <Text size="sm" weight="semibold" className="truncate leading-tight">
+      {item.name}
+    </Text>
+
+    <Text
+      size="xs"
+      className="truncate text-muted-foreground font-mono max-w-full"
     >
-      <InlineStack blockAlign="center" align="space-between">
-        <TypePill type={item.type} />
-        <Text size="xs" className="text-muted-foreground">
-          {formatRelativeTime(new Date(item.viewedAt))}
-        </Text>
-      </InlineStack>
-
-      <Text size="sm" weight="semibold" className="truncate leading-tight">
-        {item.name}
-      </Text>
-
-      <Text size="xs" className="truncate text-muted-foreground font-mono">
-        {item.id}
-      </Text>
-    </BlockStack>
-  </Link>
+      {item.id}
+    </Text>
+  </BlockStack>
 );
 
-export function DashboardRecentlyViewedView() {
-  const { recentlyViewed: allRecentlyViewed } = useRecentlyViewed();
-  const recentlyViewed = allRecentlyViewed.filter(
-    (item) => item.type !== "component",
+const RecentlyViewedCard = ({ item }: { item: RecentItem }) => {
+  if (item.type === "component") {
+    return (
+      <Link
+        to={APP_ROUTES.DASHBOARD_COMPONENTS}
+        search={{ component: item.id }}
+        className="no-underline block"
+      >
+        <RecentlyViewedCardBody item={item} />
+      </Link>
+    );
+  }
+
+  return (
+    <Link to={getRecentlyViewedUrl(item)} className="no-underline block">
+      <RecentlyViewedCardBody item={item} />
+    </Link>
   );
+};
+
+export function DashboardRecentlyViewedView() {
+  const { recentlyViewed } = useRecentlyViewed();
   const [page, setPage] = useState(0);
 
   const totalPages = Math.ceil(recentlyViewed.length / PAGE_SIZE);
@@ -59,7 +75,8 @@ export function DashboardRecentlyViewedView() {
 
       {recentlyViewed.length === 0 ? (
         <Paragraph tone="subdued" size="sm">
-          Nothing viewed yet. Open a pipeline or run to see it here.
+          Nothing viewed yet. Open a pipeline, run, component, or tour to see it
+          here.
         </Paragraph>
       ) : (
         <BlockStack gap="4">

--- a/src/routes/Dashboard/Learn/Tour.tsx
+++ b/src/routes/Dashboard/Learn/Tour.tsx
@@ -7,11 +7,13 @@ import {
 } from "@tanstack/react-router";
 import { useEffect, useRef, useState } from "react";
 
+import { tours } from "@/components/Learn/tours";
 import {
   getTour,
   type TourDefinition,
 } from "@/components/Learn/tours/registry";
 import { useFlagValue } from "@/components/shared/Settings/useFlags";
+import { addRecentlyViewed } from "@/hooks/useRecentlyViewed";
 import useToastNotification from "@/hooks/useToastNotification";
 import { useBackend } from "@/providers/BackendProvider";
 import {
@@ -220,6 +222,15 @@ function TourPageBody({
       clearLayout(TOUR_WINDOW_LAYOUT_ID);
     };
   }, []);
+
+  useEffect(() => {
+    addRecentlyViewed({
+      type: "tour",
+      id: tourId,
+      name:
+        tours.find((t) => t.id === tourId)?.title ?? tour.displayName ?? tourId,
+    });
+  }, [tourId, tour]);
 
   useEffect(() => {
     setResolved(null);

--- a/src/routes/Dashboard/TypePill.tsx
+++ b/src/routes/Dashboard/TypePill.tsx
@@ -1,12 +1,12 @@
 import { Icon, type IconName } from "@/components/ui/icon";
 import type { FavoriteItem } from "@/hooks/useFavorites";
-import type { RecentlyViewedItem } from "@/hooks/useRecentlyViewed";
+import type { RecentItem } from "@/hooks/useRecentlyViewed";
 import { cn } from "@/lib/utils";
 import { getDefaultEditorPath } from "@/routes/editorRoutes";
 import { APP_ROUTES } from "@/routes/router";
 import { getDefaultRunPath } from "@/routes/runRoutes";
 
-type ItemType = "pipeline" | "run" | "component";
+type ItemType = "pipeline" | "run" | "component" | "tour";
 
 const TYPE_CONFIG: Record<
   ItemType,
@@ -28,6 +28,11 @@ const TYPE_CONFIG: Record<
     className: "bg-sky-100 text-sky-700 dark:bg-sky-500/15 dark:text-sky-300",
     icon: "Package",
     label: "Component",
+  },
+  tour: {
+    className: "bg-amber-100 text-amber-700",
+    icon: "Compass",
+    label: "Tour",
   },
 };
 
@@ -58,8 +63,9 @@ export function getFavoriteUrl(item: FavoriteItem): string {
   return getDefaultRunPath(item.id);
 }
 
-export function getRecentlyViewedUrl(item: RecentlyViewedItem): string {
+export function getRecentlyViewedUrl(item: RecentItem): string {
   if (item.type === "pipeline") return getDefaultEditorPath(item.id);
   if (item.type === "run") return getDefaultRunPath(item.id);
+  if (item.type === "tour") return `${APP_ROUTES.TOUR}/${item.id}`;
   return APP_ROUTES.DASHBOARD_COMPONENTS;
 }

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -112,9 +112,9 @@ const dashboardComponentsRoute = createRoute({
   getParentRoute: () => dashboardRoute,
   path: "/components",
   component: DashboardComponentsView,
-  beforeLoad: () => {
+  beforeLoad: ({ search }) => {
     if (isFlagEnabled("component-search-v2")) {
-      throw redirect({ to: APP_ROUTES.DASHBOARD_COMPONENTS_V2 });
+      throw redirect({ to: APP_ROUTES.DASHBOARD_COMPONENTS_V2, search });
     }
   },
 });
@@ -123,9 +123,9 @@ const dashboardComponentsV2Route = createRoute({
   getParentRoute: () => dashboardRoute,
   path: "/components-v2",
   component: DashboardComponentsV2View,
-  beforeLoad: () => {
+  beforeLoad: ({ search }) => {
     if (!isFlagEnabled("component-search-v2")) {
-      throw redirect({ to: APP_ROUTES.DASHBOARD_COMPONENTS });
+      throw redirect({ to: APP_ROUTES.DASHBOARD_COMPONENTS, search });
     }
   },
 });


### PR DESCRIPTION
## Description

Building on the recent Learning Hub additions and new Component Browser two new card types have been added to the "Recently Viewed" section: components & guided tours.

Also, for completeness in terminology the existing "recently used" components section has had internal code renamed from "Recenlty viewed" to "recently used" so there is a clear distinction between components that have been used vs viewed and the separation between the two lists. 



This also means that the recently used has been split out from recently viewed in local storage. This will reset all user's recently viewed / recently used lists - but these are low impact features so I consider the reset to be okay.

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

- [x] New feature
- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

![image.png](https://app.graphite.com/user-attachments/assets/70c36483-d10c-4c94-92dd-b1d6efb99d7f.png)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->