### PR TITLE
chore: add basic mini-content to all windows for consistency

### DIFF
--- a/src/routes/v2/pages/Editor/components/DebugPanel.tsx
+++ b/src/routes/v2/pages/Editor/components/DebugPanel.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/routes/v2/shared/clipboard/clipboardEnvelope";
 import { ShortcutBadge } from "@/routes/v2/shared/components/ShortcutBadge";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
+import { WindowMiniButton } from "@/routes/v2/shared/windows/WindowMiniButton";
 import { tracking } from "@/utils/tracking";
 
 import { getSelectedInfo, getSpecStats, getSpecYaml } from "./debugPanel.utils";
@@ -357,6 +358,13 @@ export function useDebugPanelWindow() {
         disabledActions: ["close"],
         persisted: true,
         defaultDockState: "left",
+        miniContent: (
+          <WindowMiniButton
+            tooltip="View Debug Panel"
+            label="Debug Panel"
+            icon="Bug"
+          />
+        ),
       });
     }
   }, [windows]);

--- a/src/routes/v2/pages/Editor/hooks/useAiChatWindow.tsx
+++ b/src/routes/v2/pages/Editor/hooks/useAiChatWindow.tsx
@@ -5,6 +5,7 @@ import { useEditorSession } from "@/routes/v2/pages/Editor/store/EditorSessionCo
 import { AiChatContent } from "@/routes/v2/shared/components/AiChat/AiChatContent";
 import type { SuggestedPrompt } from "@/routes/v2/shared/components/AiChat/types";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
+import { WindowMiniButton } from "@/routes/v2/shared/windows/WindowMiniButton";
 
 const AI_CHAT_WINDOW_ID = "ai-assistant-chat";
 
@@ -45,6 +46,13 @@ export function useAiChatWindow(enabled: boolean) {
         startVisible: true,
         persisted: true,
         defaultDockState: "left",
+        miniContent: (
+          <WindowMiniButton
+            tooltip="Open Sidekick"
+            label="Sidekick"
+            icon="Sparkles"
+          />
+        ),
       },
     );
   }, [enabled, windows, editorSession]);

--- a/src/routes/v2/pages/Editor/hooks/useHistoryWindow.tsx
+++ b/src/routes/v2/pages/Editor/hooks/useHistoryWindow.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 
 import { HistoryContent } from "@/routes/v2/pages/Editor/components/HistoryContent/HistoryContent";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
+import { WindowMiniButton } from "@/routes/v2/shared/windows/WindowMiniButton";
 
 const HISTORY_WINDOW_ID = "history";
 
@@ -17,6 +18,13 @@ export function useHistoryWindow() {
         disabledActions: ["close"],
         persisted: true,
         defaultDockState: "left",
+        miniContent: (
+          <WindowMiniButton
+            tooltip="View History"
+            label="History"
+            icon="History"
+          />
+        ),
       });
     }
   }, [windows]);

--- a/src/routes/v2/pages/Editor/hooks/usePipelineDetailsWindow.tsx
+++ b/src/routes/v2/pages/Editor/hooks/usePipelineDetailsWindow.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 
 import { PipelineDetailsContent } from "@/routes/v2/pages/Editor/components/PipelineDetailsContent/PipelineDetailsContent";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
+import { WindowMiniButton } from "@/routes/v2/shared/windows/WindowMiniButton";
 
 const PIPELINE_DETAILS_WINDOW_ID = "pipeline-details";
 
@@ -20,6 +21,13 @@ export function usePipelineDetailsWindow() {
         disabledActions: ["close"],
         persisted: true,
         defaultDockState: "right",
+        miniContent: (
+          <WindowMiniButton
+            tooltip="View Pipeline Details"
+            label="Pipeline Details"
+            icon="Info"
+          />
+        ),
       });
     }
   }, [windows, title]);

--- a/src/routes/v2/pages/Editor/hooks/useRecentRunsWindow.tsx
+++ b/src/routes/v2/pages/Editor/hooks/useRecentRunsWindow.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 
 import { RecentRunsContent } from "@/routes/v2/pages/Editor/components/RecentRunsContent";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
