### PR TITLE
Support overlay-injected feature flags and schema-driven launcher filtering

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/utils.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/utils.ts
@@ -1,3 +1,4 @@
+import { isFlagEnabled } from "@/components/shared/Settings/useFlags";
 import schema from "@/config/launcherTaskAnnotationSchema.json";
 import type { AnnotationConfig, AnnotationOption } from "@/types/annotations";
 
@@ -28,6 +29,7 @@ interface JSONSchemaObject {
   title?: string;
   properties: Record<string, JSONSchemaProperty>;
   "x-label"?: string;
+  "feature-flag-key"?: string;
 }
 
 interface CloudProviderSchema extends JSONSchemaProperty {
@@ -172,13 +174,18 @@ export function getCloudProviderConfig(
   if (!config.options) {
     const options: AnnotationOption[] = Object.entries(
       schema.launcher_annotation_schemas,
-    ).map(([key, launcherSchema]) => ({
-      value: key,
-      name:
-        launcherSchema["x-label"] ||
-        launcherSchema.title ||
-        key.charAt(0).toUpperCase() + key.slice(1),
-    }));
+    )
+      .filter(([, launcherSchema]) => {
+        const flagKey = launcherSchema["feature-flag-key"];
+        return !flagKey || isFlagEnabled(flagKey);
+      })
+      .map(([key, launcherSchema]) => ({
+        value: key,
+        name:
+          launcherSchema["x-label"] ||
+          launcherSchema.title ||
+          key.charAt(0).toUpperCase() + key.slice(1),
+      }));
     config.options = options;
   }
 

--- a/src/routes/Settings/SettingsFlagsContext.tsx
+++ b/src/routes/Settings/SettingsFlagsContext.tsx
@@ -7,9 +7,15 @@ import {
   useRequiredContext,
 } from "@/hooks/useRequiredContext";
 import { useBackend } from "@/providers/BackendProvider";
-import type { Flag } from "@/types/configuration";
+import type { ConfigFlags, Flag } from "@/types/configuration";
 import { USER_SETTINGS_PATH } from "@/utils/constants";
 import { fetchWithErrorHandling } from "@/utils/fetchWithErrorHandling";
+
+declare global {
+  interface Window {
+    __TANGLE_EXTRA_FLAGS__?: ConfigFlags;
+  }
+}
 
 interface SettingsFlagsContextValue {
   betaFlags: Flag[];
@@ -21,8 +27,13 @@ const SettingsFlagsContext = createRequiredContext<SettingsFlagsContextValue>(
   "SettingsFlagsContext",
 );
 
+const allFlags: ConfigFlags = {
+  ...ExistingFlags,
+  ...(window.__TANGLE_EXTRA_FLAGS__ ?? {}),
+};
+
 export function SettingsFlagsProvider({ children }: { children: ReactNode }) {
-  const [flags, dispatch] = useFlagsReducer(ExistingFlags);
+  const [flags, dispatch] = useFlagsReducer(allFlags);
   const { backendUrl, available } = useBackend();
 
   const handleSetFlag = (flag: string, enabled: boolean) => {


### PR DESCRIPTION
## Summary

- Adds `window.__TANGLE_EXTRA_FLAGS__` as an OSS extension point: host overlays (e.g. `oasis-frontend`) can inject additional flag definitions into `index.html` before the app mounts, and `SettingsFlagsContext` merges them with the built-in flags. No Davies-specific flag key or name appears anywhere in this repo.
- Extends `JSONSchemaObject` with an optional `"feature-flag-key"` field. When a launcher annotation schema entry carries this field, `getCloudProviderConfig` hides that launcher option from the compute-provider dropdown unless the named beta flag is enabled. Entries without the field are always shown.
- Exports `ConfigFlag` from `configuration.ts` to support the `Window` interface augmentation.

## System / UX impact

- **OSS consumers**: no visible change — `launcher_annotation_schemas` is empty in the base schema, so the filter never runs; no extra flags are injected.
- **YourOrg/frontend-wrapper**: a companion PR would inject the launcher flag via `window.__TANGLE_EXTRA_FLAGS__`; the additional comptue backend option in the dropdown only appears after the user enables that flag in Beta Settings.