### PR TITLE
feat: Artifact Previews on v2 Runs Output Nodes

### DIFF
--- a/src/routes/v2/pages/RunView/nodes/IONode/context/RunViewOutputDetails.test.tsx
+++ b/src/routes/v2/pages/RunView/nodes/IONode/context/RunViewOutputDetails.test.tsx
@@ -1,0 +1,128 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { type ReactElement } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ArtifactNodeResponse } from "@/api/types.gen";
+
+import { RunViewOutputDetails } from "./RunViewOutputDetails";
+
+const mockSpec = {
+  outputs: [
+    {
+      $id: "out-1",
+      name: "model",
+      type: "String",
+      description: "The trained model",
+    },
+  ],
+};
+
+let mockExecutionData: { rootExecutionId?: string } | null = {
+  rootExecutionId: "root-exec-1",
+};
+
+vi.mock("@/routes/v2/shared/providers/SpecContext", () => ({
+  useSpec: () => mockSpec,
+}));
+
+vi.mock("@/providers/ExecutionDataProvider", () => ({
+  useExecutionDataOptional: () => mockExecutionData,
+}));
+
+vi.mock("@/providers/BackendProvider", () => ({
+  useBackend: () => ({ backendUrl: "http://backend" }),
+}));
+
+vi.mock("@/providers/AnalyticsProvider", () => ({
+  useAnalytics: () => ({ track: vi.fn() }),
+}));
+
+vi.mock("@/components/shared/Buttons/LinkNodeButton", () => ({
+  LinkNodeButton: () => <button type="button">Link</button>,
+}));
+
+vi.mock(
+  "@/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/IOCell",
+  () => ({
+    default: ({
+      name,
+      type,
+      artifact,
+    }: {
+      name: string;
+      type?: string;
+      artifact: ArtifactNodeResponse | null | undefined;
+    }) => (
+      <div
+        data-testid="io-cell"
+        data-name={name}
+        data-type={type}
+        data-artifact-id={artifact?.id ?? ""}
+      />
+    ),
+  }),
+);
+
+const getExecutionArtifacts = vi.fn();
+vi.mock("@/services/executionService", () => ({
+  getExecutionArtifacts: (...args: unknown[]) => getExecutionArtifacts(...args),
+}));
+
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } },
+});
+
+const renderPanel = (ui: ReactElement) =>
+  render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+
+beforeEach(() => {
+  queryClient.clear();
+  getExecutionArtifacts.mockReset();
+  getExecutionArtifacts.mockResolvedValue({ output_artifacts: {} });
+  mockExecutionData = { rootExecutionId: "root-exec-1" };
+});
+
+afterEach(cleanup);
+
+describe("RunViewOutputDetails", () => {
+  it("fetches root-execution artifacts and renders the matching output in IOCell", async () => {
+    getExecutionArtifacts.mockResolvedValue({
+      output_artifacts: {
+        model: { id: "artifact-model" } as ArtifactNodeResponse,
+      },
+    });
+
+    renderPanel(<RunViewOutputDetails entityId="out-1" />);
+
+    await waitFor(() => {
+      const cell = screen.getByTestId("io-cell");
+      expect(cell).toHaveAttribute("data-name", "model");
+      expect(cell).toHaveAttribute("data-type", "String");
+      expect(cell).toHaveAttribute("data-artifact-id", "artifact-model");
+    });
+
+    expect(getExecutionArtifacts).toHaveBeenCalledWith(
+      "root-exec-1",
+      "http://backend",
+    );
+  });
+
+  it("does not render the artifact preview when there is no execution", async () => {
+    mockExecutionData = null;
+
+    renderPanel(<RunViewOutputDetails entityId="out-1" />);
+
+    expect(await screen.findByText("model")).toBeInTheDocument();
+    expect(screen.queryByTestId("io-cell")).toBeNull();
+    expect(screen.queryByText("Value")).toBeNull();
+    expect(getExecutionArtifacts).not.toHaveBeenCalled();
+  });
+
+  it("shows a not-found message for an unknown output id", () => {
+    renderPanel(<RunViewOutputDetails entityId="missing" />);
+
+    expect(screen.getByText("Output not found")).toBeInTheDocument();
+    expect(screen.queryByTestId("io-cell")).toBeNull();
+  });
+});

