### PR TITLE
Add snap-to-collapse preview and toggle when resizing dock areas

### DIFF
--- a/src/components/ui/resize-handle.test.tsx
+++ b/src/components/ui/resize-handle.test.tsx
@@ -1,0 +1,99 @@
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { VerticalResizeHandle } from "./resize-handle";
+
+afterEach(cleanup);
+
+interface ResizeCase {
+  name: string;
+  side: "left" | "right";
+  startWidth: number;
+  minWidth: number;
+  maxWidth: number;
+  startX: number;
+  endX: number;
+  attemptedWidth: number;
+  renderedWidth: number;
+}
+
+const resizeCases: ResizeCase[] = [
+  {
+    name: "left dock past its collapsed threshold",
+    side: "right",
+    startWidth: 320,
+    minWidth: 220,
+    maxWidth: 600,
+    startX: 300,
+    endX: 100,
+    attemptedWidth: 120,
+    renderedWidth: 220,
+  },
+  {
+    name: "right dock past its collapsed threshold",
+    side: "left",
+    startWidth: 320,
+    minWidth: 220,
+    maxWidth: 600,
+    startX: 100,
+    endX: 300,
+    attemptedWidth: 120,
+    renderedWidth: 220,
+  },
+  {
+    name: "left mini dock toward its expanded state",
+    side: "right",
+    startWidth: 36,
+    minWidth: 36,
+    maxWidth: 36,
+    startX: 100,
+    endX: 300,
+    attemptedWidth: 236,
+    renderedWidth: 36,
+  },
+  {
+    name: "right mini dock toward its expanded state",
+    side: "left",
+    startWidth: 36,
+    minWidth: 36,
+    maxWidth: 36,
+    startX: 300,
+    endX: 100,
+    attemptedWidth: 236,
+    renderedWidth: 36,
+  },
+];
+
+describe("VerticalResizeHandle", () => {
+  it.each(resizeCases)("reports resize progress for $name", (resizeCase) => {
+    const onResize = vi.fn();
+    const onResizeEnd = vi.fn();
+    const { container } = render(
+      <div>
+        <VerticalResizeHandle
+          side={resizeCase.side}
+          minWidth={resizeCase.minWidth}
+          maxWidth={resizeCase.maxWidth}
+          onResize={onResize}
+          onResizeEnd={onResizeEnd}
+        />
+      </div>,
+    );
+    const handle = container.querySelector<HTMLElement>(".cursor-col-resize");
+    const parent = handle?.parentElement;
+    if (!handle || !parent) throw new Error("Missing resize handle");
+    Object.defineProperty(parent, "offsetWidth", {
+      value: resizeCase.startWidth,
+    });
+
+    fireEvent.mouseDown(handle, { clientX: resizeCase.startX });
+    fireEvent.mouseMove(document, { clientX: resizeCase.endX });
+
+    expect(parent).toHaveStyle({ width: `${resizeCase.renderedWidth}px` });
+    expect(onResize).toHaveBeenCalledWith(resizeCase.attemptedWidth);
+
+    fireEvent.mouseUp(document);
+
+    expect(onResizeEnd).toHaveBeenCalledWith(resizeCase.attemptedWidth);
+  });
+});

--- a/src/components/ui/resize-handle.tsx
+++ b/src/components/ui/resize-handle.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from "react";
+import { type MouseEvent as ReactMouseEvent, useCallback, useRef } from "react";
 
 import { Icon } from "@/components/ui/icon";
 import { cn } from "@/lib/utils";
