### PR TITLE
feat: Explore Run Comparison Tool

### DIFF
--- a/src/components/Home/RunSection/RunBulkActionsBar.tsx
+++ b/src/components/Home/RunSection/RunBulkActionsBar.tsx
@@ -1,0 +1,59 @@
+import { useNavigate } from "@tanstack/react-router";
+
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icon";
+import { InlineStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
+import { APP_ROUTES } from "@/routes/appRoutes";
+import { pluralize } from "@/utils/string";
+import { tracking } from "@/utils/tracking";
+
+interface RunBulkActionsBarProps {
+  selectedRuns: string[];
+  onClearSelection: () => void;
+}
+
+const RunBulkActionsBar = ({
+  selectedRuns,
+  onClearSelection,
+}: RunBulkActionsBarProps) => {
+  const navigate = useNavigate();
+
+  const canCompare = selectedRuns.length === 2;
+
+  const handleCompare = () => {
+    if (!canCompare) return;
+    const [a, b] = selectedRuns;
+    navigate({ to: APP_ROUTES.COMPARE, search: { a, b } });
+  };
+
+  return (
+    <div className="fixed bottom-4 left-1/2 -translate-x-1/2 transform rounded-lg border border-border bg-background p-4 shadow-lg z-50">
+      <InlineStack gap="4" blockAlign="center">
+        <Text size="sm" weight="semibold">
+          {selectedRuns.length} {pluralize(selectedRuns.length, "run")} selected
+        </Text>
+
+        <InlineStack gap="2" blockAlign="center">
+          <Button
+            variant="default"
+            size="sm"
+            onClick={handleCompare}
+            disabled={!canCompare}
+            title={canCompare ? undefined : "Select exactly 2 runs to compare"}
+            {...tracking("compare_runs.dashboard.compare_selected")}
+          >
+            <Icon name="GitCompare" />
+            Compare
+          </Button>
+
+          <Button variant="ghost" size="sm" onClick={onClearSelection}>
+            <Icon name="X" />
+          </Button>
+        </InlineStack>
+      </InlineStack>
+    </div>
+  );
+};
+
+export default RunBulkActionsBar;

--- a/src/components/Home/RunSection/RunRow.tsx
+++ b/src/components/Home/RunSection/RunRow.tsx
@@ -9,6 +9,7 @@ import { RunSourceIcon } from "@/components/shared/RunSource";
 import { StatusBar, StatusIcon } from "@/components/shared/Status";
 import { TagList } from "@/components/shared/Tags/TagList";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { InlineStack } from "@/components/ui/layout";
 import { TableCell, TableRow } from "@/components/ui/table";
 import {
@@ -32,9 +33,18 @@ import { getOverallExecutionStatusFromStats } from "@/utils/executionStatus";
 interface RunRowProps {
   run: PipelineRunResponse;
   onFilterByUser?: (createdBy: string) => void;
+  selectable?: boolean;
+  isSelected?: boolean;
+  onToggleSelected?: (runId: string) => void;
 }
 
-const RunRow = ({ run, onFilterByUser }: RunRowProps) => {
+const RunRow = ({
+  run,
+  onFilterByUser,
+  selectable = false,
+  isSelected = false,
+  onToggleSelected,
+}: RunRowProps) => {
   const navigate = useNavigate();
   const { backendUrl } = useBackend();
 
@@ -111,6 +121,20 @@ const RunRow = ({ run, onFilterByUser }: RunRowProps) => {
       onClick={handleRowClick}
       className="cursor-pointer text-muted-foreground text-xs h-10"
     >
+      {selectable && (
+        <TableCell className="w-8">
+          <div
+            onClick={(e) => e.stopPropagation()}
+            className="flex items-center"
+          >
+            <Checkbox
+              checked={isSelected}
+              onCheckedChange={() => onToggleSelected?.(runId)}
+              aria-label={`Select run ${runId}`}
+            />
+          </div>
+        </TableCell>
+      )}
       <TableCell>
         <InlineStack gap="2" blockAlign="center" wrap="nowrap">
           <StatusIcon status={overallStatus} />

--- a/src/components/Home/RunSection/RunSection.tsx
+++ b/src/components/Home/RunSection/RunSection.tsx
@@ -6,6 +6,7 @@ import type { ListPipelineJobsResponse } from "@/api/types.gen";
 import { InfoBox } from "@/components/shared/InfoBox";
 import { useFlagValue } from "@/components/shared/Settings/useFlags";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Icon } from "@/components/ui/icon";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -29,6 +30,7 @@ import {
   parseFilterParam,
 } from "@/utils/pipelineRunFilterUtils";
 
+import RunBulkActionsBar from "./RunBulkActionsBar";
 import RunRow from "./RunRow";
 
 const PIPELINE_RUNS_QUERY_URL = "/api/pipeline_runs/";
@@ -58,8 +60,23 @@ export const RunSection = ({
   const { pathname } = useLocation();
   const search = useSearch({ strict: false }) as RunSectionSearch;
   const isCreatedByMeDefault = useFlagValue("created-by-me-default");
+  const compareEnabled = useFlagValue("compare-runs");
   const { setFilter } = useRunSearchParams();
   const dataVersion = useRef(0);
+
+  const [selectedRuns, setSelectedRuns] = useState<Set<string>>(new Set());
+
+  const toggleRun = (runId: string) => {
+    setSelectedRuns((prev) => {
+      const next = new Set(prev);
+      if (next.has(runId)) {
+        next.delete(runId);
+      } else {
+        next.add(runId);
+      }
+      return next;
+    });
+  };
 
   const onFilterByUser = forcedFilter
     ? undefined
@@ -279,12 +296,42 @@ export const RunSection = ({
     );
   }
 
+  const pageRuns = maxItems
+    ? data.pipeline_runs?.slice(0, maxItems)
+    : data.pipeline_runs;
+
+  const allPageRunsSelected =
+    !!pageRuns?.length &&
+    pageRuns.every((run) => selectedRuns.has(`${run.id}`));
+
+  const toggleSelectAll = () => {
+    setSelectedRuns((prev) => {
+      const next = new Set(prev);
+      const pageRunIds = pageRuns?.map((run) => `${run.id}`) ?? [];
+      if (allPageRunsSelected) {
+        pageRunIds.forEach((id) => next.delete(id));
+      } else {
+        pageRunIds.forEach((id) => next.add(id));
+      }
+      return next;
+    });
+  };
+
   return (
     <BlockStack gap="4">
       {searchMarkup}
       <Table>
         <TableHeader>
           <TableRow className="text-xs">
+            {compareEnabled && (
+              <TableHead className="w-8">
+                <Checkbox
+                  checked={allPageRunsSelected}
+                  onCheckedChange={toggleSelectAll}
+                  aria-label="Select all runs on this page"
+                />
+              </TableHead>
+            )}
             <TableHead className="w-1/4">Name</TableHead>
             <TableHead className="w-1/4">Status</TableHead>
             <TableHead className="w-3/20">Date</TableHead>
@@ -293,14 +340,25 @@ export const RunSection = ({
           </TableRow>
         </TableHeader>
         <TableBody>
-          {(maxItems
-            ? data.pipeline_runs?.slice(0, maxItems)
-            : data.pipeline_runs
-          )?.map((run) => (
-            <RunRow key={run.id} run={run} onFilterByUser={onFilterByUser} />
+          {pageRuns?.map((run) => (
+            <RunRow
+              key={run.id}
+              run={run}
+              onFilterByUser={onFilterByUser}
+              selectable={compareEnabled}
+              isSelected={selectedRuns.has(`${run.id}`)}
+              onToggleSelected={toggleRun}
+            />
           ))}
         </TableBody>
       </Table>
+
+      {compareEnabled && selectedRuns.size > 0 && (
+        <RunBulkActionsBar
+          selectedRuns={Array.from(selectedRuns)}
+          onClearSelection={() => setSelectedRuns(new Set())}
+        />
+      )}
 
       {(data.next_page_token || previousPageTokens.length > 0) && (
         <InlineStack

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -78,4 +78,12 @@ export const ExistingFlags: ConfigFlags = {
     default: false,
     category: "beta",
   },
+
+  ["compare-runs"]: {
+    name: "Compare runs",
+    description:
+      "Select two runs to compare their pipeline structure and results side by side.",
+    default: false,
+    category: "beta",
+  },
 };

--- a/src/providers/ExecutionDataProvider.tsx
+++ b/src/providers/ExecutionDataProvider.tsx
@@ -15,7 +15,7 @@ import {
 import type { BreadcrumbSegment } from "@/hooks/useSubgraphBreadcrumbs";
 import { useSubgraphBreadcrumbs } from "@/hooks/useSubgraphBreadcrumbs";
 import { useFetchPipelineRunMetadata } from "@/services/executionService";
-import { getOverallExecutionStatusFromStats } from "@/utils/executionStatus";
+import { buildTaskExecutionStatusMap } from "@/utils/executionStatus";
 
 import { useComponentSpec } from "./ComponentSpecProvider";
 
@@ -50,30 +50,6 @@ const ROOT_PATH_START_INDEX = 1;
 const isAtRootLevel = (path: string[]) => path.length <= 1;
 
 const buildPathKey = (path: string[]) => path.join(PATH_DELIMITER);
-
-const buildTaskExecutionStatusMap = (
-  details?: GetExecutionInfoResponse,
-  state?: GetGraphExecutionStateResponse,
-): Map<string, string> => {
-  const taskExecutionStatusMap = new Map<string, string>();
-
-  if (!details?.child_task_execution_ids) {
-    return taskExecutionStatusMap;
-  }
-
-  Object.entries(details.child_task_execution_ids).forEach(
-    ([taskId, executionId]) => {
-      const statusStats = state?.child_execution_status_stats?.[executionId];
-      const aggregated = getOverallExecutionStatusFromStats(statusStats);
-
-      if (aggregated) {
-        taskExecutionStatusMap.set(taskId, aggregated);
-      }
-    },
-  );
-
-  return taskExecutionStatusMap;
-};
 
 const findExecutionIdAtPath = (
   path: string[],

--- a/src/routes/appRoutes.ts
+++ b/src/routes/appRoutes.ts
@@ -46,4 +46,5 @@ export const APP_ROUTES = {
   PIPELINE_FOLDERS: "/pipeline-folders",
   PLAYGROUND: "/playground",
   ARTIFACT_PREVIEW: "/artifact/$artifactId",
+  COMPARE: "/compare",
 } as const;

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -44,6 +44,7 @@ import { BetaFeaturesSettings } from "./Settings/sections/BetaFeaturesSettings";
 import { PreferencesSettings } from "./Settings/sections/PreferencesSettings";
 import { SecretsSettings } from "./Settings/sections/SecretsSettings";
 import { SettingsLayout } from "./Settings/SettingsLayout";
+import { CompareView } from "./v2/pages/CompareView/CompareView";
 import { EditorV2 } from "./v2/pages/Editor/EditorV2";
 import { PipelineFoldersPage } from "./v2/pages/PipelineFolders/PipelineFoldersPage";
 import { RunViewV2 } from "./v2/pages/RunView/RunViewV2";
@@ -363,6 +364,17 @@ const runV2WithSubgraphRoute = createRoute({
   },
 });
 
+const compareRoute = createRoute({
+  getParentRoute: () => mainLayout,
+  path: APP_ROUTES.COMPARE,
+  component: CompareView,
+  beforeLoad: () => {
+    if (!isFlagEnabled("compare-runs")) {
+      throw redirect({ to: APP_ROUTES.DASHBOARD_RUNS });
+    }
+  },
+});
+
 const pipelineFoldersRoute = createRoute({
   getParentRoute: () => mainLayout,
   path: APP_ROUTES.PIPELINE_FOLDERS,
@@ -403,6 +415,7 @@ const appRouteTree = mainLayout.addChildren([
   editorV2PipelineRoute,
   runV2Route,
   runV2WithSubgraphRoute,
+  compareRoute,
   pipelineFoldersRoute,
   artifactPreviewRoute,
   tourRoute,

--- a/src/routes/v2/pages/CompareView/CompareView.tsx
+++ b/src/routes/v2/pages/CompareView/CompareView.tsx
@@ -1,0 +1,262 @@
+import { Link, useNavigate, useSearch } from "@tanstack/react-router";
+import { useEffect, useState } from "react";
+
+import { InfoBox } from "@/components/shared/InfoBox";
+import { LoadingScreen } from "@/components/shared/LoadingScreen";
+import { RemoteAuthErrorView } from "@/components/shared/RemoteAuthErrorView";
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icon";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Heading, Text } from "@/components/ui/typography";
+import { cn } from "@/lib/utils";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
+import { APP_ROUTES } from "@/routes/appRoutes";
+import { RemoteAuthError } from "@/utils/fetchWithErrorHandling";
+import { tracking } from "@/utils/tracking";
+
+import { CompareRunPicker } from "./components/CompareRunPicker";
+import { GraphDiffPlaceholder } from "./components/GraphDiffPlaceholder";
+import { StructuredDiffView } from "./components/StructuredDiffView";
+import { YamlDiffView } from "./components/YamlDiffView";
+import { useRunComparisonSide } from "./hooks/useRunComparisonSide";
+import { buildPipelineComparison } from "./utils/comparePipelines";
+
+interface CompareSearch {
+  a?: string;
+  b?: string;
+}
+
+const LABEL_A = "A";
+const LABEL_B = "B";
+
+export function CompareView() {
+  const search = useSearch({ strict: false }) as CompareSearch;
+  const navigate = useNavigate();
+  const { track } = useAnalytics();
+
+  const a = search.a ?? "";
+  const b = search.b ?? "";
+
+  const sideA = useRunComparisonSide(a);
+  const sideB = useRunComparisonSide(b);
+
+  const bothSelected = Boolean(a && b && a !== b);
+
+  const [activeTab, setActiveTab] = useState("structured");
+  const [yamlMounted, setYamlMounted] = useState(false);
+
+  useEffect(() => {
+    if (bothSelected) {
+      track("compare_runs.comparison.impression", { run_a: a, run_b: b });
+    }
+  }, [bothSelected, a, b, track]);
+
+  useEffect(() => {
+    if (activeTab === "yaml") {
+      setYamlMounted(true);
+    }
+  }, [activeTab]);
+
+  const comparison = buildPipelineComparison(
+    sideA.spec,
+    sideB.spec,
+    sideA.taskStatusMap,
+    sideB.taskStatusMap,
+  );
+
+  const setSide = (side: "a" | "b", id: string) => {
+    navigate({
+      to: APP_ROUTES.COMPARE,
+      search: (prev: CompareSearch) => ({ ...prev, [side]: id }),
+    });
+  };
+
+  if (!a) {
+    return (
+      <PageShell>
+        <CompareRunPicker
+          title="Select the first run to compare"
+          excludeRunId={b}
+          onSelect={(id) => setSide("a", id)}
+        />
+      </PageShell>
+    );
+  }
+
+  if (!b || a === b) {
+    return (
+      <PageShell>
+        {a === b && (
+          <InfoBox
+            title="Pick two different runs"
+            variant="warning"
+            width="full"
+          >
+            You selected the same run twice. Choose a different second run.
+          </InfoBox>
+        )}
+        <CompareRunPicker
+          title="Select the second run to compare"
+          excludeRunId={a}
+          onSelect={(id) => setSide("b", id)}
+        />
+      </PageShell>
+    );
+  }
+
+  const error = sideA.error ?? sideB.error;
+  if (error) {
+    if (error instanceof RemoteAuthError) {
+      return <RemoteAuthErrorView />;
+    }
+    return (
+      <PageShell>
+        <InfoBox title="Error loading runs" variant="error" width="full">
+          {error.message}
+        </InfoBox>
+      </PageShell>
+    );
+  }
+
+  if (sideA.isLoading || sideB.isLoading || !sideA.spec || !sideB.spec) {
+    return <LoadingScreen message="Loading runs to compare" />;
+  }
+
+  const nameA = sideA.spec.name ?? `Run #${a}`;
+  const nameB = sideB.spec.name ?? `Run #${b}`;
+
+  return (
+    <PageShell>
+      <InlineStack
+        align="space-between"
+        blockAlign="center"
+        gap="4"
+        className="w-full"
+      >
+        <InlineStack gap="3" blockAlign="center" wrap="wrap">
+          <Heading level={2}>Compare runs</Heading>
+          <RunLabel label={LABEL_A} name={nameA} runId={a} tone="a" />
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label="Swap runs"
+            onClick={() =>
+              navigate({
+                to: APP_ROUTES.COMPARE,
+                search: { a: b, b: a },
+              })
+            }
+            {...tracking("compare_runs.comparison.swap")}
+          >
+            <Icon name="ArrowLeftRight" size="sm" />
+          </Button>
+          <RunLabel label={LABEL_B} name={nameB} runId={b} tone="b" />
+        </InlineStack>
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label="Close comparison"
+          onClick={() => navigate({ to: APP_ROUTES.DASHBOARD_RUNS })}
+          {...tracking("compare_runs.comparison.close")}
+        >
+          <Icon name="X" size="sm" />
+        </Button>
+      </InlineStack>
+
+      <Tabs
+        value={activeTab}
+        onValueChange={setActiveTab}
+        className="flex-1 min-h-0 w-full"
+      >
+        <TabsList>
+          <TabsTrigger
+            value="structured"
+            {...tracking("compare_runs.tab.structured")}
+          >
+            Structured
+          </TabsTrigger>
+          <TabsTrigger value="yaml" {...tracking("compare_runs.tab.yaml")}>
+            YAML
+          </TabsTrigger>
+          <TabsTrigger value="graph" {...tracking("compare_runs.tab.graph")}>
+            Graph
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="structured" className="min-h-0 overflow-auto">
+          <StructuredDiffView
+            comparison={comparison}
+            labelA={LABEL_A}
+            labelB={LABEL_B}
+          />
+        </TabsContent>
+
+        <TabsContent
+          value="yaml"
+          forceMount
+          className={cn("min-h-0", activeTab !== "yaml" && "hidden")}
+        >
+          {yamlMounted && (
+            <YamlDiffView specA={sideA.spec} specB={sideB.spec} />
+          )}
+        </TabsContent>
+
+        <TabsContent value="graph" className="min-h-0">
+          <GraphDiffPlaceholder />
+        </TabsContent>
+      </Tabs>
+    </PageShell>
+  );
+}
+
+function PageShell({ children }: { children: React.ReactNode }) {
+  return (
+    <BlockStack gap="4" className="h-full w-full p-4">
+      {children}
+    </BlockStack>
+  );
+}
+
+interface RunLabelProps {
+  label: string;
+  name: string;
+  runId: string;
+  tone: "a" | "b";
+}
+
+function RunLabel({ label, name, runId, tone }: RunLabelProps) {
+  const toneClass =
+    tone === "a"
+      ? "border-blue-400 bg-blue-50 text-blue-800 hover:bg-blue-100"
+      : "border-emerald-400 bg-emerald-50 text-emerald-800 hover:bg-emerald-100";
+
+  return (
+    <Link
+      to={APP_ROUTES.RUN_DETAIL}
+      params={{ id: runId }}
+      target="_blank"
+      rel="noopener noreferrer"
+      title={`Open ${name} in a new tab`}
+      className={`group rounded border px-2 py-1 transition-colors ${toneClass}`}
+      {...tracking("compare_runs.comparison.open_run", { side: label })}
+    >
+      <InlineStack gap="2" blockAlign="center" wrap="nowrap">
+        <Text as="span" size="sm" weight="semibold">
+          {label}
+        </Text>
+        <Text as="span" size="sm" className="truncate max-w-64">
+          {name}
+        </Text>
+        <Text as="span" size="xs" tone="subdued">
+          #{runId}
+        </Text>
+        <Icon
+          name="ExternalLink"
+          size="xs"
+          className="opacity-40 group-hover:opacity-80"
+        />
+      </InlineStack>
+    </Link>
+  );
+}

--- a/src/routes/v2/pages/CompareView/components/CompareRunPicker.tsx
+++ b/src/routes/v2/pages/CompareView/components/CompareRunPicker.tsx
@@ -1,0 +1,102 @@
+import { useQuery } from "@tanstack/react-query";
+
+import type { ListPipelineJobsResponse } from "@/api/types.gen";
+import { InfoBox } from "@/components/shared/InfoBox";
+import { StatusIcon } from "@/components/shared/Status";
+import { Button } from "@/components/ui/button";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Spinner } from "@/components/ui/spinner";
+import { Heading, Text } from "@/components/ui/typography";
+import { useBackend } from "@/providers/BackendProvider";
+import { formatDate } from "@/utils/date";
+import { getOverallExecutionStatusFromStats } from "@/utils/executionStatus";
+import { fetchWithErrorHandling } from "@/utils/fetchWithErrorHandling";
+import { tracking } from "@/utils/tracking";
+
+const PIPELINE_RUNS_QUERY_URL = "/api/pipeline_runs/";
+
+interface CompareRunPickerProps {
+  title: string;
+  excludeRunId?: string;
+  onSelect: (runId: string) => void;
+}
+
+export function CompareRunPicker({
+  title,
+  excludeRunId,
+  onSelect,
+}: CompareRunPickerProps) {
+  const { backendUrl, configured, available } = useBackend();
+
+  const { data, isLoading, error } = useQuery<ListPipelineJobsResponse>({
+    queryKey: ["compare-run-picker", backendUrl],
+    refetchOnWindowFocus: false,
+    enabled: configured && available,
+    queryFn: async () => {
+      const url = new URL(PIPELINE_RUNS_QUERY_URL, backendUrl);
+      url.searchParams.set("include_pipeline_names", "true");
+      url.searchParams.set("include_execution_stats", "true");
+      return fetchWithErrorHandling(url.toString());
+    },
+  });
+
+  return (
+    <BlockStack gap="3" className="w-full">
+      <Heading level={3}>{title}</Heading>
+
+      {isLoading && (
+        <InlineStack gap="2" blockAlign="center">
+          <Spinner /> <Text>Loading runs…</Text>
+        </InlineStack>
+      )}
+
+      {error && (
+        <InfoBox title="Error loading runs" variant="error" width="full">
+          {error.message}
+        </InfoBox>
+      )}
+
+      {data && (
+        <BlockStack as="ul" gap="1">
+          {(data.pipeline_runs ?? [])
+            .filter((run) => `${run.id}` !== excludeRunId)
+            .map((run) => {
+              const runId = `${run.id}`;
+              const status = getOverallExecutionStatusFromStats(
+                run.execution_status_stats ?? undefined,
+              );
+
+              return (
+                <InlineStack as="li" key={runId} className="w-full">
+                  <Button
+                    variant="ghost"
+                    className="w-full justify-start"
+                    onClick={() => onSelect(runId)}
+                    {...tracking("compare_runs.run_picker.select_run")}
+                  >
+                    <InlineStack
+                      gap="2"
+                      blockAlign="center"
+                      wrap="nowrap"
+                      className="w-full"
+                    >
+                      <StatusIcon status={status} />
+                      <Text as="span" size="sm" className="truncate">
+                        {run.pipeline_name ?? "Unknown pipeline"}
+                      </Text>
+                      <Text as="span" size="xs" tone="subdued">
+                        #{runId}
+                      </Text>
+                      <Text as="span" size="xs" tone="subdued">
+                        {run.created_at ? formatDate(run.created_at) : ""}
+                      </Text>
+                    </InlineStack>
+                  </Button>
+                </InlineStack>
+              );
+            })}
+        </BlockStack>
+      )}
+    </BlockStack>
+  );
+}

--- a/src/routes/v2/pages/CompareView/components/DiffStatusBadge.tsx
+++ b/src/routes/v2/pages/CompareView/components/DiffStatusBadge.tsx
@@ -1,0 +1,44 @@
+import { Icon } from "@/components/ui/icon";
+import { InlineStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
+import { cn } from "@/lib/utils";
+import type { DiffStatus } from "@/routes/v2/pages/CompareView/utils/comparePipelines";
+import {
+  DIFF_STATUS_CLASSES,
+  STATUS_ICON,
+} from "@/routes/v2/pages/Editor/components/UpgradeComponents/components/upgradePreviewConstants";
+
+const DIFF_STATUS_LABELS: Record<DiffStatus, string> = {
+  unchanged: "Unchanged",
+  lost: "Removed",
+  new: "Added",
+  changed: "Changed",
+};
+
+interface DiffStatusBadgeProps {
+  status: DiffStatus;
+  className?: string;
+}
+
+export function DiffStatusBadge({ status, className }: DiffStatusBadgeProps) {
+  const icon = STATUS_ICON[status];
+
+  return (
+    <InlineStack
+      as="span"
+      gap="1"
+      blockAlign="center"
+      wrap="nowrap"
+      className={cn(
+        "rounded px-1.5 py-0.5",
+        DIFF_STATUS_CLASSES[status],
+        className,
+      )}
+    >
+      {icon && <Icon name={icon.name} size="xs" className={icon.className} />}
+      <Text as="span" size="xs" weight="semibold">
+        {DIFF_STATUS_LABELS[status]}
+      </Text>
+    </InlineStack>
+  );
+}

--- a/src/routes/v2/pages/CompareView/components/FieldDiffRow.tsx
+++ b/src/routes/v2/pages/CompareView/components/FieldDiffRow.tsx
@@ -1,0 +1,54 @@
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
+import type { KeyedDiffEntry } from "@/routes/v2/pages/CompareView/utils/comparePipelines";
+
+import { DiffStatusBadge } from "./DiffStatusBadge";
+
+function formatValue(value: unknown): string {
+  if (value === undefined) return "—";
+  if (typeof value === "string") return value;
+  return JSON.stringify(value);
+}
+
+interface ValueLineProps {
+  label: string;
+  value: unknown;
+}
+
+function ValueLine({ label, value }: ValueLineProps) {
+  return (
+    <InlineStack gap="2" blockAlign="start" wrap="nowrap">
+      <Text as="span" size="xs" tone="subdued" className="w-10 shrink-0">
+        {label}
+      </Text>
+      <Text
+        as="span"
+        size="xs"
+        className="font-mono break-all whitespace-pre-wrap"
+      >
+        {formatValue(value)}
+      </Text>
+    </InlineStack>
+  );
+}
+
+interface FieldDiffRowProps {
+  entry: KeyedDiffEntry<unknown>;
+  labelA: string;
+  labelB: string;
+}
+
+export function FieldDiffRow({ entry, labelA, labelB }: FieldDiffRowProps) {
+  return (
+    <BlockStack gap="1" className="rounded border border-border p-2">
+      <InlineStack gap="2" blockAlign="center">
+        <Text as="span" size="sm" weight="semibold" className="font-mono">
+          {entry.key}
+        </Text>
+        <DiffStatusBadge status={entry.status} />
+      </InlineStack>
+      {entry.status !== "new" && <ValueLine label={labelA} value={entry.a} />}
+      {entry.status !== "lost" && <ValueLine label={labelB} value={entry.b} />}
+    </BlockStack>
+  );
+}

--- a/src/routes/v2/pages/CompareView/components/GraphDiffPlaceholder.tsx
+++ b/src/routes/v2/pages/CompareView/components/GraphDiffPlaceholder.tsx
@@ -1,0 +1,16 @@
+import { Icon } from "@/components/ui/icon";
+import { BlockStack } from "@/components/ui/layout";
+import { Heading, Paragraph } from "@/components/ui/typography";
+
+export function GraphDiffPlaceholder() {
+  return (
+    <BlockStack fill gap="2" className="py-16 text-center">
+      <Icon name="GitCompare" size="lg" className="text-muted-foreground" />
+      <Heading level={3}>Visual graph comparison is coming soon</Heading>
+      <Paragraph size="sm" tone="subdued">
+        A merged graph that overlays both runs and highlights where they differ
+        will live here. For now, use the Structured and YAML tabs.
+      </Paragraph>
+    </BlockStack>
+  );
+}

--- a/src/routes/v2/pages/CompareView/components/StructuredDiffView.tsx
+++ b/src/routes/v2/pages/CompareView/components/StructuredDiffView.tsx
@@ -1,0 +1,116 @@
+import { useState } from "react";
+
+import { InfoBox } from "@/components/shared/InfoBox";
+import { Label } from "@/components/ui/label";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Switch } from "@/components/ui/switch";
+import { Text } from "@/components/ui/typography";
+import type { PipelineComparison } from "@/routes/v2/pages/CompareView/utils/comparePipelines";
+import { tracking } from "@/utils/tracking";
+
+import { TaskDiffRow } from "./TaskDiffRow";
+
+interface SummaryCountProps {
+  label: string;
+  value: number;
+}
+
+function SummaryCount({ label, value }: SummaryCountProps) {
+  return (
+    <InlineStack gap="1" blockAlign="baseline">
+      <Text as="span" size="sm" weight="semibold">
+        {value}
+      </Text>
+      <Text as="span" size="sm" tone="subdued">
+        {label}
+      </Text>
+    </InlineStack>
+  );
+}
+
+interface StructuredDiffViewProps {
+  comparison: PipelineComparison;
+  labelA: string;
+  labelB: string;
+}
+
+export function StructuredDiffView({
+  comparison,
+  labelA,
+  labelB,
+}: StructuredDiffViewProps) {
+  const [showUnchanged, setShowUnchanged] = useState(false);
+
+  if (!comparison.hasComparableTasks) {
+    return (
+      <InfoBox title="No tasks to compare" variant="info" width="full">
+        Neither run has a graph pipeline, so there are no tasks to align. Use
+        the YAML tab to compare the raw specifications.
+      </InfoBox>
+    );
+  }
+
+  const { counts } = comparison;
+  const visibleDiffs = showUnchanged
+    ? comparison.taskDiffs
+    : comparison.taskDiffs.filter(
+        (diff) => diff.status !== "unchanged" || diff.outcomeChanged,
+      );
+
+  return (
+    <BlockStack gap="4" className="w-full">
+      <InlineStack
+        align="space-between"
+        blockAlign="center"
+        gap="4"
+        className="w-full"
+      >
+        <InlineStack gap="4" blockAlign="center" wrap="wrap">
+          <SummaryCount label="added" value={counts.added} />
+          <SummaryCount label="removed" value={counts.removed} />
+          <SummaryCount label="changed" value={counts.changed} />
+          <SummaryCount label="unchanged" value={counts.unchanged} />
+          {counts.outcomeChanged > 0 && (
+            <InlineStack gap="1" blockAlign="center">
+              <span className="h-2 w-2 rounded-full bg-amber-500" />
+              <Text as="span" size="sm" weight="semibold">
+                {counts.outcomeChanged}
+              </Text>
+              <Text as="span" size="sm" tone="subdued">
+                outcome differs
+              </Text>
+            </InlineStack>
+          )}
+        </InlineStack>
+        <InlineStack gap="2" blockAlign="center" wrap="nowrap">
+          <Switch
+            id="compare-show-unchanged"
+            checked={showUnchanged}
+            onCheckedChange={setShowUnchanged}
+            {...tracking("compare_runs.structured_diff.show_unchanged", {
+              new_value: !showUnchanged,
+            })}
+          />
+          <Label htmlFor="compare-show-unchanged">Show unchanged tasks</Label>
+        </InlineStack>
+      </InlineStack>
+
+      {visibleDiffs.length === 0 ? (
+        <InfoBox title="No differences" variant="success" width="full">
+          These two runs have identical task configurations.
+        </InfoBox>
+      ) : (
+        <BlockStack gap="2" className="w-full">
+          {visibleDiffs.map((diff) => (
+            <TaskDiffRow
+              key={diff.taskId}
+              diff={diff}
+              labelA={labelA}
+              labelB={labelB}
+            />
+          ))}
+        </BlockStack>
+      )}
+    </BlockStack>
+  );
+}

--- a/src/routes/v2/pages/CompareView/components/TaskDiffRow.tsx
+++ b/src/routes/v2/pages/CompareView/components/TaskDiffRow.tsx
@@ -1,0 +1,142 @@
+import { Icon } from "@/components/ui/icon";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
+import { cn } from "@/lib/utils";
+import type { TaskDiff } from "@/routes/v2/pages/CompareView/utils/comparePipelines";
+import {
+  EXECUTION_STATUS_BG_COLORS,
+  getExecutionStatusLabel,
+} from "@/utils/executionStatus";
+
+import { DiffStatusBadge } from "./DiffStatusBadge";
+import { FieldDiffRow } from "./FieldDiffRow";
+
+interface ExecutionStatusPillProps {
+  label: string;
+  status: string | undefined;
+}
+
+function ExecutionStatusPill({ label, status }: ExecutionStatusPillProps) {
+  if (!status) return null;
+
+  return (
+    <InlineStack gap="1" blockAlign="center" wrap="nowrap">
+      <Text as="span" size="xs" tone="subdued">
+        {label}
+      </Text>
+      <span
+        className={cn(
+          "h-2 w-2 rounded-full",
+          EXECUTION_STATUS_BG_COLORS[status] ?? "bg-gray-400",
+        )}
+      />
+      <Text as="span" size="xs">
+        {getExecutionStatusLabel(status)}
+      </Text>
+    </InlineStack>
+  );
+}
+
+interface TaskDiffRowProps {
+  diff: TaskDiff;
+  labelA: string;
+  labelB: string;
+}
+
+export function TaskDiffRow({ diff, labelA, labelB }: TaskDiffRowProps) {
+  const changedArguments = diff.argumentDiffs.filter(
+    (entry) => entry.status !== "unchanged",
+  );
+  const changedAnnotations = diff.annotationDiffs.filter(
+    (entry) => entry.status !== "unchanged",
+  );
+
+  const componentChanged =
+    diff.status === "changed" && !diff.sameComponentVersion;
+  const hasFieldChanges =
+    componentChanged ||
+    changedArguments.length > 0 ||
+    changedAnnotations.length > 0;
+
+  return (
+    <BlockStack
+      gap="4"
+      className={cn(
+        "rounded-lg border p-4",
+        diff.outcomeChanged ? "border-amber-300" : "border-border",
+      )}
+    >
+      <BlockStack gap="2">
+        <InlineStack gap="2" blockAlign="center" wrap="wrap">
+          <Text as="span" size="sm" weight="semibold" className="font-mono">
+            {diff.taskId}
+          </Text>
+          <DiffStatusBadge status={diff.status} />
+        </InlineStack>
+        <InlineStack gap="2" blockAlign="center" wrap="wrap">
+          <ExecutionStatusPill label={labelA} status={diff.statusA} />
+          {diff.outcomeChanged && diff.statusA && diff.statusB && (
+            <Icon
+              name="ArrowRight"
+              size="xs"
+              className="text-muted-foreground"
+            />
+          )}
+          <ExecutionStatusPill label={labelB} status={diff.statusB} />
+        </InlineStack>
+      </BlockStack>
+
+      {componentChanged && (
+        <BlockStack gap="1">
+          <Text as="span" size="xs" weight="semibold" tone="subdued">
+            Component
+          </Text>
+          <Text as="span" size="xs" className="font-mono">
+            {diff.digestA?.slice(0, 8) ?? "—"} →{" "}
+            {diff.digestB?.slice(0, 8) ?? "—"}
+          </Text>
+        </BlockStack>
+      )}
+
+      {changedArguments.length > 0 && (
+        <BlockStack gap="1">
+          <Text as="span" size="xs" weight="semibold" tone="subdued">
+            Arguments
+          </Text>
+          {changedArguments.map((entry) => (
+            <FieldDiffRow
+              key={entry.key}
+              entry={entry}
+              labelA={labelA}
+              labelB={labelB}
+            />
+          ))}
+        </BlockStack>
+      )}
+
+      {changedAnnotations.length > 0 && (
+        <BlockStack gap="1">
+          <Text as="span" size="xs" weight="semibold" tone="subdued">
+            Annotations
+          </Text>
+          {changedAnnotations.map((entry) => (
+            <FieldDiffRow
+              key={entry.key}
+              entry={entry}
+              labelA={labelA}
+              labelB={labelB}
+            />
+          ))}
+        </BlockStack>
+      )}
+
+      {!hasFieldChanges && (
+        <Text as="span" size="sm" tone="subdued">
+          {diff.outcomeChanged
+            ? "No configuration changes — the execution outcome differs between runs."
+            : "No differences in this task."}
+        </Text>
+      )}
+    </BlockStack>
+  );
+}

--- a/src/routes/v2/pages/CompareView/components/YamlDiffView.tsx
+++ b/src/routes/v2/pages/CompareView/components/YamlDiffView.tsx
@@ -1,0 +1,36 @@
+import { DiffEditor } from "@monaco-editor/react";
+
+import type { ComponentSpec } from "@/utils/componentSpec";
+import { componentSpecToText } from "@/utils/yaml";
+
+interface YamlDiffViewProps {
+  specA: ComponentSpec;
+  specB: ComponentSpec;
+}
+
+export function YamlDiffView({ specA, specB }: YamlDiffViewProps) {
+  const yamlA = componentSpecToText(specA);
+  const yamlB = componentSpecToText(specB);
+
+  return (
+    <DiffEditor
+      original={yamlA}
+      modified={yamlB}
+      language="yaml"
+      theme="vs-dark"
+      options={{
+        readOnly: true,
+        renderSideBySide: true,
+        minimap: { enabled: false },
+        scrollBeyondLastLine: false,
+        automaticLayout: true,
+        wordWrap: "on",
+        renderOverviewRuler: false,
+        scrollbar: {
+          verticalScrollbarSize: 10,
+          horizontalScrollbarSize: 10,
+        },
+      }}
+    />
+  );
+}

--- a/src/routes/v2/pages/CompareView/hooks/useRunComparisonSide.ts
+++ b/src/routes/v2/pages/CompareView/hooks/useRunComparisonSide.ts
@@ -1,0 +1,37 @@
+import { usePipelineRunData } from "@/hooks/usePipelineRunData";
+import type { ComponentSpec } from "@/utils/componentSpec";
+import { buildTaskExecutionStatusMap } from "@/utils/executionStatus";
+
+export interface RunComparisonSide {
+  runId: string;
+  spec: ComponentSpec | undefined;
+  taskStatusMap: Map<string, string>;
+  isLoading: boolean;
+  error: Error | null;
+}
+
+/**
+ * Loads a single run's spec and per-task execution status for the comparison
+ * view. Safe to call twice in one component (once per side) because
+ * `usePipelineRunData` scopes all of its queries by id. Pass an empty string
+ * for an unselected side — the underlying queries stay disabled.
+ */
+export function useRunComparisonSide(runId: string): RunComparisonSide {
+  const { executionData, isLoading, error } = usePipelineRunData(runId);
+
+  const details = executionData?.details;
+  const state = executionData?.state;
+
+  const spec = details?.task_spec.componentRef.spec as
+    ComponentSpec | undefined;
+
+  const taskStatusMap = buildTaskExecutionStatusMap(details, state);
+
+  return {
+    runId,
+    spec,
+    taskStatusMap,
+    isLoading,
+    error: error ?? null,
+  };
+}

--- a/src/routes/v2/pages/CompareView/utils/comparePipelines.test.ts
+++ b/src/routes/v2/pages/CompareView/utils/comparePipelines.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, test } from "vitest";
+
+import type { ComponentSpec, TaskSpec } from "@/utils/componentSpec";
+
+import { buildPipelineComparison } from "./comparePipelines";
+
+const task = (digest: string, overrides: Partial<TaskSpec> = {}): TaskSpec => ({
+  componentRef: { name: "comp", digest },
+  ...overrides,
+});
+
+const graphSpec = (tasks: Record<string, TaskSpec>): ComponentSpec => ({
+  implementation: { graph: { tasks } },
+});
+
+const containerSpec = (): ComponentSpec => ({
+  implementation: { container: { image: "python:3.11" } },
+});
+
+const noStatus = new Map<string, string>();
+
+describe("buildPipelineComparison()", () => {
+  test("flags added, removed, and unchanged tasks by id", () => {
+    const specA = graphSpec({ train: task("d1"), evaluate: task("d2") });
+    const specB = graphSpec({ train: task("d1"), deploy: task("d3") });
+
+    const { taskDiffs, counts } = buildPipelineComparison(
+      specA,
+      specB,
+      noStatus,
+      noStatus,
+    );
+
+    const byId = Object.fromEntries(taskDiffs.map((d) => [d.taskId, d.status]));
+    expect(byId).toEqual({
+      train: "unchanged",
+      evaluate: "lost",
+      deploy: "new",
+    });
+    expect(counts).toEqual({
+      added: 1,
+      removed: 1,
+      changed: 0,
+      unchanged: 1,
+      outcomeChanged: 0,
+    });
+  });
+
+  test("marks a task changed when the component digest differs", () => {
+    const specA = graphSpec({ train: task("d1") });
+    const specB = graphSpec({ train: task("d2") });
+
+    const [diff] = buildPipelineComparison(
+      specA,
+      specB,
+      noStatus,
+      noStatus,
+    ).taskDiffs;
+
+    expect(diff.status).toBe("changed");
+    expect(diff.sameComponentVersion).toBe(false);
+  });
+
+  test("marks a task changed when arguments differ but the component is identical", () => {
+    const specA = graphSpec({
+      train: task("d1", { arguments: { epochs: "10" } }),
+    });
+    const specB = graphSpec({
+      train: task("d1", { arguments: { epochs: "20" } }),
+    });
+
+    const [diff] = buildPipelineComparison(
+      specA,
+      specB,
+      noStatus,
+      noStatus,
+    ).taskDiffs;
+
+    expect(diff.status).toBe("changed");
+    expect(diff.sameComponentVersion).toBe(true);
+    const epochs = diff.argumentDiffs.find((a) => a.key === "epochs");
+    expect(epochs?.status).toBe("changed");
+  });
+
+  test("treats structurally equal object arguments as unchanged", () => {
+    const arg = { taskOutput: { taskId: "prep", outputName: "data" } };
+    const specA = graphSpec({ train: task("d1", { arguments: { in: arg } }) });
+    const specB = graphSpec({
+      train: task("d1", { arguments: { in: { ...arg } } }),
+    });
+
+    const [diff] = buildPipelineComparison(
+      specA,
+      specB,
+      noStatus,
+      noStatus,
+    ).taskDiffs;
+
+    expect(diff.status).toBe("unchanged");
+  });
+
+  test("carries per-run execution status onto each task diff", () => {
+    const specA = graphSpec({ train: task("d1") });
+    const specB = graphSpec({ train: task("d1") });
+
+    const [diff] = buildPipelineComparison(
+      specA,
+      specB,
+      new Map([["train", "SUCCEEDED"]]),
+      new Map([["train", "FAILED"]]),
+    ).taskDiffs;
+
+    expect(diff.statusA).toBe("SUCCEEDED");
+    expect(diff.statusB).toBe("FAILED");
+  });
+
+  test("flags an outcome difference even when the task spec is unchanged", () => {
+    const specA = graphSpec({ train: task("d1") });
+    const specB = graphSpec({ train: task("d1") });
+
+    const { taskDiffs, counts } = buildPipelineComparison(
+      specA,
+      specB,
+      new Map([["train", "SUCCEEDED"]]),
+      new Map([["train", "FAILED"]]),
+    );
+
+    expect(taskDiffs[0].status).toBe("unchanged");
+    expect(taskDiffs[0].outcomeChanged).toBe(true);
+    expect(counts.outcomeChanged).toBe(1);
+  });
+
+  test("does not flag an outcome difference when both runs share a status", () => {
+    const specA = graphSpec({ train: task("d1") });
+    const specB = graphSpec({ train: task("d1") });
+
+    const { taskDiffs, counts } = buildPipelineComparison(
+      specA,
+      specB,
+      new Map([["train", "SUCCEEDED"]]),
+      new Map([["train", "SUCCEEDED"]]),
+    );
+
+    expect(taskDiffs[0].outcomeChanged).toBe(false);
+    expect(counts.outcomeChanged).toBe(0);
+  });
+
+  test("reports no comparable tasks for container-implementation specs", () => {
+    const { taskDiffs, hasComparableTasks } = buildPipelineComparison(
+      containerSpec(),
+      containerSpec(),
+      noStatus,
+      noStatus,
+    );
+
+    expect(taskDiffs).toHaveLength(0);
+    expect(hasComparableTasks).toBe(false);
+  });
+
+  test("treats unrelated pipelines as fully added/removed", () => {
+    const specA = graphSpec({ a1: task("d1"), a2: task("d2") });
+    const specB = graphSpec({ b1: task("d3") });
+
+    const { counts } = buildPipelineComparison(
+      specA,
+      specB,
+      noStatus,
+      noStatus,
+    );
+
+    expect(counts).toEqual({
+      added: 1,
+      removed: 2,
+      changed: 0,
+      unchanged: 0,
+      outcomeChanged: 0,
+    });
+  });
+});

--- a/src/routes/v2/pages/CompareView/utils/comparePipelines.ts
+++ b/src/routes/v2/pages/CompareView/utils/comparePipelines.ts
@@ -1,0 +1,192 @@
+import equal from "fast-deep-equal";
+
+import type { DiffStatus } from "@/routes/v2/pages/Editor/store/actions/task.utils";
+import type {
+  ArgumentType,
+  ComponentSpec,
+  TaskSpec,
+} from "@/utils/componentSpec";
+import { isGraphImplementation } from "@/utils/componentSpec";
+
+export type { DiffStatus };
+
+export interface KeyedDiffEntry<T> {
+  key: string;
+  a?: T;
+  b?: T;
+  status: DiffStatus;
+}
+
+export interface TaskDiff {
+  taskId: string;
+  status: DiffStatus;
+  a?: TaskSpec;
+  b?: TaskSpec;
+  digestA?: string;
+  digestB?: string;
+  sameComponentVersion: boolean;
+  statusA?: string;
+  statusB?: string;
+  outcomeChanged: boolean;
+  argumentDiffs: KeyedDiffEntry<ArgumentType>[];
+  annotationDiffs: KeyedDiffEntry<unknown>[];
+}
+
+interface ComparisonCounts {
+  added: number;
+  removed: number;
+  changed: number;
+  unchanged: number;
+  outcomeChanged: number;
+}
+
+export interface PipelineComparison {
+  taskDiffs: TaskDiff[];
+  counts: ComparisonCounts;
+  hasComparableTasks: boolean;
+}
+
+/**
+ * Union of keys preserving `a`'s order first, then appending keys present only
+ * in `b` in `b`'s order. Mirrors the ordering of the editor's diff lists so the
+ * two features read consistently.
+ */
+function unionKeysAFirst(
+  a: Record<string, unknown>,
+  b: Record<string, unknown>,
+): string[] {
+  const seen = new Set<string>();
+  const keys: string[] = [];
+  for (const key of Object.keys(a)) {
+    seen.add(key);
+    keys.push(key);
+  }
+  for (const key of Object.keys(b)) {
+    if (!seen.has(key)) keys.push(key);
+  }
+  return keys;
+}
+
+function diffKeyedRecords<T>(
+  a: Record<string, T> | undefined,
+  b: Record<string, T> | undefined,
+): KeyedDiffEntry<T>[] {
+  const aRecord = a ?? {};
+  const bRecord = b ?? {};
+
+  return unionKeysAFirst(aRecord, bRecord).map((key) => {
+    const inA = key in aRecord;
+    const inB = key in bRecord;
+    const aValue = inA ? aRecord[key] : undefined;
+    const bValue = inB ? bRecord[key] : undefined;
+
+    let status: DiffStatus;
+    if (inA && !inB) status = "lost";
+    else if (!inA && inB) status = "new";
+    else status = equal(aValue, bValue) ? "unchanged" : "changed";
+
+    return { key, a: aValue, b: bValue, status };
+  });
+}
+
+function isComponentChanged(a: TaskSpec, b: TaskSpec): boolean {
+  const digestA = a.componentRef.digest;
+  const digestB = b.componentRef.digest;
+  if (digestA && digestB) return digestA !== digestB;
+  return !equal(a.componentRef, b.componentRef);
+}
+
+function buildTaskDiff(
+  taskId: string,
+  a: TaskSpec | undefined,
+  b: TaskSpec | undefined,
+  statusA: string | undefined,
+  statusB: string | undefined,
+): TaskDiff {
+  const argumentDiffs = diffKeyedRecords(a?.arguments, b?.arguments);
+  const annotationDiffs = diffKeyedRecords(a?.annotations, b?.annotations);
+  const digestA = a?.componentRef.digest;
+  const digestB = b?.componentRef.digest;
+
+  let status: DiffStatus;
+  if (a && !b) status = "lost";
+  else if (!a && b) status = "new";
+  else if (a && b) {
+    const hasFieldChanges = [...argumentDiffs, ...annotationDiffs].some(
+      (entry) => entry.status !== "unchanged",
+    );
+    status =
+      isComponentChanged(a, b) || hasFieldChanges ? "changed" : "unchanged";
+  } else {
+    status = "unchanged";
+  }
+
+  return {
+    taskId,
+    status,
+    a,
+    b,
+    digestA,
+    digestB,
+    sameComponentVersion: Boolean(digestA && digestB && digestA === digestB),
+    statusA,
+    statusB,
+    outcomeChanged: (statusA ?? "") !== (statusB ?? ""),
+    argumentDiffs,
+    annotationDiffs,
+  };
+}
+
+function getGraphTasks(
+  spec: ComponentSpec | undefined,
+): Record<string, TaskSpec> {
+  if (!spec || !isGraphImplementation(spec.implementation)) return {};
+  return spec.implementation.graph.tasks;
+}
+
+/**
+ * Aligns two runs' pipeline specs by task id and produces a per-task diff of
+ * component version, arguments, annotations, and execution status. Task
+ * ordering follows run A first, with tasks only present in run B appended.
+ */
+export function buildPipelineComparison(
+  specA: ComponentSpec | undefined,
+  specB: ComponentSpec | undefined,
+  statusMapA: Map<string, string>,
+  statusMapB: Map<string, string>,
+): PipelineComparison {
+  const tasksA = getGraphTasks(specA);
+  const tasksB = getGraphTasks(specB);
+
+  const taskDiffs = unionKeysAFirst(tasksA, tasksB).map((taskId) =>
+    buildTaskDiff(
+      taskId,
+      tasksA[taskId],
+      tasksB[taskId],
+      statusMapA.get(taskId),
+      statusMapB.get(taskId),
+    ),
+  );
+
+  const counts: ComparisonCounts = {
+    added: 0,
+    removed: 0,
+    changed: 0,
+    unchanged: 0,
+    outcomeChanged: 0,
+  };
+  for (const diff of taskDiffs) {
+    if (diff.status === "new") counts.added += 1;
+    else if (diff.status === "lost") counts.removed += 1;
+    else if (diff.status === "changed") counts.changed += 1;
+    else counts.unchanged += 1;
+
+    if (diff.outcomeChanged) counts.outcomeChanged += 1;
+  }
+
+  return {
+    taskDiffs,
+    counts,
+    hasComparableTasks: taskDiffs.length > 0,
+  };
+}

--- a/src/routes/v2/pages/RunView/components/RunViewMenuBar/components/RunMenu.tsx
+++ b/src/routes/v2/pages/RunView/components/RunViewMenuBar/components/RunMenu.tsx
@@ -1,4 +1,7 @@
+import { useNavigate } from "@tanstack/react-router";
+
 import ConfirmationDialog from "@/components/shared/Dialogs/ConfirmationDialog";
+import { useFlagValue } from "@/components/shared/Settings/useFlags";
 import TaskImplementation from "@/components/shared/TaskDetails/Implementation";
 import {
   DropdownMenu,
@@ -8,6 +11,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Icon } from "@/components/ui/icon";
+import { APP_ROUTES } from "@/routes/appRoutes";
 import { useCancelPipelineRun } from "@/routes/v2/pages/RunView/hooks/useCancelPipelineRun";
 import { useClonePipelineRun } from "@/routes/v2/pages/RunView/hooks/useClonePipelineRun";
 import { useExportPipelineYaml } from "@/routes/v2/pages/RunView/hooks/useExportPipelineYaml";
@@ -19,7 +23,9 @@ import { MenuTriggerButton } from "@/routes/v2/shared/components/MenuTriggerButt
 import { tracking } from "@/utils/tracking";
 
 export function RunMenu() {
+  const navigate = useNavigate();
   const actions = useRunViewActions();
+  const compareEnabled = useFlagValue("compare-runs");
   const componentSpec = actions.ready ? actions.componentSpec : undefined;
   const runId = actions.ready ? actions.runId : undefined;
   const pipelineName = actions.ready ? actions.pipelineName : undefined;
@@ -36,6 +42,12 @@ export function RunMenu() {
   } = useCancelPipelineRun(runId);
   const { inspect } = useInspectPipeline(pipelineName);
   const { exportYaml } = useExportPipelineYaml(componentSpec, pipelineName);
+
+  const handleCompare = () => {
+    if (runId) {
+      navigate({ to: APP_ROUTES.COMPARE, search: { a: runId } });
+    }
+  };
 
   if (!actions.ready) {
     return (
@@ -83,6 +95,16 @@ export function RunMenu() {
             <Icon name="FileCode" size="sm" />
             View YAML
           </DropdownMenuItem>
+
+          {compareEnabled && runId && (
+            <DropdownMenuItem
+              onSelect={handleCompare}
+              {...tracking("compare_runs.run_view.compare_with_another")}
+            >
+              <Icon name="GitCompare" size="sm" />
+              Compare with another run…
+            </DropdownMenuItem>
+          )}
 
           <DropdownMenuItem
             onSelect={clone}

--- a/src/utils/executionStatus.ts
+++ b/src/utils/executionStatus.ts
@@ -1,5 +1,6 @@
 import type {
   ContainerExecutionStatus,
+  GetExecutionInfoResponse,
   GetGraphExecutionStateResponse,
 } from "@/api/types.gen";
 
@@ -169,4 +170,32 @@ export function countInProgressFromStats(stats: ExecutionStatusStats): number {
 export function isExecutionComplete(stats: ExecutionStatusStats): boolean {
   const total = Object.values(stats).reduce((sum, c) => sum + (c ?? 0), 0);
   return total > 0 && countInProgressFromStats(stats) === 0;
+}
+
+/**
+ * Build a map of task id → aggregated execution status by joining a run's
+ * task→execution id mapping against its per-execution status stats.
+ */
+export function buildTaskExecutionStatusMap(
+  details?: GetExecutionInfoResponse,
+  state?: GetGraphExecutionStateResponse,
+): Map<string, string> {
+  const taskExecutionStatusMap = new Map<string, string>();
+
+  if (!details?.child_task_execution_ids) {
+    return taskExecutionStatusMap;
+  }
+
+  for (const [taskId, executionId] of Object.entries(
+    details.child_task_execution_ids,
+  )) {
+    const statusStats = state?.child_execution_status_stats?.[executionId];
+    const aggregated = getOverallExecutionStatusFromStats(statusStats);
+
+    if (aggregated) {
+      taskExecutionStatusMap.set(taskId, aggregated);
+    }
+  }
+
+  return taskExecutionStatusMap;
 }


### PR DESCRIPTION
## Description

First PR in the run-comparison stack. Adds the foundation for comparing two pipeline runs side by side, behind a new `compare-runs` beta flag.

**What you can do with it:**
- Select exactly two runs from the dashboard (new checkboxes + a floating "Compare" action bar), or start a comparison from a single run's menu ("Compare with another run…").
- Land on a new Compare page that shows both runs side by side with a picker to choose/swap which runs you're comparing.
- View the differences in two ways:
  - **Structured view** — a task-by-task breakdown highlighting added / removed / changed / unchanged tasks, plus argument, annotation, component and execution-outcome changes.
  - **YAML view** — a side-by-side YAML diff of the two runs (Monaco diff editor).
- A **Graph view** tab exists but is a "coming soon" placeholder in this PR (built out in #2519).

Also does a small refactor: extracts `buildTaskExecutionStatusMap` into a shared util so both the executor and the comparison logic can use it.

## Type of Change

- [x] New feature

## Screenshots

![image.png](https://app.graphite.com/user-attachments/assets/8901b26f-9d34-4bc4-bf9e-aafef6232ebb.png)

![image.png](https://app.graphite.com/user-attachments/assets/eaa0f55c-4408-4114-943e-0183e4652c9c.png)
