### PR TITLE
feat: adjust dark mode colours

### DIFF
--- a/src/components/Editor/PipelineEditor.tsx
+++ b/src/components/Editor/PipelineEditor.tsx
@@ -67,7 +67,11 @@ const PipelineEditor = () => {
                 <FlowSidebar />
                 <BlockStack fill className="flex-1 relative">
                   <FlowCanvas ref={flowCanvasRef} {...flowConfig}>
-                    <MiniMap position="bottom-left" pannable />
+                    <MiniMap
+                      position="bottom-left"
+                      className="dark:rounded-md dark:border dark:border-border"
+                      pannable
+                    />
                     <FlowControls
                       className="ml-56! mb-3!"
                       config={flowConfig}

--- a/src/components/PipelineRun/PipelineRunPage.tsx
+++ b/src/components/PipelineRun/PipelineRunPage.tsx
@@ -52,7 +52,11 @@ const PipelineRunPage = () => {
               readOnly
               fitViewOnInit={!linkedNodeId}
             >
-              <MiniMap position="bottom-left" pannable />
+              <MiniMap
+                position="bottom-left"
+                className="dark:rounded-md dark:border dark:border-border"
+                pannable
+              />
               <RunToolbar />
               <FlowControls
                 className="ml-56! mb-3!"

--- a/src/components/shared/ComponentEditor/components/NewComponentTemplateSelector.tsx
+++ b/src/components/shared/ComponentEditor/components/NewComponentTemplateSelector.tsx
@@ -38,7 +38,7 @@ export const NewComponentTemplateSelector = ({
             >
               <InlineStack
                 align="center"
-                className="bg-gray-200 rounded-md p-4 mb-2 w-full h-24"
+                className="bg-gray-200 dark:bg-muted rounded-md p-4 mb-2 w-full h-24"
               >
                 {!!template.icon && template.icon}
               </InlineStack>

--- a/src/components/shared/PipelineRunDisplay/RunOverview.tsx
+++ b/src/components/shared/PipelineRunDisplay/RunOverview.tsx
@@ -90,7 +90,7 @@ const RunOverview = ({
     <div
       onClick={handleClick}
       className={cn(
-        "flex flex-col p-2 text-sm hover:bg-gray-50 cursor-pointer dark:hover:bg-muted",
+        "flex flex-col p-2 text-sm hover:bg-gray-50 cursor-pointer dark:hover:bg-accent",
         className,
       )}
     >

--- a/src/components/shared/ReactFlow/FlowCanvas/IONode/IONode.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/IONode/IONode.tsx
@@ -98,8 +98,12 @@ const IONode = ({ id, type, data, selected = false }: IONodeProps) => {
   const handleType = isInput ? "source" : "target";
   const handlePosition = isInput ? Position.Right : Position.Left;
   const bgColor = isInput ? "bg-io-input" : "bg-io-output";
-  const selectedBorderColor = isInput ? "border-blue-500" : "border-violet-500";
-  const defaultBorderColor = isInput ? "border-blue-300" : "border-violet-300";
+  const selectedBorderColor = isInput
+    ? "border-blue-500 dark:ring-2 dark:ring-blue-400/60"
+    : "border-violet-500 dark:ring-2 dark:ring-violet-400/60";
+  const defaultBorderColor = isInput
+    ? "border-blue-300 dark:border-blue-500"
+    : "border-violet-300 dark:border-violet-500";
   const edgeHighlightClasses =
     "border-edge-selected! ring-2 ring-edge-selected/30";
 

--- a/src/components/shared/TaskDetails/IO.tsx
+++ b/src/components/shared/TaskDetails/IO.tsx
@@ -19,7 +19,9 @@ const TaskIO = ({ componentSpec }: TaskIOProps) => {
                 </div>
                 <div className="flex flex-wrap gap-2">
                   {!input.optional && (
-                    <Badge className="bg-rose-400 text-white">Required</Badge>
+                    <Badge className="bg-rose-400 text-white dark:bg-rose-500/75">
+                      Required
+                    </Badge>
                   )}
                   {input.type && <Badge>Type: {String(input.type)}</Badge>}
                 </div>

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ const inputVariants = cva("", {
   variants: {
     variant: {
       default:
-        "border-input border aria-invalid:border-destructive shadow-xs focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] rounded-md aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40",
+        "border-input border aria-invalid:border-destructive shadow-xs focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] rounded-md aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 dark:bg-input/30",
       noBorder: "",
       readOnly:
         "text-gray-500 bg-gray-100 cursor-not-allowed border-input border shadow-xs rounded-md dark:text-muted-foreground dark:bg-muted",
@@ -38,7 +38,7 @@ function Input({
       type={type}
       data-slot="input"
       className={cn(
-        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 flex h-9 w-full min-w-0 bg-transparent px-3 py-1 text-base transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground flex h-9 w-full min-w-0 bg-transparent px-3 py-1 text-base transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         inputVariants({ variant }),
         className,
       )}
@@ -75,7 +75,7 @@ function InputGroup({
     <div
       className={cn(
         "h-8",
-        "flex p-0 items-center gap-1 border-input border aria-invalid:border-destructive shadow-xs transition-[border,box-shadow,outline] rounded-md",
+        "flex p-0 items-center gap-1 border-input border aria-invalid:border-destructive shadow-xs transition-[border,box-shadow,outline] rounded-md dark:bg-input/30",
         "has-[input:focus-within]:outline-2 has-[input:focus-within]:-outline-offset-2 has-[input:focus-within]:outline-gray-400/50",
         className,
       )}

--- a/src/providers/TourProvider/TourPopover.tsx
+++ b/src/providers/TourProvider/TourPopover.tsx
@@ -23,6 +23,9 @@ const POPOVER_DEFAULT_MAX_WIDTH = 420;
 export const POPOVER_STYLES = {
   popover: (base: object) => ({
     ...base,
+    background: "var(--popover)",
+    color: "var(--popover-foreground)",
+    border: "1px solid var(--border)",
     borderRadius: "0.75rem",
     padding: "1.25rem",
     boxShadow: "0 10px 30px rgba(0,0,0,0.12)",

--- a/src/routes/v2/pages/Editor/components/EditorMenuBar/EditorMenuBar.tsx
+++ b/src/routes/v2/pages/Editor/components/EditorMenuBar/EditorMenuBar.tsx
@@ -151,7 +151,7 @@ export const EditorMenuBar = observer(function EditorMenuBar() {
             variant="ghost"
             onClick={handleExitTour}
             aria-label="Exit tour"
-            className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-[100001] text-background/80 hover:text-background hover:bg-transparent"
+            className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-[100001] text-white/80 hover:text-white hover:bg-transparent"
             {...tracking("v2.pipeline_editor.tour.exit")}
           >
             <Icon name="X" size="sm" />

--- a/src/routes/v2/pages/Editor/components/FlowCanvas/FlowCanvas.tsx
+++ b/src/routes/v2/pages/Editor/components/FlowCanvas/FlowCanvas.tsx
@@ -136,6 +136,7 @@ export const FlowCanvas = observer(function FlowCanvas({
         />
         <MiniMap
           position="bottom-left"
+          className="dark:rounded-md dark:border dark:border-border"
           pannable
           zoomable
           onClick={() => track("v2.pipeline_canvas.minimap.click")}

--- a/src/routes/v2/pages/Editor/components/ValidationSummary.tsx
+++ b/src/routes/v2/pages/Editor/components/ValidationSummary.tsx
@@ -154,8 +154,8 @@ export const ValidationSummary = observer(function ValidationSummary({
                   className={cn(
                     "shrink-0 uppercase tracking-wide",
                     issue.severity === "error"
-                      ? "text-red-600"
-                      : "text-amber-600",
+                      ? "text-red-600 dark:text-red-300"
+                      : "text-amber-600 dark:text-amber-300",
                   )}
                 >
                   {issueTypeLabel(issue.type)}
@@ -164,8 +164,8 @@ export const ValidationSummary = observer(function ValidationSummary({
                   size="xs"
                   className={
                     issue.severity === "error"
-                      ? "text-red-700"
-                      : "text-amber-700"
+                      ? "text-red-700 dark:text-red-200"
+                      : "text-amber-700 dark:text-amber-200"
                   }
                 >
                   {issue.subgraphPath.length > 1 && (

--- a/src/routes/v2/pages/RunView/components/RunViewFlowCanvas.tsx
+++ b/src/routes/v2/pages/RunView/components/RunViewFlowCanvas.tsx
@@ -112,6 +112,7 @@ export const RunViewFlowCanvas = observer(function RunViewFlowCanvas({
         />
         <MiniMap
           position="bottom-left"
+          className="dark:rounded-md dark:border dark:border-border"
           pannable
           zoomable
           onClick={() => track("v2.run_view.canvas.minimap.click")}

--- a/src/routes/v2/shared/nodes/IONode/IONodeCard.tsx
+++ b/src/routes/v2/shared/nodes/IONode/IONodeCard.tsx
@@ -22,13 +22,13 @@ export function IONodeCard({
   const bgColor = isInput ? "bg-io-input" : "bg-io-output";
   const borderColor = selected
     ? isInput
-      ? "border-blue-500"
-      : "border-violet-500"
+      ? "border-blue-500 dark:ring-2 dark:ring-blue-400/60"
+      : "border-violet-500 dark:ring-2 dark:ring-violet-400/60"
     : isHovered
       ? "border-amber-400 ring-2 ring-amber-300"
       : isInput
-        ? "border-blue-300 hover:border-blue-400"
-        : "border-violet-300 hover:border-violet-400";
+        ? "border-blue-300 hover:border-blue-400 dark:border-blue-500 dark:hover:border-blue-600"
+        : "border-violet-300 hover:border-violet-400 dark:border-violet-500 dark:hover:border-violet-600";
 
   return (
     <Card

--- a/src/routes/v2/shared/nodes/IONode/IONodeSimplified.tsx
+++ b/src/routes/v2/shared/nodes/IONode/IONodeSimplified.tsx
@@ -25,13 +25,13 @@ export function IONodeSimplified({
   const bgColor = isInput ? "bg-io-input" : "bg-io-output";
   const borderColor = selected
     ? isInput
-      ? "border-blue-500"
-      : "border-violet-500"
+      ? "border-blue-500 dark:ring-2 dark:ring-blue-400/60"
+      : "border-violet-500 dark:ring-2 dark:ring-violet-400/60"
     : isHovered
       ? "border-amber-400 ring-2 ring-amber-300"
       : isInput
-        ? "border-blue-300 hover:border-blue-400"
-        : "border-violet-300 hover:border-violet-400";
+        ? "border-blue-300 hover:border-blue-400 dark:border-blue-500 dark:hover:border-blue-600"
+        : "border-violet-300 hover:border-violet-400 dark:border-violet-500 dark:hover:border-violet-600";
 
   return (
     <Card

--- a/src/routes/v2/shared/nodes/TaskNode/TaskNodeCard.tsx
+++ b/src/routes/v2/shared/nodes/TaskNode/TaskNodeCard.tsx
@@ -14,6 +14,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
+import { useTheme } from "@/providers/ThemeProvider";
 import { useSpec } from "@/routes/v2/shared/providers/SpecContext";
 import { AGGREGATOR_ADD_INPUT_HANDLE_ID } from "@/utils/aggregatorInputs";
 import { pluralize } from "@/utils/string";
@@ -91,6 +92,8 @@ interface ClassicInputHandleProps {
   hideValue?: boolean;
   /** When true the node has no custom colour, so section chrome follows the theme. */
   themed: boolean;
+  /** Whether the app is in dark mode — used to darken coloured-node chrome. */
+  isDark: boolean;
   onInputClick: (name: string, event: ReactMouseEvent) => void;
   onHandleClick: (handleId: string, event: ReactMouseEvent) => void;
 }
@@ -101,6 +104,7 @@ const ClassicInputHandle = observer(function ClassicInputHandle({
   displayValue,
   hideValue,
   themed,
+  isDark,
   onInputClick,
   onHandleClick,
 }: ClassicInputHandleProps) {
@@ -156,7 +160,9 @@ const ClassicInputHandle = observer(function ClassicInputHandle({
               }),
               themed
                 ? "text-foreground bg-muted hover:bg-accent"
-                : "text-gray-800 bg-black/5 hover:bg-black/10",
+                : isDark
+                  ? "text-gray-100 bg-white/10 hover:bg-white/15"
+                  : "text-gray-800 bg-black/5 hover:bg-black/10",
             )}
             title={`${input.name}${input.type ? `: ${input.type}` : ""}`}
           >
@@ -168,7 +174,11 @@ const ClassicInputHandle = observer(function ClassicInputHandle({
             <div
               className={cn(
                 "text-xs truncate inline-block text-right pr-2",
-                themed ? "text-foreground" : "text-gray-800",
+                themed
+                  ? "text-foreground"
+                  : isDark
+                    ? "text-gray-100"
+                    : "text-gray-800",
                 !hasValue &&
                   (themed
                     ? "text-muted-foreground italic"
@@ -207,7 +217,8 @@ export const TaskNodeCard = observer(function TaskNodeCard({
   outputType,
   onOutputTypeChange,
 }: TaskNodeViewProps) {
-  const palette = taskColor ? deriveColorPalette(taskColor) : undefined;
+  const isDark = useTheme().resolvedTheme === "dark";
+  const palette = taskColor ? deriveColorPalette(taskColor, isDark) : undefined;
   const cardStyle = palette
     ? {
         backgroundColor: palette.background,
@@ -366,6 +377,7 @@ export const TaskNodeCard = observer(function TaskNodeCard({
                   input={input}
                   entityId={entityId}
                   themed={!palette}
+                  isDark={isDark}
                   displayValue={
                     showCondensedInputs
                       ? index === 0
@@ -437,7 +449,11 @@ export const TaskNodeCard = observer(function TaskNodeCard({
                       <div
                         className={cn(
                           "text-xs italic px-2",
-                          palette ? "text-gray-500" : "text-muted-foreground",
+                          palette
+                            ? isDark
+                              ? "text-gray-300"
+                              : "text-gray-500"
+                            : "text-muted-foreground",
                         )}
                       >
                         {`+${hiddenOutputCount} more ${pluralize(hiddenOutputCount, "output")}`}
@@ -448,7 +464,9 @@ export const TaskNodeCard = observer(function TaskNodeCard({
                         className={cn(
                           "text-xs rounded-md px-2 py-1 truncate",
                           palette
-                            ? "text-gray-800 bg-black/5 hover:bg-black/10"
+                            ? isDark
+                              ? "text-gray-100 bg-white/10 hover:bg-white/15"
+                              : "text-gray-800 bg-black/5 hover:bg-black/10"
                             : "text-foreground bg-muted hover:bg-accent",
                         )}
                         title={`${output.name}${output.type ? `: ${output.type}` : ""}`}

--- a/src/routes/v2/shared/nodes/TaskNode/TaskNodeSimplified.tsx
+++ b/src/routes/v2/shared/nodes/TaskNode/TaskNodeSimplified.tsx
@@ -8,10 +8,8 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
-import {
-  deriveColorPalette,
-  getContrastTextColor,
-} from "@/routes/v2/shared/nodes/TaskNode/color.utils";
+import { useTheme } from "@/providers/ThemeProvider";
+import { deriveColorPalette } from "@/routes/v2/shared/nodes/TaskNode/color.utils";
 import { AGGREGATOR_ADD_INPUT_HANDLE_ID } from "@/utils/aggregatorInputs";
 
 import type { TaskNodeViewProps } from "./TaskNode";
@@ -40,10 +38,9 @@ export function TaskNodeSimplified({
   isAggregator,
   onNodeClick,
 }: TaskNodeViewProps) {
-  const palette = taskColor ? deriveColorPalette(taskColor) : undefined;
-  const headerTextColor = taskColor
-    ? getContrastTextColor(taskColor)
-    : undefined;
+  const isDark = useTheme().resolvedTheme === "dark";
+  const palette = taskColor ? deriveColorPalette(taskColor, isDark) : undefined;
+  const headerTextColor = palette?.text;
 
   const visibleInputs = isAggregator
     ? inputs.filter((input) => !AGGREGATOR_INTERNAL_INPUTS.has(input.name))
@@ -59,11 +56,11 @@ export function TaskNodeSimplified({
       style={{
         width: `calc(${s} * 240px)`,
         height: `calc(${s} * 96px)`,
-        ...(taskColor
+        ...(palette
           ? {
-              backgroundColor: taskColor,
+              backgroundColor: palette.background,
               color: headerTextColor,
-              borderColor: palette?.border,
+              borderColor: palette.border,
             }
           : {}),
       }}
@@ -114,12 +111,12 @@ export function TaskNodeSimplified({
             style={{
               width: `calc(${s} * 32px)`,
               height: `calc(${s} * 32px)`,
-              ...(taskColor ? { color: headerTextColor } : {}),
+              ...(palette ? { color: headerTextColor } : {}),
             }}
           >
             <Icon
               name="Workflow"
-              className={cn("h-full! w-full!", !taskColor && "text-blue-600")}
+              className={cn("h-full! w-full!", !palette && "text-blue-600")}
             />
           </div>
         )}
@@ -128,7 +125,7 @@ export function TaskNodeSimplified({
             <span
               className={cn(
                 "font-medium min-w-0 line-clamp-2 wrap-break-word",
-                !taskColor && "text-card-foreground",
+                !palette && "text-card-foreground",
               )}
               style={{
                 fontSize: `calc(${s} * ${PERCEIVED_FONT_SIZE})`,

--- a/src/routes/v2/shared/nodes/TaskNode/color.utils.ts
+++ b/src/routes/v2/shared/nodes/TaskNode/color.utils.ts
@@ -12,13 +12,43 @@ interface TaskColorPalette {
 /**
  * Derives a cohesive color palette from a single base hex color.
  * Returns undefined for transparent/invalid input so callers fall back to defaults.
+ *
+ * In light mode the chosen colour is used as-is for a bright card with a lighter
+ * tinted section overlay. In dark mode that treatment is inverted: the hue is
+ * folded into a dark, muted card with a darker recessed section, so coloured
+ * nodes sit in the dark canvas instead of glowing as bright pastels.
  */
-export function deriveColorPalette(hex: string): TaskColorPalette | undefined {
+export function deriveColorPalette(
+  hex: string,
+  isDark = false,
+): TaskColorPalette | undefined {
   if (!hex || hex === "transparent") return undefined;
   const rgb = parseHexToRgb(hex);
   if (!rgb) return undefined;
 
   const [h, s, l] = rgbToHsl(rgb.r, rgb.g, rgb.b);
+
+  if (isDark) {
+    // Dark, muted card derived from the hue.
+    const bgL = Math.max(l * 0.32, 0.2);
+    const bgS = Math.min(s * 0.55, 0.6);
+    const background = hslToHex(h, bgS, bgL);
+
+    // Section overlay recessed slightly darker than the card.
+    const sectionL = Math.max(bgL - 0.06, 0.12);
+    const sectionS = Math.min(s * 0.45, 0.5);
+
+    // Border a touch lighter than the card so the outline stays visible.
+    const borderL = Math.min(bgL + 0.22, 0.5);
+    const borderS = Math.min(s * 0.55, 0.6);
+
+    return {
+      background,
+      border: hslToHex(h, borderS, borderL),
+      sectionBg: hslToHex(h, sectionS, sectionL),
+      text: getContrastTextColor(background),
+    };
+  }
 
   // Border: darken by 35% of current lightness, boost saturation slightly
   const borderL = Math.max(l * 0.35, 0.12);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -60,6 +60,9 @@ code {
   --sidebar-ring: oklch(0.708 0 0);
   --edge-selected: #5b2ef4;
 
+  /* Brand accent (the logo purple) — reserved for deliberate brand usage. */
+  --brand: #5b2ef4;
+
   /* Canvas (ReactFlow pane) — subtly distinct from card so nodes read against it. */
   --canvas: oklch(0.985 0 0);
 
@@ -86,66 +89,67 @@ code {
 }
 
 .dark {
-  --background: oklch(0.205 0.004 264);
-  --foreground: oklch(0.97 0 0);
-  --card: oklch(0.241 0.004 264);
-  --card-foreground: oklch(0.97 0 0);
-  --popover: oklch(0.241 0.004 264);
-  --popover-foreground: oklch(0.97 0 0);
-  --primary: oklch(0.985 0 0);
+  --background: oklch(0.258 0.01 280);
+  --foreground: oklch(0.96 0.004 280);
+  --card: oklch(0.302 0.012 280);
+  --card-foreground: oklch(0.96 0.004 280);
+  --popover: oklch(0.302 0.012 280);
+  --popover-foreground: oklch(0.96 0.004 280);
+  --primary: oklch(0.93 0 0);
   --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.278 0.005 264);
-  --secondary-foreground: oklch(0.97 0 0);
-  --muted: oklch(0.278 0.005 264);
-  --muted-foreground: oklch(0.72 0.006 264);
-  --accent: oklch(0.305 0.006 264);
-  --accent-foreground: oklch(0.97 0 0);
+  --secondary: oklch(0.342 0.014 280);
+  --secondary-foreground: oklch(0.96 0.004 280);
+  --muted: oklch(0.342 0.014 280);
+  --muted-foreground: oklch(0.8 0.014 280);
+  --accent: oklch(0.398 0.017 280);
+  --accent-foreground: oklch(0.98 0.004 280);
   --destructive: oklch(0.637 0.208 25.3);
   --destructive-foreground: oklch(0.704 0.191 22.2);
-  --warning: oklch(0.85 0.2 50);
-  --warning-foreground: oklch(0.145 0 0);
+  --warning: oklch(0.8 0.13 75);
+  --warning-foreground: oklch(0.92 0.05 80);
   --success: oklch(0.7 0.18 140);
   --success-foreground: oklch(0.145 0 0);
   --info: oklch(0.6 0.13 235);
   --info-foreground: oklch(0.145 0 0);
-  --border: oklch(0.34 0.006 264);
-  --input: oklch(0.3 0.006 264);
-  --ring: oklch(0.55 0.02 264);
+  --border: oklch(0.43 0.018 280);
+  --input: oklch(0.36 0.014 280);
+  --ring: oklch(0.62 0.04 280);
   --chart-1: oklch(0.488 0.243 264.376);
   --chart-2: oklch(0.696 0.17 162.48);
   --chart-3: oklch(0.769 0.188 70.08);
   --chart-4: oklch(0.627 0.265 303.9);
   --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.185 0.004 264);
-  --sidebar-foreground: oklch(0.97 0 0);
+  --sidebar: oklch(0.238 0.01 280);
+  --sidebar-foreground: oklch(0.96 0.004 280);
   --sidebar-primary: oklch(0.488 0.243 264.376);
   --sidebar-primary-foreground: oklch(0.97 0 0);
-  --sidebar-accent: oklch(0.278 0.005 264);
-  --sidebar-accent-foreground: oklch(0.97 0 0);
-  --sidebar-border: oklch(0.3 0.006 264);
-  --sidebar-ring: oklch(0.55 0.02 264);
-  --edge-selected: #5b2ef4;
+  --sidebar-accent: oklch(0.342 0.014 280);
+  --sidebar-accent-foreground: oklch(0.96 0.004 280);
+  --sidebar-border: oklch(0.372 0.014 280);
+  --sidebar-ring: oklch(0.62 0.04 280);
+  --brand: #5b2ef4;
+  --edge-selected: oklch(0.62 0.2 290);
 
-  --canvas: oklch(0.223 0.004 264);
+  --canvas: oklch(0.245 0.009 280);
 
   --ink-fixed: oklch(0.205 0 0);
 
-  --io-input: oklch(0.78 0.06 255);
-  --io-output: oklch(0.79 0.055 294);
-  --io-value: oklch(0.9 0.008 264);
+  --io-input: oklch(0.7 0.07 255);
+  --io-output: oklch(0.71 0.065 294);
+  --io-value: oklch(0.8 0.012 264);
 
-  --status-succeeded: oklch(0.68 0.15 149);
-  --status-failed: oklch(0.62 0.19 25);
-  --status-system-error: oklch(0.54 0.17 27);
-  --status-invalid: oklch(0.58 0.18 27);
-  --status-running: oklch(0.64 0.15 260);
-  --status-pending: oklch(0.75 0.13 86);
-  --status-queued: oklch(0.72 0.13 70);
-  --status-waiting: oklch(0.62 0.025 257);
-  --status-skipped: oklch(0.6 0.02 257);
-  --status-cancelled: oklch(0.58 0.01 286);
-  --status-cancelling: oklch(0.68 0.15 42);
-  --status-uninitialized: oklch(0.76 0.13 90);
+  --status-succeeded: oklch(0.58 0.12 149);
+  --status-failed: oklch(0.55 0.16 25);
+  --status-system-error: oklch(0.5 0.15 27);
+  --status-invalid: oklch(0.53 0.15 27);
+  --status-running: oklch(0.58 0.12 260);
+  --status-pending: oklch(0.68 0.11 86);
+  --status-queued: oklch(0.66 0.11 70);
+  --status-waiting: oklch(0.56 0.022 257);
+  --status-skipped: oklch(0.54 0.018 257);
+  --status-cancelled: oklch(0.52 0.01 286);
+  --status-cancelling: oklch(0.6 0.13 42);
+  --status-uninitialized: oklch(0.68 0.11 90);
 }
 
 /*
@@ -166,6 +170,17 @@ code {
   --xy-controls-button-color-default: var(--foreground);
   --xy-controls-button-color-hover-default: var(--foreground);
   --xy-controls-button-border-color-default: var(--border);
+
+  /*
+   * Dim the canvas grid dots. Against the darkened canvas the default
+   * dot colour reads as too prominent, so blend it most of the way back
+   * into the canvas for a subtle texture.
+   */
+  --xy-background-pattern-dots-color-default: color-mix(
+    in oklch,
+    var(--muted-foreground) 34%,
+    var(--canvas)
+  );
 }
 
 @media (prefers-color-scheme: dark) {
@@ -220,6 +235,7 @@ code {
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-edge-selected: var(--edge-selected);
+  --color-brand: var(--brand);
   --color-canvas: var(--canvas);
   --color-ink-fixed: var(--ink-fixed);
   --color-io-input: var(--io-input);


### PR DESCRIPTION
## Description

Softens up the midnight black default darkmode theme and adjusts it into a slightly lighter black/grey with a mild hint of lavendar,

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

![image.png](https://app.graphite.com/user-attachments/assets/4495c152-5005-4925-b33b-03891ff141da.png)

![image.png](https://app.graphite.com/user-attachments/assets/b089c2b7-1c0d-4a57-841d-41d5ed0ead9c.png)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

![image.png](https://app.graphite.com/user-attachments/assets/0139c571-2739-4f32-a7d5-1663a16e9baa.png)



## Test Instructions

Explore the app in dark mode and check there's no unexpected outliers

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->