### PR TITLE
garden(react): GoogleCloud submitter labels → Paragraph primitive (2026-W30)

### DIFF
--- a/src/components/shared/Submitters/GoogleCloud/ConfigInput.tsx
+++ b/src/components/shared/Submitters/GoogleCloud/ConfigInput.tsx
@@ -8,6 +8,7 @@ import {
   CommandItem,
   CommandList,
 } from "@/components/ui/command";
+import { Paragraph } from "@/components/ui/typography";
 import type { GoogleCloudSubmitterConfiguration } from "@/hooks/useGoogleCloudSubmitter";
 import { cn } from "@/lib/utils";
 
@@ -64,7 +65,9 @@ export const ConfigInput = ({
 
   return (
     <div className="flex flex-col gap-1">
-      <p className="text-sm font-semibold">Project Id</p>
+      <Paragraph size="sm" weight="semibold">
+        Project Id
+      </Paragraph>
       <div className="flex items-center gap-2 mb-1">
         <div className="relative w-full" ref={containerRef}>
           <Command shouldFilter={false} className="w-full py-1">

--- a/src/components/shared/Submitters/GoogleCloud/GoogleCloudSubmitter.tsx
+++ b/src/components/shared/Submitters/GoogleCloud/GoogleCloudSubmitter.tsx
@@ -3,6 +3,7 @@ import type { ChangeEvent } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Link } from "@/components/ui/link";
+import { Paragraph } from "@/components/ui/typography";
 import { useGoogleCloudSubmitter } from "@/hooks/useGoogleCloudSubmitter";
 import type { ComponentSpec } from "@/utils/componentSpec";
 
@@ -39,7 +40,9 @@ const GoogleCloudSubmitter = ({ componentSpec }: GoogleCloudSubmitterProps) => {
   return (
     <div className="flex flex-col gap-4">
       <div className="flex flex-col gap-1">
-        <p className="text-sm font-semibold">OAuth Client Id</p>
+        <Paragraph size="sm" weight="semibold">
+          OAuth Client Id
+        </Paragraph>
         <Input
           type="text"
           value={config.googleCloudOAuthClientId}
@@ -55,7 +58,9 @@ const GoogleCloudSubmitter = ({ componentSpec }: GoogleCloudSubmitterProps) => {
       />
       <RegionInput config={config} onChange={updateConfig} />
       <div className="flex flex-col gap-1">
-        <p className="text-sm font-semibold">Output Directory</p>
+        <Paragraph size="sm" weight="semibold">
+          Output Directory
+        </Paragraph>
         <Input
           type="text"
           value={config.gcsOutputDirectory}

--- a/src/components/shared/Submitters/GoogleCloud/RegionInput.tsx
+++ b/src/components/shared/Submitters/GoogleCloud/RegionInput.tsx
@@ -7,6 +7,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Paragraph } from "@/components/ui/typography";
 import { type GoogleCloudSubmitterConfiguration } from "@/hooks/useGoogleCloudSubmitter";
 
 const VERTEX_AI_PIPELINES_REGIONS = [
@@ -33,7 +34,9 @@ export const RegionInput = ({ config, onChange }: RegionInputProps) => {
 
   return (
     <div className="flex flex-col gap-1">
-      <p className="text-sm font-semibold">Region</p>
+      <Paragraph size="sm" weight="semibold">
+        Region
+      </Paragraph>
       <Select
         onValueChange={handleSelectChange}
         value={config.region}


### PR DESCRIPTION
> 🤖 **Automated gardening draft — do not expect this to merge itself.** Opened by the `react` pillar (primitives) of the weekly gardening skill. Nothing here auto-merges; a human reviews and merges. Full-tree sweep.

## What this is

Moves 4 raw `<p>` form labels onto the `Paragraph` primitive in the Google Cloud submitter. Rule: `ui-primitives#paragraph` — *"Use `Paragraph` for paragraph text instead of raw `<p>`."*

Each swap is **exact-mapping**: `text-sm` → `size="sm"`, `font-semibold` → `weight="semibold"`. `Paragraph` renders as `<p>` (same DOM element). The only class delta is an explicit `text-foreground` (from the default `tone="inherit"`) where the label previously inherited color — hence the visual-diff checkbox below.

## Findings (4 across 3 files)

- [ ] `RegionInput.tsx` — `<p className="text-sm font-semibold">Region</p>` → `<Paragraph size="sm" weight="semibold">`
- [ ] `ConfigInput.tsx` — `<p className="text-sm font-semibold">Project Id</p>` → `<Paragraph …>`
- [ ] `GoogleCloudSubmitter.tsx` — `OAuth Client Id` and `Output Directory` labels → `<Paragraph …>`

## Deliberately NOT swapped (flagged, rejected on read → backlog)

- Bare `<h4>` / `<p className="text-muted-foreground">` — no size class, so `Heading`/`Paragraph` would **inject** a default size/weight and change rendering. Not exact-mapping.
- `IO.tsx` `<h4 className="text-sm font-medium mb-2">` — `font-medium` ≠ Heading's `font-regular`, and `mb-2` margin would be dropped.
- All `flex flex-col gap-N` → `BlockStack` swaps — `BlockStack` applies its own spacing token; not null. Deferred.

## Reviewer checklist

- [ ] **Visually diffed the rendered output — no layout/spacing regression** (labels still render at the same size/weight/color)
- [ ] Confirmed each swap preserved the `<p>` element and the `text-sm font-semibold` styling

<!-- gardening-manifest
{"week":"2026-W30","pillar":"react","category":"primitives","findings":[{"strongKey":"7bf4bdb07814f63204842c1be5dcb9fe7f7bd71f","weakKey":"8698a5c907ad78057ca4db9d4f3c060b2cf74802","file":"src/components/shared/Submitters/GoogleCloud/RegionInput.tsx","rule":"ui-primitives#paragraph"},{"strongKey":"ba8f79344738eec5de0a9f1eabd4726d460d147c","weakKey":"4f9fd01220a681100a9aadd6019b98f0442e3419","file":"src/components/shared/Submitters/GoogleCloud/ConfigInput.tsx","rule":"ui-primitives#paragraph"},{"strongKey":"e21dab5bd05cbd7f1e579e917d64054aa7cf464c","weakKey":"1064bc7653fdc21c78280780af051eb0b4c148db","file":"src/components/shared/Submitters/GoogleCloud/GoogleCloudSubmitter.tsx","rule":"ui-primitives#paragraph"},{"strongKey":"db7c1f5f0c72cad2b3be2a107a015ed2f9a59f13","weakKey":"42e1d7efbe47d020537740677ad3963cb230fe2c","file":"src/components/shared/Submitters/GoogleCloud/GoogleCloudSubmitter.tsx","rule":"ui-primitives#paragraph"}]}
-->
