### PR TITLE
chore: v2 - runview actions bar

### DIFF
--- a/src/routes/v2/pages/RunView/components/RunActionsBar.tsx
+++ b/src/routes/v2/pages/RunView/components/RunActionsBar.tsx
@@ -1,0 +1,183 @@
+import TooltipButton from "@/components/shared/Buttons/TooltipButton";
+import ConfirmationDialog from "@/components/shared/Dialogs/ConfirmationDialog";
+import { StatusBar } from "@/components/shared/Status";
+import TaskImplementation from "@/components/shared/TaskDetails/Implementation";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Icon } from "@/components/ui/icon";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
+import { useCancelPipelineRun } from "@/routes/v2/pages/RunView/hooks/useCancelPipelineRun";
+import { useClonePipelineRun } from "@/routes/v2/pages/RunView/hooks/useClonePipelineRun";
+import { useExportPipelineYaml } from "@/routes/v2/pages/RunView/hooks/useExportPipelineYaml";
+import { useInspectPipeline } from "@/routes/v2/pages/RunView/hooks/useInspectPipeline";
+import { useRerunPipelineRun } from "@/routes/v2/pages/RunView/hooks/useRerunPipelineRun";
+import { useRunViewActions } from "@/routes/v2/pages/RunView/hooks/useRunViewActions";
+import { useYamlViewer } from "@/routes/v2/pages/RunView/hooks/useYamlViewer";
+import type { ExecutionStatusStats } from "@/utils/executionStatus";
+import { tracking } from "@/utils/tracking";
+
+interface RunActionsBarProps {
+  executionStatusStats: ExecutionStatusStats | null | undefined;
+  statusLabel: string;
+}
+
+export function RunActionsBar({
+  executionStatusStats,
+  statusLabel,
+}: RunActionsBarProps) {
+  const actions = useRunViewActions();
+  const componentSpec = actions.ready ? actions.componentSpec : undefined;
+  const runId = actions.ready ? actions.runId : undefined;
+  const pipelineName = actions.ready ? actions.pipelineName : undefined;
+
+  const { yamlViewerOpen, openYamlViewer, closeYamlViewer } = useYamlViewer();
+  const { clone, isCloning } = useClonePipelineRun(componentSpec, runId);
+  const { rerun, isRerunning } = useRerunPipelineRun(componentSpec);
+  const {
+    cancelDialogOpen,
+    isCancelling,
+    requestCancel,
+    confirmCancel,
+    dismissCancel,
+  } = useCancelPipelineRun(runId);
+  const { inspect } = useInspectPipeline(pipelineName);
+  const { exportYaml } = useExportPipelineYaml(componentSpec, pipelineName);
+
+  const status = (
+    <BlockStack gap="1" className="min-w-0 flex-1">
+      <Text size="xs" weight="semibold" className="truncate">
+        {statusLabel}
+      </Text>
+      <StatusBar executionStatusStats={executionStatusStats} />
+    </BlockStack>
+  );
+
+  if (!actions.ready) {
+    return (
+      <InlineStack
+        gap="2"
+        blockAlign="center"
+        wrap="nowrap"
+        className="w-full rounded-md border px-2 py-1"
+      >
+        {status}
+      </InlineStack>
+    );
+  }
+
+  const { canAccessEditorSpec, isRunCreator, isInProgress, isComplete } =
+    actions;
+  const showCancel = isInProgress && isRunCreator;
+  const showSeparator = showCancel || isComplete;
+
+  return (
+    <>
+      <InlineStack
+        gap="2"
+        blockAlign="center"
+        wrap="nowrap"
+        className="w-full rounded-md border px-2 py-1"
+      >
+        {status}
+
+        <InlineStack blockAlign="center" className="shrink-0">
+          <TooltipButton
+            variant="ghost"
+            size="min"
+            onClick={openYamlViewer}
+            tooltip="View YAML"
+            {...tracking("v2.run_view.menu_bar.view_yaml")}
+          >
+            <Icon name="FileCode" size="sm" />
+          </TooltipButton>
+
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="ghost" size="min">
+                <Icon name="EllipsisVertical" size="sm" />
+              </Button>
+            </DropdownMenuTrigger>
+
+            <DropdownMenuContent align="end">
+              {canAccessEditorSpec && pipelineName && (
+                <DropdownMenuItem
+                  onSelect={inspect}
+                  {...tracking("v2.run_view.menu_bar.inspect_pipeline")}
+                >
+                  <Icon name="ExternalLink" size="sm" />
+                  Inspect Pipeline
+                </DropdownMenuItem>
+              )}
+
+              <DropdownMenuItem
+                onSelect={clone}
+                disabled={isCloning}
+                {...tracking("v2.run_view.menu_bar.clone_pipeline")}
+              >
+                <Icon name="CopyPlus" size="sm" />
+                Clone Pipeline
+              </DropdownMenuItem>
+
+              <DropdownMenuItem
+                onSelect={exportYaml}
+                {...tracking("v2.run_view.menu_bar.export_yaml")}
+              >
+                <Icon name="FileDown" size="sm" />
+                Export YAML
+              </DropdownMenuItem>
+
+              {showSeparator && <DropdownMenuSeparator />}
+
+              {showCancel && (
+                <DropdownMenuItem
+                  onSelect={requestCancel}
+                  disabled={isCancelling}
+                  className="text-destructive focus:text-destructive"
+                  {...tracking("v2.run_view.menu_bar.cancel_run")}
+                >
+                  <Icon name="CircleX" size="sm" />
+                  Cancel Run
+                </DropdownMenuItem>
+              )}
+
+              {isComplete && (
+                <DropdownMenuItem
+                  onSelect={rerun}
+                  disabled={isRerunning}
+                  {...tracking("v2.run_view.menu_bar.rerun_pipeline")}
+                >
+                  <Icon name="RefreshCcw" size="sm" />
+                  Rerun Pipeline
+                </DropdownMenuItem>
+              )}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </InlineStack>
+      </InlineStack>
+
+      <ConfirmationDialog
+        isOpen={cancelDialogOpen}
+        title="Cancel run"
+        description="The run will be scheduled for cancellation. This action cannot be undone."
+        onConfirm={confirmCancel}
+        onCancel={dismissCancel}
+      />
+
+      {yamlViewerOpen && (
+        <TaskImplementation
+          componentSpec={componentSpec}
+          displayName={pipelineName ?? componentSpec?.name ?? "Pipeline"}
+          fullscreen
+          onClose={closeYamlViewer}
+        />
+      )}
+    </>
+  );
+}

