### PR TITLE
chore: empty state for recent runs window

### DIFF
--- a/src/components/shared/PipelineRunDisplay/PipelineRunsList.tsx
+++ b/src/components/shared/PipelineRunDisplay/PipelineRunsList.tsx
@@ -1,4 +1,4 @@
-import { type ComponentProps, useState } from "react";
+import { type ComponentProps, type ReactNode, useState } from "react";
 
 import RunOverview from "@/components/shared/PipelineRunDisplay/RunOverview";
 import { withSuspenseWrapper } from "@/components/shared/SuspenseWrapper";
@@ -21,6 +21,7 @@ interface PipelineRunsListProps {
   defaultShowingRuns?: number;
   overviewConfig?: ComponentProps<typeof RunOverview>["config"];
   onRunClick?: (run: PipelineRun) => void;
+  emptyState?: ReactNode;
 }
 
 export const PipelineRunsList = withSuspenseWrapper(
@@ -32,6 +33,7 @@ export const PipelineRunsList = withSuspenseWrapper(
     defaultShowingRuns = DEFAULT_SHOWING_RUNS,
     overviewConfig,
     onRunClick,
+    emptyState,
   }: PipelineRunsListProps) => {
     const { data: pipelineRuns } = usePipelineRuns(pipelineName);
 
@@ -41,6 +43,17 @@ export const PipelineRunsList = withSuspenseWrapper(
 
     if (!pipelineRuns) {
       return <RecentRunsTitle pipelineName={pipelineName} runsCount={0} />;
+    }
+
+    if (pipelineRuns.length === 0 && emptyState) {
+      return (
+        <>
+          {showTitle && (
+            <RecentRunsTitle pipelineName={pipelineName} runsCount={0} />
+          )}
+          {emptyState}
+        </>
+      );
     }
 
     return (

--- a/src/routes/v2/pages/Editor/components/RecentRunsContent.tsx
+++ b/src/routes/v2/pages/Editor/components/RecentRunsContent.tsx
@@ -1,6 +1,7 @@
 import { observer } from "mobx-react-lite";
 
 import { PipelineRunsList } from "@/components/shared/PipelineRunDisplay/PipelineRunsList";
+import { EmptyState } from "@/components/ui/empty-state";
 import { BlockStack } from "@/components/ui/layout";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 
@@ -15,6 +16,12 @@ export const RecentRunsContent = observer(function RecentRunsContent() {
         showTitle={false}
         defaultShowingRuns={10}
         showMoreButton={false}
+        emptyState={
+          <EmptyState
+            size="sm"
+            description="No runs yet. Submit this pipeline to see runs here."
+          />
+        }
         overviewConfig={{
           showName: false,
           showDescription: true,


### PR DESCRIPTION
## Description

Adds an optional `emptyState` prop to `PipelineRunsList` that allows consumers to render a custom empty state when no pipeline runs exist. When `pipelineRuns.length === 0` and an `emptyState` node is provided, it renders alongside the optional title instead of falling back to the default behavior.

This is used in the Editor's `RecentRunsContent` to display a descriptive empty state message ("No runs yet. Submit this pipeline to see runs here.") when no runs have been submitted for the pipeline.

## Screenshots (if applicable)

| Before | After |
| --- | --- |
| ![image.png](https://app.graphite.com/user-attachments/assets/de14717d-0795-44b1-931a-9883fdd3dff8.png)<br> | ![image.png](https://app.graphite.com/user-attachments/assets/9fe43604-9651-4167-99ed-65012b18988e.png)<br> |

## Test Instructions

1. Open the Editor for a pipeline that has no runs.
2. Navigate to the Recent Runs panel.
3. Verify the empty state message "No runs yet. Submit this pipeline to see runs here." is displayed.
4. Submit a run and confirm the empty state is replaced by the run list.

## Additional Comments

The `emptyState` prop is fully optional and backward-compatible — existing usages of `PipelineRunsList` without the prop are unaffected.