+import { WindowMiniButton } from "@/routes/v2/shared/windows/WindowMiniButton";
 
 const RECENT_RUNS_WINDOW_ID = "recent-runs";
 
@@ -17,6 +18,13 @@ export function useRecentRunsWindow() {
         disabledActions: ["close"],
         persisted: true,
         defaultDockState: "left",
+        miniContent: (
+          <WindowMiniButton
+            tooltip="View Recent Runs"
+            label="Recent Runs"
+            icon="List"
+          />
+        ),
       });
     }
   }, [windows]);

--- a/src/routes/v2/pages/Editor/hooks/useSelectionWindowSync.tsx
+++ b/src/routes/v2/pages/Editor/hooks/useSelectionWindowSync.tsx
@@ -7,6 +7,7 @@ import { useDeselectAll } from "@/routes/v2/shared/hooks/useDeselectAll";
 import type { EditorStore } from "@/routes/v2/shared/store/editorStore";
 import type { NavigationStore } from "@/routes/v2/shared/store/navigationStore";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
+import { WindowMiniButton } from "@/routes/v2/shared/windows/WindowMiniButton";
 import type { WindowStoreImpl } from "@/routes/v2/shared/windows/windowStore";
 
 const CONTEXT_PANEL_WINDOW_ID = "context-panel";
@@ -102,6 +103,13 @@ function ensureContextPanelVisible(
     defaultDockState: "right",
     disabledActions: ["hide"],
     onClose: deselectAll,
+    miniContent: (
+      <WindowMiniButton
+        tooltip="View Properties"
+        label="Properties"
+        icon="SlidersHorizontal"
+      />
+    ),
   });
   scrollWindowIntoView();
 }

--- a/src/routes/v2/pages/Editor/hooks/useTipOfTheDayWindow.tsx
+++ b/src/routes/v2/pages/Editor/hooks/useTipOfTheDayWindow.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 
 import { TipOfTheDay } from "@/components/Learn/TipOfTheDay";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
+import { WindowMiniButton } from "@/routes/v2/shared/windows/WindowMiniButton";
 
 const TIP_OF_THE_DAY_WINDOW_ID = "tip-of-the-day";
 
@@ -16,6 +17,13 @@ export function useTipOfTheDayWindow() {
       size: { width: 280, height: 240 },
       persisted: true,
       defaultDockState: "left",
+      miniContent: (
+        <WindowMiniButton
+          tooltip="View Tip of the Day"
+          label="Tip of the Day"
+          icon="Lightbulb"
+        />
+      ),
     });
   }, [windows]);
 }

--- a/src/routes/v2/pages/RunView/hooks/useAiChatWindow.tsx
+++ b/src/routes/v2/pages/RunView/hooks/useAiChatWindow.tsx
@@ -5,6 +5,7 @@ import { createRunViewToolBridge } from "@/routes/v2/pages/RunView/toolBridge/ru
 import { AiChatContent } from "@/routes/v2/shared/components/AiChat/AiChatContent";
 import type { SuggestedPrompt } from "@/routes/v2/shared/components/AiChat/types";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
+import { WindowMiniButton } from "@/routes/v2/shared/windows/WindowMiniButton";
 
 const SUGGESTED_PROMPTS_RUN: SuggestedPrompt[] = [
   { label: "Summarize this run", icon: "FileText" },
@@ -37,6 +38,13 @@ export function useAiChatWindow(enabled: boolean) {
         defaultVisible: true,
         defaultDockState: "left",
         persisted: true,
+        miniContent: (
+          <WindowMiniButton
+            tooltip="Open AI Assistant"
+            label="AI Assistant"
+            icon="Sparkles"
+          />
+        ),
       },
     );
   }, [enabled, windows]);

--- a/src/routes/v2/pages/RunView/hooks/useRunViewSelectionSync.tsx
+++ b/src/routes/v2/pages/RunView/hooks/useRunViewSelectionSync.tsx
@@ -3,6 +3,7 @@ import { useEffect } from "react";
 
 import { RunViewContextPanel } from "@/routes/v2/pages/RunView/components/RunViewContextPanel";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
+import { WindowMiniButton } from "@/routes/v2/shared/windows/WindowMiniButton";
 
 const CONTEXT_PANEL_WINDOW_ID = "context-panel";
 
