### PR TITLE
fix: new windows docked by default may not be visible

### DIFF
--- a/src/routes/v2/shared/windows/DockArea.tsx
+++ b/src/routes/v2/shared/windows/DockArea.tsx
@@ -28,7 +28,8 @@ const FOCUS_MODE_ALLOWED_WINDOW_IDS = new Set(["context-panel"]);
 export const DockArea = observer(function DockArea({ side }: DockAreaProps) {
   const { windows } = useSharedStores();
   const dockArea = windows.getDockAreaConfig(side);
-  const { collapsed, windowOrder } = dockArea;
+  const { collapsed } = dockArea;
+  const windowOrder = windows.getDockedWindowOrder(side);
   const containerRef = useRef<HTMLDivElement | null>(null);
 
   const visibleWindows = windowOrder.filter((id) => {

--- a/src/routes/v2/shared/windows/windowPersistence.ts
+++ b/src/routes/v2/shared/windows/windowPersistence.ts
@@ -120,7 +120,9 @@ function serializeDockArea(
   return {
     width: config.width,
     collapsed: config.collapsed,
-    windowOrder: config.windowOrder.filter((id) => store.isWindowPersisted(id)),
+    windowOrder: store
+      .getDockedWindowOrder(side)
+      .filter((id) => store.isWindowPersisted(id)),
   };
 }
 

--- a/src/routes/v2/shared/windows/windowStore.dockReconcile.test.ts
+++ b/src/routes/v2/shared/windows/windowStore.dockReconcile.test.ts
@@ -1,0 +1,76 @@
+import { createElement } from "react";
+import { describe, expect, it } from "vitest";
+
+import { WindowStoreImpl } from "./windowStore";
+
+const stubContent = createElement("span");
+
+describe("WindowStoreImpl dock order reconciliation", () => {
+  it("restoreDockArea keeps a docked window that the persisted order omits", () => {
+    const store = new WindowStoreImpl();
+    store.enableDockSide("left");
+
+    store.openWindow(stubContent, {
+      id: "component-library",
+      title: "Components",
+      defaultDockState: "left",
+    });
+    store.openWindow(stubContent, {
+      id: "tip-of-the-day",
+      title: "Tip",
+      defaultDockState: "left",
+    });
+
+    // Simulate persisted layout saved before "tip-of-the-day" existed.
+    store.restoreDockArea("left", {
+      width: 320,
+      collapsed: false,
+      windowOrder: ["component-library"],
+    });
+
+    expect(store.getDockAreaWindowIds("left")).toEqual([
+      "component-library",
+      "tip-of-the-day",
+    ]);
+  });
+
+  it("restoreDockArea drops ids that are no longer docked to the side", () => {
+    const store = new WindowStoreImpl();
+    store.enableDockSide("left");
+
+    store.openWindow(stubContent, {
+      id: "component-library",
+      title: "Components",
+      defaultDockState: "left",
+    });
+
+    store.restoreDockArea("left", {
+      width: 320,
+      collapsed: false,
+      windowOrder: ["component-library", "ghost-window"],
+    });
+
+    expect(store.getDockAreaWindowIds("left")).toEqual(["component-library"]);
+  });
+
+  it("getDockedWindowOrder does not duplicate windows already in the order", () => {
+    const store = new WindowStoreImpl();
+    store.enableDockSide("left");
+
+    store.openWindow(stubContent, {
+      id: "component-library",
+      title: "Components",
+      defaultDockState: "left",
+    });
+    store.openWindow(stubContent, {
+      id: "tip-of-the-day",
+      title: "Tip",
+      defaultDockState: "left",
+    });
+
+    expect(store.getDockedWindowOrder("left")).toEqual([
+      "component-library",
+      "tip-of-the-day",
+    ]);
+  });
+});

--- a/src/routes/v2/shared/windows/windowStore.ts
+++ b/src/routes/v2/shared/windows/windowStore.ts
@@ -256,6 +256,10 @@ export class WindowStoreImpl implements WindowStoreRef {
     this.dockAreas[side].width = state.width;
     this.dockAreas[side].collapsed = state.collapsed;
     this.dockAreas[side].windowOrder = [...state.windowOrder];
+    // Reconcile against actual window state so a re-run of restore (StrictMode
+    // double-invoke, dependency change) cannot orphan windows that were already
+    // docked to this side by `use*Window` hooks.
+    this.dockAreas[side].windowOrder = this.getDockedWindowOrder(side);
   }
 
   isDockSideEnabled(side: "left" | "right"): boolean {
@@ -264,6 +268,25 @@ export class WindowStoreImpl implements WindowStoreRef {
 
   getDockAreaWindowIds(side: "left" | "right"): string[] {
     return this.dockAreas[side].windowOrder;
+  }
+
+  /**
+   * Returns the dock stack order reconciled against actual window `dockState`.
+   * `dockState` is the source of truth for membership: entries no longer docked
+   * to `side` are dropped, and any window docked to `side` but missing from the
+   * stored order is appended (using the global window order for deterministic
+   * placement). Prevents docked windows from being orphaned — and thus rendered
+   * nowhere — when the persisted order diverges from window state.
+   */
+  getDockedWindowOrder(side: "left" | "right"): string[] {
+    const existing = this.dockAreas[side].windowOrder.filter(
+      (id) => this.windows[id]?.dockState === side,
+    );
+    const seen = new Set(existing);
+    const missing = this.windowOrder.filter(
+      (id) => this.windows[id]?.dockState === side && !seen.has(id),
+    );
+    return [...existing, ...missing];
   }
 
   // -- View presets --


### PR DESCRIPTION
## Description

Docked windows could be orphaned (rendered nowhere) when the persisted `windowOrder` diverged from the actual `dockState` of windows. This happened in two scenarios: a window was added after a layout was saved (so it was missing from the persisted order), or React StrictMode's double-invocation of effects caused a re-run of `restoreDockArea` that overwrote an already-correct order.

A new `getDockedWindowOrder` method on `WindowStoreImpl` reconciles the stored order against the actual `dockState` of each window. It drops entries that are no longer docked to the given side and appends any docked windows missing from the stored order, using the global window order for deterministic placement. `restoreDockArea` now runs this reconciliation immediately after applying persisted state, and both `DockArea` and `windowPersistence` use `getDockedWindowOrder` instead of reading `windowOrder` directly from the dock area config.

## Problem

A window with `dockState: "left"` that is missing from `dockAreas.left.windowOrder` renders nowhere (DockArea only renders IDs in `windowOrder`; WindowContainer only renders `dockState === "none"`). `restoreDockArea` wholesale-overwrites `windowOrder`, dropping windows that `use*Window` hooks registered, and those hooks early-return on re-run so they never re-add. The orphaned state then gets persisted.

## Type of Change

- [x] Bug fix

## Test Instructions

1. Open a layout that was saved before a docked window (e.g. `tip-of-the-day`) existed.
2. Verify the previously-missing window appears in the dock rather than being invisible.
3. Verify that ghost window IDs from old persisted layouts do not appear in the dock.
4. Run the new `windowStore.dockReconcile.test.ts` unit tests to confirm all three reconciliation scenarios pass.

## Additional Comments

The three new unit tests cover: retaining a docked window omitted from the persisted order, dropping stale IDs no longer docked to the side, and ensuring `getDockedWindowOrder` does not produce duplicates.