### PR TITLE
chore: Add EmptyState UI Primitive

### DIFF
--- a/src/components/shared/SecretsManagement/SelectSecretDialog.tsx
+++ b/src/components/shared/SecretsManagement/SelectSecretDialog.tsx
@@ -10,6 +10,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { EmptyState } from "@/components/ui/empty-state";
 import { Icon } from "@/components/ui/icon";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -51,17 +52,13 @@ function SelectableSecretsList({
 }: SelectableSecretsListProps) {
   if (secrets.length === 0) {
     return (
-      <BlockStack
-        align="center"
-        className="py-8"
+      <EmptyState
+        icon="Lock"
+        title="No secrets configured"
+        description="Add a secret to use it in your arguments"
+        placement="start"
         data-testid="select-secret-empty-state"
-      >
-        <Icon name="Lock" size="lg" className="text-gray-300" />
-        <Text tone="subdued">No secrets configured</Text>
-        <Text size="xs" tone="subdued">
-          Add a secret to use it in your arguments
-        </Text>
-      </BlockStack>
+      />
     );
   }
 

--- a/src/components/shared/SecretsManagement/components/SecretsList.tsx
+++ b/src/components/shared/SecretsManagement/components/SecretsList.tsx
@@ -2,6 +2,7 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 
 import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/empty-state";
 import { Icon } from "@/components/ui/icon";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -32,17 +33,13 @@ function SecretsListInternal({
 
   if (secrets.length === 0) {
     return (
-      <BlockStack
-        align="center"
-        className="py-8"
+      <EmptyState
+        icon="Lock"
+        title="No secrets configured"
+        description="Add a secret to get started"
+        placement="center"
         data-testid="secrets-empty-state"
-      >
-        <Icon name="Lock" size="lg" className="text-subdued" />
-        <Text tone="subdued">No secrets configured</Text>
-        <Text size="xs" tone="subdued">
-          Add a secret to get started
-        </Text>
-      </BlockStack>
+      />
     );
   }
 

--- a/src/components/ui/empty-state.tsx
+++ b/src/components/ui/empty-state.tsx
@@ -1,0 +1,100 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import type { ReactNode } from "react";
+
+import { Icon, type IconName } from "@/components/ui/icon";
+import { BlockStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
+import { cn } from "@/lib/utils";
+
+const emptyStateVariants = cva(
+  "flex w-full flex-col items-center text-center",
+  {
+    variants: {
+      placement: {
+        center: "h-full justify-center",
+        start: "justify-start",
+      },
+      size: {
+        sm: "gap-2 p-4",
+        md: "gap-3 p-6",
+      },
+    },
+    defaultVariants: {
+      placement: "center",
+      size: "md",
+    },
+  },
+);
+
+const toneClass = {
+  neutral: "text-muted-foreground",
+  success: "text-green-500",
+  critical: "text-destructive",
+} as const;
+
+interface EmptyStateProps extends VariantProps<typeof emptyStateVariants> {
+  icon?: IconName;
+  media?: ReactNode;
+  spotlight?: boolean;
+  tone?: keyof typeof toneClass;
+  title?: ReactNode;
+  description?: ReactNode;
+  children?: ReactNode;
+  className?: string;
+  "data-testid"?: string;
+}
+
+/**
+ * Centered (or top-anchored) placeholder for "nothing here yet" states:
+ * a hero icon/media, a title, a subtitle, and optional action content.
+ */
+export function EmptyState({
+  icon,
+  media,
+  spotlight = false,
+  tone = "neutral",
+  title,
+  description,
+  children,
+  placement,
+  size,
+  className,
+  ...rest
+}: EmptyStateProps) {
+  const iconSize = size === "sm" ? "md" : "lg";
+  const hero =
+    media ??
+    (icon &&
+      (spotlight ? (
+        <div
+          className={cn(
+            "flex items-center justify-center rounded-full bg-accent",
+            size === "sm" ? "size-9" : "size-11",
+          )}
+        >
+          <Icon name={icon} size={iconSize} className={toneClass[tone]} />
+        </div>
+      ) : (
+        <Icon name={icon} size={iconSize} className={toneClass[tone]} />
+      )));
+
+  return (
+    <div
+      className={cn(emptyStateVariants({ placement, size }), className)}
+      {...rest}
+    >
+      {hero}
+      {(title || description) && (
+        <BlockStack gap="1" align="center">
+          {title && <Text weight="semibold">{title}</Text>}
+          {description && (
+            <Text size="sm" tone="subdued" className="text-balance">
+              {description}
+            </Text>
+          )}
+        </BlockStack>
+      )}
+      {children && <div className="w-full">{children}</div>}
+    </div>
+  );
+}

--- a/src/routes/v2/pages/Editor/components/PinnedTaskContent/PinnedTaskContent.tsx
+++ b/src/routes/v2/pages/Editor/components/PinnedTaskContent/PinnedTaskContent.tsx
@@ -1,6 +1,7 @@
 import { observer } from "mobx-react-lite";
 
 import { TaskDetails, TaskIO } from "@/components/shared/TaskDetails";
+import { EmptyState } from "@/components/ui/empty-state";
 import { Icon } from "@/components/ui/icon";
 import { BlockStack } from "@/components/ui/layout";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -105,7 +106,7 @@ export const PinnedTaskContent = observer(function PinnedTaskContent({
                 }
               />
             ) : (
-              <EmptyState message="No inputs or outputs defined" />
+              <EmptyState description="No inputs or outputs defined" />
             )}
           </TabsContent>
 
@@ -116,7 +117,7 @@ export const PinnedTaskContent = observer(function PinnedTaskContent({
             {code ? (
               <CodeBlock code={code} language="yaml" showLineNumbers={false} />
             ) : (
-              <EmptyState message="No implementation code available" />
+              <EmptyState description="No implementation code available" />
             )}
           </TabsContent>
         </div>
@@ -131,28 +132,15 @@ interface NotFoundStateProps {
 
 function NotFoundState({ entityId }: NotFoundStateProps) {
   return (
-    <BlockStack className="h-full items-center justify-center p-4 bg-white">
-      <Icon name="CircleAlert" size="lg" className="text-gray-300" />
-      <Text size="sm" tone="subdued" className="text-center mt-2">
-        Task not found
-      </Text>
-      <Text size="xs" tone="subdued" className="text-center font-mono">
-        {entityId}
-      </Text>
-    </BlockStack>
-  );
-}
-
-interface EmptyStateProps {
-  message: string;
-}
-
-function EmptyState({ message }: EmptyStateProps) {
-  return (
-    <BlockStack className="items-center justify-center p-4">
-      <Text size="sm" tone="subdued">
-        {message}
-      </Text>
-    </BlockStack>
+    <EmptyState
+      icon="CircleAlert"
+      title="Task not found"
+      description={
+        <Text size="xs" tone="subdued" font="mono">
+          {entityId}
+        </Text>
+      }
+      className="bg-white"
+    />
   );
 }

--- a/src/routes/v2/pages/Editor/components/RunsAndSubmissionContent.tsx
+++ b/src/routes/v2/pages/Editor/components/RunsAndSubmissionContent.tsx
@@ -4,9 +4,8 @@ import { useAwaitAuthorization } from "@/components/shared/Authentication/useAwa
 import { HuggingFaceAuthButton } from "@/components/shared/HuggingFaceAuth/HuggingFaceAuthButton";
 import GoogleCloudSubmissionDialog from "@/components/shared/Submitters/GoogleCloud/GoogleCloudSubmissionDialog";
 import TangleSubmitter from "@/components/shared/Submitters/Tangle/TangleSubmitter";
-import { Icon } from "@/components/ui/icon";
+import { EmptyState } from "@/components/ui/empty-state";
 import { BlockStack } from "@/components/ui/layout";
-import { Text } from "@/components/ui/typography";
 import { serializeComponentSpec } from "@/models/componentSpec";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 import { ENABLE_GOOGLE_CLOUD_SUBMITTER } from "@/utils/constants";
@@ -25,7 +24,9 @@ export const RunsAndSubmissionContent = observer(() => {
     : undefined;
 
   if (!serializedRootPipelineSpec) {
-    return <EmptyState />;
+    return (
+      <EmptyState icon="FileQuestionMark" description="No pipeline loaded" />
+    );
   }
 
   return (
@@ -64,14 +65,3 @@ export const RunsAndSubmissionContent = observer(() => {
     </BlockStack>
   );
 });
-
-function EmptyState() {
-  return (
-    <BlockStack fill className="p-4" inlineAlign="center" align="center">
-      <Icon name="FileQuestionMark" size="lg" className="text-gray-300" />
-      <Text size="sm" tone="subdued" className="text-center mt-2">
-        No pipeline loaded
-      </Text>
-    </BlockStack>
-  );
-}

--- a/src/routes/v2/pages/Editor/components/UpgradeComponents/components/UpgradeCandidateDetail.tsx
+++ b/src/routes/v2/pages/Editor/components/UpgradeComponents/components/UpgradeCandidateDetail.tsx
@@ -1,4 +1,5 @@
 import { Badge } from "@/components/ui/badge";
+import { EmptyState } from "@/components/ui/empty-state";
 import { Icon } from "@/components/ui/icon";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Text } from "@/components/ui/typography";
@@ -19,16 +20,11 @@ function truncateDigest(digest: string): string {
 
 function EmptyDetail() {
   return (
-    <BlockStack className="flex-1 items-center justify-center p-4" gap="1">
-      <Icon
-        name="MousePointerClick"
-        size="md"
-        className="text-muted-foreground"
-      />
-      <Text size="xs" tone="subdued">
-        Select a component to see details
-      </Text>
-    </BlockStack>
+    <EmptyState
+      icon="MousePointerClick"
+      size="sm"
+      description="Select a component to see details"
+    />
   );
 }
 

--- a/src/routes/v2/pages/Editor/components/UpgradeComponents/components/UpgradeEmptyState.tsx
+++ b/src/routes/v2/pages/Editor/components/UpgradeComponents/components/UpgradeEmptyState.tsx
@@ -1,14 +1,11 @@
-import { Icon } from "@/components/ui/icon";
-import { BlockStack } from "@/components/ui/layout";
-import { Text } from "@/components/ui/typography";
+import { EmptyState } from "@/components/ui/empty-state";
 
 export function UpgradeEmptyState() {
   return (
-    <BlockStack className="flex-1 items-center justify-center p-6" gap="2">
-      <Icon name="CircleCheck" size="lg" className="text-green-500" />
-      <Text size="sm" tone="subdued">
-        All components are up to date.
-      </Text>
-    </BlockStack>
+    <EmptyState
+      icon="CircleCheck"
+      tone="success"
+      description="All components are up to date."
+    />
   );
 }

--- a/src/routes/v2/shared/components/AiChat/components/ChatMessageList.tsx
+++ b/src/routes/v2/shared/components/AiChat/components/ChatMessageList.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from "react";
 
 import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/empty-state";
 import { Icon } from "@/components/ui/icon";
 import { BlockStack } from "@/components/ui/layout";
 import { Text } from "@/components/ui/typography";
@@ -33,50 +34,43 @@ export function ChatMessageList({
 
   if (messages.length === 0 && !thinkingText) {
     return (
-      <BlockStack gap="5" className="flex-1 min-h-0 overflow-y-auto p-4">
-        <BlockStack
-          gap="2"
-          align="center"
-          inlineAlign="center"
-          className="pt-6"
+      <div className="flex-1 min-h-0 overflow-y-auto">
+        <EmptyState
+          placement="start"
+          icon="Sparkles"
+          spotlight
+          title="How can I help?"
+          description="Ask about this pipeline, or pick a starting point below."
         >
-          <div className="flex size-11 items-center justify-center rounded-full bg-accent">
-            <Icon name="Sparkles" size="lg" className="text-muted-foreground" />
-          </div>
-          <Text weight="semibold">How can I help?</Text>
-          <Text size="sm" tone="subdued" className="text-center text-balance">
-            Ask about this pipeline, or pick a starting point below.
-          </Text>
-        </BlockStack>
-
-        {suggestedPrompts && suggestedPrompts.length > 0 && (
-          <BlockStack gap="2">
-            <Text
-              size="xs"
-              tone="subdued"
-              weight="semibold"
-              className="uppercase tracking-wide px-1"
-            >
-              Try asking
-            </Text>
-            <BlockStack gap="2" as="ul">
-              {suggestedPrompts.map((prompt) => (
-                <li key={prompt.label}>
-                  <Button
-                    variant="link"
-                    size="sm"
-                    onClick={() => onSelectPrompt?.(prompt.label)}
-                    className="h-auto w-full justify-start gap-2 px-1 py-0.5 text-left font-normal whitespace-normal underline"
-                  >
-                    <Icon name={prompt.icon} size="sm" className="shrink-0" />
-                    <span className="flex-1">{prompt.label}</span>
-                  </Button>
-                </li>
-              ))}
+          {suggestedPrompts && suggestedPrompts.length > 0 && (
+            <BlockStack gap="2">
+              <Text
+                size="xs"
+                tone="subdued"
+                weight="semibold"
+                className="uppercase tracking-wide px-1"
+              >
+                Try asking
+              </Text>
+              <BlockStack gap="2" as="ul">
+                {suggestedPrompts.map((prompt) => (
+                  <li key={prompt.label}>
+                    <Button
+                      variant="link"
+                      size="sm"
+                      onClick={() => onSelectPrompt?.(prompt.label)}
+                      className="h-auto w-full justify-start gap-2 px-1 py-0.5 text-left font-normal whitespace-normal underline"
+                    >
+                      <Icon name={prompt.icon} size="sm" className="shrink-0" />
+                      <span className="flex-1">{prompt.label}</span>
+                    </Button>
+                  </li>
+                ))}
+              </BlockStack>
             </BlockStack>
-          </BlockStack>
-        )}
-      </BlockStack>
+          )}
+        </EmptyState>
+      </div>
     );
   }
 

--- a/src/routes/v2/shared/components/ContextPanelEmptyState.tsx
+++ b/src/routes/v2/shared/components/ContextPanelEmptyState.tsx
@@ -1,14 +1,10 @@
-import { Icon } from "@/components/ui/icon";
-import { BlockStack } from "@/components/ui/layout";
-import { Text } from "@/components/ui/typography";
+import { EmptyState } from "@/components/ui/empty-state";
 
 export function ContextPanelEmptyState() {
   return (
-    <BlockStack className="h-full items-center justify-center p-4">
-      <Icon name="MousePointerClick" size="lg" className="text-gray-300" />
-      <Text size="sm" tone="subdued" className="text-center mt-2">
-        Select a node to view details
-      </Text>
-    </BlockStack>
+    <EmptyState
+      icon="MousePointerClick"
+      description="Select a node to view details"
+    />
   );
 }


### PR DESCRIPTION
## Description

Adds an EmptyState UI Primitive - to standardize layout and visuals for empty state scenarios - and applies it to a couple of places around the app:

1. Sidekick Window
2. ContextPanelEmptyState
3. RunsAndSubmission
4. UpgradeEmptyState
5. UpgradeCandidateDetail
6. PinnedTaskContent
7. SecretsList
8. SelectSecretDialog

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

- [x] Improvement
- [x] Cleanup/Refactor

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->