### PR TITLE
feat: Improve Parquet Viewer

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ArtifactPreviewContent.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ArtifactPreviewContent.tsx
@@ -12,52 +12,6 @@ import { JsonVisualizerRemote, JsonVisualizerValue } from "./JsonVisualizer";
 import ParquetVisualizer from "./ParquetVisualizer";
 import { TextVisualizerRemote, TextVisualizerValue } from "./TextVisualizer";
 
-const VISUALIZABLE_TYPES = [
-  "text",
-  "image",
-  "jsonobject",
-  "jsonarray",
-  "csv",
-  "tsv",
-  "apacheparquet",
-] as const;
-
-type VisualizableType = (typeof VISUALIZABLE_TYPES)[number];
-
-const TYPE_ALIASES: Record<string, VisualizableType> = {
-  txt: "text",
-  log: "text",
-  yaml: "text",
-  yml: "text",
-  xml: "text",
-  png: "image",
-  jpg: "image",
-  jpeg: "image",
-  gif: "image",
-  bmp: "image",
-  svg: "image",
-  json: "jsonobject",
-  parquet: "apacheparquet",
-  table: "apacheparquet",
-};
-
-export const normalizeRawType = (type?: string | null): string =>
-  (type ?? "text").toLowerCase().replace(/\s/g, "");
-
-export const resolveArtifactType = (raw: string): string =>
-  TYPE_ALIASES[raw] ?? raw;
-
-export const isVisualizableType = (type: string): type is VisualizableType =>
-  (VISUALIZABLE_TYPES as readonly string[]).includes(type);
-
-export const inferTypeFromUri = (uri?: string | null): string | undefined => {
-  if (!uri) return undefined;
-  const stripped = uri.split(/[?#]/)[0];
-  const ext = stripped.split(".").pop()?.toLowerCase();
-  if (!ext) return undefined;
-  return TYPE_ALIASES[ext] ?? (isVisualizableType(ext) ? ext : undefined);
-};
-
 interface InlineContentProps {
   type: string;
   name: string;

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ArtifactVisualizer.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ArtifactVisualizer.tsx
@@ -20,14 +20,16 @@ import { getArtifactPreviewUrl } from "@/utils/URL";
 
 import {
   InlineContent,
-  isVisualizableType,
-  normalizeRawType,
   PreviewContent,
   PreviewSkeleton,
-  resolveArtifactType,
 } from "./ArtifactPreviewContent";
 import { ArtifactPreviewError } from "./ArtifactPreviewError";
 import { ArtifactPreviewHeader } from "./ArtifactPreviewHeader";
+import {
+  isVisualizableType,
+  normalizeRawType,
+  resolveArtifactType,
+} from "./artifactType";
 
 type ArtifactVisualizerProps = {
   artifact: ArtifactNodeResponse;
@@ -160,6 +162,19 @@ const ArtifactVisualizer = ({
                     <ArtifactPreviewError
                       title="Artifact unavailable"
                       preamble="This artifact could not be found."
+                      variant="warning"
+                    />
+                  );
+                }
+
+                if (
+                  error instanceof ArtifactFetchError &&
+                  error.status === 413
+                ) {
+                  return (
+                    <ArtifactPreviewError
+                      title="Too large to preview"
+                      preamble={error.message}
                       variant="warning"
                     />
                   );

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ParquetVisualizer.test.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ParquetVisualizer.test.tsx
@@ -1,8 +1,11 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
 import { type ReactElement, Suspense } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ArtifactFetchError } from "@/services/executionService";
 
 import ParquetVisualizer from "./ParquetVisualizer";
 import type { ArtifactColumn } from "./utils";
@@ -10,27 +13,62 @@ import type { ArtifactColumn } from "./utils";
 vi.mock("hyparquet", () => ({
   parquetReadObjects: vi.fn(),
   parquetMetadata: vi.fn(),
+  parquetMetadataAsync: vi.fn(),
+  asyncBufferFromUrl: vi.fn(),
+  byteLengthFromUrl: vi.fn(),
+  cachedAsyncBuffer: vi.fn((buffer) => buffer),
+  toJson: vi.fn((value) => value),
+}));
+
+vi.mock("@/utils/URL", () => ({
+  downloadStringAsFile: vi.fn(),
 }));
 
 vi.mock("./TableVisualizer", () => ({
   default: ({
     data,
     isFullscreen,
+    totalRows,
+    columnCount,
+    onDownloadSchema,
   }: {
-    data: { columns: ArtifactColumn[]; rows: string[][] };
+    data: { columns: ArtifactColumn[]; rows: string[][]; hasMore: boolean };
     isFullscreen: boolean;
+    totalRows?: number;
+    columnCount?: number;
+    onDownloadSchema?: () => void;
   }) => (
     <div
       data-testid="table-visualizer"
       data-fullscreen={isFullscreen}
+      data-has-more={data.hasMore}
       data-headers={data.columns.map((c) => c.name).join(",")}
       data-row-count={data.rows.length}
       data-columns={JSON.stringify(data.columns)}
-    />
+      data-total-rows={totalRows}
+      data-column-count={columnCount}
+    >
+      <button type="button" onClick={onDownloadSchema}>
+        Download schema
+      </button>
+    </div>
   ),
 }));
 
-const { parquetReadObjects, parquetMetadata } = await import("hyparquet");
+const {
+  parquetReadObjects,
+  parquetMetadata,
+  parquetMetadataAsync,
+  asyncBufferFromUrl,
+  byteLengthFromUrl,
+} = await import("hyparquet");
+const { downloadStringAsFile } = await import("@/utils/URL");
+
+const SCHEMA = [
+  { name: "root", num_children: 2 },
+  { name: "name", type: "BYTE_ARRAY", repetition_type: "OPTIONAL" },
+  { name: "score", type: "INT64", repetition_type: "REQUIRED" },
+];
 
 const queryClient = new QueryClient({
   defaultOptions: { queries: { retry: false } },
@@ -53,34 +91,40 @@ const renderWithSuspense = (ui: ReactElement) =>
     </QueryClientProvider>,
   );
 
-const mockMetadata = (schema: unknown[] = []) =>
-  vi.mocked(parquetMetadata).mockReturnValue({
+/** Range-backed reads: `parquetReadObjects` slices a synthetic dataset. */
+const mockDataset = (schema: unknown[], numRows: number) => {
+  vi.mocked(parquetMetadataAsync).mockResolvedValue({
     schema,
-  } as unknown as ReturnType<typeof parquetMetadata>);
+    num_rows: numRows,
+  } as unknown as Awaited<ReturnType<typeof parquetMetadataAsync>>);
+  vi.mocked(parquetReadObjects).mockImplementation(
+    async ({ rowStart = 0, rowEnd }) => {
+      const end = Math.min(rowEnd ?? numRows, numRows);
+      return Array.from({ length: Math.max(0, end - rowStart) }, (_, i) => ({
+        name: `row-${rowStart + i}`,
+        score: (rowStart + i) * 10,
+      }));
+    },
+  );
+};
 
 beforeEach(() => {
   queryClient.clear();
+  vi.restoreAllMocks();
   vi.mocked(parquetMetadata).mockReset();
+  vi.mocked(parquetMetadataAsync).mockReset();
   vi.mocked(parquetReadObjects).mockReset();
+  vi.mocked(downloadStringAsFile).mockReset();
+  vi.mocked(byteLengthFromUrl).mockResolvedValue(1024);
+  vi.mocked(asyncBufferFromUrl).mockResolvedValue({
+    byteLength: 1024,
+    slice: vi.fn(),
+  } as unknown as Awaited<ReturnType<typeof asyncBufferFromUrl>>);
 });
 
 describe("ParquetVisualizer", () => {
-  it("fetches, parses parquet, and renders TableVisualizer", async () => {
-    const buffer = new ArrayBuffer(8);
-    vi.spyOn(globalThis, "fetch").mockResolvedValue({
-      ok: true,
-      arrayBuffer: () => Promise.resolve(buffer),
-    } as Response);
-
-    mockMetadata([
-      { name: "root" },
-      { name: "name", type: "BYTE_ARRAY", repetition_type: "OPTIONAL" },
-      { name: "score", type: "INT64", repetition_type: "REQUIRED" },
-    ]);
-    vi.mocked(parquetReadObjects).mockResolvedValue([
-      { name: "Alice", score: 100 },
-      { name: "Bob", score: 90 },
-    ]);
+  it("reads via range requests, parses, and renders TableVisualizer with stats", async () => {
+    mockDataset(SCHEMA, 2);
 
     renderWithSuspense(
       <ParquetVisualizer
@@ -93,16 +137,172 @@ describe("ParquetVisualizer", () => {
       const table = screen.getByTestId("table-visualizer");
       expect(table).toHaveAttribute("data-headers", "name,score");
       expect(table).toHaveAttribute("data-row-count", "2");
+      expect(table).toHaveAttribute("data-total-rows", "2");
+      expect(table).toHaveAttribute("data-column-count", "2");
+      expect(table).toHaveAttribute("data-has-more", "false");
     });
 
-    vi.restoreAllMocks();
+    // Only the top preview rows are read, never the whole file up front.
+    expect(vi.mocked(parquetReadObjects)).toHaveBeenCalledWith(
+      expect.objectContaining({ rowEnd: 100 }),
+    );
   });
 
-  it("renders error boundary on fetch failure", async () => {
+  it("previews the top rows and reports more remain for a large file", async () => {
+    mockDataset(SCHEMA, 2500);
+
+    renderWithSuspense(
+      <ParquetVisualizer
+        signedUrl="https://storage.example.com/big.parquet"
+        isFullscreen={false}
+      />,
+    );
+
+    await waitFor(() => {
+      const table = screen.getByTestId("table-visualizer");
+      expect(table).toHaveAttribute("data-row-count", "100");
+      expect(table).toHaveAttribute("data-total-rows", "2500");
+      expect(table).toHaveAttribute("data-has-more", "true");
+    });
+  });
+
+  const mockFullDownload = (contentLength: string | null) =>
     vi.spyOn(globalThis, "fetch").mockResolvedValue({
-      ok: false,
-      status: 500,
-    } as Response);
+      ok: true,
+      status: 200,
+      headers: { get: () => contentLength },
+      arrayBuffer: async () => new ArrayBuffer(1024),
+    } as unknown as Response);
+
+  it("falls back to a full download when range requests are unavailable", async () => {
+    // Simulate a CORS/network failure on the range path (not an HTTP error).
+    vi.mocked(byteLengthFromUrl).mockRejectedValue(
+      new TypeError("Failed to fetch"),
+    );
+    mockFullDownload(String(1024));
+    vi.mocked(parquetMetadata).mockReturnValue({
+      schema: SCHEMA,
+      num_rows: 1,
+    } as unknown as ReturnType<typeof parquetMetadata>);
+    vi.mocked(parquetReadObjects).mockResolvedValue([
+      { name: "Alice", score: 100 },
+    ]);
+
+    renderWithSuspense(
+      <ParquetVisualizer
+        signedUrl="https://storage.example.com/no-range.parquet"
+        isFullscreen={false}
+      />,
+    );
+
+    await waitFor(() => {
+      const table = screen.getByTestId("table-visualizer");
+      expect(table).toHaveAttribute("data-row-count", "1");
+      expect(table).toHaveAttribute("data-total-rows", "1");
+    });
+  });
+
+  it("errors instead of downloading a huge file when range requests are unavailable", async () => {
+    vi.mocked(byteLengthFromUrl).mockRejectedValue(
+      new TypeError("Failed to fetch"),
+    );
+    // 200 MB — well past the full-download cap.
+    mockFullDownload(String(200 * 1024 * 1024));
+
+    renderWithSuspense(
+      <ParquetVisualizer
+        signedUrl="https://storage.example.com/huge.parquet"
+        isFullscreen={false}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("error")).toBeInTheDocument();
+      expect(screen.getByText(/too large to preview/i)).toBeInTheDocument();
+    });
+  });
+
+  it("errors instead of downloading when Content-Length is absent", async () => {
+    vi.mocked(byteLengthFromUrl).mockRejectedValue(
+      new TypeError("Failed to fetch"),
+    );
+    // No Content-Length header — size is unknown, so we must not download.
+    mockFullDownload(null);
+
+    renderWithSuspense(
+      <ParquetVisualizer
+        signedUrl="https://storage.example.com/no-length.parquet"
+        isFullscreen={false}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("error")).toBeInTheDocument();
+      expect(screen.getByText(/too large to preview/i)).toBeInTheDocument();
+    });
+  });
+
+  it("downloads a clean schema JSON when requested", async () => {
+    vi.mocked(parquetMetadataAsync).mockResolvedValue({
+      schema: [
+        { name: "root", num_children: 2 },
+        { name: "id", type: "INT64", repetition_type: "REQUIRED" },
+        {
+          name: "label",
+          type: "BYTE_ARRAY",
+          repetition_type: "OPTIONAL",
+          logical_type: { type: "STRING" },
+        },
+      ],
+      num_rows: 5,
+    } as unknown as Awaited<ReturnType<typeof parquetMetadataAsync>>);
+    vi.mocked(parquetReadObjects).mockResolvedValue([{ id: 1, label: "a" }]);
+
+    renderWithSuspense(
+      <ParquetVisualizer
+        signedUrl="https://storage.example.com/data.parquet"
+        isFullscreen={false}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("table-visualizer")).toBeInTheDocument(),
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Download schema" }),
+    );
+
+    expect(vi.mocked(downloadStringAsFile)).toHaveBeenCalledOnce();
+    const [content, filename, contentType] =
+      vi.mocked(downloadStringAsFile).mock.calls[0];
+    expect(filename).toBe("schema.json");
+    expect(contentType).toBe("application/json");
+    expect(JSON.parse(content)).toEqual({
+      num_rows: 5,
+      num_columns: 2,
+      columns: [
+        {
+          name: "id",
+          type: "INT64",
+          repetition_type: "REQUIRED",
+          nullable: false,
+        },
+        {
+          name: "label",
+          type: "STRING",
+          logical_type: { type: "STRING" },
+          repetition_type: "OPTIONAL",
+          nullable: true,
+        },
+      ],
+    });
+  });
+
+  it("surfaces artifact failures to the error boundary", async () => {
+    vi.mocked(byteLengthFromUrl).mockRejectedValue(
+      new ArtifactFetchError(500, "Server Error", "Failed to fetch artifact."),
+    );
 
     renderWithSuspense(
       <ParquetVisualizer
@@ -115,18 +315,10 @@ describe("ParquetVisualizer", () => {
       expect(screen.getByTestId("error")).toBeInTheDocument();
       expect(screen.getByText(/Failed to fetch artifact/)).toBeInTheDocument();
     });
-
-    vi.restoreAllMocks();
   });
 
   it("shows 'No data' for empty parquet files", async () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValue({
-      ok: true,
-      arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
-    } as Response);
-
-    mockMetadata([]);
-    vi.mocked(parquetReadObjects).mockResolvedValue([]);
+    mockDataset([], 0);
 
     renderWithSuspense(
       <ParquetVisualizer
@@ -138,21 +330,16 @@ describe("ParquetVisualizer", () => {
     await waitFor(() => {
       expect(screen.getByText("No data")).toBeInTheDocument();
     });
-
-    vi.restoreAllMocks();
   });
 
   it("passes isFullscreen to TableVisualizer", async () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValue({
-      ok: true,
-      arrayBuffer: () => Promise.resolve(new ArrayBuffer(8)),
-    } as Response);
-
-    mockMetadata([
-      { name: "root" },
-      { name: "col", type: "BYTE_ARRAY", repetition_type: "OPTIONAL" },
-    ]);
-    vi.mocked(parquetReadObjects).mockResolvedValue([{ col: "val" }]);
+    mockDataset(
+      [
+        { name: "root", num_children: 1 },
+        { name: "name", type: "BYTE_ARRAY", repetition_type: "OPTIONAL" },
+      ],
+      1,
+    );
 
     renderWithSuspense(
       <ParquetVisualizer
@@ -167,26 +354,22 @@ describe("ParquetVisualizer", () => {
         "true",
       );
     });
-
-    vi.restoreAllMocks();
   });
 
   it("attaches schema-derived type and nullable flags to each column", async () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValue({
-      ok: true,
-      arrayBuffer: () => Promise.resolve(new ArrayBuffer(8)),
-    } as Response);
-
-    mockMetadata([
-      { name: "root" },
-      { name: "id", type: "INT64", repetition_type: "REQUIRED" },
-      {
-        name: "label",
-        type: "BYTE_ARRAY",
-        repetition_type: "OPTIONAL",
-        logical_type: { type: "STRING" },
-      },
-    ]);
+    vi.mocked(parquetMetadataAsync).mockResolvedValue({
+      schema: [
+        { name: "root", num_children: 2 },
+        { name: "id", type: "INT64", repetition_type: "REQUIRED" },
+        {
+          name: "label",
+          type: "BYTE_ARRAY",
+          repetition_type: "OPTIONAL",
+          logical_type: { type: "STRING" },
+        },
+      ],
+      num_rows: 1,
+    } as unknown as Awaited<ReturnType<typeof parquetMetadataAsync>>);
     vi.mocked(parquetReadObjects).mockResolvedValue([{ id: 1, label: "a" }]);
 
     renderWithSuspense(
@@ -204,7 +387,5 @@ describe("ParquetVisualizer", () => {
         { name: "label", type: "STRING", nullable: true },
       ]);
     });
-
-    vi.restoreAllMocks();
   });
 });

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ParquetVisualizer.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ParquetVisualizer.tsx
@@ -1,57 +1,58 @@
-import {
-  parquetMetadata,
-  parquetReadObjects,
-  type SchemaElement,
-} from "hyparquet";
+import { useSuspenseQuery } from "@tanstack/react-query";
 
 import { Paragraph } from "@/components/ui/typography";
+import { HOURS } from "@/utils/constants";
+import { downloadStringAsFile } from "@/utils/URL";
 
-import TableVisualizer from "./TableVisualizer";
-import { useArtifactFetch } from "./useArtifactFetch";
-import { useRowCap } from "./useRowCap";
 import {
-  type ArtifactColumn,
-  MAX_PREVIEW_ROWS,
-  type ParsedArtifact,
-} from "./utils";
+  buildSchemaJson,
+  countColumns,
+  openParquet,
+  PARQUET_PREVIEW_ROWS,
+  readParquetPreview,
+} from "./parquetUtils";
+import TableVisualizer from "./TableVisualizer";
+import { type ArtifactColumn } from "./utils";
 
 interface ParquetVisualizerProps {
   signedUrl: string;
   isFullscreen: boolean;
 }
 
+interface ParquetBase {
+  columns: ArtifactColumn[];
+  rows: string[][];
+  totalRows: number;
+  columnCount: number;
+  schemaJson: unknown;
+}
+
 const ParquetVisualizer = ({
   signedUrl,
   isFullscreen,
 }: ParquetVisualizerProps) => {
-  const parsed = useArtifactFetch<ParsedArtifact>(
-    "parquet",
-    signedUrl,
-    async (response) => {
-      const arrayBuffer = await response.arrayBuffer();
-      const metadata = parquetMetadata(arrayBuffer);
-      const objects = await parquetReadObjects({
-        file: arrayBuffer,
-        rowEnd: MAX_PREVIEW_ROWS + 1,
-      });
+  const { data: base } = useSuspenseQuery<ParquetBase>({
+    queryKey: ["artifact-parquet", signedUrl],
+    queryFn: async () => {
+      const opened = await openParquet(signedUrl);
+      const { columns, rows } = await readParquetPreview(
+        opened,
+        PARQUET_PREVIEW_ROWS,
+      );
 
-      if (objects.length === 0) {
-        return { columns: [], rows: [], truncated: false };
-      }
-
-      const columns = buildColumns(metadata.schema, objects[0]);
-      const truncated = objects.length > MAX_PREVIEW_ROWS;
-      const rows = objects
-        .slice(0, MAX_PREVIEW_ROWS)
-        .map((obj) => columns.map((col) => obj[col.name])) as string[][];
-
-      return { columns, rows, truncated };
+      return {
+        columns,
+        rows,
+        totalRows: Number(opened.metadata.num_rows),
+        columnCount: countColumns(opened.metadata),
+        schemaJson: buildSchemaJson(opened.metadata),
+      };
     },
-  );
+    staleTime: 24 * HOURS,
+    retry: false,
+  });
 
-  const { data, onLoadMore, onLoadAll } = useRowCap(parsed);
-
-  if (data.columns.length === 0) {
+  if (base.columns.length === 0) {
     return (
       <Paragraph tone="subdued" size="xs">
         No data
@@ -59,36 +60,27 @@ const ParquetVisualizer = ({
     );
   }
 
+  const handleDownloadSchema = () => {
+    downloadStringAsFile(
+      JSON.stringify(base.schemaJson, null, 2),
+      "schema.json",
+      "application/json",
+    );
+  };
+
   return (
     <TableVisualizer
-      data={data}
+      data={{
+        columns: base.columns,
+        rows: base.rows,
+        hasMore: base.rows.length < base.totalRows,
+      }}
       isFullscreen={isFullscreen}
-      onLoadMore={onLoadMore}
-      onLoadAll={onLoadAll}
+      totalRows={base.totalRows}
+      columnCount={base.columnCount}
+      onDownloadSchema={handleDownloadSchema}
     />
   );
 };
 
 export default ParquetVisualizer;
-
-function buildColumns(
-  schema: SchemaElement[],
-  firstRow: Record<string, unknown>,
-): ArtifactColumn[] {
-  const schemaByName = new Map(
-    schema.filter((el) => el.type !== undefined).map((el) => [el.name, el]),
-  );
-  return Object.keys(firstRow).map((name) => {
-    const el = schemaByName.get(name);
-    return {
-      name,
-      type: el ? formatParquetType(el) : undefined,
-      nullable: el?.repetition_type === "OPTIONAL",
-    };
-  });
-}
-
-function formatParquetType(el: SchemaElement): string {
-  if (el.logical_type) return el.logical_type.type;
-  return el.type ?? "";
-}

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/TableVisualizer.test.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/TableVisualizer.test.tsx
@@ -32,7 +32,7 @@ describe("TableVisualizer", () => {
     expect(screen.getByText("Showing all 5 rows")).toBeInTheDocument();
   });
 
-  it("says 'Showing first N rows' when hasMore is true and load handlers are provided", () => {
+  it("says 'Showing first N rows' when more remain and rows can still be loaded", () => {
     const data = makeData(100, true);
     render(
       <TableVisualizer
@@ -46,12 +46,12 @@ describe("TableVisualizer", () => {
     expect(screen.getByText("Showing first 100 rows")).toBeInTheDocument();
   });
 
-  it("flags the preview limit when hasMore is true but no onLoadMore is provided", () => {
-    const data = makeData(10000, true);
+  it("says 'preview limit reached' when more remain but no loader is offered", () => {
+    const data = makeData(100, true);
     render(<TableVisualizer data={data} isFullscreen={false} />);
 
     expect(
-      screen.getByText("Showing first 10000 rows (preview limit reached)"),
+      screen.getByText("Showing first 100 rows (preview limit reached)"),
     ).toBeInTheDocument();
   });
 
@@ -69,13 +69,10 @@ describe("TableVisualizer", () => {
       />,
     );
 
-    const loadMore = screen.getByRole("button", { name: "Load more" });
-    const loadAll = screen.getByRole("button", { name: "Load all" });
-
-    await userEvent.click(loadMore);
+    await userEvent.click(screen.getByRole("button", { name: "Load more" }));
     expect(onLoadMore).toHaveBeenCalledOnce();
 
-    await userEvent.click(loadAll);
+    await userEvent.click(screen.getByRole("button", { name: "Load all" }));
     expect(onLoadAll).toHaveBeenCalledOnce();
   });
 
@@ -117,5 +114,48 @@ describe("TableVisualizer", () => {
     const footer = screen.getByText("Showing all 3 rows");
 
     expect(tableContainer?.contains(footer)).toBe(false);
+  });
+
+  it("renders row/column stats with thousands separators when provided", () => {
+    const data = makeData(3);
+    const totalRows = 1234567;
+    const columnCount = 12;
+    render(
+      <TableVisualizer
+        data={data}
+        isFullscreen={false}
+        totalRows={totalRows}
+        columnCount={columnCount}
+      />,
+    );
+
+    const expected = `${totalRows.toLocaleString()} rows · ${columnCount.toLocaleString()} columns`;
+    expect(screen.getByText(expected)).toBeInTheDocument();
+  });
+
+  it("does not render the stats header when no stats are provided", () => {
+    const data = makeData(3);
+    render(<TableVisualizer data={data} isFullscreen={false} />);
+
+    expect(screen.queryByText(/columns$/)).toBeNull();
+  });
+
+  it("renders a Download schema button and fires the handler on click", async () => {
+    const onDownloadSchema = vi.fn();
+    const data = makeData(3);
+    render(
+      <TableVisualizer
+        data={data}
+        isFullscreen={false}
+        totalRows={3}
+        columnCount={2}
+        onDownloadSchema={onDownloadSchema}
+      />,
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: /Download schema/ }),
+    );
+    expect(onDownloadSchema).toHaveBeenCalledOnce();
   });
 });

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/TableVisualizer.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/TableVisualizer.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icon";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import {
   Table,
@@ -17,6 +18,9 @@ interface TableVisualizerProps {
   isFullscreen: boolean;
   onLoadMore?: () => void;
   onLoadAll?: () => void;
+  totalRows?: number;
+  columnCount?: number;
+  onDownloadSchema?: () => void;
 }
 
 const getRowCountMessage = (
@@ -34,15 +38,32 @@ const TableVisualizer = ({
   isFullscreen,
   onLoadMore,
   onLoadAll,
+  totalRows,
+  columnCount,
+  onDownloadSchema,
 }: TableVisualizerProps) => {
   const limitReached = data.hasMore && !onLoadMore;
   const rowCountMessage = getRowCountMessage(data, limitReached);
+  const hasStats = totalRows !== undefined && columnCount !== undefined;
 
   return (
     <BlockStack
       gap="2"
       className={isFullscreen ? "h-full min-h-0" : "max-h-100"}
     >
+      {hasStats && (
+        <InlineStack gap="4" align="space-between" blockAlign="center">
+          <Text size="xs" tone="subdued">
+            {`${totalRows.toLocaleString()} rows · ${columnCount.toLocaleString()} columns`}
+          </Text>
+          {onDownloadSchema && (
+            <Button variant="link" size="inline-xs" onClick={onDownloadSchema}>
+              <Icon name="Download" size="xs" aria-hidden="true" />
+              Download schema
+            </Button>
+          )}
+        </InlineStack>
+      )}
       <ArtifactTable columns={data.columns} rows={data.rows} />
       <InlineStack gap="4">
         <Paragraph tone="subdued" size="xs">
@@ -77,12 +98,12 @@ const ArtifactTable = ({ columns, rows }: ArtifactTableProps) => (
         {columns.map((col) => (
           <TableHead
             key={col.name}
-            className="bg-background sticky top-0 z-10 h-auto py-2 align-bottom text-xs"
+            className="bg-background sticky top-0 z-10 h-auto py-2 align-bottom"
           >
             <BlockStack>
-              <Text>{col.name}</Text>
+              <Text size="xs">{col.name}</Text>
               {col.type && (
-                <Text tone="subdued" className="text-[10px]">
+                <Text tone="subdued" size="xs">
                   {col.type}
                   {col.nullable ? "?" : ""}
                 </Text>

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/artifactType.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/artifactType.ts
@@ -1,0 +1,45 @@
+const VISUALIZABLE_TYPES = [
+  "text",
+  "image",
+  "jsonobject",
+  "jsonarray",
+  "csv",
+  "tsv",
+  "apacheparquet",
+] as const;
+
+type VisualizableType = (typeof VISUALIZABLE_TYPES)[number];
+
+const TYPE_ALIASES: Record<string, VisualizableType> = {
+  txt: "text",
+  log: "text",
+  yaml: "text",
+  yml: "text",
+  xml: "text",
+  png: "image",
+  jpg: "image",
+  jpeg: "image",
+  gif: "image",
+  bmp: "image",
+  svg: "image",
+  json: "jsonobject",
+  parquet: "apacheparquet",
+  table: "apacheparquet",
+};
+
+export const normalizeRawType = (type?: string | null): string =>
+  (type ?? "text").toLowerCase().replace(/\s/g, "");
+
+export const resolveArtifactType = (raw: string): string =>
+  TYPE_ALIASES[raw] ?? raw;
+
+export const isVisualizableType = (type: string): type is VisualizableType =>
+  (VISUALIZABLE_TYPES as readonly string[]).includes(type);
+
+export const inferTypeFromUri = (uri?: string | null): string | undefined => {
+  if (!uri) return undefined;
+  const stripped = uri.split(/[?#]/)[0];
+  const ext = stripped.split(".").pop()?.toLowerCase();
+  if (!ext) return undefined;
+  return TYPE_ALIASES[ext] ?? (isVisualizableType(ext) ? ext : undefined);
+};

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/parquetUtils.test.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/parquetUtils.test.ts
@@ -1,0 +1,76 @@
+import type { FileMetaData } from "hyparquet";
+import { describe, expect, it } from "vitest";
+
+import { buildSchemaJson, countColumns } from "./parquetUtils";
+
+const metadata = (schema: unknown[], numRows: bigint): FileMetaData =>
+  ({ schema, num_rows: numRows }) as unknown as FileMetaData;
+
+describe("countColumns", () => {
+  it("uses the root's num_children when present", () => {
+    const meta = metadata(
+      [
+        { name: "root", num_children: 2 },
+        { name: "a", type: "INT64" },
+        { name: "b", type: "BYTE_ARRAY" },
+      ],
+      0n,
+    );
+    expect(countColumns(meta)).toBe(2);
+  });
+
+  it("falls back to the leaf (typed) element count", () => {
+    const meta = metadata(
+      [
+        { name: "a", type: "INT64" },
+        { name: "b", type: "BYTE_ARRAY" },
+      ],
+      0n,
+    );
+    expect(countColumns(meta)).toBe(2);
+  });
+});
+
+describe("buildSchemaJson", () => {
+  it("produces a clean, JSON-serializable column schema and sanitizes bigints", () => {
+    const meta = metadata(
+      [
+        { name: "root", num_children: 2 },
+        { name: "id", type: "INT64", repetition_type: "REQUIRED" },
+        {
+          name: "label",
+          type: "BYTE_ARRAY",
+          repetition_type: "OPTIONAL",
+          logical_type: { type: "STRING" },
+        },
+      ],
+      // A bigint row count exercises hyparquet's toJson bigint sanitization.
+      42n,
+    );
+
+    const json = buildSchemaJson(meta);
+
+    expect(json).toEqual({
+      num_rows: 42,
+      num_columns: 2,
+      columns: [
+        {
+          name: "id",
+          type: "INT64",
+          repetition_type: "REQUIRED",
+          nullable: false,
+        },
+        {
+          name: "label",
+          type: "STRING",
+          logical_type: { type: "STRING" },
+          repetition_type: "OPTIONAL",
+          nullable: true,
+        },
+      ],
+    });
+
+    // Must round-trip through JSON without throwing on bigint.
+    expect(() => JSON.stringify(json)).not.toThrow();
+  });
+});

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/parquetUtils.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/parquetUtils.ts
@@ -1,0 +1,135 @@
+import {
+  type AsyncBuffer,
+  asyncBufferFromUrl,
+  byteLengthFromUrl,
+  cachedAsyncBuffer,
+  type FileMetaData,
+  parquetMetadata,
+  parquetMetadataAsync,
+  parquetReadObjects,
+  type SchemaElement,
+  toJson,
+} from "hyparquet";
+
+import { ArtifactFetchError } from "@/services/executionService";
+
+import {
+  fetchArtifactForHyparquet,
+  fetchArtifactOrThrow,
+} from "./useArtifactFetch";
+import { type ArtifactColumn, MAX_VISUALIZABLE_SIZE_BYTES } from "./utils";
+
+export const PARQUET_PREVIEW_ROWS = 100;
+
+type ParquetSource = AsyncBuffer | ArrayBuffer;
+
+export interface OpenedParquet {
+  source: ParquetSource;
+  metadata: FileMetaData;
+}
+
+export async function openParquet(signedUrl: string): Promise<OpenedParquet> {
+  try {
+    const byteLength = await byteLengthFromUrl(
+      signedUrl,
+      undefined,
+      fetchArtifactForHyparquet,
+    );
+    const source = cachedAsyncBuffer(
+      await asyncBufferFromUrl({
+        url: signedUrl,
+        byteLength,
+        fetch: fetchArtifactForHyparquet,
+      }),
+    );
+    const metadata = await parquetMetadataAsync(source);
+    return { source, metadata };
+  } catch (error) {
+    if (error instanceof ArtifactFetchError) throw error;
+
+    const response = await fetchArtifactOrThrow(signedUrl);
+    const contentLengthHeader = response.headers.get("Content-Length");
+    const contentLength = contentLengthHeader
+      ? Number(contentLengthHeader)
+      : NaN;
+    if (
+      !Number.isFinite(contentLength) ||
+      contentLength > MAX_VISUALIZABLE_SIZE_BYTES
+    ) {
+      throw new ArtifactFetchError(
+        413,
+        "Payload Too Large",
+        "This parquet file is too large to preview without range-request support.",
+      );
+    }
+
+    const source = await response.arrayBuffer();
+    return { source, metadata: parquetMetadata(source) };
+  }
+}
+
+export async function readParquetPreview(
+  opened: OpenedParquet,
+  previewRows: number,
+): Promise<{ columns: ArtifactColumn[]; rows: string[][] }> {
+  const objects = await parquetReadObjects({
+    file: opened.source,
+    metadata: opened.metadata,
+    rowEnd: previewRows,
+  });
+  if (objects.length === 0) return { columns: [], rows: [] };
+
+  const columns = buildColumns(opened.metadata.schema, objects[0]);
+  const rows = objects.map((obj) =>
+    columns.map((col) => obj[col.name]),
+  ) as string[][];
+  return { columns, rows };
+}
+
+function formatParquetType(el: SchemaElement): string {
+  if (el.logical_type) return el.logical_type.type;
+  return el.type ?? "";
+}
+
+function buildColumns(
+  schema: SchemaElement[],
+  firstRow: Record<string, unknown>,
+): ArtifactColumn[] {
+  const schemaByName = new Map(
+    schema.filter((el) => el.type !== undefined).map((el) => [el.name, el]),
+  );
+  return Object.keys(firstRow).map((name) => {
+    const el = schemaByName.get(name);
+    return {
+      name,
+      type: el ? formatParquetType(el) : undefined,
+      nullable: el?.repetition_type === "OPTIONAL",
+    };
+  });
+}
+
+function leafElements(schema: SchemaElement[]): SchemaElement[] {
+  return schema.filter((el) => el.type !== undefined);
+}
+
+export function countColumns(metadata: FileMetaData): number {
+  return (
+    metadata.schema[0]?.num_children ?? leafElements(metadata.schema).length
+  );
+}
+
+export function buildSchemaJson(metadata: FileMetaData): unknown {
+  const columns = leafElements(metadata.schema).map((el) => ({
+    name: el.name,
+    type: formatParquetType(el),
+    logical_type: el.logical_type,
+    repetition_type: el.repetition_type,
+    nullable: el.repetition_type === "OPTIONAL",
+  }));
+
+  return toJson({
+    num_rows: metadata.num_rows,
+    num_columns: countColumns(metadata),
+    columns,
+  });
+}

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/useArtifactFetch.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/useArtifactFetch.tsx
@@ -3,11 +3,34 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { ArtifactFetchError } from "@/services/executionService";
 import { HOURS } from "@/utils/constants";
 
-/**
- * Fetches artifact content from a signed URL using suspense mode.
- * Loading and error states are handled by the nearest SuspenseWrapper.
- * Throws ArtifactFetchError on non-2xx responses so callers can branch on status.
- */
+export const fetchArtifactOrThrow: typeof fetch = async (input, init) => {
+  const response = await fetch(input, init);
+  if (!response.ok) {
+    throw new ArtifactFetchError(
+      response.status,
+      response.statusText,
+      "Failed to fetch artifact.",
+    );
+  }
+  return response;
+};
+
+export const fetchArtifactForHyparquet: typeof fetch = async (input, init) => {
+  const response = await fetch(input, init);
+  if (response.ok) return response;
+
+  const method = (init?.method ?? "GET").toUpperCase();
+  if (method === "HEAD" && response.status === 403) {
+    return response;
+  }
+
+  throw new ArtifactFetchError(
+    response.status,
+    response.statusText,
+    "Failed to fetch artifact.",
+  );
+};
+
 export function useArtifactFetch<T>(
   queryKey: string,
   signedUrl: string,
@@ -16,15 +39,7 @@ export function useArtifactFetch<T>(
   const { data } = useSuspenseQuery({
     queryKey: [`artifact-${queryKey}`, signedUrl],
     queryFn: async () => {
-      const response = await fetch(signedUrl);
-      if (!response.ok) {
-        throw new ArtifactFetchError(
-          response.status,
-          response.statusText,
-          "Failed to fetch artifact.",
-        );
-      }
-
+      const response = await fetchArtifactOrThrow(signedUrl);
       return transform(response);
     },
     staleTime: 24 * HOURS,

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/utils.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/utils.ts
@@ -19,6 +19,7 @@ export type ParsedArtifact = {
 };
 
 export const MAX_PREVIEW_ROWS = 1000;
+export const MAX_VISUALIZABLE_SIZE_BYTES = 50 * 1024 * 1024; // 50 MB
 
 const HEADER_ROW = 1;
 const TRUNCATION_LOOKAHEAD = 1;

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/IOCell.test.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/IOCell.test.tsx
@@ -200,6 +200,61 @@ describe("IOCell", () => {
     expect(screen.queryByTestId("artifact-visualizer")).not.toBeInTheDocument();
   });
 
+  const OVER_LIMIT_BYTES = 60 * 1024 * 1024; // > 50 MB
+
+  it("hides the preview for large fully-downloaded artifacts (> 50 MB)", () => {
+    renderWithQuery(
+      <IOCell
+        name="output"
+        type="CSV"
+        artifact={makeArtifact({
+          artifact_data: {
+            total_size: OVER_LIMIT_BYTES,
+            is_dir: false,
+            uri: "gs://bucket/huge.csv",
+          },
+        })}
+      />,
+    );
+
+    expect(screen.queryByTestId("artifact-visualizer")).not.toBeInTheDocument();
+  });
+
+  it("still shows the preview for large parquet artifacts (read via range requests)", () => {
+    renderWithQuery(
+      <IOCell
+        name="output"
+        type="parquet"
+        artifact={makeArtifact({
+          artifact_data: {
+            total_size: OVER_LIMIT_BYTES,
+            is_dir: false,
+            uri: "gs://bucket/huge.parquet",
+          },
+        })}
+      />,
+    );
+
+    expect(screen.getByTestId("artifact-visualizer")).toBeInTheDocument();
+  });
+
+  it("still shows the preview for a large parquet detected only from the URI", () => {
+    renderWithQuery(
+      <IOCell
+        name="output"
+        artifact={makeArtifact({
+          artifact_data: {
+            total_size: OVER_LIMIT_BYTES,
+            is_dir: false,
+            uri: "gs://bucket/huge.parquet",
+          },
+        })}
+      />,
+    );
+
+    expect(screen.getByTestId("artifact-visualizer")).toBeInTheDocument();
+  });
+
   it("defaults type to 'Any' for inline values without explicit type or type_name", () => {
     renderWithQuery(
       <IOCell

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/IOCell.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/IOCell.tsx
@@ -5,9 +5,13 @@ import { Text } from "@/components/ui/typography";
 import { formatBytes } from "@/utils/string";
 
 import ArtifactURI from "./ArtifactURI";
+import {
+  inferTypeFromUri,
+  normalizeRawType,
+  resolveArtifactType,
+} from "./ArtifactVisualizer/artifactType";
 import ArtifactVisualizer from "./ArtifactVisualizer/ArtifactVisualizer";
-
-const MAX_VISUALIZABLE_SIZE_BYTES = 50 * 1024 * 1024; // 50 MB
+import { MAX_VISUALIZABLE_SIZE_BYTES } from "./ArtifactVisualizer/utils";
 
 interface IOCellProps {
   name: string;
@@ -20,13 +24,20 @@ const IOCell = ({ name, type, artifact }: IOCellProps) => {
   const inlineValue = artifactData?.value;
   const hasInlineValue = canShowInlineValue(inlineValue);
   const hasDetails = Boolean(artifactData?.uri || hasInlineValue);
-  const isTooLargeToVisualize =
-    !hasInlineValue &&
-    !!artifactData?.total_size &&
-    artifactData.total_size > MAX_VISUALIZABLE_SIZE_BYTES;
 
   const artifactType =
     type ?? artifact?.type_name ?? (artifactData?.is_dir ? "Directory" : "Any");
+
+  const rawType = type ?? artifact?.type_name;
+  const detectedType = rawType
+    ? resolveArtifactType(normalizeRawType(rawType))
+    : inferTypeFromUri(artifactData?.uri);
+  const isRangeReadable = detectedType === "apacheparquet";
+  const isTooLargeToVisualize =
+    !hasInlineValue &&
+    !isRangeReadable &&
+    !!artifactData?.total_size &&
+    artifactData.total_size > MAX_VISUALIZABLE_SIZE_BYTES;
 
   return (
     <BlockStack gap="1" className="w-full p-2 border bg-card rounded-md">

--- a/src/routes/PipelineRun/ArtifactPreview.tsx
+++ b/src/routes/PipelineRun/ArtifactPreview.tsx
@@ -3,15 +3,17 @@ import { useParams, useSearch } from "@tanstack/react-router";
 import { useEffect } from "react";
 
 import {
-  inferTypeFromUri,
-  isVisualizableType,
-  normalizeRawType,
   PreviewContent,
   PreviewSkeleton,
-  resolveArtifactType,
 } from "@/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ArtifactPreviewContent";
 import { ArtifactPreviewError } from "@/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ArtifactPreviewError";
 import { ArtifactPreviewHeader } from "@/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ArtifactPreviewHeader";
+import {
+  inferTypeFromUri,
+  isVisualizableType,
+  normalizeRawType,
+  resolveArtifactType,
+} from "@/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/artifactType";
 import { SuspenseWrapper } from "@/components/shared/SuspenseWrapper";
 import { Paragraph } from "@/components/ui/typography";
 import useToastNotification from "@/hooks/useToastNotification";


### PR DESCRIPTION
## What this does

Improves how Parquet files are previewed in the artifact viewer.

**Before:** opening a Parquet preview downloaded the whole file and then showed up to 1,000 rows. Big files were slow, and files above the preview size limit couldn't be opened at all.

**Now:** the viewer reads the file in pages — it only pulls the parts it actually needs (the file's metadata plus the first rows) instead of downloading everything up front. In practice this means:

- **Large files open quickly, at any size.** Because we no longer download the whole file, Parquet previews are no longer blocked by the size limit that applies to other artifact types.
- **You get a fast preview of the first rows** of data as soon as it opens.
- **The header shows the total row and column counts** read straight from the file.
- **A "Download schema" button** lets you save the file's column layout (names, types, nullability) as a JSON file.

## Type of Change

- [x] Improvement

## Test Instructions

1. Open a run that has a Parquet output artifact.
2. Select the task (or output) and open its artifact preview.
3. Confirm you see: the data preview table, the total row/column counts in the header, and a working **Download schema** button.
4. Try a large Parquet file and confirm it opens quickly — previously a file this size may have been blocked as too large to preview.

## Notes

Also includes some internal cleanup raised in review: Parquet-only code was moved into its own module so non-Parquet previews (CSV/TSV) stay lightweight, and the fetch/error-handling logic that was duplicated is now shared.

## Follow-up

Additional viewer affordances — incremental **Load more / Load max**, a **Download full dataset** escape hatch, and CSV/TSV row/column-count parity — are stacked on top in #2593.