--- a/src/routes/v2/pages/RunView/nodes/IONode/context/RunViewOutputDetails.tsx
+++ b/src/routes/v2/pages/RunView/nodes/IONode/context/RunViewOutputDetails.tsx
@@ -1,12 +1,18 @@
+import { useQuery } from "@tanstack/react-query";
 import { observer } from "mobx-react-lite";
 
 import { LinkNodeButton } from "@/components/shared/Buttons/LinkNodeButton";
 import { ActionBlock } from "@/components/shared/ContextPanel/Blocks/ActionBlock";
 import { CopyText } from "@/components/shared/CopyText/CopyText";
+import IOCell from "@/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/IOCell";
 import { Icon } from "@/components/ui/icon";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Spinner } from "@/components/ui/spinner";
 import { Text } from "@/components/ui/typography";
+import { useBackend } from "@/providers/BackendProvider";
+import { useExecutionDataOptional } from "@/providers/ExecutionDataProvider";
 import { useSpec } from "@/routes/v2/shared/providers/SpecContext";
+import { getExecutionArtifacts } from "@/services/executionService";
 import { tracking } from "@/utils/tracking";
 
 interface RunViewOutputDetailsProps {
@@ -17,7 +23,16 @@ export const RunViewOutputDetails = observer(function RunViewOutputDetails({
   entityId,
 }: RunViewOutputDetailsProps) {
   const spec = useSpec();
+  const executionData = useExecutionDataOptional();
+  const { backendUrl } = useBackend();
   const output = spec?.outputs.find((o) => o.$id === entityId);
+
+  const rootExecutionId = executionData?.rootExecutionId;
+  const { data: artifacts, isLoading: isLoadingArtifacts } = useQuery({
+    queryKey: ["artifacts", rootExecutionId],
+    queryFn: () => getExecutionArtifacts(String(rootExecutionId), backendUrl),
+    enabled: !!rootExecutionId,
+  });
 
   if (!output) {
     return (
@@ -30,6 +45,7 @@ export const RunViewOutputDetails = observer(function RunViewOutputDetails({
   }
 
   const type = output.type ? String(output.type) : undefined;
+  const artifact = artifacts?.output_artifacts?.[output.name];
 
   return (
     <BlockStack
@@ -72,6 +88,24 @@ export const RunViewOutputDetails = observer(function RunViewOutputDetails({
               Description
             </Text>
             <CopyText size="sm">{output.description}</CopyText>
+          </BlockStack>
+        )}
+
+        {rootExecutionId && (
+          <BlockStack gap="1">
+            <Text size="xs" tone="subdued" weight="semibold">
+              Value
+            </Text>
+            {isLoadingArtifacts ? (
+              <InlineStack gap="2" blockAlign="center">
+                <Spinner />
+                <Text size="sm" tone="subdued">
+                  Loading artifact…
+                </Text>
+              </InlineStack>
+            ) : (
+              <IOCell name={output.name} type={type} artifact={artifact} />
+            )}
           </BlockStack>
         )}
       </BlockStack>


### PR DESCRIPTION
## Description

Adds artifact previews to Output Node Properties in v2 Run View, as per v1 run view. The two versions now have parity for artifact preview offerings.



Also adds a test file for RunViewOutputDetails.

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

![image.png](https://app.graphite.com/user-attachments/assets/4665971a-6e34-4f48-834d-2f4b9d39f65c.png)



<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

Run a pipeline that outputs tabulated data to an output node.  
Confirm in the v2 run view that the artifact preview appears when the output node is seletced and the run is complete.



Note that artifact previews do not work locally, so if you actually try to preview the data it will not load. This is a known limitation. Try in staging/tophat!

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->