### PR TITLE
fix: persist hidden closed state of the window

### DIFF
--- a/src/routes/v2/WINDOWS.md
+++ b/src/routes/v2/WINDOWS.md
@@ -389,15 +389,26 @@ interface PersistedWindowState {
 
 ### Initial State Resolution
 
-When a persisted window is opened, `resolveInitialState` determines the starting state:
+When a persisted window is opened, `resolveInitialState` determines the starting state.
 
-| Persisted Hidden | `startVisible` | Persisted Minimized | Docked | Result                                         |
-| ---------------- | -------------- | ------------------- | ------ | ---------------------------------------------- |
-| true             | false          | -                   | -      | `"hidden"` + seed `previous*`                  |
-| true             | true           | -                   | -      | `"normal"` (override hidden)                   |
-| false            | -              | true                | yes    | `"minimized"` + seed `previous*`               |
-| false            | -              | true                | no     | `"normal"` (minimized only honored for docked) |
-| false            | -              | false               | -      | `"normal"`                                     |
+**A persisted entry always wins.** If the window has a saved entry, its `isHidden` / `isMinimized` is honored on reload. `startVisible` does **not** override a persisted hidden state -- it only forces visibility on a first visit (no saved layout for that window yet). This keeps a window the user deliberately hid hidden across reloads. Selection-driven panels that must pop open on an explicit action call `restore()` directly rather than relying on `startVisible`.
+
+Persisted entry exists:
+
+| Persisted Hidden | Persisted Minimized | Docked | Result                                         |
+| ---------------- | ------------------- | ------ | ---------------------------------------------- |
+| true             | -                   | -      | `"hidden"` + seed `previous*`                  |
+| false            | true                | yes    | `"minimized"` + seed `previous*`               |
+| false            | true                | no     | `"normal"` (minimized only honored for docked) |
+| false            | false               | -      | `"normal"`                                     |
+
+No persisted entry (first visit):
+
+| `startVisible` | In `DEFAULT_VIEW_PRESET.visible` | Result                        |
+| -------------- | -------------------------------- | ----------------------------- |
+| true           | -                                | `"normal"`                    |
+| false          | true                             | `"normal"`                    |
+| false          | false                            | `"hidden"` + seed `previous*` |
 
 ## Plugin System
 

--- a/src/routes/v2/pages/RunView/hooks/runWindowVisibilityPersistence.test.tsx
+++ b/src/routes/v2/pages/RunView/hooks/runWindowVisibilityPersistence.test.tsx
@@ -102,4 +102,29 @@ describe("Run View window visibility persistence", () => {
       expect(windows.getWindowById(id)?.state).toBe("hidden");
     }
   });
+
+  it("keeps hidden Run View windows hidden when the hooks remount", () => {
+    persistenceMocks.getPersistedWindowState.mockReturnValue({
+      position: { x: 0, y: 0 },
+      size: { width: 320, height: 420 },
+      dockState: "left",
+      isHidden: true,
+      isMinimized: false,
+    });
+    persistenceMocks.hasPersistedLayout.mockReturnValue(true);
+
+    const first = renderRunWindowHooks();
+    for (const id of RUN_WINDOW_IDS) {
+      expect(windows.getWindowById(id)?.state).toBe("hidden");
+    }
+
+    // Remount against the same store (StrictMode double-invoke, navigation
+    // remount). Re-opening must not un-hide a window the user hid.
+    first.unmount();
+    renderRunWindowHooks();
+
+    for (const id of RUN_WINDOW_IDS) {
+      expect(windows.getWindowById(id)?.state).toBe("hidden");
+    }
+  });
 });

--- a/src/routes/v2/pages/RunView/hooks/useRunViewSelectionSync.tsx
+++ b/src/routes/v2/pages/RunView/hooks/useRunViewSelectionSync.tsx
@@ -31,6 +31,9 @@ export function useRunViewSelectionSync() {
               startVisible: true,
               persisted: true,
             });
