### PR TITLE
refactor(react): use tone prop over hardcoded text-muted-foreground in RecentlyViewed

### DIFF
--- a/src/routes/Dashboard/DashboardRecentlyViewedView.tsx
+++ b/src/routes/Dashboard/DashboardRecentlyViewedView.tsx
@@ -20,7 +20,7 @@ const RecentlyViewedCardBody = ({ item }: { item: RecentItem }) => (
   >
     <InlineStack blockAlign="center" align="space-between" gap="2">
       <TypePill type={item.type} />
-      <Text size="xs" className="text-muted-foreground">
+      <Text size="xs" tone="subdued">
         {formatRelativeTime(new Date(item.timestamp))}
       </Text>
     </InlineStack>
@@ -97,7 +97,7 @@ export function DashboardRecentlyViewedView() {
               >
                 <Icon name="ChevronLeft" />
               </Button>
-              <Text size="sm" className="text-muted-foreground">
+              <Text size="sm" tone="subdued">
                 {safePage + 1} / {totalPages}
               </Text>
               <Button


### PR DESCRIPTION
## 🌱 Automated gardening — `react` pillar

Swaps a hardcoded color className for the equivalent `tone` prop on two existing `<Text>` primitives, per the **ui-primitives** convention (color should come from the `tone` prop, not utility classes).

### Change
`src/routes/Dashboard/DashboardRecentlyViewedView.tsx`
- L23 `<Text size="xs" className="text-muted-foreground">` → `<Text size="xs" tone="subdued">`
- L100 `<Text size="sm" className="text-muted-foreground">` → `<Text size="sm" tone="subdued">`

### Why this is a null render transform
`Text` renders `cn(textVariants({ tone, size, ... }), className)`. With the default `tone="inherit"`, the variant emits `text-foreground`, and the appended `className="text-muted-foreground"` overrides it. Switching to `tone="subdued"` emits `text-muted-foreground` directly and removes the competing `text-foreground` — the rendered color token is identical, and there is no element or size change. The third `text-muted-foreground` on this file (L34) was **left untouched** because it is bundled with other utility classes (`truncate font-mono max-w-full`) and is not a pure single-class swap.

### Safeguards
- ✅ `pnpm run validate:test` green at branch tip (185 files, 1906 tests; format / import-sort / knip clean).
- ⚠️ Visual review required (this pillar carries `requiresVisualReview`):

- [ ] Rendered output is visually unchanged in the Recently Viewed dashboard cards and pager (colours identical to `master`).

<!-- gardening-manifest
pillar: react
category: react-primitives
run: 2026-W30
files:
  - path: src/routes/Dashboard/DashboardRecentlyViewedView.tsx
    findings: 2
    strongKey: daa9438ecfc90845219e4afab06a6ba6a53e2c4f
    weakKey: f901d1a4773587a558dddc081c0d9dfc98b4fb28
requiresVisualReview: true
-->

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
