### PR TITLE
feat: dark mode

### DIFF
--- a/react-compiler.config.js
+++ b/react-compiler.config.js
@@ -80,6 +80,7 @@ export const REACT_COMPILER_ENABLED_DIRS = [
   "src/providers/DialogProvider",
   "src/providers/TourProvider",
   "src/providers/OnboardingProvider",
+  "src/providers/ThemeProvider.tsx",
   "src/routes/EditorV2",
 
   // 11-20 useCallback/useMemo

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,6 +8,7 @@ import ReactDOM from "react-dom/client";
 import { scan } from "react-scan";
 
 import { ErrorBoundary } from "@/components/shared/ErrorBoundary";
+import { ThemeProvider } from "@/providers/ThemeProvider";
 
 import { router } from "./routes/router";
 import { initializeBugsnag } from "./services/errorManagement/bugsnag";
@@ -27,11 +28,13 @@ if (!rootElement.innerHTML) {
   const root = ReactDOM.createRoot(rootElement);
   root.render(
     <StrictMode>
-      <ErrorBoundary>
-        <QueryClientProvider client={queryClient}>
-          <RouterProvider router={router} />
-        </QueryClientProvider>
-      </ErrorBoundary>
+      <ThemeProvider>
+        <ErrorBoundary>
+          <QueryClientProvider client={queryClient}>
+            <RouterProvider router={router} />
+          </QueryClientProvider>
+        </ErrorBoundary>
+      </ThemeProvider>
     </StrictMode>,
   );
 }

--- a/src/providers/ThemeProvider.tsx
+++ b/src/providers/ThemeProvider.tsx
@@ -1,0 +1,81 @@
+import type { ReactNode } from "react";
+import { useEffect, useLayoutEffect, useState } from "react";
+
+import {
+  createRequiredContext,
+  useRequiredContext,
+} from "@/hooks/useRequiredContext";
+import { getStorage } from "@/utils/typedStorage";
+
+export type Theme = "light" | "dark" | "system";
+export type ResolvedTheme = "light" | "dark";
+
+const THEME_STORAGE_KEY = "App/theme";
+
+const themeStorage = getStorage<
+  typeof THEME_STORAGE_KEY,
+  Record<typeof THEME_STORAGE_KEY, Theme>
+>();
+
+interface ThemeContextValue {
+  theme: Theme;
+  resolvedTheme: ResolvedTheme;
+  setTheme: (theme: Theme) => void;
+}
+
+const ThemeContext = createRequiredContext<ThemeContextValue>("ThemeContext");
+
+const DARK_MEDIA_QUERY = "(prefers-color-scheme: dark)";
+
+function getSystemTheme(): ResolvedTheme {
+  return window.matchMedia(DARK_MEDIA_QUERY).matches ? "dark" : "light";
+}
+
+function readStoredTheme(): Theme {
+  const stored = themeStorage.getItem(THEME_STORAGE_KEY);
+  if (stored === "light" || stored === "dark" || stored === "system") {
+    return stored;
+  }
+  return "system";
+}
+
+function applyTheme(resolved: ResolvedTheme) {
+  const root = document.documentElement;
+  root.classList.toggle("dark", resolved === "dark");
+  root.classList.toggle("light", resolved === "light");
+  root.style.colorScheme = resolved;
+}
+
+export const ThemeProvider = ({ children }: { children: ReactNode }) => {
+  const [theme, setThemeState] = useState<Theme>(readStoredTheme);
+  const [systemTheme, setSystemTheme] = useState<ResolvedTheme>(getSystemTheme);
+
+  const resolvedTheme = theme === "system" ? systemTheme : theme;
+
+  // Follow OS-level changes so "system" stays accurate while it's selected.
+  useEffect(() => {
+    const media = window.matchMedia(DARK_MEDIA_QUERY);
+    const handleChange = (event: MediaQueryListEvent) => {
+      setSystemTheme(event.matches ? "dark" : "light");
+    };
+    media.addEventListener("change", handleChange);
+    return () => media.removeEventListener("change", handleChange);
+  }, []);
+
+  useLayoutEffect(() => {
+    applyTheme(resolvedTheme);
+  }, [resolvedTheme]);
+
+  const setTheme = (next: Theme) => {
+    setThemeState(next);
+    themeStorage.setItem(THEME_STORAGE_KEY, next);
+  };
+
+  return (
+    <ThemeContext value={{ theme, resolvedTheme, setTheme }}>
+      {children}
+    </ThemeContext>
+  );
+};
+
+export const useTheme = () => useRequiredContext(ThemeContext);

--- a/src/routes/Settings/sections/PreferencesSettings.tsx
+++ b/src/routes/Settings/sections/PreferencesSettings.tsx
@@ -1,7 +1,9 @@
 import { Settings } from "@/components/shared/Settings/Settings";
+import { BlockStack } from "@/components/ui/layout";
 import { useAnalytics } from "@/providers/AnalyticsProvider";
 
 import { useSettingsFlags } from "../SettingsFlagsContext";
+import { ThemeSetting } from "./ThemeSetting";
 
 export function PreferencesSettings() {
   const { settings, handleSetFlag } = useSettingsFlags();
@@ -16,5 +18,10 @@ export function PreferencesSettings() {
     handleSetFlag(key, enabled);
   };
 
-  return <Settings settings={settings} onChange={handleChange} />;
+  return (
+    <BlockStack gap="6">
+      <ThemeSetting />
+      <Settings settings={settings} onChange={handleChange} />
+    </BlockStack>
+  );
 }

--- a/src/routes/Settings/sections/ThemeSetting.tsx
+++ b/src/routes/Settings/sections/ThemeSetting.tsx
@@ -1,0 +1,55 @@
+import { Button } from "@/components/ui/button";
+import { Icon, type IconName } from "@/components/ui/icon";
+import { BlockStack } from "@/components/ui/layout";
+import { Paragraph } from "@/components/ui/typography";
+import { cn } from "@/lib/utils";
+import { type Theme, useTheme } from "@/providers/ThemeProvider";
+import { tracking } from "@/utils/tracking";
+
+const THEME_OPTIONS: { value: Theme; label: string; icon: IconName }[] = [
+  { value: "light", label: "Light", icon: "Sun" },
+  { value: "dark", label: "Dark", icon: "Moon" },
+  { value: "system", label: "System", icon: "Monitor" },
+];
+
+export function ThemeSetting() {
+  const { theme, setTheme } = useTheme();
+
+  return (
+    <BlockStack gap="2">
+      <BlockStack>
+        <Paragraph>Appearance</Paragraph>
+        <Paragraph size="sm" tone="subdued">
+          Choose how Tangle looks. System follows your device settings.
+        </Paragraph>
+      </BlockStack>
+      <div
+        role="radiogroup"
+        aria-label="Theme"
+        className="flex w-fit gap-1 rounded-md border border-border p-0.5"
+      >
+        {THEME_OPTIONS.map((option) => {
+          const isActive = theme === option.value;
+          return (
+            <Button
+              key={option.value}
+              variant={isActive ? "secondary" : "ghost"}
+              size="sm"
+              role="radio"
+              aria-checked={isActive}
+              onClick={() => setTheme(option.value)}
+              className={cn(!isActive && "text-muted-foreground")}
+              data-testid={`theme-option-${option.value}`}
+              {...tracking("settings.appearance.theme_select", {
+                theme: option.value,
+              })}
+            >
+              <Icon name={option.icon} size="sm" />
+              {option.label}
+            </Button>
+          );
+        })}
+      </div>
+    </BlockStack>
+  );
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -103,6 +103,14 @@ code {
   --edge-selected: #5b2ef4;
 }
 
+@media (prefers-color-scheme: dark) {
+  html:not(.light):not(.dark) {
+    --background: oklch(0.145 0 0);
+    --foreground: oklch(0.985 0 0);
+    color-scheme: dark;
+  }
+}
+
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);


### PR DESCRIPTION
## Description

Adds a setting to settings > preferences for dark mode.



No changes to exisiting css classes - refinement and fine-tuning of the darkmode theme will come int he enxt few prs

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

- [x] New feature
- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

![image.png](https://app.graphite.com/user-attachments/assets/475f3b22-4e63-4508-b293-942fd9bc4cec.png)



<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->