### PR TITLE
Add optional targetCluster to pipeline submission

### DIFF
--- a/src/utils/annotations.ts
+++ b/src/utils/annotations.ts
@@ -13,6 +13,8 @@ export const PIPELINE_TAGS_ANNOTATION = "tags";
 export const PIPELINE_CANONICAL_NAME_ANNOTATION = "canonical-pipeline-name";
 export const RUN_NAME_TEMPLATE_ANNOTATION = "run-name-template";
 export const RUN_SOURCE_ANNOTATION = "source";
+export const ORCHESTRATION_TARGET_CLUSTER_ANNOTATION =
+  "tangleml.com/orchestration/target_cluster";
 export const EDITOR_POSITION_ANNOTATION = "editor.position";
 export const EDITOR_COLLAPSED_ANNOTATION = "editor.collapsed";
 export const EDITOR_FLOW_DIRECTION_ANNOTATION = "editor.flow-direction";

--- a/src/utils/submitPipeline.test.ts
+++ b/src/utils/submitPipeline.test.ts
@@ -227,6 +227,43 @@ describe("submitPipelineRun", () => {
     });
   });
 
+  describe("targetCluster handling", () => {
+    const componentSpec: ComponentSpec = {
+      name: "simple-component",
+      implementation: {
+        container: {
+          image: "test:latest",
+        },
+      },
+    };
+
+    it("adds the target_cluster annotation when targetCluster is set", async () => {
+      await submitPipelineRun(componentSpec, mockBackendUrl, {
+        targetCluster: "ml-offline-us-ce1-eo9",
+      });
+
+      expect(pipelineRunService.createPipelineRun).toHaveBeenCalledWith(
+        expect.objectContaining({
+          annotations: {
+            source: "web-app",
+            "tangleml.com/orchestration/target_cluster":
+              "ml-offline-us-ce1-eo9",
+          },
+        }),
+        mockBackendUrl,
+        undefined,
+      );
+    });
+
+    it("leaves run annotations unchanged when targetCluster is unset", async () => {
+      await submitPipelineRun(componentSpec, mockBackendUrl, {});
+
+      const payload = vi.mocked(pipelineRunService.createPipelineRun).mock
+        .calls[0][0];
+      expect(payload.annotations).toEqual({ source: "web-app" });
+    });
+  });
+
   describe("taskArguments handling", () => {
     it("should include taskArguments in payload when provided", async () => {
       // Arrange

--- a/src/utils/submitPipeline.ts
+++ b/src/utils/submitPipeline.ts
@@ -12,7 +12,10 @@ import {
 import type { PipelineRun } from "@/types/pipelineRun";
 
 import { transformAggregatorComponentSpec } from "./aggregatorTransform";
-import { RUN_SOURCE_ANNOTATION } from "./annotations";
+import {
+  ORCHESTRATION_TARGET_CLUSTER_ANNOTATION,
+  RUN_SOURCE_ANNOTATION,
+} from "./annotations";
 import { buildAnnotationsWithCanonicalName } from "./canonicalPipelineName";
 import type {
   ArgumentType,
@@ -30,6 +33,7 @@ export async function submitPipelineRun(
     authorizationToken?: string;
     runNameOverride?: boolean;
     canonicalName?: string;
+    targetCluster?: string;
     onSuccess?: (data: PipelineRun) => void;
     onError?: (error: Error) => void;
   },
@@ -91,6 +95,14 @@ export async function submitPipelineRun(
     const payload = {
       annotations: {
         [RUN_SOURCE_ANNOTATION]: "web-app",
+        // Opt-in override selecting which execution cluster the orchestrator
+        // routes this run to. Omitted entirely when unset, so the default
+        // routing (and the run payload) is unchanged.
+        ...(options?.targetCluster
+          ? {
+              [ORCHESTRATION_TARGET_CLUSTER_ANNOTATION]: options.targetCluster,
+            }
+          : {}),
       },
       root_task: {
         componentRef: {


### PR DESCRIPTION
## What

Adds an optional `targetCluster` to `submitPipelineRun`. When set, it adds the run annotation `cloud-pipelines.net/orchestration/target_cluster`, which the backend launcher router uses to pick which GKE execution cluster the run lands on. When unset, the run payload is **byte-identical** to today.

## Why

Part of the eo9 execution migration. The backend (oasis-backend) routes a run to the "next" GKE cluster when this annotation matches `GKE_CLUSTER_ID_NEXT`; otherwise default routing is unchanged. This PR is the plumbing — it does not yet surface a picker (that's the stacked follow-up). The annotation key is centralized in `src/utils/annotations.ts` (`ORCHESTRATION_TARGET_CLUSTER_ANNOTATION`) to avoid drift with the backend constant.

## Changes

- `src/utils/annotations.ts`: `ORCHESTRATION_TARGET_CLUSTER_ANNOTATION` constant.
- `src/utils/submitPipeline.ts`: optional `targetCluster` option, conditionally spread into `payload.annotations`.

## Tests

`submitPipeline.test.ts`: annotation present when `targetCluster` set; run annotations `{ source: "web-app" }` unchanged when unset. Full suite (31) green; `tsc --noEmit`, eslint, prettier clean.

Draft — Stack C1 of the eo9 execution migration; the submit-dialog cluster picker stacks on top.
