### PR TITLE
Add run v2 version toggle and default run path routing

### DIFF
--- a/src/components/Home/RunSection/RunRow.tsx
+++ b/src/components/Home/RunSection/RunRow.tsx
@@ -18,7 +18,7 @@ import {
 } from "@/components/ui/tooltip";
 import { Text } from "@/components/ui/typography";
 import { useBackend } from "@/providers/BackendProvider";
-import { APP_ROUTES } from "@/routes/router";
+import { getDefaultRunPath } from "@/routes/runRoutes";
 import { fetchRunAnnotations } from "@/services/pipelineRunService";
 import {
   getAnnotationValue,
@@ -65,7 +65,7 @@ const RunRow = ({ run, onFilterByUser }: RunRowProps) => {
     run.execution_status_stats ?? undefined,
   );
 
-  const clickThroughUrl = `${APP_ROUTES.RUNS}/${runId}`;
+  const clickThroughUrl = getDefaultRunPath(runId);
 
   const handleRowClick = (e: MouseEvent<HTMLElement>) => {
     if (e.target instanceof HTMLElement && e.target.closest("button")) {

--- a/src/components/PipelineRun/components/RerunPipelineButton.test.tsx
+++ b/src/components/PipelineRun/components/RerunPipelineButton.test.tsx
@@ -186,7 +186,7 @@ describe("<RerunPipelineButton/>", () => {
 
     await waitFor(() => {
       expect(navigateMock).toHaveBeenCalledWith({
-        to: "/runs/123",
+        to: "/runs-v2/123",
       });
     });
   });

--- a/src/components/PipelineRun/components/RerunPipelineButton.tsx
+++ b/src/components/PipelineRun/components/RerunPipelineButton.tsx
@@ -12,7 +12,7 @@ import { Icon } from "@/components/ui/icon";
 import useToastNotification from "@/hooks/useToastNotification";
 import { useBackend } from "@/providers/BackendProvider";
 import { useExecutionDataOptional } from "@/providers/ExecutionDataProvider";
-import { APP_ROUTES } from "@/routes/router";
+import { getDefaultRunPath } from "@/routes/runRoutes";
 import type { PipelineRun } from "@/types/pipelineRun";
 import { extractCanonicalName } from "@/utils/canonicalPipelineName";
 import type { ArgumentType, ComponentSpec } from "@/utils/componentSpec";
@@ -45,7 +45,7 @@ export const RerunPipelineButton = ({
   const { getToken } = useAuthLocalStorage();
 
   const onSuccess = useCallback((response: PipelineRun) => {
-    navigate({ to: `${APP_ROUTES.RUNS}/${response.id}` });
+    navigate({ to: getDefaultRunPath(response.id) });
   }, []);
 
   const onError = useCallback(

--- a/src/components/layout/AppMenu.tsx
+++ b/src/components/layout/AppMenu.tsx
@@ -12,6 +12,7 @@ import { TopBarAuthentication } from "@/components/shared/Authentication/TopBarA
 import { CopyText } from "@/components/shared/CopyText/CopyText";
 import { EditorVersionToggle } from "@/components/shared/EditorVersionToggle";
 import ImportPipeline from "@/components/shared/ImportPipeline";
+import { RunVersionToggle } from "@/components/shared/RunVersionToggle";
 import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
@@ -122,6 +123,7 @@ const DefaultAppMenu = () => {
           {showAiModelQuickSelect && <AiModelQuickSelect />}
 
           <EditorVersionToggle />
+          <RunVersionToggle />
 
           {/* Settings & status */}
           {isOnSettingsRoute ? (

--- a/src/components/shared/EditorVersionToggle.tsx
+++ b/src/components/shared/EditorVersionToggle.tsx
@@ -1,17 +1,11 @@
-import { useLocation, useNavigate } from "@tanstack/react-router";
-import { useCallback, useRef, useState } from "react";
+import { useLocation } from "@tanstack/react-router";
 
-import TooltipButton from "@/components/shared/Buttons/TooltipButton";
+import { VersionToggle } from "@/components/shared/VersionToggle";
 import {
-  EditorV2WelcomeSpotlight,
   hasSeenEditorV2Welcome,
   markEditorV2WelcomeSeen,
-} from "@/components/shared/EditorV2WelcomeSpotlight";
-import { Icon } from "@/components/ui/icon";
-import { cn } from "@/lib/utils";
+} from "@/components/shared/WelcomeSpotlight";
 import { APP_ROUTES, EDITOR_PATH } from "@/routes/router";
-
-import { useFlagValue } from "./Settings/useFlags";
 
 type EditorVersion = "v1" | "v2";
 
@@ -29,18 +23,6 @@ export const EditorVersionToggle = ({
   showWelcomeSpotlight = false,
 }: EditorVersionToggleProps) => {
   const location = useLocation();
-  const navigate = useNavigate();
-  const isEnabled = useFlagValue("v2_editor");
-  const toggleRef = useRef<HTMLButtonElement>(null);
-  const [welcomeSeen, setWelcomeSeen] = useState(hasSeenEditorV2Welcome);
-
-  const dismissWelcome = useCallback(() => {
-    markEditorV2WelcomeSeen();
-    setWelcomeSeen(true);
-  }, []);
-
-  if (!isEnabled) return null;
-
   const version = detectEditorVersion(location.pathname);
   if (!version) return null;
 
@@ -55,28 +37,23 @@ export const EditorVersionToggle = ({
       : `${EDITOR_PATH}/${encodeURIComponent(pipelineName)}`;
   const tooltip =
     targetVersion === "v2" ? "Switch to new editor" : "Switch to legacy editor";
-  const showWelcome = showWelcomeSpotlight && version === "v2" && !welcomeSeen;
 
   return (
-    <>
-      <TooltipButton
-        ref={toggleRef}
-        tooltip={tooltip}
-        className={cn(showWelcome && "relative z-[1001]")}
-        onClick={() => {
-          if (showWelcome) dismissWelcome();
-          navigate({ to: targetPath });
-        }}
-        aria-label={tooltip}
-      >
-        <Icon name={targetVersion === "v2" ? "Zap" : "Snail"} />
-      </TooltipButton>
-      {showWelcome && (
-        <EditorV2WelcomeSpotlight
-          targetRef={toggleRef}
-          onDismiss={dismissWelcome}
-        />
-      )}
-    </>
+    <VersionToggle
+      flagName="v2_editor"
+      targetVersion={targetVersion}
+      targetPath={targetPath}
+      tooltip={tooltip}
+      showWelcomeSpotlight={showWelcomeSpotlight && version === "v2"}
+      welcome={{
+        hasSeen: hasSeenEditorV2Welcome,
+        markSeen: markEditorV2WelcomeSeen,
+        title: "Welcome to the new editor",
+        description:
+          "You can easily switch between the new and old editor here.",
+        titleId: "editor-v2-welcome-title",
+        dismissLabel: "Dismiss new editor welcome",
+      }}
+    />
   );
 };

--- a/src/components/shared/PipelineRunDisplay/RunOverview.tsx
+++ b/src/components/shared/PipelineRunDisplay/RunOverview.tsx
@@ -4,7 +4,7 @@ import type { MouseEvent } from "react";
 import { StatusBar, StatusText } from "@/components/shared/Status/";
 import { Text } from "@/components/ui/typography";
 import { cn } from "@/lib/utils";
-import { APP_ROUTES } from "@/routes/router";
+import { getDefaultRunPath } from "@/routes/runRoutes";
 import type { PipelineRun, TaskStatusCounts } from "@/types/pipelineRun";
 import { formatDate } from "@/utils/date";
 import type { ExecutionStatusStats } from "@/utils/executionStatus";
@@ -75,7 +75,7 @@ const RunOverview = ({
     if (onClick) {
       onClick(run);
     } else {
-      const clickThroughUrl = `${APP_ROUTES.RUNS}/${run.id}`;
+      const clickThroughUrl = getDefaultRunPath(run.id);
 
       if (e.ctrlKey || e.metaKey) {
         window.open(clickThroughUrl, "_blank");

--- a/src/components/shared/RunVersionToggle.test.tsx
+++ b/src/components/shared/RunVersionToggle.test.tsx
@@ -1,0 +1,90 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { RunVersionToggle } from "./RunVersionToggle";
+
+const mocks = vi.hoisted(() => ({
+  navigate: vi.fn(),
+  pathname: "/runs/run-1",
+  params: { id: "run-1" } as Record<string, string>,
+  enabled: true,
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  useLocation: () => ({ pathname: mocks.pathname }),
+  useNavigate: () => mocks.navigate,
+  useParams: () => mocks.params,
+}));
+
+vi.mock("@/components/shared/Settings/useFlags", () => ({
+  useFlagValue: () => mocks.enabled,
+}));
+
+describe("RunVersionToggle", () => {
+  beforeEach(() => {
+    mocks.navigate.mockReset();
+    mocks.pathname = "/runs/run-1";
+    mocks.params = { id: "run-1" };
+    mocks.enabled = true;
+    localStorage.removeItem("seen-run-v2-welcome");
+  });
+
+  afterEach(cleanup);
+
+  it("switches from the V1 run view to V2", () => {
+    render(<RunVersionToggle />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Switch to V2 run view" }),
+    );
+
+    expect(mocks.navigate).toHaveBeenCalledWith({ to: "/runs-v2/run-1" });
+  });
+
+  it("switches from V2 to V1 while preserving the subgraph execution", () => {
+    mocks.pathname = "/runs-v2/run-1/subgraph-1";
+    mocks.params = { id: "run-1", subgraphExecutionId: "subgraph-1" };
+    render(<RunVersionToggle />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Switch to V1 run view" }),
+    );
+
+    expect(mocks.navigate).toHaveBeenCalledWith({
+      to: "/runs/run-1/subgraph-1",
+    });
+  });
+
+  it("introduces the version toggle in the V2 run view", async () => {
+    mocks.pathname = "/runs-v2/run-1";
+    render(<RunVersionToggle showWelcomeSpotlight />);
+
+    expect(
+      await screen.findByRole("dialog", {
+        name: "Welcome to the new run view",
+      }),
+    ).toHaveTextContent(
+      "You can easily switch between the new and old run views here.",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Got it" }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+    expect(localStorage.getItem("seen-run-v2-welcome")).toBe("true");
+  });
+
+  it("does not render when the V2 experience flag is disabled", () => {
+    mocks.enabled = false;
+    render(<RunVersionToggle />);
+
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/shared/RunVersionToggle.tsx
+++ b/src/components/shared/RunVersionToggle.tsx
@@ -1,0 +1,58 @@
+import { useLocation, useParams } from "@tanstack/react-router";
+
+import { VersionToggle } from "@/components/shared/VersionToggle";
+import {
+  hasSeenRunV2Welcome,
+  markRunV2WelcomeSeen,
+} from "@/components/shared/WelcomeSpotlight";
+import { APP_ROUTES } from "@/routes/appRoutes";
+import { getRunPath, type RunViewVersion } from "@/routes/runRoutes";
+
+function detectRunViewVersion(pathname: string): RunViewVersion | null {
+  if (pathname.startsWith(`${APP_ROUTES.RUNS_V2}/`)) return "v2";
+  if (pathname.startsWith(`${APP_ROUTES.RUNS}/`)) return "v1";
+  return null;
+}
+
+interface RunVersionToggleProps {
+  showWelcomeSpotlight?: boolean;
+}
+
+export function RunVersionToggle({
+  showWelcomeSpotlight = false,
+}: RunVersionToggleProps) {
+  const location = useLocation();
+  const params = useParams({ strict: false });
+  const version = detectRunViewVersion(location.pathname);
+  const runId =
+    "id" in params && typeof params.id === "string" ? params.id : undefined;
+  if (!version || !runId) return null;
+
+  const subgraphExecutionId =
+    "subgraphExecutionId" in params &&
+    typeof params.subgraphExecutionId === "string"
+      ? params.subgraphExecutionId
+      : undefined;
+  const targetVersion = version === "v1" ? "v2" : "v1";
+  const label = `Switch to ${targetVersion.toUpperCase()} run view`;
+
+  return (
+    <VersionToggle
+      flagName="v2_editor"
+      targetVersion={targetVersion}
+      targetPath={getRunPath(runId, targetVersion, subgraphExecutionId)}
+      tooltip={label}
+      showWelcomeSpotlight={showWelcomeSpotlight && version === "v2"}
+      trackingId="run_view.version_toggle"
+      welcome={{
+        hasSeen: hasSeenRunV2Welcome,
+        markSeen: markRunV2WelcomeSeen,
+        title: "Welcome to the new run view",
+        description:
+          "You can easily switch between the new and old run views here.",
+        titleId: "run-v2-welcome-title",
+        dismissLabel: "Dismiss new run view welcome",
+      }}
+    />
+  );
+}

--- a/src/components/shared/Submitters/Tangle/TangleSubmitter.tsx
+++ b/src/components/shared/Submitters/Tangle/TangleSubmitter.tsx
@@ -14,7 +14,7 @@ import { cn } from "@/lib/utils";
 import { useBackend } from "@/providers/BackendProvider";
 import { ONBOARDING_MY_RUN_COUNT_KEY } from "@/providers/OnboardingProvider/onboardingQueryKeys";
 import { useTourMockBackend } from "@/providers/TourProvider/tourMockBackend";
-import { APP_ROUTES } from "@/routes/router";
+import { getDefaultRunPath } from "@/routes/runRoutes";
 import { updateRunAnnotation } from "@/services/pipelineRunService";
 import type { PipelineRun } from "@/types/pipelineRun";
 import {
@@ -142,7 +142,7 @@ const TangleSubmitter = ({
   };
 
   const handleViewRun = (runId: number, e: MouseEvent) => {
-    const href = `${APP_ROUTES.RUNS}/${runId}`;
+    const href = getDefaultRunPath(runId);
     if (e.ctrlKey || e.metaKey) {
       window.open(href, "_blank");
     } else {
@@ -183,7 +183,7 @@ const TangleSubmitter = ({
     showSuccessNotification(response.id);
 
     if (isAutoRedirect) {
-      const href = `${APP_ROUTES.RUNS}/${response.id}`;
+      const href = getDefaultRunPath(response.id);
       window.open(href, "_blank");
     }
   };

--- a/src/components/shared/VersionToggle.tsx
+++ b/src/components/shared/VersionToggle.tsx
@@ -1,0 +1,85 @@
+import { useNavigate } from "@tanstack/react-router";
+import { useRef, useState } from "react";
+
+import TooltipButton from "@/components/shared/Buttons/TooltipButton";
+import { useFlagValue } from "@/components/shared/Settings/useFlags";
+import { WelcomeSpotlight } from "@/components/shared/WelcomeSpotlight";
+import { Icon } from "@/components/ui/icon";
+import { ExistingFlags } from "@/flags";
+import { cn } from "@/lib/utils";
+import { tracking } from "@/utils/tracking";
+
+type Version = "v1" | "v2";
+
+interface VersionToggleWelcome {
+  hasSeen: () => boolean;
+  markSeen: () => void;
+  title: string;
+  description: string;
+  titleId: string;
+  dismissLabel: string;
+}
+
+interface VersionToggleProps {
+  flagName: keyof typeof ExistingFlags;
+  targetVersion: Version;
+  targetPath: string;
+  tooltip: string;
+  welcome: VersionToggleWelcome;
+  showWelcomeSpotlight?: boolean;
+  trackingId?: string;
+}
+
+export function VersionToggle({
+  flagName,
+  targetVersion,
+  targetPath,
+  tooltip,
+  welcome,
+  showWelcomeSpotlight = false,
+  trackingId,
+}: VersionToggleProps) {
+  const navigate = useNavigate();
+  const isEnabled = useFlagValue(flagName);
+  const toggleRef = useRef<HTMLButtonElement>(null);
+  const [welcomeSeen, setWelcomeSeen] = useState(welcome.hasSeen);
+
+  const dismissWelcome = () => {
+    welcome.markSeen();
+    setWelcomeSeen(true);
+  };
+
+  if (!isEnabled) return null;
+
+  const showWelcome = showWelcomeSpotlight && !welcomeSeen;
+
+  return (
+    <>
+      <TooltipButton
+        ref={toggleRef}
+        tooltip={tooltip}
+        className={cn(showWelcome && "relative z-[1001]")}
+        onClick={() => {
+          if (showWelcome) dismissWelcome();
+          navigate({ to: targetPath });
+        }}
+        aria-label={tooltip}
+        {...(trackingId
+          ? tracking(trackingId, { target_version: targetVersion })
+          : {})}
+      >
+        <Icon name={targetVersion === "v2" ? "Zap" : "Snail"} />
+      </TooltipButton>
+      {showWelcome && (
+        <WelcomeSpotlight
+          targetRef={toggleRef}
+          onDismiss={dismissWelcome}
+          title={welcome.title}
+          description={welcome.description}
+          titleId={welcome.titleId}
+          dismissLabel={welcome.dismissLabel}
+        />
+      )}
+    </>
+  );
+}

--- a/src/components/shared/WelcomeSpotlight.tsx
+++ b/src/components/shared/WelcomeSpotlight.tsx
@@ -12,15 +12,14 @@ import { BlockStack } from "@/components/ui/layout";
 import { Paragraph, Text } from "@/components/ui/typography";
 import { getStorage } from "@/utils/typedStorage";
 
-interface EditorV2WelcomeStorage {
+interface V2WelcomeStorage {
   "seen-editor-v2-welcome": boolean;
+  "seen-run-v2-welcome": boolean;
 }
 
-const storage = getStorage<
-  keyof EditorV2WelcomeStorage,
-  EditorV2WelcomeStorage
->();
-const STORAGE_KEY = "seen-editor-v2-welcome";
+const storage = getStorage<keyof V2WelcomeStorage, V2WelcomeStorage>();
+const EDITOR_STORAGE_KEY = "seen-editor-v2-welcome";
+const RUN_STORAGE_KEY = "seen-run-v2-welcome";
 const SPOTLIGHT_PADDING = 16;
 const CARD_WIDTH = 320;
 const SPOTLIGHT_COLOR = "#5B35F5";
@@ -33,11 +32,19 @@ interface SpotlightRect {
 }
 
 export function hasSeenEditorV2Welcome(): boolean {
-  return storage.getItem(STORAGE_KEY) === true;
+  return storage.getItem(EDITOR_STORAGE_KEY) === true;
 }
 
 export function markEditorV2WelcomeSeen() {
-  storage.setItem(STORAGE_KEY, true);
+  storage.setItem(EDITOR_STORAGE_KEY, true);
+}
+
+export function hasSeenRunV2Welcome(): boolean {
+  return storage.getItem(RUN_STORAGE_KEY) === true;
+}
+
+export function markRunV2WelcomeSeen() {
+  storage.setItem(RUN_STORAGE_KEY, true);
 }
 
 function clamp(value: number, min: number, max: number): number {
@@ -56,9 +63,14 @@ function getSpotlightRect(target: HTMLElement): SpotlightRect {
 interface ClickBlockersProps {
   spotlight: SpotlightRect;
   onDismiss: () => void;
+  dismissLabel: string;
 }
 
-function ClickBlockers({ spotlight, onDismiss }: ClickBlockersProps) {
+function ClickBlockers({
+  spotlight,
+  onDismiss,
+  dismissLabel,
+}: ClickBlockersProps) {
   const { centerX, centerY, radius } = spotlight;
   const top = Math.max(centerY - radius, 0);
   const bottom = Math.min(centerY + radius, window.innerHeight);
@@ -69,28 +81,28 @@ function ClickBlockers({ spotlight, onDismiss }: ClickBlockersProps) {
     <>
       <button
         type="button"
-        aria-label="Dismiss new editor welcome"
+        aria-label={dismissLabel}
         className="fixed left-0 right-0 top-0 z-[1000] cursor-default bg-transparent"
         style={{ height: top }}
         onClick={onDismiss}
       />
       <button
         type="button"
-        aria-label="Dismiss new editor welcome"
+        aria-label={dismissLabel}
         className="fixed bottom-0 left-0 right-0 z-[1000] cursor-default bg-transparent"
         style={{ top: bottom }}
         onClick={onDismiss}
       />
       <button
         type="button"
-        aria-label="Dismiss new editor welcome"
+        aria-label={dismissLabel}
         className="fixed z-[1000] cursor-default bg-transparent"
         style={{ top, left: 0, width: left, height: bottom - top }}
         onClick={onDismiss}
       />
       <button
         type="button"
-        aria-label="Dismiss new editor welcome"
+        aria-label={dismissLabel}
         className="fixed z-[1000] cursor-default bg-transparent"
         style={{ top, left: right, right: 0, height: bottom - top }}
         onClick={onDismiss}
@@ -99,15 +111,23 @@ function ClickBlockers({ spotlight, onDismiss }: ClickBlockersProps) {
   );
 }
 
-interface EditorV2WelcomeSpotlightProps {
+interface WelcomeSpotlightProps {
   targetRef: RefObject<HTMLElement | null>;
   onDismiss: () => void;
+  title: string;
+  description: string;
+  titleId: string;
+  dismissLabel: string;
 }
 
-export function EditorV2WelcomeSpotlight({
+export function WelcomeSpotlight({
   targetRef,
   onDismiss,
-}: EditorV2WelcomeSpotlightProps) {
+  title,
+  description,
+  titleId,
+  dismissLabel,
+}: WelcomeSpotlightProps) {
   const [spotlight, setSpotlight] = useState<SpotlightRect | null>(null);
   const gotItRef = useRef<HTMLButtonElement>(null);
 
@@ -182,21 +202,25 @@ export function EditorV2WelcomeSpotlight({
           boxShadow: `0 0 0 4px ${SPOTLIGHT_HALO_COLOR}`,
         }}
       />
-      <ClickBlockers spotlight={spotlight} onDismiss={onDismiss} />
+      <ClickBlockers
+        spotlight={spotlight}
+        onDismiss={onDismiss}
+        dismissLabel={dismissLabel}
+      />
       <div
         role="dialog"
         aria-modal="true"
-        aria-labelledby="editor-v2-welcome-title"
+        aria-labelledby={titleId}
         className="fixed z-[1002] rounded-lg border border-border bg-card p-4 text-card-foreground shadow-lg"
         style={{ top: cardTop, left: cardLeft, width: CARD_WIDTH }}
       >
         <BlockStack gap="3">
           <BlockStack gap="1">
-            <Text id="editor-v2-welcome-title" weight="semibold">
-              Welcome to the new editor
+            <Text id={titleId} weight="semibold">
+              {title}
             </Text>
             <Paragraph size="sm" tone="subdued">
-              You can easily switch between the new and old editor here.
+              {description}
             </Paragraph>
           </BlockStack>
           <Button ref={gotItRef} size="sm" onClick={onDismiss}>

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -48,9 +48,9 @@ export const ExistingFlags: ConfigFlags = {
   },
 
   ["v2_editor"]: {
-    name: "V2 Editor",
+    name: "V2 Editor and Run View",
     description:
-      "Enable the V2 Editor. You can switch back and forth between the V1 and V2 editors.",
+      "Enable the V2 editor and run view. You can switch between the V1 and V2 experiences.",
     default: true,
     category: "beta",
   },

--- a/src/hooks/useTrackRecentlyViewedRun.test.ts
+++ b/src/hooks/useTrackRecentlyViewedRun.test.ts
@@ -1,0 +1,40 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { addRecentlyViewed } from "@/hooks/useRecentlyViewed";
+
+import { useTrackRecentlyViewedRun } from "./useTrackRecentlyViewedRun";
+
+vi.mock("@/hooks/useRecentlyViewed", () => ({
+  addRecentlyViewed: vi.fn(),
+}));
+
+interface RunProps {
+  runId?: string;
+  pipelineName?: string;
+}
+
+describe("useTrackRecentlyViewedRun", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("records the run once its data is available", () => {
+    const initialProps: RunProps = {};
+    const { rerender } = renderHook(
+      ({ runId, pipelineName }: RunProps) =>
+        useTrackRecentlyViewedRun(runId, pipelineName),
+      { initialProps },
+    );
+
+    expect(addRecentlyViewed).not.toHaveBeenCalled();
+
+    rerender({ runId: "run-1", pipelineName: "Test Pipeline" });
+
+    expect(addRecentlyViewed).toHaveBeenCalledWith({
+      type: "run",
+      id: "run-1",
+      name: "Test Pipeline",
+    });
+  });
+});

--- a/src/hooks/useTrackRecentlyViewedRun.ts
+++ b/src/hooks/useTrackRecentlyViewedRun.ts
@@ -1,0 +1,18 @@
+import { useEffect } from "react";
+
+import { addRecentlyViewed } from "@/hooks/useRecentlyViewed";
+
+export function useTrackRecentlyViewedRun(
+  runId: string | null | undefined,
+  pipelineName: string | null | undefined,
+) {
+  useEffect(() => {
+    if (!runId || !pipelineName) return;
+
+    addRecentlyViewed({
+      type: "run",
+      id: runId,
+      name: pipelineName,
+    });
+  }, [runId, pipelineName]);
+}

--- a/src/routes/Dashboard/TypePill.tsx
+++ b/src/routes/Dashboard/TypePill.tsx
@@ -3,7 +3,8 @@ import type { FavoriteItem } from "@/hooks/useFavorites";
 import type { RecentlyViewedItem } from "@/hooks/useRecentlyViewed";
 import { cn } from "@/lib/utils";
 import { getDefaultEditorPath } from "@/routes/editorRoutes";
-import { APP_ROUTES, RUNS_BASE_PATH } from "@/routes/router";
+import { APP_ROUTES } from "@/routes/router";
+import { getDefaultRunPath } from "@/routes/runRoutes";
 
 type ItemType = "pipeline" | "run" | "component";
 
@@ -52,11 +53,11 @@ export const TypePill = ({
 
 export function getFavoriteUrl(item: FavoriteItem): string {
   if (item.type === "pipeline") return getDefaultEditorPath(item.id);
-  return `${RUNS_BASE_PATH}/${item.id}`;
+  return getDefaultRunPath(item.id);
 }
 
 export function getRecentlyViewedUrl(item: RecentlyViewedItem): string {
   if (item.type === "pipeline") return getDefaultEditorPath(item.id);
-  if (item.type === "run") return `${RUNS_BASE_PATH}/${item.id}`;
+  if (item.type === "run") return getDefaultRunPath(item.id);
   return APP_ROUTES.DASHBOARD_COMPONENTS;
 }

--- a/src/routes/PipelineRun/PipelineRun.tsx
+++ b/src/routes/PipelineRun/PipelineRun.tsx
@@ -12,7 +12,7 @@ import { BlockStack } from "@/components/ui/layout";
 import { Paragraph } from "@/components/ui/typography";
 import { faviconManager } from "@/favicon";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
-import { addRecentlyViewed } from "@/hooks/useRecentlyViewed";
+import { useTrackRecentlyViewedRun } from "@/hooks/useTrackRecentlyViewedRun";
 import { useBackend } from "@/providers/BackendProvider";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 import {
@@ -82,10 +82,7 @@ const PipelineRunContent = () => {
       `Tangle - ${componentSpec?.name || ""} - ${params.id}`,
   });
 
-  useEffect(() => {
-    if (!componentSpec?.name || !runId) return;
-    addRecentlyViewed({ type: "run", id: runId, name: componentSpec.name });
-  }, [componentSpec?.name, runId]);
+  useTrackRecentlyViewedRun(runId, componentSpec?.name);
 
   if (isLoading || !ready) {
     return <LoadingScreen message="Loading Pipeline Run" />;

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -334,12 +334,33 @@ const runV2Route = createRoute({
   getParentRoute: () => mainLayout,
   path: APP_ROUTES.RUN_DETAIL_V2,
   component: RunViewV2,
+  beforeLoad: ({ params }) => {
+    if (!isFlagEnabled("v2_editor")) {
+      throw redirect({
+        to: APP_ROUTES.RUN_DETAIL,
+        params: { id: params.id },
+        search: (previous) => previous,
+      });
+    }
+  },
 });
 
 const runV2WithSubgraphRoute = createRoute({
   getParentRoute: () => mainLayout,
   path: APP_ROUTES.RUN_DETAIL_V2_WITH_SUBGRAPH,
   component: RunViewV2,
+  beforeLoad: ({ params }) => {
+    if (!isFlagEnabled("v2_editor")) {
+      throw redirect({
+        to: APP_ROUTES.RUN_DETAIL_WITH_SUBGRAPH,
+        params: {
+          id: params.id,
+          subgraphExecutionId: params.subgraphExecutionId,
+        },
+        search: (previous) => previous,
+      });
+    }
+  },
 });
 
 const pipelineFoldersRoute = createRoute({

--- a/src/routes/runRoutes.test.ts
+++ b/src/routes/runRoutes.test.ts
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { isFlagEnabled } from "@/components/shared/Settings/useFlags";
+
+import { getDefaultRunPath, getRunPath } from "./runRoutes";
+
+vi.mock("@/components/shared/Settings/useFlags", () => ({
+  isFlagEnabled: vi.fn(),
+}));
+
+describe("run routes", () => {
+  beforeEach(() => {
+    vi.mocked(isFlagEnabled).mockReset();
+  });
+
+  it("builds V1 and V2 paths, including subgraph executions", () => {
+    expect(getRunPath("run 1", "v1")).toBe("/runs/run%201");
+    expect(getRunPath("run 1", "v2", "subgraph 1")).toBe(
+      "/runs-v2/run%201/subgraph%201",
+    );
+  });
+
+  it("uses the V2 run view when the V2 experience flag is enabled", () => {
+    vi.mocked(isFlagEnabled).mockReturnValue(true);
+
+    expect(getDefaultRunPath("run-1")).toBe("/runs-v2/run-1");
+  });
+
+  it("uses the V1 run view when the V2 experience flag is disabled", () => {
+    vi.mocked(isFlagEnabled).mockReturnValue(false);
+
+    expect(getDefaultRunPath("run-1")).toBe("/runs/run-1");
+  });
+});

--- a/src/routes/runRoutes.ts
+++ b/src/routes/runRoutes.ts
@@ -1,0 +1,21 @@
+import { isFlagEnabled } from "@/components/shared/Settings/useFlags";
+
+import { APP_ROUTES } from "./appRoutes";
+
+export type RunViewVersion = "v1" | "v2";
+
+export function getRunPath(
+  runId: string | number,
+  version: RunViewVersion,
+  subgraphExecutionId?: string,
+): string {
+  const basePath = version === "v2" ? APP_ROUTES.RUNS_V2 : APP_ROUTES.RUNS;
+  const runPath = `${basePath}/${encodeURIComponent(runId)}`;
+  return subgraphExecutionId
+    ? `${runPath}/${encodeURIComponent(subgraphExecutionId)}`
+    : runPath;
+}
+
+export function getDefaultRunPath(runId: string | number): string {
+  return getRunPath(runId, isFlagEnabled("v2_editor") ? "v2" : "v1");
+}

--- a/src/routes/v2/pages/RunView/RunViewV2.tsx
+++ b/src/routes/v2/pages/RunView/RunViewV2.tsx
@@ -12,6 +12,7 @@ import { RemoteAuthErrorView } from "@/components/shared/RemoteAuthErrorView";
 import { useFlagValue } from "@/components/shared/Settings/useFlags";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Paragraph } from "@/components/ui/typography";
+import { useTrackRecentlyViewedRun } from "@/hooks/useTrackRecentlyViewedRun";
 import type { ComponentSpec } from "@/models/componentSpec";
 import {
   IncrementingIdGenerator,
@@ -58,11 +59,21 @@ function deserializeRunSpec(data: unknown): ComponentSpec {
   return spec;
 }
 
-const RunViewContent = observer(function RunViewContent() {
+interface RunViewContentProps {
+  runId: string;
+}
+
+const RunViewContent = observer(function RunViewContent({
+  runId,
+}: RunViewContentProps) {
   const { setComponentSpec, clearComponentSpec } = useComponentSpec();
   const { configured, available, ready } = useBackend();
 
   const { details, state, rootDetails, isLoading, error } = useExecutionData();
+  useTrackRecentlyViewedRun(
+    runId,
+    rootDetails?.task_spec.componentRef.spec?.name,
+  );
 
   const specRef = useRef<ComponentSpec | null>(null);
 
@@ -217,7 +228,7 @@ export function RunViewV2() {
                 pipelineRunId={id}
                 subgraphExecutionId={subgraphExecutionId}
               >
-                <RunViewContent />
+                <RunViewContent runId={id} />
               </ExecutionDataProvider>
             </ContextPanelProvider>
           </ReactFlowProvider>

--- a/src/routes/v2/shared/components/AppMenuActions.tsx
+++ b/src/routes/v2/shared/components/AppMenuActions.tsx
@@ -6,6 +6,7 @@ import { isAuthorizationRequired } from "@/components/shared/Authentication/help
 import { TopBarAuthentication } from "@/components/shared/Authentication/TopBarAuthentication";
 import TooltipButton from "@/components/shared/Buttons/TooltipButton";
 import { EditorVersionToggle } from "@/components/shared/EditorVersionToggle";
+import { RunVersionToggle } from "@/components/shared/RunVersionToggle";
 import { Icon } from "@/components/ui/icon";
 import { InlineStack } from "@/components/ui/layout";
 import { Link } from "@/components/ui/link";
@@ -28,6 +29,7 @@ export function AppMenuActions() {
       {!tourMode && <OnboardingNavPill />}
       <AiModelQuickSelect />
       <EditorVersionToggle showWelcomeSpotlight />
+      <RunVersionToggle showWelcomeSpotlight />
       {tourMode ? (
         <TooltipButton
           tooltip="Settings"


### PR DESCRIPTION
## Description

Adds a `RunVersionToggle` component to the app menu that lets users switch between the V1 and V2 run views, mirroring the existing `EditorVersionToggle` behaviour. When a user is on a V2 run page for the first time, a spotlight welcome dialog introduces the toggle.

A new `runRoutes.ts` module centralises run path construction via `getRunPath` and `getDefaultRunPath`. `getDefaultRunPath` automatically routes to the V2 run view when the `v2_editor` flag is enabled, and all previous inline `APP_ROUTES.RUNS/${id}` path constructions across `RunRow`, `RerunPipelineButton`, `RunOverview`, `TangleSubmitter`, and the Dashboard `TypePill` have been replaced with calls to this helper.

The `v2_editor` flag description has been updated to reflect that it now governs both the editor and the run view. The V2 run routes (`/runs-v2/:id` and `/runs-v2/:id/:subgraphExecutionId`) now redirect to their V1 equivalents when the flag is disabled.

`EditorV2WelcomeSpotlight` has been made generic so its title, description, ARIA label, and storage key behaviour can be reused for the run view welcome spotlight without duplication.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Improvement
- [x] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)



![image.png](https://app.graphite.com/user-attachments/assets/34d24702-45dd-45ca-ba2c-6368a8764f5d.png)



## Test Instructions

1. Enable the `v2_editor` flag in settings.
2. Navigate to any run — confirm you are taken to `/runs-v2/:id`.
3. Verify the `RunVersionToggle` button appears in the app menu and that clicking it switches between `/runs/:id` and `/runs-v2/:id`, preserving any subgraph execution segment.
4. On first visit to a V2 run page, confirm the welcome spotlight appears and is dismissed by clicking "Got it" or clicking outside it. Confirm it does not reappear after dismissal.
5. Disable the `v2_editor` flag and confirm that navigating directly to a `/runs-v2/` URL redirects to the V1 equivalent, and that the toggle is hidden.

## Additional Comments

The `RunVersionToggle` reuses `EditorV2WelcomeSpotlight` with custom props rather than duplicating the spotlight implementation. The `seen-run-v2-welcome` localStorage key tracks first-time spotlight dismissal independently of the editor welcome key.