### PR TITLE
Display secret input references with lock icon and amber styling in task nodes

### DIFF
--- a/src/components/shared/ComponentEditor/utils/buildPreviewTaskNodeViewProps.ts
+++ b/src/components/shared/ComponentEditor/utils/buildPreviewTaskNodeViewProps.ts
@@ -46,6 +46,7 @@ export function buildPreviewTaskNodeViewProps(
     cacheDisabled: false,
     digest: undefined,
     inputDisplayValues: {},
+    secretInputNames: new Set(),
     isAggregator: false,
     outputType: AggregatorOutputType.JsonArray,
     onOutputTypeChange: noop,

--- a/src/routes/v2/shared/nodes/TaskNode/TaskNode.tsx
+++ b/src/routes/v2/shared/nodes/TaskNode/TaskNode.tsx
@@ -2,6 +2,7 @@ import { type Node, type NodeProps, useReactFlow } from "@xyflow/react";
 import { observer } from "mobx-react-lite";
 import type { MouseEvent, ReactElement } from "react";
 
+import { extractSecretName } from "@/components/shared/SecretsManagement/types";
 import { useFlagValue } from "@/components/shared/Settings/useFlags";
 import { Card } from "@/components/ui/card";
 import { Text } from "@/components/ui/typography";
@@ -24,6 +25,7 @@ import {
   isPipelineAggregator,
   TASK_COLOR_ANNOTATION,
 } from "@/utils/annotations";
+import { isSecretArgument } from "@/utils/componentSpec";
 import { ISO8601_DURATION_ZERO_DAYS } from "@/utils/constants";
 import type { ExecutionStatusStats } from "@/utils/executionStatus";
 
@@ -65,6 +67,7 @@ export interface TaskNodeViewProps {
   cacheDisabled: boolean;
   digest?: string;
   inputDisplayValues: Record<string, string | undefined>;
+  secretInputNames: Set<string>;
   isAggregator: boolean;
   outputType: AggregatorOutputType;
   subgraphExecutionStats?: ExecutionStatusStats | null;
@@ -83,28 +86,43 @@ function isTaskSubgraph(componentSpec: ComponentSpecJson | undefined): boolean {
   return "graph" in implementation;
 }
 
+interface InputDisplayData {
+  values: Record<string, string | undefined>;
+  secretInputNames: Set<string>;
+}
+
 /**
- * Resolve display values for task inputs by merging literal argument values
- * with binding-derived connection labels.
+ * Resolve task input display data from literal, secret, and bound arguments.
  */
-function resolveInputDisplayValues(
+export function resolveInputDisplayData(
   task: Task,
   entityId: string,
   spec: ComponentSpec | null,
-): Record<string, string | undefined> {
+): InputDisplayData {
   const values: Record<string, string | undefined> = {};
+  const secretInputNames = new Set<string>();
 
   for (const arg of task.arguments) {
     if (typeof arg.value === "string") {
       values[arg.name] = arg.value;
+      continue;
+    }
+
+    if (isSecretArgument(arg.value)) {
+      const secretName = extractSecretName(arg.value);
+      if (secretName) {
+        values[arg.name] = secretName;
+        secretInputNames.add(arg.name);
+      }
     }
   }
 
-  if (!spec) return values;
+  if (!spec) return { values, secretInputNames };
 
   for (const binding of spec.bindings) {
     if (binding.targetEntityId !== entityId) continue;
 
+    secretInputNames.delete(binding.targetPortName);
     const sourceTask = spec.tasks.find((t) => t.$id === binding.sourceEntityId);
     if (sourceTask) {
       values[binding.targetPortName] =
@@ -120,7 +138,7 @@ function resolveInputDisplayValues(
     }
   }
 
-  return values;
+  return { values, secretInputNames };
 }
 
 function resolveConnectedPortNames(
@@ -268,6 +286,7 @@ export const TaskNode = observer(function TaskNode({
   };
 
   const connectedPorts = resolveConnectedPortNames(entityId, spec);
+  const inputDisplayData = resolveInputDisplayData(task, entityId, spec);
 
   const isSelected = isEditorVisualNodeSelected(editor, id, !!selected);
 
@@ -298,7 +317,8 @@ export const TaskNode = observer(function TaskNode({
     subgraphExecutionStats,
     onOutputTypeChange: handleOutputTypeChange,
     digest: task.componentRef.digest,
-    inputDisplayValues: resolveInputDisplayValues(task, entityId, spec),
+    inputDisplayValues: inputDisplayData.values,
+    secretInputNames: inputDisplayData.secretInputNames,
     onNodeClick: handleClick,
     onInputClick: handleInputClick,
     onOutputClick: handleOutputClick,

--- a/src/routes/v2/shared/nodes/TaskNode/TaskNodeCard.test.tsx
+++ b/src/routes/v2/shared/nodes/TaskNode/TaskNodeCard.test.tsx
@@ -1,14 +1,20 @@
 import { cleanup, render, screen } from "@testing-library/react";
+import { ReactFlowProvider } from "@xyflow/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { Task } from "@/models/componentSpec";
 import { AggregatorOutputType } from "@/types/aggregator";
 
-import type { TaskNodeViewProps } from "./TaskNode";
+import { resolveInputDisplayData, type TaskNodeViewProps } from "./TaskNode";
 import { TaskNodeCard } from "./TaskNodeCard";
 import { TaskNodeSimplified } from "./TaskNodeSimplified";
 
 vi.mock("@/providers/ThemeProvider", () => ({
   useTheme: () => ({ resolvedTheme: "light" }),
+}));
+
+vi.mock("@/routes/v2/shared/providers/SpecContext", () => ({
+  useSpec: () => null,
 }));
 
 const buildProps = (
@@ -29,6 +35,7 @@ const buildProps = (
   annotations: [],
   cacheDisabled: false,
   inputDisplayValues: {},
+  secretInputNames: new Set(),
   isAggregator: false,
   outputType: AggregatorOutputType.JsonArray,
   onOutputTypeChange: vi.fn(),
@@ -42,6 +49,56 @@ const buildProps = (
 afterEach(cleanup);
 
 describe("TaskNodeCard", () => {
+  it("resolves secret argument references for display", () => {
+    const task = new Task({
+      $id: "task-1",
+      name: "Generate response",
+      componentRef: {},
+      arguments: [
+        {
+          name: "api_key",
+          value: { dynamicData: { secret: { name: "OPENAI_API_KEY" } } },
+        },
+        { name: "prompt", value: "Write a haiku" },
+      ],
+    });
+
+    const displayData = resolveInputDisplayData(task, task.$id, null);
+
+    expect(displayData.values).toEqual({
+      api_key: "OPENAI_API_KEY",
+      prompt: "Write a haiku",
+    });
+    expect(displayData.secretInputNames).toEqual(new Set(["api_key"]));
+  });
+
+  it("marks secret input references and leaves ordinary inputs unmarked", () => {
+    render(
+      <ReactFlowProvider>
+        <TaskNodeCard
+          {...buildProps({
+            isSubgraph: false,
+            inputs: [{ name: "api_key" }, { name: "prompt" }],
+            inputDisplayValues: {
+              api_key: "OPENAI_API_KEY",
+              prompt: "Write a haiku",
+            },
+            secretInputNames: new Set(["api_key"]),
+          })}
+        />
+      </ReactFlowProvider>,
+    );
+
+    expect(screen.getByTestId("input-secret-icon-api_key")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("input-secret-icon-prompt"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText(/OPENAI_API_KEY/)).toHaveClass("text-amber-600");
+    expect(screen.getByText(/OPENAI_API_KEY/)).toHaveTextContent(
+      "Secret: OPENAI_API_KEY",
+    );
+  });
+
   it("shows child execution progress for a subgraph", () => {
     render(
       <TaskNodeCard

--- a/src/routes/v2/shared/nodes/TaskNode/TaskNodeCard.tsx
+++ b/src/routes/v2/shared/nodes/TaskNode/TaskNodeCard.tsx
@@ -91,6 +91,7 @@ interface ClassicInputHandleProps {
   entityId: string;
   displayValue: string | undefined;
   hideValue?: boolean;
+  isSecret: boolean;
   /** When true the node has no custom colour, so section chrome follows the theme. */
   themed: boolean;
   /** Whether the app is in dark mode — used to darken coloured-node chrome. */
@@ -104,6 +105,7 @@ const ClassicInputHandle = observer(function ClassicInputHandle({
   entityId,
   displayValue,
   hideValue,
+  isSecret,
   themed,
   isDark,
   onInputClick,
@@ -172,6 +174,15 @@ const ClassicInputHandle = observer(function ClassicInputHandle({
         </div>
         {showValueDisplay && (
           <div className="flex w-fit max-w-1/2 min-w-0 items-center gap-1">
+            {isSecret && (
+              <Icon
+                name="Lock"
+                size="xs"
+                className="shrink-0 text-amber-600"
+                aria-hidden="true"
+                data-testid={`input-secret-icon-${input.name}`}
+              />
+            )}
             <div
               className={cn(
                 "text-xs truncate inline-block text-right pr-2",
@@ -184,8 +195,10 @@ const ClassicInputHandle = observer(function ClassicInputHandle({
                   (themed
                     ? "text-muted-foreground italic"
                     : "text-gray-400 italic"),
+                isSecret && "text-amber-600",
               )}
             >
+              {isSecret && <span className="sr-only">Secret: </span>}
               {hasValue ? displayValue : input.default}
             </div>
           </div>
@@ -207,6 +220,7 @@ export const TaskNodeCard = observer(function TaskNodeCard({
   connectedInputNames,
   connectedOutputNames,
   inputDisplayValues,
+  secretInputNames,
   onNodeClick,
   onInputClick,
   onOutputClick,
@@ -391,6 +405,7 @@ export const TaskNodeCard = observer(function TaskNodeCard({
                       : inputDisplayValues[input.name]
                   }
                   hideValue={showCondensedInputs && index !== 0}
+                  isSecret={secretInputNames.has(input.name)}
                   onInputClick={onInputClick}
                   onHandleClick={onHandleClick}
                 />


### PR DESCRIPTION
## Description

Task nodes that receive secret arguments now display a lock icon next to the input handle and render the secret name in amber, making it immediately clear which inputs are wired to secrets rather than plain literal values. A screen-reader-only "Secret: " prefix is also included for accessibility.

The resolution logic has been refactored into `resolveInputDisplayData`, which returns both the display values and a `secretInputNames` set. When a bound connection overrides a secret argument, the input is removed from `secretInputNames` so the secret indicator is not shown for connected ports.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## ![image.png](https://app.graphite.com/user-attachments/assets/a39fd5f6-9efa-47cf-80bb-90b88db24edd.png)



## Test Instructions

1. Create a pipeline with a task that has a secret argument (e.g. an `api_key` input wired to a secret reference).
2. Open the pipeline canvas and inspect the task node — the secret input should show a lock icon and the secret name rendered in amber.
3. Connect an output port to the same input; confirm the lock icon disappears once the binding overrides the secret.
4. Run the unit tests with `vitest` and confirm `TaskNodeCard.test.tsx` passes, including the two new cases covering secret resolution and rendering.

## Additional Comments

`resolveInputDisplayData` is now exported so it can be called directly in tests and in the component editor preview path, which also receives the new `secretInputNames: new Set()` default.