### PR TITLE
chore: v2 - runview set default dock side to right for properties

### DIFF
--- a/src/routes/v2/pages/RunView/hooks/useRunViewSelectionSync.tsx
+++ b/src/routes/v2/pages/RunView/hooks/useRunViewSelectionSync.tsx
@@ -31,6 +31,7 @@ export function useRunViewSelectionSync() {
               startVisible: true,
               persisted: true,
               fillDockHeight: true,
+              defaultDockState: "right",
             });
             // Selecting a node is an explicit request to see properties, so force
             // the panel visible even if a persisted layout restored it as hidden.


### PR DESCRIPTION
## Description

When a node is selected in the Run View, the properties panel now defaults to docking on the right side. This ensures a consistent and predictable panel placement when the properties panel is opened via node selection.

## Test Instructions

1. Open the Run View
2. Select a node in the graph
3. Verify that the properties panel opens docked to the right side by default

## 