### PR TITLE
fix: v2 - runview - show argumentvalue in input node

### DIFF
--- a/src/routes/v2/shared/nodes/IONode/IONode.tsx
+++ b/src/routes/v2/shared/nodes/IONode/IONode.tsx
@@ -2,11 +2,13 @@ import { type Node, type NodeProps } from "@xyflow/react";
 import { observer } from "mobx-react-lite";
 import { type MouseEvent } from "react";
 
+import { useExecutionDataOptional } from "@/providers/ExecutionDataProvider";
 import { useIsDetailedView } from "@/routes/v2/shared/hooks/useIsDetailedView";
 import type { IONodeData } from "@/routes/v2/shared/nodes/types";
 import { useSpec } from "@/routes/v2/shared/providers/SpecContext";
 import { isEditorVisualNodeSelected } from "@/routes/v2/shared/store/isEditorVisualNodeSelected";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
+import { getArgumentValue } from "@/utils/nodes/taskArguments";
 
 import { IONodeCard } from "./IONodeCard";
 import { IONodeSimplified } from "./IONodeSimplified";
@@ -20,6 +22,7 @@ export interface IONodeViewProps {
   type?: string;
   description?: string;
   defaultValue?: string;
+  argumentValue?: string;
   connectedValue: string | null;
   isInput: boolean;
   selected: boolean;
@@ -41,6 +44,7 @@ export const IONode = observer(function IONode({
   const { entityId, ioType } = data;
   const { editor } = useSharedStores();
   const showContent = useIsDetailedView();
+  const executionData = useExecutionDataOptional();
 
   const spec = useSpec();
   const isInput = ioType === "input";
@@ -81,6 +85,11 @@ export const IONode = observer(function IONode({
       ? (entity.defaultValue ?? undefined)
       : undefined;
 
+  const taskArguments = executionData?.details?.task_spec.arguments;
+  const argumentValue = isInput
+    ? getArgumentValue(taskArguments, name)
+    : undefined;
+
   const isSelected = isEditorVisualNodeSelected(editor, id, !!selected);
 
   const viewProps: IONodeViewProps = {
@@ -89,6 +98,7 @@ export const IONode = observer(function IONode({
     type,
     description,
     defaultValue,
+    argumentValue,
     connectedValue,
     isInput,
     selected: isSelected,

--- a/src/routes/v2/shared/nodes/IONode/IONodeCard.tsx
+++ b/src/routes/v2/shared/nodes/IONode/IONodeCard.tsx
@@ -13,6 +13,7 @@ export function IONodeCard({
   type,
   description,
   defaultValue,
+  argumentValue,
   connectedValue,
   isInput,
   selected,
@@ -76,7 +77,7 @@ export function IONodeCard({
               className="truncate text-ink-fixed/70"
             >
               {isInput
-                ? (defaultValue ?? "No value")
+                ? (argumentValue ?? defaultValue ?? "No value")
                 : (connectedValue ?? "No value")}
             </Paragraph>
           </InlineStack>


### PR DESCRIPTION
## Description

Displays the task argument value on input `IONode` cards when execution data is available. The argument value takes precedence over the default value, falling back to the default value if no argument value is present, and then to "No value" if neither exists.

This is achieved by reading `task_spec.arguments` from the optional execution data context and resolving the relevant argument value by input name using the `getArgumentValue` utility.

## Screenshots (if applicable)

| Before | After |
| --- | --- |
| ![image.png](https://app.graphite.com/user-attachments/assets/54bacde6-cf66-44e7-a318-e23fcd451762.png)<br> | ![image.png](https://app.graphite.com/user-attachments/assets/6ef71363-c8fc-4aa6-b709-78d6111d5e13.png)<br> |

## Test Instructions

1. Open a pipeline that has a run/execution with task arguments defined.
2. Navigate to the visual editor for that execution.
3. Inspect an input `IONode` card — it should display the argument value passed to the task rather than the default value.
4. Verify that input nodes without a matching argument still fall back to the default value or "No value".
5. Verify that output nodes are unaffected and continue to display the connected value or "No value".

## Additional Comments