### PR TITLE
Add Windows menu and dock layout presets to Run View

### DIFF
--- a/src/routes/v2/pages/Editor/components/EditorMenuBar/components/WindowsMenu.tsx
+++ b/src/routes/v2/pages/Editor/components/EditorMenuBar/components/WindowsMenu.tsx
@@ -1,100 +1,14 @@
-import { observer } from "mobx-react-lite";
-
 import { useFlagValue } from "@/components/shared/Settings/useFlags";
-import {
-  DropdownMenu,
-  DropdownMenuCheckboxItem,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuSub,
-  DropdownMenuSubContent,
-  DropdownMenuSubTrigger,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { Icon } from "@/components/ui/icon";
-import { useAnalytics } from "@/providers/AnalyticsProvider";
-import { MenuTriggerButton } from "@/routes/v2/shared/components/MenuTriggerButton";
-import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
-import {
-  type ViewPreset,
-  viewPresetForComponentSearchMode,
-  viewPresetsForComponentSearchMode,
-} from "@/routes/v2/shared/windows/viewPresets";
-import { tracking } from "@/utils/tracking";
+import { viewPresetsForComponentSearchMode } from "@/routes/v2/shared/windows/viewPresets";
+import { WindowManagementMenu } from "@/routes/v2/shared/windows/WindowManagementMenu";
 
-export const WindowsMenu = observer(function WindowsMenu() {
-  const { track } = useAnalytics();
+export const WindowsMenu = () => {
   const componentSearchV2Enabled = useFlagValue("component-search-v2");
-  const { windows } = useSharedStores();
-  const sortedWindows = [...windows.getAllWindows()]
-    .filter((window) => window.persisted)
-    .sort((a, b) => a.title.localeCompare(b.title));
-
-  const applyPreset = (preset: ViewPreset) => {
-    track("v2.pipeline_editor.windows_menu.view_preset.click", {
-      preset_label: preset.label,
-    });
-    windows.applyViewPreset(
-      viewPresetForComponentSearchMode(preset, componentSearchV2Enabled),
-    );
-  };
 
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <MenuTriggerButton {...tracking("v2.pipeline_editor.windows_menu")}>
-          Windows
-        </MenuTriggerButton>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent
-        align="start"
-        sideOffset={2}
-        data-tour="windows-menu-content"
-      >
-        {sortedWindows.map((win) => (
-          <DropdownMenuCheckboxItem
-            key={win.id}
-            checked={win.state !== "hidden"}
-            onSelect={(e) => e.preventDefault()}
-            onCheckedChange={(checked) => {
-              track(
-                "v2.pipeline_editor.windows_menu.window_visibility.toggle",
-                {
-                  window_id: win.id,
-                  visible: checked,
-                },
-              );
-              if (checked) {
-                win.restore();
-              } else {
-                win.hide();
-              }
-            }}
-          >
-            {win.title}
-          </DropdownMenuCheckboxItem>
-        ))}
-        <DropdownMenuSeparator />
-        <DropdownMenuSub>
-          <DropdownMenuSubTrigger>
-            <Icon name="LayoutDashboard" size="sm" />
-            Views
-          </DropdownMenuSubTrigger>
-          <DropdownMenuSubContent data-tour="windows-menu-submenu-content">
-            {viewPresetsForComponentSearchMode(componentSearchV2Enabled).map(
-              (preset) => (
-                <DropdownMenuItem
-                  key={preset.label}
-                  onSelect={() => applyPreset(preset)}
-                >
-                  {preset.label}
-                </DropdownMenuItem>
-              ),
-            )}
-          </DropdownMenuSubContent>
-        </DropdownMenuSub>
-      </DropdownMenuContent>
-    </DropdownMenu>
+    <WindowManagementMenu
+      presets={viewPresetsForComponentSearchMode(componentSearchV2Enabled)}
+      trackingPrefix="v2.pipeline_editor.windows_menu"
+    />
   );
-});
+};

