### PR TITLE
fix: v2 - ai window sticky header in docked position

### DIFF
--- a/src/routes/v2/shared/windows/components/WindowStickyHeader.tsx
+++ b/src/routes/v2/shared/windows/components/WindowStickyHeader.tsx
@@ -2,7 +2,6 @@ import type { ReactNode } from "react";
 
 import { cn } from "@/lib/utils";
 import { useOptionalWindowContext } from "@/routes/v2/shared/windows/ContentWindowStateContext";
-import { DOCKED_HEADER_HEIGHT } from "@/routes/v2/shared/windows/types";
 
 interface WindowStickyHeaderProps {
   children: ReactNode;
@@ -12,11 +11,12 @@ interface WindowStickyHeaderProps {
 /**
  * Pins content to the top of a window's scroll region.
  *
- * When docked, the whole dock column scrolls as one and each window's chrome
- * header is sticky at `dockIndex * DOCKED_HEADER_HEIGHT`, so this must stick one
- * header-height lower to sit just below it. When floating, the content lives in
- * a height-bounded scroll box, so a flex-sibling header pins on its own and no
- * offset is needed.
+ * A docked window wraps its content in its own height-bounded scroll box, so
+ * the sticky container is that per-window box (not the dock column) and its top
+ * already sits below the chrome header. Pinning at `top: 0` therefore keeps the
+ * header flush with the top of the chat's scroll area. When floating, the
+ * content likewise lives in a height-bounded scroll box, so a flex-sibling
+ * header pins on its own and no sticky positioning is needed.
  */
 export function WindowStickyHeader({
   children,
@@ -24,15 +24,9 @@ export function WindowStickyHeader({
 }: WindowStickyHeaderProps) {
   const ctx = useOptionalWindowContext();
   const isDocked = ctx?.model.isDocked ?? false;
-  const dockIndex = ctx?.dockIndex ?? 0;
 
   return (
-    <div
-      className={cn(className, isDocked && "sticky z-10 bg-white")}
-      style={
-        isDocked ? { top: (dockIndex + 1) * DOCKED_HEADER_HEIGHT } : undefined
-      }
-    >
+    <div className={cn(className, isDocked && "sticky top-0 z-10 bg-white")}>
       {children}
     </div>
   );


### PR DESCRIPTION
## Description

Docked windows now wrap their content in their own height-bounded scroll box, meaning the sticky container's scroll root is already scoped to that per-window box and its top naturally sits below the chrome header. As a result, `WindowStickyHeader` no longer needs to calculate a top offset based on `dockIndex * DOCKED_HEADER_HEIGHT` — pinning at `top: 0` is sufficient to keep the sticky header flush with the top of the chat's scroll area. The `dockIndex` reference and the `DOCKED_HEADER_HEIGHT` import have been removed accordingly.

![image.png](https://app.graphite.com/user-attachments/assets/b0d4bd9e-225b-4207-9c51-92d36e6883ca.png)



## Screenshots (if applicable)

[Screen Recording 2026-07-15 at 4.54.14 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/3672bfdd-91e3-40ed-b6e6-581cd35b4e77.mov" />](https://app.graphite.com/user-attachments/video/3672bfdd-91e3-40ed-b6e6-581cd35b4e77.mov)

## Test Instructions

Open a docked window with a sticky header (e.g. a chat window) and verify the sticky header remains flush with the top of the scroll area without any visible gap or overlap with the chrome header. Confirm the same behaviour for floating windows.

## Additional Comments