### PR TITLE
fix: v2 - minicontent popover to dismiss on outside onclick on canvas

### DIFF
--- a/src/routes/v2/shared/windows/CollapsedDockWindowMini.tsx
+++ b/src/routes/v2/shared/windows/CollapsedDockWindowMini.tsx
@@ -1,5 +1,5 @@
 import { observer } from "mobx-react-lite";
-import type { CSSProperties } from "react";
+import { type CSSProperties, useEffect, useState } from "react";
 
 import {
   Popover,
@@ -24,9 +24,35 @@ export const CollapsedDockWindowMini = observer(
     dockSide,
   }: CollapsedDockWindowMiniProps) {
     const { windows } = useSharedStores();
+    const [open, setOpen] = useState(false);
     const model = windows.getWindowById(windowId);
     const mini = windows.getWindowMiniContent(windowId);
     const content = windows.getWindowContent(windowId);
+
+    // Radix handles outside-clicks by listening for a bubbling `pointerdown`
+    // on `document`. The React Flow canvas (d3-zoom) stops propagation of
+    // `pointerdown`, so that listener never fires and the popover stays open
+    // when clicking the canvas. We can't use a modal popover to work around
+    // this: modal disables outside pointer events, which breaks drag-and-drop
+    // of components onto the canvas. Instead we close explicitly on the one
+    // case Radix misses - a capture-phase pointerdown that lands on the canvas.
+    useEffect(() => {
+      if (!open) return;
+      const handlePointerDownCapture = (event: PointerEvent) => {
+        const target = event.target;
+        if (target instanceof Element && target.closest(".react-flow")) {
+          setOpen(false);
+        }
+      };
+      document.addEventListener("pointerdown", handlePointerDownCapture, true);
+      return () => {
+        document.removeEventListener(
+          "pointerdown",
+          handlePointerDownCapture,
+          true,
+        );
+      };
+    }, [open]);
 
     if (!model || model.state === "hidden" || !mini || !content) {
       return null;
@@ -36,7 +62,7 @@ export const CollapsedDockWindowMini = observer(
     const panelWidth = Math.min(model.size.width, MAX_DOCK_AREA_WIDTH);
 
     return (
-      <Popover>
+      <Popover open={open} onOpenChange={setOpen}>
         {/*
           Radix asChild merges ref and listeners onto one DOM node. Mini content
           is often a MobX observer() component that does not forwardRef to a host


### PR DESCRIPTION
## Description

Fixes an issue where the `CollapsedDockWindowMini` popover would remain open after clicking on the React Flow canvas. Radix UI closes popovers by listening for a bubbling `pointerdown` event on `document`, but the React Flow canvas (via d3-zoom) stops propagation of `pointerdown`, so Radix never receives the event.

**Root cause**

The bug is a Radix + React Flow interaction: React Flow's pane (d3-zoom) calls `stopImmediatePropagation()` on `pointerdown`, so the event never bubbles to `document` → Radix never fires "pointer down outside" → the popover stays open.

**Alternatives**

A modal popover cannot be used as a workaround because it disables outside pointer events, which breaks drag-and-drop of components onto the canvas. Instead, the popover is converted to controlled mode (`open`/`onOpenChange`) and a capture-phase `pointerdown` listener is registered on `document` only while the popover is open. When a click lands on an element inside `.react-flow`, the popover is explicitly closed.

## Screenshots (if applicable)

[Screen Recording 2026-07-15 at 7.25.58 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/11090e3d-77f5-4858-b92b-5424d67ea738.mov" />](https://app.graphite.com/user-attachments/video/11090e3d-77f5-4858-b92b-5424d67ea738.mov)

## Test Instructions

1. Open a `CollapsedDockWindowMini` popover by clicking its trigger.
2. Click anywhere on the React Flow canvas.
3. Verify the popover closes immediately.
4. Verify that drag-and-drop of components onto the canvas still works correctly.

## Additional Comments

The capture-phase listener is only active while the popover is open, so there is no persistent overhead when the popover is closed.

Related