### PR TITLE
Reorder tip-of-the-day in dock layout and remove from default view preset

### DIFF
--- a/src/routes/v2/shared/components/AiChat/components/ChatMessageList.tsx
+++ b/src/routes/v2/shared/components/AiChat/components/ChatMessageList.tsx
@@ -33,13 +33,8 @@ export function ChatMessageList({
 
   if (messages.length === 0 && !thinkingText) {
     return (
-      <BlockStack gap="5" className="flex-1 min-h-0 overflow-y-auto p-4">
-        <BlockStack
-          gap="2"
-          align="center"
-          inlineAlign="center"
-          className="pt-6"
-        >
+      <BlockStack gap="4" className="flex-1 min-h-0 overflow-y-auto p-3">
+        <BlockStack gap="2" align="center" inlineAlign="center">
           <div className="flex size-11 items-center justify-center rounded-full bg-accent">
             <Icon name="Sparkles" size="lg" className="text-muted-foreground" />
           </div>

--- a/src/routes/v2/shared/windows/viewPresets.ts
+++ b/src/routes/v2/shared/windows/viewPresets.ts
@@ -18,11 +18,11 @@ const COMPONENT_LIBRARY_WINDOW_ID = "component-library";
 
 export const DEFAULT_DOCK_AREAS: PresetDockAreas = {
   left: [
-    "tip-of-the-day",
     "runs-and-submission",
     COMPONENT_SEARCH_WINDOW_ID,
     COMPONENT_LIBRARY_WINDOW_ID,
     AI_ASSISTANT_WINDOW_ID,
+    "tip-of-the-day",
     "pipeline-tree",
     "history",
     "debug-panel",
@@ -56,7 +56,6 @@ export const DEFAULT_VIEW_PRESET: ViewPreset = {
     "component-library",
     AI_ASSISTANT_WINDOW_ID,
     "pipeline-details",
-    "tip-of-the-day",
   ]),
   dockAreas: DEFAULT_DOCK_AREAS,
 };


### PR DESCRIPTION
## Description

Moves "tip-of-the-day" to the end of the left dock area order (after the AI Assistant and before "pipeline-tree") and removes it from the default visible windows in the default view preset so it no longer appears open by default. Also tightens the spacing in the AI Chat empty state — reducing the outer gap and padding, and removing the top padding from the inner centered block.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Open the application and verify the "tip-of-the-day" panel is not visible by default on load.
2. Confirm the "tip-of-the-day" panel can still be opened manually and appears in the correct position in the left dock order.
3. Open the AI Chat panel with no messages and verify the empty state layout renders with the updated, tighter spacing.

## Additional Comments