### PR TITLE
fix: v2 - keep display name to rootspec

### DIFF
--- a/src/routes/v2/pages/Editor/components/EditorMenuBar/EditorMenuBar.tsx
+++ b/src/routes/v2/pages/Editor/components/EditorMenuBar/EditorMenuBar.tsx
@@ -37,8 +37,7 @@ export const EditorMenuBar = observer(function EditorMenuBar() {
   const { setIsOpen: setTourPopupOpen } = useTour();
   const navigate = useNavigate();
 
-  const spec = navigation.activeSpec;
-  const pipelineNameFromSpec = spec?.name ?? "Untitled pipeline";
+  const pipelineNameFromSpec = navigation.rootSpec?.name ?? "Untitled pipeline";
   const displayName =
     tourMode?.tour.displayName ?? tourMode?.tour.id ?? pipelineNameFromSpec;
 

--- a/src/routes/v2/pages/RunView/components/RunViewMenuBar/RunViewMenuBar.tsx
+++ b/src/routes/v2/pages/RunView/components/RunViewMenuBar/RunViewMenuBar.tsx
@@ -15,8 +15,8 @@ import { RunViewWindowsMenu } from "./components/RunViewWindowsMenu";
 
 export const RunViewMenuBar = observer(function RunViewMenuBar() {
   const { navigation } = useSharedStores();
-  const spec = navigation.activeSpec;
-  const pipelineName = spec?.name ?? "Pipeline Run";
+
+  const pipelineName = navigation.rootSpec?.name ?? "Pipeline Run";
 
   return (
     <div


### PR DESCRIPTION
## Description

Both the `EditorMenuBar` and `RunViewMenuBar` now use `navigation.rootSpec` instead of `navigation.activeSpec` when resolving the pipeline display name. This ensures the pipeline name shown in the menu bar always reflects the root-level pipeline, rather than whichever spec is currently active (which may be a nested or child spec).

## Screenshots (if applicable)

[Screen Recording 2026-07-16 at 4.23.27 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/6e96afad-3122-4c2d-88d7-3879a0f51d98.mov" />](https://app.graphite.com/user-attachments/video/6e96afad-3122-4c2d-88d7-3879a0f51d98.mov)



## Test Instructions

1. Open a pipeline in the Editor and verify the menu bar displays the root pipeline name correctly, including when navigating into nested specs.
2. Open a pipeline run in the Run View and verify the menu bar displays the root pipeline name rather than any active sub-spec name.

## Additional Comments