### PR TITLE
Replace default Controls with FlowControls and add accessibility labels in canvas views

### DIFF
--- a/src/components/shared/ReactFlow/FlowControls/FlowControls.test.tsx
+++ b/src/components/shared/ReactFlow/FlowControls/FlowControls.test.tsx
@@ -1,0 +1,84 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { type ReactFlowProps, ReactFlowProvider } from "@xyflow/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import FlowControls from "./FlowControls";
+
+vi.mock("@/providers/AnalyticsProvider", () => ({
+  useAnalytics: () => ({ track: vi.fn() }),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+const config: ReactFlowProps = {
+  nodesDraggable: true,
+  panOnDrag: true,
+  selectionOnDrag: false,
+};
+
+function renderControls({
+  updateConfig = vi.fn(),
+  onAutoLayout = vi.fn(),
+}: {
+  updateConfig?: (updatedConfig: Partial<ReactFlowProps>) => void;
+  onAutoLayout?: () => void;
+} = {}) {
+  render(
+    <ReactFlowProvider>
+      <FlowControls
+        config={config}
+        updateConfig={updateConfig}
+        onAutoLayout={onAutoLayout}
+        showInteractive={false}
+      />
+    </ReactFlowProvider>,
+  );
+
+  return { updateConfig, onAutoLayout };
+}
+
+describe("FlowControls", () => {
+  it("renders viewport controls and toggles canvas interaction modes", () => {
+    const { updateConfig } = renderControls();
+
+    expect(screen.getByLabelText("Zoom In")).toBeInTheDocument();
+    expect(screen.getByLabelText("Zoom Out")).toBeInTheDocument();
+    expect(screen.getByLabelText("Fit View")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Lock nodes" }));
+    expect(updateConfig).toHaveBeenCalledWith({ nodesDraggable: false });
+    expect(
+      screen.getByRole("button", { name: "Unlock nodes" }),
+    ).toHaveAttribute("aria-pressed", "true");
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Enable area selection" }),
+    );
+    expect(updateConfig).toHaveBeenCalledWith({
+      selectionOnDrag: true,
+      panOnDrag: false,
+    });
+  });
+
+  it("runs the selected auto-layout algorithm", async () => {
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+      callback(0);
+      return 0;
+    });
+    const { onAutoLayout } = renderControls();
+
+    fireEvent.click(screen.getByRole("button", { name: "Auto layout" }));
+    fireEvent.click(screen.getByRole("button", { name: /Sugiyama.*Layered/ }));
+
+    await waitFor(() => expect(onAutoLayout).toHaveBeenCalledWith("sugiyama"));
+  });
+});

--- a/src/components/shared/ReactFlow/FlowControls/FlowControls.tsx
+++ b/src/components/shared/ReactFlow/FlowControls/FlowControls.tsx
@@ -98,6 +98,11 @@ export default function FlowControls({
     }
   };
 
+  const lockLabel = lockActive ? "Unlock nodes" : "Lock nodes";
+  const areaSelectLabel = multiSelectActive
+    ? "Disable area selection"
+    : "Enable area selection";
+
   return (
     <Controls
       {...props}
@@ -109,6 +114,9 @@ export default function FlowControls({
         <ControlButton
           onClick={handleLockChange}
           className={cn(lockActive && "bg-gray-100! dark:bg-accent!")}
+          aria-label={lockLabel}
+          aria-pressed={lockActive}
+          title={lockLabel}
           {...tracking("pipeline_canvas.tool_bar.tool", {
             tool: "lock_unlock",
             page_type: pageType,
@@ -124,6 +132,9 @@ export default function FlowControls({
       <ControlButton
         onClick={onClickMultiSelect}
         className={cn(multiSelectActive && "bg-gray-100! dark:bg-accent!")}
+        aria-label={areaSelectLabel}
+        aria-pressed={multiSelectActive}
+        title={areaSelectLabel}
         {...tracking("pipeline_canvas.tool_bar.tool", {
           tool: "area_select",
           page_type: pageType,
@@ -134,7 +145,11 @@ export default function FlowControls({
       {onAutoLayout && (
         <Popover open={layoutPopoverOpen} onOpenChange={setLayoutPopoverOpen}>
           <PopoverTrigger asChild>
-            <ControlButton disabled={isLayouting}>
+            <ControlButton
+              disabled={isLayouting}
+              aria-label="Auto layout"
+              title="Auto layout"
+            >
               {isLayouting ? (
                 <Spinner className="fill-none! scale-120" />
               ) : (

--- a/src/routes/v2/pages/Editor/components/FlowCanvas/FlowCanvas.tsx
+++ b/src/routes/v2/pages/Editor/components/FlowCanvas/FlowCanvas.tsx
@@ -1,14 +1,16 @@
 import {
   Background,
-  Controls,
   MiniMap,
   ReactFlow,
   type ReactFlowInstance,
+  type ReactFlowProps,
   useConnection,
 } from "@xyflow/react";
 import { observer } from "mobx-react-lite";
 import { useState } from "react";
 
+import type { LayoutAlgorithm } from "@/components/shared/ReactFlow/FlowCanvas/utils/autolayout";
+import FlowControls from "@/components/shared/ReactFlow/FlowControls/FlowControls";
 import { BlockStack } from "@/components/ui/layout";
 import { cn } from "@/lib/utils";
 import type { ComponentSpec } from "@/models/componentSpec";
@@ -53,6 +55,11 @@ export const FlowCanvas = observer(function FlowCanvas({
   const { containerRef, handleViewportChange } = useViewportScaling();
   const [reactFlowInstance, setReactFlowInstance] =
     useState<ReactFlowInstance | null>(null);
+  const [flowConfig, setFlowConfig] = useState<ReactFlowProps>({
+    nodesDraggable: true,
+    selectionOnDrag: false,
+    panOnDrag: true,
+  });
   const focusModeActive = focusModeStore.active;
 
   const metaKeyPressed = keyboard.pressed.has(CMDALT);
@@ -85,6 +92,14 @@ export const FlowCanvas = observer(function FlowCanvas({
   const doubleClickBehavior = useDoubleClickBehavior(spec);
   const paneClickBehavior = usePaneClickBehavior(spec, reactFlowInstance);
 
+  const updateFlowConfig = (config: Partial<ReactFlowProps>) => {
+    setFlowConfig((current) => ({ ...current, ...config }));
+  };
+
+  const handleAutoLayout = (algorithm: LayoutAlgorithm) => {
+    keyboard.invokeShortcut("auto-layout", { algorithm });
+  };
+
   return (
     <BlockStack
       ref={containerRef}
@@ -98,6 +113,7 @@ export const FlowCanvas = observer(function FlowCanvas({
       <SubgraphBreadcrumbs />
       <ReactFlow
         {...FLOW_CANVAS_DEFAULT_PROPS}
+        {...flowConfig}
         nodeTypes={nodeTypes}
         edgeTypes={edgeTypes}
         nodes={displayNodes}
@@ -117,23 +133,13 @@ export const FlowCanvas = observer(function FlowCanvas({
         connectionLineComponent={ConnectionLine}
         deleteKeyCode={["Delete", "Backspace"]}
         className={cn(
-          shiftKeyPressed && !isConnecting && "cursor-crosshair",
+          (flowConfig.selectionOnDrag || (shiftKeyPressed && !isConnecting)) &&
+            "cursor-crosshair",
           !isDetailedView && "connections-disabled",
         )}
       >
         <FloatingSelectionToolbar spec={spec} />
         <Background gap={10} className="bg-canvas!" />
-        <Controls
-          position="bottom-right"
-          onZoomIn={() => track("v2.pipeline_canvas.controls.zoom_in.click")}
-          onZoomOut={() => track("v2.pipeline_canvas.controls.zoom_out.click")}
-          onFitView={() => track("v2.pipeline_canvas.controls.fit_view.click")}
-          onInteractiveChange={(interactive) =>
-            track("v2.pipeline_canvas.controls.interactive.toggle", {
-              interactive,
-            })
-          }
-        />
         <MiniMap
           position="bottom-left"
           className="dark:rounded-md dark:border dark:border-border"
@@ -141,6 +147,15 @@ export const FlowCanvas = observer(function FlowCanvas({
           zoomable
           onClick={() => track("v2.pipeline_canvas.minimap.click")}
           onNodeClick={() => track("v2.pipeline_canvas.minimap.node.click")}
+        />
+        <FlowControls
+          position="bottom-left"
+          className="ml-56! mb-3!"
+          config={flowConfig}
+          updateConfig={updateFlowConfig}
+          onAutoLayout={handleAutoLayout}
+          showInteractive={false}
+          pageType="pipeline_editor"
         />
       </ReactFlow>
       <CanvasUndoRedo />

--- a/src/routes/v2/pages/RunView/components/RunViewFlowCanvas.tsx
+++ b/src/routes/v2/pages/RunView/components/RunViewFlowCanvas.tsx
@@ -1,13 +1,16 @@
 import {
   Background,
-  Controls,
   MiniMap,
   type NodeChange,
   ReactFlow,
+  type ReactFlowProps,
   useReactFlow,
 } from "@xyflow/react";
 import { observer } from "mobx-react-lite";
+import { useState } from "react";
 
+import type { LayoutAlgorithm } from "@/components/shared/ReactFlow/FlowCanvas/utils/autolayout";
+import FlowControls from "@/components/shared/ReactFlow/FlowControls/FlowControls";
 import { BlockStack } from "@/components/ui/layout";
 import { cn } from "@/lib/utils";
 import type { ComponentSpec } from "@/models/componentSpec";
@@ -41,9 +44,14 @@ export const RunViewFlowCanvas = observer(function RunViewFlowCanvas({
   const registry = useNodeRegistry();
   const nodeTypes = registry.getNodeTypes();
   const edgeTypes = registry.getEdgeTypes();
-  const { editor } = useSharedStores();
+  const { editor, keyboard } = useSharedStores();
   const { containerRef, handleViewportChange } = useViewportScaling();
   const { setNodes: rfSetNodes } = useReactFlow();
+  const [flowConfig, setFlowConfig] = useState<ReactFlowProps>({
+    nodesDraggable: true,
+    selectionOnDrag: false,
+    panOnDrag: true,
+  });
 
   const {
     displayNodes,
@@ -73,6 +81,14 @@ export const RunViewFlowCanvas = observer(function RunViewFlowCanvas({
     editor.clearSelection();
   };
 
+  const updateFlowConfig = (config: Partial<ReactFlowProps>) => {
+    setFlowConfig((current) => ({ ...current, ...config }));
+  };
+
+  const handleAutoLayout = (algorithm: LayoutAlgorithm) => {
+    keyboard.invokeShortcut("auto-layout", { algorithm });
+  };
+
   return (
     <BlockStack
       ref={containerRef}
@@ -82,6 +98,7 @@ export const RunViewFlowCanvas = observer(function RunViewFlowCanvas({
       <SubgraphBreadcrumbs />
       <ReactFlow
         {...FLOW_CANVAS_DEFAULT_PROPS}
+        {...flowConfig}
         nodeTypes={nodeTypes}
         edgeTypes={edgeTypes}
         nodes={displayNodes}
@@ -93,23 +110,12 @@ export const RunViewFlowCanvas = observer(function RunViewFlowCanvas({
         {...doubleClickBehavior}
         onViewportChange={handleViewportChange}
         nodesConnectable={false}
-        nodesDraggable
         elementsSelectable
         deleteKeyCode={null}
+        className={cn(flowConfig.selectionOnDrag && "cursor-crosshair")}
       >
         <RunViewSelectionToolbar spec={spec} />
         <Background gap={GRID_SIZE} className="bg-canvas!" />
-        <Controls
-          position="bottom-right"
-          onZoomIn={() => track("v2.run_view.canvas.controls.zoom_in.click")}
-          onZoomOut={() => track("v2.run_view.canvas.controls.zoom_out.click")}
-          onFitView={() => track("v2.run_view.canvas.controls.fit_view.click")}
-          onInteractiveChange={(interactive) =>
-            track("v2.run_view.canvas.controls.interactive.toggle", {
-              interactive,
-            })
-          }
-        />
         <MiniMap
           position="bottom-left"
           className="dark:rounded-md dark:border dark:border-border"
@@ -117,6 +123,15 @@ export const RunViewFlowCanvas = observer(function RunViewFlowCanvas({
           zoomable
           onClick={() => track("v2.run_view.canvas.minimap.click")}
           onNodeClick={() => track("v2.run_view.canvas.minimap.node.click")}
+        />
+        <FlowControls
+          position="bottom-left"
+          className="ml-56! mb-3!"
+          config={flowConfig}
+          updateConfig={updateFlowConfig}
+          onAutoLayout={handleAutoLayout}
+          showInteractive={false}
+          pageType="pipeline_run"
         />
       </ReactFlow>
     </BlockStack>


### PR DESCRIPTION
## Description  
Users didn't like the controls hidden away.

Replaces the default ReactFlow `Controls` component in both the pipeline editor (`FlowCanvas`) and run view (`RunViewFlowCanvas`) with the shared `FlowControls` component. This brings canvas interaction controls (lock/unlock nodes, area selection, auto-layout) into both views, driven by a local `flowConfig` state that is passed into `ReactFlow` as props.

Accessibility attributes (`aria-label`, `aria-pressed`, `title`) have been added to the lock, area selection, and auto-layout buttons in `FlowControls` to support screen readers and enable reliable test targeting.

A new test file covers the core `FlowControls` behaviors: rendering viewport controls, toggling lock/area-selection modes, and triggering the auto-layout algorithm.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)



![image.png](https://app.graphite.com/user-attachments/assets/1d33f8ed-cc24-42ec-a5b8-db5a9e8203bb.png)



## Test Instructions

1. Open the pipeline editor and verify the controls panel appears at the bottom-left (next to the minimap).
2. Click **Lock nodes** — nodes should become non-draggable and the button should appear pressed.
3. Click **Enable area selection** — dragging on the canvas should draw a selection rectangle instead of panning, and the cursor should change to crosshair.
4. Click **Auto layout** and select a layout algorithm — the pipeline should re-layout using the chosen algorithm.
5. Repeat steps 1–4 in the run view.
6. Run `vitest` and confirm the new `FlowControls.test.tsx` tests pass.

## Additional Comments

The `showInteractive={false}` prop hides the built-in interactive toggle from `FlowControls`, since interactivity is now managed explicitly through `flowConfig` state.