### PR TITLE
feat: rename subgraphs from inside the subgraph

### DIFF
--- a/src/models/componentSpec/entities/componentSpec.ts
+++ b/src/models/componentSpec/entities/componentSpec.ts
@@ -225,6 +225,9 @@ export class ComponentSpec extends Model({
     if (this.tasks.some((t) => t.name === newName && t.$id !== entityId))
       return false;
     task.name = newName;
+    if (task.subgraphSpec) {
+      task.componentRef = { ...task.componentRef, name: newName };
+    }
     return true;
   }
 

--- a/src/routes/v2/pages/Editor/components/PipelineDetailsContent/PipelineDetailsContent.tsx
+++ b/src/routes/v2/pages/Editor/components/PipelineDetailsContent/PipelineDetailsContent.tsx
@@ -5,6 +5,7 @@ import { Icon } from "@/components/ui/icon";
 import { BlockStack } from "@/components/ui/layout";
 import { Separator } from "@/components/ui/separator";
 import { Text } from "@/components/ui/typography";
+import useToastNotification from "@/hooks/useToastNotification";
 import { serializeComponentSpecToYaml } from "@/models/componentSpec";
 import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { AnnotationsBlock } from "@/routes/v2/pages/Editor/components/AnnotationsBlock/AnnotationsBlock";
@@ -30,7 +31,8 @@ export const PipelineDetailsContent = observer(
     const { track } = useAnalytics();
     const { navigation } = useSharedStores();
     const pipelineSpec = useSpec();
-    const { updatePipelineDescription, updatePipelineNotes } =
+    const notify = useToastNotification();
+    const { updatePipelineDescription, updatePipelineNotes, renameSubgraph } =
       usePipelineActions();
 
     if (!pipelineSpec) {
@@ -67,6 +69,16 @@ export const PipelineDetailsContent = observer(
       }
     };
 
+    const handleRenameSubgraph = (newName: string): boolean => {
+      const success = renameSubgraph(newName);
+      if (success) {
+        track("v2.pipeline_editor.subgraph_details.rename.completed");
+      } else {
+        notify("A subgraph with that name already exists", "error");
+      }
+      return success;
+    };
+
     return (
       <BlockStack
         className="h-full min-h-0 w-full"
@@ -79,6 +91,7 @@ export const PipelineDetailsContent = observer(
           isNestedSubgraph={isNestedSubgraph}
           pipelineName={pipelineSpec.name}
           yamlText={yamlText}
+          onRenameSubgraph={handleRenameSubgraph}
         />
 
         <Separator />

--- a/src/routes/v2/pages/Editor/components/PipelineDetailsContent/components/PipelineDetailsHeader.tsx
+++ b/src/routes/v2/pages/Editor/components/PipelineDetailsContent/components/PipelineDetailsHeader.tsx
@@ -1,7 +1,12 @@
+import { useRef, useState } from "react";
+
+import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
+import { Input } from "@/components/ui/input";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Text } from "@/components/ui/typography";
 import type { NavigationEntry } from "@/routes/v2/shared/store/navigationStore";
+import { tracking } from "@/utils/tracking";
 
 import { PipelineDigestBar } from "./PipelineDigestBar";
 import { PipelineNavigationBreadcrumb } from "./PipelineNavigationBreadcrumb";
@@ -13,6 +18,7 @@ interface PipelineDetailsHeaderProps {
   isNestedSubgraph: boolean;
   pipelineName: string;
   yamlText: string;
+  onRenameSubgraph?: (newName: string) => boolean;
 }
 
 export function PipelineDetailsHeader({
@@ -22,7 +28,29 @@ export function PipelineDetailsHeader({
   isNestedSubgraph,
   pipelineName,
   yamlText,
+  onRenameSubgraph,
 }: PipelineDetailsHeaderProps) {
+  const [isRenaming, setIsRenaming] = useState(false);
+  const renameInputRef = useRef<HTMLInputElement>(null);
+
+  const canRename = isNestedSubgraph && onRenameSubgraph !== undefined;
+
+  const handleRenameSubmit = () => {
+    const newName = renameInputRef.current?.value.trim();
+    setIsRenaming(false);
+    if (newName && newName !== pipelineName) {
+      onRenameSubgraph?.(newName);
+    }
+  };
+
+  const startRename = () => {
+    setIsRenaming(true);
+    requestAnimationFrame(() => {
+      renameInputRef.current?.focus();
+      renameInputRef.current?.select();
+    });
+  };
+
   return (
     <BlockStack gap="2" className="shrink-0 px-4 pb-2 pt-3">
       <PipelineNavigationBreadcrumb
@@ -39,9 +67,42 @@ export function PipelineDetailsHeader({
         {isNestedSubgraph && (
           <Icon name="Workflow" size="sm" className="shrink-0" />
         )}
-        <Text size="md" weight="semibold" className="wrap-anywhere min-w-0">
-          {pipelineName}
-        </Text>
+        {canRename && isRenaming ? (
+          <Input
+            ref={renameInputRef}
+            defaultValue={pipelineName}
+            className="h-7 text-sm font-semibold flex-1 min-w-0"
+            onBlur={handleRenameSubmit}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") handleRenameSubmit();
+              if (e.key === "Escape") setIsRenaming(false);
+            }}
+          />
+        ) : canRename ? (
+          <div className="group min-w-0 flex items-baseline gap-1">
+            <Text
+              size="md"
+              weight="semibold"
+              className="wrap-anywhere select-text"
+            >
+              {pipelineName}
+            </Text>
+            <Button
+              variant="ghost"
+              size="inline-xs"
+              className="shrink-0 p-0 text-muted-foreground hover:bg-transparent hover:text-foreground opacity-0 group-hover:opacity-100 transition-opacity"
+              onClick={startRename}
+              aria-label="Rename subgraph"
+              {...tracking("v2.pipeline_editor.subgraph_details.rename_start")}
+            >
+              <Icon name="Pencil" size="xs" />
+            </Button>
+          </div>
+        ) : (
+          <Text size="md" weight="semibold" className="wrap-anywhere min-w-0">
+            {pipelineName}
+          </Text>
+        )}
       </InlineStack>
 
       <PipelineDigestBar

--- a/src/routes/v2/pages/Editor/hooks/usePipelineDetailsWindow.tsx
+++ b/src/routes/v2/pages/Editor/hooks/usePipelineDetailsWindow.tsx
@@ -6,12 +6,15 @@ import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 const PIPELINE_DETAILS_WINDOW_ID = "pipeline-details";
 
 export function usePipelineDetailsWindow() {
-  const { windows } = useSharedStores();
+  const { windows, navigation } = useSharedStores();
+  const isNestedSubgraph = navigation.navigationDepth > 0;
+  const title = isNestedSubgraph ? "Subgraph Details" : "Pipeline Details";
+
   useEffect(() => {
     if (!windows.getWindowById(PIPELINE_DETAILS_WINDOW_ID)) {
       windows.openWindow(<PipelineDetailsContent />, {
         id: PIPELINE_DETAILS_WINDOW_ID,
-        title: "Pipeline Details",
+        title,
         position: { x: 0, y: 460 },
         size: { width: 280, height: 350 },
         disabledActions: ["close"],
@@ -19,5 +22,9 @@ export function usePipelineDetailsWindow() {
         defaultDockState: "right",
       });
     }
-  }, [windows]);
+  }, [windows, title]);
+
+  useEffect(() => {
+    windows.getWindowById(PIPELINE_DETAILS_WINDOW_ID)?.setTitle(title);
+  }, [windows, title]);
 }

--- a/src/routes/v2/pages/Editor/store/actions/pipeline.actions.ts
+++ b/src/routes/v2/pages/Editor/store/actions/pipeline.actions.ts
@@ -7,6 +7,7 @@ import {
 } from "@/models/componentSpec";
 import { generateUniqueTaskName } from "@/routes/v2/pages/Editor/store/nameUtils";
 import type { UndoGroupable } from "@/routes/v2/shared/nodes/types";
+import type { NavigationStore } from "@/routes/v2/shared/store/navigationStore";
 import {
   EDITOR_POSITION_ANNOTATION,
   PIPELINE_NOTES_ANNOTATION,
@@ -24,6 +25,16 @@ export function renamePipeline(
     spec.setName(newName);
     return true;
   });
+}
+
+export function renameSubgraph(
+  undo: UndoGroupable,
+  navigation: NavigationStore,
+  newName: string,
+): boolean {
+  return undo.withGroup("Rename subgraph", () =>
+    navigation.renameCurrentSubgraph(newName),
+  );
 }
 
 export function updatePipelineDescription(

--- a/src/routes/v2/pages/Editor/store/actions/usePipelineActions.ts
+++ b/src/routes/v2/pages/Editor/store/actions/usePipelineActions.ts
@@ -1,8 +1,10 @@
 import { useEditorSession } from "@/routes/v2/pages/Editor/store/EditorSessionContext";
+import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 
 import {
   createSubgraph,
   renamePipeline,
+  renameSubgraph,
   updatePipelineDescription,
   updatePipelineNotes,
   updatePipelineTags,
@@ -10,9 +12,11 @@ import {
 
 export function usePipelineActions() {
   const { undo } = useEditorSession();
+  const { navigation } = useSharedStores();
 
   return {
     renamePipeline: renamePipeline.bind(null, undo),
+    renameSubgraph: renameSubgraph.bind(null, undo, navigation),
     updatePipelineDescription: updatePipelineDescription.bind(null, undo),
     updatePipelineNotes: updatePipelineNotes.bind(null, undo),
     updatePipelineTags: updatePipelineTags.bind(null, undo),

--- a/src/routes/v2/shared/store/navigationStore.ts
+++ b/src/routes/v2/shared/store/navigationStore.ts
@@ -142,6 +142,44 @@ export class NavigationStore {
   }
 
   /**
+   * Renames the subgraph at the current navigation depth (depth >= 1) by
+   * renaming the owning task in the parent spec — the same operation a regular
+   * task rename performs. Also re-syncs the nested spec name and the navigation
+   * path key so the subgraph keeps resolving via `getSpecAtDepth`.
+   *
+   * Returns false when at the root level, the name is empty or unchanged, the
+   * owning task can't be found, or the rename collides with a sibling.
+   */
+  @action renameCurrentSubgraph(newName: string): boolean {
+    const trimmed = newName.trim();
+    if (!trimmed) return false;
+
+    const depth = this.navigationDepth;
+    if (depth === 0) return false;
+
+    const oldName = this.navigationPath[depth].displayName;
+    if (oldName === trimmed) return false;
+
+    const parentSpec = this.getSpecAtDepth(depth - 1);
+    if (!parentSpec) return false;
+
+    const task = parentSpec.tasks.find((t) => t.name === oldName);
+    if (!task) return false;
+
+    const nestedSpec = this.getSpecAtDepth(depth);
+
+    if (!parentSpec.renameTask(task.$id, trimmed)) return false;
+
+    nestedSpec?.setName(trimmed);
+
+    const newPath = [...this.navigationPath];
+    newPath[depth] = { ...newPath[depth], displayName: trimmed };
+    this.navigationPath = newPath;
+
+    return true;
+  }
+
+  /**
    * Trims navigationPath to the deepest level that still resolves to a valid
    * spec. Handles cases where undo/redo removes a subgraph the user is viewing.
    */

--- a/src/routes/v2/shared/windows/windowModel.ts
+++ b/src/routes/v2/shared/windows/windowModel.ts
@@ -205,6 +205,10 @@ export class WindowModel {
     this.store.bringToFront(this.id);
   }
 
+  @action setTitle(title: string): void {
+    this.title = title;
+  }
+
   @action updatePosition(pos: Position): void {
     this.position = pos;
   }


### PR DESCRIPTION
## Description

Adds an edit button to a subgraph name when inside a subgraph. This allows the name of the subgraph to be edited whilst inside it & looking at the contents.

UX/flow is exactly the same as renaming tasks.

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

- [x] New feature
- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

![image.png](https://app.graphite.com/user-attachments/assets/bb3f77da-b5f8-4387-a88a-099cf2f636dd.png)

![image.png](https://app.graphite.com/user-attachments/assets/c2bb6234-7c5b-4b10-988b-abbfe839cc9b.png)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

In V2 editor open a pipeline with a subgraph on it. Go inside the subgraph. In the "Subgraph Details" window confirm that you can edit the subgraph name by clicking the edit icon that appears when hovering the title text. Confirm the name update propagates through to all o the expected places.

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->