### PR TITLE
fix: v2 - runview logs panel height

### DIFF
--- a/src/routes/v2/pages/RunView/hooks/useRunViewSelectionSync.tsx
+++ b/src/routes/v2/pages/RunView/hooks/useRunViewSelectionSync.tsx
@@ -30,6 +30,7 @@ export function useRunViewSelectionSync() {
               size: { width: 300, height: 400 },
               startVisible: true,
               persisted: true,
+              fillDockHeight: true,
             });
             // Selecting a node is an explicit request to see properties, so force
             // the panel visible even if a persisted layout restored it as hidden.

--- a/src/routes/v2/shared/windows/DockArea.tsx
+++ b/src/routes/v2/shared/windows/DockArea.tsx
@@ -44,6 +44,12 @@ export const DockArea = observer(function DockArea({ side }: DockAreaProps) {
     Boolean(windows.getWindowMiniContent(id)),
   );
   const isEmpty = visibleWindows.length === 0;
+  // A fill window needs the stack to have an explicit height so flex-grow can
+  // distribute free space. Without a fill window we keep `min-h-full` so a tall
+  // stack of windows overflows and scrolls instead of being squished.
+  const hasFillWindow = visibleWindows.some(
+    (id) => windows.getWindowById(id)?.fillDockHeight,
+  );
 
   useEffect(() => {
     windows.enableDockSide(side);
@@ -127,7 +133,7 @@ export const DockArea = observer(function DockArea({ side }: DockAreaProps) {
         data-dock-scroll
         className="absolute inset-0 overflow-y-auto overflow-x-hidden hide-scrollbar"
       >
-        <BlockStack>
+        <BlockStack className={cn(hasFillWindow ? "h-full" : "min-h-full")}>
           {visibleWindows.map((windowId, index) => (
             <Window
               key={windowId}

--- a/src/routes/v2/shared/windows/components/DockedWindow.tsx
+++ b/src/routes/v2/shared/windows/components/DockedWindow.tsx
@@ -145,7 +145,7 @@ export const DockedWindow = observer(function DockedWindow() {
           data-dock-window={model.id}
           data-window-id={model.id}
           className={cn(
-            "group/window w-full sticky text-left",
+            "group/window w-full sticky text-left shrink-0",
             (isDragging || isResizing) && "select-none",
             isDragging && "cursor-grabbing opacity-50",
             showCollapsedStyle
@@ -181,36 +181,44 @@ export const DockedWindow = observer(function DockedWindow() {
       </CollapsibleTrigger>
 
       <CollapsibleContent
-        className="w-full"
+        className={cn(
+          "w-full",
+          model.fillDockHeight ? "flex-1 min-h-0" : "shrink-0",
+        )}
         data-dock-window-content={model.id}
       >
         <div
           ref={contentRef}
           className={cn(
             "w-full bg-card text-foreground flex flex-col overflow-hidden",
-
+            model.fillDockHeight && "h-full",
             (isDragging || isResizing) && "select-none",
             isDragging && "opacity-50",
           )}
           style={{
             minHeight: MIN_DOCKED_HEIGHT,
-            // undefined height => fit-to-content; a concrete value => fixed
+            // fillDockHeight => grow to fill the dock column; otherwise an
+            // undefined height fits content and a concrete value fixes the
             // height with the inner content area scrolling.
-            height: model.dockedHeight ?? undefined,
+            height: model.fillDockHeight
+              ? undefined
+              : (model.dockedHeight ?? undefined),
           }}
           onMouseDown={handleContainerMouseDown}
           onClick={handleContainerClick}
         >
           <div className="flex-1 min-h-0 overflow-auto bg-card">{content}</div>
-          <div
-            className="h-1 cursor-ns-resize hover:bg-accent transition-colors shrink-0"
-            onMouseDown={handleResizeMouseDown}
-            onDoubleClick={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              model.resetDockedHeight();
-            }}
-          />
+          {!model.fillDockHeight && (
+            <div
+              className="h-1 cursor-ns-resize hover:bg-accent transition-colors shrink-0"
+              onMouseDown={handleResizeMouseDown}
+              onDoubleClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                model.resetDockedHeight();
+              }}
+            />
+          )}
         </div>
       </CollapsibleContent>
 

--- a/src/routes/v2/shared/windows/types.ts
+++ b/src/routes/v2/shared/windows/types.ts
@@ -81,6 +81,12 @@ export interface WindowOptions {
   persisted?: boolean;
   /** Default dock side for first-time users (no persisted state). */
   defaultDockState?: "left" | "right";
+  /**
+   * When docked, grow to fill remaining dock-area height instead of fitting
+   * content. Useful for panels whose content (e.g. logs) should expand to use
+   * all available vertical space.
+   */
+  fillDockHeight?: boolean;
   /** Callback to invoke when the window is closed */
   onClose?: () => void;
   /**

--- a/src/routes/v2/shared/windows/windowModel.ts
+++ b/src/routes/v2/shared/windows/windowModel.ts
@@ -42,6 +42,7 @@ export interface WindowModelInit {
   dockedHeight?: number;
   dockState: DockState;
   persisted: boolean;
+  fillDockHeight?: boolean;
   onClose?: () => void;
 }
 
@@ -68,6 +69,8 @@ export class WindowModel {
   @observable accessor dockState: DockState;
   @observable accessor persisted: boolean;
 
+  /** Static config: when docked, fill remaining dock-area height. */
+  readonly fillDockHeight: boolean;
   readonly onClose: (() => void) | undefined;
   private readonly store: WindowStoreRef;
 
@@ -88,6 +91,7 @@ export class WindowModel {
     this.dockedHeight = init.dockedHeight;
     this.dockState = init.dockState;
     this.persisted = init.persisted;
+    this.fillDockHeight = init.fillDockHeight ?? false;
     this.onClose = init.onClose;
     this.store = store;
     makeObservable(this);

--- a/src/routes/v2/shared/windows/windowStore.utils.ts
+++ b/src/routes/v2/shared/windows/windowStore.utils.ts
@@ -40,6 +40,7 @@ export function buildWindowModelInit(
       : undefined,
     previousSize: initial.needsPreviousState ? { ...geo.size } : undefined,
     persisted: !!options.persisted,
+    fillDockHeight: options.fillDockHeight,
     onClose: options.onClose,
   };
 }


### PR DESCRIPTION
## Description

Adds a minimum height to the `Logs` component wrapper in the task details panel to prevent the log view from collapsing to a very small size. Also adds `flex flex-col gap-2` to the logs `TabsContent` to improve vertical spacing between elements within the tab.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

| Before | After |
| --- | --- |
| ![image.png](https://app.graphite.com/user-attachments/assets/583deab9-5251-4cb7-af8a-e29e0bfb94f8.png)<br> | ![image.png](https://app.graphite.com/user-attachments/assets/40f47c3d-37dc-4f81-aa54-7d3f7d28d2fc.png)<br> |

## Test Instructions

1. Open a run in the Run View
2. Click on a task node to open the task details panel
3. Navigate to the **Logs** tab
4. Verify that the log area maintains a minimum height and that spacing between the "Open Logs in New Window" link and the log content appears correct

## Additional Comments