@@ -8,6 +8,10 @@ interface ResizeHandleProps {
   maxWidth?: number;
   side?: "left" | "right";
   onDoubleClick?: () => void;
+  /** Called while dragging with the width requested before min/max constraints. */
+  onResize?: (attemptedWidth: number) => void;
+  /** Called when dragging ends with the width requested before min/max constraints. */
+  onResizeEnd?: (attemptedWidth: number) => void;
 }
 
 export const VerticalResizeHandle = ({
@@ -15,11 +19,15 @@ export const VerticalResizeHandle = ({
   maxWidth = 600,
   side = "left",
   onDoubleClick,
+  onResize,
+  onResizeEnd,
 }: ResizeHandleProps) => {
   const parentElementRef = useRef<HTMLElement | null>(null);
-  const resizingRef = useRef<{ startX: number; startWidth: number } | null>(
-    null,
-  );
+  const resizingRef = useRef<{
+    startX: number;
+    startWidth: number;
+    attemptedWidth: number;
+  } | null>(null);
 
   const captureParentElement = useCallback((element: HTMLElement | null) => {
     parentElementRef.current = element?.parentElement ?? null;
@@ -38,21 +46,28 @@ export const VerticalResizeHandle = ({
         newWidth = resizingRef.current.startWidth + deltaX;
       }
 
+      resizingRef.current.attemptedWidth = newWidth;
+      onResize?.(newWidth);
       const constrainedWidth = Math.max(minWidth, Math.min(maxWidth, newWidth));
       parentElementRef.current.style.width = `${constrainedWidth}px`;
     },
-    [minWidth, maxWidth, side],
+    [minWidth, maxWidth, side, onResize],
   );
 
   const handleMouseUp = useCallback(() => {
+    const attemptedWidth = resizingRef.current?.attemptedWidth;
     resizingRef.current = null;
 
     document.removeEventListener("mousemove", handleMouseMove);
     document.removeEventListener("mouseup", handleMouseUp);
-  }, [handleMouseMove]);
+
+    if (attemptedWidth !== undefined) {
+      onResizeEnd?.(attemptedWidth);
+    }
+  }, [handleMouseMove, onResizeEnd]);
 
   const handleMouseDown = useCallback(
-    (e: React.MouseEvent) => {
+    (e: ReactMouseEvent) => {
       e.preventDefault();
       e.stopPropagation();
 
@@ -61,6 +76,7 @@ export const VerticalResizeHandle = ({
       resizingRef.current = {
         startX: e.clientX,
         startWidth: parentElementRef.current.offsetWidth,
+        attemptedWidth: parentElementRef.current.offsetWidth,
       };
       document.addEventListener("mousemove", handleMouseMove);
       document.addEventListener("mouseup", handleMouseUp);

--- a/src/routes/v2/shared/windows/DockArea.tsx
+++ b/src/routes/v2/shared/windows/DockArea.tsx
@@ -1,5 +1,5 @@
 import { observer } from "mobx-react-lite";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { BlockStack } from "@/components/ui/layout";
 import { VerticalResizeHandle } from "@/components/ui/resize-handle";
@@ -11,6 +11,7 @@ import { CollapsedDockWindowMini } from "./CollapsedDockWindowMini";
 import { registerDockAreaElement } from "./snapUtils";
 import {
   COLLAPSED_DOCK_AREA_WIDTH,
+  DOCK_AREA_RESIZE_SNAP_THRESHOLD,
   MAX_DOCK_AREA_WIDTH,
   MIN_DOCK_AREA_WIDTH,
 } from "./types";
@@ -31,6 +32,9 @@ export const DockArea = observer(function DockArea({ side }: DockAreaProps) {
   const { collapsed } = dockArea;
   const windowOrder = windows.getDockedWindowOrder(side);
   const containerRef = useRef<HTMLDivElement | null>(null);
+  const [snapPreview, setSnapPreview] = useState<"collapse" | "expand" | null>(
+    null,
+  );
 
   const visibleWindows = windowOrder.filter((id) => {
     const win = windows.getWindowById(id);
@@ -89,6 +93,24 @@ export const DockArea = observer(function DockArea({ side }: DockAreaProps) {
     windows.toggleDockAreaCollapsed(side);
   };
 
+  const shouldSnap = (attemptedWidth: number) =>
+    collapsed
+      ? attemptedWidth >= DOCK_AREA_RESIZE_SNAP_THRESHOLD
+      : attemptedWidth <= DOCK_AREA_RESIZE_SNAP_THRESHOLD;
+
+  const handleResize = (attemptedWidth: number) => {
+    setSnapPreview(
+      shouldSnap(attemptedWidth) ? (collapsed ? "expand" : "collapse") : null,
+    );
+  };
+
+  const handleResizeEnd = (attemptedWidth: number) => {
+    setSnapPreview(null);
+    if (shouldSnap(attemptedWidth)) {
+      windows.toggleDockAreaCollapsed(side);
+    }
+  };
+
   const handleSide = side === "left" ? "right" : "left";
 
   if (collapsed) {
@@ -99,6 +121,18 @@ export const DockArea = observer(function DockArea({ side }: DockAreaProps) {
         className={cn("relative shrink-0 bg-muted flex flex-col")}
         style={{ width: COLLAPSED_DOCK_AREA_WIDTH }}
       >
+        {snapPreview === "expand" && (
+          <div
+            aria-hidden="true"
+            data-dock-resize-preview="expand"
+            className={cn(
+              "absolute inset-y-0 z-10 pointer-events-none bg-card/75",
+              "border-primary/40 ring-1 ring-primary/30 shadow-2xl",
+              side === "left" ? "left-0 border-r" : "right-0 border-l",
+            )}
+            style={{ width: dockArea.width }}
+          />
+        )}
         <BlockStack
           gap="1"
           align="center"
@@ -117,6 +151,8 @@ export const DockArea = observer(function DockArea({ side }: DockAreaProps) {
           minWidth={COLLAPSED_DOCK_AREA_WIDTH}
           maxWidth={COLLAPSED_DOCK_AREA_WIDTH}
           onDoubleClick={handleToggleCollapse}
+          onResize={handleResize}
+          onResizeEnd={handleResizeEnd}
         />
       </div>
     );
@@ -129,6 +165,20 @@ export const DockArea = observer(function DockArea({ side }: DockAreaProps) {
       className={cn("relative shrink-0 bg-card")}
       style={{ width: dockArea.width }}
     >
+      {snapPreview === "collapse" && (
+        <div
+          aria-hidden="true"
+          data-dock-resize-preview="collapse"
+          className="absolute inset-0 z-20 pointer-events-none bg-background/60 backdrop-blur-[1px]"
+        >
+          <div
+            className={cn(
+              "absolute inset-y-0 w-9 bg-primary/15 border-primary/40 shadow-xl",
+              side === "left" ? "left-0 border-r" : "right-0 border-l",
+            )}
+          />
+        </div>
+      )}
       <div
         data-dock-scroll
         className="absolute inset-0 overflow-y-auto overflow-x-hidden hide-scrollbar"
@@ -150,6 +200,8 @@ export const DockArea = observer(function DockArea({ side }: DockAreaProps) {
         minWidth={MIN_DOCK_AREA_WIDTH}
         maxWidth={MAX_DOCK_AREA_WIDTH}
         onDoubleClick={handleToggleCollapse}
+        onResize={handleResize}
+        onResizeEnd={handleResizeEnd}
       />
     </div>
   );

--- a/src/routes/v2/shared/windows/types.ts
+++ b/src/routes/v2/shared/windows/types.ts
@@ -124,6 +124,9 @@ export const DEFAULT_DOCK_AREA_WIDTH = 320;
 /** Minimum dock area width (px) */
 export const MIN_DOCK_AREA_WIDTH = 220;
 
+/** Resize width where dock areas preview and snap between expanded and collapsed. */
+export const DOCK_AREA_RESIZE_SNAP_THRESHOLD = MIN_DOCK_AREA_WIDTH - 20;
+
 /** Maximum dock area width (px) */
 export const MAX_DOCK_AREA_WIDTH = 600;
 


### PR DESCRIPTION
## Description

Adds snap-to-collapse and snap-to-expand behaviour when dragging dock area resize handles. When the user drags a dock panel below the snap threshold (`MIN_DOCK_AREA_WIDTH - 20`), a visual preview overlay appears indicating the panel will collapse on mouse release. Conversely, dragging the resize handle of a collapsed (mini) dock past the threshold previews expansion. Releasing the mouse at either snap point toggles the dock's collapsed state.

To support this, `VerticalResizeHandle` now exposes two new callbacks — `onResize` and `onResizeEnd` — which report the unconstrained (pre-min/max) width attempted during drag. This allows `DockArea` to detect snap conditions independently of the clamped visual width.

Tests covering the new `onResize` and `onResizeEnd` callbacks are included, validating both left and right dock behavior for collapsed and expanded states.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)



## [docking.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/ee7e83b1-21ef-43fb-a7c4-2e85db5fea5b.mov" />](https://app.graphite.com/user-attachments/video/ee7e83b1-21ef-43fb-a7c4-2e85db5fea5b.mov)



## Test Instructions

1. Open the application with a left or right dock panel visible.
2. Drag the resize handle toward the collapsed threshold and observe the collapse preview overlay appearing.
3. Release the mouse while the preview is active and confirm the dock collapses.
4. Drag the resize handle of the collapsed (mini) dock outward past the threshold and confirm the expand preview appears, then releases into the expanded state.
5. Verify that dragging without crossing the threshold does not trigger a snap.

## Additional Comments

The snap threshold is defined as `MIN_DOCK_AREA_WIDTH - 20` (200px), giving a small buffer zone before collapse is triggered.