### PR TITLE
garden(tests): weekly groundskeeping — 2026-W30

### DIFF
--- a/src/utils/yaml.test.ts
+++ b/src/utils/yaml.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import type { ComponentSpec } from "./componentSpec";
+import {
+  componentSpecFromYaml,
+  componentSpecToText,
+  componentSpecToYaml,
+} from "./yaml";
+
+const minimalSpec: ComponentSpec = {
+  name: "Test Component",
+  implementation: {
+    container: {
+      image: "python:3.11",
+    },
+  },
+};
+
+describe("yaml", () => {
+  describe("componentSpecToYaml / componentSpecFromYaml", () => {
+    it("round-trips a component spec through YAML", () => {
+      const yamlText = componentSpecToYaml(minimalSpec);
+
+      expect(typeof yamlText).toBe("string");
+      expect(componentSpecFromYaml(yamlText)).toEqual(minimalSpec);
+    });
+  });
+
+  describe("componentSpecFromYaml", () => {
+    it("throws when the YAML is not an object", () => {
+      expect(() => componentSpecFromYaml("just a plain string")).toThrow(
+        "Invalid component specification format",
+      );
+    });
+
+    it("throws when the parsed object has no implementation", () => {
+      expect(() =>
+        componentSpecFromYaml("name: missing implementation"),
+      ).toThrow("Invalid component specification format");
+    });
+  });
+
+  describe("componentSpecToText", () => {
+    it("serializes with two-space indentation and without YAML anchors", () => {
+      const text = componentSpecToText(minimalSpec);
+
+      expect(text).toContain("implementation:");
+      expect(text).toContain("  container:");
+      expect(text).not.toContain("&");
+    });
+  });
+});


### PR DESCRIPTION
> 🤖 **Automated codebase gardening — DRAFT.** Opened by the `/gardening` skill (pillar: `tests`, week 2026-W30). Nothing auto-merges.

## What changed

Added a co-located unit test for `src/utils/yaml.ts` — a leaf, side-effect-free module that had no test. Covers the round-trip (`componentSpecToYaml` → `componentSpecFromYaml`), the two `ComponentSpecParsingError` paths, and `componentSpecToText` serialization options.

- [x] `src/utils/yaml.test.ts` (new) — 4 tests. Rule: `vitest-testing` (co-located, `import { describe, expect, it } from "vitest"`, pure-function assertions).

This was the only pure-function candidate above the `tests` confidence threshold (0.90); other candidates (hooks needing providers, IndexedDB-backed utils, a constants barrel) were deferred to the backlog.

## Gate

`pnpm run validate:test` — ✅ passed (186 test files incl. the new one, 1910 tests).

## Reviewer checklist

- [ ] **Each new assertion reflects intended behavior, not merely that the test passes.** (A green test can still assert the wrong thing.)
- [ ] The minimal fixture is representative enough to be worth keeping.

<!-- gardening-manifest
{"week":"2026-W30","pillar":"tests","category":"tests","findings":[{"strong":"cadab1f25e1ca4b577f35f3fef19c213931bbbd2","weak":"55f2c1c66a4ac0c36b817506107fa6b79d97e917","file":"src/utils/yaml.test.ts","rule":"vitest-testing"}]}
-->
