### PR TITLE
fix: v2 - runview url sync

### DIFF
--- a/src/routes/v2/pages/RunView/RunViewV2.tsx
+++ b/src/routes/v2/pages/RunView/RunViewV2.tsx
@@ -47,6 +47,7 @@ import { useAiChatWindow } from "./hooks/useAiChatWindow";
 import { useFocusTaskFromUrl } from "./hooks/useFocusTaskFromUrl";
 import { useRunViewSelectionSync } from "./hooks/useRunViewSelectionSync";
 import { useRunViewSpecLifecycle } from "./hooks/useRunViewSpecLifecycle";
+import { useRunViewSubgraphUrlSync } from "./hooks/useRunViewSubgraphUrlSync";
 import { useRunViewWindows } from "./hooks/useRunViewWindows";
 import { runViewRegistry } from "./nodes";
 import { createRunViewAgentWorker } from "./toolBridge/runViewAgentWorker";
@@ -165,6 +166,7 @@ const RunViewLayout = observer(function RunViewLayout({
   useDockAreaAccordion();
   useRunViewWindows();
   useRunViewSelectionSync();
+  useRunViewSubgraphUrlSync();
   useFocusTaskFromUrl(spec);
 
   const aiEnabled = useFlagValue("ai-assistant");

--- a/src/routes/v2/pages/RunView/hooks/useRunViewSubgraphUrlSync.test.tsx
+++ b/src/routes/v2/pages/RunView/hooks/useRunViewSubgraphUrlSync.test.tsx
@@ -1,0 +1,210 @@
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { makeAutoObservable } from "mobx";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useRunViewSubgraphUrlSync } from "./useRunViewSubgraphUrlSync";
+
+const routerMocks = vi.hoisted(() => ({
+  navigate: vi.fn(),
+  params: {} as Record<string, unknown>,
+}));
+
+const executionDataMock = vi.hoisted(() => ({
+  // Loosely typed on purpose: the hook only reads a small slice of the
+  // execution data context, so tests provide just those fields.
+  current: {} as {
+    runId?: string | null;
+    details?: { child_task_execution_ids?: Record<string, string> };
+    segments?: { taskId: string; executionId: string; taskName: string }[];
+  },
+}));
+
+const sharedStoreMock = vi.hoisted(() => ({
+  navigation: undefined as unknown as MockNavigationStore,
+}));
+
+vi.mock("@tanstack/react-router", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@tanstack/react-router")>();
+  return {
+    ...actual,
+    useNavigate: () => routerMocks.navigate,
+    useParams: () => routerMocks.params,
+  };
+});
+
+vi.mock("@/providers/ExecutionDataProvider", () => ({
+  useExecutionData: () => executionDataMock.current,
+}));
+
+vi.mock("@/routes/v2/shared/store/SharedStoreContext", () => ({
+  useSharedStores: () => ({ navigation: sharedStoreMock.navigation }),
+}));
+
+const ROOT_NAME = "root-pipeline";
+
+/**
+ * Minimal observable stand-in for the V2 NavigationStore exposing just the
+ * surface the hook touches (`navigationPath`, `rootSpec`, and the navigation
+ * actions). Reassigning `navigationPath` triggers the hook's mobx reaction.
+ */
+class MockNavigationStore {
+  navigationPath: { specId: string; displayName: string }[];
+  rootSpec: { name: string } | null;
+
+  constructor(rootName = ROOT_NAME) {
+    this.rootSpec = { name: rootName };
+    this.navigationPath = [{ specId: "root", displayName: rootName }];
+    makeAutoObservable(this);
+  }
+
+  navigateToSubgraph(displayName: string) {
+    this.navigationPath = [
+      ...this.navigationPath,
+      { specId: displayName, displayName },
+    ];
+  }
+
+  navigateToLevel(index: number) {
+    this.navigationPath = this.navigationPath.slice(0, index + 1);
+  }
+
+  navigateToPath(displayNames: string[]) {
+    this.navigationPath = displayNames.map((name) => ({
+      specId: name,
+      displayName: name,
+    }));
+  }
+
+  clearNavigation() {
+    this.navigationPath = [];
+  }
+
+  get displayNames() {
+    return this.navigationPath.map((entry) => entry.displayName);
+  }
+}
+
+const renderSyncHook = () => renderHook(() => useRunViewSubgraphUrlSync());
+
+describe("useRunViewSubgraphUrlSync", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    routerMocks.params = {};
+    sharedStoreMock.navigation = new MockNavigationStore();
+    executionDataMock.current = {
+      runId: "run-1",
+      details: { child_task_execution_ids: {} },
+      segments: [],
+    };
+  });
+
+  afterEach(cleanup);
+
+  it("does not navigate on mount at the root level", () => {
+    renderSyncHook();
+
+    expect(routerMocks.navigate).not.toHaveBeenCalled();
+  });
+
+  it("pushes the child execution id onto the URL when entering a subgraph", () => {
+    executionDataMock.current.details = {
+      child_task_execution_ids: { "sub-task": "exec-sub" },
+    };
+
+    const navigation = sharedStoreMock.navigation;
+    renderSyncHook();
+
+    act(() => navigation.navigateToSubgraph("sub-task"));
+
+    expect(routerMocks.navigate).toHaveBeenCalledTimes(1);
+    expect(routerMocks.navigate).toHaveBeenCalledWith({
+      to: "/runs-v2/run-1/exec-sub",
+    });
+  });
+
+  it("does not navigate when the child execution id cannot be resolved", () => {
+    executionDataMock.current.details = { child_task_execution_ids: {} };
+
+    const navigation = sharedStoreMock.navigation;
+    renderSyncHook();
+
+    act(() => navigation.navigateToSubgraph("sub-task"));
+
+    expect(routerMocks.navigate).not.toHaveBeenCalled();
+  });
+
+  it("drops the subgraph segment when navigating back to the root", () => {
+    const navigation = sharedStoreMock.navigation;
+    navigation.navigateToSubgraph("sub-task");
+
+    renderSyncHook();
+
+    act(() => navigation.navigateToLevel(0));
+
+    expect(routerMocks.navigate).toHaveBeenCalledTimes(1);
+    expect(routerMocks.navigate).toHaveBeenCalledWith({ to: "/runs-v2/run-1" });
+  });
+
+  it("resolves the target execution id from breadcrumb segments when going shallower", () => {
+    executionDataMock.current.segments = [
+      { taskId: "t-a", executionId: "exec-a", taskName: "a" },
+      { taskId: "t-b", executionId: "exec-b", taskName: "b" },
+    ];
+
+    const navigation = sharedStoreMock.navigation;
+    navigation.navigateToSubgraph("a");
+    navigation.navigateToSubgraph("b");
+
+    renderSyncHook();
+
+    act(() => navigation.navigateToLevel(1));
+
+    expect(routerMocks.navigate).toHaveBeenCalledTimes(1);
+    expect(routerMocks.navigate).toHaveBeenCalledWith({
+      to: "/runs-v2/run-1/exec-a",
+    });
+  });
+
+  it("syncs the navigation store from an external subgraph URL without pushing back", () => {
+    routerMocks.params = { subgraphExecutionId: "exec-sub" };
+    executionDataMock.current.segments = [
+      { taskId: "t-sub", executionId: "exec-sub", taskName: "sub-task" },
+    ];
+
+    const navigation = sharedStoreMock.navigation;
+    renderSyncHook();
+
+    expect(navigation.displayNames).toEqual([ROOT_NAME, "sub-task"]);
+    // The URL already matches, so direction A must not push a redundant nav.
+    expect(routerMocks.navigate).not.toHaveBeenCalled();
+  });
+
+  it("does not push a root URL when the navigation store is cleared (unmount / StrictMode remount)", () => {
+    executionDataMock.current.segments = [
+      { taskId: "t-sub", executionId: "exec-sub", taskName: "sub-task" },
+    ];
+
+    const navigation = sharedStoreMock.navigation;
+    navigation.navigateToSubgraph("sub-task");
+
+    renderSyncHook();
+
+    // Simulates the spec-lifecycle cleanup emptying the path while the
+    // direction A reaction is still active.
+    act(() => navigation.clearNavigation());
+
+    expect(routerMocks.navigate).not.toHaveBeenCalled();
+  });
+
+  it("does not resync the navigation store while breadcrumb segments are still loading", () => {
+    routerMocks.params = { subgraphExecutionId: "exec-sub" };
+    executionDataMock.current.segments = [];
+
+    const navigation = sharedStoreMock.navigation;
+    renderSyncHook();
+
+    expect(navigation.displayNames).toEqual([ROOT_NAME]);
+    expect(routerMocks.navigate).not.toHaveBeenCalled();
+  });
+});

