### PR TITLE
feat: Improve Table Previews

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ArtifactPreviewContent.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ArtifactPreviewContent.tsx
@@ -28,7 +28,13 @@ export const InlineContent = ({
   switch (type) {
     case "csv":
     case "tsv":
-      return <CsvVisualizerValue value={value} isFullscreen={isFullscreen} />;
+      return (
+        <CsvVisualizerValue
+          value={value}
+          type={type}
+          isFullscreen={isFullscreen}
+        />
+      );
     case "jsonobject":
     case "jsonarray":
       return <JsonVisualizerValue value={value} name={name} />;
@@ -78,6 +84,7 @@ export const PreviewContent = ({
       return (
         <CsvVisualizerRemote
           signedUrl={signedUrl}
+          type={type}
           isFullscreen={isFullscreen}
         />
       );

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ArtifactVisualizer.test.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ArtifactVisualizer.test.tsx
@@ -61,11 +61,21 @@ vi.mock("./ImageVisualizer", () => ({
 }));
 
 vi.mock("./CsvVisualizer", () => ({
-  CsvVisualizerValue: ({ value }: { value: string }) => (
-    <div data-testid="csv-visualizer" data-value={value} />
+  CsvVisualizerValue: ({ value, type }: { value: string; type: string }) => (
+    <div data-testid="csv-visualizer" data-value={value} data-type={type} />
   ),
-  CsvVisualizerRemote: ({ signedUrl }: { signedUrl: string }) => (
-    <div data-testid="csv-visualizer" data-signed-url={signedUrl} />
+  CsvVisualizerRemote: ({
+    signedUrl,
+    type,
+  }: {
+    signedUrl: string;
+    type: string;
+  }) => (
+    <div
+      data-testid="csv-visualizer"
+      data-signed-url={signedUrl}
+      data-type={type}
+    />
   ),
 }));
 
@@ -190,6 +200,7 @@ describe("ArtifactVisualizer", () => {
       await waitFor(() => {
         const viz = screen.getByTestId("csv-visualizer");
         expect(viz).toHaveAttribute("data-value", "a,b\n1,2");
+        expect(viz).toHaveAttribute("data-type", "csv");
       });
     });
 
@@ -208,6 +219,8 @@ describe("ArtifactVisualizer", () => {
       await waitFor(() => {
         const viz = screen.getByTestId("csv-visualizer");
         expect(viz).toHaveAttribute("data-value", "a\tb\n1\t2");
+        // The type drives the download filename/MIME, so it must survive routing.
+        expect(viz).toHaveAttribute("data-type", "tsv");
       });
     });
 
@@ -260,6 +273,23 @@ describe("ArtifactVisualizer", () => {
 
       await waitFor(() => {
         expect(screen.getByTestId("image-visualizer")).toBeInTheDocument();
+      });
+    });
+
+    it("renders CsvVisualizerRemote with the tsv type for tsv artifacts", async () => {
+      renderWithQuery(
+        <ArtifactVisualizer artifact={makeArtifact()} name="data" type="TSV" />,
+      );
+
+      await userEvent.click(screen.getByText("Preview"));
+
+      await waitFor(() => {
+        const viz = screen.getByTestId("csv-visualizer");
+        expect(viz).toHaveAttribute(
+          "data-signed-url",
+          "https://storage.example.com/signed",
+        );
+        expect(viz).toHaveAttribute("data-type", "tsv");
       });
     });
 

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/CsvVisualizer.test.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/CsvVisualizer.test.tsx
@@ -6,21 +6,39 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { CsvVisualizerRemote, CsvVisualizerValue } from "./CsvVisualizer";
 
+type DownloadFull = { filename: string; getBlob: () => Promise<Blob> };
+
+// The real TableVisualizer owns the download click; here we just capture the
+// `downloadFull` prop so tests can exercise its `getBlob` contract directly.
+let lastDownloadFull: DownloadFull | undefined;
+
 vi.mock("./TableVisualizer", () => ({
   default: ({
     data,
     isFullscreen,
+    totalRows,
+    columnCount,
+    downloadFull,
   }: {
     data: { columns: { name: string }[]; rows: string[][] };
     isFullscreen: boolean;
-  }) => (
-    <div
-      data-testid="table-visualizer"
-      data-fullscreen={isFullscreen}
-      data-headers={data.columns.map((c) => c.name).join(",")}
-      data-row-count={data.rows.length}
-    />
-  ),
+    totalRows?: number;
+    columnCount?: number;
+    downloadFull?: DownloadFull;
+  }) => {
+    lastDownloadFull = downloadFull;
+    return (
+      <div
+        data-testid="table-visualizer"
+        data-fullscreen={isFullscreen}
+        data-headers={data.columns.map((c) => c.name).join(",")}
+        data-row-count={data.rows.length}
+        data-total-rows={totalRows}
+        data-column-count={columnCount}
+        data-download-filename={downloadFull?.filename}
+      />
+    );
+  },
 }));
 
 const queryClient = new QueryClient({
@@ -49,13 +67,15 @@ const renderWithSuspense = (ui: ReactElement) =>
 
 beforeEach(() => {
   queryClient.clear();
+  lastDownloadFull = undefined;
 });
 
 describe("CsvVisualizerValue", () => {
-  it("parses CSV and renders TableVisualizer", () => {
+  it("parses CSV and renders TableVisualizer with row/column stats", () => {
     renderWithQuery(
       <CsvVisualizerValue
         value={"Name,Age\nAlice,30\nBob,25"}
+        type="csv"
         isFullscreen={false}
       />,
     );
@@ -63,12 +83,28 @@ describe("CsvVisualizerValue", () => {
     const table = screen.getByTestId("table-visualizer");
     expect(table).toHaveAttribute("data-headers", "Name,Age");
     expect(table).toHaveAttribute("data-row-count", "2");
+    expect(table).toHaveAttribute("data-total-rows", "2");
+    expect(table).toHaveAttribute("data-column-count", "2");
+  });
+
+  it("offers the inline value itself as the full-dataset download", async () => {
+    const value = "Name,Age\nAlice,30\nBob,25";
+    renderWithQuery(
+      <CsvVisualizerValue value={value} type="csv" isFullscreen={false} />,
+    );
+
+    // The inline value is served as-is on demand — no fetch, no mount-time URL.
+    expect(lastDownloadFull?.filename).toBe("data.csv");
+    const blob = await lastDownloadFull?.getBlob();
+    expect(await blob?.text()).toBe(value);
+    expect(blob?.type).toBe("text/csv;charset=utf-8");
   });
 
   it("parses TSV with tab delimiter", () => {
     renderWithQuery(
       <CsvVisualizerValue
         value={"Name\tAge\nAlice\t30"}
+        type="tsv"
         isFullscreen={false}
       />,
     );
@@ -77,15 +113,29 @@ describe("CsvVisualizerValue", () => {
     expect(table).toHaveAttribute("data-headers", "Name,Age");
   });
 
+  it("downloads TSV artifacts as .tsv with a tab-separated MIME type", async () => {
+    const value = "Name\tAge\nAlice\t30";
+    renderWithQuery(
+      <CsvVisualizerValue value={value} type="tsv" isFullscreen={false} />,
+    );
+
+    expect(lastDownloadFull?.filename).toBe("data.tsv");
+    const blob = await lastDownloadFull?.getBlob();
+    expect(await blob?.text()).toBe(value);
+    expect(blob?.type).toBe("text/tab-separated-values;charset=utf-8");
+  });
+
   it("shows 'No data' for empty CSV", () => {
-    renderWithQuery(<CsvVisualizerValue value="" isFullscreen={false} />);
+    renderWithQuery(
+      <CsvVisualizerValue value="" type="csv" isFullscreen={false} />,
+    );
     expect(screen.getByText("No data")).toBeInTheDocument();
   });
 
   it("does not fetch", () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch");
     renderWithQuery(
-      <CsvVisualizerValue value="a,b\n1,2" isFullscreen={false} />,
+      <CsvVisualizerValue value="a,b\n1,2" type="csv" isFullscreen={false} />,
     );
     expect(fetchSpy).not.toHaveBeenCalled();
     fetchSpy.mockRestore();
@@ -102,6 +152,7 @@ describe("CsvVisualizerRemote", () => {
     renderWithSuspense(
       <CsvVisualizerRemote
         signedUrl="https://storage.example.com/data.csv"
+        type="csv"
         isFullscreen={false}
       />,
     );
@@ -124,6 +175,7 @@ describe("CsvVisualizerRemote", () => {
     renderWithSuspense(
       <CsvVisualizerRemote
         signedUrl="https://storage.example.com/forbidden.csv"
+        type="csv"
         isFullscreen={false}
       />,
     );
@@ -145,6 +197,7 @@ describe("CsvVisualizerRemote", () => {
     renderWithSuspense(
       <CsvVisualizerRemote
         signedUrl="https://storage.example.com/data.csv"
+        type="csv"
         isFullscreen={true}
       />,
     );
@@ -155,6 +208,59 @@ describe("CsvVisualizerRemote", () => {
         "true",
       );
     });
+
+    vi.restoreAllMocks();
+  });
+
+  it("fetches the signed URL for the full-dataset download", async () => {
+    const fullBlob = new Blob(["X,Y\n1,2\n3,4"], { type: "text/csv" });
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve("X,Y\n1,2\n3,4"),
+      blob: () => Promise.resolve(fullBlob),
+    } as unknown as Response);
+    const signedUrl = "https://storage.example.com/data.csv";
+
+    renderWithSuspense(
+      <CsvVisualizerRemote
+        signedUrl={signedUrl}
+        type="csv"
+        isFullscreen={false}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("table-visualizer")).toBeInTheDocument(),
+    );
+
+    expect(lastDownloadFull?.filename).toBe("data.csv");
+    fetchSpy.mockClear();
+    const blob = await lastDownloadFull?.getBlob();
+    expect(fetchSpy).toHaveBeenCalledWith(signedUrl, undefined);
+    expect(blob).toBe(fullBlob);
+
+    vi.restoreAllMocks();
+  });
+
+  it("names the TSV download data.tsv", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve("X\tY\n1\t2"),
+    } as Response);
+
+    renderWithSuspense(
+      <CsvVisualizerRemote
+        signedUrl="https://storage.example.com/data.tsv"
+        type="tsv"
+        isFullscreen={false}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("table-visualizer")).toBeInTheDocument(),
+    );
+
+    expect(lastDownloadFull?.filename).toBe("data.tsv");
 
     vi.restoreAllMocks();
   });

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/CsvVisualizer.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/CsvVisualizer.tsx
@@ -1,26 +1,43 @@
 import { Paragraph } from "@/components/ui/typography";
 
-import TableVisualizer from "./TableVisualizer";
-import { useArtifactFetch } from "./useArtifactFetch";
+import TableVisualizer, { type DownloadFullDataset } from "./TableVisualizer";
+import { fetchArtifactOrThrow, useArtifactFetch } from "./useArtifactFetch";
 import { useRowCap } from "./useRowCap";
 import { parseCsv, type ParsedArtifact } from "./utils";
 
+type DelimitedArtifactType = "csv" | "tsv";
+
+const DOWNLOAD_FORMATS: Record<
+  DelimitedArtifactType,
+  { filename: string; mimeType: string }
+> = {
+  csv: { filename: "data.csv", mimeType: "text/csv;charset=utf-8" },
+  tsv: {
+    filename: "data.tsv",
+    mimeType: "text/tab-separated-values;charset=utf-8",
+  },
+};
+
 interface CsvVisualizerValueProps {
   value: string;
+  type: DelimitedArtifactType;
   isFullscreen: boolean;
 }
 
 interface CsvVisualizerRemoteProps {
   signedUrl: string;
+  type: DelimitedArtifactType;
   isFullscreen: boolean;
 }
 
 const CsvContent = ({
   parsed,
   isFullscreen,
+  downloadFull,
 }: {
   parsed: ParsedArtifact;
   isFullscreen: boolean;
+  downloadFull?: DownloadFullDataset;
 }) => {
   const { data, onLoadMore, onLoadAll } = useRowCap(parsed);
 
@@ -38,19 +55,35 @@ const CsvContent = ({
       isFullscreen={isFullscreen}
       onLoadMore={onLoadMore}
       onLoadAll={onLoadAll}
+      totalRows={parsed.totalRows}
+      columnCount={parsed.columns.length}
+      downloadFull={downloadFull}
     />
   );
 };
 
 export const CsvVisualizerValue = ({
   value,
+  type,
   isFullscreen,
-}: CsvVisualizerValueProps) => (
-  <CsvContent parsed={parseCsv(value)} isFullscreen={isFullscreen} />
-);
+}: CsvVisualizerValueProps) => {
+  const { filename, mimeType } = DOWNLOAD_FORMATS[type];
+
+  return (
+    <CsvContent
+      parsed={parseCsv(value)}
+      isFullscreen={isFullscreen}
+      downloadFull={{
+        filename,
+        getBlob: async () => new Blob([value], { type: mimeType }),
+      }}
+    />
+  );
+};
 
 export const CsvVisualizerRemote = ({
   signedUrl,
+  type,
   isFullscreen,
 }: CsvVisualizerRemoteProps) => {
   const parsed = useArtifactFetch<ParsedArtifact>(
@@ -59,5 +92,14 @@ export const CsvVisualizerRemote = ({
     async (response) => parseCsv(await response.text()),
   );
 
-  return <CsvContent parsed={parsed} isFullscreen={isFullscreen} />;
+  return (
+    <CsvContent
+      parsed={parsed}
+      isFullscreen={isFullscreen}
+      downloadFull={{
+        filename: DOWNLOAD_FORMATS[type].filename,
+        getBlob: async () => (await fetchArtifactOrThrow(signedUrl)).blob(),
+      }}
+    />
+  );
 };

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ParquetVisualizer.test.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ParquetVisualizer.test.tsx
@@ -5,10 +5,17 @@ import { type ReactElement, Suspense } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import useToastNotification from "@/hooks/useToastNotification";
 import { ArtifactFetchError } from "@/services/executionService";
 
+import { PARQUET_PREVIEW_ROWS } from "./parquetUtils";
 import ParquetVisualizer from "./ParquetVisualizer";
-import type { ArtifactColumn } from "./utils";
+import { type ArtifactColumn, getPreviewRowLimit } from "./utils";
+
+type DownloadFull = { filename: string; getBlob: () => Promise<Blob> };
+
+// Captures the `downloadFull` prop so tests can exercise its `getBlob` contract.
+let lastDownloadFull: DownloadFull | undefined;
 
 vi.mock("hyparquet", () => ({
   parquetReadObjects: vi.fn(),
@@ -24,35 +31,62 @@ vi.mock("@/utils/URL", () => ({
   downloadStringAsFile: vi.fn(),
 }));
 
+vi.mock("@/hooks/useToastNotification");
+
+const mockNotify = vi.fn();
+
 vi.mock("./TableVisualizer", () => ({
   default: ({
     data,
     isFullscreen,
+    isLoading,
     totalRows,
     columnCount,
     onDownloadSchema,
+    onLoadMore,
+    onLoadAll,
+    downloadFull,
   }: {
     data: { columns: ArtifactColumn[]; rows: string[][]; hasMore: boolean };
     isFullscreen: boolean;
+    isLoading?: boolean;
     totalRows?: number;
     columnCount?: number;
     onDownloadSchema?: () => void;
-  }) => (
-    <div
-      data-testid="table-visualizer"
-      data-fullscreen={isFullscreen}
-      data-has-more={data.hasMore}
-      data-headers={data.columns.map((c) => c.name).join(",")}
-      data-row-count={data.rows.length}
-      data-columns={JSON.stringify(data.columns)}
-      data-total-rows={totalRows}
-      data-column-count={columnCount}
-    >
-      <button type="button" onClick={onDownloadSchema}>
-        Download schema
-      </button>
-    </div>
-  ),
+    onLoadMore?: () => void;
+    onLoadAll?: () => void;
+    downloadFull?: DownloadFull;
+  }) => {
+    lastDownloadFull = downloadFull;
+    return (
+      <div
+        data-testid="table-visualizer"
+        data-fullscreen={isFullscreen}
+        data-loading={isLoading}
+        data-has-more={data.hasMore}
+        data-headers={data.columns.map((c) => c.name).join(",")}
+        data-row-count={data.rows.length}
+        data-columns={JSON.stringify(data.columns)}
+        data-total-rows={totalRows}
+        data-column-count={columnCount}
+        data-download-filename={downloadFull?.filename}
+      >
+        <button type="button" onClick={onDownloadSchema}>
+          Download schema
+        </button>
+        {onLoadMore && (
+          <button type="button" onClick={onLoadMore}>
+            Load more
+          </button>
+        )}
+        {onLoadAll && (
+          <button type="button" onClick={onLoadAll}>
+            Load max
+          </button>
+        )}
+      </div>
+    );
+  },
 }));
 
 const {
@@ -108,9 +142,36 @@ const mockDataset = (schema: unknown[], numRows: number) => {
   );
 };
 
+/** Same as `mockDataset`, but with `columnCount` generated columns per row. */
+const mockWideDataset = (columnCount: number, numRows: number) => {
+  const names = Array.from({ length: columnCount }, (_, i) => `col_${i}`);
+  vi.mocked(parquetMetadataAsync).mockResolvedValue({
+    schema: [
+      { name: "root", num_children: columnCount },
+      ...names.map((name) => ({
+        name,
+        type: "INT64",
+        repetition_type: "REQUIRED",
+      })),
+    ],
+    num_rows: numRows,
+  } as unknown as Awaited<ReturnType<typeof parquetMetadataAsync>>);
+  vi.mocked(parquetReadObjects).mockImplementation(
+    async ({ rowStart = 0, rowEnd }) => {
+      const end = Math.min(rowEnd ?? numRows, numRows);
+      return Array.from({ length: Math.max(0, end - rowStart) }, (_, i) =>
+        Object.fromEntries(names.map((name) => [name, rowStart + i])),
+      );
+    },
+  );
+};
+
 beforeEach(() => {
   queryClient.clear();
+  lastDownloadFull = undefined;
   vi.restoreAllMocks();
+  mockNotify.mockReset();
+  vi.mocked(useToastNotification).mockReturnValue(mockNotify);
   vi.mocked(parquetMetadata).mockReset();
   vi.mocked(parquetMetadataAsync).mockReset();
   vi.mocked(parquetReadObjects).mockReset();
@@ -148,8 +209,8 @@ describe("ParquetVisualizer", () => {
     );
   });
 
-  it("previews the top rows and reports more remain for a large file", async () => {
-    mockDataset(SCHEMA, 2500);
+  it("loads more rows on demand without re-reading the whole file", async () => {
+    mockDataset(SCHEMA, 250);
 
     renderWithSuspense(
       <ParquetVisualizer
@@ -158,12 +219,166 @@ describe("ParquetVisualizer", () => {
       />,
     );
 
-    await waitFor(() => {
-      const table = screen.getByTestId("table-visualizer");
-      expect(table).toHaveAttribute("data-row-count", "100");
-      expect(table).toHaveAttribute("data-total-rows", "2500");
-      expect(table).toHaveAttribute("data-has-more", "true");
-    });
+    await waitFor(() =>
+      expect(screen.getByTestId("table-visualizer")).toHaveAttribute(
+        "data-row-count",
+        "100",
+      ),
+    );
+    expect(screen.getByTestId("table-visualizer")).toHaveAttribute(
+      "data-has-more",
+      "true",
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Load more" }));
+    await waitFor(() =>
+      expect(screen.getByTestId("table-visualizer")).toHaveAttribute(
+        "data-row-count",
+        "200",
+      ),
+    );
+
+    // The second read only pulls the new range, not rows already loaded.
+    expect(vi.mocked(parquetReadObjects)).toHaveBeenCalledWith(
+      expect.objectContaining({ rowStart: 100, rowEnd: 200 }),
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Load max" }));
+    await waitFor(() =>
+      expect(screen.getByTestId("table-visualizer")).toHaveAttribute(
+        "data-row-count",
+        "250",
+      ),
+    );
+    expect(screen.getByTestId("table-visualizer")).toHaveAttribute(
+      "data-has-more",
+      "false",
+    );
+  });
+
+  it("caps rendered rows at the preview limit and offers a full-dataset download", async () => {
+    // SCHEMA has two columns, so the cell budget resolves to the row backstop.
+    const cap = getPreviewRowLimit(2);
+    const total = cap + 2000;
+    mockDataset(SCHEMA, total);
+    const signedUrl = "https://storage.example.com/huge-rows.parquet";
+
+    renderWithSuspense(
+      <ParquetVisualizer signedUrl={signedUrl} isFullscreen={false} />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("table-visualizer")).toHaveAttribute(
+        "data-row-count",
+        "100",
+      ),
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Load max" }));
+    await waitFor(() =>
+      expect(screen.getByTestId("table-visualizer")).toHaveAttribute(
+        "data-row-count",
+        String(cap),
+      ),
+    );
+
+    const table = screen.getByTestId("table-visualizer");
+    expect(table).toHaveAttribute("data-has-more", "true");
+    expect(table).toHaveAttribute("data-total-rows", String(total));
+    expect(screen.queryByRole("button", { name: "Load more" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Load max" })).toBeNull();
+
+    expect(lastDownloadFull?.filename).toBe("data.parquet");
+    const fullBlob = new Blob(["parquet-bytes"]);
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      blob: () => Promise.resolve(fullBlob),
+    } as unknown as Response);
+    const blob = await lastDownloadFull?.getBlob();
+    expect(fetchSpy).toHaveBeenCalledWith(signedUrl, undefined);
+    expect(blob).toBe(fullBlob);
+  });
+
+  it("notifies and keeps the loaded rows when a later read fails", async () => {
+    const consoleSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    mockDataset(SCHEMA, 250);
+    vi.mocked(parquetReadObjects).mockImplementation(
+      async ({ rowStart = 0, rowEnd }) => {
+        if (rowStart > 0) throw new Error("Signed URL expired");
+        return Array.from({ length: rowEnd ?? 0 }, (_, i) => ({
+          name: `row-${i}`,
+          score: i * 10,
+        }));
+      },
+    );
+
+    renderWithSuspense(
+      <ParquetVisualizer
+        signedUrl="https://storage.example.com/expiring.parquet"
+        isFullscreen={false}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("table-visualizer")).toHaveAttribute(
+        "data-row-count",
+        "100",
+      ),
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Load more" }));
+
+    await waitFor(() =>
+      expect(mockNotify).toHaveBeenCalledWith(
+        "Failed to load more rows. Please try again.",
+        "error",
+      ),
+    );
+
+    // The already-loaded rows survive and the user can retry.
+    const table = screen.getByTestId("table-visualizer");
+    expect(table).toHaveAttribute("data-row-count", "100");
+    expect(table).toHaveAttribute("data-loading", "false");
+    expect(
+      screen.getByRole("button", { name: "Load more" }),
+    ).toBeInTheDocument();
+
+    expect(consoleSpy).toHaveBeenCalled();
+  });
+
+  it("caps the initial read at the cell budget for very wide schemas", async () => {
+    // 1,000 columns exhausts MAX_PREVIEW_CELLS well before the 100-row preview.
+    const columnCount = 1000;
+    const cap = getPreviewRowLimit(columnCount);
+    expect(cap).toBeLessThan(PARQUET_PREVIEW_ROWS);
+    mockWideDataset(columnCount, 500);
+
+    renderWithSuspense(
+      <ParquetVisualizer
+        signedUrl="https://storage.example.com/wide.parquet"
+        isFullscreen={false}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("table-visualizer")).toHaveAttribute(
+        "data-row-count",
+        String(cap),
+      ),
+    );
+
+    // The cap is applied to the read itself, not just to what gets rendered.
+    expect(vi.mocked(parquetReadObjects)).toHaveBeenCalledWith(
+      expect.objectContaining({ rowEnd: cap }),
+    );
+
+    const table = screen.getByTestId("table-visualizer");
+    expect(table).toHaveAttribute("data-column-count", String(columnCount));
+    expect(table).toHaveAttribute("data-has-more", "true");
+    expect(screen.queryByRole("button", { name: "Load more" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Load max" })).toBeNull();
   });
 
   const mockFullDownload = (contentLength: string | null) =>
@@ -206,7 +421,6 @@ describe("ParquetVisualizer", () => {
     vi.mocked(byteLengthFromUrl).mockRejectedValue(
       new TypeError("Failed to fetch"),
     );
-    // 200 MB — well past the full-download cap.
     mockFullDownload(String(200 * 1024 * 1024));
 
     renderWithSuspense(
@@ -226,7 +440,7 @@ describe("ParquetVisualizer", () => {
     vi.mocked(byteLengthFromUrl).mockRejectedValue(
       new TypeError("Failed to fetch"),
     );
-    // No Content-Length header — size is unknown, so we must not download.
+
     mockFullDownload(null);
 
     renderWithSuspense(

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ParquetVisualizer.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ParquetVisualizer.tsx
@@ -1,18 +1,24 @@
 import { useSuspenseQuery } from "@tanstack/react-query";
+import { useState } from "react";
 
 import { Paragraph } from "@/components/ui/typography";
+import useToastNotification from "@/hooks/useToastNotification";
 import { HOURS } from "@/utils/constants";
 import { downloadStringAsFile } from "@/utils/URL";
 
 import {
   buildSchemaJson,
   countColumns,
+  type OpenedParquet,
   openParquet,
+  PARQUET_LOAD_MORE_ROWS,
   PARQUET_PREVIEW_ROWS,
   readParquetPreview,
+  readParquetRows,
 } from "./parquetUtils";
 import TableVisualizer from "./TableVisualizer";
-import { type ArtifactColumn } from "./utils";
+import { fetchArtifactOrThrow } from "./useArtifactFetch";
+import { type ArtifactColumn, getPreviewRowLimit } from "./utils";
 
 interface ParquetVisualizerProps {
   signedUrl: string;
@@ -20,8 +26,9 @@ interface ParquetVisualizerProps {
 }
 
 interface ParquetBase {
+  opened: OpenedParquet;
   columns: ArtifactColumn[];
-  rows: string[][];
+  initialRows: string[][];
   totalRows: number;
   columnCount: number;
   schemaJson: unknown;
@@ -35,16 +42,18 @@ const ParquetVisualizer = ({
     queryKey: ["artifact-parquet", signedUrl],
     queryFn: async () => {
       const opened = await openParquet(signedUrl);
+      const columnCount = countColumns(opened.metadata);
       const { columns, rows } = await readParquetPreview(
         opened,
-        PARQUET_PREVIEW_ROWS,
+        Math.min(PARQUET_PREVIEW_ROWS, getPreviewRowLimit(columnCount)),
       );
 
       return {
+        opened,
         columns,
-        rows,
+        initialRows: rows,
         totalRows: Number(opened.metadata.num_rows),
-        columnCount: countColumns(opened.metadata),
+        columnCount,
         schemaJson: buildSchemaJson(opened.metadata),
       };
     },
@@ -60,6 +69,60 @@ const ParquetVisualizer = ({
     );
   }
 
+  return (
+    <ParquetTable
+      key={signedUrl}
+      base={base}
+      isFullscreen={isFullscreen}
+      signedUrl={signedUrl}
+    />
+  );
+};
+
+export default ParquetVisualizer;
+
+interface ParquetTableProps {
+  base: ParquetBase;
+  isFullscreen: boolean;
+  signedUrl: string;
+}
+
+/**
+ * Renders the loaded rows and pulls in more on demand. Kept as a child keyed by
+ * the signed URL so its row state resets cleanly when a different artifact loads.
+ */
+const ParquetTable = ({ base, isFullscreen, signedUrl }: ParquetTableProps) => {
+  const [rows, setRows] = useState(base.initialRows);
+  const [isLoading, setIsLoading] = useState(false);
+  const notify = useToastNotification();
+
+  const loadedCount = rows.length;
+  const renderCap = Math.min(
+    base.totalRows,
+    getPreviewRowLimit(base.columnCount),
+  );
+  const hasMore = loadedCount < base.totalRows;
+  const canLoadMore = loadedCount < renderCap;
+
+  const loadUpTo = async (target: number) => {
+    if (isLoading || target <= loadedCount) return;
+    setIsLoading(true);
+    try {
+      const more = await readParquetRows(
+        base.opened,
+        base.columns,
+        loadedCount,
+        target,
+      );
+      setRows((prev) => [...prev, ...more]);
+    } catch (error) {
+      console.error("Failed to load more parquet rows:", error);
+      notify("Failed to load more rows. Please try again.", "error");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
   const handleDownloadSchema = () => {
     downloadStringAsFile(
       JSON.stringify(base.schemaJson, null, 2),
@@ -70,17 +133,25 @@ const ParquetVisualizer = ({
 
   return (
     <TableVisualizer
-      data={{
-        columns: base.columns,
-        rows: base.rows,
-        hasMore: base.rows.length < base.totalRows,
-      }}
+      data={{ columns: base.columns, rows, hasMore }}
       isFullscreen={isFullscreen}
+      onLoadMore={
+        canLoadMore
+          ? () =>
+              loadUpTo(
+                Math.min(loadedCount + PARQUET_LOAD_MORE_ROWS, renderCap),
+              )
+          : undefined
+      }
+      onLoadAll={canLoadMore ? () => loadUpTo(renderCap) : undefined}
+      isLoading={isLoading}
       totalRows={base.totalRows}
       columnCount={base.columnCount}
       onDownloadSchema={handleDownloadSchema}
+      downloadFull={{
+        filename: "data.parquet",
+        getBlob: async () => (await fetchArtifactOrThrow(signedUrl)).blob(),
+      }}
     />
   );
 };
-
-export default ParquetVisualizer;

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/TableVisualizer.test.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/TableVisualizer.test.tsx
@@ -17,7 +17,14 @@ const makeData = (rowCount: number, hasMore = false): ArtifactTableData => ({
 describe("TableVisualizer", () => {
   it("renders headers and all rows it was given", () => {
     const data = makeData(3);
-    render(<TableVisualizer data={data} isFullscreen={false} />);
+    render(
+      <TableVisualizer
+        data={data}
+        isFullscreen={false}
+        totalRows={3}
+        columnCount={2}
+      />,
+    );
 
     expect(screen.getByText("Name")).toBeInTheDocument();
     expect(screen.getByText("Score")).toBeInTheDocument();
@@ -27,35 +34,37 @@ describe("TableVisualizer", () => {
 
   it("says 'Showing all N rows' when hasMore is false", () => {
     const data = makeData(5);
-    render(<TableVisualizer data={data} isFullscreen={false} />);
+    render(
+      <TableVisualizer
+        data={data}
+        isFullscreen={false}
+        totalRows={5}
+        columnCount={2}
+      />,
+    );
 
     expect(screen.getByText("Showing all 5 rows")).toBeInTheDocument();
   });
 
-  it("says 'Showing first N rows' when more remain and rows can still be loaded", () => {
+  it("says 'Showing first X of Y rows' when more remain", () => {
     const data = makeData(100, true);
     render(
       <TableVisualizer
         data={data}
         isFullscreen={false}
+        totalRows={2500000}
+        columnCount={2}
         onLoadMore={() => {}}
         onLoadAll={() => {}}
       />,
     );
 
-    expect(screen.getByText("Showing first 100 rows")).toBeInTheDocument();
-  });
-
-  it("says 'preview limit reached' when more remain but no loader is offered", () => {
-    const data = makeData(100, true);
-    render(<TableVisualizer data={data} isFullscreen={false} />);
-
     expect(
-      screen.getByText("Showing first 100 rows (preview limit reached)"),
+      screen.getByText("Showing first 100 of 2,500,000 rows"),
     ).toBeInTheDocument();
   });
 
-  it("renders Load more / Load all buttons when handlers are provided and fires them on click", async () => {
+  it("renders Load more / Load max buttons when handlers are provided and fires them on click", async () => {
     const onLoadMore = vi.fn();
     const onLoadAll = vi.fn();
     const data = makeData(100, true);
@@ -64,30 +73,111 @@ describe("TableVisualizer", () => {
       <TableVisualizer
         data={data}
         isFullscreen={false}
+        totalRows={2500000}
+        columnCount={2}
         onLoadMore={onLoadMore}
         onLoadAll={onLoadAll}
       />,
     );
 
-    await userEvent.click(screen.getByRole("button", { name: "Load more" }));
+    const loadMore = screen.getByRole("button", { name: "Load more" });
+    const loadAll = screen.getByRole("button", { name: "Load max" });
+
+    await userEvent.click(loadMore);
     expect(onLoadMore).toHaveBeenCalledOnce();
 
-    await userEvent.click(screen.getByRole("button", { name: "Load all" }));
+    await userEvent.click(loadAll);
     expect(onLoadAll).toHaveBeenCalledOnce();
   });
 
-  it("does not render Load more / Load all when no handlers are provided", () => {
+  it("does not render Load more / Load max when no handlers are provided", () => {
     const data = makeData(100, true);
-    render(<TableVisualizer data={data} isFullscreen={false} />);
+    render(
+      <TableVisualizer
+        data={data}
+        isFullscreen={false}
+        totalRows={100}
+        columnCount={2}
+      />,
+    );
 
     expect(screen.queryByRole("button", { name: "Load more" })).toBeNull();
-    expect(screen.queryByRole("button", { name: "Load all" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Load max" })).toBeNull();
+  });
+
+  it("fetches the full dataset and saves it with the correct filename when the limit is reached", async () => {
+    const blob = new Blob(["full,data"], { type: "text/csv" });
+    const getBlob = vi.fn(async () => blob);
+    // jsdom has no object-URL implementation, so install mocks to observe.
+    const createObjectURL = vi.fn(() => "blob:mock-url");
+    const revokeObjectURL = vi.fn();
+    URL.createObjectURL = createObjectURL;
+    URL.revokeObjectURL = revokeObjectURL;
+    // The generated anchor's click would otherwise navigate jsdom.
+    const anchorClick = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => {});
+    const data = makeData(1000, true);
+
+    render(
+      <TableVisualizer
+        data={data}
+        isFullscreen={false}
+        totalRows={2500000}
+        columnCount={2}
+        downloadFull={{ getBlob, filename: "data.parquet" }}
+      />,
+    );
+
+    expect(screen.getByText(/Preview limit reached/)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Load more" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Load max" })).toBeNull();
+
+    // The bytes are fetched only on click, then saved same-origin so our
+    // filename sticks (a cross-origin <a download> would be ignored).
+    await userEvent.click(
+      screen.getByRole("button", { name: /Download full dataset/ }),
+    );
+
+    expect(getBlob).toHaveBeenCalledOnce();
+    expect(createObjectURL).toHaveBeenCalledWith(blob);
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:mock-url");
+
+    anchorClick.mockRestore();
+  });
+
+  it("does not prompt to download while more rows can still be loaded", () => {
+    const data = makeData(100, true);
+    render(
+      <TableVisualizer
+        data={data}
+        isFullscreen={false}
+        totalRows={2500000}
+        columnCount={2}
+        onLoadMore={() => {}}
+        onLoadAll={() => {}}
+        downloadFull={{
+          getBlob: async () => new Blob(),
+          filename: "data.parquet",
+        }}
+      />,
+    );
+
+    expect(screen.queryByText(/Preview limit reached/)).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: /Download full dataset/ }),
+    ).toBeNull();
   });
 
   it("uses the Table container as the scroll element with sticky header cells", () => {
     const data = makeData(3);
     const { container } = render(
-      <TableVisualizer data={data} isFullscreen={false} />,
+      <TableVisualizer
+        data={data}
+        isFullscreen={false}
+        totalRows={3}
+        columnCount={2}
+      />,
     );
 
     const tableContainer = container.querySelector(
@@ -105,7 +195,12 @@ describe("TableVisualizer", () => {
   it("renders the row-count footer outside the Table scroll container", () => {
     const data = makeData(3);
     const { container } = render(
-      <TableVisualizer data={data} isFullscreen={false} />,
+      <TableVisualizer
+        data={data}
+        isFullscreen={false}
+        totalRows={3}
+        columnCount={2}
+      />,
     );
 
     const tableContainer = container.querySelector(
@@ -116,7 +211,7 @@ describe("TableVisualizer", () => {
     expect(tableContainer?.contains(footer)).toBe(false);
   });
 
-  it("renders row/column stats with thousands separators when provided", () => {
+  it("renders row/column stats with thousands separators", () => {
     const data = makeData(3);
     const totalRows = 1234567;
     const columnCount = 12;
@@ -131,13 +226,6 @@ describe("TableVisualizer", () => {
 
     const expected = `${totalRows.toLocaleString()} rows · ${columnCount.toLocaleString()} columns`;
     expect(screen.getByText(expected)).toBeInTheDocument();
-  });
-
-  it("does not render the stats header when no stats are provided", () => {
-    const data = makeData(3);
-    render(<TableVisualizer data={data} isFullscreen={false} />);
-
-    expect(screen.queryByText(/columns$/)).toBeNull();
   });
 
   it("renders a Download schema button and fires the handler on click", async () => {

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/TableVisualizer.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/TableVisualizer.tsx
@@ -1,3 +1,5 @@
+import { useState } from "react";
+
 import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
@@ -10,74 +12,129 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Paragraph, Text } from "@/components/ui/typography";
+import useToastNotification from "@/hooks/useToastNotification";
+import { downloadBlobAsFile } from "@/utils/URL";
 
 import { type ArtifactColumn, type ArtifactTableData } from "./utils";
+
+/**
+ * The full dataset usually lives behind a cross-origin signed URL, where the
+ * browser ignores an `<a download>` filename. So the caller hands us a `getBlob`
+ * that materializes the bytes same-origin (a fetch, or the in-memory value),
+ * and we save them with the correct name — only when the user actually clicks.
+ */
+export type DownloadFullDataset = {
+  filename: string;
+  getBlob: () => Promise<Blob>;
+};
 
 interface TableVisualizerProps {
   data: ArtifactTableData;
   isFullscreen: boolean;
   onLoadMore?: () => void;
   onLoadAll?: () => void;
-  totalRows?: number;
-  columnCount?: number;
+  isLoading?: boolean;
+  totalRows: number;
+  columnCount: number;
   onDownloadSchema?: () => void;
+  downloadFull?: DownloadFullDataset;
 }
 
 const getRowCountMessage = (
   data: ArtifactTableData,
-  limitReached: boolean,
-): string => {
-  if (!data.hasMore) return `Showing all ${data.rows.length} rows`;
-  if (limitReached)
-    return `Showing first ${data.rows.length} rows (preview limit reached)`;
-  return `Showing first ${data.rows.length} rows`;
-};
+  totalRows: number,
+): string =>
+  data.hasMore
+    ? `Showing first ${data.rows.length.toLocaleString()} of ${totalRows.toLocaleString()} rows`
+    : `Showing all ${totalRows.toLocaleString()} rows`;
 
 const TableVisualizer = ({
   data,
   isFullscreen,
   onLoadMore,
   onLoadAll,
+  isLoading = false,
   totalRows,
   columnCount,
   onDownloadSchema,
+  downloadFull,
 }: TableVisualizerProps) => {
   const limitReached = data.hasMore && !onLoadMore;
-  const rowCountMessage = getRowCountMessage(data, limitReached);
-  const hasStats = totalRows !== undefined && columnCount !== undefined;
+  const rowCountMessage = getRowCountMessage(data, totalRows);
+
+  const notify = useToastNotification();
+  const [isDownloading, setIsDownloading] = useState(false);
+
+  const handleDownloadFull = async () => {
+    if (!downloadFull || isDownloading) return;
+    setIsDownloading(true);
+    try {
+      const blob = await downloadFull.getBlob();
+      downloadBlobAsFile(blob, downloadFull.filename);
+    } catch (error) {
+      console.error("Failed to download full dataset:", error);
+      notify("Failed to download the dataset. Please try again.", "error");
+    } finally {
+      setIsDownloading(false);
+    }
+  };
 
   return (
     <BlockStack
       gap="2"
       className={isFullscreen ? "h-full min-h-0" : "max-h-100"}
     >
-      {hasStats && (
-        <InlineStack gap="4" align="space-between" blockAlign="center">
-          <Text size="xs" tone="subdued">
-            {`${totalRows.toLocaleString()} rows · ${columnCount.toLocaleString()} columns`}
-          </Text>
-          {onDownloadSchema && (
-            <Button variant="link" size="inline-xs" onClick={onDownloadSchema}>
-              <Icon name="Download" size="xs" aria-hidden="true" />
-              Download schema
-            </Button>
-          )}
-        </InlineStack>
-      )}
+      <InlineStack gap="4" align="space-between" blockAlign="center">
+        <Text size="xs" tone="subdued">
+          {`${totalRows.toLocaleString()} rows · ${columnCount.toLocaleString()} columns`}
+        </Text>
+        {onDownloadSchema && (
+          <Button variant="link" size="inline-xs" onClick={onDownloadSchema}>
+            <Icon name="Download" size="xs" aria-hidden="true" />
+            Download schema
+          </Button>
+        )}
+      </InlineStack>
       <ArtifactTable columns={data.columns} rows={data.rows} />
-      <InlineStack gap="4">
+      <InlineStack gap="4" blockAlign="center">
         <Paragraph tone="subdued" size="xs">
-          {rowCountMessage}
+          {isLoading ? "Loading…" : rowCountMessage}
         </Paragraph>
         {onLoadMore && (
-          <Button variant="link" size="inline-xs" onClick={onLoadMore}>
+          <Button
+            variant="link"
+            size="inline-xs"
+            onClick={onLoadMore}
+            disabled={isLoading}
+          >
             Load more
           </Button>
         )}
         {onLoadAll && (
-          <Button variant="link" size="inline-xs" onClick={onLoadAll}>
-            Load all
+          <Button
+            variant="link"
+            size="inline-xs"
+            onClick={onLoadAll}
+            disabled={isLoading}
+          >
+            Load max
           </Button>
+        )}
+        {limitReached && downloadFull && (
+          <InlineStack gap="2" blockAlign="center" wrap="nowrap">
+            <Text size="xs" tone="subdued">
+              Preview limit reached
+            </Text>
+            <Button
+              variant="link"
+              size="inline-xs"
+              onClick={handleDownloadFull}
+              disabled={isDownloading}
+            >
+              <Icon name="Download" size="xs" aria-hidden="true" />
+              {isDownloading ? "Preparing…" : "Download full dataset"}
+            </Button>
+          </InlineStack>
         )}
       </InlineStack>
     </BlockStack>

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/parquetUtils.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/parquetUtils.ts
@@ -20,6 +20,7 @@ import {
 import { type ArtifactColumn, MAX_VISUALIZABLE_SIZE_BYTES } from "./utils";
 
 export const PARQUET_PREVIEW_ROWS = 100;
+export const PARQUET_LOAD_MORE_ROWS = 100;
 
 type ParquetSource = AsyncBuffer | ArrayBuffer;
 
@@ -66,6 +67,23 @@ export async function openParquet(signedUrl: string): Promise<OpenedParquet> {
     const source = await response.arrayBuffer();
     return { source, metadata: parquetMetadata(source) };
   }
+}
+
+export async function readParquetRows(
+  { source, metadata }: OpenedParquet,
+  columns: ArtifactColumn[],
+  rowStart: number,
+  rowEnd: number,
+): Promise<string[][]> {
+  const objects = await parquetReadObjects({
+    file: source,
+    metadata,
+    rowStart,
+    rowEnd,
+  });
+  return objects.map((obj) =>
+    columns.map((col) => obj[col.name]),
+  ) as string[][];
 }
 
 export async function readParquetPreview(

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/useRowCap.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/useRowCap.ts
@@ -1,7 +1,7 @@
 import { useState } from "react";
 
 import type { ArtifactTableData, ParsedArtifact } from "./utils";
-import { MAX_PREVIEW_ROWS } from "./utils";
+import { getPreviewRowLimit } from "./utils";
 
 const INITIAL_PREVIEW_ROWS = 100;
 const PREVIEW_BATCH_SIZE = 100;
@@ -13,11 +13,12 @@ interface UseRowCapReturn {
 }
 
 export function useRowCap(parsed: ParsedArtifact): UseRowCapReturn {
+  const rowLimit = getPreviewRowLimit(parsed.columns.length);
   const [rowCap, setRowCap] = useState(INITIAL_PREVIEW_ROWS);
 
   const handleLoadMore = () =>
-    setRowCap((prev) => Math.min(prev + PREVIEW_BATCH_SIZE, MAX_PREVIEW_ROWS));
-  const handleLoadAll = () => setRowCap(MAX_PREVIEW_ROWS);
+    setRowCap((prev) => Math.min(prev + PREVIEW_BATCH_SIZE, rowLimit));
+  const handleLoadAll = () => setRowCap(rowLimit);
 
   const canLoadMore = rowCap < parsed.rows.length;
 

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/utils.test.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/utils.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getPreviewRowLimit,
+  MAX_PREVIEW_CELLS,
+  MAX_PREVIEW_ROWS,
+  parseCsv,
+} from "./utils";
+
+const buildCsv = (dataRows: number) => {
+  const lines = ["id,name"];
+  for (let i = 0; i < dataRows; i++) lines.push(`${i},row-${i}`);
+  return lines.join("\n");
+};
+
+// buildCsv emits two columns, so its per-shape row limit is the absolute cap.
+const CSV_ROW_LIMIT = getPreviewRowLimit(2);
+
+describe("parseCsv", () => {
+  it("parses headers and rows", () => {
+    const parsed = parseCsv("Name,Age\nAlice,30\nBob,25");
+
+    expect(parsed.columns.map((c) => c.name)).toEqual(["Name", "Age"]);
+    expect(parsed.rows).toEqual([
+      ["Alice", "30"],
+      ["Bob", "25"],
+    ]);
+    expect(parsed.totalRows).toBe(2);
+    expect(parsed.truncated).toBe(false);
+  });
+
+  it("auto-detects a tab delimiter", () => {
+    const parsed = parseCsv("Name\tAge\nAlice\t30");
+
+    expect(parsed.columns.map((c) => c.name)).toEqual(["Name", "Age"]);
+    expect(parsed.rows).toEqual([["Alice", "30"]]);
+  });
+
+  it("returns empty result for blank input", () => {
+    expect(parseCsv("")).toEqual({
+      columns: [],
+      rows: [],
+      truncated: false,
+      totalRows: 0,
+    });
+  });
+
+  it("counts every row but only retains the preview rows when truncated", () => {
+    const total = CSV_ROW_LIMIT + 2500;
+    const parsed = parseCsv(buildCsv(total));
+
+    expect(parsed.totalRows).toBe(total);
+    expect(parsed.rows).toHaveLength(CSV_ROW_LIMIT);
+    expect(parsed.truncated).toBe(true);
+    // The retained rows are the first ones, in order.
+    expect(parsed.rows[0]).toEqual(["0", "row-0"]);
+    expect(parsed.rows[CSV_ROW_LIMIT - 1]).toEqual([
+      String(CSV_ROW_LIMIT - 1),
+      `row-${CSV_ROW_LIMIT - 1}`,
+    ]);
+  });
+
+  it("is not truncated when the row count exactly hits the preview limit", () => {
+    const parsed = parseCsv(buildCsv(CSV_ROW_LIMIT));
+
+    expect(parsed.totalRows).toBe(CSV_ROW_LIMIT);
+    expect(parsed.rows).toHaveLength(CSV_ROW_LIMIT);
+    expect(parsed.truncated).toBe(false);
+  });
+
+  it("caps preview rows by the cell budget for wide tables", () => {
+    const columnCount = 100;
+    const rowLimit = getPreviewRowLimit(columnCount);
+    const header = Array.from({ length: columnCount }, (_, i) => `c${i}`).join(
+      ",",
+    );
+    const dataRow = Array.from({ length: columnCount }, () => "x").join(",");
+    const lines = [header];
+    for (let i = 0; i < rowLimit + 50; i++) lines.push(dataRow);
+    const parsed = parseCsv(lines.join("\n"));
+
+    // A wide table is bounded well below the absolute row cap.
+    expect(rowLimit).toBeLessThan(MAX_PREVIEW_ROWS);
+    expect(rowLimit).toBe(MAX_PREVIEW_CELLS / columnCount);
+    expect(parsed.rows).toHaveLength(rowLimit);
+    expect(parsed.truncated).toBe(true);
+  });
+
+  it("counts rows correctly when a field contains a quoted newline", () => {
+    const parsed = parseCsv('a,b\n"line1\nline2",x\ny,z');
+
+    expect(parsed.totalRows).toBe(2);
+    expect(parsed.rows).toEqual([
+      ["line1\nline2", "x"],
+      ["y", "z"],
+    ]);
+  });
+});
+
+describe("getPreviewRowLimit", () => {
+  it("bounds narrow tables by the absolute row cap", () => {
+    expect(getPreviewRowLimit(1)).toBe(MAX_PREVIEW_ROWS);
+    // 50_000 / 5 = 10_000, which equals the cap.
+    expect(getPreviewRowLimit(5)).toBe(MAX_PREVIEW_ROWS);
+  });
+
+  it("bounds wide tables by the cell budget", () => {
+    expect(getPreviewRowLimit(50)).toBe(MAX_PREVIEW_CELLS / 50);
+    expect(getPreviewRowLimit(100)).toBe(MAX_PREVIEW_CELLS / 100);
+  });
+
+  it("always allows at least one row, even past the budget", () => {
+    expect(getPreviewRowLimit(MAX_PREVIEW_CELLS * 2)).toBe(1);
+  });
+
+  it("treats a zero column count as a single column", () => {
+    expect(getPreviewRowLimit(0)).toBe(MAX_PREVIEW_ROWS);
+  });
+});

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/utils.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/utils.ts
@@ -16,28 +16,45 @@ export type ParsedArtifact = {
   columns: ArtifactColumn[];
   rows: string[][];
   truncated: boolean;
+  totalRows: number;
 };
 
-export const MAX_PREVIEW_ROWS = 1000;
 export const MAX_VISUALIZABLE_SIZE_BYTES = 50 * 1024 * 1024; // 50 MB
 
-const HEADER_ROW = 1;
-const TRUNCATION_LOOKAHEAD = 1;
+export const MAX_PREVIEW_CELLS = 50_000;
+export const MAX_PREVIEW_ROWS = 10_000;
+
+export function getPreviewRowLimit(columnCount: number): number {
+  const byCellBudget = Math.floor(MAX_PREVIEW_CELLS / Math.max(1, columnCount));
+  return Math.min(MAX_PREVIEW_ROWS, Math.max(1, byCellBudget));
+}
 
 export function parseCsv(text: string, delimiter?: string): ParsedArtifact {
-  const result = Papa.parse<string[]>(text, {
+  let headers: string[] | undefined;
+  let rowLimit = MAX_PREVIEW_ROWS;
+  const rows: string[][] = [];
+  let totalRows = 0;
+
+  Papa.parse<string[]>(text, {
     delimiter,
     header: false,
-    preview: MAX_PREVIEW_ROWS + HEADER_ROW + TRUNCATION_LOOKAHEAD,
     skipEmptyLines: true,
+    step: (result) => {
+      const row = result.data;
+      if (headers === undefined) {
+        headers = row;
+        rowLimit = getPreviewRowLimit(headers.length);
+        return;
+      }
+      totalRows++;
+      if (rows.length < rowLimit) rows.push(row);
+    },
   });
 
-  if (result.data.length === 0) {
-    return { columns: [], rows: [], truncated: false };
+  if (headers === undefined) {
+    return { columns: [], rows: [], truncated: false, totalRows: 0 };
   }
 
-  const [headers, ...rows] = result.data;
   const columns = headers.map((name) => ({ name }));
-  const truncated = rows.length > MAX_PREVIEW_ROWS;
-  return { columns, rows: rows.slice(0, MAX_PREVIEW_ROWS), truncated };
+  return { columns, rows, truncated: totalRows > rowLimit, totalRows };
 }

--- a/src/utils/URL.ts
+++ b/src/utils/URL.ts
@@ -134,12 +134,7 @@ const buildComponentSourceUrl = ({
   return `${baseUrl}/${pathParts.join("/")}`;
 };
 
-const downloadStringAsFile = (
-  content: string,
-  filename: string,
-  contentType: string,
-) => {
-  const blob = new Blob([content], { type: contentType });
+const downloadBlobAsFile = (blob: Blob, filename: string) => {
   const url = URL.createObjectURL(blob);
   const a = document.createElement("a");
   a.href = url;
@@ -148,6 +143,14 @@ const downloadStringAsFile = (
   a.click();
   document.body.removeChild(a);
   URL.revokeObjectURL(url);
+};
+
+const downloadStringAsFile = (
+  content: string,
+  filename: string,
+  contentType: string,
+) => {
+  downloadBlobAsFile(new Blob([content], { type: contentType }), filename);
 };
 
 const downloadYamlFromComponentText = (text: string, displayName: string) => {
@@ -213,6 +216,7 @@ export {
   convertGcsUrlToBrowserUrl,
   convertGithubUrlToDirectoryUrl,
   convertHfUrlToDirectoryUrl,
+  downloadBlobAsFile,
   downloadStringAsFile,
   downloadYamlFromComponentText,
   getArtifactPreviewUrl,


### PR DESCRIPTION
## Description

Follow-up to #2557. This PR adds extra viewer affordances for both Parquet and CSV/TSV.

**1\. Load more / Load max (Parquet).** The base PR previews the top 100 rows and stops. Here the viewer can pull additional pages on demand via range reads — **Load more** fetches the next batch, **Load max** fills up to the preview cap. Only the newly requested range is fetched each time; rows already loaded are never re-read, and the whole file is never downloaded.

**2\. Preview limit is a cell budget, not a row count.** The preview table renders every cell into the DOM (no virtualization), so its cost scales with **rows × columns**, not rows alone. A flat 1,000-row cap therefore over-protects narrow tables and under-protects wide ones. Instead, the preview is bounded by a **50,000-cell budget**: the row limit is `floor(50,000 / columnCount)`, with an absolute backstop of **10,000 rows** so a very narrow table still can't flood the DOM. This adapts to table shape:

| Columns | Preview row limit |
| --- | --- |
| ≤ 5 | 10,000 (backstop) |
| 10 | 5,000 |
| 20 | 2,500 |
| 100 | 500 |

Rows are atomic: the budget is floored to whole rows up front, so the rendered cell count never exceeds 50,000 and no partial rows are shown. The same limit applies to both Parquet (**Load max**) and CSV/TSV previews.

**3\. Download full dataset.** When the preview limit is reached but the file still has more rows than are shown, the footer surfaces a **Download full dataset** link so the user has a clear escape hatch to the complete data (opens the signed URL for remote artifacts).

**4\. CSV/TSV parity.** CSV/TSV previews now report the **exact** total row count and column count in the header, matching Parquet. Counting is done with a streaming parse (every row is counted, only the preview rows are retained). Remote CSVs get a **Download full dataset** link to the signed URL; inline CSV values trigger a direct file download.



![image.png](https://app.graphite.com/user-attachments/assets/edeca1ee-c59d-433c-9a34-fe9cf84c43f8.png)



## Related Issue and Pull requests

- Stacked on #2557

## Type of Change

- [x] Improvement

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

1. Open a run with a **Parquet** artifact that has more than 100 rows and open its preview.
2. Confirm a top-100 preview loads, then use **Load more** / **Load max** and confirm additional rows load without a full-file download.
3. Confirm the preview stops at the cell budget: for a **wide** table (e.g. 50+ columns) **Load max** stops well below 10,000 rows, and once the limit is reached a **Download full dataset** link appears.
4. Open a **CSV/TSV** artifact and confirm the header shows exact row/column counts, and that the download affordance works for both remote and inline CSV.

## Additional Comments
