### PR TITLE
fix: v2 - window order not persisted

### DIFF
--- a/src/routes/v2/shared/windows/windowStore.dockReconcile.test.ts
+++ b/src/routes/v2/shared/windows/windowStore.dockReconcile.test.ts
@@ -34,7 +34,7 @@ describe("WindowStoreImpl dock order reconciliation", () => {
     ]);
   });
 
-  it("restoreDockArea drops ids that are no longer docked to the side", () => {
+  it("getDockedWindowOrder drops ids that are no longer docked to the side", () => {
     const store = new WindowStoreImpl();
     store.enableDockSide("left");
 
@@ -50,7 +50,50 @@ describe("WindowStoreImpl dock order reconciliation", () => {
       windowOrder: ["component-library", "ghost-window"],
     });
 
-    expect(store.getDockAreaWindowIds("left")).toEqual(["component-library"]);
+    // The read path reconciles against actual window state, so a ghost id with
+    // no live window is filtered out (and cleaned up on the next save).
+    expect(store.getDockedWindowOrder("left")).toEqual(["component-library"]);
+  });
+
+  it("restoreDockArea preserves persisted order when windows are created afterwards", () => {
+    const store = new WindowStoreImpl();
+    store.enableDockSide("left");
+
+    // Restore runs before any window exists (real reload: useWindowPersistence
+    // effect runs before the use*Window hooks that call openWindow).
+    store.restoreDockArea("left", {
+      width: 320,
+      collapsed: false,
+      windowOrder: ["runs-and-submission", "component-library", "history"],
+    });
+
+    // Windows are then opened in a different (creation) order.
+    store.openWindow(stubContent, {
+      id: "component-library",
+      title: "Components",
+      defaultDockState: "left",
+    });
+    store.openWindow(stubContent, {
+      id: "history",
+      title: "History",
+      defaultDockState: "left",
+    });
+    store.openWindow(stubContent, {
+      id: "runs-and-submission",
+      title: "Runs",
+      defaultDockState: "left",
+    });
+
+    expect(store.getDockAreaWindowIds("left")).toEqual([
+      "runs-and-submission",
+      "component-library",
+      "history",
+    ]);
+    expect(store.getDockedWindowOrder("left")).toEqual([
+      "runs-and-submission",
+      "component-library",
+      "history",
+    ]);
   });
 
   it("getDockedWindowOrder does not duplicate windows already in the order", () => {

--- a/src/routes/v2/shared/windows/windowStore.ts
+++ b/src/routes/v2/shared/windows/windowStore.ts
@@ -255,11 +255,16 @@ export class WindowStoreImpl implements WindowStoreRef {
   ): void {
     this.dockAreas[side].width = state.width;
     this.dockAreas[side].collapsed = state.collapsed;
-    this.dockAreas[side].windowOrder = [...state.windowOrder];
-    // Reconcile against actual window state so a re-run of restore (StrictMode
-    // double-invoke, dependency change) cannot orphan windows that were already
-    // docked to this side by `use*Window` hooks.
-    this.dockAreas[side].windowOrder = this.getDockedWindowOrder(side);
+    // Preserve the persisted order verbatim, including ids whose windows have not
+    // been created yet (use*Window hooks run after this effect). Append any window
+    // already docked to this side but missing from the persisted order so a re-run
+    // (StrictMode double-invoke, dependency change) cannot orphan it. Stale/ghost
+    // ids are filtered out later by getDockedWindowOrder (render) and at save time.
+    const seen = new Set(state.windowOrder);
+    const extras = this.windowOrder.filter(
+      (id) => this.windows[id]?.dockState === side && !seen.has(id),
+    );
+    this.dockAreas[side].windowOrder = [...state.windowOrder, ...extras];
   }
 
   isDockSideEnabled(side: "left" | "right"): boolean {


### PR DESCRIPTION
## Description

`restoreDockArea` previously called `getDockedWindowOrder` immediately after writing the persisted order, which filtered out any window IDs whose windows hadn't been created yet. Since `useWindowPersistence` runs before the `use*Window` hooks that call `openWindow`, this caused the persisted order to be discarded on page load — windows would appear in creation order rather than the saved order.

The fix changes `restoreDockArea` to write the persisted order verbatim, appending only windows that are already docked to the side but missing from the persisted list (to handle StrictMode double-invokes and dependency changes without orphaning live windows). Ghost/stale IDs that exist in the persisted order but have no live window are left in place and filtered out lazily by `getDockedWindowOrder` at render time and at save time.

A new test covers the reload scenario where `restoreDockArea` is called before any windows exist, verifying that windows subsequently opened via `openWindow` appear in the persisted order rather than creation order. The existing test description was also corrected to reference `getDockedWindowOrder` instead of `restoreDockArea`.

## Root cause

On reload, `useWindowPersistence` (declared first in [EditorV2.tsx](src/routes/v2/pages/Editor/EditorV2.tsx) line 88) runs its effect and calls `restoreDockArea` before the `use*Window` hooks (lines 96-112) create any windows. At that point `store.windows` is empty.

`restoreDockArea` reconciles the just-restored order through `getDockedWindowOrder`, which drops every id whose window is not yet docked to that side. With no windows created, this wipes the persisted order to `[]`. Windows are then re-added in hook-declaration (creation) order via `openWindow` -> `registerNewWindowInDockArea`, so the persisted stack order is lost.

The premature reconcile cannot distinguish "window not created yet" from "stale ghost id" at restore time.

## Screenshots (if applicable)

[Screen Recording 2026-07-15 at 7.38.22 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/bf35763a-9757-4f99-9831-5f8fbeb4e56b.mov" />](https://app.graphite.com/user-attachments/video/bf35763a-9757-4f99-9831-5f8fbeb4e56b.mov)

## Test Instructions

1. Open the application with a saved dock layout containing multiple windows in a specific order.
2. Reload the page and verify the dock windows appear in the previously saved order rather than their creation order.
3. Confirm that removing a window from the dock and reloading does not leave ghost entries visible in the dock.

## Additional Comments

The deferred reconciliation approach means `getDockedWindowOrder` is the single source of truth for the live, filtered order, while `restoreDockArea` is responsible only for seeding the intended order from persistence.