### PR TITLE
feat: v2 - runview tools window to become a panel

### DIFF
--- a/src/routes/v2/pages/RunView/components/RunToolsContent.tsx
+++ b/src/routes/v2/pages/RunView/components/RunToolsContent.tsx
@@ -1,18 +1,29 @@
+import { observer } from "mobx-react-lite";
+
 import { CancelPipelineRunButton } from "@/components/PipelineRun/components/CancelPipelineRunButton";
 import { ClonePipelineButton } from "@/components/PipelineRun/components/ClonePipelineButton";
 import { InspectPipelineButton } from "@/components/PipelineRun/components/InspectPipelineButton";
 import { RerunPipelineButton } from "@/components/PipelineRun/components/RerunPipelineButton";
 import { ViewYamlButton } from "@/components/shared/Buttons/ViewYamlButton";
-import { BlockStack } from "@/components/ui/layout";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { useRunViewActions } from "@/routes/v2/pages/RunView/hooks/useRunViewActions";
+import { useOptionalWindowContext } from "@/routes/v2/shared/windows/ContentWindowStateContext";
 import { tracking } from "@/utils/tracking";
 
 const RUN_TOOL_CLASS_NAME =
   "h-10 w-full justify-start gap-3 border-transparent bg-transparent px-3 shadow-none hover:border-border hover:bg-muted";
 const RUN_TOOL_WRAPPER_CLASS_NAME = "w-full";
 
-export function RunToolsContent() {
+const ROW_TOOL_CLASS_NAME =
+  "h-10 justify-start gap-3 px-3 shadow-none hover:border-border hover:bg-muted";
+const ROW_TOOL_WRAPPER_CLASS_NAME = "shrink-0";
+
+export const RunToolsContent = observer(function RunToolsContent() {
   const actions = useRunViewActions();
+  const windowContext = useOptionalWindowContext();
+  const isFloatingPanel =
+    windowContext?.model.variant === "panel" &&
+    windowContext.model.dockState === "none";
 
   if (!actions.ready) return null;
 
@@ -26,14 +37,21 @@ export function RunToolsContent() {
     pipelineName,
   } = actions;
 
-  return (
-    <BlockStack gap="1" className="p-2">
+  const toolClassName = isFloatingPanel
+    ? ROW_TOOL_CLASS_NAME
+    : RUN_TOOL_CLASS_NAME;
+  const wrapperClassName = isFloatingPanel
+    ? ROW_TOOL_WRAPPER_CLASS_NAME
+    : RUN_TOOL_WRAPPER_CLASS_NAME;
+
+  const tools = (
+    <>
       <ViewYamlButton
         componentSpec={componentSpec}
         displayLabel="View YAML"
         showTooltip={false}
-        className={RUN_TOOL_CLASS_NAME}
-        wrapperClassName={RUN_TOOL_WRAPPER_CLASS_NAME}
+        className={toolClassName}
+        wrapperClassName={wrapperClassName}
         {...tracking("v2.run_view.tools.view_yaml")}
       />
 
@@ -42,8 +60,8 @@ export function RunToolsContent() {
           pipelineName={pipelineName}
           displayLabel="Inspect pipeline"
           showTooltip={false}
-          className={RUN_TOOL_CLASS_NAME}
-          wrapperClassName={RUN_TOOL_WRAPPER_CLASS_NAME}
+          className={toolClassName}
+          wrapperClassName={wrapperClassName}
           {...tracking("v2.run_view.tools.inspect_pipeline")}
         />
       )}
@@ -53,8 +71,8 @@ export function RunToolsContent() {
         runId={runId}
         displayLabel="Clone pipeline"
         showTooltip={false}
-        className={RUN_TOOL_CLASS_NAME}
-        wrapperClassName={RUN_TOOL_WRAPPER_CLASS_NAME}
+        className={toolClassName}
+        wrapperClassName={wrapperClassName}
         {...tracking("v2.run_view.tools.clone_pipeline")}
       />
 
@@ -63,8 +81,8 @@ export function RunToolsContent() {
           runId={runId}
           displayLabel="Cancel run"
           showTooltip={false}
-          className={`${RUN_TOOL_CLASS_NAME} text-destructive hover:text-destructive`}
-          wrapperClassName={RUN_TOOL_WRAPPER_CLASS_NAME}
+          className={`${toolClassName} text-destructive hover:text-destructive`}
+          wrapperClassName={wrapperClassName}
           {...tracking("v2.run_view.tools.cancel_run")}
         />
       )}
@@ -74,11 +92,30 @@ export function RunToolsContent() {
           componentSpec={componentSpec}
           displayLabel="Rerun pipeline"
           showTooltip={false}
-          className={RUN_TOOL_CLASS_NAME}
-          wrapperClassName={RUN_TOOL_WRAPPER_CLASS_NAME}
+          className={toolClassName}
+          wrapperClassName={wrapperClassName}
           {...tracking("v2.run_view.tools.rerun_pipeline")}
         />
       )}
+    </>
+  );
+
+  if (isFloatingPanel) {
+    return (
+      <InlineStack
+        gap="1"
+        wrap="nowrap"
+        blockAlign="center"
+        className="p-2 bg-background rounded-md border"
+      >
+        {tools}
+      </InlineStack>
+    );
+  }
+
+  return (
+    <BlockStack gap="1" className="p-2">
+      {tools}
     </BlockStack>
   );
-}
+});

