### PR TITLE
feat: sidekick prompts

### DIFF
--- a/src/routes/v2/pages/Editor/hooks/useAiChatWindow.tsx
+++ b/src/routes/v2/pages/Editor/hooks/useAiChatWindow.tsx
@@ -3,9 +3,20 @@ import { useEffect } from "react";
 import { createEditorToolBridge } from "@/routes/v2/pages/Editor/components/AiChat/toolBridge";
 import { useEditorSession } from "@/routes/v2/pages/Editor/store/EditorSessionContext";
 import { AiChatContent } from "@/routes/v2/shared/components/AiChat/AiChatContent";
+import type { SuggestedPrompt } from "@/routes/v2/shared/components/AiChat/types";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 
 const AI_CHAT_WINDOW_ID = "ai-assistant-chat";
+
+const SUGGESTED_PROMPTS_EDITOR: SuggestedPrompt[] = [
+  { label: "Explain what this pipeline does", icon: "FileText" },
+  { label: "Find a component I can add", icon: "Search" },
+  { label: "Fix validation issues on this pipeline", icon: "HeartPulse" },
+  {
+    label: "Fix the latest failed run of this pipeline",
+    icon: "Wrench",
+  },
+];
 
 export function useAiChatWindow(enabled: boolean) {
   const { windows } = useSharedStores();
@@ -23,6 +34,7 @@ export function useAiChatWindow(enabled: boolean) {
         createBridge={(deps) =>
           createEditorToolBridge({ ...deps, undo: editorSession.undo })
         }
+        suggestedPrompts={SUGGESTED_PROMPTS_EDITOR}
       />,
       {
         id: AI_CHAT_WINDOW_ID,

--- a/src/routes/v2/pages/RunView/hooks/useAiChatWindow.tsx
+++ b/src/routes/v2/pages/RunView/hooks/useAiChatWindow.tsx
@@ -2,9 +2,17 @@ import { useEffect } from "react";
 
 import { createRunViewToolBridge } from "@/routes/v2/pages/RunView/toolBridge/runViewToolBridge";
 import { AiChatContent } from "@/routes/v2/shared/components/AiChat/AiChatContent";
+import type { SuggestedPrompt } from "@/routes/v2/shared/components/AiChat/types";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 
 const AI_CHAT_WINDOW_ID = "run-ai-assistant-chat";
+
+const SUGGESTED_PROMPTS_RUN: SuggestedPrompt[] = [
+  { label: "Summarize this run", icon: "FileText" },
+  { label: "Why did this run fail?", icon: "CircleAlert" },
+  { label: "Which tasks failed and why?", icon: "ListChecks" },
+  { label: "Explain the outputs of this run", icon: "ArrowUpFromLine" },
+];
 
 export function useAiChatWindow(enabled: boolean) {
   const { windows } = useSharedStores();
@@ -17,7 +25,10 @@ export function useAiChatWindow(enabled: boolean) {
     if (windows.getWindowById(AI_CHAT_WINDOW_ID)) return;
 
     windows.openWindow(
-      <AiChatContent createBridge={createRunViewToolBridge} />,
+      <AiChatContent
+        createBridge={createRunViewToolBridge}
+        suggestedPrompts={SUGGESTED_PROMPTS_RUN}
+      />,
       {
         id: AI_CHAT_WINDOW_ID,
         title: "AI Assistant",

--- a/src/routes/v2/shared/components/AiChat/AiChatContent.tsx
+++ b/src/routes/v2/shared/components/AiChat/AiChatContent.tsx
@@ -7,11 +7,18 @@ import type { ToolBridgeApi } from "@/agent/toolBridgeApi";
 import { useAuthLocalStorage } from "@/components/shared/Authentication/useAuthLocalStorage";
 import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
-import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { BlockStack } from "@/components/ui/layout";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { Text } from "@/components/ui/typography";
 import { useAiProviderSettings } from "@/hooks/useAiProviderSettings";
 import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { useBackend } from "@/providers/BackendProvider";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
+import { WindowStickyHeader } from "@/routes/v2/shared/windows/components/WindowStickyHeader";
 import { fetchPipelineRuns } from "@/services/pipelineRunService";
 import type { PipelineRun } from "@/types/pipelineRun";
 
@@ -20,6 +27,7 @@ import { AiProviderSetup } from "./components/AiProviderSetup";
 import { ChatInput } from "./components/ChatInput";
 import { ChatMessageList } from "./components/ChatMessageList";
 import type { BridgeDeps } from "./toolBridge/utils";
+import type { SuggestedPrompt } from "./types";
 
 const RECENT_RUNS_LIMIT = 5;
 
@@ -33,6 +41,7 @@ type CreateBridge = (deps: BridgeDeps) => ToolBridgeApi;
 
 interface AiChatContentProps {
   createBridge: CreateBridge;
+  suggestedPrompts?: SuggestedPrompt[];
 }
 
 function projectRecentRuns(runs: PipelineRun[]): RecentPipelineRun[] {
@@ -47,6 +56,7 @@ function projectRecentRuns(runs: PipelineRun[]): RecentPipelineRun[] {
 
 export const AiChatContent = observer(function AiChatContent({
   createBridge,
+  suggestedPrompts,
 }: AiChatContentProps) {
   const aiChat = useAiChatStore();
   const { track } = useAnalytics();
@@ -136,25 +146,44 @@ export const AiChatContent = observer(function AiChatContent({
 
   if (!thread) return null;
 
+  const hasMessages = thread.messages.length > 0;
+  const threadTitle =
+    thread.messages.find((m) => m.role === "user")?.content ?? "New chat";
+
   return (
     <BlockStack fill>
-      <InlineStack
-        className="border-b p-2 w-full"
-        align="end"
-        blockAlign="center"
-      >
-        <Button
-          size="sm"
-          variant="ghost"
-          onClick={() => aiChat.newThread()}
-          aria-label="New chat"
-        >
-          <Icon name="SquarePen" />
-        </Button>
-      </InlineStack>
+      {hasMessages && (
+        <WindowStickyHeader className="border-b w-full">
+          <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-2 p-2">
+            <Text
+              size="sm"
+              weight="semibold"
+              className="truncate"
+              title={threadTitle}
+            >
+              {threadTitle}
+            </Text>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => aiChat.newThread()}
+                  aria-label="New chat"
+                >
+                  <Icon name="SquarePen" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">New chat</TooltipContent>
+            </Tooltip>
+          </div>
+        </WindowStickyHeader>
+      )}
       <ChatMessageList
         messages={thread.messages}
         thinkingText={thread.thinkingText}
+        suggestedPrompts={suggestedPrompts}
+        onSelectPrompt={handleSend}
       />
       <ChatInput isPending={thread.isPending} onSubmit={handleSend} />
     </BlockStack>

--- a/src/routes/v2/shared/components/AiChat/components/ChatInput.tsx
+++ b/src/routes/v2/shared/components/AiChat/components/ChatInput.tsx
@@ -28,7 +28,7 @@ export function ChatInput({ isPending, onSubmit }: ChatInputProps) {
   }
 
   return (
-    <InlineStack gap="2" className="border-t p-2 w-full" blockAlign="start">
+    <InlineStack gap="2" className="border-t p-2 w-full" blockAlign="center">
       <Textarea
         className="flex-1 resize-none max-h-32 overflow-y-auto"
         rows={2}

--- a/src/routes/v2/shared/components/AiChat/components/ChatMessage.tsx
+++ b/src/routes/v2/shared/components/AiChat/components/ChatMessage.tsx
@@ -15,12 +15,12 @@ export function ChatMessage({ message }: ChatMessageProps) {
   return (
     <MessageBubble variant={isUser ? "user" : "assistant"} gap="1">
       {isUser ? (
-        <Text size="sm" className="break-words">
+        <Text size="sm" className="wrap-break-word">
           {message.content}
         </Text>
       ) : (
         <>
-          <div className="text-sm break-words min-w-0 overflow-x-auto">
+          <div className="text-sm wrap-break-word min-w-0 overflow-x-auto">
             {renderMarkdown(message.content, message.componentReferences)}
           </div>
           <ResponseFeedback

--- a/src/routes/v2/shared/components/AiChat/components/ChatMessageList.tsx
+++ b/src/routes/v2/shared/components/AiChat/components/ChatMessageList.tsx
@@ -1,8 +1,13 @@
 import { useEffect, useRef } from "react";
 
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icon";
 import { BlockStack } from "@/components/ui/layout";
 import { Text } from "@/components/ui/typography";
-import type { ChatMessage as ChatMessageType } from "@/routes/v2/shared/components/AiChat/types";
+import type {
+  ChatMessage as ChatMessageType,
+  SuggestedPrompt,
+} from "@/routes/v2/shared/components/AiChat/types";
 
 import { ChatMessage } from "./ChatMessage";
 import { ThinkingMessage } from "./ThinkingMessage";
@@ -10,11 +15,15 @@ import { ThinkingMessage } from "./ThinkingMessage";
 interface ChatMessageListProps {
   messages: ChatMessageType[];
   thinkingText?: string | null;
+  suggestedPrompts?: SuggestedPrompt[];
+  onSelectPrompt?: (prompt: string) => void;
 }
 
 export function ChatMessageList({
   messages,
   thinkingText,
+  suggestedPrompts,
+  onSelectPrompt,
 }: ChatMessageListProps) {
   const bottomRef = useRef<HTMLDivElement>(null);
 
@@ -24,16 +33,58 @@ export function ChatMessageList({
 
   if (messages.length === 0 && !thinkingText) {
     return (
-      <BlockStack align="center" inlineAlign="center" className="flex-1 p-4">
-        <Text size="sm" tone="subdued">
-          Ask anything about your pipeline
-        </Text>
+      <BlockStack gap="5" className="flex-1 min-h-0 overflow-y-auto p-4">
+        <BlockStack
+          gap="2"
+          align="center"
+          inlineAlign="center"
+          className="pt-6"
+        >
+          <div className="flex size-11 items-center justify-center rounded-full bg-accent">
+            <Icon name="Sparkles" size="lg" className="text-muted-foreground" />
+          </div>
+          <Text weight="semibold">How can I help?</Text>
+          <Text size="sm" tone="subdued" className="text-center text-balance">
+            Ask about this pipeline, or pick a starting point below.
+          </Text>
+        </BlockStack>
+
+        {suggestedPrompts && suggestedPrompts.length > 0 && (
+          <BlockStack gap="2">
+            <Text
+              size="xs"
+              tone="subdued"
+              weight="semibold"
+              className="uppercase tracking-wide px-1"
+            >
+              Try asking
+            </Text>
+            <BlockStack gap="2" as="ul">
+              {suggestedPrompts.map((prompt) => (
+                <li key={prompt.label}>
+                  <Button
+                    variant="link"
+                    size="sm"
+                    onClick={() => onSelectPrompt?.(prompt.label)}
+                    className="h-auto w-full justify-start gap-2 px-1 py-0.5 text-left font-normal whitespace-normal underline"
+                  >
+                    <Icon name={prompt.icon} size="sm" className="shrink-0" />
+                    <span className="flex-1">{prompt.label}</span>
+                  </Button>
+                </li>
+              ))}
+            </BlockStack>
+          </BlockStack>
+        )}
       </BlockStack>
     );
   }
 
   return (
-    <BlockStack gap="2" className="flex-1 overflow-y-auto p-3">
+    <BlockStack
+      gap="2"
+      className="flex-1 min-h-0 overflow-y-auto p-3 select-text"
+    >
       {messages.map((msg) => (
         <ChatMessage key={msg.id} message={msg} />
       ))}

--- a/src/routes/v2/shared/components/AiChat/types.ts
+++ b/src/routes/v2/shared/components/AiChat/types.ts
@@ -1,6 +1,14 @@
+import type { IconName } from "@/components/ui/icon";
+
 export interface ComponentRefData {
   name: string;
   yamlText: string;
+}
+
+/** An example question shown in the chat's empty state. */
+export interface SuggestedPrompt {
+  label: string;
+  icon: IconName;
 }
 
 interface BaseChatMessage {

--- a/src/routes/v2/shared/windows/components/DockedWindow.tsx
+++ b/src/routes/v2/shared/windows/components/DockedWindow.tsx
@@ -14,13 +14,13 @@ import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { useWindowContext } from "@/routes/v2/shared/windows/ContentWindowStateContext";
 import { useWindowDrag } from "@/routes/v2/shared/windows/hooks/useWindowDrag";
 import { SnapPreview } from "@/routes/v2/shared/windows/SnapPreview";
-import { MIN_DOCKED_HEIGHT } from "@/routes/v2/shared/windows/types";
+import {
+  DOCKED_HEADER_HEIGHT as HEADER_HEIGHT,
+  MIN_DOCKED_HEIGHT,
+} from "@/routes/v2/shared/windows/types";
 
 import { WindowActions } from "./WindowActions";
 import { WindowHeader } from "./WindowHeader";
-
-/** Height of a docked window header (px). Used to stack sticky headers. */
-const HEADER_HEIGHT = 36;
 
 export const DockedWindow = observer(function DockedWindow() {
   const { model, content, dockIndex = 0 } = useWindowContext();

--- a/src/routes/v2/shared/windows/components/WindowStickyHeader.tsx
+++ b/src/routes/v2/shared/windows/components/WindowStickyHeader.tsx
@@ -1,0 +1,39 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+import { useOptionalWindowContext } from "@/routes/v2/shared/windows/ContentWindowStateContext";
+import { DOCKED_HEADER_HEIGHT } from "@/routes/v2/shared/windows/types";
+
+interface WindowStickyHeaderProps {
+  children: ReactNode;
+  className?: string;
+}
+
+/**
+ * Pins content to the top of a window's scroll region.
+ *
+ * When docked, the whole dock column scrolls as one and each window's chrome
+ * header is sticky at `dockIndex * DOCKED_HEADER_HEIGHT`, so this must stick one
+ * header-height lower to sit just below it. When floating, the content lives in
+ * a height-bounded scroll box, so a flex-sibling header pins on its own and no
+ * offset is needed.
+ */
+export function WindowStickyHeader({
+  children,
+  className,
+}: WindowStickyHeaderProps) {
+  const ctx = useOptionalWindowContext();
+  const isDocked = ctx?.model.isDocked ?? false;
+  const dockIndex = ctx?.dockIndex ?? 0;
+
+  return (
+    <div
+      className={cn(className, isDocked && "sticky z-10 bg-white")}
+      style={
+        isDocked ? { top: (dockIndex + 1) * DOCKED_HEADER_HEIGHT } : undefined
+      }
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/routes/v2/shared/windows/types.ts
+++ b/src/routes/v2/shared/windows/types.ts
@@ -128,5 +128,8 @@ export const DEFAULT_DOCKED_HEIGHT = 300;
 /** Minimum height for a docked window (px) */
 export const MIN_DOCKED_HEIGHT = 50;
 
+/** Height of a docked window header (px). Used to stack sticky headers. */
+export const DOCKED_HEADER_HEIGHT = 36;
+
 /** Distance from dock area edge to trigger dock insert preview (px) */
 export const DOCK_AREA_SNAP_THRESHOLD = 40;


### PR DESCRIPTION
## Description

exploring making the "sidekick" window a little less "empty" or spacious, and a little more helpful/interactive. Adds a title, derived from the first message int he chat, as well as some pre-made prompts. The header (with the title and "new" button is now sticky and so always accessible when scrolling the chat window.

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

before

![image.png](https://app.graphite.com/user-attachments/assets/b9cea047-7339-418c-b8e7-5e450efb0e29.png)



after

![image.png](https://app.graphite.com/user-attachments/assets/acf10642-aeaf-40bd-969d-4fbba6c2c1c5.png)

![image.png](https://app.graphite.com/user-attachments/assets/da18b023-8293-453e-919b-efcf790784fa.png)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->