### PR TITLE
fix: v2 - support value and default in input nodes

### DIFF
--- a/src/routes/v2/pages/Editor/nodes/IONode/context/InputDetails.tsx
+++ b/src/routes/v2/pages/Editor/nodes/IONode/context/InputDetails.tsx
@@ -1,6 +1,7 @@
 import { observer } from "mobx-react-lite";
 import { type ChangeEvent, type FocusEvent } from "react";
 
+import { Icon } from "@/components/ui/icon";
 import { Input } from "@/components/ui/input";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Textarea } from "@/components/ui/textarea";
@@ -51,10 +52,12 @@ export const InputDetails = observer(function InputDetails({
     }
   };
 
-  const handleDefaultValueChange = (value: string) => {
-    const newDefault = value || undefined;
-    if (newDefault !== input.defaultValue) {
-      ioActions.setInputDefaultValue(spec, entityId, newDefault);
+  const effectiveValue = input.value ?? input.defaultValue;
+
+  const handleValueChange = (value: string) => {
+    const newValue = value || undefined;
+    if (newValue !== effectiveValue) {
+      ioActions.setInputValue(spec, entityId, newValue);
       track("v2.pipeline_editor.input_details.default_value.updated");
     }
   };
@@ -111,23 +114,37 @@ export const InputDetails = observer(function InputDetails({
         </BlockStack>
 
         <BlockStack gap="2">
-          <InputLabel
-            htmlFor="input-default-value"
-            onCopy={() => input.defaultValue}
+          <InlineStack
+            gap="2"
+            blockAlign="center"
+            align="space-between"
+            className="w-full"
           >
-            Default Value
-          </InputLabel>
+            <InputLabel htmlFor="input-value" onCopy={() => effectiveValue}>
+              Value
+            </InputLabel>
+            <InlineStack gap="1" blockAlign="center">
+              <Icon
+                name="SquareCheckBig"
+                size="sm"
+                className="text-muted-foreground"
+              />
+              <Text size="xs" className="text-muted-foreground">
+                Use as default
+              </Text>
+            </InlineStack>
+          </InlineStack>
 
           <AutoGrowTextarea
-            id="input-default-value"
-            key={`${entityId}-default-value`}
-            expandDialogTitle="Default Value"
+            id="input-value"
+            key={`${entityId}-value`}
+            expandDialogTitle="Value"
             highlightSyntax={true}
-            defaultValue={input.defaultValue}
-            onChangeComplete={handleDefaultValueChange}
-            placeholder="Default value"
+            defaultValue={effectiveValue}
+            onChangeComplete={handleValueChange}
+            placeholder="Value"
             className="h-4 min-h-4 text-xs font-mono"
-            data-testid="input-default-value"
+            data-testid="input-value"
           />
         </BlockStack>
 

--- a/src/routes/v2/pages/Editor/store/actions/io.actions.ts
+++ b/src/routes/v2/pages/Editor/store/actions/io.actions.ts
@@ -136,6 +136,19 @@ export function setInputDefaultValue(
   });
 }
 
+export function setInputValue(
+  undo: UndoGroupable,
+  spec: ComponentSpec,
+  entityId: string,
+  value: string | undefined,
+): void {
+  undo.withGroup("Set input value", () => {
+    const input = spec.inputs.find((i) => i.$id === entityId);
+    input?.setValue(value);
+    input?.setDefaultValue(value);
+  });
+}
+
 export function setOutputDescription(
   undo: UndoGroupable,
   spec: ComponentSpec,

--- a/src/routes/v2/pages/Editor/store/actions/useIOActions.ts
+++ b/src/routes/v2/pages/Editor/store/actions/useIOActions.ts
@@ -14,6 +14,7 @@ import {
   setInputDefaultValue,
   setInputDescription,
   setInputType,
+  setInputValue,
   setOutputDescription,
 } from "./io.actions";
 
@@ -35,6 +36,7 @@ export function useIOActions() {
     setInputDescription: setInputDescription.bind(null, undo),
     setInputType: setInputType.bind(null, undo),
     setInputDefaultValue: setInputDefaultValue.bind(null, undo),
+    setInputValue: setInputValue.bind(null, undo),
     setOutputDescription: setOutputDescription.bind(null, undo),
     createConnectedIONode: createConnectedIONode.bind(null, undo),
     createInputAndConnect: createInputAndConnect.bind(null, undo),

--- a/src/routes/v2/shared/nodes/IONode/IONode.tsx
+++ b/src/routes/v2/shared/nodes/IONode/IONode.tsx
@@ -21,6 +21,7 @@ export interface IONodeViewProps {
   name: string;
   type?: string;
   description?: string;
+  value?: string;
   defaultValue?: string;
   argumentValue?: string;
   connectedValue: string | null;
@@ -90,6 +91,11 @@ export const IONode = observer(function IONode({
     ? getArgumentValue(taskArguments, name)
     : undefined;
 
+  const value =
+    isInput && entity && "value" in entity
+      ? (entity.value ?? undefined)
+      : undefined;
+
   const isSelected = isEditorVisualNodeSelected(editor, id, !!selected);
 
   const viewProps: IONodeViewProps = {
@@ -97,6 +103,7 @@ export const IONode = observer(function IONode({
     name,
     type,
     description,
+    value,
     defaultValue,
     argumentValue,
     connectedValue,

--- a/src/routes/v2/shared/nodes/IONode/IONodeCard.tsx
+++ b/src/routes/v2/shared/nodes/IONode/IONodeCard.tsx
@@ -12,6 +12,7 @@ export function IONodeCard({
   name,
   type,
   description,
+  value,
   defaultValue,
   argumentValue,
   connectedValue,
@@ -77,7 +78,7 @@ export function IONodeCard({
               className="truncate text-ink-fixed/70"
             >
               {isInput
-                ? (argumentValue ?? defaultValue ?? "No value")
+                ? (argumentValue ?? value ?? defaultValue ?? "No value")
                 : (connectedValue ?? "No value")}
             </Paragraph>
           </InlineStack>


### PR DESCRIPTION
## Description

Introduces a distinct `value` field for pipeline inputs that sits above `defaultValue` in the resolution hierarchy. When a user sets a value in the Input Details panel, it now calls `setInputValue`, which sets both `value` and `defaultValue` on the input simultaneously. The displayed label has been renamed from "Default Value" to "Value", and the resolved display uses `value ?? defaultValue` so that an explicitly set value takes precedence. A "Use as default" indicator has also been added to the input label area.

## Screenshots (if applicable)

[Screen Recording 2026-07-29 at 12.40.03 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/e1048b36-ac2e-443f-8e9d-25146aae736b.mov" />](https://app.graphite.com/user-attachments/video/e1048b36-ac2e-443f-8e9d-25146aae736b.mov)



## Test Instructions

1. Open a pipeline in the editor and select an input node.
2. In the Input Details panel, confirm the field is now labelled "Value" with a "Use as default" indicator.
3. Enter a value and confirm it is reflected on the node card, taking precedence over any existing default value.
4. Confirm undo/redo correctly reverts the value change.
5. Confirm that pipelines with existing default values continue to display correctly when no explicit value is set.

## Additional Comments