### PR TITLE
garden(tests): unit tests for clamp / isRecord / canonicalPipelineName / unique (2026-W30)

### DIFF
--- a/src/utils/canonicalPipelineName.test.ts
+++ b/src/utils/canonicalPipelineName.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import type { TaskSpecShape } from "@/components/shared/PipelineRunNameTemplate/types";
+
+import { PIPELINE_CANONICAL_NAME_ANNOTATION } from "./annotations";
+import {
+  buildAnnotationsWithCanonicalName,
+  extractCanonicalName,
+} from "./canonicalPipelineName";
+
+describe("extractCanonicalName()", () => {
+  it("reads the canonical-name annotation from the task spec", () => {
+    const taskSpec = {
+      annotations: {
+        [PIPELINE_CANONICAL_NAME_ANNOTATION]: "my-pipeline",
+      },
+    } as unknown as TaskSpecShape;
+
+    expect(extractCanonicalName(taskSpec)).toBe("my-pipeline");
+  });
+
+  it("returns undefined when the annotation is absent", () => {
+    const taskSpec = { annotations: {} } as unknown as TaskSpecShape;
+    expect(extractCanonicalName(taskSpec)).toBeUndefined();
+  });
+
+  it("returns undefined when the task spec is undefined", () => {
+    expect(extractCanonicalName(undefined)).toBeUndefined();
+  });
+});
+
+describe("buildAnnotationsWithCanonicalName()", () => {
+  it("wraps the canonical name under the canonical-name annotation key", () => {
+    expect(buildAnnotationsWithCanonicalName("my-pipeline")).toEqual({
+      [PIPELINE_CANONICAL_NAME_ANNOTATION]: "my-pipeline",
+    });
+  });
+
+  it("returns an empty object when the canonical name is undefined", () => {
+    expect(buildAnnotationsWithCanonicalName(undefined)).toEqual({});
+  });
+
+  it("returns an empty object for an empty string (falsy)", () => {
+    expect(buildAnnotationsWithCanonicalName("")).toEqual({});
+  });
+
+  it("round-trips through extractCanonicalName", () => {
+    const built = buildAnnotationsWithCanonicalName("round-trip");
+    const taskSpec = { annotations: built } as unknown as TaskSpecShape;
+    expect(extractCanonicalName(taskSpec)).toBe("round-trip");
+  });
+});

--- a/src/utils/math.test.ts
+++ b/src/utils/math.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { clamp } from "./math";
+
+describe("clamp()", () => {
+  it("returns the value unchanged when it is within bounds", () => {
+    expect(clamp(5, 0, 10)).toBe(5);
+  });
+
+  it("clamps to the lower bound when below min", () => {
+    expect(clamp(-3, 0, 10)).toBe(0);
+  });
+
+  it("clamps to the upper bound when above max", () => {
+    expect(clamp(42, 0, 10)).toBe(10);
+  });
+
+  it("returns the value as-is when no bounds are given", () => {
+    expect(clamp(1234)).toBe(1234);
+    expect(clamp(-1234)).toBe(-1234);
+  });
+
+  it("applies only the lower bound when max is omitted", () => {
+    expect(clamp(-5, 0)).toBe(0);
+    expect(clamp(100, 0)).toBe(100);
+  });
+
+  it("applies only the upper bound when min is omitted", () => {
+    expect(clamp(100, undefined, 10)).toBe(10);
+    expect(clamp(-100, undefined, 10)).toBe(-100);
+  });
+
+  it("returns the boundary value when equal to a bound", () => {
+    expect(clamp(0, 0, 10)).toBe(0);
+    expect(clamp(10, 0, 10)).toBe(10);
+  });
+});

