### PR TITLE
feat: v2 - runview fast preview button for outputs

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ArtifactVisualizer.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ArtifactVisualizer.tsx
@@ -34,6 +34,7 @@ type ArtifactVisualizerProps = {
   name: string;
   type: string;
   value?: string;
+  triggerVariant?: "ghost" | "secondary" | "outline";
 };
 
 const ArtifactVisualizer = ({
@@ -41,6 +42,7 @@ const ArtifactVisualizer = ({
   name,
   type,
   value,
+  triggerVariant = "ghost",
 }: ArtifactVisualizerProps) => {
   const { track } = useAnalytics();
   const [isFullscreen, setIsFullscreen] = useState(false);
@@ -88,7 +90,7 @@ const ArtifactVisualizer = ({
     <Dialog onOpenChange={handleOpenChange}>
       <DialogTrigger asChild>
         {value ? (
-          <Button variant="ghost" size="xs">
+          <Button variant={triggerVariant} size="xs">
             <Icon
               name="Maximize2"
               size="xs"
@@ -96,7 +98,7 @@ const ArtifactVisualizer = ({
             />
           </Button>
         ) : (
-          <Button variant="ghost" size="xs">
+          <Button variant={triggerVariant} size="xs">
             <Icon name="Eye" />
             Preview
           </Button>

--- a/src/routes/v2/pages/RunView/nodes/TaskNode/RunViewOutputPreview.tsx
+++ b/src/routes/v2/pages/RunView/nodes/TaskNode/RunViewOutputPreview.tsx
@@ -1,0 +1,54 @@
+import type { ArtifactNodeResponse } from "@/api/types.gen";
+import ArtifactVisualizer from "@/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ArtifactVisualizer";
+import type { TypeSpecType } from "@/models/componentSpec";
+
+const MAX_VISUALIZABLE_SIZE_BYTES = 50 * 1024 * 1024; // 50 MB
+
+interface RunViewOutputPreviewProps {
+  artifact: ArtifactNodeResponse | null | undefined;
+  name: string;
+  type?: TypeSpecType;
+}
+
+/**
+ * Renders the artifact Preview trigger for a single task output in RunView.
+ * Returns null when there is no previewable artifact, mirroring the
+ * eligibility rules used by IOCell in the task Artifacts panel.
+ */
+export const RunViewOutputPreview = ({
+  artifact,
+  name,
+  type,
+}: RunViewOutputPreviewProps) => {
+  if (!artifact) return null;
+
+  const artifactData = artifact.artifact_data;
+  const inlineValue = artifactData?.value;
+  const hasInlineValue = canShowInlineValue(inlineValue);
+  const hasDetails = Boolean(artifactData?.uri || hasInlineValue);
+  const isTooLargeToVisualize =
+    !hasInlineValue &&
+    !!artifactData?.total_size &&
+    artifactData.total_size > MAX_VISUALIZABLE_SIZE_BYTES;
+
+  if (!hasDetails || isTooLargeToVisualize) return null;
+
+  const artifactType =
+    type?.toString() ??
+    artifact.type_name ??
+    (artifactData?.is_dir ? "Directory" : "Any");
+
+  return (
+    <ArtifactVisualizer
+      triggerVariant="outline"
+      artifact={artifact}
+      name={name}
+      type={artifactType}
+      value={hasInlineValue ? inlineValue : undefined}
+    />
+  );
+};
+
+const canShowInlineValue = (
+  value: string | null | undefined,
+): value is string => !!value && String(value).trim() !== "";

--- a/src/routes/v2/pages/RunView/nodes/TaskNode/RunViewTaskNode.tsx
+++ b/src/routes/v2/pages/RunView/nodes/TaskNode/RunViewTaskNode.tsx
@@ -1,3 +1,4 @@
+import { useQuery } from "@tanstack/react-query";
 import { type Node, type NodeProps } from "@xyflow/react";
 import { observer } from "mobx-react-lite";
 
@@ -5,11 +6,18 @@ import { StatusIndicator } from "@/components/shared/ReactFlow/FlowCanvas/TaskNo
 import Logs from "@/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/logs";
 import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
-import { TaskNode } from "@/routes/v2/shared/nodes/TaskNode/TaskNode";
+import { useBackend } from "@/providers/BackendProvider";
+import { OutputActionsProvider } from "@/routes/v2/shared/nodes/TaskNode/OutputActionsContext";
+import {
+  TaskNode,
+  type TaskNodeOutput,
+} from "@/routes/v2/shared/nodes/TaskNode/TaskNode";
 import type { TaskNodeData } from "@/routes/v2/shared/nodes/types";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
+import { getExecutionArtifacts } from "@/services/executionService";
 import { tracking } from "@/utils/tracking";
 
+import { RunViewOutputPreview } from "./RunViewOutputPreview";
 import { useTaskRunStatus } from "./useTaskRunStatus";
 
 type TaskNodeType = Node<TaskNodeData, "task">;
@@ -19,8 +27,15 @@ export const RunViewTaskNode = observer(function RunViewTaskNode(
 ) {
   const { entityId } = props.data;
   const { windows } = useSharedStores();
+  const { backendUrl } = useBackend();
   const { task, status, disabledCache, executionId, showLogsButton } =
     useTaskRunStatus(entityId);
+
+  const { data: artifacts } = useQuery({
+    queryKey: ["artifacts", executionId],
+    queryFn: () => getExecutionArtifacts(String(executionId), backendUrl),
+    enabled: !!executionId,
+  });
 
   const handleOpenLogs = () => {
     if (!task || !executionId) return;
@@ -30,6 +45,14 @@ export const RunViewTaskNode = observer(function RunViewTaskNode(
       size: { width: 500, height: 400 },
     });
   };
+
+  const renderOutputAction = (output: TaskNodeOutput) => (
+    <RunViewOutputPreview
+      artifact={artifacts?.output_artifacts?.[output.name]}
+      name={output.name}
+      type={output.type}
+    />
+  );
 
   return (
     <div className="relative">
@@ -49,7 +72,9 @@ export const RunViewTaskNode = observer(function RunViewTaskNode(
         </Button>
       )}
 
-      <TaskNode {...props} />
+      <OutputActionsProvider value={renderOutputAction}>
+        <TaskNode {...props} />
+      </OutputActionsProvider>
     </div>
   );
 });

--- a/src/routes/v2/shared/nodes/TaskNode/OutputActionsContext.tsx
+++ b/src/routes/v2/shared/nodes/TaskNode/OutputActionsContext.tsx
@@ -1,0 +1,18 @@
+import { createContext, type ReactNode, useContext } from "react";
+
+import type { TaskNodeOutput } from "./TaskNode";
+
+type RenderOutputAction = (output: TaskNodeOutput) => ReactNode;
+
+const OutputActionsContext = createContext<RenderOutputAction | null>(null);
+
+export const OutputActionsProvider = OutputActionsContext.Provider;
+
+/**
+ * Returns the optional per-output action renderer supplied by a surrounding
+ * provider (e.g. RunView). Returns null when no provider is present, so the
+ * shared TaskNodeCard stays decoupled from execution-specific behavior.
+ */
+export function useOutputAction(): RenderOutputAction | null {
+  return useContext(OutputActionsContext);
+}

--- a/src/routes/v2/shared/nodes/TaskNode/TaskNodeCard.tsx
+++ b/src/routes/v2/shared/nodes/TaskNode/TaskNodeCard.tsx
@@ -21,6 +21,7 @@ import { pluralize } from "@/utils/string";
 
 import { deriveColorPalette } from "./color.utils";
 import { InputAggregatorHandle } from "./InputAggregatorHandle";
+import { useOutputAction } from "./OutputActionsContext";
 import type { TaskNodeInput, TaskNodeViewProps } from "./TaskNode";
 
 const AGGREGATOR_INTERNAL_INPUTS = new Set([
@@ -217,6 +218,7 @@ export const TaskNodeCard = observer(function TaskNodeCard({
   outputType,
   onOutputTypeChange,
 }: TaskNodeViewProps) {
+  const renderOutputAction = useOutputAction();
   const isDark = useTheme().resolvedTheme === "dark";
   const palette = taskColor ? deriveColorPalette(taskColor, isDark) : undefined;
   const cardStyle = palette
@@ -459,19 +461,29 @@ export const TaskNodeCard = observer(function TaskNodeCard({
                         {`+${hiddenOutputCount} more ${pluralize(hiddenOutputCount, "output")}`}
                       </div>
                     )}
-                    <div className="translate-x-3 min-w-0 inline-block max-w-full">
-                      <div
-                        className={cn(
-                          "text-xs rounded-md px-2 py-1 truncate",
-                          palette
-                            ? isDark
-                              ? "text-gray-100 bg-white/10 hover:bg-white/15"
-                              : "text-gray-800 bg-black/5 hover:bg-black/10"
-                            : "text-foreground bg-muted hover:bg-accent",
-                        )}
-                        title={`${output.name}${output.type ? `: ${output.type}` : ""}`}
-                      >
-                        {output.name.replace(/_/g, " ")}
+                    <div className="flex items-center gap-0.5 min-w-0">
+                      {!showCondensedOutputs && renderOutputAction && (
+                        <span
+                          className="nodrag nopan"
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          {renderOutputAction(output)}
+                        </span>
+                      )}
+                      <div className="translate-x-3 min-w-0 inline-block max-w-full">
+                        <div
+                          className={cn(
+                            "text-xs rounded-md px-2 py-1 truncate",
+                            palette
+                              ? isDark
+                                ? "text-gray-100 bg-white/10 hover:bg-white/15"
+                                : "text-gray-800 bg-black/5 hover:bg-black/10"
+                              : "text-foreground bg-muted hover:bg-accent",
+                          )}
+                          title={`${output.name}${output.type ? `: ${output.type}` : ""}`}
+                        >
+                          {output.name.replace(/_/g, " ")}
+                        </div>
                       </div>
                     </div>
                   </div>


### PR DESCRIPTION
## Description

Adds artifact preview buttons directly to task output rows in the RunView pipeline graph. When a task has completed execution, each output row now shows an `ArtifactVisualizer` trigger inline, allowing users to preview output artifacts without opening the full Artifacts panel.

To support this without coupling the shared `TaskNodeCard` to execution-specific logic, an `OutputActionsContext` was introduced. This context accepts an optional render function for per-output actions. `RunViewTaskNode` provides this renderer, which fetches execution artifacts via `getExecutionArtifacts` and maps each output to a `RunViewOutputPreview` component. The preview is suppressed when the artifact is missing, has no URI or inline value, or exceeds 50 MB.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

[Screen Recording 2026-07-14 at 1.46.15 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/67ecd4c4-c38d-4aea-be23-55208184d8aa.mov" />](https://app.graphite.com/user-attachments/video/67ecd4c4-c38d-4aea-be23-55208184d8aa.mov)



## Test Instructions

1. Open a completed pipeline run in RunView.
2. Inspect task nodes that have outputs with artifacts.
3. Verify that a preview trigger appears inline next to each eligible output name.
4. Confirm that outputs without artifacts, with no URI/inline value, or exceeding 50 MB do not show a preview trigger.
5. Verify that clicking the preview trigger opens the artifact visualizer correctly.
6. Confirm that task nodes in non-RunView contexts (e.g., the pipeline editor) are unaffected and show no preview triggers.

## Additional Comments

The `OutputActionsContext` is intentionally generic so other views can inject their own per-output actions in the future without modifying `TaskNodeCard`.