### PR TITLE
Add published component badge to task nodes in run view

### DIFF
--- a/src/routes/v2/pages/RunView/RunViewV2.tsx
+++ b/src/routes/v2/pages/RunView/RunViewV2.tsx
@@ -19,6 +19,7 @@ import {
   YamlDeserializer,
 } from "@/models/componentSpec";
 import { useBackend } from "@/providers/BackendProvider";
+import { ComponentLibraryProvider } from "@/providers/ComponentLibraryProvider";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 import { ContextPanelProvider } from "@/providers/ContextPanelProvider";
 import {
@@ -232,7 +233,9 @@ export function RunViewV2() {
                 pipelineRunId={id}
                 subgraphExecutionId={subgraphExecutionId}
               >
-                <RunViewContent runId={id} />
+                <ComponentLibraryProvider>
+                  <RunViewContent runId={id} />
+                </ComponentLibraryProvider>
               </ExecutionDataProvider>
             </ContextPanelProvider>
           </ReactFlowProvider>

--- a/src/routes/v2/pages/RunView/nodes/TaskNode/RunViewTaskNode.tsx
+++ b/src/routes/v2/pages/RunView/nodes/TaskNode/RunViewTaskNode.tsx
@@ -55,7 +55,11 @@ export const RunViewTaskNode = observer(function RunViewTaskNode(
         </Button>
       )}
 
-      <TaskNode {...props} subgraphExecutionStats={subgraphExecutionStats} />
+      <TaskNode
+        {...props}
+        subgraphExecutionStats={subgraphExecutionStats}
+        publishedComponentBadgeReadOnly
+      />
     </div>
   );
 });