+            // Selecting a node is an explicit request to see properties, so force
+            // the panel visible even if a persisted layout restored it as hidden.
+            windows.restoreWindow(CONTEXT_PANEL_WINDOW_ID);
           }
         } else {
           const existing = windows.getWindowById(CONTEXT_PANEL_WINDOW_ID);

--- a/src/routes/v2/pages/RunView/hooks/useRunViewWindows.tsx
+++ b/src/routes/v2/pages/RunView/hooks/useRunViewWindows.tsx
@@ -11,24 +11,32 @@ import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 export function useRunViewWindows() {
   const { windows } = useSharedStores();
   useEffect(() => {
-    windows.openWindow(<RunToolsContent />, {
-      id: RUN_TOOLS_WINDOW_ID,
-      title: "Run Tools",
-      defaultVisible: true,
-      disabledActions: ["close", "maximize"],
-      size: { width: 280, height: 240 },
-      position: { x: 0, y: 60 },
-      minSize: { width: 240, height: 180 },
-      defaultDockState: "left",
-      persisted: true,
-    });
+    // Guard each openWindow: calling it for an existing window restores it if
+    // hidden (see focusExistingWindow), which would un-hide a window the user
+    // deliberately hid whenever this effect re-runs (StrictMode double-invoke,
+    // remount on run/subgraph navigation). Only open when absent.
+    if (!windows.getWindowById(RUN_TOOLS_WINDOW_ID)) {
+      windows.openWindow(<RunToolsContent />, {
+        id: RUN_TOOLS_WINDOW_ID,
+        title: "Run Tools",
+        defaultVisible: true,
+        disabledActions: ["close", "maximize"],
+        size: { width: 280, height: 240 },
+        position: { x: 0, y: 60 },
+        minSize: { width: 240, height: 180 },
+        defaultDockState: "left",
+        persisted: true,
+      });
+    }
 
-    windows.openWindow(<RunDetailsContent />, {
-      id: RUN_DETAILS_WINDOW_ID,
-      title: "Run Details",
-      defaultVisible: true,
-      defaultDockState: "right",
-      persisted: true,
-    });
+    if (!windows.getWindowById(RUN_DETAILS_WINDOW_ID)) {
+      windows.openWindow(<RunDetailsContent />, {
+        id: RUN_DETAILS_WINDOW_ID,
+        title: "Run Details",
+        defaultVisible: true,
+        defaultDockState: "right",
+        persisted: true,
+      });
+    }
   }, [windows]);
 }

--- a/src/routes/v2/shared/windows/windowStore.utils.test.ts
+++ b/src/routes/v2/shared/windows/windowStore.utils.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { Position, Size, WindowOptions } from "./types";
+import { DEFAULT_VIEW_PRESET } from "./viewPresets";
+import { buildWindowModelInit } from "./windowStore.utils";
+
+// Mirrors CURRENT_VERSION in windowPersistence.ts. If the schema version is
+// bumped there, these fixtures must be updated (and loadWindowLayout would
+// otherwise discard them, causing these tests to fail loudly).
+const LAYOUT_VERSION = 4;
+
+// Default storage key used when no active layout id is set (see getStorageKey).
+const STORAGE_KEY = "editorV2-window-layout";
+
+const DEFAULT_POSITION: Position = { x: 100, y: 100 };
+const DEFAULT_SIZE: Size = { width: 320, height: 420 };
+
+interface SeedWindowState {
+  isHidden?: boolean;
+  isMinimized?: boolean;
+  dockState?: "left" | "right" | "none";
+}
+
+function seedPersistedWindow(id: string, state: SeedWindowState): void {
+  const layout = {
+    windows: {
+      [id]: {
+        position: DEFAULT_POSITION,
+        size: DEFAULT_SIZE,
+        dockState: state.dockState ?? "none",
+        isHidden: state.isHidden ?? false,
+        isMinimized: state.isMinimized ?? false,
+      },
+    },
+    windowOrder: [id],
+    dockAreas: {
+      left: { width: 320, collapsed: false, windowOrder: [] },
+      right: { width: 320, collapsed: false, windowOrder: [] },
+    },
+    version: LAYOUT_VERSION,
+  };
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(layout));
+}
+
+function baseOptions(overrides: Partial<WindowOptions> = {}): WindowOptions {
+  return { title: "Test Window", persisted: true, ...overrides };
+}
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe("resolveInitialState (via buildWindowModelInit)", () => {
+  it("honors persisted hidden state even when startVisible is set", () => {
+    const id = "persisted-hidden-window";
+    seedPersistedWindow(id, { isHidden: true });
+
+    const init = buildWindowModelInit(
+      id,
+      baseOptions({ startVisible: true }),
+      DEFAULT_POSITION,
+    );
+
+    expect(init.state).toBe("hidden");
+  });
+
+  it("starts visible on first visit when startVisible is set", () => {
+    const id = "first-visit-start-visible";
+
+    const init = buildWindowModelInit(
+      id,
+      baseOptions({ startVisible: true }),
+      DEFAULT_POSITION,
+    );
+
+    expect(init.state).toBe("normal");
+  });
+
+  it("starts hidden on first visit for a window absent from the default preset without startVisible", () => {
+    const id = "window-not-in-default-preset";
+    expect(DEFAULT_VIEW_PRESET.visible.has(id)).toBe(false);
+
+    const init = buildWindowModelInit(id, baseOptions(), DEFAULT_POSITION);
+
+    expect(init.state).toBe("hidden");
+  });
+
+  it("restores a persisted minimized docked window as minimized", () => {
+    const id = "persisted-minimized-docked";
+    seedPersistedWindow(id, { isMinimized: true, dockState: "left" });
+
+    const init = buildWindowModelInit(id, baseOptions(), DEFAULT_POSITION);
+
+    expect(init.state).toBe("minimized");
+  });
+});