--- a/src/routes/v2/pages/RunView/hooks/useRunViewWindows.tsx
+++ b/src/routes/v2/pages/RunView/hooks/useRunViewWindows.tsx
@@ -22,6 +22,7 @@ export function useRunViewWindows() {
         title: "Run Tools",
         defaultVisible: true,
         disabledActions: ["close", "maximize"],
+        variant: "panel",
         size: { width: 280, height: 240 },
         position: { x: 0, y: 60 },
         minSize: { width: 240, height: 180 },

--- a/src/routes/v2/shared/windows/components/FloatingWindow.tsx
+++ b/src/routes/v2/shared/windows/components/FloatingWindow.tsx
@@ -3,6 +3,7 @@ import { observer } from "mobx-react-lite";
 import { type CSSProperties, type MouseEventHandler, useState } from "react";
 import { createPortal } from "react-dom";
 
+import { cn } from "@/lib/utils";
 import { useWindowContext } from "@/routes/v2/shared/windows/ContentWindowStateContext";
 import { useWindowDrag } from "@/routes/v2/shared/windows/hooks/useWindowDrag";
 import { SnapPreview } from "@/routes/v2/shared/windows/SnapPreview";
@@ -20,11 +21,20 @@ const containerVariants = cva(
       interacting: { true: "select-none", false: "" },
       dragging: { true: "cursor-grabbing", false: "" },
       maximized: { true: "rounded-none", false: "rounded" },
+      panel: {
+        // Chrome-less by default; border/background/shadow fade in on hover to
+        // match a regular floating window. Uses a dedicated `group/panel` (not
+        // `group/window`) so WindowHeader's window-hover purple tint never fires.
+        // Only color/shadow transition (never position) so dragging stays smooth.
+        true: "group/panel overflow-visible border-transparent bg-transparent shadow-none transition-[background-color,border-color,box-shadow] duration-200 group-hover/panel:border-gray-400 group-hover/panel:bg-gray-100 group-hover/panel:shadow-xl",
+        false: "overflow-hidden border-gray-400 bg-gray-100 shadow-xl",
+      },
     },
     defaultVariants: {
       interacting: false,
       dragging: false,
       maximized: false,
+      panel: false,
     },
   },
 );
