### PR TITLE
feat: Run Comparison Improvements

### DIFF
--- a/src/routes/v2/pages/CompareView/CompareView.tsx
+++ b/src/routes/v2/pages/CompareView/CompareView.tsx
@@ -9,14 +9,17 @@ import { Icon } from "@/components/ui/icon";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Heading, Text } from "@/components/ui/typography";
+import useToastNotification from "@/hooks/useToastNotification";
 import { cn } from "@/lib/utils";
 import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { APP_ROUTES } from "@/routes/appRoutes";
 import { RemoteAuthError } from "@/utils/fetchWithErrorHandling";
+import { copyToClipboard } from "@/utils/string";
 import { tracking } from "@/utils/tracking";
 
 import { CompareRunPicker } from "./components/CompareRunPicker";
 import { GraphDiffView } from "./components/GraphDiffView";
+import { RunMetadataSection } from "./components/RunMetadataSection";
 import { StructuredDiffView } from "./components/StructuredDiffView";
 import { YamlDiffView } from "./components/YamlDiffView";
 import { useRunComparisonSide } from "./hooks/useRunComparisonSide";
@@ -34,6 +37,7 @@ export function CompareView() {
   const search = useSearch({ strict: false }) as CompareSearch;
   const navigate = useNavigate();
   const { track } = useAnalytics();
+  const notify = useToastNotification();
 
   const a = search.a ?? "";
   const b = search.b ?? "";
@@ -159,16 +163,47 @@ export function CompareView() {
           </Button>
           <RunLabel label={LABEL_B} name={nameB} runId={b} tone="b" />
         </InlineStack>
-        <Button
-          variant="ghost"
-          size="icon"
-          aria-label="Close comparison"
-          onClick={() => navigate({ to: APP_ROUTES.DASHBOARD_RUNS })}
-          {...tracking("compare_runs.comparison.close")}
-        >
-          <Icon name="X" size="sm" />
-        </Button>
+        <InlineStack gap="1" blockAlign="center" wrap="nowrap">
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label="Copy link to this comparison"
+            onClick={() => {
+              copyToClipboard(window.location.href);
+              notify("Link copied to clipboard", "success");
+            }}
+            {...tracking("compare_runs.comparison.share")}
+          >
+            <Icon name="Share2" size="sm" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label="Close comparison"
+            onClick={() => navigate({ to: APP_ROUTES.DASHBOARD_RUNS })}
+            {...tracking("compare_runs.comparison.close")}
+          >
+            <Icon name="X" size="sm" />
+          </Button>
+        </InlineStack>
       </InlineStack>
+
+      <RunMetadataSection
+        a={{
+          createdBy: sideA.createdBy,
+          createdAt: sideA.createdAt,
+          annotations: sideA.runAnnotations,
+          arguments: sideA.runArguments,
+        }}
+        b={{
+          createdBy: sideB.createdBy,
+          createdAt: sideB.createdAt,
+          annotations: sideB.runAnnotations,
+          arguments: sideB.runArguments,
+        }}
+        labelA={LABEL_A}
+        labelB={LABEL_B}
+      />
 
       <Tabs
         value={activeTab}

--- a/src/routes/v2/pages/CompareView/components/ArtifactComparisonDialog.tsx
+++ b/src/routes/v2/pages/CompareView/components/ArtifactComparisonDialog.tsx
@@ -1,0 +1,137 @@
+import type { ArtifactNodeResponse } from "@/api/types.gen";
+import {
+  isVisualizableType,
+  normalizeRawType,
+  PreviewContent,
+  PreviewSkeleton,
+  resolveArtifactType,
+} from "@/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ArtifactPreviewContent";
+import { SuspenseWrapper } from "@/components/shared/SuspenseWrapper";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
+
+import { RunTag } from "./RunTag";
+
+interface ArtifactComparisonSide {
+  run: "a" | "b";
+  label: string;
+  artifact: ArtifactNodeResponse | undefined;
+  type: string | undefined;
+}
+
+function ComparisonPane({
+  run,
+  label,
+  artifact,
+  type,
+}: ArtifactComparisonSide) {
+  const normalizedType = resolveArtifactType(
+    normalizeRawType(type ?? undefined),
+  );
+
+  return (
+    <BlockStack
+      align="stretch"
+      gap="2"
+      className="min-h-0 min-w-0 flex-1 overflow-hidden rounded-lg border p-2"
+    >
+      <InlineStack gap="2" blockAlign="center" wrap="nowrap">
+        <RunTag run={run} label={label} />
+        <Text as="span" size="xs" tone="subdued" className="truncate">
+          {type ?? "—"}
+        </Text>
+      </InlineStack>
+      <BlockStack fill className="min-h-0 min-w-0 overflow-auto">
+        {!artifact ? (
+          <Text as="span" size="sm" tone="subdued">
+            Not produced in run {label}.
+          </Text>
+        ) : !isVisualizableType(normalizedType) ? (
+          <Text as="span" size="sm" tone="subdued">
+            This artifact type cannot be previewed.
+          </Text>
+        ) : (
+          <SuspenseWrapper
+            fallback={<PreviewSkeleton />}
+            errorFallback={() => (
+              <Text as="span" size="sm" tone="subdued">
+                Failed to load artifact.
+              </Text>
+            )}
+          >
+            <PreviewContent
+              name={`${label}:${artifact.id}`}
+              artifactId={artifact.id}
+              type={normalizedType}
+              isFullscreen={false}
+            />
+          </SuspenseWrapper>
+        )}
+      </BlockStack>
+    </BlockStack>
+  );
+}
+
+interface ArtifactComparisonDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  name: string;
+  labelA: string;
+  labelB: string;
+  artifactA: ArtifactNodeResponse | undefined;
+  artifactB: ArtifactNodeResponse | undefined;
+  typeA: string | undefined;
+  typeB: string | undefined;
+}
+
+export function ArtifactComparisonDialog({
+  open,
+  onOpenChange,
+  name,
+  labelA,
+  labelB,
+  artifactA,
+  artifactB,
+  typeA,
+  typeB,
+}: ArtifactComparisonDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="flex h-[90vh] w-[95vw] max-w-[95vw] flex-col sm:max-w-[95vw]">
+        <DialogHeader>
+          <DialogTitle>
+            <Text as="span" className="font-mono">
+              {name}
+            </Text>{" "}
+            — artifact comparison
+          </DialogTitle>
+        </DialogHeader>
+        <InlineStack
+          gap="3"
+          blockAlign="stretch"
+          wrap="nowrap"
+          className="min-h-0 w-full flex-1"
+        >
+          <ComparisonPane
+            run="a"
+            label={labelA}
+            artifact={artifactA}
+            type={typeA}
+          />
+          <ComparisonPane
+            run="b"
+            label={labelB}
+            artifact={artifactB}
+            type={typeB}
+          />
+        </InlineStack>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/routes/v2/pages/CompareView/components/ArtifactDiffSection.tsx
+++ b/src/routes/v2/pages/CompareView/components/ArtifactDiffSection.tsx
@@ -1,0 +1,267 @@
+import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+
+import type {
+  ArtifactNodeResponse,
+  GetExecutionArtifactsResponse,
+} from "@/api/types.gen";
+import {
+  isVisualizableType,
+  normalizeRawType,
+  resolveArtifactType,
+} from "@/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ArtifactPreviewContent";
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icon";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Spinner } from "@/components/ui/spinner";
+import { Text } from "@/components/ui/typography";
+import { useBackend } from "@/providers/BackendProvider";
+import type { DiffStatus } from "@/routes/v2/pages/CompareView/utils/comparePipelines";
+import { unionKeysAFirst } from "@/routes/v2/pages/CompareView/utils/comparePipelines";
+import { getExecutionArtifacts } from "@/services/executionService";
+import { formatBytes } from "@/utils/string";
+import { tracking } from "@/utils/tracking";
+
+import { ArtifactComparisonDialog } from "./ArtifactComparisonDialog";
+import { DiffStatusBadge } from "./DiffStatusBadge";
+import { RunTag } from "./RunTag";
+
+const MAX_VISUALIZABLE_SIZE_BYTES = 50 * 1024 * 1024;
+
+function inlineValue(
+  artifact: ArtifactNodeResponse | undefined,
+): string | undefined {
+  const value = artifact?.artifact_data?.value;
+  return value && value.trim() !== "" ? value : undefined;
+}
+
+function artifactTypeLabel(
+  artifact: ArtifactNodeResponse | undefined,
+): string | undefined {
+  if (!artifact) return undefined;
+  return (
+    artifact.type_name ?? (artifact.artifact_data?.is_dir ? "Directory" : "Any")
+  );
+}
+
+function isPreviewable(artifact: ArtifactNodeResponse | undefined): boolean {
+  if (!artifact) return false;
+  const totalSize = artifact.artifact_data?.total_size;
+  if (totalSize && totalSize > MAX_VISUALIZABLE_SIZE_BYTES) return false;
+  const type = resolveArtifactType(
+    normalizeRawType(artifactTypeLabel(artifact) ?? undefined),
+  );
+  return isVisualizableType(type);
+}
+
+function artifactStatus(
+  a: ArtifactNodeResponse | undefined,
+  b: ArtifactNodeResponse | undefined,
+): DiffStatus {
+  if (a && !b) return "lost";
+  if (!a && b) return "new";
+  if (!a || !b) return "unchanged";
+  const same =
+    (a.artifact_data?.value ?? null) === (b.artifact_data?.value ?? null) &&
+    (a.artifact_data?.total_size ?? null) ===
+      (b.artifact_data?.total_size ?? null) &&
+    (a.artifact_data?.is_dir ?? null) === (b.artifact_data?.is_dir ?? null);
+  return same ? "unchanged" : "changed";
+}
+
+interface InlineValueLineProps {
+  run: "a" | "b";
+  label: string;
+  value: string | undefined;
+  present: boolean;
+}
+
+function InlineValueLine({ run, label, value, present }: InlineValueLineProps) {
+  return (
+    <InlineStack gap="2" blockAlign="start" wrap="nowrap" className="min-w-0">
+      <RunTag run={run} label={label} />
+      <Text
+        as="span"
+        size="xs"
+        className="font-mono break-all whitespace-pre-wrap text-success"
+      >
+        {present ? (value ?? "—") : "absent"}
+      </Text>
+    </InlineStack>
+  );
+}
+
+interface MetadataLineProps {
+  run: "a" | "b";
+  label: string;
+  artifact: ArtifactNodeResponse | undefined;
+}
+
+function MetadataLine({ run, label, artifact }: MetadataLineProps) {
+  const totalSize = artifact?.artifact_data?.total_size;
+  return (
+    <InlineStack gap="2" blockAlign="center" wrap="nowrap" className="min-w-0">
+      <RunTag run={run} label={label} />
+      {!artifact ? (
+        <Text as="span" size="xs" tone="subdued">
+          absent
+        </Text>
+      ) : (
+        <>
+          <Text as="span" size="xs" tone="subdued" className="truncate">
+            {artifactTypeLabel(artifact)}
+          </Text>
+          {!!totalSize && (
+            <Text as="span" size="xs" tone="subdued" font="mono">
+              ({formatBytes(totalSize)})
+            </Text>
+          )}
+        </>
+      )}
+    </InlineStack>
+  );
+}
+
+interface ArtifactDiffRowProps {
+  name: string;
+  a: ArtifactNodeResponse | undefined;
+  b: ArtifactNodeResponse | undefined;
+  labelA: string;
+  labelB: string;
+}
+
+function ArtifactDiffRow({ name, a, b, labelA, labelB }: ArtifactDiffRowProps) {
+  const [compareOpen, setCompareOpen] = useState(false);
+
+  const aVal = inlineValue(a);
+  const bVal = inlineValue(b);
+  const hasInline = aVal !== undefined || bVal !== undefined;
+  const canCompare = isPreviewable(a) || isPreviewable(b);
+
+  return (
+    <BlockStack gap="1" className="rounded-md border p-2">
+      <InlineStack
+        gap="2"
+        blockAlign="center"
+        align="space-between"
+        wrap="wrap"
+        className="w-full"
+      >
+        <InlineStack gap="2" blockAlign="center" wrap="wrap">
+          <Text as="span" size="xs" weight="semibold" className="font-mono">
+            {name}
+          </Text>
+          <DiffStatusBadge status={artifactStatus(a, b)} />
+        </InlineStack>
+        {!hasInline && canCompare && (
+          <Button
+            variant="outline"
+            size="xs"
+            onClick={() => setCompareOpen(true)}
+            {...tracking("compare_runs.task.compare_artifact")}
+          >
+            <Icon name="Columns2" size="xs" />
+            Compare
+          </Button>
+        )}
+      </InlineStack>
+
+      {hasInline ? (
+        <BlockStack gap="1">
+          <InlineValueLine run="a" label={labelA} value={aVal} present={!!a} />
+          <InlineValueLine run="b" label={labelB} value={bVal} present={!!b} />
+        </BlockStack>
+      ) : (
+        <InlineStack gap="4" wrap="wrap">
+          <MetadataLine run="a" label={labelA} artifact={a} />
+          <MetadataLine run="b" label={labelB} artifact={b} />
+        </InlineStack>
+      )}
+
+      {!hasInline && canCompare && (
+        <ArtifactComparisonDialog
+          open={compareOpen}
+          onOpenChange={setCompareOpen}
+          name={name}
+          labelA={labelA}
+          labelB={labelB}
+          artifactA={a}
+          artifactB={b}
+          typeA={artifactTypeLabel(a)}
+          typeB={artifactTypeLabel(b)}
+        />
+      )}
+    </BlockStack>
+  );
+}
+
+function useSideArtifacts(executionId: string | undefined, backendUrl: string) {
+  return useQuery({
+    queryKey: ["artifacts", executionId],
+    queryFn: () => getExecutionArtifacts(String(executionId), backendUrl),
+    enabled: !!executionId,
+  });
+}
+
+function outputArtifacts(
+  data: GetExecutionArtifactsResponse | null | undefined,
+): Record<string, ArtifactNodeResponse> {
+  return data?.output_artifacts ?? {};
+}
+
+interface ArtifactDiffSectionProps {
+  executionIdA?: string;
+  executionIdB?: string;
+  labelA: string;
+  labelB: string;
+}
+
+export function ArtifactDiffSection({
+  executionIdA,
+  executionIdB,
+  labelA,
+  labelB,
+}: ArtifactDiffSectionProps) {
+  const { backendUrl, configured } = useBackend();
+
+  const queryA = useSideArtifacts(executionIdA, backendUrl);
+  const queryB = useSideArtifacts(executionIdB, backendUrl);
+
+  if (!configured || (!executionIdA && !executionIdB)) return null;
+
+  const isLoading =
+    (queryA.isFetching && !queryA.data) || (queryB.isFetching && !queryB.data);
+
+  const artifactsA = outputArtifacts(queryA.data);
+  const artifactsB = outputArtifacts(queryB.data);
+  const names = unionKeysAFirst(artifactsA, artifactsB);
+
+  if (!isLoading && names.length === 0) return null;
+
+  return (
+    <BlockStack gap="2">
+      <Text as="span" size="xs" weight="semibold" tone="subdued">
+        Artifacts
+      </Text>
+      {isLoading && (
+        <InlineStack gap="2" blockAlign="center">
+          <Spinner />
+          <Text as="span" size="xs" tone="subdued">
+            Loading artifacts…
+          </Text>
+        </InlineStack>
+      )}
+      {!isLoading &&
+        names.map((name) => (
+          <ArtifactDiffRow
+            key={name}
+            name={name}
+            a={artifactsA[name]}
+            b={artifactsB[name]}
+            labelA={labelA}
+            labelB={labelB}
+          />
+        ))}
+    </BlockStack>
+  );
+}

--- a/src/routes/v2/pages/CompareView/components/GraphDiffView.tsx
+++ b/src/routes/v2/pages/CompareView/components/GraphDiffView.tsx
@@ -253,7 +253,7 @@ function MergedGraphCanvas({
             {selectedNode && (
               <BlockStack
                 gap="3"
-                className="max-h-96 w-80 overflow-y-auto rounded-lg border bg-background p-4 shadow-lg"
+                className="nowheel nopan max-h-96 w-80 overflow-y-auto overscroll-contain rounded-lg border bg-background p-4 shadow-lg"
               >
                 <InlineStack
                   align="space-between"

--- a/src/routes/v2/pages/CompareView/components/MergedIoNode.tsx
+++ b/src/routes/v2/pages/CompareView/components/MergedIoNode.tsx
@@ -6,6 +6,7 @@ import { Text } from "@/components/ui/typography";
 import { cn } from "@/lib/utils";
 import type { MergedIoNodeData } from "@/routes/v2/pages/CompareView/utils/buildMergedGraph";
 import type { DiffStatus } from "@/routes/v2/pages/CompareView/utils/comparePipelines";
+import { summarizeIoChange } from "@/routes/v2/pages/CompareView/utils/summarizeChange";
 
 import { DiffStatusBadge } from "./DiffStatusBadge";
 
@@ -21,6 +22,8 @@ type MergedIoNodeType = Node<MergedIoNodeData, "mergedIo">;
 export function MergedIoNode({ data }: NodeProps<MergedIoNodeType>) {
   const { diff } = data;
   const isInput = diff.kind === "input";
+  const changeSummary =
+    diff.status === "changed" ? summarizeIoChange(diff) : "";
 
   return (
     <BlockStack
@@ -58,6 +61,11 @@ export function MergedIoNode({ data }: NodeProps<MergedIoNodeType>) {
       <Text as="span" size="sm" weight="semibold" className="wrap-break-word">
         {diff.name}
       </Text>
+      {changeSummary && (
+        <Text as="span" size="xs" tone="subdued">
+          {changeSummary}
+        </Text>
+      )}
 
       {isInput ? (
         <Handle

--- a/src/routes/v2/pages/CompareView/components/MergedTaskNode.tsx
+++ b/src/routes/v2/pages/CompareView/components/MergedTaskNode.tsx
@@ -1,11 +1,14 @@
 import { Handle, type Node, type NodeProps, Position } from "@xyflow/react";
 
 import { StatusTab } from "@/components/shared/ReactFlow/FlowCanvas/TaskNode/StatusIndicator";
+import { Icon } from "@/components/ui/icon";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { QuickTooltip } from "@/components/ui/tooltip";
 import { Text } from "@/components/ui/typography";
 import { cn } from "@/lib/utils";
 import type { MergedTaskNodeData } from "@/routes/v2/pages/CompareView/utils/buildMergedGraph";
 import type { DiffStatus } from "@/routes/v2/pages/CompareView/utils/comparePipelines";
+import { summarizeTaskChange } from "@/routes/v2/pages/CompareView/utils/summarizeChange";
 
 import { DiffStatusBadge } from "./DiffStatusBadge";
 
@@ -28,8 +31,26 @@ export function MergedTaskNode({ data }: NodeProps<MergedTaskNodeType>) {
     diff.b?.componentRef.spec?.name ??
     diff.taskId;
 
+  const changeSummary =
+    diff.status === "changed" ? summarizeTaskChange(diff) : "";
+
   const componentChanged =
     diff.status === "changed" && !diff.sameComponentVersion;
+  const sideDigest =
+    (spotlight === "b" ? diff.digestB : diff.digestA) ??
+    diff.digestA ??
+    diff.digestB;
+  const digestDisplay =
+    componentChanged && diff.digestA && diff.digestB
+      ? `${diff.digestA.slice(0, 10)} → ${diff.digestB.slice(0, 10)}`
+      : sideDigest?.slice(0, 10);
+
+  const cacheDisabled =
+    spotlight === "b" ? diff.cacheDisabledB : diff.cacheDisabledA;
+  const showCacheIcon = cacheDisabled || diff.cacheChanged;
+  const cacheTooltip = diff.cacheChanged
+    ? "Cache setting differs between runs"
+    : "Caching disabled";
 
   const statusA = spotlight === "b" ? undefined : diff.statusA;
   const statusB = spotlight === "a" ? undefined : diff.statusB;
@@ -47,18 +68,36 @@ export function MergedTaskNode({ data }: NodeProps<MergedTaskNodeType>) {
           gap="1"
           blockAlign="start"
           wrap="nowrap"
-          className="absolute -top-5 left-0 -z-1"
+          className="absolute -top-5 left-0 right-0 w-full -z-1"
         >
-          {statusA && (
-            <StatusTab status={statusA} label="A" className="max-w-36" />
+          {statusA ? (
+            <StatusTab status={statusA} label="A" className="min-w-0 flex-1" />
+          ) : (
+            <div className="flex-1" />
           )}
-          {statusB && (
-            <StatusTab status={statusB} label="B" className="max-w-36" />
+          {statusB ? (
+            <StatusTab status={statusB} label="B" className="min-w-0 flex-1" />
+          ) : (
+            <div className="flex-1" />
           )}
         </InlineStack>
       )}
 
-      <DiffStatusBadge status={diff.status} />
+      <InlineStack gap="1" blockAlign="center" wrap="nowrap">
+        <DiffStatusBadge status={diff.status} />
+        {showCacheIcon && (
+          <QuickTooltip content={cacheTooltip}>
+            <Icon
+              name="ZapOff"
+              size="xs"
+              className={cn(
+                "shrink-0",
+                diff.cacheChanged ? "text-amber-500" : "text-orange-500",
+              )}
+            />
+          </QuickTooltip>
+        )}
+      </InlineStack>
 
       <Text as="span" size="sm" weight="semibold" className="wrap-break-word">
         {name}
@@ -66,10 +105,19 @@ export function MergedTaskNode({ data }: NodeProps<MergedTaskNodeType>) {
       <Text as="span" size="xs" tone="subdued" className="font-mono break-all">
         {diff.taskId}
       </Text>
-      {componentChanged && (
-        <Text as="span" size="xs" tone="subdued" className="font-mono">
-          {diff.digestA?.slice(0, 8) ?? "—"} →{" "}
-          {diff.digestB?.slice(0, 8) ?? "—"}
+      {digestDisplay && (
+        <Text
+          as="span"
+          size="xs"
+          tone="subdued"
+          className="font-mono break-all"
+        >
+          {digestDisplay}
+        </Text>
+      )}
+      {changeSummary && (
+        <Text as="span" size="xs" tone="subdued">
+          {changeSummary}
         </Text>
       )}
 

--- a/src/routes/v2/pages/CompareView/components/RunMetadataSection.tsx
+++ b/src/routes/v2/pages/CompareView/components/RunMetadataSection.tsx
@@ -1,0 +1,204 @@
+import { useState } from "react";
+
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { Icon } from "@/components/ui/icon";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
+import { cn } from "@/lib/utils";
+import type { KeyedDiffEntry } from "@/routes/v2/pages/CompareView/utils/comparePipelines";
+import {
+  buildRunMetadataComparison,
+  type RunMetadataInput,
+} from "@/routes/v2/pages/CompareView/utils/compareRunMetadata";
+import { formatDate } from "@/utils/date";
+import { tracking } from "@/utils/tracking";
+
+import { DiffStatusBadge } from "./DiffStatusBadge";
+import { FieldDiffRow } from "./FieldDiffRow";
+import { RunTag } from "./RunTag";
+
+interface RunMetadataSectionProps {
+  a: RunMetadataInput;
+  b: RunMetadataInput;
+  labelA: string;
+  labelB: string;
+}
+
+function scalarEntry(
+  key: string,
+  a: string | undefined,
+  b: string | undefined,
+  changed: boolean,
+): KeyedDiffEntry<unknown> {
+  return { key, a, b, status: changed ? "changed" : "unchanged" };
+}
+
+interface RunSummaryProps {
+  run: "a" | "b";
+  label: string;
+  author: string | undefined;
+  createdAt: string | undefined;
+}
+
+function RunSummary({ run, label, author, createdAt }: RunSummaryProps) {
+  return (
+    <InlineStack gap="2" blockAlign="center" wrap="nowrap" className="min-w-0">
+      <RunTag run={run} label={label} />
+      <Text as="span" size="xs" weight="semibold" className="truncate">
+        {author ?? "Unknown author"}
+      </Text>
+      <Text as="span" size="xs" tone="subdued" className="whitespace-nowrap">
+        {createdAt ? formatDate(createdAt) : "—"}
+      </Text>
+    </InlineStack>
+  );
+}
+
+export function RunMetadataSection({
+  a,
+  b,
+  labelA,
+  labelB,
+}: RunMetadataSectionProps) {
+  const [open, setOpen] = useState(false);
+  const comparison = buildRunMetadataComparison(a, b);
+
+  const changedAnnotations = comparison.annotationDiffs.filter(
+    (entry) => entry.status !== "unchanged",
+  );
+  const changedArguments = comparison.argumentDiffs.filter(
+    (entry) => entry.status !== "unchanged",
+  );
+
+  const summary = (
+    <InlineStack gap="4" wrap="wrap" blockAlign="center">
+      <RunSummary
+        run="a"
+        label={labelA}
+        author={comparison.author.a}
+        createdAt={comparison.createdAt.a}
+      />
+      <RunSummary
+        run="b"
+        label={labelB}
+        author={comparison.author.b}
+        createdAt={comparison.createdAt.b}
+      />
+    </InlineStack>
+  );
+
+  if (!comparison.hasChanges) {
+    return (
+      <InlineStack
+        gap="3"
+        blockAlign="center"
+        wrap="wrap"
+        className="w-full rounded-lg border px-3 py-2"
+      >
+        <Text as="span" size="sm" weight="semibold">
+          Run metadata
+        </Text>
+        {summary}
+      </InlineStack>
+    );
+  }
+
+  return (
+    <Collapsible
+      open={open}
+      onOpenChange={setOpen}
+      className="w-full rounded-lg border"
+    >
+      <CollapsibleTrigger
+        className="flex w-full flex-wrap items-center gap-3 px-3 py-2"
+        {...tracking("compare_runs.run_metadata.toggle")}
+      >
+        <InlineStack gap="2" blockAlign="center" wrap="nowrap">
+          <Icon
+            name="ChevronRight"
+            size="sm"
+            className={cn("transition-transform", open && "rotate-90")}
+          />
+          <Text as="span" size="sm" weight="semibold">
+            Run metadata
+          </Text>
+          <InlineStack
+            as="span"
+            className="rounded-full bg-amber-100 px-2 py-0.5 text-amber-800"
+          >
+            <Text as="span" size="xs" weight="semibold">
+              {comparison.changeCount} changed
+            </Text>
+          </InlineStack>
+        </InlineStack>
+        {summary}
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        <BlockStack gap="2" className="px-3 pb-3">
+          <FieldDiffRow
+            entry={scalarEntry(
+              "author",
+              comparison.author.a,
+              comparison.author.b,
+              comparison.author.changed,
+            )}
+            labelA={labelA}
+            labelB={labelB}
+          />
+          <FieldDiffRow
+            entry={scalarEntry(
+              "created",
+              comparison.createdAt.a,
+              comparison.createdAt.b,
+              comparison.createdAt.changed,
+            )}
+            labelA={labelA}
+            labelB={labelB}
+          />
+
+          {changedAnnotations.length > 0 && (
+            <BlockStack gap="1">
+              <InlineStack gap="2" blockAlign="center">
+                <Text as="span" size="xs" weight="semibold" tone="subdued">
+                  Run annotations
+                </Text>
+                <DiffStatusBadge status="changed" />
+              </InlineStack>
+              {changedAnnotations.map((entry) => (
+                <FieldDiffRow
+                  key={entry.key}
+                  entry={entry}
+                  labelA={labelA}
+                  labelB={labelB}
+                />
+              ))}
+            </BlockStack>
+          )}
+
+          {changedArguments.length > 0 && (
+            <BlockStack gap="1">
+              <InlineStack gap="2" blockAlign="center">
+                <Text as="span" size="xs" weight="semibold" tone="subdued">
+                  Run arguments
+                </Text>
+                <DiffStatusBadge status="changed" />
+              </InlineStack>
+              {changedArguments.map((entry) => (
+                <FieldDiffRow
+                  key={entry.key}
+                  entry={entry}
+                  labelA={labelA}
+                  labelB={labelB}
+                />
+              ))}
+            </BlockStack>
+          )}
+        </BlockStack>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}

--- a/src/routes/v2/pages/CompareView/components/TaskDiffDetail.tsx
+++ b/src/routes/v2/pages/CompareView/components/TaskDiffDetail.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/utils/executionStatus";
 import { tracking } from "@/utils/tracking";
 
+import { ArtifactDiffSection } from "./ArtifactDiffSection";
 import { DiffStatusBadge } from "./DiffStatusBadge";
 import { FieldDiffRow } from "./FieldDiffRow";
 import { RunTags } from "./RunTag";
@@ -76,8 +77,11 @@ export function TaskDiffDetail({
     diff.status === "changed" && !diff.sameComponentVersion;
   const hasFieldChanges =
     componentChanged ||
+    diff.cacheChanged ||
     changedArguments.length > 0 ||
     changedAnnotations.length > 0;
+
+  const cacheState = (disabled: boolean) => (disabled ? "disabled" : "enabled");
 
   return (
     <BlockStack gap="4">
@@ -115,20 +119,20 @@ export function TaskDiffDetail({
         )}
       </BlockStack>
 
+      {diff.cacheChanged && (
+        <BlockStack gap="1">
+          <Text as="span" size="xs" weight="semibold" tone="subdued">
+            Cache
+          </Text>
+          <Text as="span" size="xs">
+            {cacheState(diff.cacheDisabledA)} →{" "}
+            {cacheState(diff.cacheDisabledB)}
+          </Text>
+        </BlockStack>
+      )}
+
       {!wholeTaskChange && (
         <>
-          {componentChanged && (
-            <BlockStack gap="1">
-              <Text as="span" size="xs" weight="semibold" tone="subdued">
-                Component
-              </Text>
-              <Text as="span" size="xs" className="font-mono">
-                {diff.digestA?.slice(0, 8) ?? "—"} →{" "}
-                {diff.digestB?.slice(0, 8) ?? "—"}
-              </Text>
-            </BlockStack>
-          )}
-
           {changedArguments.length > 0 && (
             <BlockStack gap="1">
               <Text as="span" size="xs" weight="semibold" tone="subdued">
@@ -170,6 +174,13 @@ export function TaskDiffDetail({
           )}
         </>
       )}
+
+      <ArtifactDiffSection
+        executionIdA={diff.executionIdA}
+        executionIdB={diff.executionIdB}
+        labelA={labelA}
+        labelB={labelB}
+      />
 
       {canCompareLogs && (
         <TaskLogComparisonDialog

--- a/src/routes/v2/pages/CompareView/components/TaskLogComparisonDialog.tsx
+++ b/src/routes/v2/pages/CompareView/components/TaskLogComparisonDialog.tsx
@@ -1,6 +1,9 @@
-import Logs, {
-  OpenLogsInNewWindowLink,
-} from "@/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/logs";
+import { DiffEditor } from "@monaco-editor/react";
+import { useQuery } from "@tanstack/react-query";
+
+import type { GetContainerExecutionLogResponse } from "@/api/types.gen";
+import { InfoBox } from "@/components/shared/InfoBox";
+import { OpenLogsInNewWindowLink } from "@/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/logs";
 import {
   Dialog,
   DialogContent,
@@ -8,8 +11,11 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Spinner } from "@/components/ui/spinner";
 import { Text } from "@/components/ui/typography";
+import { useBackend } from "@/providers/BackendProvider";
 import type { TaskDiff } from "@/routes/v2/pages/CompareView/utils/comparePipelines";
+import { fetchContainerLog } from "@/services/executionService";
 import { isGraphImplementation } from "@/utils/componentSpec";
 
 import { RunTag } from "./RunTag";
@@ -41,63 +47,64 @@ function taskLogSides(diff: TaskDiff): {
   };
 }
 
+/**
+ * Log comparison is only meaningful when both runs executed this task and the
+ * task changed or produced a different outcome. Added/removed tasks (present in
+ * only one run) have nothing to diff.
+ */
 export function taskHasComparableLogs(diff: TaskDiff): boolean {
   const { a, b } = taskLogSides(diff);
-  return a.canLog || b.canLog;
+  return (
+    a.canLog && b.canLog && (diff.status === "changed" || diff.outcomeChanged)
+  );
 }
 
-interface LogColumnProps {
+function composeLogText(
+  data: GetContainerExecutionLogResponse | undefined,
+): string {
+  if (!data) return "";
+  const parts: string[] = [];
+  if (data.log_text) parts.push(data.log_text);
+  if (data.system_error_exception_full) {
+    parts.push(`=== System error ===\n${data.system_error_exception_full}`);
+  }
+  return parts.join("\n\n").trim();
+}
+
+function useSideLog(side: TaskLogSide, backendUrl: string) {
+  return useQuery({
+    queryKey: ["logs", side.executionId],
+    queryFn: () => fetchContainerLog(String(side.executionId), backendUrl),
+    enabled: side.canLog && !!side.executionId,
+  });
+}
+
+interface LogHeaderSideProps {
   run: "a" | "b";
   label: string;
   runName: string;
   side: TaskLogSide;
 }
 
-function LogColumn({ run, label, runName, side }: LogColumnProps) {
+function LogHeaderSide({ run, label, runName, side }: LogHeaderSideProps) {
   return (
-    <BlockStack gap="2" className="min-h-0 min-w-0 flex-1">
-      <InlineStack
-        align="space-between"
-        blockAlign="center"
-        gap="2"
-        wrap="nowrap"
-        className="w-full"
-      >
-        <InlineStack
-          gap="2"
-          blockAlign="center"
-          wrap="nowrap"
-          className="min-w-0"
-        >
-          <RunTag run={run} label={label} />
-          <Text as="span" size="sm" weight="semibold" className="truncate">
-            {runName}
-          </Text>
-        </InlineStack>
-        {side.canLog && side.executionId && (
-          <OpenLogsInNewWindowLink
-            executionId={side.executionId}
-            status={side.status}
-          />
-        )}
-      </InlineStack>
-      <BlockStack
-        align="stretch"
-        className="min-h-0 min-w-0 flex-1 overflow-hidden rounded-lg border p-2"
-      >
-        {side.canLog && side.executionId ? (
-          <Logs executionId={side.executionId} status={side.status} />
-        ) : (
-          <BlockStack fill>
-            <Text as="span" size="sm" tone="subdued">
-              {side.executionId
-                ? "Subgraph tasks have no container logs."
-                : `This task did not run in ${label}.`}
-            </Text>
-          </BlockStack>
-        )}
-      </BlockStack>
-    </BlockStack>
+    <InlineStack
+      gap="2"
+      blockAlign="center"
+      wrap="nowrap"
+      className="min-w-0 flex-1"
+    >
+      <RunTag run={run} label={label} />
+      <Text as="span" size="sm" weight="semibold" className="truncate">
+        {runName}
+      </Text>
+      {side.executionId && (
+        <OpenLogsInNewWindowLink
+          executionId={side.executionId}
+          status={side.status}
+        />
+      )}
+    </InlineStack>
   );
 }
 
@@ -122,7 +129,18 @@ export function TaskLogComparisonDialog({
   nameA,
   nameB,
 }: TaskLogComparisonDialogProps) {
+  const { backendUrl } = useBackend();
   const { a, b } = taskLogSides(diff);
+
+  const queryA = useSideLog(a, backendUrl);
+  const queryB = useSideLog(b, backendUrl);
+
+  const textA = composeLogText(queryA.data);
+  const textB = composeLogText(queryB.data);
+
+  const isLoading =
+    (a.canLog && queryA.isLoading) || (b.canLog && queryB.isLoading);
+  const bothEmpty = !textA && !textB;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -135,15 +153,54 @@ export function TaskLogComparisonDialog({
             — logs
           </DialogTitle>
         </DialogHeader>
-        <InlineStack
-          gap="3"
-          blockAlign="stretch"
-          wrap="nowrap"
-          className="min-h-0 w-full flex-1"
-        >
-          <LogColumn run="a" label={labelA} runName={nameA} side={a} />
-          <LogColumn run="b" label={labelB} runName={nameB} side={b} />
+        <InlineStack gap="3" wrap="nowrap" className="w-full">
+          <LogHeaderSide run="a" label={labelA} runName={nameA} side={a} />
+          <LogHeaderSide run="b" label={labelB} runName={nameB} side={b} />
         </InlineStack>
+        <BlockStack
+          align="stretch"
+          className="min-h-0 min-w-0 flex-1 overflow-hidden rounded-lg border"
+        >
+          {isLoading ? (
+            <BlockStack fill align="center" inlineAlign="center" gap="2">
+              <Spinner />
+              <Text as="span" size="sm" tone="subdued">
+                Loading logs…
+              </Text>
+            </BlockStack>
+          ) : bothEmpty ? (
+            <BlockStack
+              fill
+              align="center"
+              inlineAlign="center"
+              className="p-4"
+            >
+              <InfoBox title="No logs" variant="info">
+                Neither run produced container logs for this task.
+              </InfoBox>
+            </BlockStack>
+          ) : (
+            <DiffEditor
+              original={textA}
+              modified={textB}
+              language="text"
+              theme="vs-dark"
+              options={{
+                readOnly: true,
+                renderSideBySide: true,
+                minimap: { enabled: false },
+                scrollBeyondLastLine: false,
+                automaticLayout: true,
+                wordWrap: "on",
+                renderOverviewRuler: false,
+                scrollbar: {
+                  verticalScrollbarSize: 10,
+                  horizontalScrollbarSize: 10,
+                },
+              }}
+            />
+          )}
+        </BlockStack>
       </DialogContent>
     </Dialog>
   );

--- a/src/routes/v2/pages/CompareView/hooks/useRunComparisonSide.ts
+++ b/src/routes/v2/pages/CompareView/hooks/useRunComparisonSide.ts
@@ -1,4 +1,5 @@
 import { usePipelineRunData } from "@/hooks/usePipelineRunData";
+import { useFetchPipelineRunMetadata } from "@/services/executionService";
 import type { ComponentSpec } from "@/utils/componentSpec";
 import { buildTaskExecutionStatusMap } from "@/utils/executionStatus";
 
@@ -7,6 +8,10 @@ export interface RunComparisonSide {
   spec: ComponentSpec | undefined;
   taskStatusMap: Map<string, string>;
   taskExecutionIdMap: Map<string, string>;
+  createdBy?: string;
+  createdAt?: string;
+  runAnnotations?: Record<string, unknown>;
+  runArguments?: Record<string, unknown>;
   isLoading: boolean;
   error: Error | null;
 }
@@ -19,6 +24,7 @@ export interface RunComparisonSide {
  */
 export function useRunComparisonSide(runId: string): RunComparisonSide {
   const { executionData, isLoading, error } = usePipelineRunData(runId);
+  const { data: runMetadata } = useFetchPipelineRunMetadata(runId || undefined);
 
   const details = executionData?.details;
   const state = executionData?.state;
@@ -37,6 +43,11 @@ export function useRunComparisonSide(runId: string): RunComparisonSide {
     spec,
     taskStatusMap,
     taskExecutionIdMap,
+    createdBy: runMetadata?.created_by ?? undefined,
+    createdAt: runMetadata?.created_at ?? undefined,
+    runAnnotations: runMetadata?.annotations ?? undefined,
+    runArguments: (details?.task_spec.arguments ?? undefined) as
+      Record<string, unknown> | undefined,
     isLoading,
     error: error ?? null,
   };

--- a/src/routes/v2/pages/CompareView/utils/comparePipelines.test.ts
+++ b/src/routes/v2/pages/CompareView/utils/comparePipelines.test.ts
@@ -82,6 +82,52 @@ describe("buildPipelineComparison()", () => {
     expect(epochs?.status).toBe("changed");
   });
 
+  test("ignores frontend-only annotation changes", () => {
+    const specA = graphSpec({
+      train: task("d1", {
+        annotations: { "editor.position": "{x:0}", zIndex: "1" },
+      }),
+    });
+    const specB = graphSpec({
+      train: task("d1", {
+        annotations: { "editor.position": "{x:999}", zIndex: "5" },
+      }),
+    });
+
+    const [diff] = buildPipelineComparison(
+      specA,
+      specB,
+      noStatus,
+      noStatus,
+    ).taskDiffs;
+
+    expect(diff.status).toBe("unchanged");
+    expect(
+      diff.annotationDiffs.some((entry) => entry.status !== "unchanged"),
+    ).toBe(false);
+  });
+
+  test("flags a cache-only change as changed and carries per-run cache state", () => {
+    const specA = graphSpec({
+      train: task("d1", {
+        executionOptions: { cachingStrategy: { maxCacheStaleness: "P0D" } },
+      }),
+    });
+    const specB = graphSpec({ train: task("d1") });
+
+    const [diff] = buildPipelineComparison(
+      specA,
+      specB,
+      noStatus,
+      noStatus,
+    ).taskDiffs;
+
+    expect(diff.status).toBe("changed");
+    expect(diff.cacheChanged).toBe(true);
+    expect(diff.cacheDisabledA).toBe(true);
+    expect(diff.cacheDisabledB).toBe(false);
+  });
+
   test("treats structurally equal object arguments as unchanged", () => {
     const arg = { taskOutput: { taskId: "prep", outputName: "data" } };
     const specA = graphSpec({ train: task("d1", { arguments: { in: arg } }) });

--- a/src/routes/v2/pages/CompareView/utils/comparePipelines.ts
+++ b/src/routes/v2/pages/CompareView/utils/comparePipelines.ts
@@ -1,6 +1,7 @@
 import equal from "fast-deep-equal";
 
 import type { DiffStatus } from "@/routes/v2/pages/Editor/store/actions/task.utils";
+import { isCacheDisabled } from "@/utils/cache";
 import type {
   ArgumentType,
   ComponentSpec,
@@ -12,6 +13,34 @@ import type {
 import { isGraphImplementation } from "@/utils/componentSpec";
 
 export type { DiffStatus };
+
+/**
+ * Annotation keys the editor writes for layout/presentation only. They carry no
+ * technical meaning for a run comparison and would otherwise surface as noise,
+ * so they are stripped before diffing. Duplicated as literals rather than
+ * imported from `@/utils/annotations` because that module transitively pulls in
+ * the components tree, which breaks vitest mock hoisting for this leaf util.
+ */
+const FRONTEND_ONLY_ANNOTATION_KEYS = new Set<string>([
+  "editor.position",
+  "editor.collapsed",
+  "editor.flow-direction",
+  "zIndex",
+  "flex-nodes",
+  "sdk",
+  "tangleml.com/editor/task-color",
+  "tangleml.com/editor/edge-conduits",
+]);
+
+export function stripFrontendAnnotations<T>(
+  annotations: Record<string, T> | undefined,
+): Record<string, T> {
+  const result: Record<string, T> = {};
+  for (const [key, value] of Object.entries(annotations ?? {})) {
+    if (!FRONTEND_ONLY_ANNOTATION_KEYS.has(key)) result[key] = value;
+  }
+  return result;
+}
 
 export interface KeyedDiffEntry<T> {
   key: string;
@@ -43,6 +72,9 @@ export interface TaskDiff {
   statusB?: string;
   executionIdA?: string;
   executionIdB?: string;
+  cacheDisabledA: boolean;
+  cacheDisabledB: boolean;
+  cacheChanged: boolean;
   outcomeChanged: boolean;
   argumentDiffs: KeyedDiffEntry<ArgumentType>[];
   annotationDiffs: KeyedDiffEntry<unknown>[];
@@ -70,7 +102,7 @@ export interface PipelineComparison {
  * in `b` in `b`'s order. Mirrors the ordering of the editor's diff lists so the
  * two features read consistently.
  */
-function unionKeysAFirst(
+export function unionKeysAFirst(
   a: Record<string, unknown>,
   b: Record<string, unknown>,
 ): string[] {
@@ -86,7 +118,7 @@ function unionKeysAFirst(
   return keys;
 }
 
-function diffKeyedRecords<T>(
+export function diffKeyedRecords<T>(
   a: Record<string, T> | undefined,
   b: Record<string, T> | undefined,
 ): KeyedDiffEntry<T>[] {
@@ -125,9 +157,16 @@ function buildTaskDiff(
   executionIdB: string | undefined,
 ): TaskDiff {
   const argumentDiffs = diffKeyedRecords(a?.arguments, b?.arguments);
-  const annotationDiffs = diffKeyedRecords(a?.annotations, b?.annotations);
+  const annotationDiffs = diffKeyedRecords(
+    stripFrontendAnnotations(a?.annotations),
+    stripFrontendAnnotations(b?.annotations),
+  );
   const digestA = a?.componentRef.digest;
   const digestB = b?.componentRef.digest;
+
+  const cacheDisabledA = isCacheDisabled(a);
+  const cacheDisabledB = isCacheDisabled(b);
+  const cacheChanged = Boolean(a && b && cacheDisabledA !== cacheDisabledB);
 
   let status: DiffStatus;
   if (a && !b) status = "lost";
@@ -137,7 +176,9 @@ function buildTaskDiff(
       (entry) => entry.status !== "unchanged",
     );
     status =
-      isComponentChanged(a, b) || hasFieldChanges ? "changed" : "unchanged";
+      isComponentChanged(a, b) || hasFieldChanges || cacheChanged
+        ? "changed"
+        : "unchanged";
   } else {
     status = "unchanged";
   }
@@ -154,6 +195,9 @@ function buildTaskDiff(
     statusB,
     executionIdA,
     executionIdB,
+    cacheDisabledA,
+    cacheDisabledB,
+    cacheChanged,
     outcomeChanged: (statusA ?? "") !== (statusB ?? ""),
     argumentDiffs,
     annotationDiffs,

--- a/src/routes/v2/pages/CompareView/utils/compareRunMetadata.test.ts
+++ b/src/routes/v2/pages/CompareView/utils/compareRunMetadata.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "vitest";
+
+import { buildRunMetadataComparison } from "./compareRunMetadata";
+
+describe("buildRunMetadataComparison()", () => {
+  test("flags an author change but ignores a differing timestamp", () => {
+    const result = buildRunMetadataComparison(
+      { createdBy: "alice", createdAt: "2026-01-01T00:00:00Z" },
+      { createdBy: "bob", createdAt: "2026-02-02T00:00:00Z" },
+    );
+
+    expect(result.author.changed).toBe(true);
+    expect(result.createdAt.changed).toBe(true);
+    expect(result.hasChanges).toBe(true);
+    expect(result.changeCount).toBe(1);
+  });
+
+  test("does not treat a differing timestamp alone as a change", () => {
+    const result = buildRunMetadataComparison(
+      { createdBy: "alice", createdAt: "2026-01-01T00:00:00Z" },
+      { createdBy: "alice", createdAt: "2026-02-02T00:00:00Z" },
+    );
+
+    expect(result.hasChanges).toBe(false);
+    expect(result.changeCount).toBe(0);
+  });
+
+  test("surfaces an arbitrary run-annotation key change generically", () => {
+    const result = buildRunMetadataComparison(
+      { annotations: { "run.serviceAccount": "svc-a@project" } },
+      { annotations: { "run.serviceAccount": "svc-b@project" } },
+    );
+
+    const entry = result.annotationDiffs.find(
+      (diff) => diff.key === "run.serviceAccount",
+    );
+    expect(entry?.status).toBe("changed");
+    expect(result.hasChanges).toBe(true);
+  });
+
+  test("excludes superficial and frontend-only annotations", () => {
+    const result = buildRunMetadataComparison(
+      {
+        annotations: {
+          notes: "first run",
+          tags: "a,b",
+          "editor.position": "{x:0}",
+        },
+      },
+      {
+        annotations: {
+          notes: "second run",
+          tags: "c,d",
+          "editor.position": "{x:9}",
+        },
+      },
+    );
+
+    expect(result.annotationDiffs).toHaveLength(0);
+    expect(result.hasChanges).toBe(false);
+  });
+
+  test("diffs run arguments generically", () => {
+    const result = buildRunMetadataComparison(
+      { arguments: { epochs: "10", region: "us" } },
+      { arguments: { epochs: "20", region: "us" } },
+    );
+
+    const epochs = result.argumentDiffs.find((diff) => diff.key === "epochs");
+    const region = result.argumentDiffs.find((diff) => diff.key === "region");
+    expect(epochs?.status).toBe("changed");
+    expect(region?.status).toBe("unchanged");
+    expect(result.changeCount).toBe(1);
+  });
+});

--- a/src/routes/v2/pages/CompareView/utils/compareRunMetadata.ts
+++ b/src/routes/v2/pages/CompareView/utils/compareRunMetadata.ts
@@ -1,0 +1,84 @@
+import {
+  diffKeyedRecords,
+  type KeyedDiffEntry,
+  stripFrontendAnnotations,
+} from "./comparePipelines";
+
+const SUPERFICIAL_ANNOTATION_KEYS = new Set<string>(["notes", "tags"]);
+
+export interface RunMetadataInput {
+  createdBy?: string;
+  createdAt?: string;
+  annotations?: Record<string, unknown>;
+  arguments?: Record<string, unknown>;
+}
+
+interface ScalarDiff {
+  a?: string;
+  b?: string;
+  changed: boolean;
+}
+
+export interface RunMetadataComparison {
+  author: ScalarDiff;
+  createdAt: ScalarDiff;
+  annotationDiffs: KeyedDiffEntry<unknown>[];
+  argumentDiffs: KeyedDiffEntry<unknown>[];
+  changeCount: number;
+  hasChanges: boolean;
+}
+
+function stripComparableAnnotations(
+  annotations: Record<string, unknown> | undefined,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(
+    stripFrontendAnnotations(annotations),
+  )) {
+    if (!SUPERFICIAL_ANNOTATION_KEYS.has(key)) result[key] = value;
+  }
+  return result;
+}
+
+function scalarDiff(a: string | undefined, b: string | undefined): ScalarDiff {
+  return { a, b, changed: (a ?? "") !== (b ?? "") };
+}
+
+function countChanged(entries: KeyedDiffEntry<unknown>[]): number {
+  return entries.filter((entry) => entry.status !== "unchanged").length;
+}
+
+/**
+ * Compares run-level context between two runs. Annotation and argument keys are
+ * treated generically — the platform is agnostic about which keys exist, so
+ * whatever a deployment stores surfaces here. Superficial keys (notes, tags)
+ * and frontend-only annotations are excluded. `createdAt` is surfaced for
+ * context but does not count toward `hasChanges`, since two distinct runs
+ * always have different timestamps.
+ */
+export function buildRunMetadataComparison(
+  a: RunMetadataInput,
+  b: RunMetadataInput,
+): RunMetadataComparison {
+  const author = scalarDiff(a.createdBy, b.createdBy);
+  const createdAt = scalarDiff(a.createdAt, b.createdAt);
+  const annotationDiffs = diffKeyedRecords(
+    stripComparableAnnotations(a.annotations),
+    stripComparableAnnotations(b.annotations),
+  );
+  const argumentDiffs = diffKeyedRecords(a.arguments, b.arguments);
+
+  const changeCount =
+    (author.changed ? 1 : 0) +
+    countChanged(annotationDiffs) +
+    countChanged(argumentDiffs);
+
+  return {
+    author,
+    createdAt,
+    annotationDiffs,
+    argumentDiffs,
+    changeCount,
+    hasChanges: changeCount > 0,
+  };
+}

--- a/src/routes/v2/pages/CompareView/utils/summarizeChange.test.ts
+++ b/src/routes/v2/pages/CompareView/utils/summarizeChange.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from "vitest";
+
+import type { IoDiff, TaskDiff } from "./comparePipelines";
+import { summarizeIoChange, summarizeTaskChange } from "./summarizeChange";
+
+const taskDiff = (overrides: Partial<TaskDiff> = {}): TaskDiff => ({
+  taskId: "train",
+  status: "changed",
+  a: { componentRef: { name: "comp", digest: "d1" } },
+  b: { componentRef: { name: "comp", digest: "d1" } },
+  digestA: "d1",
+  digestB: "d1",
+  sameComponentVersion: true,
+  cacheDisabledA: false,
+  cacheDisabledB: false,
+  cacheChanged: false,
+  outcomeChanged: false,
+  argumentDiffs: [],
+  annotationDiffs: [],
+  ...overrides,
+});
+
+const ioDiff = (overrides: Partial<IoDiff> = {}): IoDiff => ({
+  name: "model",
+  kind: "output",
+  status: "changed",
+  fieldDiffs: [],
+  ...overrides,
+});
+
+describe("summarizeTaskChange()", () => {
+  test("reports a component version change", () => {
+    const summary = summarizeTaskChange(
+      taskDiff({ digestA: "d1", digestB: "d2", sameComponentVersion: false }),
+    );
+    expect(summary).toBe("component");
+  });
+
+  test("counts and pluralizes changed arguments", () => {
+    const summary = summarizeTaskChange(
+      taskDiff({
+        argumentDiffs: [
+          { key: "epochs", status: "changed" },
+          { key: "lr", status: "new" },
+          { key: "region", status: "unchanged" },
+        ],
+      }),
+    );
+    expect(summary).toBe("2 arguments");
+  });
+
+  test("combines component, arguments, and cache into one caption", () => {
+    const summary = summarizeTaskChange(
+      taskDiff({
+        digestA: "d1",
+        digestB: "d2",
+        sameComponentVersion: false,
+        argumentDiffs: [{ key: "epochs", status: "changed" }],
+        cacheChanged: true,
+        cacheDisabledB: true,
+      }),
+    );
+    expect(summary).toBe("component · 1 argument · cache disabled");
+  });
+
+  test("describes a cache re-enable", () => {
+    const summary = summarizeTaskChange(
+      taskDiff({
+        cacheChanged: true,
+        cacheDisabledA: true,
+        cacheDisabledB: false,
+      }),
+    );
+    expect(summary).toBe("cache enabled");
+  });
+
+  test("returns an empty string when nothing structural changed", () => {
+    expect(summarizeTaskChange(taskDiff())).toBe("");
+  });
+});
+
+describe("summarizeIoChange()", () => {
+  test("calls out a rewired producing task", () => {
+    const summary = summarizeIoChange(
+      ioDiff({
+        fieldDiffs: [
+          { key: "source", status: "changed" },
+          { key: "type", status: "changed" },
+        ],
+      }),
+    );
+    expect(summary).toBe("source rewired");
+  });
+
+  test("counts and pluralizes changed fields", () => {
+    const summary = summarizeIoChange(
+      ioDiff({
+        fieldDiffs: [
+          { key: "type", status: "changed" },
+          { key: "default", status: "changed" },
+          { key: "description", status: "unchanged" },
+        ],
+      }),
+    );
+    expect(summary).toBe("2 fields changed");
+  });
+
+  test("returns an empty string with no changed fields", () => {
+    expect(summarizeIoChange(ioDiff({ fieldDiffs: [] }))).toBe("");
+  });
+});

--- a/src/routes/v2/pages/CompareView/utils/summarizeChange.ts
+++ b/src/routes/v2/pages/CompareView/utils/summarizeChange.ts
@@ -1,0 +1,57 @@
+import type { IoDiff, TaskDiff } from "./comparePipelines";
+
+function countChanged<T extends { status: string }>(entries: T[]): number {
+  return entries.filter((entry) => entry.status !== "unchanged").length;
+}
+
+function pluralize(count: number, noun: string): string {
+  return `${count} ${noun}${count === 1 ? "" : "s"}`;
+}
+
+function componentChanged(diff: TaskDiff): boolean {
+  if (!diff.a || !diff.b) return false;
+  if (diff.digestA && diff.digestB) return diff.digestA !== diff.digestB;
+  return !diff.sameComponentVersion;
+}
+
+/**
+ * Short human summary of how a changed task differs between the two runs, used
+ * as a subdued caption on graph nodes. Returns an empty string when there is
+ * nothing structural to report (e.g. an outcome-only difference), letting the
+ * caller decide whether to render anything.
+ */
+export function summarizeTaskChange(diff: TaskDiff): string {
+  const parts: string[] = [];
+
+  if (componentChanged(diff)) parts.push("component");
+
+  const changedArguments = countChanged(diff.argumentDiffs);
+  if (changedArguments > 0) parts.push(pluralize(changedArguments, "argument"));
+
+  const changedAnnotations = countChanged(diff.annotationDiffs);
+  if (changedAnnotations > 0) {
+    parts.push(pluralize(changedAnnotations, "annotation"));
+  }
+
+  if (diff.cacheChanged) {
+    parts.push(diff.cacheDisabledB ? "cache disabled" : "cache enabled");
+  }
+
+  return parts.join(" · ");
+}
+
+/**
+ * Short human summary of how a changed pipeline input/output differs. A rewired
+ * producing task is called out explicitly; otherwise the count of changed
+ * fields is reported.
+ */
+export function summarizeIoChange(diff: IoDiff): string {
+  const changedFields = diff.fieldDiffs.filter(
+    (entry) => entry.status !== "unchanged",
+  );
+  if (changedFields.some((entry) => entry.key === "source")) {
+    return "source rewired";
+  }
+  if (changedFields.length === 0) return "";
+  return `${pluralize(changedFields.length, "field")} changed`;
+}


### PR DESCRIPTION
## Description

Third PR in the run-comparison stack. A batch of improvements that make the comparison more useful and detailed.

**What's new:**
- **Run metadata comparison** — a section at the top of the Compare page showing differences in run-level info (author, created time, run arguments, annotations), with a count of how many things changed.
- **Artifact comparison** — from a task's detail you can now open a side-by-side view of that task's output artifacts across both runs.
- **Cache awareness** — tasks now surface whether caching was enabled/disabled and flag it as a change when it differs between runs.
- **Change summaries** — graph nodes show a short human-readable caption of what changed (e.g. "component · 2 arguments · cache disabled").
- **Better log comparison** — the log dialog now uses a proper side-by-side diff editor instead of two stacked log panes.
- **Share button** — copies a link to the current comparison to your clipboard.
- Also filters out editor-only annotations (positions, z-index, etc.) so cosmetic changes don't show up as real diffs.

## Type of Change

- [x] New feature
- [x] Improvement
