### PR TITLE
chore: v2 - bring floating windows into viewport

### DIFF
--- a/src/routes/v2/pages/Editor/hooks/usePropertiesWindowPositioning.ts
+++ b/src/routes/v2/pages/Editor/hooks/usePropertiesWindowPositioning.ts
@@ -5,6 +5,10 @@ import { useEffect, useRef } from "react";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 import type { Position } from "@/routes/v2/shared/windows/types";
 import { COLLAPSED_DOCK_AREA_WIDTH } from "@/routes/v2/shared/windows/types";
+import {
+  bringIntoViewport,
+  type ViewportBounds,
+} from "@/routes/v2/shared/windows/viewportUtils";
 
 const CONTEXT_PANEL_WINDOW_ID = "context-panel";
 const GAP = 12;
@@ -16,19 +20,12 @@ interface Rect {
   bottom: number;
 }
 
-interface Bounds {
-  left: number;
-  top: number;
-  right: number;
-  bottom: number;
-}
-
 function getAvailableBounds(store: {
   getDockAreaConfig: (side: "left" | "right") => {
     collapsed: boolean;
     width: number;
   };
-}): Bounds {
+}): ViewportBounds {
   const effectiveWidth = (side: "left" | "right") => {
     const area = store.getDockAreaConfig(side);
     return area.collapsed ? COLLAPSED_DOCK_AREA_WIDTH : area.width;
@@ -41,18 +38,6 @@ function getAvailableBounds(store: {
   };
 }
 
-function clampPosition(
-  pos: Position,
-  windowWidth: number,
-  windowHeight: number,
-  bounds: Bounds,
-): Position {
-  return {
-    x: Math.max(bounds.left, Math.min(pos.x, bounds.right - windowWidth)),
-    y: Math.max(bounds.top, Math.min(pos.y, bounds.bottom - windowHeight)),
-  };
-}
-
 /**
  * Try placements in priority order: right, left, below, above.
  * Returns the first position that fits entirely within the available bounds,
@@ -62,7 +47,7 @@ function calculateWindowPosition(
   nodeRect: Rect,
   windowWidth: number,
   windowHeight: number,
-  bounds: Bounds,
+  bounds: ViewportBounds,
 ): Position {
   const candidates: Position[] = [
     { x: nodeRect.right + GAP, y: nodeRect.top },
@@ -82,7 +67,11 @@ function calculateWindowPosition(
     }
   }
 
-  return clampPosition(candidates[0], windowWidth, windowHeight, bounds);
+  return bringIntoViewport(
+    candidates[0],
+    { width: windowWidth, height: windowHeight },
+    bounds,
+  );
 }
 
 /**

--- a/src/routes/v2/shared/components/MiniMap/useCanvasControlsWindow.tsx
+++ b/src/routes/v2/shared/components/MiniMap/useCanvasControlsWindow.tsx
@@ -1,12 +1,12 @@
 import { useEffect } from "react";
 
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
+import { WINDOW_CHROME_HEIGHT } from "@/routes/v2/shared/windows/types";
 
 import { CanvasControlsContent } from "./CanvasControlsContent";
 
 const CANVAS_CONTROLS_WINDOW_ID = "canvas-controls";
 const CANVAS_CONTROLS_WINDOW_HEIGHT = 150;
-const WINDOW_CHROME_HEIGHT = 30;
 
 export function useCanvasControlsWindow(trackingSpace: string) {
   const { windows } = useSharedStores();

--- a/src/routes/v2/shared/windows/types.ts
+++ b/src/routes/v2/shared/windows/types.ts
@@ -146,3 +146,6 @@ export const DOCKED_HEADER_HEIGHT = 36;
 
 /** Distance from dock area edge to trigger dock insert preview (px) */
 export const DOCK_AREA_SNAP_THRESHOLD = 40;
+
+/** Height of a window chrome (px) */
+export const WINDOW_CHROME_HEIGHT = 30;

--- a/src/routes/v2/shared/windows/viewportUtils.test.ts
+++ b/src/routes/v2/shared/windows/viewportUtils.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+
+import { type Position, type Size, WINDOW_CHROME_HEIGHT } from "./types";
+import {
+  bringIntoViewport,
+  getFloatingViewportBounds,
+  isFullyWithinViewport,
+  type ViewportBounds,
+  type ViewportBoundsStore,
+} from "./viewportUtils";
+
+const BOUNDS: ViewportBounds = {
+  left: 0,
+  top: 56,
+  right: 1000,
+  bottom: 800,
+};
+
+const SIZE: Size = { width: 320, height: 420 };
+
+describe("bringIntoViewport", () => {
+  it("leaves a fully-visible window untouched", () => {
+    const position: Position = { x: 100, y: 100 };
+    expect(bringIntoViewport(position, SIZE, BOUNDS)).toEqual(position);
+  });
+
+  it("snaps a window off the right edge back to the right boundary", () => {
+    const result = bringIntoViewport({ x: 5000, y: 100 }, SIZE, BOUNDS);
+    expect(result.x).toBe(BOUNDS.right - SIZE.width);
+    expect(result.y).toBe(100);
+  });
+
+  it("snaps a window off the bottom edge back to the bottom boundary", () => {
+    const result = bringIntoViewport({ x: 100, y: 5000 }, SIZE, BOUNDS);
+    expect(result.x).toBe(100);
+    expect(result.y).toBe(BOUNDS.bottom - SIZE.height - WINDOW_CHROME_HEIGHT);
+  });
+
+  it("snaps a window off the left edge to the left boundary", () => {
+    const result = bringIntoViewport({ x: -500, y: 100 }, SIZE, BOUNDS);
+    expect(result.x).toBe(BOUNDS.left);
+  });
+
+  it("snaps a window above the top boundary down to the top", () => {
+    const result = bringIntoViewport({ x: 100, y: -500 }, SIZE, BOUNDS);
+    expect(result.y).toBe(BOUNDS.top);
+  });
+
+  it("pins an oversized window to the top-left corner", () => {
+    const huge: Size = { width: 2000, height: 2000 };
+    const result = bringIntoViewport({ x: 400, y: 400 }, huge, BOUNDS);
+    expect(result).toEqual({ x: BOUNDS.left, y: BOUNDS.top });
+  });
+
+  it("respects dock-area-shrunk bounds", () => {
+    const dockedBounds: ViewportBounds = {
+      left: 320,
+      top: 56,
+      right: 680,
+      bottom: 800,
+    };
+    const result = bringIntoViewport({ x: 0, y: 100 }, SIZE, dockedBounds);
+    expect(result.x).toBe(dockedBounds.left);
+
+    const rightResult = bringIntoViewport(
+      { x: 5000, y: 100 },
+      SIZE,
+      dockedBounds,
+    );
+    expect(rightResult.x).toBe(dockedBounds.right - SIZE.width);
+  });
+});
+
+describe("isFullyWithinViewport", () => {
+  it("returns true when the window fits entirely", () => {
+    expect(isFullyWithinViewport({ x: 100, y: 100 }, SIZE, BOUNDS)).toBe(true);
+  });
+
+  it("returns false when the window extends past the right edge", () => {
+    expect(isFullyWithinViewport({ x: 900, y: 100 }, SIZE, BOUNDS)).toBe(false);
+  });
+
+  it("returns false when the window sits above the top boundary", () => {
+    expect(isFullyWithinViewport({ x: 100, y: 0 }, SIZE, BOUNDS)).toBe(false);
+  });
+});
+
+describe("getFloatingViewportBounds", () => {
+  function makeStore(
+    overrides: Partial<{
+      left: { collapsed: boolean; width: number; windowIds: string[] };
+      right: { collapsed: boolean; width: number; windowIds: string[] };
+    }> = {},
+  ): ViewportBoundsStore {
+    const left = {
+      collapsed: false,
+      width: 320,
+      windowIds: [] as string[],
+      ...overrides.left,
+    };
+    const right = {
+      collapsed: false,
+      width: 320,
+      windowIds: [] as string[],
+      ...overrides.right,
+    };
+    return {
+      getDockAreaConfig: (side) =>
+        side === "left"
+          ? { collapsed: left.collapsed, width: left.width }
+          : { collapsed: right.collapsed, width: right.width },
+      getDockAreaWindowIds: (side) =>
+        side === "left" ? left.windowIds : right.windowIds,
+    };
+  }
+
+  it("reserves no dock space when both dock areas are empty", () => {
+    window.innerWidth = 1200;
+    window.innerHeight = 800;
+    const bounds = getFloatingViewportBounds(makeStore());
+    expect(bounds).toEqual({ left: 0, top: 56, right: 1200, bottom: 800 });
+  });
+
+  it("subtracts an occupied left dock area from the usable area", () => {
+    window.innerWidth = 1200;
+    window.innerHeight = 800;
+    const bounds = getFloatingViewportBounds(
+      makeStore({ left: { collapsed: false, width: 300, windowIds: ["a"] } }),
+    );
+    expect(bounds.left).toBe(300);
+    expect(bounds.right).toBe(1200);
+  });
+
+  it("uses the collapsed strip width for a collapsed, occupied dock area", () => {
+    window.innerWidth = 1200;
+    window.innerHeight = 800;
+    const bounds = getFloatingViewportBounds(
+      makeStore({ right: { collapsed: true, width: 300, windowIds: ["b"] } }),
+    );
+    expect(bounds.right).toBe(1200 - 36);
+  });
+});

--- a/src/routes/v2/shared/windows/viewportUtils.ts
+++ b/src/routes/v2/shared/windows/viewportUtils.ts
@@ -1,0 +1,91 @@
+import { TOP_NAV_HEIGHT } from "@/utils/constants";
+
+import {
+  COLLAPSED_DOCK_AREA_WIDTH,
+  type Position,
+  type Size,
+  WINDOW_CHROME_HEIGHT,
+} from "./types";
+
+/** Usable viewport region for placing a floating window, in viewport coordinates. */
+export interface ViewportBounds {
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+}
+
+/**
+ * Minimal store surface needed to compute floating-window viewport bounds.
+ * Kept structural so both the window store and tests can satisfy it without a
+ * runtime import of {@link WindowStoreImpl}.
+ */
+export interface ViewportBoundsStore {
+  getDockAreaConfig(side: "left" | "right"): {
+    collapsed: boolean;
+    width: number;
+  };
+  getDockAreaWindowIds(side: "left" | "right"): string[];
+}
+
+/**
+ * Effective horizontal space a dock area occupies. A side that has no docked
+ * windows renders nothing (see DockArea's `isEmpty` early-return), so it
+ * reserves no space; a collapsed side shrinks to the collapsed strip width.
+ */
+function effectiveDockWidth(
+  store: ViewportBoundsStore,
+  side: "left" | "right",
+): number {
+  if (store.getDockAreaWindowIds(side).length === 0) return 0;
+  const area = store.getDockAreaConfig(side);
+  return area.collapsed ? COLLAPSED_DOCK_AREA_WIDTH : area.width;
+}
+
+/**
+ * Current usable region for floating windows: below the top nav and between the
+ * left/right dock areas. Reads live `window` dimensions, so call at runtime.
+ */
+export function getFloatingViewportBounds(
+  store: ViewportBoundsStore,
+): ViewportBounds {
+  return {
+    left: effectiveDockWidth(store, "left"),
+    top: TOP_NAV_HEIGHT,
+    right: window.innerWidth - effectiveDockWidth(store, "right"),
+    bottom: window.innerHeight,
+  };
+}
+
+/** True when the window rect fits entirely inside the usable bounds. */
+export function isFullyWithinViewport(
+  position: Position,
+  size: Size,
+  bounds: ViewportBounds,
+): boolean {
+  return (
+    position.x >= bounds.left &&
+    position.y >= bounds.top &&
+    position.x + size.width <= bounds.right &&
+    position.y + size.height <= bounds.bottom
+  );
+}
+
+/**
+ * Reposition a window so it is fully visible within `bounds`, snapping to the
+ * nearest edge. When the window is larger than the available area it pins to the
+ * top-left corner (`bounds.left` / `bounds.top`) so its header stays reachable.
+ */
+export function bringIntoViewport(
+  position: Position,
+  size: Size,
+  bounds: ViewportBounds,
+): Position {
+  return {
+    x: Math.max(bounds.left, Math.min(position.x, bounds.right - size.width)),
+    y: Math.max(
+      bounds.top,
+      Math.min(position.y, bounds.bottom - size.height - WINDOW_CHROME_HEIGHT),
+    ),
+  };
+}

--- a/src/routes/v2/shared/windows/windowStore.ts
+++ b/src/routes/v2/shared/windows/windowStore.ts
@@ -12,6 +12,7 @@ import {
   type WindowOptions,
   type WindowRef,
 } from "./types";
+import { getFloatingViewportBounds } from "./viewportUtils";
 import { dockSideByWindowId, type ViewPreset } from "./viewPresets";
 import { WindowModel, type WindowStoreRef } from "./windowModel";
 import { buildWindowModelInit } from "./windowStore.utils";
@@ -93,7 +94,12 @@ export class WindowStoreImpl implements WindowStoreRef {
     if (options.miniContent !== undefined) {
       this.miniContentMap.set(id, options.miniContent);
     }
-    const init = buildWindowModelInit(id, options, this.calculateNewPosition());
+    const init = buildWindowModelInit(
+      id,
+      options,
+      this.calculateNewPosition(),
+      getFloatingViewportBounds(this),
+    );
     const model = new WindowModel(init, this);
 
     this.windows[id] = model;

--- a/src/routes/v2/shared/windows/windowStore.utils.test.ts
+++ b/src/routes/v2/shared/windows/windowStore.utils.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, describe, expect, it } from "vitest";
 
-import type { Position, Size, WindowOptions } from "./types";
+import {
+  type Position,
+  type Size,
+  WINDOW_CHROME_HEIGHT,
+  type WindowOptions,
+} from "./types";
+import type { ViewportBounds } from "./viewportUtils";
 import { DEFAULT_VIEW_PRESET } from "./viewPresets";
 import { buildWindowModelInit } from "./windowStore.utils";
 
@@ -19,14 +25,16 @@ interface SeedWindowState {
   isHidden?: boolean;
   isMinimized?: boolean;
   dockState?: "left" | "right" | "none";
+  position?: Position;
+  size?: Size;
 }
 
 function seedPersistedWindow(id: string, state: SeedWindowState): void {
   const layout = {
     windows: {
       [id]: {
-        position: DEFAULT_POSITION,
-        size: DEFAULT_SIZE,
+        position: state.position ?? DEFAULT_POSITION,
+        size: state.size ?? DEFAULT_SIZE,
         dockState: state.dockState ?? "none",
         isHidden: state.isHidden ?? false,
         isMinimized: state.isMinimized ?? false,
@@ -92,5 +100,87 @@ describe("resolveInitialState (via buildWindowModelInit)", () => {
     const init = buildWindowModelInit(id, baseOptions(), DEFAULT_POSITION);
 
     expect(init.state).toBe("minimized");
+  });
+});
+
+describe("resolveGeometry viewport clamping (via buildWindowModelInit)", () => {
+  const VIEWPORT_BOUNDS: ViewportBounds = {
+    left: 0,
+    top: 56,
+    right: 1000,
+    bottom: 800,
+  };
+
+  it("brings an off-viewport persisted floating window back into view", () => {
+    const id = "off-screen-floating";
+    seedPersistedWindow(id, {
+      dockState: "none",
+      position: { x: 5000, y: 5000 },
+      size: { width: 320, height: 420 },
+    });
+
+    const init = buildWindowModelInit(
+      id,
+      baseOptions(),
+      DEFAULT_POSITION,
+      VIEWPORT_BOUNDS,
+    );
+
+    expect(init.position).toEqual({
+      x: VIEWPORT_BOUNDS.right - 320,
+      y: VIEWPORT_BOUNDS.bottom - 420 - WINDOW_CHROME_HEIGHT,
+    });
+  });
+
+  it("leaves an in-viewport persisted floating window untouched", () => {
+    const id = "in-view-floating";
+    const position: Position = { x: 120, y: 140 };
+    seedPersistedWindow(id, {
+      dockState: "none",
+      position,
+      size: { width: 320, height: 420 },
+    });
+
+    const init = buildWindowModelInit(
+      id,
+      baseOptions(),
+      DEFAULT_POSITION,
+      VIEWPORT_BOUNDS,
+    );
+
+    expect(init.position).toEqual(position);
+  });
+
+  it("does not clamp the position of a persisted docked window", () => {
+    const id = "off-screen-docked";
+    const position: Position = { x: 5000, y: 5000 };
+    seedPersistedWindow(id, {
+      dockState: "left",
+      position,
+      size: { width: 320, height: 420 },
+    });
+
+    const init = buildWindowModelInit(
+      id,
+      baseOptions(),
+      DEFAULT_POSITION,
+      VIEWPORT_BOUNDS,
+    );
+
+    expect(init.position).toEqual(position);
+  });
+
+  it("does not clamp a first-visit default position (no persisted state)", () => {
+    const id = "first-visit-default";
+    const optionPosition: Position = { x: 5000, y: 5000 };
+
+    const init = buildWindowModelInit(
+      id,
+      baseOptions({ position: optionPosition, startVisible: true }),
+      DEFAULT_POSITION,
+      VIEWPORT_BOUNDS,
+    );
+
+    expect(init.position).toEqual(optionPosition);
   });
 });

--- a/src/routes/v2/shared/windows/windowStore.utils.ts
+++ b/src/routes/v2/shared/windows/windowStore.utils.ts
@@ -7,6 +7,7 @@ import {
   type WindowOptions,
   type WindowState,
 } from "./types";
+import { bringIntoViewport, type ViewportBounds } from "./viewportUtils";
 import { DEFAULT_VIEW_PRESET } from "./viewPresets";
 import type { WindowModelInit } from "./windowModel";
 import {
@@ -20,10 +21,17 @@ export function buildWindowModelInit(
   id: string,
   options: WindowOptions,
   defaultPosition: Position,
+  viewportBounds?: ViewportBounds,
 ): WindowModelInit {
   const persisted = options.persisted ? getPersistedWindowState(id) : null;
-  const geo = resolveGeometry(persisted, options, defaultPosition);
   const docked = resolveDockedOverrides(persisted, options.defaultDockState);
+  const geo = resolveGeometry(
+    persisted,
+    options,
+    defaultPosition,
+    docked.dockState,
+    viewportBounds,
+  );
   const initial = resolveInitialState(persisted, options, docked.dockState, id);
 
   return {
@@ -86,12 +94,24 @@ function resolveGeometry(
   persisted: PersistedState,
   options: WindowOptions,
   defaultPosition: Position,
+  dockState: DockState,
+  viewportBounds?: ViewportBounds,
 ): { position: Position; size: Size; minSize: Size } {
-  return {
-    position: persisted?.position ?? options.position ?? defaultPosition,
-    size: persisted?.size ?? options.size ?? { ...DEFAULT_WINDOW_SIZE },
-    minSize: options.minSize ?? { ...DEFAULT_MIN_SIZE },
-  };
+  const position = persisted?.position ?? options.position ?? defaultPosition;
+  const size = persisted?.size ?? options.size ?? { ...DEFAULT_WINDOW_SIZE };
+  const minSize = options.minSize ?? { ...DEFAULT_MIN_SIZE };
+
+  // A floating window restored from persisted state may have been saved on a
+  // larger screen and now sit off the current viewport. Snap it back in so it
+  // stays reachable. Only persisted floating windows are adjusted — docked
+  // windows lay out via their dock area, and fresh/default positions are honored.
+  const restoredFloating = persisted !== null && dockState === "none";
+  const resolvedPosition =
+    restoredFloating && viewportBounds
+      ? bringIntoViewport(position, size, viewportBounds)
+      : position;
+
+  return { position: resolvedPosition, size, minSize };
 }
 function resolveDockedOverrides(
   persisted: PersistedState,


### PR DESCRIPTION
## Description

Floating windows that were saved on a larger screen could be restored in an off-screen position, making them unreachable. This adds a viewport clamping step that snaps persisted floating windows back into the visible area when they are restored.

A new `viewportUtils.ts` module centralises the shared logic:

- `ViewportBounds` — a common interface replacing the local `Bounds` type that existed in `usePropertiesWindowPositioning.ts`.
- `bringIntoViewport` — repositions a window to the nearest in-bounds edge, replacing the local `clampPosition` function and accounting for the window chrome height so the title bar always remains reachable.
- `isFullyWithinViewport` — checks whether a window already fits within the usable area.
- `getFloatingViewportBounds` — computes the usable region (below the top nav, between the left/right dock areas) from live `window` dimensions, taking into account whether dock areas are empty or collapsed.

`WINDOW_CHROME_HEIGHT` is promoted to the shared `types.ts` constants file so it can be referenced from `viewportUtils` without duplication.

The clamping is applied only to persisted floating windows (`dockState === "none"` and `persisted !== null`). Docked windows and first-visit default positions are left untouched.

## Screenshots (if applicable)

[Screen Recording 2026-07-27 at 12.11.23 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/0376e6b0-f38a-4386-a7e9-86d8ed9d852d.mov" />](https://app.graphite.com/user-attachments/video/0376e6b0-f38a-4386-a7e9-86d8ed9d852d.mov)



## Test Instructions

1. Open the application and arrange several floating windows, then save/close.
2. Reduce the browser window size (or simulate a smaller viewport) so that the saved positions would be off-screen.
3. Reload the application and verify that all floating windows snap back into the visible area with their title bars accessible.
4. Verify that docked windows are unaffected by the clamping logic.
5. Verify that windows opened for the first time (no persisted state) appear at their configured default positions.

## Additional Comments

Unit tests covering `bringIntoViewport`, `isFullyWithinViewport`, and `getFloatingViewportBounds` are included in `viewportUtils.test.ts`. Tests for the viewport clamping behaviour within `buildWindowModelInit` are added to `windowStore.utils.test.ts`.