--- a/src/routes/v2/shared/windows/windowStore.utils.ts
+++ b/src/routes/v2/shared/windows/windowStore.utils.ts
@@ -50,7 +50,10 @@ function resolveInitialState(
   id: string,
 ): { state: WindowState; needsPreviousState: boolean } {
   if (persisted) {
-    const shouldStartHidden = !!persisted.isHidden && !options.startVisible;
+    // A persisted entry reflects the user's last explicit choice, so honor it on
+    // reload. `startVisible` only governs the first-visit branch below (no saved
+    // layout yet); it must not override a window the user deliberately hid.
+    const shouldStartHidden = !!persisted.isHidden;
     const shouldStartMinimized =
       !shouldStartHidden && !!persisted.isMinimized && dockState !== "none";
 


### PR DESCRIPTION
## Description

Windows that a user deliberately hides were being un-hidden on remount (e.g. StrictMode double-invoke, run/subgraph navigation). This happened because `openWindow` calls `focusExistingWindow` when a window already exists, which restores hidden windows, and because `resolveInitialState` allowed `startVisible` to override a persisted `isHidden: true` entry.

The fix has two parts:

1. **`resolveInitialState`** no longer lets `startVisible` override a persisted hidden state. A persisted entry always reflects the user's last explicit choice and is honored on reload. `startVisible` now only applies on a first visit (no saved layout entry yet). Windows that need to pop open on an explicit user action (e.g. selecting a node to open the context panel) call `restoreWindow()` directly instead.
2. **`useRunViewWindows`** guards each `openWindow` call with a presence check (`getWindowById`), so re-running the effect on remount never touches already-registered windows.

The `WINDOWS.md` documentation is updated to reflect the corrected resolution logic, splitting the table into "persisted entry exists" and "no persisted entry (first visit)" cases.

## Screenshots

## [Screen Recording 2026-07-15 at 12.35.11 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/317ea8c7-9efe-40a9-8f7e-4fe76b7c11be.mov" />](https://app.graphite.com/user-attachments/video/317ea8c7-9efe-40a9-8f7e-4fe76b7c11be.mov)



## Type of Change

- [x] Bug fix
- [x] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

1. Open the Run View and hide a panel (e.g. Run Tools or Run Details) using its hide action.
2. Navigate away and back, or trigger a remount (e.g. switch subgraphs).
3. Confirm the panel remains hidden after remount.
4. Select a node in the graph and confirm the context panel opens even if it was previously hidden.
5. Run the new unit tests: `windowStore.utils.test.ts` and the updated `runWindowVisibilityPersistence.test.tsx`.

## Additional Comments

Selection-driven panels (context panel) must call `restoreWindow()` explicitly on selection rather than relying on `startVisible`, since `startVisible` no longer overrides persisted state.