### PR TITLE
Show subgraph child execution progress in task node cards

### DIFF
--- a/src/components/shared/Status/TaskStatusBar.tsx
+++ b/src/components/shared/Status/TaskStatusBar.tsx
@@ -66,13 +66,19 @@ const StatusSegment = ({
   );
 };
 
+interface TaskStatusBarProps {
+  executionStatusStats?: ExecutionStatusStats | null;
+  barClassName?: string;
+}
+
 const TaskStatusBar = ({
   executionStatusStats,
-}: {
-  executionStatusStats?: ExecutionStatusStats | null;
-}) => {
+  barClassName,
+}: TaskStatusBarProps) => {
   if (!executionStatusStats) {
-    return <InlineStack wrap="nowrap" className={BAR_CLASS} />;
+    return (
+      <InlineStack wrap="nowrap" className={cn(BAR_CLASS, barClassName)} />
+    );
   }
 
   const entries = Object.entries(executionStatusStats).filter(
@@ -80,7 +86,9 @@ const TaskStatusBar = ({
   );
 
   if (entries.length === 0) {
-    return <InlineStack wrap="nowrap" className={BAR_CLASS} />;
+    return (
+      <InlineStack wrap="nowrap" className={cn(BAR_CLASS, barClassName)} />
+    );
   }
 
   const total = entries.reduce((sum, [, count]) => sum + (count ?? 0), 0);
@@ -101,7 +109,7 @@ const TaskStatusBar = ({
 
   return (
     <BlockStack className="relative">
-      <InlineStack wrap="nowrap" className={BAR_CLASS}>
+      <InlineStack wrap="nowrap" className={cn(BAR_CLASS, barClassName)}>
         {sortedEntries.map(([status, count]) => (
           <StatusSegment
             key={status}

--- a/src/routes/v2/pages/RunView/nodes/TaskNode/RunViewTaskNode.tsx
+++ b/src/routes/v2/pages/RunView/nodes/TaskNode/RunViewTaskNode.tsx
@@ -19,8 +19,14 @@ export const RunViewTaskNode = observer(function RunViewTaskNode(
 ) {
   const { entityId } = props.data;
   const { windows } = useSharedStores();
-  const { task, status, disabledCache, executionId, showLogsButton } =
-    useTaskRunStatus(entityId);
+  const {
+    task,
+    status,
+    disabledCache,
+    executionId,
+    showLogsButton,
+    subgraphExecutionStats,
+  } = useTaskRunStatus(entityId);
 
   const handleOpenLogs = () => {
     if (!task || !executionId) return;
@@ -49,7 +55,7 @@ export const RunViewTaskNode = observer(function RunViewTaskNode(
         </Button>
       )}
 
-      <TaskNode {...props} />
+      <TaskNode {...props} subgraphExecutionStats={subgraphExecutionStats} />
     </div>
   );
 });

--- a/src/routes/v2/pages/RunView/nodes/TaskNode/useTaskRunStatus.test.ts
+++ b/src/routes/v2/pages/RunView/nodes/TaskNode/useTaskRunStatus.test.ts
@@ -1,0 +1,83 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { useExecutionDataOptionalMock, useSpecMock } = vi.hoisted(() => ({
+  useExecutionDataOptionalMock: vi.fn(),
+  useSpecMock: vi.fn(),
+}));
+
+vi.mock(
+  "@/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/logs",
+  () => ({
+    shouldStatusHaveLogs: (status: string | undefined) => status === "RUNNING",
+  }),
+);
+
+vi.mock("@/providers/ExecutionDataProvider", () => ({
+  useExecutionDataOptional: useExecutionDataOptionalMock,
+}));
+
+vi.mock("@/routes/v2/shared/providers/SpecContext", () => ({
+  useSpec: useSpecMock,
+}));
+
+import { useTaskRunStatus } from "./useTaskRunStatus";
+
+const executionData = {
+  taskExecutionStatusMap: new Map([["subgraph-task", "RUNNING"]]),
+  details: {
+    child_task_execution_ids: {
+      "subgraph-task": "subgraph-execution-1",
+    },
+  },
+  state: {
+    child_execution_status_stats: {
+      "subgraph-execution-1": {
+        SUCCEEDED: 2,
+        RUNNING: 1,
+      },
+    },
+  },
+};
+
+describe("useTaskRunStatus", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useExecutionDataOptionalMock.mockReturnValue(executionData);
+  });
+
+  it("returns child execution progress for a subgraph task", () => {
+    useSpecMock.mockReturnValue({
+      tasks: [
+        {
+          $id: "task-1",
+          name: "subgraph-task",
+          subgraphSpec: {},
+        },
+      ],
+    });
+
+    const { result } = renderHook(() => useTaskRunStatus("task-1"));
+
+    expect(result.current.subgraphExecutionStats).toEqual({
+      SUCCEEDED: 2,
+      RUNNING: 1,
+    });
+  });
+
+  it("does not return child progress for a container task", () => {
+    useSpecMock.mockReturnValue({
+      tasks: [
+        {
+          $id: "task-1",
+          name: "subgraph-task",
+          subgraphSpec: undefined,
+        },
+      ],
+    });
+
+    const { result } = renderHook(() => useTaskRunStatus("task-1"));
+
+    expect(result.current.subgraphExecutionStats).toBeNull();
+  });
+});

--- a/src/routes/v2/pages/RunView/nodes/TaskNode/useTaskRunStatus.ts
+++ b/src/routes/v2/pages/RunView/nodes/TaskNode/useTaskRunStatus.ts
@@ -3,6 +3,7 @@ import type { Task } from "@/models/componentSpec";
 import { useExecutionDataOptional } from "@/providers/ExecutionDataProvider";
 import { useSpec } from "@/routes/v2/shared/providers/SpecContext";
 import { ISO8601_DURATION_ZERO_DAYS } from "@/utils/constants";
+import type { ExecutionStatusStats } from "@/utils/executionStatus";
 
 interface TaskRunStatus {
   task: Task | undefined;
@@ -10,6 +11,7 @@ interface TaskRunStatus {
   disabledCache: boolean;
   executionId: string | undefined;
   showLogsButton: boolean;
+  subgraphExecutionStats: ExecutionStatusStats | null;
 }
 
 function resolveStatus(
@@ -28,6 +30,17 @@ function resolveExecutionId(
   return executionData?.details?.child_task_execution_ids?.[taskName];
 }
 
+function resolveSubgraphExecutionStats(
+  task: Task | undefined,
+  executionId: string | undefined,
+  executionData: ReturnType<typeof useExecutionDataOptional>,
+): ExecutionStatusStats | null {
+  if (!task?.subgraphSpec || !executionId) return null;
+  return (
+    executionData?.state?.child_execution_status_stats?.[executionId] ?? null
+  );
+}
+
 export function useTaskRunStatus(entityId: string): TaskRunStatus {
   const executionData = useExecutionDataOptional();
   const spec = useSpec();
@@ -40,6 +53,18 @@ export function useTaskRunStatus(entityId: string): TaskRunStatus {
 
   const executionId = resolveExecutionId(task, executionData);
   const showLogsButton = !!executionId && shouldStatusHaveLogs(status);
+  const subgraphExecutionStats = resolveSubgraphExecutionStats(
+    task,
+    executionId,
+    executionData,
+  );
 
-  return { task, status, disabledCache, executionId, showLogsButton };
+  return {
+    task,
+    status,
+    disabledCache,
+    executionId,
+    showLogsButton,
+    subgraphExecutionStats,
+  };
 }

--- a/src/routes/v2/shared/nodes/TaskNode/TaskNode.tsx
+++ b/src/routes/v2/shared/nodes/TaskNode/TaskNode.tsx
@@ -25,12 +25,15 @@ import {
   TASK_COLOR_ANNOTATION,
 } from "@/utils/annotations";
 import { ISO8601_DURATION_ZERO_DAYS } from "@/utils/constants";
+import type { ExecutionStatusStats } from "@/utils/executionStatus";
 
 import { TaskNodeCard } from "./TaskNodeCard";
 import { TaskNodeSimplified } from "./TaskNodeSimplified";
 
 type TaskNodeType = Node<TaskNodeData, "task">;
-type TaskNodeProps = NodeProps<TaskNodeType>;
+type TaskNodeProps = NodeProps<TaskNodeType> & {
+  subgraphExecutionStats?: ExecutionStatusStats | null;
+};
 
 export interface TaskNodeInput {
   name: string;
@@ -64,6 +67,7 @@ export interface TaskNodeViewProps {
   inputDisplayValues: Record<string, string | undefined>;
   isAggregator: boolean;
   outputType: AggregatorOutputType;
+  subgraphExecutionStats?: ExecutionStatusStats | null;
   onOutputTypeChange: (value: AggregatorOutputType) => void;
   onNodeClick: (event: MouseEvent) => void;
   onInputClick: (inputName: string, event: MouseEvent) => void;
@@ -208,6 +212,7 @@ export const TaskNode = observer(function TaskNode({
   id,
   data,
   selected,
+  subgraphExecutionStats,
 }: TaskNodeProps) {
   const { entityId } = data;
   const { editor, canvasOverlay } = useSharedStores();
@@ -290,6 +295,7 @@ export const TaskNode = observer(function TaskNode({
       ISO8601_DURATION_ZERO_DAYS,
     isAggregator,
     outputType: resolveAggregatorOutputType(task),
+    subgraphExecutionStats,
     onOutputTypeChange: handleOutputTypeChange,
     digest: task.componentRef.digest,
     inputDisplayValues: resolveInputDisplayValues(task, entityId, spec),

--- a/src/routes/v2/shared/nodes/TaskNode/TaskNodeCard.test.tsx
+++ b/src/routes/v2/shared/nodes/TaskNode/TaskNodeCard.test.tsx
@@ -1,0 +1,84 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { AggregatorOutputType } from "@/types/aggregator";
+
+import type { TaskNodeViewProps } from "./TaskNode";
+import { TaskNodeCard } from "./TaskNodeCard";
+import { TaskNodeSimplified } from "./TaskNodeSimplified";
+
+vi.mock("@/providers/ThemeProvider", () => ({
+  useTheme: () => ({ resolvedTheme: "light" }),
+}));
+
+const buildProps = (
+  overrides: Partial<TaskNodeViewProps> = {},
+): TaskNodeViewProps => ({
+  id: "node-task-1",
+  entityId: "task-1",
+  taskName: "Subgraph task",
+  selected: false,
+  isHovered: false,
+  isSubgraph: true,
+  collapsed: false,
+  description: "",
+  inputs: [],
+  outputs: [],
+  connectedInputNames: new Set(),
+  connectedOutputNames: new Set(),
+  annotations: [],
+  cacheDisabled: false,
+  inputDisplayValues: {},
+  isAggregator: false,
+  outputType: AggregatorOutputType.JsonArray,
+  onOutputTypeChange: vi.fn(),
+  onNodeClick: vi.fn(),
+  onInputClick: vi.fn(),
+  onOutputClick: vi.fn(),
+  onHandleClick: vi.fn(),
+  ...overrides,
+});
+
+afterEach(cleanup);
+
+describe("TaskNodeCard", () => {
+  it("shows child execution progress for a subgraph", () => {
+    render(
+      <TaskNodeCard
+        {...buildProps({
+          subgraphExecutionStats: { SUCCEEDED: 2, RUNNING: 1 },
+        })}
+      />,
+    );
+
+    expect(screen.getByLabelText("2 Succeeded")).toBeInTheDocument();
+    expect(screen.getByLabelText("1 Running")).toBeInTheDocument();
+  });
+
+  it("shows child execution progress in the simplified subgraph card", () => {
+    render(
+      <TaskNodeSimplified
+        {...buildProps({
+          subgraphExecutionStats: { SUCCEEDED: 2, RUNNING: 1 },
+        })}
+      />,
+    );
+
+    expect(screen.getByLabelText("2 Succeeded")).toBeInTheDocument();
+    expect(screen.getByLabelText("1 Running")).toBeInTheDocument();
+  });
+
+  it("does not show child execution progress for a container task", () => {
+    render(
+      <TaskNodeCard
+        {...buildProps({
+          isSubgraph: false,
+          subgraphExecutionStats: { SUCCEEDED: 2, RUNNING: 1 },
+        })}
+      />,
+    );
+
+    expect(screen.queryByLabelText("2 Succeeded")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("1 Running")).not.toBeInTheDocument();
+  });
+});

--- a/src/routes/v2/shared/nodes/TaskNode/TaskNodeCard.tsx
+++ b/src/routes/v2/shared/nodes/TaskNode/TaskNodeCard.tsx
@@ -5,6 +5,7 @@ import { type MouseEvent as ReactMouseEvent, useEffect, useState } from "react";
 
 import { trimDigest } from "@/components/shared/ManageComponent/utils/digest";
 import { OutputTypeSelector } from "@/components/shared/ReactFlow/FlowCanvas/TaskNode/OutputTypeSelector/OutputTypeSelector";
+import TaskStatusBar from "@/components/shared/Status/TaskStatusBar";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Icon } from "@/components/ui/icon";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
@@ -215,6 +216,7 @@ export const TaskNodeCard = observer(function TaskNodeCard({
   digest,
   isAggregator,
   outputType,
+  subgraphExecutionStats,
   onOutputTypeChange,
 }: TaskNodeViewProps) {
   const isDark = useTheme().resolvedTheme === "dark";
@@ -344,6 +346,9 @@ export const TaskNodeCard = observer(function TaskNodeCard({
       </CardHeader>
 
       <CardContent className="p-2 flex flex-col gap-2">
+        {isSubgraph && subgraphExecutionStats && (
+          <TaskStatusBar executionStatusStats={subgraphExecutionStats} />
+        )}
         {showInputsSection && (
           <div
             className={cn(

--- a/src/routes/v2/shared/nodes/TaskNode/TaskNodeSimplified.tsx
+++ b/src/routes/v2/shared/nodes/TaskNode/TaskNodeSimplified.tsx
@@ -1,5 +1,6 @@
 import { Handle, Position } from "@xyflow/react";
 
+import TaskStatusBar from "@/components/shared/Status/TaskStatusBar";
 import { Card } from "@/components/ui/card";
 import { Icon } from "@/components/ui/icon";
 import {
@@ -24,7 +25,7 @@ const PERCEIVED_FONT_SIZE = "32px";
 const s = "var(--simplified-scale, 1)";
 
 const simplifiedCardVariants = createTaskNodeCardVariants(
-  "flex flex-col justify-center rounded-xl border-2 p-0 drop-shadow-sm cursor-pointer select-none transition-[border-color,box-shadow]",
+  "relative flex flex-col justify-center rounded-xl border-2 p-0 drop-shadow-sm cursor-pointer select-none transition-[border-color,box-shadow]",
 );
 
 export function TaskNodeSimplified({
@@ -36,11 +37,13 @@ export function TaskNodeSimplified({
   isHovered,
   taskColor,
   isAggregator,
+  subgraphExecutionStats,
   onNodeClick,
 }: TaskNodeViewProps) {
   const isDark = useTheme().resolvedTheme === "dark";
   const palette = taskColor ? deriveColorPalette(taskColor, isDark) : undefined;
   const headerTextColor = palette?.text;
+  const showSubgraphProgress = isSubgraph && !!subgraphExecutionStats;
 
   const visibleInputs = isAggregator
     ? inputs.filter((input) => !AGGREGATOR_INTERNAL_INPUTS.has(input.name))
@@ -101,7 +104,9 @@ export function TaskNodeSimplified({
       <div
         className="flex items-center w-full h-full"
         style={{
-          padding: `calc(${s} * 14px) calc(${s} * 18px)`,
+          padding: showSubgraphProgress
+            ? `calc(${s} * 10px) calc(${s} * 18px) calc(${s} * 26px)`
+            : `calc(${s} * 14px) calc(${s} * 18px)`,
           gap: `calc(${s} * 10px)`,
         }}
       >
@@ -124,7 +129,8 @@ export function TaskNodeSimplified({
           <TooltipTrigger asChild>
             <span
               className={cn(
-                "font-medium min-w-0 line-clamp-2 wrap-break-word",
+                "font-medium min-w-0 wrap-break-word",
+                showSubgraphProgress ? "line-clamp-1" : "line-clamp-2",
                 !palette && "text-card-foreground",
               )}
               style={{
@@ -138,6 +144,22 @@ export function TaskNodeSimplified({
           <TooltipContent side="top">{taskName}</TooltipContent>
         </Tooltip>
       </div>
+
+      {showSubgraphProgress && (
+        <div
+          className="absolute"
+          style={{
+            left: `calc(${s} * 18px)`,
+            right: `calc(${s} * 18px)`,
+            bottom: `calc(${s} * 10px)`,
+          }}
+        >
+          <TaskStatusBar
+            executionStatusStats={subgraphExecutionStats}
+            barClassName="h-[calc(var(--simplified-scale,1)*8px)]"
+          />
+        </div>
+      )}
 
       {outputs.map((output) => (
         <Handle


### PR DESCRIPTION
## Description

Subgraph task nodes in the Run View now display a child execution progress bar showing the status breakdown (e.g. Succeeded, Running, Failed) of tasks within the subgraph. The progress bar appears in both the full `TaskNodeCard` and the simplified `TaskNodeSimplified` views, and is only shown for subgraph tasks (not container tasks).

`useTaskRunStatus` now resolves `subgraphExecutionStats` by looking up the child execution's status stats from `child_execution_status_stats` using the task's execution ID. This is only populated when the task has a `subgraphSpec`. The stats are passed down through `RunViewTaskNode` → `TaskNode` → `TaskNodeCard` / `TaskNodeSimplified`.

`TaskStatusBar` now accepts an optional `barClassName` prop, allowing callers to customize the bar's appearance — used in the simplified node to scale the bar height with the node's zoom scale variable.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)



![image.png](https://app.graphite.com/user-attachments/assets/a8a2d352-93f1-43b3-8cfe-5d55d13286f2.png)

![image.png](https://app.graphite.com/user-attachments/assets/8e984f7e-4b70-4911-9017-0d499ea7df67.png)

![image.png](https://app.graphite.com/user-attachments/assets/da2af576-1741-4e77-a466-a3eef9dc0a61.png)

![image.png](https://app.graphite.com/user-attachments/assets/5afafee4-9fef-4dd8-a91d-589e08d52598.png)



## Test Instructions

1. Open a run that contains a subgraph task.
2. Verify that the subgraph task node displays a status bar reflecting the child execution progress (e.g. how many child tasks have Succeeded, are Running, etc.).
3. Verify that regular container task nodes do not display a status bar.
4. Zoom out to the simplified node view and confirm the status bar is visible and scales correctly with the node.

## Additional Comments

Unit tests cover the `useTaskRunStatus` hook to confirm `subgraphExecutionStats` is returned for subgraph tasks and is `null` for container tasks. `TaskNodeCard` tests verify the progress bar renders for subgraph tasks and is absent for container tasks.