--- a/src/routes/v2/pages/RunView/components/RunDetailsHeader.tsx
+++ b/src/routes/v2/pages/RunView/components/RunDetailsHeader.tsx
@@ -1,8 +1,8 @@
 import { CopyText } from "@/components/shared/CopyText/CopyText";
-import { StatusBar } from "@/components/shared/Status";
-import { BlockStack, InlineStack } from "@/components/ui/layout";
-import { Text } from "@/components/ui/typography";
+import { BlockStack } from "@/components/ui/layout";
 import type { ExecutionStatusStats } from "@/utils/executionStatus";
+
+import { RunActionsBar } from "./RunActionsBar";
 
 interface RunDetailsHeaderProps {
   pipelineName: string;
@@ -24,19 +24,10 @@ export function RunDetailsHeader({
         {pipelineName}
       </CopyText>
 
-      <InlineStack
-        gap="2"
-        blockAlign="center"
-        wrap="nowrap"
-        className="w-full rounded-md border px-2 py-1"
-      >
-        <BlockStack gap="1" className="min-w-0 flex-1">
-          <Text size="xs" weight="semibold" className="truncate">
-            {statusLabel}
-          </Text>
-          <StatusBar executionStatusStats={executionStatusStats} />
-        </BlockStack>
-      </InlineStack>
+      <RunActionsBar
+        executionStatusStats={executionStatusStats}
+        statusLabel={statusLabel}
+      />
     </BlockStack>
   );
 }

--- a/src/routes/v2/pages/RunView/hooks/useCancelPipelineRun.ts
+++ b/src/routes/v2/pages/RunView/hooks/useCancelPipelineRun.ts
@@ -1,0 +1,55 @@
+import { useMutation } from "@tanstack/react-query";
+import { useState } from "react";
+
+import useToastNotification from "@/hooks/useToastNotification";
+import { useBackend } from "@/providers/BackendProvider";
+import { cancelPipelineRun } from "@/services/pipelineRunService";
+
+export function useCancelPipelineRun(runId?: string | null) {
+  const notify = useToastNotification();
+  const { backendUrl, available } = useBackend();
+
+  const [cancelDialogOpen, setCancelDialogOpen] = useState(false);
+
+  const { mutate: cancelRun, isPending: isCancelling } = useMutation({
+    mutationFn: (runId: string) => cancelPipelineRun(runId, backendUrl),
+    onSuccess: () => {
+      notify("Pipeline run cancelled", "success");
+    },
+    onError: (error) => {
+      notify(`Error cancelling run: ${error}`, "error");
+    },
+  });
+
+  const requestCancel = () => {
+    setCancelDialogOpen(true);
+  };
+
+  const dismissCancel = () => {
+    setCancelDialogOpen(false);
+  };
+
+  const confirmCancel = () => {
+    setCancelDialogOpen(false);
+
+    if (!runId) {
+      notify("Failed to cancel run. No run ID found.", "warning");
+      return;
+    }
+
+    if (!available) {
+      notify("Backend is not available. Cannot cancel run.", "warning");
+      return;
+    }
+
+    cancelRun(runId);
+  };
+
+  return {
+    cancelDialogOpen,
+    isCancelling,
+    requestCancel,
+    confirmCancel,
+    dismissCancel,
+  };
+}

--- a/src/routes/v2/pages/RunView/hooks/useClonePipelineRun.ts
+++ b/src/routes/v2/pages/RunView/hooks/useClonePipelineRun.ts
@@ -1,0 +1,86 @@
+import { useMutation } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
+
+import { buildTaskSpecShape } from "@/components/shared/PipelineRunNameTemplate/types";
+import useToastNotification from "@/hooks/useToastNotification";
+import { useExecutionData } from "@/providers/ExecutionDataProvider";
+import { copyRunToPipeline } from "@/services/pipelineRunService";
+import { extractCanonicalName } from "@/utils/canonicalPipelineName";
+import {
+  type ArgumentType,
+  type ComponentSpec,
+  isSecretArgument,
+} from "@/utils/componentSpec";
+import { getInitialName } from "@/utils/getComponentName";
+import { extractTaskArguments } from "@/utils/nodes/taskArguments";
+
+interface CloneVariables {
+  componentSpec: ComponentSpec;
+  runId: string | null | undefined;
+  name: string;
+  taskArguments: Record<string, string>;
+}
+
+export function useClonePipelineRun(
+  componentSpec?: ComponentSpec,
+  runId?: string | null,
+) {
+  const navigate = useNavigate();
+  const notify = useToastNotification();
+  const { rootDetails } = useExecutionData();
+
+  const { mutate: clonePipeline, isPending: isCloning } = useMutation({
+    mutationFn: ({
+      componentSpec,
+      runId,
+      name,
+      taskArguments,
+    }: CloneVariables) =>
+      copyRunToPipeline(componentSpec, runId, name, taskArguments),
+    onSuccess: (result) => {
+      if (!result?.url) return;
+      notify(`Pipeline "${result.name}" cloned`, "success");
+      navigate({ to: result.url });
+    },
+    onError: (error) => {
+      notify(`Error cloning pipeline: ${error}`, "error");
+    },
+  });
+
+  const clone = () => {
+    if (!componentSpec) return;
+
+    const taskSpecArguments = rootDetails?.task_spec.arguments ?? {};
+
+    /**
+     * SecretArguments cannot be converted into strings compatible with inputs,
+     * so drop them from the cloned pipeline's arguments.
+     */
+    const secretArgumentKeys = new Set(
+      Object.entries(taskSpecArguments)
+        .filter(([, value]) => isSecretArgument(value as ArgumentType))
+        .map(([key]) => key),
+    );
+
+    const plainTaskArguments = extractTaskArguments(taskSpecArguments);
+    const taskArguments: Record<string, string> = Object.fromEntries(
+      Object.entries(plainTaskArguments).filter(
+        ([key]) => !secretArgumentKeys.has(key),
+      ),
+    );
+
+    const canonicalName = extractCanonicalName(
+      buildTaskSpecShape(rootDetails?.task_spec, componentSpec),
+    );
+    const name = getInitialName(componentSpec, canonicalName);
+
+    clonePipeline({
+      componentSpec,
+      runId,
+      name,
+      taskArguments,
+    });
+  };
+
+  return { clone, isCloning };
+}

--- a/src/routes/v2/pages/RunView/hooks/useExportPipelineYaml.ts
+++ b/src/routes/v2/pages/RunView/hooks/useExportPipelineYaml.ts
@@ -1,0 +1,19 @@
+import { exportPipeline } from "@/components/shared/ReactFlow/FlowSidebar/sections/components/ExportPipelineButton";
+import type { ComponentSpec } from "@/utils/componentSpec";
+import { componentSpecToYaml } from "@/utils/yaml";
+
+export function useExportPipelineYaml(
+  componentSpec?: ComponentSpec,
+  pipelineName?: string,
+) {
+  const exportYaml = () => {
+    if (!componentSpec) return;
+    const yaml = componentSpecToYaml(componentSpec);
+    exportPipeline(
+      pipelineName ?? componentSpec.name ?? "Untitled Pipeline",
+      yaml,
+    );
+  };
+
+  return { exportYaml };
+}

--- a/src/routes/v2/pages/RunView/hooks/useInspectPipeline.ts
+++ b/src/routes/v2/pages/RunView/hooks/useInspectPipeline.ts
@@ -1,0 +1,12 @@
+import { useNavigate } from "@tanstack/react-router";
+
+export function useInspectPipeline(pipelineName?: string) {
+  const navigate = useNavigate();
+
+  const inspect = () => {
+    if (!pipelineName) return;
+    navigate({ to: `/editor/${encodeURIComponent(pipelineName)}` });
+  };
+
+  return { inspect };
+}

--- a/src/routes/v2/pages/RunView/hooks/useRerunPipelineRun.ts
+++ b/src/routes/v2/pages/RunView/hooks/useRerunPipelineRun.ts
@@ -1,0 +1,86 @@
+import { useMutation } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
+
+import { isAuthorizationRequired } from "@/components/shared/Authentication/helpers";
+import { useAuthLocalStorage } from "@/components/shared/Authentication/useAuthLocalStorage";
+import { useAwaitAuthorization } from "@/components/shared/Authentication/useAwaitAuthorization";
+import { buildTaskSpecShape } from "@/components/shared/PipelineRunNameTemplate/types";
+import { useFlagValue } from "@/components/shared/Settings/useFlags";
+import useToastNotification from "@/hooks/useToastNotification";
+import { useBackend } from "@/providers/BackendProvider";
+import { useExecutionData } from "@/providers/ExecutionDataProvider";
+import { APP_ROUTES } from "@/routes/router";
+import type { PipelineRun } from "@/types/pipelineRun";
+import { extractCanonicalName } from "@/utils/canonicalPipelineName";
+import type { ArgumentType, ComponentSpec } from "@/utils/componentSpec";
+import { submitPipelineRun } from "@/utils/submitPipeline";
+
+interface RerunVariables {
+  componentSpec: ComponentSpec;
+  canonicalName?: string;
+  taskArguments?: Record<string, ArgumentType>;
+}
+
+export function useRerunPipelineRun(componentSpec?: ComponentSpec) {
+  const navigate = useNavigate();
+  const notify = useToastNotification();
+  const { backendUrl } = useBackend();
+  const runNameOverride = useFlagValue("templatized-pipeline-run-name");
+  const { awaitAuthorization, isAuthorized } = useAwaitAuthorization();
+  const { getToken } = useAuthLocalStorage();
+  const { rootDetails } = useExecutionData();
+
+  const getAuthToken = async (): Promise<string | undefined> => {
+    if (isAuthorizationRequired() && !isAuthorized) {
+      const token = await awaitAuthorization();
+      if (token) {
+        return token;
+      }
+    }
+    return getToken();
+  };
+
+  const { mutate: rerunPipeline, isPending: isRerunning } = useMutation({
+    mutationFn: async ({
+      componentSpec,
+      canonicalName,
+      taskArguments,
+    }: RerunVariables) => {
+      const authorizationToken = await getAuthToken();
+      return new Promise<PipelineRun>((resolve, reject) => {
+        submitPipelineRun(componentSpec, backendUrl, {
+          canonicalName,
+          taskArguments,
+          authorizationToken,
+          runNameOverride,
+          onSuccess: resolve,
+          onError: reject,
+        });
+      });
+    },
+    onSuccess: (response) => {
+      navigate({ to: `${APP_ROUTES.RUNS}/${response.id}` });
+    },
+    onError: (error) => {
+      const message = `Failed to submit pipeline. ${error instanceof Error ? error.message : String(error)}`;
+      notify(message, "error");
+    },
+  });
+
+  const rerun = () => {
+    if (!componentSpec) return;
+
+    const canonicalName = extractCanonicalName(
+      buildTaskSpecShape(rootDetails?.task_spec, componentSpec),
+    );
+
+    rerunPipeline({
+      componentSpec,
+      canonicalName,
+      taskArguments: rootDetails?.task_spec.arguments as
+        Record<string, ArgumentType> | undefined,
+    });
+  };
+
+  return { rerun, isRerunning };
+}

--- a/src/routes/v2/pages/RunView/hooks/useYamlViewer.ts
+++ b/src/routes/v2/pages/RunView/hooks/useYamlViewer.ts
@@ -1,0 +1,15 @@
+import { useState } from "react";
+
+export function useYamlViewer() {
+  const [yamlViewerOpen, setYamlViewerOpen] = useState(false);
+
+  const openYamlViewer = () => {
+    setYamlViewerOpen(true);
+  };
+
+  const closeYamlViewer = () => {
+    setYamlViewerOpen(false);
+  };
+
+  return { yamlViewerOpen, openYamlViewer, closeYamlViewer };
+}

--- a/src/routes/v2/pages/RunView/nodes/TaskNode/context/RunViewTaskDetails.tsx
+++ b/src/routes/v2/pages/RunView/nodes/TaskNode/context/RunViewTaskDetails.tsx
@@ -93,7 +93,7 @@ export const RunViewTaskDetails = observer(function RunViewTaskDetails({
             })
           }
         >
-          <TabsList className="mb-2">
+          <TabsList className="mb-2 w-full">
             <TabsTrigger value="artifacts" className="flex-1">
               <AmphoraIcon className="w-4 h-4" />
               Artifacts


### PR DESCRIPTION
## Description

Adds a `RunActionsBar` component to the Run View header that surfaces pipeline actions directly in the status bar area. The bar displays the run status label and progress bar, and exposes the following actions:

- **View YAML** – opens a fullscreen YAML viewer for the pipeline spec
- **Inspect Pipeline** – navigates to the pipeline editor (shown only when the user has editor access and a pipeline name is available)
- **Clone Pipeline** – copies the run to a new pipeline, stripping secret arguments before cloning
- **Export YAML** – downloads the pipeline spec as a YAML file
- **Cancel Run** – available for in-progress runs owned by the current user, with a confirmation dialog before cancelling
- **Rerun Pipeline** – available for completed runs, resubmits the pipeline with the original arguments and navigates to the new run

Each action is backed by a dedicated hook (`useCancelPipelineRun`, `useClonePipelineRun`, `useExportPipelineYaml`, `useInspectPipeline`, `useRerunPipelineRun`, `useYamlViewer`) to keep concerns separated. The `RunDetailsHeader` now delegates its status bar rendering to `RunActionsBar`. The tabs list in `RunViewTaskDetails` is also updated to be full-width.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

![image.png](https://app.graphite.com/user-attachments/assets/2fc1b35e-c248-4b3e-9dea-9250aca9da6a.png)



## Test Instructions

1. Open a run in the Run View.
2. Verify the status bar displays the status label and progress bar as before.
3. Click the **View YAML** button and confirm the fullscreen YAML viewer opens.
4. Open the overflow menu (⋮) and verify:
    - **Inspect Pipeline** appears only when you have editor access and a pipeline name is present, and navigates to the editor.
    - **Clone Pipeline** creates a new pipeline and navigates to it, with secret arguments excluded.
    - **Export YAML** downloads the pipeline spec as a `.yaml` file.
    - **Cancel Run** appears only for in-progress runs you own, shows a confirmation dialog, and cancels the run on confirm.
    - **Rerun Pipeline** appears only for completed runs, resubmits the pipeline, and navigates to the new run.

## Additional Comments

Secret arguments are intentionally dropped during cloning since they cannot be serialised as plain string inputs.