### PR TITLE
Refactor run tools layout and add displayLabel/showTooltip props to pipeline buttons

### DIFF
--- a/src/components/PipelineRun/components/CancelPipelineRunButton.test.tsx
+++ b/src/components/PipelineRun/components/CancelPipelineRunButton.test.tsx
@@ -123,7 +123,9 @@ describe("<CancelPipelineRunButton/>", () => {
     test("successfully cancels pipeline run", async () => {
       // arrange
       cancelPipelineRun.mockResolvedValue();
-      renderWithQueryClient(<CancelPipelineRunButton runId="test-run-123" />);
+      renderWithQueryClient(
+        <CancelPipelineRunButton runId="test-run-123" displayLabel="Stop" />,
+      );
 
       // act
       const button = screen.getByTestId("cancel-pipeline-run-button");
@@ -141,6 +143,7 @@ describe("<CancelPipelineRunButton/>", () => {
         "success",
       );
       expect(button).toBeDisabled();
+      expect(button).toHaveTextContent("Stop");
     });
 
     test("handles cancellation error", async () => {

--- a/src/components/PipelineRun/components/CancelPipelineRunButton.tsx
+++ b/src/components/PipelineRun/components/CancelPipelineRunButton.tsx
@@ -12,6 +12,8 @@ import { cancelPipelineRun } from "@/services/pipelineRunService";
 type CancelPipelineRunButtonProps = {
   runId: string | null | undefined;
   showLabel?: boolean;
+  displayLabel?: string;
+  showTooltip?: boolean;
 } & Omit<
   ComponentPropsWithoutRef<typeof TooltipButton>,
   "onClick" | "tooltip" | "variant" | "children"
@@ -20,6 +22,8 @@ type CancelPipelineRunButtonProps = {
 export const CancelPipelineRunButton = ({
   runId,
   showLabel,
+  displayLabel,
+  showTooltip = true,
   ...rest
 }: CancelPipelineRunButtonProps) => {
   const { backendUrl, available } = useBackend();
@@ -71,9 +75,13 @@ export const CancelPipelineRunButton = ({
 
   if (isSuccess) {
     return (
-      <TooltipButton disabled tooltip="Run cancelled" {...rest}>
+      <TooltipButton
+        disabled
+        tooltip={showTooltip ? "Run cancelled" : undefined}
+        {...rest}
+      >
         <Icon name="CircleSlash" />
-        {showLabel && "Cancelled"}
+        {displayLabel ?? (showLabel ? "Cancelled" : null)}
       </TooltipButton>
     );
   }
@@ -83,7 +91,7 @@ export const CancelPipelineRunButton = ({
       <TooltipButton
         variant="destructive"
         onClick={onClick}
-        tooltip="Cancel run"
+        tooltip={showTooltip ? "Cancel run" : undefined}
         disabled={isPending || !available}
         data-testid="cancel-pipeline-run-button"
         {...rest}
@@ -95,7 +103,7 @@ export const CancelPipelineRunButton = ({
             <Icon name="CircleX" />
           </div>
         )}
-        {showLabel && "Cancel"}
+        {displayLabel ?? (showLabel ? "Cancel" : null)}
       </TooltipButton>
 
       <ConfirmationDialog

--- a/src/components/PipelineRun/components/ClonePipelineButton.tsx
+++ b/src/components/PipelineRun/components/ClonePipelineButton.tsx
@@ -26,6 +26,8 @@ type ClonePipelineButtonProps = {
   componentSpec: ComponentSpec;
   runId?: string | null;
   showLabel?: boolean;
+  displayLabel?: string;
+  showTooltip?: boolean;
 } & Omit<
   ComponentPropsWithoutRef<typeof TooltipButton>,
   "onClick" | "tooltip" | "variant" | "children"
@@ -35,6 +37,8 @@ export const ClonePipelineButton = ({
   componentSpec,
   runId,
   showLabel,
+  displayLabel,
+  showTooltip = true,
   ...rest
 }: ClonePipelineButtonProps) => {
   const navigate = useNavigate();
@@ -102,13 +106,13 @@ export const ClonePipelineButton = ({
     <TooltipButton
       variant="outline"
       onClick={handleClone}
-      tooltip="Clone pipeline"
+      tooltip={showTooltip ? "Clone pipeline" : undefined}
       disabled={isPending}
       data-testid="clone-pipeline-run-button"
       {...rest}
     >
       <Icon name="CopyPlus" />
-      {showLabel && "Clone"}
+      {displayLabel ?? (showLabel ? "Clone" : null)}
     </TooltipButton>
   );
 };

--- a/src/components/PipelineRun/components/InspectPipelineButton.tsx
+++ b/src/components/PipelineRun/components/InspectPipelineButton.tsx
@@ -12,6 +12,8 @@ import { getDefaultEditorPath } from "@/routes/editorRoutes";
 type InspectPipelineButtonProps = {
   pipelineName: string;
   showLabel?: boolean;
+  displayLabel?: string;
+  showTooltip?: boolean;
 } & Omit<
   ComponentPropsWithoutRef<typeof TooltipButton>,
   "onClick" | "tooltip" | "variant" | "children"
@@ -20,6 +22,8 @@ type InspectPipelineButtonProps = {
 export const InspectPipelineButton = ({
   pipelineName,
   showLabel,
+  displayLabel,
+  showTooltip = true,
   ...rest
 }: InspectPipelineButtonProps) => {
   const navigate = useNavigate();
@@ -42,12 +46,12 @@ export const InspectPipelineButton = ({
     <TooltipButton
       variant="outline"
       onClick={handleInspect}
-      tooltip="Inspect pipeline"
+      tooltip={showTooltip ? "Inspect pipeline" : undefined}
       data-testid="inspect-pipeline-button"
       {...rest}
     >
       <Icon name="Network" className="rotate-270" />
-      {showLabel && "Inspect"}
+      {displayLabel ?? (showLabel ? "Inspect" : null)}
     </TooltipButton>
   );
 };

--- a/src/components/PipelineRun/components/RerunPipelineButton.tsx
+++ b/src/components/PipelineRun/components/RerunPipelineButton.tsx
@@ -21,6 +21,8 @@ import { submitPipelineRun } from "@/utils/submitPipeline";
 type RerunPipelineButtonProps = {
   componentSpec: ComponentSpec;
   showLabel?: boolean;
+  displayLabel?: string;
+  showTooltip?: boolean;
 } & Omit<
   ComponentPropsWithoutRef<typeof TooltipButton>,
   "onClick" | "tooltip" | "variant" | "children"
@@ -29,6 +31,8 @@ type RerunPipelineButtonProps = {
 export const RerunPipelineButton = ({
   componentSpec,
   showLabel,
+  displayLabel,
+  showTooltip = true,
   ...rest
 }: RerunPipelineButtonProps) => {
   const runNameOverride = useFlagValue("templatized-pipeline-run-name");
@@ -95,13 +99,13 @@ export const RerunPipelineButton = ({
     <TooltipButton
       variant="outline"
       onClick={() => mutate()}
-      tooltip="Rerun pipeline"
+      tooltip={showTooltip ? "Rerun pipeline" : undefined}
       disabled={isPending}
       data-testid="rerun-pipeline-button"
       {...rest}
     >
       <Icon name="RefreshCcw" />
-      {showLabel && "Rerun"}
+      {displayLabel ?? (showLabel ? "Rerun" : null)}
     </TooltipButton>
   );
 };

--- a/src/components/shared/Buttons/TooltipButton.tsx
+++ b/src/components/shared/Buttons/TooltipButton.tsx
@@ -7,11 +7,13 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
 
 interface TooltipButtonProps extends ButtonProps {
   tooltip: ReactNode;
   tooltipSide?: "top" | "right" | "bottom" | "left";
   tooltipAlign?: "start" | "center" | "end";
+  wrapperClassName?: string;
 }
 
 const TooltipButton = forwardRef<HTMLButtonElement, TooltipButtonProps>(
@@ -20,28 +22,33 @@ const TooltipButton = forwardRef<HTMLButtonElement, TooltipButtonProps>(
       tooltip,
       tooltipSide = "top",
       tooltipAlign = "center",
+      wrapperClassName,
       children,
       ...buttonProps
     },
     ref,
-  ) => (
-    <TooltipProvider>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <div className="w-fit">
-            <Button ref={ref} {...buttonProps}>
-              {children}
-            </Button>
-          </div>
-        </TooltipTrigger>
-        {!!tooltip && (
+  ) => {
+    const button = (
+      <div className={cn("w-fit", wrapperClassName)}>
+        <Button ref={ref} {...buttonProps}>
+          {children}
+        </Button>
+      </div>
+    );
+
+    if (!tooltip) return button;
+
+    return (
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>{button}</TooltipTrigger>
           <TooltipContent side={tooltipSide} align={tooltipAlign}>
             {tooltip}
           </TooltipContent>
-        )}
-      </Tooltip>
-    </TooltipProvider>
-  ),
+        </Tooltip>
+      </TooltipProvider>
+    );
+  },
 );
 
 TooltipButton.displayName = "TooltipButton";

--- a/src/components/shared/Buttons/ViewYamlButton.tsx
+++ b/src/components/shared/Buttons/ViewYamlButton.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { type ComponentPropsWithoutRef, useState } from "react";
 
 import type {
   ComponentSpec,
@@ -11,17 +11,21 @@ import { ActionButton } from "./ActionButton";
 
 type ViewYamlButtonProps = {
   displayLabel?: string;
-  "data-tracking-id"?: string;
-  "data-tracking-metadata"?: string;
-} & (
-  | { componentRef: HydratedComponentReference; componentSpec?: never }
-  | { componentSpec: ComponentSpec; componentRef?: never }
-);
+  showTooltip?: boolean;
+} & Omit<
+  ComponentPropsWithoutRef<typeof ActionButton>,
+  "children" | "icon" | "label" | "onClick" | "tooltip"
+> &
+  (
+    | { componentRef: HydratedComponentReference; componentSpec?: never }
+    | { componentSpec: ComponentSpec; componentRef?: never }
+  );
 
 export const ViewYamlButton = ({
   componentRef,
   componentSpec,
   displayLabel,
+  showTooltip = true,
   ...rest
 }: ViewYamlButtonProps) => {
   const [showCodeViewer, setShowCodeViewer] = useState(false);
@@ -30,13 +34,16 @@ export const ViewYamlButton = ({
     ? getComponentName(componentRef)
     : componentSpec.name || "Component";
 
+  const tooltipOrLabel = showTooltip
+    ? { tooltip: "View YAML", label: displayLabel }
+    : { label: displayLabel ?? "View YAML" };
+
   return (
     <>
       <ActionButton
-        tooltip="View YAML"
+        {...tooltipOrLabel}
         icon="FileCodeCorner"
         onClick={() => setShowCodeViewer(true)}
-        label={displayLabel}
         {...rest}
       />
 

--- a/src/routes/v2/pages/RunView/components/RunToolsContent.tsx
+++ b/src/routes/v2/pages/RunView/components/RunToolsContent.tsx
@@ -3,9 +3,13 @@ import { ClonePipelineButton } from "@/components/PipelineRun/components/ClonePi
 import { InspectPipelineButton } from "@/components/PipelineRun/components/InspectPipelineButton";
 import { RerunPipelineButton } from "@/components/PipelineRun/components/RerunPipelineButton";
 import { ViewYamlButton } from "@/components/shared/Buttons/ViewYamlButton";
-import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { BlockStack } from "@/components/ui/layout";
 import { useRunViewActions } from "@/routes/v2/pages/RunView/hooks/useRunViewActions";
 import { tracking } from "@/utils/tracking";
+
+const RUN_TOOL_CLASS_NAME =
+  "h-10 w-full justify-start gap-3 border-transparent bg-transparent px-3 shadow-none hover:border-border hover:bg-muted";
+const RUN_TOOL_WRAPPER_CLASS_NAME = "w-full";
 
 export function RunToolsContent() {
   const actions = useRunViewActions();
@@ -23,45 +27,58 @@ export function RunToolsContent() {
   } = actions;
 
   return (
-    <BlockStack gap="2" className="p-2">
-      <InlineStack gap="2">
-        <ViewYamlButton
-          componentSpec={componentSpec}
-          displayLabel="View"
-          {...tracking("v2.run_view.tools.view_yaml")}
+    <BlockStack gap="1" className="p-2">
+      <ViewYamlButton
+        componentSpec={componentSpec}
+        displayLabel="View YAML"
+        showTooltip={false}
+        className={RUN_TOOL_CLASS_NAME}
+        wrapperClassName={RUN_TOOL_WRAPPER_CLASS_NAME}
+        {...tracking("v2.run_view.tools.view_yaml")}
+      />
+
+      {canAccessEditorSpec && pipelineName && (
+        <InspectPipelineButton
+          pipelineName={pipelineName}
+          displayLabel="Inspect pipeline"
+          showTooltip={false}
+          className={RUN_TOOL_CLASS_NAME}
+          wrapperClassName={RUN_TOOL_WRAPPER_CLASS_NAME}
+          {...tracking("v2.run_view.tools.inspect_pipeline")}
         />
+      )}
 
-        {canAccessEditorSpec && pipelineName && (
-          <InspectPipelineButton
-            pipelineName={pipelineName}
-            showLabel
-            {...tracking("v2.run_view.tools.inspect_pipeline")}
-          />
-        )}
+      <ClonePipelineButton
+        componentSpec={componentSpec}
+        runId={runId}
+        displayLabel="Clone pipeline"
+        showTooltip={false}
+        className={RUN_TOOL_CLASS_NAME}
+        wrapperClassName={RUN_TOOL_WRAPPER_CLASS_NAME}
+        {...tracking("v2.run_view.tools.clone_pipeline")}
+      />
 
-        <ClonePipelineButton
-          componentSpec={componentSpec}
+      {isInProgress && isRunCreator && (
+        <CancelPipelineRunButton
           runId={runId}
-          showLabel
-          {...tracking("v2.run_view.tools.clone_pipeline")}
+          displayLabel="Cancel run"
+          showTooltip={false}
+          className={`${RUN_TOOL_CLASS_NAME} text-destructive hover:text-destructive`}
+          wrapperClassName={RUN_TOOL_WRAPPER_CLASS_NAME}
+          {...tracking("v2.run_view.tools.cancel_run")}
         />
+      )}
 
-        {isInProgress && isRunCreator && (
-          <CancelPipelineRunButton
-            runId={runId}
-            showLabel
-            {...tracking("v2.run_view.tools.cancel_run")}
-          />
-        )}
-
-        {isComplete && (
-          <RerunPipelineButton
-            componentSpec={componentSpec}
-            showLabel
-            {...tracking("v2.run_view.tools.rerun_pipeline")}
-          />
-        )}
-      </InlineStack>
+      {isComplete && (
+        <RerunPipelineButton
+          componentSpec={componentSpec}
+          displayLabel="Rerun pipeline"
+          showTooltip={false}
+          className={RUN_TOOL_CLASS_NAME}
+          wrapperClassName={RUN_TOOL_WRAPPER_CLASS_NAME}
+          {...tracking("v2.run_view.tools.rerun_pipeline")}
+        />
+      )}
     </BlockStack>
   );
 }


### PR DESCRIPTION
## Description

Refactors the run tools panel in the `RunView` to display action buttons as a vertical list with full-width, text-labeled menu items instead of a compact inline row of icon buttons. Tooltips are now hidden for these buttons since the labels are always visible, and a `displayLabel` prop allows overriding the button text independently of `showLabel`. A `showTooltip` prop has been added to all relevant pipeline action buttons (`CancelPipelineRunButton`, `ClonePipelineButton`, `InspectPipelineButton`, `RerunPipelineButton`, and `ViewYamlButton`) to control tooltip visibility.

`TooltipButton` has also been updated to skip rendering the tooltip wrapper entirely when no tooltip is provided, and now accepts a `wrapperClassName` prop to allow styling the inner wrapper `div`.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [x] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Navigate to a run in the Run View.
2. Open the tools panel and verify the action buttons appear as a vertical list with full-width labels (e.g., "View YAML", "Inspect pipeline", "Clone pipeline", "Cancel run", "Rerun pipeline").
3. Confirm that no tooltips appear on hover for these buttons.
4. Verify that buttons only appear when their conditions are met (e.g., "Cancel run" only when the run is in progress and the user is the run creator, "Rerun pipeline" only when the run is complete).
5. Confirm that pipeline action buttons used elsewhere still show tooltips and behave as expected.

## Additional Comments