### PR TITLE
fix: v2 - show argument value in runview

### DIFF
--- a/src/routes/v2/pages/RunView/nodes/IONode/context/RunViewInputDetails.tsx
+++ b/src/routes/v2/pages/RunView/nodes/IONode/context/RunViewInputDetails.tsx
@@ -6,7 +6,9 @@ import { CopyText } from "@/components/shared/CopyText/CopyText";
 import { Icon } from "@/components/ui/icon";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Text } from "@/components/ui/typography";
+import { useExecutionDataOptional } from "@/providers/ExecutionDataProvider";
 import { useSpec } from "@/routes/v2/shared/providers/SpecContext";
+import { getArgumentValue } from "@/utils/nodes/taskArguments";
 import { tracking } from "@/utils/tracking";
 
 interface RunViewInputDetailsProps {
@@ -17,6 +19,7 @@ export const RunViewInputDetails = observer(function RunViewInputDetails({
   entityId,
 }: RunViewInputDetailsProps) {
   const spec = useSpec();
+  const executionData = useExecutionDataOptional();
   const input = spec?.inputs.find((i) => i.$id === entityId);
 
   if (!input) {
@@ -30,6 +33,10 @@ export const RunViewInputDetails = observer(function RunViewInputDetails({
   }
 
   const type = input.type ? String(input.type) : undefined;
+
+  const taskArguments = executionData?.details?.task_spec.arguments;
+  const argumentValue = getArgumentValue(taskArguments, input.name);
+  const showDefaultValue = argumentValue === undefined;
 
   return (
     <BlockStack
@@ -75,7 +82,18 @@ export const RunViewInputDetails = observer(function RunViewInputDetails({
           </BlockStack>
         )}
 
-        {input.defaultValue && (
+        {argumentValue && (
+          <BlockStack gap="1">
+            <Text size="xs" tone="subdued" weight="semibold">
+              Value
+            </Text>
+            <CopyText size="sm" className="font-mono whitespace-pre-wrap">
+              {argumentValue}
+            </CopyText>
+          </BlockStack>
+        )}
+
+        {input.defaultValue && showDefaultValue && (
           <BlockStack gap="1">
             <Text size="xs" tone="subdued" weight="semibold">
               Default Value


### PR DESCRIPTION
## Description

When viewing input details in the Run View, the actual argument value passed during execution is now displayed alongside (or instead of) the default value. If an argument value exists for the input, it is shown under a "Value" label. The default value is only shown when no argument value is present, preventing redundant or misleading information from being displayed.

## Screenshots (if applicable)

![image.png](https://app.graphite.com/user-attachments/assets/7702f79d-6560-4dd6-83f6-b5972c816247.png)



## Test Instructions

1. Open a completed run in the Run View.
2. Click on an input node that has an argument value passed to it.
3. Verify that the "Value" field is displayed showing the actual argument value used during execution.
4. Verify that the "Default Value" field is hidden when an argument value is present.
5. Click on an input node that has no argument value but has a default value defined.
6. Verify that only the "Default Value" field is shown.

## Additional Comments