@@ -32,6 +33,13 @@ export function useRunViewSelectionSync() {
               persisted: true,
               fillDockHeight: true,
               defaultDockState: "right",
+              miniContent: (
+                <WindowMiniButton
+                  tooltip="View Properties"
+                  label="Properties"
+                  icon="SlidersHorizontal"
+                />
+              ),
             });
             // Selecting a node is an explicit request to see properties, so force
             // the panel visible even if a persisted layout restored it as hidden.

--- a/src/routes/v2/pages/RunView/hooks/useRunViewWindows.tsx
+++ b/src/routes/v2/pages/RunView/hooks/useRunViewWindows.tsx
@@ -7,6 +7,7 @@ import {
   RUN_TOOLS_WINDOW_ID,
 } from "@/routes/v2/pages/RunView/runViewWindowPresets";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
+import { WindowMiniButton } from "@/routes/v2/shared/windows/WindowMiniButton";
 
 export function useRunViewWindows() {
   const { windows } = useSharedStores();
@@ -26,6 +27,13 @@ export function useRunViewWindows() {
         minSize: { width: 240, height: 180 },
         defaultDockState: "left",
         persisted: true,
+        miniContent: (
+          <WindowMiniButton
+            tooltip="View Run Tools"
+            label="Run Tools"
+            icon="Wrench"
+          />
+        ),
       });
     }
 
@@ -36,6 +44,13 @@ export function useRunViewWindows() {
         defaultVisible: true,
         defaultDockState: "right",
         persisted: true,
+        miniContent: (
+          <WindowMiniButton
+            tooltip="View Run Details"
+            label="Run Details"
+            icon="Info"
+          />
+        ),
       });
     }
   }, [windows]);

--- a/src/routes/v2/shared/windows/WindowMiniButton.tsx
+++ b/src/routes/v2/shared/windows/WindowMiniButton.tsx
@@ -1,0 +1,26 @@
+import TooltipButton from "@/components/shared/Buttons/TooltipButton";
+import { Icon, type IconName } from "@/components/ui/icon";
+
+interface WindowMiniButtonProps {
+  tooltip: string;
+  label: string;
+  icon: IconName;
+}
+
+export function WindowMiniButton({
+  tooltip,
+  label,
+  icon,
+}: WindowMiniButtonProps) {
+  return (
+    <TooltipButton
+      tooltip={tooltip}
+      tooltipSide="right"
+      variant="outline"
+      size="icon"
+      aria-label={label}
+    >
+      <Icon name={icon} size="sm" className="text-muted-foreground" />
+    </TooltipButton>
+  );
+}


### PR DESCRIPTION
## Description

Adds a `WindowMiniButton` component and registers it as `miniContent` for all editor and run view windows. When a window is in a minimized/mini state, it now displays a compact icon button with a tooltip, giving users a clear visual affordance to restore each panel. The panels covered include:

- **Editor view:** Debug Panel, AI Sidekick, History, Pipeline Details, Recent Runs, Properties (context panel), and Tip of the Day
- **Run view:** AI Assistant, Properties (context panel), Run Tools, and Run Details

Each button uses an appropriate icon (e.g. `Sparkles` for AI, `Bug` for Debug, `History` for History) and a descriptive tooltip.

## Screenshots (if applicable)

[Screen Recording 2026-07-15 at 5.26.00 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/f75bb8b6-493d-4bfd-a705-3467134f8fbd.mov" />](https://app.graphite.com/user-attachments/video/f75bb8b6-493d-4bfd-a705-3467134f8fbd.mov)



## Test Instructions

1. Open the Editor and minimize any panel (Debug Panel, Sidekick, History, Pipeline Details, Recent Runs, Properties, Tip of the Day).
2. Verify that the minimized panel displays the correct icon button with the expected tooltip on hover.
3. Click the mini button and confirm the panel restores correctly.
4. Repeat steps 1–3 in the Run view for the AI Assistant, Properties, Run Tools, and Run Details panels.

## Additional Comments

The `WindowMiniButton` component is a thin wrapper around `TooltipButton` and accepts a `tooltip`, `label`, and `icon` prop, making it straightforward to apply consistently across all window definitions.