### PR TITLE
garden(comments): weekly groundskeeping — 2026-W30

### DIFF
--- a/src/hooks/useGoogleCloudSubmitter.ts
+++ b/src/hooks/useGoogleCloudSubmitter.ts
@@ -265,7 +265,6 @@ const authorizeGoogleCloudClient = async (
         immediate: immediate,
       },
       (authResult) => {
-        // console.debug("authorizeGoogleCloudClient: called back");
         if (authResult === undefined) {
           console.error("authorizeGoogleCloudClient failed");
           reject("gapi.auth.authorize result is undefined");
@@ -273,7 +272,6 @@ const authorizeGoogleCloudClient = async (
           console.error("authorizeGoogleCloudClient failed", authResult.error);
           reject(authResult.error);
         } else {
-          // console.debug("authorizeGoogleCloudClient: Success");
           // Working around the Google Auth bug: The request succeeds, but the returned token does not have the requested scopes.
           // See https://github.com/google/google-api-javascript-client/issues/743
           const receivedScopesString = (authResult as any).scope as


### PR DESCRIPTION
> 🤖 **Automated codebase gardening — DRAFT.** Opened by the `/gardening` skill (pillar: `comments`, week 2026-W30). Nothing auto-merges. This is the first real gardening run; the broader backlog is tracked in the gardening backlog issue.

## What changed

Removed two dead commented-out `console.debug` logging lines in `src/hooks/useGoogleCloudSubmitter.ts` (inside `authorizeGoogleCloudClient`). No behavior change — the lines were already inert.

- [x] `src/hooks/useGoogleCloudSubmitter.ts` — remove commented-out `console.debug` calls (dead code). Rule: `project-conventions#comments` (keep the _why_, drop dead code). The adjacent Google-Auth-bug workaround comment + issue link was **kept**.

## Gate

`pnpm run validate:test` — ✅ passed (185 test files, 1906 tests).

## Reviewer checklist

- [ ] The removed lines are genuinely dead (not a toggle a developer re-enables locally).
- [ ] No _why_ / workaround comment was lost.

<!-- gardening-manifest
{"week":"2026-W30","pillar":"comments","category":"comments","findings":[{"strong":"353a11e01b3a3b26cf007459bb9d92b6f88d3c8f","weak":"057515f3d82779154f3c79ca9d03616cf418de51","file":"src/hooks/useGoogleCloudSubmitter.ts","rule":"project-conventions#comments"}]}
-->
