### PR TITLE
chore: v2 - runview run menu actions

### DIFF
--- a/src/routes/v2/pages/RunView/components/RunViewMenuBar/components/RunMenu.tsx
+++ b/src/routes/v2/pages/RunView/components/RunViewMenuBar/components/RunMenu.tsx
@@ -1,5 +1,5 @@
-import { useNavigate } from "@tanstack/react-router";
-
+import ConfirmationDialog from "@/components/shared/Dialogs/ConfirmationDialog";
+import TaskImplementation from "@/components/shared/TaskDetails/Implementation";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -8,14 +8,34 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Icon } from "@/components/ui/icon";
-import { getDefaultEditorPath } from "@/routes/editorRoutes";
+import { useCancelPipelineRun } from "@/routes/v2/pages/RunView/hooks/useCancelPipelineRun";
+import { useClonePipelineRun } from "@/routes/v2/pages/RunView/hooks/useClonePipelineRun";
+import { useExportPipelineYaml } from "@/routes/v2/pages/RunView/hooks/useExportPipelineYaml";
+import { useInspectPipeline } from "@/routes/v2/pages/RunView/hooks/useInspectPipeline";
+import { useRerunPipelineRun } from "@/routes/v2/pages/RunView/hooks/useRerunPipelineRun";
 import { useRunViewActions } from "@/routes/v2/pages/RunView/hooks/useRunViewActions";
