### PR TITLE
fix: v2 - allow pasting into the component editor

### DIFF
--- a/src/components/shared/ReactFlow/FlowSidebar/components/ImportComponent.test.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/components/ImportComponent.test.tsx
@@ -1,0 +1,77 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactElement, ReactNode } from "react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import useToastNotification from "@/hooks/useToastNotification";
+import { useComponentLibrary } from "@/providers/ComponentLibraryProvider";
+
+import ImportComponent from "./ImportComponent";
+
+vi.mock("@/hooks/useToastNotification", () => ({
+  default: vi.fn(),
+}));
+
+vi.mock("@/providers/AnalyticsProvider", () => ({
+  useAnalytics: vi.fn().mockReturnValue({ track: vi.fn() }),
+}));
+
+vi.mock("@/providers/ComponentLibraryProvider", () => ({
+  useComponentLibrary: vi.fn(),
+}));
+
+vi.mock("@/components/shared/ComponentEditor/ComponentEditorDialog", () => ({
+  ComponentEditorDialog: ({ templateName }: { templateName?: string }) => (
+    <div data-testid="component-editor-dialog">editor:{templateName}</div>
+  ),
+}));
+
+describe("<ImportComponent />", () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  const TestWrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  const renderWithProviders = (component: ReactElement) =>
+    render(component, { wrapper: TestWrapper });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useToastNotification).mockReturnValue(vi.fn());
+    vi.mocked(useComponentLibrary).mockReturnValue({
+      addToComponentLibrary: vi.fn(),
+    } as any);
+  });
+
+  test("closes the add-component modal when a template is selected so the fullscreen editor can receive focus", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<ImportComponent />);
+
+    await user.click(screen.getByTestId("import-component-button"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("import-component-dialog")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("tab", { name: "New" }));
+
+    const emptyTemplate = await screen.findByTestId(
+      "new-component-template-selector-option-empty",
+    );
+    await user.click(emptyTemplate);
+
+    expect(screen.getByTestId("component-editor-dialog")).toHaveTextContent(
+      "editor:empty",
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("import-component-dialog"),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/shared/ReactFlow/FlowSidebar/components/ImportComponent.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/components/ImportComponent.tsx
@@ -65,6 +65,7 @@ const ImportComponent = ({
       selected_template: template,
     });
     setComponentEditorTemplateSelected(template);
+    setIsOpen(false);
   };
 
   const handleComponentEditorDialogClose = () => {

--- a/src/routes/v2/shared/shortcuts/shortcutUtils.test.ts
+++ b/src/routes/v2/shared/shortcuts/shortcutUtils.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "vitest";
+
+import { isEditableTarget } from "./shortcutUtils";
+
+describe("isEditableTarget", () => {
+  test("returns false for non-elements", () => {
+    expect(isEditableTarget(null)).toBe(false);
+  });
+
+  test("returns true for inputs and textareas", () => {
+    expect(isEditableTarget(document.createElement("input"))).toBe(true);
+    expect(isEditableTarget(document.createElement("textarea"))).toBe(true);
+  });
+
+  test("returns false for a plain div", () => {
+    expect(isEditableTarget(document.createElement("div"))).toBe(false);
+  });
+
+  test("returns true for elements inside a Monaco editor", () => {
+    const editor = document.createElement("div");
+    editor.className = "monaco-editor";
+    const inner = document.createElement("div");
+    editor.appendChild(inner);
+    document.body.appendChild(editor);
+
+    expect(isEditableTarget(inner)).toBe(true);
+
+    editor.remove();
+  });
+});

--- a/src/routes/v2/shared/shortcuts/shortcutUtils.ts
+++ b/src/routes/v2/shared/shortcuts/shortcutUtils.ts
@@ -3,6 +3,7 @@ export function isEditableTarget(target: EventTarget | null): boolean {
   return (
     target.tagName === "INPUT" ||
     target.tagName === "TEXTAREA" ||
-    target.isContentEditable
+    target.isContentEditable ||
+    target.closest(".monaco-editor") !== null
   );
 }


### PR DESCRIPTION
## What

Fixes the inability to paste into the **v2** component editor when creating/editing a custom component. Verified end-to-end in a real browser driving the actual v2 editor.

![component-paste-before-after.gif](https://app.graphite.com/user-attachments/assets/d1ea36ce-d3f1-4b7f-9ce7-bcda86a4ab65.gif)



Two independent v2 problems combined to block paste:

### 1\. Modal dialog left open behind the editor

`Add Component → New → pick a template` opens the fullscreen `ComponentEditorDialog` (Monaco, portaled to `document.body`) but never closed the underlying **"Add Component" Radix** **`Dialog`**. That dialog is modal, so its focus scope trapped focus and set `pointer-events: none` outside its content — Monaco's textarea could never hold focus (typing _and_ paste dead).

**Fix:** close the Add Component dialog when a template is selected (`ImportComponent`). Shared component, so v1 benefits too.

### 2\. Cmd/Ctrl+V swallowed by the editor's global shortcut listener

Even with focus in Monaco, `isEditableTarget` (used by `useShortcutListener`) only recognised `INPUT` / `TEXTAREA` / `contentEditable`. A Cmd+V keydown whose target is a `<div>` inside Monaco was treated as **non-editable**, so the canvas paste shortcut fired and called `preventDefault()` before the browser could emit a `paste` event. Typing worked because plain keys match no shortcut. (v1's equivalent handler already special-cased `.monaco-editor`; v2 dropped it — a regression.)

**Fix:** treat any target inside a `.monaco-editor` as editable, matching v1.

Both fixes are required: #1 lets focus reach Monaco; #2 lets Cmd+V through once it's there.

## Evidence (real browser, v2 editor)

| Build | Modal | body pointer-events | Cmd+V keydown | Type immediately | Paste |
| --- | --- | --- | --- | --- | --- |
| main (no fix) | open | `none` | prevented | ❌ | ❌ |
| fix #1 only | closed | `auto` | **prevented** | ✅ | ❌ |
| fix #1 + #2 | closed | `auto` | not prevented | ✅ | ✅ |

## Testing

- `ImportComponent.test.tsx` — modal is dismissed when a template is selected.
- `shortcutUtils.test.ts` — `isEditableTarget` returns true for elements inside a Monaco editor.
- Manual e2e via Playwright against the real v2 editor (`/editor-v2/...`): clipboard paste lands in the editor.
- `eslint`, `tsc --noEmit`, `prettier --check` all pass.

## Note on v1/v2

Per the request this targets v2. Fix #2 lives in `src/routes/v2/**` (v2-only). Fix #1 is in the shared `ImportComponent`; it's the correct root-cause fix and also removes the same focus-trap in v1.