--- a/src/utils/typeGuards.test.ts
+++ b/src/utils/typeGuards.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { isRecord } from "./typeGuards";
+
+describe("isRecord()", () => {
+  it("returns true for plain objects", () => {
+    expect(isRecord({})).toBe(true);
+    expect(isRecord({ a: 1, b: "two" })).toBe(true);
+  });
+
+  it("returns false for arrays", () => {
+    expect(isRecord([])).toBe(false);
+    expect(isRecord([1, 2, 3])).toBe(false);
+  });
+
+  it("returns false for null", () => {
+    expect(isRecord(null)).toBe(false);
+  });
+
+  it("returns false for primitives", () => {
+    expect(isRecord(undefined)).toBe(false);
+    expect(isRecord(42)).toBe(false);
+    expect(isRecord("string")).toBe(false);
+    expect(isRecord(true)).toBe(false);
+  });
+
+  it("narrows the type so property access is allowed", () => {
+    const value: unknown = { hello: "world" };
+    if (isRecord(value)) {
+      // If this compiles, the guard narrowed `value` to Record<string, unknown>.
+      expect(value.hello).toBe("world");
+    } else {
+      throw new Error("expected value to be narrowed to a record");
+    }
+  });
+});

--- a/src/utils/unique.test.ts
+++ b/src/utils/unique.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+
+import type { ComponentSpec, GraphSpec } from "./componentSpec";
+import {
+  getUniqueInputName,
+  getUniqueName,
+  getUniqueOutputName,
+  getUniqueTaskName,
+  validateTaskName,
+} from "./unique";
+
+const specWithInputs = (names: string[]): ComponentSpec =>
+  ({ inputs: names.map((name) => ({ name })) }) as ComponentSpec;
+
+const specWithOutputs = (names: string[]): ComponentSpec =>
+  ({ outputs: names.map((name) => ({ name })) }) as ComponentSpec;
+
+const graphWithTasks = (tasks: Record<string, string | undefined>): GraphSpec =>
+  ({
+    tasks: Object.fromEntries(
+      Object.entries(tasks).map(([id, specName]) => [
+        id,
+        { componentRef: { spec: specName ? { name: specName } : undefined } },
+      ]),
+    ),
+  }) as unknown as GraphSpec;
+
+describe("getUniqueName()", () => {
+  it("returns the name unchanged when it is not taken", () => {
+    expect(getUniqueName(["A", "B"], "C")).toBe("C");
+  });
+
+  it("appends an index when the name collides", () => {
+    expect(getUniqueName(["Task"], "Task")).toBe("Task 2");
+  });
+
+  it("increments the index past consecutive collisions", () => {
+    expect(getUniqueName(["Task", "Task 2", "Task 3"], "Task")).toBe("Task 4");
+  });
+
+  it("defaults to 'Untitled' when no name is provided", () => {
+    expect(getUniqueName([])).toBe("Untitled");
+    expect(getUniqueName(["Untitled"])).toBe("Untitled 2");
+  });
+});
+
+describe("getUniqueInputName()", () => {
+  it("defaults to 'Input' and suffixes on collision", () => {
+    expect(getUniqueInputName(specWithInputs([]))).toBe("Input");
+    expect(getUniqueInputName(specWithInputs(["Input"]))).toBe("Input 2");
+  });
+
+  it("respects a custom base name", () => {
+    expect(getUniqueInputName(specWithInputs(["x"]), "x")).toBe("x 2");
+  });
+});
+
+describe("getUniqueOutputName()", () => {
+  it("defaults to 'Output' and suffixes on collision", () => {
+    expect(getUniqueOutputName(specWithOutputs([]))).toBe("Output");
+    expect(getUniqueOutputName(specWithOutputs(["Output"]))).toBe("Output 2");
+  });
+});
+
+describe("getUniqueTaskName()", () => {
+  it("defaults to 'Task' and suffixes based on existing task ids", () => {
+    expect(getUniqueTaskName(graphWithTasks({}))).toBe("Task");
+    expect(getUniqueTaskName(graphWithTasks({ Task: "A" }))).toBe("Task 2");
+  });
+});
+
+describe("validateTaskName()", () => {
+  const graph = graphWithTasks({ task_a: "Existing Task" });
+
+  it("rejects an empty or whitespace-only name", () => {
+    expect(validateTaskName("", graph)).toBe("Name cannot be empty");
+    expect(validateTaskName("   ", graph)).toBe("Name cannot be empty");
+  });
+
+  it("rejects a name that duplicates an existing task display name", () => {
+    expect(validateTaskName("Existing Task", graph)).toBe(
+      "A task with this name already exists",
+    );
+  });
+
+  it("rejects a duplicate task id only when checkId is set", () => {
+    expect(validateTaskName("task_a", graph, true)).toBe(
+      "A task with this id already exists",
+    );
+    // Without checkId the id collision is not reported (name is still free).
+    expect(validateTaskName("task_a", graph, false)).toBeNull();
+  });
+
+  it("rejects names containing special characters", () => {
+    expect(validateTaskName("bad$name", graph)).toBe(
+      "Name cannot contain special characters",
+    );
+  });
+
+  it("accepts a valid, unused name with allowed characters", () => {
+    expect(validateTaskName("New_task-1", graph)).toBeNull();
+  });
+});