+import { useYamlViewer } from "@/routes/v2/pages/RunView/hooks/useYamlViewer";
 import { MenuTriggerButton } from "@/routes/v2/shared/components/MenuTriggerButton";
 import { tracking } from "@/utils/tracking";
 
 export function RunMenu() {
-  const navigate = useNavigate();
   const actions = useRunViewActions();
+  const componentSpec = actions.ready ? actions.componentSpec : undefined;
+  const runId = actions.ready ? actions.runId : undefined;
+  const pipelineName = actions.ready ? actions.pipelineName : undefined;
+
+  const { yamlViewerOpen, openYamlViewer, closeYamlViewer } = useYamlViewer();
+  const { clone, isCloning } = useClonePipelineRun(componentSpec, runId);
+  const { rerun, isRerunning } = useRerunPipelineRun(componentSpec);
+  const {
+    cancelDialogOpen,
+    isCancelling,
+    requestCancel,
+    confirmCancel,
+    dismissCancel,
+  } = useCancelPipelineRun(runId);
+  const { inspect } = useInspectPipeline(pipelineName);
+  const { exportYaml } = useExportPipelineYaml(componentSpec, pipelineName);
 
   if (!actions.ready) {
     return (
@@ -32,54 +52,98 @@ export function RunMenu() {
     );
   }
 
-  const {
-    canAccessEditorSpec,
-    isRunCreator,
-    isInProgress,
-    isComplete,
-    pipelineName,
-  } = actions;
-
-  const handleInspect = () => {
-    if (pipelineName) {
-      navigate({ to: getDefaultEditorPath(pipelineName) });
-    }
-  };
+  const { canAccessEditorSpec, isRunCreator, isInProgress, isComplete } =
+    actions;
+  const showCancel = isInProgress && isRunCreator;
+  const showSeparator = showCancel || isComplete;
 
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <MenuTriggerButton {...tracking("v2.run_view.menu_bar.run_menu")}>
-          Run
-        </MenuTriggerButton>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" sideOffset={2}>
-        {canAccessEditorSpec && pipelineName && (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <MenuTriggerButton {...tracking("v2.run_view.menu_bar.run_menu")}>
+            Run
+          </MenuTriggerButton>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" sideOffset={2}>
+          {canAccessEditorSpec && pipelineName && (
+            <DropdownMenuItem
+              onSelect={inspect}
+              {...tracking("v2.run_view.menu_bar.inspect_pipeline")}
+            >
+              <Icon name="ExternalLink" size="sm" />
+              Inspect Pipeline
+            </DropdownMenuItem>
+          )}
+
           <DropdownMenuItem
-            onSelect={handleInspect}
-            {...tracking("v2.run_view.menu_bar.inspect_pipeline")}
+            onSelect={openYamlViewer}
+            {...tracking("v2.run_view.menu_bar.view_yaml")}
           >
-            <Icon name="ExternalLink" size="sm" />
-            Inspect Pipeline
+            <Icon name="FileCode" size="sm" />
+            View YAML
           </DropdownMenuItem>
-        )}
 
-        <DropdownMenuSeparator />
-
-        {isInProgress && isRunCreator && (
-          <DropdownMenuItem className="text-destructive" disabled>
-            <Icon name="CircleX" size="sm" />
-            Cancel Run
+          <DropdownMenuItem
+            onSelect={clone}
+            disabled={isCloning}
+            {...tracking("v2.run_view.menu_bar.clone_pipeline")}
+          >
+            <Icon name="CopyPlus" size="sm" />
+            Clone Pipeline
           </DropdownMenuItem>
-        )}
 
-        {isComplete && (
-          <DropdownMenuItem disabled>
-            <Icon name="RefreshCcw" size="sm" />
-            Rerun Pipeline
+          <DropdownMenuItem
+            onSelect={exportYaml}
+            {...tracking("v2.run_view.menu_bar.export_yaml")}
+          >
+            <Icon name="FileDown" size="sm" />
+            Export YAML
           </DropdownMenuItem>
-        )}
-      </DropdownMenuContent>
-    </DropdownMenu>
+
+          {showSeparator && <DropdownMenuSeparator />}
+
+          {showCancel && (
+            <DropdownMenuItem
+              onSelect={requestCancel}
+              disabled={isCancelling}
+              className="text-destructive focus:text-destructive"
+              {...tracking("v2.run_view.menu_bar.cancel_run")}
+            >
+              <Icon name="CircleX" size="sm" />
+              Cancel Run
+            </DropdownMenuItem>
+          )}
+
+          {isComplete && (
+            <DropdownMenuItem
+              onSelect={rerun}
+              disabled={isRerunning}
+              {...tracking("v2.run_view.menu_bar.rerun_pipeline")}
+            >
+              <Icon name="RefreshCcw" size="sm" />
+              Rerun Pipeline
+            </DropdownMenuItem>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <ConfirmationDialog
+        isOpen={cancelDialogOpen}
+        title="Cancel run"
+        description="The run will be scheduled for cancellation. This action cannot be undone."
+        onConfirm={confirmCancel}
+        onCancel={dismissCancel}
+      />
+
+      {yamlViewerOpen && (
+        <TaskImplementation
+          componentSpec={componentSpec}
+          displayName={pipelineName ?? componentSpec?.name ?? "Pipeline"}
+          fullscreen
+          onClose={closeYamlViewer}
+        />
+      )}
+    </>
   );
 }


### PR DESCRIPTION
## Description

The Run Menu has been updated to wire up previously disabled/placeholder menu items with real functionality. The menu now supports:

- **View YAML** – opens an inline YAML viewer using `TaskImplementation` in fullscreen mode
- **Clone Pipeline** – clones the current pipeline run via `useClonePipelineRun`
- **Export YAML** – exports the pipeline spec as a YAML file via `useExportPipelineYaml`
- **Cancel Run** – triggers a confirmation dialog before cancelling an in-progress run via `useCancelPipelineRun`
- **Rerun Pipeline** – reruns a completed pipeline via `useRerunPipelineRun`
- **Inspect Pipeline** – navigates to the pipeline editor using `useInspectPipeline` (replacing the inline `handleInspect` function)

A `ConfirmationDialog` has been added for the cancel action to prevent accidental cancellations. The separator between standard and destructive/contextual actions is now conditionally rendered based on whether cancel or rerun options are visible.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

![image.png](https://app.graphite.com/user-attachments/assets/0f397147-e577-46fd-bed8-68668c3d951a.png)



## Test Instructions

1. Navigate to a run view page.
2. Open the **Run** menu from the menu bar.
3. Verify **View YAML** opens the YAML viewer with the correct pipeline spec.
4. Verify **Clone Pipeline** creates a clone of the current run.
5. Verify **Export YAML** downloads the pipeline YAML file.
6. On an in-progress run (as the run creator), verify **Cancel Run** shows a confirmation dialog and cancels the run upon confirmation.
7. On a completed run, verify **Rerun Pipeline** successfully triggers a rerun.
8. Verify **Inspect Pipeline** navigates to the correct editor path when the pipeline name is available.

## Additional Comments