--- a/src/routes/v2/shared/nodes/TaskNode/TaskNode.tsx
+++ b/src/routes/v2/shared/nodes/TaskNode/TaskNode.tsx
@@ -8,6 +8,7 @@ import { Card } from "@/components/ui/card";
 import { Text } from "@/components/ui/typography";
 import { cn } from "@/lib/utils";
 import type {
+  ComponentReference,
   ComponentSpec,
   ComponentSpecJson,
   Task,
@@ -35,6 +36,7 @@ import { TaskNodeSimplified } from "./TaskNodeSimplified";
 type TaskNodeType = Node<TaskNodeData, "task">;
 type TaskNodeProps = NodeProps<TaskNodeType> & {
   subgraphExecutionStats?: ExecutionStatusStats | null;
+  publishedComponentBadgeReadOnly?: boolean;
 };
 
 export interface TaskNodeInput {
@@ -65,7 +67,9 @@ export interface TaskNodeViewProps {
   annotations: { key: string }[];
   taskColor?: string;
   cacheDisabled: boolean;
+  componentRef?: ComponentReference;
   digest?: string;
+  publishedComponentBadgeReadOnly?: boolean;
   inputDisplayValues: Record<string, string | undefined>;
   secretInputNames: Set<string>;
   isAggregator: boolean;
@@ -231,12 +235,16 @@ export const TaskNode = observer(function TaskNode({
   data,
   selected,
   subgraphExecutionStats,
+  publishedComponentBadgeReadOnly = false,
 }: TaskNodeProps) {
   const { entityId } = data;
   const { editor, canvasOverlay } = useSharedStores();
   const { getEdges, setEdges } = useReactFlow();
   const showContent = useIsDetailedView();
   const inputAggregatorEnabled = useFlagValue("input-aggregator");
+  const publishedComponentBadgeEnabled = useFlagValue(
+    "remote-component-library-search",
+  );
 
   const spec = useSpec();
   const task = spec?.tasks.find((t) => t.$id === entityId);
@@ -312,6 +320,10 @@ export const TaskNode = observer(function TaskNode({
     cacheDisabled:
       task.executionOptions?.cachingStrategy?.maxCacheStaleness ===
       ISO8601_DURATION_ZERO_DAYS,
+    componentRef: publishedComponentBadgeEnabled
+      ? task.componentRef
+      : undefined,
+    publishedComponentBadgeReadOnly,
     isAggregator,
     outputType: resolveAggregatorOutputType(task),
     subgraphExecutionStats,

--- a/src/routes/v2/shared/nodes/TaskNode/TaskNodeCard.tsx
+++ b/src/routes/v2/shared/nodes/TaskNode/TaskNodeCard.tsx
@@ -3,6 +3,7 @@ import { cva } from "class-variance-authority";
 import { observer } from "mobx-react-lite";
 import { type MouseEvent as ReactMouseEvent, useEffect, useState } from "react";
 
+import { PublishedComponentBadge } from "@/components/shared/ManageComponent/PublishedComponentBadge";
 import { trimDigest } from "@/components/shared/ManageComponent/utils/digest";
 import { OutputTypeSelector } from "@/components/shared/ReactFlow/FlowCanvas/TaskNode/OutputTypeSelector/OutputTypeSelector";
 import TaskStatusBar from "@/components/shared/Status/TaskStatusBar";
@@ -227,7 +228,9 @@ export const TaskNodeCard = observer(function TaskNodeCard({
   onHandleClick,
   taskColor,
   cacheDisabled,
+  componentRef,
   digest,
+  publishedComponentBadgeReadOnly,
   isAggregator,
   outputType,
   subgraphExecutionStats,
@@ -274,6 +277,17 @@ export const TaskNodeCard = observer(function TaskNodeCard({
   const showCondensedOutputs =
     collapsed && !outputsExpanded && hiddenOutputCount > 0;
   const visibleOutputs = showCondensedOutputs ? condensedOutputs : outputs;
+  const digestMarkup = digest ? (
+    <span
+      className={cn(
+        "text-xs font-light font-mono shrink-0",
+        !componentRef && !palette && "text-muted-foreground",
+      )}
+      style={!componentRef && palette ? { color: palette.text } : undefined}
+    >
+      {trimDigest(digest)}
+    </span>
+  ) : null;
 
   return (
     <Card
@@ -344,16 +358,15 @@ export const TaskNodeCard = observer(function TaskNodeCard({
                 {taskName}
               </CardTitle>
             </InlineStack>
-            {digest && (
-              <span
-                className={cn(
-                  "text-xs font-light font-mono shrink-0",
-                  !palette && "text-muted-foreground",
-                )}
-                style={palette ? { color: palette.text } : undefined}
+            {digestMarkup && componentRef ? (
+              <PublishedComponentBadge
+                componentRef={componentRef}
+                readOnly={publishedComponentBadgeReadOnly}
               >
-                {trimDigest(digest)}
-              </span>
+                {digestMarkup}
+              </PublishedComponentBadge>
+            ) : (
+              digestMarkup
             )}
           </InlineStack>
         </BlockStack>

--- a/src/routes/v2/shared/nodes/TaskNode/TaskNodePublishedComponentBadge.test.tsx
+++ b/src/routes/v2/shared/nodes/TaskNode/TaskNodePublishedComponentBadge.test.tsx
@@ -1,0 +1,96 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import type { PropsWithChildren } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { AggregatorOutputType } from "@/types/aggregator";
+import type { ComponentReference } from "@/utils/componentSpec";
+
+import type { TaskNodeViewProps } from "./TaskNode";
+import { TaskNodeCard } from "./TaskNodeCard";
+
+vi.mock("@/components/shared/ManageComponent/PublishedComponentBadge", () => ({
+  PublishedComponentBadge: ({
+    children,
+    componentRef,
+    readOnly,
+  }: PropsWithChildren<{
+    componentRef: ComponentReference;
+    readOnly?: boolean;
+  }>) => (
+    <div
+      data-testid="published-component-badge"
+      data-component-digest={componentRef.digest}
+      data-read-only={readOnly}
+    >
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock("@/providers/ThemeProvider", () => ({
+  useTheme: () => ({ resolvedTheme: "light" }),
+}));
+
+const componentRef = {
+  digest: "9c9388aa60fe27b6",
+  name: "Relevance",
+};
+
+const buildProps = (
+  overrides: Partial<TaskNodeViewProps> = {},
+): TaskNodeViewProps => ({
+  id: "node-task-1",
+  entityId: "task-1",
+  taskName: "Relevance",
+  selected: false,
+  isHovered: false,
+  isSubgraph: false,
+  collapsed: false,
+  description: "",
+  inputs: [],
+  outputs: [],
+  connectedInputNames: new Set(),
+  connectedOutputNames: new Set(),
+  annotations: [],
+  cacheDisabled: false,
+  componentRef,
+  digest: componentRef.digest,
+  inputDisplayValues: {},
+  secretInputNames: new Set(),
+  isAggregator: false,
+  outputType: AggregatorOutputType.JsonArray,
+  onOutputTypeChange: vi.fn(),
+  onNodeClick: vi.fn(),
+  onInputClick: vi.fn(),
+  onOutputClick: vi.fn(),
+  onHandleClick: vi.fn(),
+  ...overrides,
+});
+
+afterEach(cleanup);
+
+describe("TaskNodeCard published component badge", () => {
+  it("wraps the digest in a read-only published badge for run views", () => {
+    render(
+      <TaskNodeCard
+        {...buildProps({ publishedComponentBadgeReadOnly: true })}
+      />,
+    );
+
+    const badge = screen.getByTestId("published-component-badge");
+    expect(badge).toHaveAttribute("data-component-digest", componentRef.digest);
+    expect(badge).toHaveAttribute("data-read-only", "true");
+    expect(screen.getByText("9c9388aa")).not.toHaveClass(
+      "text-muted-foreground",
+    );
+  });
+
+  it("keeps the plain digest when the badge is disabled", () => {
+    render(<TaskNodeCard {...buildProps({ componentRef: undefined })} />);
+
+    expect(
+      screen.queryByTestId("published-component-badge"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("9c9388aa")).toHaveClass("text-muted-foreground");
+  });
+});


### PR DESCRIPTION
## Description

The digest shown on task nodes in the run view is now wrapped in a `PublishedComponentBadge` when the `remote-component-library-search` feature flag is enabled and the task has a `componentRef`. In the run view specifically, the badge is rendered in read-only mode so users can view published component details without being able to make edits.

The `ComponentLibraryProvider` has been added around `RunViewContent` to supply the context required by the badge. The digest styling was also adjusted so that the muted color is only applied when there is no `componentRef` (i.e. when the badge is not shown).

## Related Issue and Pull requests

closes: https://github.com/TangleML/tangle-ui/issues/2543

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

![image.png](https://app.graphite.com/user-attachments/assets/72631af6-fd5f-43a8-85a5-1e6228d04fce.png)

![image.png](https://app.graphite.com/user-attachments/assets/e3d7daf8-fa26-45aa-8262-7db6f54309de.png)

## Test Instructions

1. Enable the `remote-component-library-search` feature flag.
2. Open a run that contains tasks with a `componentRef` and a digest.
3. Confirm the digest on each task node is wrapped in a `PublishedComponentBadge` and that clicking it opens the published component details in read-only mode.
4. Disable the feature flag and confirm the plain digest is displayed as before with the muted color applied.
5. Verify that tasks without a `componentRef` continue to show the plain muted digest regardless of the flag.

## Additional Comments

Unit tests covering both the read-only badge path and the plain digest fallback have been added in `TaskNodePublishedComponentBadge.test.tsx`.