### PR TITLE
feat: Return Home button on Loading Screen

### DIFF
--- a/src/components/shared/LoadingScreen.test.tsx
+++ b/src/components/shared/LoadingScreen.test.tsx
@@ -1,0 +1,52 @@
+import { act, cleanup, render, screen } from "@testing-library/react";
+import type { ComponentProps } from "react";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { LOADING_ACTION_DELAY_MS, LoadingScreen } from "./LoadingScreen";
+
+vi.mock("@tanstack/react-router", async (importOriginal) => ({
+  ...(await importOriginal()),
+  Link: ({ to, children }: ComponentProps<"a"> & { to: string }) => (
+    <a href={to}>{children}</a>
+  ),
+}));
+
+describe("LoadingScreen", () => {
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  test("renders the message", () => {
+    render(<LoadingScreen message="Loading Pipeline" />);
+
+    expect(screen.getByText("Loading Pipeline")).toBeInTheDocument();
+  });
+
+  test("does not show the return-home action before the delay", () => {
+    vi.useFakeTimers();
+    render(<LoadingScreen message="Loading Pipeline" />);
+
+    act(() => {
+      vi.advanceTimersByTime(LOADING_ACTION_DELAY_MS - 1);
+    });
+
+    expect(screen.queryByText("Stuck loading?")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "Return home" }),
+    ).not.toBeInTheDocument();
+  });
+
+  test("reveals the return-home link after the delay", () => {
+    vi.useFakeTimers();
+    render(<LoadingScreen message="Loading Pipeline" />);
+
+    act(() => {
+      vi.advanceTimersByTime(LOADING_ACTION_DELAY_MS);
+    });
+
+    expect(screen.getByText("Stuck loading?")).toBeInTheDocument();
+    const link = screen.getByRole("link", { name: "Return home" });
+    expect(link).toHaveAttribute("href", "/");
+  });
+});

--- a/src/components/shared/LoadingScreen.tsx
+++ b/src/components/shared/LoadingScreen.tsx
@@ -1,6 +1,13 @@
+import { Link } from "@tanstack/react-router";
+import { useEffect, useState } from "react";
+
+import { Button } from "@/components/ui/button";
 import { BlockStack } from "@/components/ui/layout";
 import { Spinner } from "@/components/ui/spinner";
 import { Paragraph } from "@/components/ui/typography";
+import { APP_ROUTES } from "@/routes/appRoutes";
+
+export const LOADING_ACTION_DELAY_MS = 8000;
 
 interface LoadingScreenProps {
   message?: string;
@@ -9,12 +16,34 @@ interface LoadingScreenProps {
 export const LoadingScreen = ({
   message = "Loading content",
 }: LoadingScreenProps) => {
+  const [showDelayedAction, setShowDelayedAction] = useState(false);
+
+  useEffect(() => {
+    const timer = setTimeout(
+      () => setShowDelayedAction(true),
+      LOADING_ACTION_DELAY_MS,
+    );
+    return () => clearTimeout(timer);
+  }, []);
+
   return (
-    <BlockStack fill className="items-center justify-center bg-background">
-      <Spinner size={32} />
-      <Paragraph tone="subdued" size="sm">
-        {message}
-      </Paragraph>
+    <BlockStack fill gap="8" className="bg-background">
+      <BlockStack align="center">
+        <Spinner size={32} />
+        <Paragraph tone="subdued" size="sm">
+          {message}
+        </Paragraph>
+      </BlockStack>
+      {showDelayedAction && (
+        <BlockStack gap="2" align="center">
+          <Paragraph tone="subdued" size="sm">
+            Stuck loading?
+          </Paragraph>
+          <Button asChild size="sm" variant="outline">
+            <Link to={APP_ROUTES.HOME}>Return home</Link>
+          </Button>
+        </BlockStack>
+      )}
     </BlockStack>
   );
 };

--- a/src/routes/v2/pages/Editor/EditorV2.tsx
+++ b/src/routes/v2/pages/Editor/EditorV2.tsx
@@ -6,11 +6,10 @@ import { ReactFlowProvider } from "@xyflow/react";
 import { observer } from "mobx-react-lite";
 import { type ReactNode, useEffect } from "react";
 
+import { LoadingScreen } from "@/components/shared/LoadingScreen";
 import { useFlagValue } from "@/components/shared/Settings/useFlags";
 import { withSuspenseWrapper } from "@/components/shared/SuspenseWrapper";
-import { BlockStack, InlineStack } from "@/components/ui/layout";
-import { Spinner } from "@/components/ui/spinner";
-import { Text } from "@/components/ui/typography";
+import { InlineStack } from "@/components/ui/layout";
 import { ComponentLibraryProvider } from "@/providers/ComponentLibraryProvider";
 import { ForcedSearchProvider } from "@/providers/ComponentLibraryProvider/ForcedSearchProvider";
 import { DialogProvider } from "@/providers/DialogProvider/DialogProvider";
@@ -67,16 +66,9 @@ interface PipelineEditorProps {
   pipelineRef: PipelineRef;
 }
 
-const PipelineEditorSkeleton = () => {
-  return (
-    <BlockStack fill className="items-center justify-center bg-background">
-      <InlineStack gap="2">
-        <Spinner />
-        <Text>Loading pipeline... </Text>
-      </InlineStack>
-    </BlockStack>
-  );
-};
+const PipelineEditorSkeleton = () => (
+  <LoadingScreen message="Loading pipeline..." />
+);
 
 const PipelineEditor = withSuspenseWrapper(
   observer(({ pipelineRef }: PipelineEditorProps) => {


### PR DESCRIPTION
## Description

A simple improvement for Loading Screens where a button to return home will be provided after the loading has been going for 8+ seconds (or any other given delay). This is provided primarily because there is no other app-native way to leave the loading screen.

This PR also makes the v2 editor suspense use the loading screen instead of it's own bespoke component.

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

![image.png](https://app.graphite.com/user-attachments/assets/0a348400-8d62-44a8-aa70-a2f1e21fdfa1.png)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

Load a large pipeline or anything else to make it take more than 8 seconds to load the pipeline. Confirm that the text and button show up and work.

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->