--- a/src/routes/v2/pages/RunView/hooks/useRunViewSubgraphUrlSync.ts
+++ b/src/routes/v2/pages/RunView/hooks/useRunViewSubgraphUrlSync.ts
@@ -1,0 +1,127 @@
+import { useNavigate, useParams } from "@tanstack/react-router";
+import { reaction } from "mobx";
+import { useEffect, useRef } from "react";
+
+import { useExecutionData } from "@/providers/ExecutionDataProvider";
+import { getRunPath } from "@/routes/runRoutes";
+import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
+
+/**
+ * Keeps the URL `subgraphExecutionId` in sync with the V2 `navigationStore`
+ * path (and vice versa) so the canvas spec and the execution context stay
+ * aligned when entering/leaving subgraphs.
+ *
+ * Without this, subgraph navigation only updates `navigationStore.activeSpec`
+ * (what the canvas renders) while `ExecutionDataProvider` stays scoped to the
+ * root execution, so task status indicators and artifacts fail to resolve for
+ * subgraph tasks. This mirrors V1 (`TaskNodeCard.handleDoubleClick`), which
+ * pushes the child execution id onto the URL when entering a subgraph.
+ */
+export function useRunViewSubgraphUrlSync() {
+  const navigate = useNavigate();
+  const { navigation } = useSharedStores();
+  const executionData = useExecutionData();
+
+  const params = useParams({ strict: false });
+  const subgraphExecutionId =
+    "subgraphExecutionId" in params &&
+    typeof params.subgraphExecutionId === "string"
+      ? params.subgraphExecutionId
+      : undefined;
+
+  // Refs let the (stable) mobx reaction read the latest values without being
+  // recreated on every data change. Updated in a passive effect to avoid
+  // writing refs during render (React Compiler compatibility).
+  const executionDataRef = useRef(executionData);
+  const navigateRef = useRef(navigate);
+
+  useEffect(() => {
+    executionDataRef.current = executionData;
+    navigateRef.current = navigate;
+  });
+
+  // Set while direction B mutates the navigation store so the direction A
+  // reaction (which fires synchronously) does not push a redundant/incorrect
+  // URL back.
+  const isApplyingFromUrl = useRef(false);
+  // The subgraph execution id we last pushed onto the URL ourselves, used to
+  // distinguish our own URL updates from external ones (back/forward, links,
+  // initial deep-link/refresh). Starts undefined so an initial subgraph URL is
+  // treated as external and synced into the navigation store.
+  const lastPushedExecutionId = useRef<string | undefined>(undefined);
+
+  // Direction A: navigationStore path -> URL subgraphExecutionId.
+  useEffect(() => {
+    const dispose = reaction(
+      () => navigation.navigationPath.map((entry) => entry.displayName),
+      (path, prevPath) => {
+        if (isApplyingFromUrl.current) return;
+
+        // `clearNavigation()` (spec lifecycle cleanup / unmount / StrictMode
+        // remount) empties the path. Ignore it so we never push a stray root
+        // URL that would drop a valid subgraph segment.
+        if (path.length === 0) return;
+
+        const data = executionDataRef.current;
+        const runId = data.runId;
+        if (!runId) return;
+
+        let executionId: string | undefined;
+
+        if (path.length > 1) {
+          const targetDepth = path.length - 1;
+          const isDeepening = path.length > prevPath.length;
+
+          // Deepening happens one level at a time (double-click), so the
+          // current execution details are the parent level and hold the child
+          // execution id. Shallowing (breadcrumbs) reuses the already-resolved
+          // breadcrumb segments for the target level.
+          executionId = isDeepening
+            ? data.details?.child_task_execution_ids?.[path[path.length - 1]]
+            : data.segments[targetDepth - 1]?.executionId;
+
+          if (!executionId) return;
+        }
+
+        const target = getRunPath(runId, "v2", executionId);
+        if (window.location.pathname === target) return;
+
+        lastPushedExecutionId.current = executionId;
+        navigateRef.current({ to: target });
+      },
+    );
+
+    return dispose;
+  }, [navigation]);
+
+  // Direction B: external URL subgraphExecutionId -> navigationStore path.
+  useEffect(() => {
+    // Ignore URL changes we initiated ourselves in direction A.
+    if (subgraphExecutionId === lastPushedExecutionId.current) return;
+
+    const rootName = navigation.rootSpec?.name;
+    if (!rootName) return;
+
+    // The URL points at a subgraph but breadcrumbs have not resolved yet;
+    // wait for them before syncing to avoid collapsing to the root level.
+    if (subgraphExecutionId && executionData.segments.length === 0) return;
+
+    const targetPath = [
+      rootName,
+      ...executionData.segments.map((segment) => segment.taskName),
+    ];
+    const currentPath = navigation.navigationPath.map(
+      (entry) => entry.displayName,
+    );
+
+    const isSamePath =
+      currentPath.length === targetPath.length &&
+      currentPath.every((name, index) => name === targetPath[index]);
+
+    if (isSamePath) return;
+
+    isApplyingFromUrl.current = true;
+    navigation.navigateToPath(targetPath);
+    isApplyingFromUrl.current = false;
+  }, [subgraphExecutionId, executionData.segments, navigation]);
+}