@@ -32,13 +42,32 @@ const containerVariants = cva(
 const headerVariants = cva("py-1 bg-gray-800 border-gray-700", {
   variants: {
     maximized: { true: "cursor-default", false: "" },
+    panel: {
+      // Chrome hidden by default but header always reserves its space (like a
+      // regular window) so hovering never shifts layout. Only opacity fades;
+      // pointer events stay on so the invisible header is still a drag handle.
+      true: "opacity-0 transition-opacity duration-200 group-hover/panel:opacity-100",
+      false: "",
+    },
   },
-  defaultVariants: { maximized: false },
+  defaultVariants: { maximized: false, panel: false },
 });
 
-function getWindowStyle(model: WindowModel): CSSProperties {
+function getWindowStyle(model: WindowModel, isPanel: boolean): CSSProperties {
   if (model.isMaximized) {
     return { left: 0, top: 0, width: "100vw", height: "100vh", zIndex: 45 };
+  }
+
+  if (isPanel) {
+    // Auto-fit to content so buttons never wrap; minWidth keeps it usable.
+    return {
+      left: model.position.x,
+      top: model.position.y,
+      width: "max-content",
+      height: "auto",
+      minWidth: model.minSize.width,
+      zIndex: 20 + model.zIndex,
+    };
   }
 
   return {
@@ -52,8 +81,12 @@ function getWindowStyle(model: WindowModel): CSSProperties {
   };
 }
 
-function getContentHeight(model: WindowModel): string | number {
+function getContentHeight(
+  model: WindowModel,
+  isPanel: boolean,
+): string | number {
   if (model.isMaximized) return `calc(100vh - ${HEADER_HEIGHT}px)`;
+  if (isPanel) return "auto";
   return model.size.height - HEADER_HEIGHT;
 }
 
@@ -113,6 +146,8 @@ function SnapPreviewPortal({
 
 export const FloatingWindow = observer(function FloatingWindow() {
   const { model, content } = useWindowContext();
+
+  const isPanel = model.variant === "panel" && !model.isMaximized;
 
   const {
     isDragging,
@@ -192,8 +227,9 @@ export const FloatingWindow = observer(function FloatingWindow() {
           interacting: isDragging || isResizing,
           dragging: isDragging,
           maximized: model.isMaximized,
+          panel: isPanel,
         })}
-        style={getWindowStyle(model)}
+        style={getWindowStyle(model, isPanel)}
         onMouseDown={handleContainerMouseDown}
         onClick={handleContainerClick}
       >
@@ -202,13 +238,19 @@ export const FloatingWindow = observer(function FloatingWindow() {
           isDragging={isDragging}
           onMouseDown={model.isMaximized ? undefined : handleHeaderMouseDown}
           actions={<WindowActions />}
-          className={headerVariants({ maximized: model.isMaximized })}
+          className={headerVariants({
+            maximized: model.isMaximized,
+            panel: isPanel,
+          })}
           tone="dark"
         />
 
         <div
-          className="flex-1 min-h-0 overflow-auto bg-background"
-          style={{ height: getContentHeight(model) }}
+          className={cn(
+            "flex-1 min-h-0 overflow-auto bg-background",
+            isPanel && "bg-transparent overflow-visible",
+          )}
+          style={{ height: getContentHeight(model, isPanel) }}
         >
           {content}
         </div>

--- a/src/routes/v2/shared/windows/types.ts
+++ b/src/routes/v2/shared/windows/types.ts
@@ -81,6 +81,8 @@ export interface WindowOptions {
   persisted?: boolean;
   /** Default dock side for first-time users (no persisted state). */
   defaultDockState?: "left" | "right";
+  /** Visual variant. "panel" renders chrome-less (border/header on hover) and auto-fits content when floating. */
+  variant?: "window" | "panel";
   /**
    * When docked, grow to fill remaining dock-area height instead of fitting
    * content. Useful for panels whose content (e.g. logs) should expand to use

--- a/src/routes/v2/shared/windows/windowModel.ts
+++ b/src/routes/v2/shared/windows/windowModel.ts
@@ -42,6 +42,7 @@ export interface WindowModelInit {
   dockedHeight?: number;
   dockState: DockState;
   persisted: boolean;
+  variant: "window" | "panel";
   fillDockHeight?: boolean;
   onClose?: () => void;
 }
@@ -68,6 +69,7 @@ export class WindowModel {
   @observable accessor dockedHeight: number | undefined;
   @observable accessor dockState: DockState;
   @observable accessor persisted: boolean;
+  @observable accessor variant: "window" | "panel";
 
   /** Static config: when docked, fill remaining dock-area height. */
   readonly fillDockHeight: boolean;
@@ -91,6 +93,7 @@ export class WindowModel {
     this.dockedHeight = init.dockedHeight;
     this.dockState = init.dockState;
     this.persisted = init.persisted;
+    this.variant = init.variant;
     this.fillDockHeight = init.fillDockHeight ?? false;
     this.onClose = init.onClose;
     this.store = store;

--- a/src/routes/v2/shared/windows/windowStore.utils.ts
+++ b/src/routes/v2/shared/windows/windowStore.utils.ts
@@ -40,6 +40,7 @@ export function buildWindowModelInit(
       : undefined,
     previousSize: initial.needsPreviousState ? { ...geo.size } : undefined,
     persisted: !!options.persisted,
+    variant: options.variant ?? "window",
     fillDockHeight: options.fillDockHeight,
     onClose: options.onClose,
   };


### PR DESCRIPTION
## Description

Introduces a `"panel"` variant for floating windows that renders chrome-less by default — the border, background, and shadow only appear on hover, and the header fades in on hover without shifting layout. When floating (not docked), a panel auto-fits its width to content rather than using a fixed size.

The Run Tools window is configured as a `"panel"` variant. When it is floating and undocked, `RunToolsContent` detects this via `useOptionalWindowContext` and switches from a vertical `BlockStack` layout to a horizontal `InlineStack` layout, so the action buttons render in a compact row instead of a column.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

[Screen Recording 2026-07-14 at 1.42.24 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/30911eb9-3d8f-467f-aebd-d5cf7d4d4d74.mov" />](https://app.graphite.com/user-attachments/video/30911eb9-3d8f-467f-aebd-d5cf7d4d4d74.mov)



## Test Instructions

1. Open a run in the v2 Run View.
2. Confirm the Run Tools window appears floating and undocked with no visible border, background, or header until you hover over it.
3. Hover over the Run Tools window and confirm the border, background, shadow, and header fade in smoothly.
4. Confirm the action buttons render in a horizontal row when the window is floating and undocked.
5. Dock the Run Tools window to the left or right panel and confirm the buttons revert to the vertical column layout.
6. Confirm dragging the window remains smooth with no layout shifts during the hover transition.

## Additional Comments

The panel variant uses a dedicated `group/panel` Tailwind group (rather than `group/window`) to prevent the `WindowHeader`'s window-hover purple tint from triggering on panel windows. Only color, border, and shadow properties transition — never position — so dragging performance is unaffected.