--- a/src/routes/v2/pages/RunView/RunViewV2.tsx
+++ b/src/routes/v2/pages/RunView/RunViewV2.tsx
@@ -150,7 +150,7 @@ const RunViewLayout = observer(function RunViewLayout({
 }: RunViewLayoutProps) {
   useRunViewSpecLifecycle(spec);
   useShortcutListener();
-  useWindowPersistence("runview");
+  useWindowPersistence("runview-v2");
   useDockAreaAccordion();
   useRunViewWindows();
   useRunViewSelectionSync();
@@ -174,6 +174,7 @@ const RunViewLayout = observer(function RunViewLayout({
           wrap="nowrap"
           data-testid="run-view-v2"
         >
+          <DockArea side="left" />
           <div className="relative flex-1 min-w-0 h-full">
             <RunViewFlowCanvas
               key={activeSpec?.$id ?? "root"}

--- a/src/routes/v2/pages/RunView/components/RunViewMenuBar/RunViewMenuBar.tsx
+++ b/src/routes/v2/pages/RunView/components/RunViewMenuBar/RunViewMenuBar.tsx
@@ -11,6 +11,7 @@ import { tracking } from "@/utils/tracking";
 
 import { RunMenu } from "./components/RunMenu";
 import { RunViewViewMenu } from "./components/RunViewViewMenu";
+import { RunViewWindowsMenu } from "./components/RunViewWindowsMenu";
 
 export const RunViewMenuBar = observer(function RunViewMenuBar() {
   const { navigation } = useSharedStores();
@@ -62,6 +63,7 @@ export const RunViewMenuBar = observer(function RunViewMenuBar() {
             <InlineStack wrap="nowrap" blockAlign="center">
               <RunMenu />
               <RunViewViewMenu />
+              <RunViewWindowsMenu />
             </InlineStack>
           </BlockStack>
         </InlineStack>

--- a/src/routes/v2/pages/RunView/components/RunViewMenuBar/components/RunViewWindowsMenu.tsx
+++ b/src/routes/v2/pages/RunView/components/RunViewMenuBar/components/RunViewWindowsMenu.tsx
@@ -1,0 +1,9 @@
+import { RUN_VIEW_PRESETS } from "@/routes/v2/pages/RunView/runViewWindowPresets";
+import { WindowManagementMenu } from "@/routes/v2/shared/windows/WindowManagementMenu";
+
+export const RunViewWindowsMenu = () => (
+  <WindowManagementMenu
+    presets={RUN_VIEW_PRESETS}
+    trackingPrefix="v2.run_view.windows_menu"
+  />
+);

--- a/src/routes/v2/pages/RunView/hooks/runWindowVisibilityPersistence.test.tsx
+++ b/src/routes/v2/pages/RunView/hooks/runWindowVisibilityPersistence.test.tsx
@@ -1,0 +1,105 @@
+import { cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  RUN_AI_ASSISTANT_WINDOW_ID,
+  RUN_DETAILS_WINDOW_ID,
+  RUN_TOOLS_WINDOW_ID,
+} from "@/routes/v2/pages/RunView/runViewWindowPresets";
+import { WindowStoreImpl } from "@/routes/v2/shared/windows/windowStore";
+
+import { useAiChatWindow } from "./useAiChatWindow";
+import { useRunViewWindows } from "./useRunViewWindows";
+
+const persistenceMocks = vi.hoisted(() => ({
+  getPersistedWindowState: vi.fn(),
+  hasPersistedLayout: vi.fn(),
+}));
+
+vi.mock("@/routes/v2/shared/windows/windowPersistence", () => ({
+  getPersistedWindowState: persistenceMocks.getPersistedWindowState,
+  hasPersistedLayout: persistenceMocks.hasPersistedLayout,
+}));
+
+let windows: WindowStoreImpl;
+
+vi.mock("@/routes/v2/shared/store/SharedStoreContext", () => ({
+  useSharedStores: () => ({ windows }),
+}));
+
+vi.mock("@/routes/v2/pages/RunView/components/RunDetailsContent", () => ({
+  RunDetailsContent: () => null,
+}));
+vi.mock("@/routes/v2/pages/RunView/components/RunToolsContent", () => ({
+  RunToolsContent: () => null,
+}));
+vi.mock("@/routes/v2/shared/components/AiChat/AiChatContent", () => ({
+  AiChatContent: () => null,
+}));
+vi.mock("@/routes/v2/pages/RunView/toolBridge/runViewToolBridge", () => ({
+  createRunViewToolBridge: vi.fn(),
+}));
+
+const RUN_WINDOW_IDS = [
+  RUN_TOOLS_WINDOW_ID,
+  RUN_DETAILS_WINDOW_ID,
+  RUN_AI_ASSISTANT_WINDOW_ID,
+];
+
+function renderRunWindowHooks() {
+  return renderHook(() => {
+    useRunViewWindows();
+    useAiChatWindow(true);
+  });
+}
+
+describe("Run View window visibility persistence", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    windows = new WindowStoreImpl();
+  });
+
+  afterEach(cleanup);
+
+  it("shows the default Run View windows when no layout is persisted", () => {
+    persistenceMocks.getPersistedWindowState.mockReturnValue(null);
+    persistenceMocks.hasPersistedLayout.mockReturnValue(false);
+
+    renderRunWindowHooks();
+
+    for (const id of RUN_WINDOW_IDS) {
+      expect(windows.getWindowById(id)?.state).toBe("normal");
+    }
+  });
+
+  it("honors default visibility when an existing layout has no state for a window", () => {
+    persistenceMocks.getPersistedWindowState.mockReturnValue(null);
+    persistenceMocks.hasPersistedLayout.mockReturnValue(true);
+
+    windows.openWindow(null, {
+      id: "new-hidden-window",
+      title: "New Hidden Window",
+      defaultVisible: false,
+      persisted: true,
+    });
+
+    expect(windows.getWindowById("new-hidden-window")?.state).toBe("hidden");
+  });
+
+  it("restores hidden Run View windows from the persisted layout", () => {
+    persistenceMocks.getPersistedWindowState.mockReturnValue({
+      position: { x: 0, y: 0 },
+      size: { width: 320, height: 420 },
+      dockState: "left",
+      isHidden: true,
+      isMinimized: false,
+    });
+    persistenceMocks.hasPersistedLayout.mockReturnValue(true);
+
+    renderRunWindowHooks();
+
+    for (const id of RUN_WINDOW_IDS) {
+      expect(windows.getWindowById(id)?.state).toBe("hidden");
+    }
+  });
+});

--- a/src/routes/v2/pages/RunView/hooks/useAiChatWindow.tsx
+++ b/src/routes/v2/pages/RunView/hooks/useAiChatWindow.tsx
@@ -1,11 +1,10 @@
 import { useEffect } from "react";
 
+import { RUN_AI_ASSISTANT_WINDOW_ID } from "@/routes/v2/pages/RunView/runViewWindowPresets";
 import { createRunViewToolBridge } from "@/routes/v2/pages/RunView/toolBridge/runViewToolBridge";
 import { AiChatContent } from "@/routes/v2/shared/components/AiChat/AiChatContent";
 import type { SuggestedPrompt } from "@/routes/v2/shared/components/AiChat/types";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
-
-const AI_CHAT_WINDOW_ID = "run-ai-assistant-chat";
 
 const SUGGESTED_PROMPTS_RUN: SuggestedPrompt[] = [
   { label: "Summarize this run", icon: "FileText" },
@@ -19,10 +18,10 @@ export function useAiChatWindow(enabled: boolean) {
 
   useEffect(() => {
     if (!enabled) {
-      windows.closeWindow(AI_CHAT_WINDOW_ID);
+      windows.closeWindow(RUN_AI_ASSISTANT_WINDOW_ID);
       return;
     }
-    if (windows.getWindowById(AI_CHAT_WINDOW_ID)) return;
+    if (windows.getWindowById(RUN_AI_ASSISTANT_WINDOW_ID)) return;
 
     windows.openWindow(
       <AiChatContent
@@ -30,12 +29,13 @@ export function useAiChatWindow(enabled: boolean) {
         suggestedPrompts={SUGGESTED_PROMPTS_RUN}
       />,
       {
-        id: AI_CHAT_WINDOW_ID,
+        id: RUN_AI_ASSISTANT_WINDOW_ID,
         title: "AI Assistant",
         position: { x: 100, y: 80 },
         size: { width: 380, height: 520 },
         disabledActions: ["close"],
-        startVisible: true,
+        defaultVisible: true,
+        defaultDockState: "left",
         persisted: true,
       },
     );

--- a/src/routes/v2/pages/RunView/hooks/useRunViewWindows.tsx
+++ b/src/routes/v2/pages/RunView/hooks/useRunViewWindows.tsx
@@ -2,10 +2,11 @@ import { useEffect } from "react";
 
 import { RunDetailsContent } from "@/routes/v2/pages/RunView/components/RunDetailsContent";
 import { RunToolsContent } from "@/routes/v2/pages/RunView/components/RunToolsContent";
+import {
+  RUN_DETAILS_WINDOW_ID,
+  RUN_TOOLS_WINDOW_ID,
+} from "@/routes/v2/pages/RunView/runViewWindowPresets";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
-
-const RUN_TOOLS_WINDOW_ID = "run-tools";
-const RUN_DETAILS_WINDOW_ID = "run-details";
 
 export function useRunViewWindows() {
   const { windows } = useSharedStores();
@@ -13,18 +14,20 @@ export function useRunViewWindows() {
     windows.openWindow(<RunToolsContent />, {
       id: RUN_TOOLS_WINDOW_ID,
       title: "Run Tools",
-      startVisible: true,
+      defaultVisible: true,
       disabledActions: ["close", "maximize"],
-      size: { width: 400, height: 80 },
+      size: { width: 280, height: 240 },
       position: { x: 0, y: 60 },
-      minSize: { width: 400, height: 80 },
+      minSize: { width: 240, height: 180 },
+      defaultDockState: "left",
       persisted: true,
     });
 
     windows.openWindow(<RunDetailsContent />, {
       id: RUN_DETAILS_WINDOW_ID,
       title: "Run Details",
-      startVisible: true,
+      defaultVisible: true,
+      defaultDockState: "right",
       persisted: true,
     });
   }, [windows]);

--- a/src/routes/v2/pages/RunView/runViewWindowPresets.test.ts
+++ b/src/routes/v2/pages/RunView/runViewWindowPresets.test.ts
@@ -1,0 +1,61 @@
+import { createElement } from "react";
+import { describe, expect, it } from "vitest";
+
+import { WindowStoreImpl } from "@/routes/v2/shared/windows/windowStore";
+
+import {
+  RUN_AI_ASSISTANT_WINDOW_ID,
+  RUN_DEFAULT_VIEW_PRESET,
+  RUN_DETAILS_WINDOW_ID,
+  RUN_TOOLS_WINDOW_ID,
+  RUN_VIEW_PRESETS,
+} from "./runViewWindowPresets";
+
+const stubContent = createElement("span");
+
+function createRunWindowStore() {
+  const store = new WindowStoreImpl();
+  store.enableDockSide("left");
+  store.enableDockSide("right");
+
+  for (const id of [
+    RUN_TOOLS_WINDOW_ID,
+    RUN_DETAILS_WINDOW_ID,
+    RUN_AI_ASSISTANT_WINDOW_ID,
+  ]) {
+    store.openWindow(stubContent, { id, title: id, persisted: true });
+  }
+
+  return store;
+}
+
+describe("run view window presets", () => {
+  it("docks the default run windows on their intended sides", () => {
+    const store = createRunWindowStore();
+
+    store.applyViewPreset(RUN_DEFAULT_VIEW_PRESET);
+
+    expect(store.getDockAreaWindowIds("left")).toEqual([
+      RUN_TOOLS_WINDOW_ID,
+      RUN_AI_ASSISTANT_WINDOW_ID,
+    ]);
+    expect(store.getDockAreaWindowIds("right")).toEqual([
+      RUN_DETAILS_WINDOW_ID,
+    ]);
+  });
+
+  it("hides all run windows with the minimal preset", () => {
+    const store = createRunWindowStore();
+    const minimalPreset = RUN_VIEW_PRESETS.find(
+      (preset) => preset.label === "Minimal",
+    );
+
+    expect(minimalPreset).toBeDefined();
+    if (!minimalPreset) throw new Error("Missing minimal run view preset");
+    store.applyViewPreset(minimalPreset);
+
+    expect(
+      store.getAllWindows().every((window) => window.state === "hidden"),
+    ).toBe(true);
+  });
+});

--- a/src/routes/v2/pages/RunView/runViewWindowPresets.ts
+++ b/src/routes/v2/pages/RunView/runViewWindowPresets.ts
@@ -1,0 +1,29 @@
+import type { ViewPreset } from "@/routes/v2/shared/windows/viewPresets";
+
+export const RUN_TOOLS_WINDOW_ID = "run-tools";
+export const RUN_DETAILS_WINDOW_ID = "run-details";
+export const RUN_AI_ASSISTANT_WINDOW_ID = "run-ai-assistant-chat";
+
+export const RUN_DEFAULT_VIEW_PRESET: ViewPreset = {
+  label: "Default",
+  description:
+    "Run Tools and AI Assistant on the left, Run Details on the right",
+  visible: new Set([
+    RUN_TOOLS_WINDOW_ID,
+    RUN_DETAILS_WINDOW_ID,
+    RUN_AI_ASSISTANT_WINDOW_ID,
+  ]),
+  dockAreas: {
+    left: [RUN_TOOLS_WINDOW_ID, RUN_AI_ASSISTANT_WINDOW_ID],
+    right: [RUN_DETAILS_WINDOW_ID],
+  },
+};
+
+export const RUN_VIEW_PRESETS: ViewPreset[] = [
+  RUN_DEFAULT_VIEW_PRESET,
+  {
+    label: "Minimal",
+    description: "Hide all run panels",
+    visible: new Set<string>(),
+  },
+];

--- a/src/routes/v2/shared/windows/WindowManagementMenu.tsx
+++ b/src/routes/v2/shared/windows/WindowManagementMenu.tsx
@@ -1,0 +1,95 @@
+import { observer } from "mobx-react-lite";
+
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Icon } from "@/components/ui/icon";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
+import { MenuTriggerButton } from "@/routes/v2/shared/components/MenuTriggerButton";
+import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
+import type { ViewPreset } from "@/routes/v2/shared/windows/viewPresets";
+import { tracking } from "@/utils/tracking";
+
+interface WindowManagementMenuProps {
+  presets: readonly ViewPreset[];
+  trackingPrefix: string;
+}
+
+export const WindowManagementMenu = observer(function WindowManagementMenu({
+  presets,
+  trackingPrefix,
+}: WindowManagementMenuProps) {
+  const { track } = useAnalytics();
+  const { windows } = useSharedStores();
+  const sortedWindows = [...windows.getAllWindows()]
+    .filter((window) => window.persisted)
+    .sort((a, b) => a.title.localeCompare(b.title));
+
+  const applyPreset = (preset: ViewPreset) => {
+    track(`${trackingPrefix}.view_preset.click`, {
+      preset_label: preset.label,
+    });
+    windows.applyViewPreset(preset);
+  };
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <MenuTriggerButton {...tracking(trackingPrefix)}>
+          Windows
+        </MenuTriggerButton>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="start"
+        sideOffset={2}
+        data-tour="windows-menu-content"
+      >
+        {sortedWindows.map((window) => (
+          <DropdownMenuCheckboxItem
+            key={window.id}
+            checked={window.state !== "hidden"}
+            onSelect={(event) => event.preventDefault()}
+            onCheckedChange={(visible) => {
+              track(`${trackingPrefix}.window_visibility.toggle`, {
+                window_id: window.id,
+                visible,
+              });
+              if (visible) {
+                window.restore();
+              } else {
+                window.hide();
+              }
+            }}
+          >
+            {window.title}
+          </DropdownMenuCheckboxItem>
+        ))}
+        <DropdownMenuSeparator />
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger>
+            <Icon name="LayoutDashboard" size="sm" />
+            Views
+          </DropdownMenuSubTrigger>
+          <DropdownMenuSubContent data-tour="windows-menu-submenu-content">
+            {presets.map((preset) => (
+              <DropdownMenuItem
+                key={preset.label}
+                onSelect={() => applyPreset(preset)}
+              >
+                {preset.label}
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+});

--- a/src/routes/v2/shared/windows/types.ts
+++ b/src/routes/v2/shared/windows/types.ts
@@ -75,6 +75,8 @@ export interface WindowOptions {
   disabledActions?: WindowAction[];
   /** If true, window starts visible even if persisted state was hidden. Use for selection-driven windows. */
   startVisible?: boolean;
+  /** Whether the window is visible when it has no persisted window state. */
+  defaultVisible?: boolean;
   /** If true, the window's layout (position, size, dock state) is persisted to localStorage across reloads. */
   persisted?: boolean;
   /** Default dock side for first-time users (no persisted state). */

--- a/src/routes/v2/shared/windows/windowStore.utils.ts
+++ b/src/routes/v2/shared/windows/windowStore.utils.ts
@@ -64,8 +64,13 @@ function resolveInitialState(
     };
   }
 
-  if (options.persisted && !hasPersistedLayout() && !options.startVisible) {
-    if (!DEFAULT_VIEW_PRESET.visible.has(id)) {
+  if (options.persisted && !options.startVisible) {
+    const shouldStartHidden =
+      options.defaultVisible === false ||
+      (options.defaultVisible === undefined &&
+        !hasPersistedLayout() &&
+        !DEFAULT_VIEW_PRESET.visible.has(id));
+    if (shouldStartHidden) {
       return { state: "hidden", needsPreviousState: true };
     }
   }


### PR DESCRIPTION
## Description

Introduces a **Windows menu** to the Run View menu bar, allowing users to toggle the visibility of individual windows and apply layout presets. A new `runViewWindowPresets.ts` module centralizes window IDs and defines the available presets:

- **Default**: Run Tools and AI Assistant docked on the left, Run Details docked on the right.
- **Minimal**: All panels hidden.

Window IDs for Run Tools, Run Details, and AI Assistant are now exported from a single source of truth, replacing previously scattered local constants. Each window is assigned a `defaultDockState` so they snap to their intended dock side on first open.

A `DockArea` for the left side is added to the Run View layout to support docked windows.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Open a run in the Run View.
2. Confirm the **Windows** menu appears in the menu bar.
3. Toggle individual windows on/off via the Windows menu and verify visibility changes.
4. Open the **Views** submenu and apply the **Default** preset — Run Tools and AI Assistant should dock to the left, Run Details to the right.
5. Apply the **Minimal** preset and confirm all panels are hidden.

## Additional Comments

Tests for the preset logic are included in `runViewWindowPresets.test.ts`, covering both the default docking layout and the minimal hide-all behavior.