### PR TITLE
garden(comments): weekly groundskeeping — 2026-W30

### DIFF
--- a/src/components/shared/Dialogs/ComponentDuplicateDialog.tsx
+++ b/src/components/shared/Dialogs/ComponentDuplicateDialog.tsx
@@ -42,7 +42,6 @@ function useNameValidation() {
         return ["Name cannot be empty"];
       }
 
-      // check name uniqueness
       const hasDuplicate = nameIndex.has(newName);
 
       if (hasDuplicate) {

--- a/src/components/shared/Submitters/GoogleCloud/compiler/vertexAiCompiler.ts
+++ b/src/components/shared/Submitters/GoogleCloud/compiler/vertexAiCompiler.ts
@@ -181,9 +181,6 @@ const typeSpecToVertexArtifactSpec = (
     artifactType: typeSpecToVertexArtifactTypeSchema(typeSpec),
   };
 };
-// const typeSpecToVertexArtifactType(typeSpec: TypeSpecType) => {
-//     return typeof typeSpec === "string" && ["String", "Integer", "Float", "Double", "Boolean", ]
-// }
 
 const stringToMlmdValue = (
   constantString: string,

--- a/src/utils/graphUtils.ts
+++ b/src/utils/graphUtils.ts
@@ -22,7 +22,6 @@ export const calculateSpecCenter = (
 
   const allPositions: XYPosition[] = [];
 
-  // Collect positions from tasks
   Object.values(graphSpec.tasks).forEach((task) => {
     const taskPosition = extractPositionFromAnnotations(task.annotations);
     if (taskPosition) {
@@ -30,7 +29,6 @@ export const calculateSpecCenter = (
     }
   });
 
-  // Collect positions from inputs
   componentSpec.inputs?.forEach((input) => {
     const inputPosition = extractPositionFromAnnotations(input.annotations);
     if (inputPosition) {
@@ -38,7 +36,6 @@ export const calculateSpecCenter = (
     }
   });
 
-  // Collect positions from outputs
   componentSpec.outputs?.forEach((output) => {
     const outputPosition = extractPositionFromAnnotations(output.annotations);
     if (outputPosition) {

--- a/src/utils/localforage.ts
+++ b/src/utils/localforage.ts
@@ -4,7 +4,6 @@ import type { ComponentReference } from "./componentSpec";
 import { USER_COMPONENTS_LIST_NAME } from "./constants";
 
 const FILE_STORE_DB_TABLE_NAME_PREFIX = "file_store_";
-// Define the Component interface
 interface Component {
   id: string;
   url: string;
@@ -47,7 +46,6 @@ const settingsStore = localforage.createInstance({
   description: "Store for application settings",
 });
 
-// Function to save a component
 export async function saveComponent(component: Component): Promise<Component> {
   const now = Date.now();
   const updatedComponent = {
@@ -65,18 +63,15 @@ export async function saveComponent(component: Component): Promise<Component> {
   return updatedComponent;
 }
 
-// Function to check if a component exists by URL
 export async function componentExistsByUrl(url: string): Promise<boolean> {
   const componentId = await componentUrlStore.getItem<string>(url);
   return componentId !== null;
 }
 
-// Function to get a component by ID
 export async function getComponentById(id: string): Promise<Component | null> {
   return componentStore.getItem<Component>(id);
 }
 
-// Function to get a component by URL
 export async function getComponentByUrl(
   url: string,
 ): Promise<Component | null> {
@@ -86,7 +81,6 @@ export async function getComponentByUrl(
   return getComponentById(componentId);
 }
 
-// Function to fetch all components
 export async function getAllUserComponents(): Promise<UserComponent[]> {
   const userComponents: UserComponent[] = [];
 

--- a/src/utils/validations.ts
+++ b/src/utils/validations.ts
@@ -78,7 +78,6 @@ export const checkComponentSpecValidity = (
     return { isValid: false, errors };
   }
 
-  // Validate inputs and outputs
   errors.push(
     ...validateInputsAndOutputs(componentSpec, skipInputValueValidation),
   );
@@ -91,7 +90,6 @@ export const checkComponentSpecValidity = (
     return { isValid: errors.length === 0, errors };
   }
 
-  // Graph-specific validations
   const graphSpec = componentSpec.implementation.graph;
   errors.push(...validateGraphTasks(graphSpec, componentSpec));
   errors.push(...validateGraphOutputs(graphSpec, componentSpec));


### PR DESCRIPTION
> 🤖 **Automated gardening draft — do not expect this to merge itself.** Opened by the `comments` pillar of the weekly gardening skill. Nothing here auto-merges; a human reviews and merges. This run was a **full-tree** sweep (not scoped to recent churn).

## What this is

Removes low-value comments that restate the code they sit above, plus one genuinely-dead commented-out fragment. Every removal is a **null transform** (comments only — no code changed). Rule: `project-conventions#comments` — *"explain why not what"* and *"avoid redundant comments for self-explanatory functions."*

## Findings (13 across 5 files)

- [ ] `src/utils/localforage.ts` — 6 `// Function to …` / `// Define the …` comments that restate the symbol directly below them
- [ ] `src/utils/graphUtils.ts` — 3 `// Collect positions from tasks/inputs/outputs` labels on self-evident parallel blocks
- [ ] `src/utils/validations.ts` — 2 comments restating the validator being called (`validateInputsAndOutputs`, graph validators)
- [ ] `src/components/shared/Dialogs/ComponentDuplicateDialog.tsx` — `// check name uniqueness` above `nameIndex.has(newName)`
- [ ] `src/components/shared/Submitters/GoogleCloud/compiler/vertexAiCompiler.ts` — dead, syntactically-invalid commented-out `typeSpecToVertexArtifactType` fragment superseded by the function above it

## Deliberately KEPT (flagged by the scan, rejected on read)

- `logsEventsResolvers.ts` commented `utcTimezoneWorkaround` — intentional workaround-in-waiting; a TODO above explains *why* and `adjustTimestamp` references it.
- `vertexPipelineSpec.ts` commented upstream KFP/Vertex proto names — kept as provenance next to the renamed types.
- `submitPipeline.ts` "convert arguments to strings" — paired with the next line explaining *why* (secrets unsupported in templates).
- `localforage.ts` `// App Settings` / `// Setup localforage instances` and `validations.ts` non-graph guard comment — section markers / mild intent.

## Reviewer checklist

- [ ] Each removed comment was genuinely redundant with the code below it (no lost *why*)
- [ ] No behavior change (comment-only diff — confirm the diff is 15 deletions, 0 code lines)

<!-- gardening-manifest
{"week":"2026-W30","pillar":"comments","category":"comments","findings":[{"strongKey":"d63fe50160340803ffd1c0df0356360fb221a18e","weakKey":"f3790522dac15dcc7e24c6df85222d7165048530","file":"src/utils/localforage.ts","rule":"project-conventions#comments"},{"strongKey":"6ac3ace5e65adcfdc3558e9b9be0f3ef65b10d9f","weakKey":"ca216d544b5159aa72b7cdca8397f4387f4a4e45","file":"src/utils/localforage.ts","rule":"project-conventions#comments"},{"strongKey":"5e306a8649567c40bcf5f49b209eaee6332ca886","weakKey":"eaec3ad48b68245a48a829c36dc6972318d05016","file":"src/utils/localforage.ts","rule":"project-conventions#comments"},{"strongKey":"ffa93cf74aa9a8c2c3f70ad59dc7bea00172b437","weakKey":"39a1472d6b84432923522976a0931f8d3aeb62a7","file":"src/utils/localforage.ts","rule":"project-conventions#comments"},{"strongKey":"923a14ff540082a3254ade4d79503aee878945f8","weakKey":"a311ab9b9e03d0f64ef1547bebb5e52a60224b55","file":"src/utils/localforage.ts","rule":"project-conventions#comments"},{"strongKey":"2c6b6c001557f6cce6357c46ef58f02ee3873ba3","weakKey":"d870246cb001454343cafeff3725136a84cccd80","file":"src/utils/localforage.ts","rule":"project-conventions#comments"},{"strongKey":"f27621bd8e03572f052b3d44142e03b7d10378de","weakKey":"c8adf1daa5ebb18263e3aafb83abbba571276a27","file":"src/utils/graphUtils.ts","rule":"project-conventions#comments"},{"strongKey":"cf7347a037a6c40a398f4d86998d0ca9fe95a5b6","weakKey":"4498a85ea9d1068dbd26dd8da6170c94f819da0e","file":"src/utils/graphUtils.ts","rule":"project-conventions#comments"},{"strongKey":"119f196a1d001f6908b33d2d9ff9cf85ac261658","weakKey":"4b62708336bc95059defef37c8aff73b83c41d61","file":"src/utils/graphUtils.ts","rule":"project-conventions#comments"},{"strongKey":"0a7f5cb1aa302d671266bbb79e044974d60659b1","weakKey":"78999df8b8eab25a1b64b3379bef04378552ed07","file":"src/utils/validations.ts","rule":"project-conventions#comments"},{"strongKey":"80559c2485a23e4d0b7d7a1d8a787642a2d07447","weakKey":"7b141093d693a8d735566c6e95dc761f87093e97","file":"src/utils/validations.ts","rule":"project-conventions#comments"},{"strongKey":"a07b32311a777942253b48573918d61faf37ba0c","weakKey":"9c81236a06e7c620f7b4870f51d6d811a3524ade","file":"src/components/shared/Dialogs/ComponentDuplicateDialog.tsx","rule":"project-conventions#comments"},{"strongKey":"e579ceb8be83625f97855d019d98e69a88e51f44","weakKey":"d52f195622a49990715640bcc1ed945cea333524","file":"src/components/shared/Submitters/GoogleCloud/compiler/vertexAiCompiler.ts","rule":"project-conventions#comments"}]}
-->
