### PR TITLE
fix: v2 runview - cancel button style in floating mode

### DIFF
--- a/src/routes/v2/pages/RunView/components/RunToolsContent.tsx
+++ b/src/routes/v2/pages/RunView/components/RunToolsContent.tsx
@@ -15,7 +15,7 @@ const RUN_TOOL_CLASS_NAME =
 const RUN_TOOL_WRAPPER_CLASS_NAME = "w-full";
 
 const ROW_TOOL_CLASS_NAME =
-  "h-10 justify-start gap-3 px-3 shadow-none hover:border-border hover:bg-muted";
+  "h-10 justify-start gap-3 px-3 shadow-none hover:border-border hover:bg-muted border";
 const ROW_TOOL_WRAPPER_CLASS_NAME = "shrink-0";
 
 export const RunToolsContent = observer(function RunToolsContent() {
@@ -81,7 +81,7 @@ export const RunToolsContent = observer(function RunToolsContent() {
           runId={runId}
           displayLabel="Cancel run"
           showTooltip={false}
-          className={`${toolClassName} text-destructive hover:text-destructive`}
+          className={`${toolClassName} bg-transparent border-destructive/50 hover:bg-destructive/10 text-destructive hover:text-destructive`}
           wrapperClassName={wrapperClassName}
           {...tracking("v2.run_view.tools.cancel_run")}
         />


### PR DESCRIPTION
## Description

Improves the visual styling of run tool buttons in the Run View. Row tool buttons now have a visible border by default, and the Cancel Run button has been updated with a more polished destructive style — using a transparent background, a muted destructive border, and a subtle red hover background instead of relying solely on text color to indicate the destructive action.

## Screenshots (if applicable)

| Before | After |
| --- | --- |
| ![image.png](https://app.graphite.com/user-attachments/assets/c15a1ecc-0d77-4ae5-a113-4693c127652e.png)<br> | ![image.png](https://app.graphite.com/user-attachments/assets/e993a049-ed62-4e85-b075-626866058d5b.png)<br> |

## Test Instructions

1. Navigate to the Run View page.
2. Verify that row tool buttons display a visible border in their default state.
3. Verify that the Cancel Run button displays with a transparent background and a muted destructive-colored border.
4. Hover over the Cancel Run button and confirm a subtle red background appears.

## Additional Comments