### PR DESCRIPTION
## Description

Adds `useRunViewSubgraphUrlSync`, a new hook that keeps the URL `subgraphExecutionId` parameter in sync with the V2 `navigationStore` path (and vice versa) when entering or leaving subgraphs.

Previously, subgraph navigation only updated `navigationStore.activeSpec` (what the canvas renders) while `ExecutionDataProvider` remained scoped to the root execution. This caused task status indicators and artifacts to fail to resolve for subgraph tasks. The new hook mirrors the V1 behavior (`TaskNodeCard.handleDoubleClick`), which pushes the child execution id onto the URL when entering a subgraph.

The hook handles two sync directions:

- **Direction A (store → URL):** A MobX reaction watches `navigationPath` and pushes the appropriate child execution id onto the URL when the user enters a subgraph (via double-click) or navigates shallower (via breadcrumbs). It ignores `clearNavigation()` calls (spec lifecycle cleanup / StrictMode remount) to avoid dropping valid subgraph URL segments.
- **Direction B (URL → store):** On mount and whenever the URL `subgraphExecutionId` changes externally (back/forward navigation, deep-links, page refresh), the hook syncs the navigation store to match the URL. It waits for breadcrumb segments to resolve before applying the sync to avoid prematurely collapsing to the root level.

A `isApplyingFromUrl` flag prevents the two directions from triggering each other in a feedback loop.

## Screenshots (if applicable)

[Screen Recording 2026-07-16 at 4.19.51 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/0dedd172-4733-4921-9e2d-aa2b291b0c86.mov" />](https://app.graphite.com/user-attachments/video/0dedd172-4733-4921-9e2d-aa2b291b0c86.mov)



## Test Instructions

1. Open a run that contains subgraph tasks in the V2 run view.
2. Double-click a subgraph task node and verify the URL updates to include the child execution id (e.g. `/runs-v2/<runId>/<subgraphExecutionId>`).
3. Confirm task status indicators and artifacts resolve correctly inside the subgraph.
4. Use the breadcrumb navigation to go back to the root and verify the URL drops the subgraph segment.
5. Directly navigate to a subgraph URL (deep-link or page refresh) and verify the canvas and breadcrumbs reflect the correct subgraph level.
6. Use browser back/forward buttons and verify the canvas stays in sync with the URL.

## Additional Comments