### PR TITLE
Replace `headerOutline` button variant with `header` (remove border)

### DIFF
--- a/src/components/layout/AppMenu.tsx
+++ b/src/components/layout/AppMenu.tsx
@@ -99,7 +99,7 @@ const DefaultAppMenu = () => {
               triggerComponent={
                 <TooltipButton
                   tooltip="Import Pipeline"
-                  variant="headerOutline"
+                  variant="header"
                   {...tracking("header.import_pipeline")}
                 >
                   <Icon name="Upload" />
@@ -110,7 +110,7 @@ const DefaultAppMenu = () => {
               <Tooltip>
                 <TooltipTrigger asChild>
                   <NewPipelineButton
-                    variant="headerOutline"
+                    variant="header"
                     {...tracking("header.new_pipeline")}
                   >
                     <Icon name="Plus" />
@@ -134,7 +134,7 @@ const DefaultAppMenu = () => {
             <TooltipButton
               tooltip="Close Settings"
               onClick={handleGoBack}
-              variant="headerOutline"
+              variant="header"
               className="relative"
             >
               <Icon name="Settings" />
@@ -146,7 +146,7 @@ const DefaultAppMenu = () => {
             </TooltipButton>
           ) : (
             <RouterLink to="/settings/backend" {...tracking("header.settings")}>
-              <TooltipButton tooltip="Settings" variant="headerOutline">
+              <TooltipButton tooltip="Settings" variant="header">
                 <Icon name="Settings" />
               </TooltipButton>
             </RouterLink>
@@ -158,7 +158,7 @@ const DefaultAppMenu = () => {
             rel="noopener noreferrer"
             {...tracking("header.documentation")}
           >
-            <TooltipButton tooltip="Documentation" variant="headerOutline">
+            <TooltipButton tooltip="Documentation" variant="header">
               <Icon name="CircleQuestionMark" />
             </TooltipButton>
           </Link>

--- a/src/components/shared/VersionToggle.tsx
+++ b/src/components/shared/VersionToggle.tsx
@@ -63,7 +63,7 @@ export function VersionToggle({
           if (showWelcome) dismissWelcome();
           navigate({ to: targetPath });
         }}
-        variant="headerOutline"
+        variant="header"
         size="icon"
         aria-label={tooltip}
         {...(trackingId

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -26,8 +26,7 @@ const buttonVariants = cva(
         link: "text-primary underline-offset-4 hover:underline",
         "link-info": "text-info underline decoration-dotted",
         nav: "bg-stone-700 text-white text-xs font-semibold hover:bg-stone-600 hover:text-white",
-        headerOutline:
-          "border border-white/25 bg-transparent text-white hover:bg-white/10 hover:text-white",
+        header: "bg-transparent text-white hover:bg-white/10 hover:text-white",
       },
       size: {
         default: "h-9 px-4 py-2 has-[>svg]:px-3",

--- a/src/routes/v2/pages/Editor/components/EditorMenuBar/components/AutoSaveIndicator.tsx
+++ b/src/routes/v2/pages/Editor/components/EditorMenuBar/components/AutoSaveIndicator.tsx
@@ -61,7 +61,7 @@ export const AutoSaveIndicator = observer(function AutoSaveIndicator() {
   return (
     <TooltipButton
       tooltip={tooltipText}
-      variant="headerOutline"
+      variant="header"
       disabled={isSaving}
       onClick={handleClick}
       data-testid="auto-save-button"

--- a/src/routes/v2/pages/Editor/components/EditorMenuBar/components/QuickRunButton.tsx
+++ b/src/routes/v2/pages/Editor/components/EditorMenuBar/components/QuickRunButton.tsx
@@ -90,7 +90,7 @@ export const QuickRunButton = observer(function QuickRunButton({
       <TooltipButton
         {...tooltipButtonProps}
         tooltip={tooltip}
-        variant={isMini ? "outline" : "headerOutline"}
+        variant={isMini ? "outline" : "header"}
         size={isMini ? "icon" : undefined}
         className={isMini ? "relative size-8 shrink-0 rounded-md" : undefined}
         aria-label={isMini ? tooltip : undefined}

--- a/src/routes/v2/shared/components/AppMenuActions.tsx
+++ b/src/routes/v2/shared/components/AppMenuActions.tsx
@@ -34,7 +34,7 @@ export function AppMenuActions() {
         <TooltipButton
           tooltip="Settings"
           onClick={openTourSettings}
-          variant="headerOutline"
+          variant="header"
           {...tracking("v2.header.settings")}
         >
           <Icon name="Settings" />
@@ -43,7 +43,7 @@ export function AppMenuActions() {
         <RouterLink to="/settings/backend">
           <TooltipButton
             tooltip="Settings"
-            variant="headerOutline"
+            variant="header"
             {...tracking("v2.header.settings")}
           >
             <Icon name="Settings" />
@@ -53,7 +53,7 @@ export function AppMenuActions() {
       <Link href={DOCUMENTATION_URL} target="_blank" rel="noopener noreferrer">
         <TooltipButton
           tooltip="Documentation"
-          variant="headerOutline"
+          variant="header"
           {...tracking("v2.header.documentation")}
         >
           <Icon name="CircleQuestionMark" />


### PR DESCRIPTION
## Description

Replaces the `headerOutline` button variant with a new `header` variant across the application. The `headerOutline` variant included a visible border (`border border-white/25`), while the new `header` variant removes the border, keeping only the transparent background and white text with a subtle hover effect (`hover:bg-white/10`).

This affects header action buttons including Import Pipeline, New Pipeline, Settings, Documentation, Auto Save Indicator, Quick Run Button, and Version Toggle.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [x] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)



old:   
  
  
![image.png](https://app.graphite.com/user-attachments/assets/fc40ad3a-a29f-4454-b20c-09b924da5336.png)

New:  
![image.png](https://app.graphite.com/user-attachments/assets/2018d4d6-a1ab-4a65-b697-025c6086dd0e.png)



## Test Instructions

1. Navigate to the application header and verify that action buttons (Settings, Documentation, Import Pipeline, New Pipeline, etc.) no longer display a visible border outline.
2. Confirm hover states still apply the subtle white background highlight.
3. Verify the Quick Run Button in non-mini mode uses the updated `header` variant.
4. Confirm the Version Toggle button renders correctly without a border.

## Additional Comments