### PR TITLE
chore: token migration phase 2

### DIFF
--- a/src/components/layout/AppMenu.tsx
+++ b/src/components/layout/AppMenu.tsx
@@ -141,7 +141,7 @@ const DefaultAppMenu = () => {
               <Icon
                 name="X"
                 size="xs"
-                className="absolute bottom-1.5 right-1.5 bg-foreground rounded-full"
+                className="absolute bottom-1.5 right-1.5 bg-stone-900 rounded-full"
               />
             </TooltipButton>
           ) : (

--- a/src/components/shared/BetaFeatureWrapper/BetaFeatureWrapper.tsx
+++ b/src/components/shared/BetaFeatureWrapper/BetaFeatureWrapper.tsx
@@ -37,7 +37,7 @@ export function BetaFeatureWrapper({
     >
       <Tooltip>
         <TooltipTrigger asChild>
-          <div className="absolute -right-2 -top-2 flex size-6 cursor-help items-center justify-center rounded-full border border-amber-400 bg-amber-100">
+          <div className="absolute -right-2 -top-2 flex size-6 cursor-help items-center justify-center rounded-full border border-amber-400 bg-amber-100 dark:border-amber-500/60 dark:bg-amber-500/25">
             <Icon name="FlaskConical" size="sm" className="text-amber-600" />
           </div>
         </TooltipTrigger>

--- a/src/components/shared/Dialogs/ComponentDuplicateDialog.tsx
+++ b/src/components/shared/Dialogs/ComponentDuplicateDialog.tsx
@@ -171,13 +171,13 @@ const ComponentDuplicateDialog = ({
             <Input
               value={existingComponent?.name ?? ""}
               readOnly
-              className="text-xs border-blue-200 bg-blue-100/50"
+              className="text-xs border-blue-200 bg-blue-100/50 dark:border-blue-500/30 dark:bg-blue-500/15"
             />
             <Label className="text-xs font-medium">Digest</Label>
             <Input
               value={existingComponent?.componentRef.digest ?? ""}
               readOnly
-              className="text-xs border-blue-200 bg-blue-100/50"
+              className="text-xs border-blue-200 bg-blue-100/50 dark:border-blue-500/30 dark:bg-blue-500/15"
             />
           </BlockStack>
         </InfoBox>

--- a/src/components/shared/GitHubAuth/AuthorizationResultScreen.tsx
+++ b/src/components/shared/GitHubAuth/AuthorizationResultScreen.tsx
@@ -2,7 +2,7 @@ import { Spinner } from "@/components/ui/spinner";
 
 export function AuthorizationResultScreen() {
   return (
-    <div className="flex items-center justify-center min-h-screen bg-white">
+    <div className="flex items-center justify-center min-h-screen bg-white dark:bg-background">
       <Spinner size={40} />
     </div>
   );

--- a/src/components/shared/HuggingFaceAuth/AuthorizationResultScreen.tsx
+++ b/src/components/shared/HuggingFaceAuth/AuthorizationResultScreen.tsx
@@ -13,7 +13,7 @@ export function AuthorizationResultScreen() {
 
   return (
     <BlockStack
-      className="min-h-screen bg-white"
+      className="min-h-screen bg-white dark:bg-background"
       align="center"
       inlineAlign="center"
       gap="4"

--- a/src/components/shared/ImportPipeline.tsx
+++ b/src/components/shared/ImportPipeline.tsx
@@ -225,18 +225,22 @@ const ImportPipeline = ({
           )}
 
           {successMessage && (
-            <div className="border border-green-200 bg-green-50 p-3 rounded-md mt-4">
-              <h4 className="text-green-600 font-medium mb-1">
+            <div className="border border-green-200 bg-green-50 p-3 rounded-md mt-4 dark:border-green-500/30 dark:bg-green-500/10">
+              <h4 className="text-green-600 font-medium mb-1 dark:text-green-300">
                 Import Successful
               </h4>
-              <p className="text-green-500 text-sm">{successMessage}</p>
+              <p className="text-green-500 text-sm dark:text-green-400">
+                {successMessage}
+              </p>
             </div>
           )}
 
           {error && (
-            <div className="border border-red-200 bg-red-50 p-3 rounded-md mt-4">
-              <h4 className="text-red-600 font-medium mb-1">Import Failed</h4>
-              <p className="text-red-500 text-sm whitespace-pre-wrap">
+            <div className="border border-red-200 bg-red-50 p-3 rounded-md mt-4 dark:border-red-500/30 dark:bg-red-500/10">
+              <h4 className="text-red-600 font-medium mb-1 dark:text-red-300">
+                Import Failed
+              </h4>
+              <p className="text-red-500 text-sm whitespace-pre-wrap dark:text-red-400">
                 {error}
               </p>
             </div>

--- a/src/components/shared/ManageComponent/PublishedComponentBadge.tsx
+++ b/src/components/shared/ManageComponent/PublishedComponentBadge.tsx
@@ -46,7 +46,7 @@ export const PublishedComponentBadge = withSuspenseWrapper(
                 "p-0.5",
                 isOutdated
                   ? "text-orange-500 hover:text-orange-700"
-                  : "text-muted-foreground hover:text-gray-800",
+                  : "text-muted-foreground hover:text-gray-800 dark:hover:text-foreground",
               )}
             >
               <InlineStack gap="1">

--- a/src/components/shared/PipelineRunDisplay/RunOverview.tsx
+++ b/src/components/shared/PipelineRunDisplay/RunOverview.tsx
@@ -90,7 +90,7 @@ const RunOverview = ({
     <div
       onClick={handleClick}
       className={cn(
-        "flex flex-col p-2 text-sm hover:bg-gray-50 cursor-pointer",
+        "flex flex-col p-2 text-sm hover:bg-gray-50 cursor-pointer dark:hover:bg-muted",
         className,
       )}
     >

--- a/src/components/shared/ReactFlow/FlowCanvas/Multiselect/SelectionToolbar.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/Multiselect/SelectionToolbar.tsx
@@ -25,7 +25,7 @@ const SelectionToolbar = ({
   return (
     <InlineStack
       gap="1"
-      className="bg-white border border-[#0059dc66] border-b-0 rounded-xs"
+      className="bg-card border border-[#0059dc66] border-b-0 rounded-xs"
       data-testid="selection-toolbar"
     >
       <ToolbarButton

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/ArgumentInputField.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/ArgumentInputField.tsx
@@ -116,7 +116,7 @@ const PlainArgumentInput = ({
                 "border-red-200",
               argument.isRemoved &&
                 argument.inputSpec.optional &&
-                "border-gray-300 text-muted-foreground",
+                "border-gray-300 text-muted-foreground dark:border-border",
               argument.isRemoved &&
                 "opacity-80 focus:opacity-100 border-dashed",
             )}

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeInputs.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeInputs.tsx
@@ -251,7 +251,7 @@ export function TaskNodeInputs({
             />
           </div>
           <InlineStack blockAlign="center" className="rounded-md relative">
-            <div className="text-xs text-blue-600! rounded-md px-2 py-1 bg-blue-50 border border-blue-200 border-dashed">
+            <div className="text-xs text-blue-600! rounded-md px-2 py-1 bg-blue-50 border border-blue-200 border-dashed dark:text-blue-300! dark:bg-blue-500/15 dark:border-blue-500/40">
               + Add Input
             </div>
           </InlineStack>

--- a/src/components/shared/ReactFlow/FlowControls/FlowControls.tsx
+++ b/src/components/shared/ReactFlow/FlowControls/FlowControls.tsx
@@ -108,7 +108,7 @@ export default function FlowControls({
       {!props.showInteractive && (
         <ControlButton
           onClick={handleLockChange}
-          className={cn(lockActive && "bg-gray-100!")}
+          className={cn(lockActive && "bg-gray-100! dark:bg-accent!")}
           {...tracking("pipeline_canvas.tool_bar.tool", {
             tool: "lock_unlock",
             page_type: pageType,
@@ -123,7 +123,7 @@ export default function FlowControls({
       )}
       <ControlButton
         onClick={onClickMultiSelect}
-        className={cn(multiSelectActive && "bg-gray-100!")}
+        className={cn(multiSelectActive && "bg-gray-100! dark:bg-accent!")}
         {...tracking("pipeline_canvas.tool_bar.tool", {
           tool: "area_select",
           page_type: pageType,

--- a/src/components/shared/ReactFlow/FlowSidebar/components/ComponentItem.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/components/ComponentItem.tsx
@@ -87,10 +87,11 @@ const ComponentIcon = withSuspenseWrapper(
 );
 
 function rerankScoreClass(score: number): string {
-  if (score >= 0.9) return "text-emerald-700 bg-emerald-50 border-emerald-200";
+  if (score >= 0.9)
+    return "text-emerald-700 bg-emerald-50 border-emerald-200 dark:text-emerald-300 dark:bg-emerald-500/15 dark:border-emerald-500/30";
   if (score >= 0.75)
-    return "text-emerald-600 bg-emerald-50/70 border-emerald-100";
-  return "text-emerald-500 bg-white border-emerald-100";
+    return "text-emerald-600 bg-emerald-50/70 border-emerald-100 dark:text-emerald-300 dark:bg-emerald-500/10 dark:border-emerald-500/25";
+  return "text-emerald-500 bg-white border-emerald-100 dark:bg-emerald-500/15 dark:border-emerald-500/30";
 }
 
 const ComponentMarkup = ({

--- a/src/components/shared/ReactFlow/FlowSidebar/components/ImportComponent.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/components/ImportComponent.tsx
@@ -224,7 +224,7 @@ const ImportComponent = ({
                         {!selectedFileName && (
                           <div className="flex flex-col items-center justify-center border-2 border-dashed rounded-lg p-6 text-center hover:border-primary/50 transition-colors">
                             <Upload className="h-8 w-8 text-gray-400 mb-2" />
-                            <p className="text-sm text-gray-600">
+                            <p className="text-sm text-gray-600 dark:text-muted-foreground">
                               Drop your YAML file here or click to browse
                             </p>
                             <p className="text-xs text-gray-500 mt-1">

--- a/src/components/shared/ReactFlow/FlowSidebar/components/SearchResults.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/components/SearchResults.tsx
@@ -73,7 +73,7 @@ const SearchResults = ({
   return (
     <div className="py-2">
       <div
-        className="px-4 pb-2 text-sm font-medium text-gray-600 border-b"
+        className="px-4 pb-2 text-sm font-medium text-gray-600 dark:text-muted-foreground border-b"
         data-testid="search-results-header"
       >
         Search Results ({totalResults})

--- a/src/components/shared/ReactFlow/FlowSidebar/sections/GraphComponents.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/sections/GraphComponents.tsx
@@ -246,7 +246,7 @@ const GraphComponents = ({
             gap="1"
             blockAlign="center"
             align="center"
-            className="w-full py-1.5 cursor-pointer text-gray-500 hover:text-gray-900 transition-colors border border-dashed border-gray-300 rounded-lg hover:border-gray-400"
+            className="w-full py-1.5 cursor-pointer text-gray-500 hover:text-gray-900 transition-colors border border-dashed border-gray-300 rounded-lg hover:border-gray-400 dark:text-muted-foreground dark:hover:text-foreground dark:border-border dark:hover:border-muted-foreground"
             data-testid="import-component-button"
           >
             <Icon name="PackagePlus" size="sm" />

--- a/src/components/shared/SecretsManagement/SelectSecretDialog.tsx
+++ b/src/components/shared/SecretsManagement/SelectSecretDialog.tsx
@@ -81,7 +81,7 @@ function SelectableSecretsList({
             <InlineStack
               align="space-between"
               gap="2"
-              className="w-full pr-3 py-2 hover:bg-gray-100 rounded-md cursor-pointer transition-colors"
+              className="w-full pr-3 py-2 hover:bg-gray-100 rounded-md cursor-pointer transition-colors dark:hover:bg-accent"
             >
               <InlineStack gap="2" blockAlign="center" wrap="nowrap">
                 <Icon name="Lock" size="lg" className="shrink-0" />

--- a/src/components/shared/SecretsManagement/components/SecretsList.tsx
+++ b/src/components/shared/SecretsManagement/components/SecretsList.tsx
@@ -54,7 +54,7 @@ function SecretsListInternal({
             key={secret.id}
             align="space-between"
             gap="2"
-            className="w-full pr-3 py-1.5 hover:bg-gray-50 rounded-md pl-1"
+            className="w-full pr-3 py-1.5 hover:bg-gray-50 rounded-md pl-1 dark:hover:bg-muted"
             data-testid="secret-item"
             data-secret-name={secret.name}
           >

--- a/src/components/shared/Submitters/GoogleCloud/ManualSubmissionInstructions.tsx
+++ b/src/components/shared/Submitters/GoogleCloud/ManualSubmissionInstructions.tsx
@@ -15,7 +15,10 @@ export const ManualSubmissionInstructions = ({
   downloadUrl,
 }: ManualSubmissionInstructionsProps) => {
   return (
-    <InfoBox title="Manual Submission" className="text-xs text-gray-700">
+    <InfoBox
+      title="Manual Submission"
+      className="text-xs text-gray-700 dark:text-muted-foreground"
+    >
       Download{" "}
       <Link href={downloadUrl} download="vertex_pipeline_job.json">
         pipeline_job.json

--- a/src/components/shared/TaskDetails/IO.tsx
+++ b/src/components/shared/TaskDetails/IO.tsx
@@ -14,7 +14,7 @@ const TaskIO = ({ componentSpec }: TaskIOProps) => {
           <div className="border rounded-md divide-y">
             {componentSpec.inputs.map((input, index) => (
               <div key={index} className="flex flex-col px-3 py-2 gap-2">
-                <div className="shrink-0 font-bold text-sm text-gray-700 mb-1">
+                <div className="shrink-0 font-bold text-sm text-gray-700 mb-1 dark:text-foreground">
                   {input.name.replace(/_/g, " ")}
                 </div>
                 <div className="flex flex-wrap gap-2">
@@ -23,7 +23,7 @@ const TaskIO = ({ componentSpec }: TaskIOProps) => {
                   )}
                   {input.type && <Badge>Type: {String(input.type)}</Badge>}
                 </div>
-                <div className="text-gray-600 break-all text-xs font-bold">
+                <div className="text-gray-600 break-all text-xs font-bold dark:text-muted-foreground">
                   {input.default !== undefined && (
                     <>
                       Default:{" "}
@@ -34,7 +34,7 @@ const TaskIO = ({ componentSpec }: TaskIOProps) => {
                   )}
                 </div>
                 {input.description && (
-                  <div className="text-gray-600 wrap-break-word text-xs">
+                  <div className="text-gray-600 wrap-break-word text-xs dark:text-muted-foreground">
                     {input.description}
                   </div>
                 )}
@@ -50,7 +50,7 @@ const TaskIO = ({ componentSpec }: TaskIOProps) => {
           <div className="border rounded-md divide-y">
             {componentSpec.outputs.map((output) => (
               <div key={output.name} className="flex flex-col px-3 py-2 gap-2">
-                <div className="shrink-0 font-bold text-sm text-gray-700 mb-1">
+                <div className="shrink-0 font-bold text-sm text-gray-700 mb-1 dark:text-foreground">
                   {output.name.replace(/_/g, " ")}
                 </div>
                 {output.type && <Badge>Type: {String(output.type)}</Badge>}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -11,7 +11,7 @@ const inputVariants = cva("", {
         "border-input border aria-invalid:border-destructive shadow-xs focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] rounded-md aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40",
       noBorder: "",
       readOnly:
-        "text-gray-500 bg-gray-100 cursor-not-allowed border-input border shadow-xs rounded-md",
+        "text-gray-500 bg-gray-100 cursor-not-allowed border-input border shadow-xs rounded-md dark:text-muted-foreground dark:bg-muted",
     },
   },
   defaultVariants: {

--- a/src/routes/Dashboard/DashboardComponentsV2View.tsx
+++ b/src/routes/Dashboard/DashboardComponentsV2View.tsx
@@ -124,10 +124,11 @@ const SOURCE_ICON_TONE_BY_KIND: Record<ComponentSearchSource["kind"], string> =
   };
 
 function rerankScoreClass(score: number): string {
-  if (score >= 0.9) return "text-emerald-700 bg-emerald-50 border-emerald-200";
+  if (score >= 0.9)
+    return "text-emerald-700 bg-emerald-50 border-emerald-200 dark:text-emerald-300 dark:bg-emerald-500/15 dark:border-emerald-500/30";
   if (score >= 0.75)
-    return "text-emerald-600 bg-emerald-50/70 border-emerald-100";
-  return "text-emerald-500 bg-white border-emerald-100";
+    return "text-emerald-600 bg-emerald-50/70 border-emerald-100 dark:text-emerald-300 dark:bg-emerald-500/10 dark:border-emerald-500/25";
+  return "text-emerald-500 bg-white border-emerald-100 dark:bg-emerald-500/15 dark:border-emerald-500/30";
 }
 
 /** How many lexical hits to display before the user asks for AI judgment. */

--- a/src/routes/v2/pages/Editor/EditorV2.tsx
+++ b/src/routes/v2/pages/Editor/EditorV2.tsx
@@ -208,7 +208,7 @@ export function EditorV2({
         : null;
 
   return (
-    <div className="h-full w-full flex flex-col bg-slate-100 select-none">
+    <div className="h-full w-full flex flex-col bg-slate-100 dark:bg-background select-none">
       <SharedStoreProvider>
         <EditorSessionProvider>
           <AiChatStoreProvider

--- a/src/routes/v2/pages/Editor/components/AnnotationsBlock/AnnotationsBlock.tsx
+++ b/src/routes/v2/pages/Editor/components/AnnotationsBlock/AnnotationsBlock.tsx
@@ -216,7 +216,7 @@ function AnnotationRow({
         gap="2"
         wrap="nowrap"
         blockAlign="center"
-        className="group w-full rounded-xs px-1 py-0.5 hover:bg-gray-50"
+        className="group w-full rounded-xs px-1 py-0.5 hover:bg-gray-50 dark:hover:bg-muted"
       >
         <BlockStack align="stretch" className="flex-1 min-w-0">
           {annotation.key ? (

--- a/src/routes/v2/pages/Editor/components/ArgumentRow/ArgumentRow.tsx
+++ b/src/routes/v2/pages/Editor/components/ArgumentRow/ArgumentRow.tsx
@@ -32,7 +32,10 @@ const rowVariants = cva("group rounded-lg py-2 px-1 w-full");
 
 const nameVariants = cva("shrink-0", {
   variants: {
-    unset: { true: "text-gray-400", false: "text-gray-900" },
+    unset: {
+      true: "text-gray-400 dark:text-muted-foreground",
+      false: "text-gray-900 dark:text-foreground",
+    },
   },
   defaultVariants: { unset: false },
 });

--- a/src/routes/v2/pages/Editor/components/ArgumentRow/components/ArgumentValueDisplay.tsx
+++ b/src/routes/v2/pages/Editor/components/ArgumentRow/components/ArgumentValueDisplay.tsx
@@ -77,7 +77,7 @@ export function ArgumentValueDisplay({
       className={cn(
         "min-h-4 text-xs! font-mono mt-1 rounded-lg",
         isBound && "text-blue-600",
-        isUnset && "border-dashed border-gray-300",
+        isUnset && "border-dashed border-gray-300 dark:border-border",
       )}
       data-testid="argument-input"
     />

--- a/src/routes/v2/pages/Editor/components/ComponentLibraryWindowMiniContent.tsx
+++ b/src/routes/v2/pages/Editor/components/ComponentLibraryWindowMiniContent.tsx
@@ -10,7 +10,11 @@ export function ComponentLibraryWindowMiniContent() {
       size="icon"
       aria-label="Components"
     >
-      <Icon name="LayoutGrid" size="sm" className="text-gray-700" />
+      <Icon
+        name="LayoutGrid"
+        size="sm"
+        className="text-gray-700 dark:text-muted-foreground"
+      />
     </TooltipButton>
   );
 }

--- a/src/routes/v2/pages/Editor/components/ComponentSearchResults.tsx
+++ b/src/routes/v2/pages/Editor/components/ComponentSearchResults.tsx
@@ -60,7 +60,7 @@ function ComponentSearchResultsSkeleton() {
               <Skeleton
                 size="full"
                 shape="circle"
-                className="h-3.5 bg-gray-100"
+                className="h-3.5 bg-gray-100 dark:bg-muted"
                 data-testid="component-result-why-skeleton"
               />
             </BlockStack>

--- a/src/routes/v2/pages/Editor/components/ComponentSearchV2Content.tsx
+++ b/src/routes/v2/pages/Editor/components/ComponentSearchV2Content.tsx
@@ -175,7 +175,7 @@ export function ComponentSearchV2Content() {
               gap="1"
               blockAlign="center"
               align="center"
-              className="w-full py-1.5 cursor-pointer text-gray-500 hover:text-gray-900 transition-colors border border-dashed border-gray-300 rounded-lg hover:border-gray-400"
+              className="w-full py-1.5 cursor-pointer text-gray-500 hover:text-gray-900 transition-colors border border-dashed border-gray-300 rounded-lg hover:border-gray-400 dark:text-muted-foreground dark:hover:text-foreground dark:border-border dark:hover:border-muted-foreground"
               data-testid="import-component-button"
             >
               <Icon name="PackagePlus" size="sm" />

--- a/src/routes/v2/pages/Editor/components/ContextPanel/components/MultiSelectionDetails/MultiSelectionDetails.tsx
+++ b/src/routes/v2/pages/Editor/components/ContextPanel/components/MultiSelectionDetails/MultiSelectionDetails.tsx
@@ -102,11 +102,15 @@ export const MultiSelectionDetails = observer(function MultiSelectionDetails() {
   }
 
   return (
-    <BlockStack className="h-full bg-white overflow-y-auto">
+    <BlockStack className="h-full bg-card overflow-y-auto">
       <BlockStack gap="4" className="p-3">
         <InlineStack gap="2" blockAlign="center">
           <Icon name="MousePointer2" size="sm" className="text-blue-500" />
-          <Text size="sm" weight="semibold" className="text-slate-700">
+          <Text
+            size="sm"
+            weight="semibold"
+            className="text-slate-700 dark:text-foreground"
+          >
             {multiSelection.length} nodes selected
           </Text>
         </InlineStack>
@@ -120,7 +124,9 @@ export const MultiSelectionDetails = observer(function MultiSelectionDetails() {
             <Separator />
             <BlockStack gap="2">
               <InlineStack gap="2" blockAlign="center">
-                <Label className="text-gray-600">Common Arguments</Label>
+                <Label className="text-gray-600 dark:text-muted-foreground">
+                  Common Arguments
+                </Label>
                 <Badge
                   variant="secondary"
                   className="text-[10px] px-1.5 py-0 h-4"

--- a/src/routes/v2/pages/Editor/components/ContextPanel/components/MultiSelectionDetails/SelectedNodesList.tsx
+++ b/src/routes/v2/pages/Editor/components/ContextPanel/components/MultiSelectionDetails/SelectedNodesList.tsx
@@ -18,21 +18,26 @@ export function SelectedNodesList({ nodes, spec }: SelectedNodesListProps) {
 
   return (
     <BlockStack gap="2">
-      <Label className="text-gray-600">Selected Nodes</Label>
+      <Label className="text-gray-600 dark:text-muted-foreground">
+        Selected Nodes
+      </Label>
       <BlockStack gap="1" className="max-h-48 overflow-y-auto">
         {nodes.map((node) => (
           <InlineStack
             key={node.id}
             gap="2"
             blockAlign="center"
-            className="text-xs py-1.5 px-2 bg-slate-50 rounded border border-slate-100"
+            className="text-xs py-1.5 px-2 bg-slate-50 rounded border border-slate-100 dark:bg-muted dark:border-border"
           >
             <Icon
               name={getNodeIcon(registry, node.type) as any}
               size="xs"
               className={`shrink-0 ${getNodeIconColor(registry, node.type)}`}
             />
-            <Text size="xs" className="text-slate-700 truncate flex-1">
+            <Text
+              size="xs"
+              className="text-slate-700 dark:text-foreground truncate flex-1"
+            >
               {getNodeDisplayName(registry, node, spec)}
             </Text>
             <Text size="xs" className="text-slate-400 capitalize">

--- a/src/routes/v2/pages/Editor/components/ContextPanel/components/MultiSelectionDetails/components/BatchArgumentRow.tsx
+++ b/src/routes/v2/pages/Editor/components/ContextPanel/components/MultiSelectionDetails/components/BatchArgumentRow.tsx
@@ -180,14 +180,20 @@ export const BatchArgumentRow = observer(function BatchArgumentRow({
     <div
       className={cn(
         "group rounded px-2 py-1 cursor-pointer transition-colors w-full",
-        editing ? "bg-blue-50 ring-1 ring-blue-200" : "hover:bg-gray-50",
+        editing
+          ? "bg-blue-50 ring-1 ring-blue-200 dark:bg-blue-500/15 dark:ring-blue-500/30"
+          : "hover:bg-gray-50 dark:hover:bg-muted",
         !hasValue && "opacity-60",
       )}
       onClick={handleClick}
     >
       <InlineStack gap="1" blockAlign="center" className="w-full min-h-6">
         <InlineStack gap="1" blockAlign="baseline" className="flex-1 min-w-0">
-          <Text size="xs" weight="semibold" className="shrink-0 text-gray-700">
+          <Text
+            size="xs"
+            weight="semibold"
+            className="shrink-0 text-gray-700 dark:text-foreground"
+          >
             {aggArg.name}
           </Text>
           {aggArg.typeLabel && (

--- a/src/routes/v2/pages/Editor/components/ContextPanel/components/MultiSelectionDetails/components/BatchTaskColor.tsx
+++ b/src/routes/v2/pages/Editor/components/ContextPanel/components/MultiSelectionDetails/components/BatchTaskColor.tsx
@@ -31,7 +31,7 @@ export const BatchTaskColor = observer(function BatchTaskColor({
       <Separator />
       <InlineStack align="space-between" gap="2" className="w-full">
         <InlineStack gap="2" blockAlign="center">
-          <Text size="xs" className="text-gray-600">
+          <Text size="xs" className="text-gray-600 dark:text-muted-foreground">
             Task color
           </Text>
           {!allSame && (

--- a/src/routes/v2/pages/Editor/components/CreateSubgraphForm.tsx
+++ b/src/routes/v2/pages/Editor/components/CreateSubgraphForm.tsx
@@ -36,7 +36,9 @@ export function CreateSubgraphForm({
   return (
     <BlockStack gap="3">
       <BlockStack gap="1">
-        <Label className="text-gray-600">Create Subgraph</Label>
+        <Label className="text-gray-600 dark:text-muted-foreground">
+          Create Subgraph
+        </Label>
         <Text size="xs" className="text-gray-400">
           Group {selectedTaskCount} tasks into a reusable component
         </Text>

--- a/src/routes/v2/pages/Editor/components/EmptyEditorState.tsx
+++ b/src/routes/v2/pages/Editor/components/EmptyEditorState.tsx
@@ -33,7 +33,7 @@ export function EmptyEditorState() {
       align="center"
     >
       <BlockStack
-        className="w-full max-w-5xl mx-auto bg-white p-4 rounded-lg shadow-md"
+        className="w-full max-w-5xl mx-auto bg-card p-4 rounded-lg shadow-md"
         gap="4"
       >
         <InlineStack gap="2" blockAlign="center">

--- a/src/routes/v2/pages/Editor/components/FlowCanvas/components/SelectionToolbar.tsx
+++ b/src/routes/v2/pages/Editor/components/FlowCanvas/components/SelectionToolbar.tsx
@@ -42,7 +42,7 @@ export const SelectionToolbar = observer(function SelectionToolbar({
   return (
     <InlineStack
       gap="1"
-      className="rounded-md border border-blue-200 bg-white px-1 py-1 shadow-lg"
+      className="rounded-md border border-blue-200 bg-card px-1 py-1 shadow-lg"
       data-testid="selection-toolbar"
     >
       <ToolbarButton

--- a/src/routes/v2/pages/Editor/components/HistoryContent/components/InitialStateMarker.tsx
+++ b/src/routes/v2/pages/Editor/components/HistoryContent/components/InitialStateMarker.tsx
@@ -18,15 +18,16 @@ export function InitialStateMarker({
       disabled={isCurrent}
       className={cn(
         "flex items-start gap-1.5 px-2 py-1 rounded w-full text-left transition-colors",
-        "hover:bg-slate-100 focus:outline-none focus:ring-1 focus:ring-blue-400 focus:ring-inset",
-        isCurrent && "bg-green-50 border border-green-200 hover:bg-green-50",
+        "hover:bg-slate-100 dark:hover:bg-accent focus:outline-none focus:ring-1 focus:ring-blue-400 focus:ring-inset",
+        isCurrent &&
+          "bg-green-50 border border-green-200 hover:bg-green-50 dark:bg-green-500/15 dark:border-green-500/30 dark:hover:bg-green-500/15",
         !isCurrent && "border border-transparent",
       )}
     >
       <div
         className={cn(
           "w-1.5 h-1.5 rounded-full shrink-0 mt-1",
-          isCurrent ? "bg-green-500" : "bg-slate-300",
+          isCurrent ? "bg-green-500" : "bg-slate-300 dark:bg-slate-600",
         )}
       />
       <Text
@@ -34,7 +35,9 @@ export function InitialStateMarker({
         weight={isCurrent ? "semibold" : "regular"}
         className={cn(
           "min-w-0 flex-1 break-words",
-          isCurrent ? "text-green-700" : "text-slate-500",
+          isCurrent
+            ? "text-green-700 dark:text-green-300"
+            : "text-slate-500 dark:text-muted-foreground",
         )}
       >
         Initial state
@@ -48,7 +51,7 @@ export function InitialStateMarker({
         <Icon
           name="RotateCcw"
           size="xs"
-          className="shrink-0 mt-0.5 text-slate-400"
+          className="shrink-0 mt-0.5 text-slate-400 dark:text-slate-500"
         />
       )}
     </button>

--- a/src/routes/v2/pages/Editor/components/IssueResolution/resolutions/BadReferenceResolution.tsx
+++ b/src/routes/v2/pages/Editor/components/IssueResolution/resolutions/BadReferenceResolution.tsx
@@ -47,7 +47,11 @@ export const BadReferenceResolution = observer(function BadReferenceResolution({
   return (
     <BlockStack gap="3">
       <BlockStack gap="2">
-        <Text size="xs" weight="semibold" className="text-gray-700">
+        <Text
+          size="xs"
+          weight="semibold"
+          className="text-gray-700 dark:text-foreground"
+        >
           Fix reference for &ldquo;{argumentName}&rdquo; on task &ldquo;
           {task.name}&rdquo;
         </Text>
@@ -70,7 +74,7 @@ export const BadReferenceResolution = observer(function BadReferenceResolution({
       </Button>
 
       {inputSpec && (
-        <div className="border-t border-slate-200 pt-2">
+        <div className="border-t border-slate-200 pt-2 dark:border-border">
           <Text size="xs" tone="subdued" className="mb-2">
             Or set a new value:
           </Text>

--- a/src/routes/v2/pages/Editor/components/IssueResolution/resolutions/DuplicateNameResolution.tsx
+++ b/src/routes/v2/pages/Editor/components/IssueResolution/resolutions/DuplicateNameResolution.tsx
@@ -42,7 +42,11 @@ export function DuplicateNameResolution({
   return (
     <BlockStack gap="3">
       <BlockStack gap="2">
-        <Text size="xs" weight="semibold" className="text-gray-700">
+        <Text
+          size="xs"
+          weight="semibold"
+          className="text-gray-700 dark:text-foreground"
+        >
           Rename {entityType}
         </Text>
         <InlineStack gap="2" blockAlign="end">
@@ -70,7 +74,7 @@ export function DuplicateNameResolution({
         </InlineStack>
       </BlockStack>
 
-      <div className="border-t border-slate-200 pt-2">
+      <div className="border-t border-slate-200 pt-2 dark:border-border">
         <Text size="xs" tone="subdued" className="mb-2">
           Or remove the duplicate:
         </Text>

--- a/src/routes/v2/pages/Editor/components/IssueResolution/resolutions/InfoOnlyResolution.tsx
+++ b/src/routes/v2/pages/Editor/components/IssueResolution/resolutions/InfoOnlyResolution.tsx
@@ -7,7 +7,7 @@ export function InfoOnlyResolution({ message }: { message: string }) {
     <InlineStack
       gap="2"
       blockAlign="start"
-      className="rounded-md bg-slate-50 p-3"
+      className="rounded-md bg-slate-50 p-3 dark:bg-muted"
     >
       <Icon name="Info" size="sm" className="text-slate-500 shrink-0 mt-0.5" />
       <Text size="xs" tone="subdued">

--- a/src/routes/v2/pages/Editor/components/IssueResolution/resolutions/MissingPipelineInputValueResolution.tsx
+++ b/src/routes/v2/pages/Editor/components/IssueResolution/resolutions/MissingPipelineInputValueResolution.tsx
@@ -46,7 +46,11 @@ export const MissingPipelineInputValueResolution = observer(
 
     return (
       <BlockStack gap="2">
-        <Text size="xs" weight="semibold" className="text-gray-700">
+        <Text
+          size="xs"
+          weight="semibold"
+          className="text-gray-700 dark:text-foreground"
+        >
           Set a default value for pipeline input &ldquo;{input.name}&rdquo;
         </Text>
         <BlockStack gap="2">

--- a/src/routes/v2/pages/Editor/components/IssueResolution/resolutions/MissingRequiredInputResolution.tsx
+++ b/src/routes/v2/pages/Editor/components/IssueResolution/resolutions/MissingRequiredInputResolution.tsx
@@ -48,7 +48,11 @@ export const MissingRequiredInputResolution = observer(
 
     return (
       <BlockStack gap="2">
-        <Text size="xs" weight="semibold" className="text-gray-700">
+        <Text
+          size="xs"
+          weight="semibold"
+          className="text-gray-700 dark:text-foreground"
+        >
           Set value for &ldquo;{inputSpec.name}&rdquo; on task &ldquo;
           {task.name}&rdquo;
         </Text>

--- a/src/routes/v2/pages/Editor/components/IssueResolution/resolutions/RenameEntityResolution.tsx
+++ b/src/routes/v2/pages/Editor/components/IssueResolution/resolutions/RenameEntityResolution.tsx
@@ -37,7 +37,11 @@ export function RenameEntityResolution({
 
   return (
     <BlockStack gap="2">
-      <Text size="xs" weight="semibold" className="text-gray-700">
+      <Text
+        size="xs"
+        weight="semibold"
+        className="text-gray-700 dark:text-foreground"
+      >
         Set {label} name
       </Text>
       <InlineStack gap="2" blockAlign="end">

--- a/src/routes/v2/pages/Editor/components/PinnedTaskContent/PinnedTaskContent.tsx
+++ b/src/routes/v2/pages/Editor/components/PinnedTaskContent/PinnedTaskContent.tsx
@@ -51,7 +51,7 @@ export const PinnedTaskContent = observer(function PinnedTaskContent({
   })();
 
   return (
-    <BlockStack className="h-full w-full bg-white overflow-hidden">
+    <BlockStack className="h-full w-full bg-card overflow-hidden">
       <Tabs
         defaultValue="details"
         className="flex flex-col flex-1 min-h-0 min-w-0 w-full"
@@ -140,7 +140,7 @@ function NotFoundState({ entityId }: NotFoundStateProps) {
           {entityId}
         </Text>
       }
-      className="bg-white"
+      className="bg-card"
     />
   );
 }

--- a/src/routes/v2/pages/Editor/components/PipelineTreeContent/PipelineTreeWindowMiniContent.tsx
+++ b/src/routes/v2/pages/Editor/components/PipelineTreeContent/PipelineTreeWindowMiniContent.tsx
@@ -29,9 +29,13 @@ export const PipelineTreeWindowMiniContent = observer(
         className="relative"
         aria-label="Pipeline Structure"
       >
-        <Icon name="GitBranch" size="sm" className="text-gray-700" />
+        <Icon
+          name="GitBranch"
+          size="sm"
+          className="text-gray-700 dark:text-muted-foreground"
+        />
         {showValidBadge && (
-          <span className="pointer-events-none absolute -bottom-0.5 -right-0.5 flex size-3.5 items-center justify-center rounded-full bg-white shadow-sm ring-1 ring-green-200">
+          <span className="pointer-events-none absolute -bottom-0.5 -right-0.5 flex size-3.5 items-center justify-center rounded-full bg-white dark:bg-card shadow-sm ring-1 ring-green-200 dark:ring-green-500/30">
             <Icon name="CircleCheck" size="xs" className="text-green-600" />
           </span>
         )}

--- a/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/RootNode.tsx
+++ b/src/routes/v2/pages/Editor/components/PipelineTreeContent/components/RootNode.tsx
@@ -85,7 +85,7 @@ export const RootNode = observer(function RootNode({
           <BlockStack
             gap="0"
             align="stretch"
-            className="ml-2 min-w-0 w-full border-l border-slate-200"
+            className="ml-2 min-w-0 w-full border-l border-slate-200 dark:border-border"
           >
             <div className="-ml-1.5 min-w-0 w-full">
               {tasks.map((task) => {

--- a/src/routes/v2/pages/Editor/components/UpgradeComponents/UpgradeComponentsContent.tsx
+++ b/src/routes/v2/pages/Editor/components/UpgradeComponents/UpgradeComponentsContent.tsx
@@ -64,7 +64,7 @@ const UpgradeComponentsInner = observer(function UpgradeComponentsInner({
   const issueCount = candidates.filter(candidateHasIssues).length;
 
   return (
-    <BlockStack className="h-full bg-white">
+    <BlockStack className="h-full bg-card">
       <UpgradeHeader
         total={candidates.length}
         issueCount={issueCount}

--- a/src/routes/v2/pages/Editor/components/UpgradeComponents/components/IssuesBanner.tsx
+++ b/src/routes/v2/pages/Editor/components/UpgradeComponents/components/IssuesBanner.tsx
@@ -7,14 +7,14 @@ export function IssuesBanner({ count }: { count: number }) {
     <InlineStack
       gap="1"
       blockAlign="center"
-      className="px-2 py-1 bg-amber-50 border border-amber-200 rounded-md"
+      className="px-2 py-1 bg-amber-50 border border-amber-200 rounded-md dark:bg-amber-500/10 dark:border-amber-500/30"
     >
       <Icon
         name="TriangleAlert"
         size="xs"
         className="text-amber-500 shrink-0"
       />
-      <Text size="xs" className="text-amber-700">
+      <Text size="xs" className="text-amber-700 dark:text-amber-300">
         {count} predicted {count === 1 ? "issue" : "issues"}
       </Text>
     </InlineStack>

--- a/src/routes/v2/pages/Editor/components/UpgradeComponents/components/UpgradePreviewTaskNode.tsx
+++ b/src/routes/v2/pages/Editor/components/UpgradeComponents/components/UpgradePreviewTaskNode.tsx
@@ -46,13 +46,13 @@ export function UpgradePreviewTaskNode({
       )}
       onClick={onNodeClick}
     >
-      <CardHeader className="border-b border-slate-200 px-2 py-2.5">
+      <CardHeader className="border-b border-slate-200 px-2 py-2.5 dark:border-border">
         <BlockStack>
           <InlineStack gap="2" wrap="nowrap" blockAlign="center">
             {isSubgraph && (
               <Icon name="Workflow" size="sm" className="text-blue-600" />
             )}
-            <CardTitle className="wrap-anywhere max-w-full text-left text-xs text-slate-900 flex-1">
+            <CardTitle className="wrap-anywhere max-w-full text-left text-xs text-slate-900 flex-1 dark:text-foreground">
               {taskName}
             </CardTitle>
             <Badge
@@ -60,8 +60,8 @@ export function UpgradePreviewTaskNode({
               className={cn(
                 "shrink-0 text-[10px] px-1.5 py-0",
                 hasIssues
-                  ? "bg-amber-100 text-amber-700"
-                  : "bg-blue-100 text-blue-700",
+                  ? "bg-amber-100 text-amber-700 dark:bg-amber-500/20 dark:text-amber-300"
+                  : "bg-blue-100 text-blue-700 dark:bg-blue-500/20 dark:text-blue-300",
               )}
             >
               <Icon
@@ -82,8 +82,8 @@ export function UpgradePreviewTaskNode({
             className={cn(
               "p-2 border rounded-lg",
               hasInputChanges
-                ? "bg-gray-50 border-blue-200"
-                : "bg-gray-100 border-gray-200",
+                ? "bg-gray-50 border-blue-200 dark:bg-muted dark:border-blue-500/40"
+                : "bg-gray-100 border-gray-200 dark:bg-muted dark:border-border",
             )}
           >
             {diffInputs.map(({ entry, status }) => (
@@ -102,8 +102,8 @@ export function UpgradePreviewTaskNode({
             className={cn(
               "p-2 border rounded-lg",
               hasOutputChanges
-                ? "bg-gray-50 border-blue-200"
-                : "bg-gray-100 border-gray-200",
+                ? "bg-gray-50 border-blue-200 dark:bg-muted dark:border-blue-500/40"
+                : "bg-gray-100 border-gray-200 dark:bg-muted dark:border-border",
             )}
           >
             {diffOutputs.map(({ entry, status }) => (

--- a/src/routes/v2/pages/Editor/components/ValidationSummary.tsx
+++ b/src/routes/v2/pages/Editor/components/ValidationSummary.tsx
@@ -84,8 +84,8 @@ export const ValidationSummary = observer(function ValidationSummary({
           className={cn(
             "min-w-0 flex-1 justify-start gap-1.5 h-auto py-1.5",
             errorCount > 0
-              ? "text-red-700 hover:bg-red-50"
-              : "text-amber-700 hover:bg-amber-50",
+              ? "text-red-700 hover:bg-red-50 dark:text-red-300 dark:hover:bg-red-500/15"
+              : "text-amber-700 hover:bg-amber-50 dark:text-amber-300 dark:hover:bg-amber-500/15",
           )}
           onClick={() => setIsExpanded((prev) => !prev)}
           {...tracking(
@@ -144,8 +144,8 @@ export const ValidationSummary = observer(function ValidationSummary({
                   "flex items-baseline gap-1 py-1 px-2 rounded text-xs cursor-pointer transition-colors",
                   isSelected ? "ring-1 ring-blue-400" : "",
                   issue.severity === "error"
-                    ? "bg-red-50 text-red-800 hover:bg-red-100"
-                    : "bg-amber-50 text-amber-800 hover:bg-amber-100",
+                    ? "bg-red-50 text-red-800 hover:bg-red-100 dark:bg-red-500/15 dark:text-red-200 dark:hover:bg-red-500/25"
+                    : "bg-amber-50 text-amber-800 hover:bg-amber-100 dark:bg-amber-500/15 dark:text-amber-200 dark:hover:bg-amber-500/25",
                 )}
               >
                 <Text

--- a/src/routes/v2/pages/Editor/hooks/useComponentSearchV2Window.tsx
+++ b/src/routes/v2/pages/Editor/hooks/useComponentSearchV2Window.tsx
@@ -16,7 +16,11 @@ function ComponentSearchV2MiniContent() {
       size="icon"
       aria-label="Component Search"
     >
-      <Icon name="Search" size="sm" className="text-gray-700" />
+      <Icon
+        name="Search"
+        size="sm"
+        className="text-gray-700 dark:text-muted-foreground"
+      />
     </TooltipButton>
   );
 }

--- a/src/routes/v2/pages/Editor/nodes/ConduitNode/context/ConduitDetails.tsx
+++ b/src/routes/v2/pages/Editor/nodes/ConduitNode/context/ConduitDetails.tsx
@@ -78,7 +78,7 @@ export const ConduitDetails = observer(function ConduitDetails({
         </InlineStack>
 
         <BlockStack gap="2">
-          <Label className="text-xs! text-gray-600">
+          <Label className="text-xs! text-gray-600 dark:text-muted-foreground">
             Assigned Edges ({assignedBindings.length})
           </Label>
 
@@ -93,7 +93,7 @@ export const ConduitDetails = observer(function ConduitDetails({
                   key={binding.$id}
                   gap="2"
                   blockAlign="center"
-                  className="py-1 px-2 rounded bg-gray-50 group"
+                  className="py-1 px-2 rounded bg-gray-50 group dark:bg-muted"
                 >
                   <Button
                     variant="ghost"

--- a/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/components/TaskArgumentsEditor.tsx
+++ b/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/components/TaskArgumentsEditor.tsx
@@ -106,7 +106,7 @@ export const TaskArgumentsEditor = observer(function TaskArgumentsEditor({
     >
       <BlockStack
         gap="1"
-        className="basis-[40%] shrink-0 min-w-0 overflow-y-auto border-r border-gray-200 py-1"
+        className="basis-[40%] shrink-0 min-w-0 overflow-y-auto border-r border-gray-200 py-1 dark:border-border"
       >
         {argumentList}
       </BlockStack>

--- a/src/routes/v2/pages/RunView/RunViewV2.tsx
+++ b/src/routes/v2/pages/RunView/RunViewV2.tsx
@@ -216,7 +216,7 @@ export function RunViewV2() {
       : undefined;
 
   return (
-    <div className="h-full w-full flex flex-col bg-slate-100 select-none">
+    <div className="h-full w-full flex flex-col bg-slate-100 dark:bg-background select-none">
       <SharedStoreProvider>
         <AiChatStoreProvider
           createWorker={createRunViewAgentWorker}

--- a/src/routes/v2/pages/RunView/components/RunViewSelectionToolbar.tsx
+++ b/src/routes/v2/pages/RunView/components/RunViewSelectionToolbar.tsx
@@ -36,7 +36,7 @@ export const RunViewSelectionToolbar = observer(
       >
         <InlineStack
           gap="1"
-          className="rounded-md border border-blue-200 bg-white px-1 py-1 shadow-lg"
+          className="rounded-md border border-blue-200 bg-card px-1 py-1 shadow-lg"
           data-testid="runview-selection-toolbar"
         >
           <TooltipButton

--- a/src/routes/v2/shared/nodes/TaskNode/InputAggregatorHandle.tsx
+++ b/src/routes/v2/shared/nodes/TaskNode/InputAggregatorHandle.tsx
@@ -24,7 +24,7 @@ export function InputAggregatorHandle() {
         />
       </div>
       <InlineStack blockAlign="center" className="rounded-md relative">
-        <div className="text-xs text-blue-600! rounded-md px-2 py-1 bg-blue-50 border border-blue-200 border-dashed">
+        <div className="text-xs text-blue-600! rounded-md px-2 py-1 bg-blue-50 border border-blue-200 border-dashed dark:text-blue-300! dark:bg-blue-500/15 dark:border-blue-500/40">
           + Add Input
         </div>
       </InlineStack>


### PR DESCRIPTION
## Description

Phase 2 of the css classname token migration to variable named tokens rather than hardcoded colours. This phase addresses lesser used areas of the app.

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

Browse the app in dark mode and confirm there are no unexpected light mode colours

Browse the app in light mode and confirm there are no dark mode colours

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->