### PR DESCRIPTION
> 🤖 **Automated gardening draft — do not expect this to merge itself.** Opened by the `tests` pillar of the weekly gardening skill. Nothing here auto-merges; a human reviews and merges. Full-tree sweep.

## What this is

Adds **32 unit tests across 4 new co-located test files** for previously-untested **pure** utilities. All additive — no source files changed, no existing tests touched. Rule: `vitest-testing#pure-function` — behavior is unambiguous from the implementation and types.

## Coverage added (4 files, 32 tests)

| File under test | Tests | What is asserted |
| --- | --- | --- |
| [`math.ts`](src/utils/math.ts) → `clamp` | 7 | within-bounds passthrough; clamps to min/max; omitted min **or** max; boundary equality |
| [`typeGuards.ts`](src/utils/typeGuards.ts) → `isRecord` | 5 | plain objects → true; arrays/null/primitives → false; type narrowing compiles |
| [`canonicalPipelineName.ts`](src/utils/canonicalPipelineName.ts) | 7 | `extractCanonicalName` from annotations / undefined; `buildAnnotationsWithCanonicalName` incl. empty-string falsy case; extract↔build round-trip |
| [`unique.ts`](src/utils/unique.ts) | 13 | `getUnique{,Input,Output,Task}Name` default names + index suffixing on collision; `validateTaskName` empty/duplicate-name/duplicate-id(`checkId`)/special-char rules |

## Why these

Each target is a **pure function** with no I/O, no clock, no randomness — its correct output is fully determined by its inputs and TypeScript types, so the assertions encode intended behavior rather than incidental implementation. Non-deterministic siblings (e.g. `getInitialName`, which stamps `new Date()`) were deliberately left out — see backlog.

## Gate

`pnpm run validate:test` passed: **189 test files, 1938 passed | 2 todo, 0 failures**; format/lint/typecheck/knip all clean.

## Reviewer checklist (mandatory — `requiresBehaviorReview`)

- [ ] **Each new assertion reflects intended behavior, not merely that the test passes.** In particular confirm:
  - `validateTaskName("task_a", graph, false)` returning `null` is correct — without `checkId`, an id-only collision is *not* an error.
  - `buildAnnotationsWithCanonicalName("")` returning `{}` matches intent (empty string is treated as "no canonical name").
- [ ] The fixtures (`as ComponentSpec` / `as unknown as GraphSpec`) exercise the real code paths, not a shape that sidesteps them.

<!-- gardening-manifest
{"week":"2026-W30","pillar":"tests","category":"tests","findings":[{"strongKey":"e8e5a553ee5a105a388172a142981ab94bd9c1fd","weakKey":"adcafa5ab75859e4f62609496b44a2c318288dcd","file":"src/utils/math.test.ts","rule":"vitest-testing#pure-function"},{"strongKey":"5e8c4caead893483a8beb1f0d4dbfffea91e3568","weakKey":"f6fa28a92d0397c6479a688f5144f84ff6f333d4","file":"src/utils/typeGuards.test.ts","rule":"vitest-testing#pure-function"},{"strongKey":"d11e51a515a3d537af906e63849e98d814535599","weakKey":"583d25cf4b7b607f2c4d336374d82b5733623d94","file":"src/utils/canonicalPipelineName.test.ts","rule":"vitest-testing#pure-function"},{"strongKey":"ef13a1b3481f9758df9bf705ea934d1a8fb951dd","weakKey":"fb390b2403e1e2df138b5188cdf5955a80186e10","file":"src/utils/unique.test.ts","rule":"vitest-testing#pure-function"}]}
-->
