### PR TITLE
feat: run comparison - pipeline diff engine

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -7,7 +7,8 @@
     "src/components/ui/**",
     "src/config/announcements.ts",
     "src/config/preSubmitHooks.ts",
-    "src/components/shared/BetaFeatureWrapper/BetaFeatureWrapper.tsx"
+    "src/components/shared/BetaFeatureWrapper/BetaFeatureWrapper.tsx",
+    "src/routes/v2/pages/CompareView/**"
   ],
   "ignoreDependencies": [
     "@tanstack/react-query-devtools",

--- a/src/providers/ExecutionDataProvider.tsx
+++ b/src/providers/ExecutionDataProvider.tsx
@@ -15,7 +15,7 @@ import {
 import type { BreadcrumbSegment } from "@/hooks/useSubgraphBreadcrumbs";
 import { useSubgraphBreadcrumbs } from "@/hooks/useSubgraphBreadcrumbs";
 import { useFetchPipelineRunMetadata } from "@/services/executionService";
-import { getOverallExecutionStatusFromStats } from "@/utils/executionStatus";
+import { buildTaskExecutionStatusMap } from "@/utils/executionStatus";
 
 import { useComponentSpec } from "./ComponentSpecProvider";
 
@@ -50,30 +50,6 @@ const ROOT_PATH_START_INDEX = 1;
 const isAtRootLevel = (path: string[]) => path.length <= 1;
 
 const buildPathKey = (path: string[]) => path.join(PATH_DELIMITER);
-
-const buildTaskExecutionStatusMap = (
-  details?: GetExecutionInfoResponse,
-  state?: GetGraphExecutionStateResponse,
-): Map<string, string> => {
-  const taskExecutionStatusMap = new Map<string, string>();
-
-  if (!details?.child_task_execution_ids) {
-    return taskExecutionStatusMap;
-  }
-
-  Object.entries(details.child_task_execution_ids).forEach(
-    ([taskId, executionId]) => {
-      const statusStats = state?.child_execution_status_stats?.[executionId];
-      const aggregated = getOverallExecutionStatusFromStats(statusStats);
-
-      if (aggregated) {
-        taskExecutionStatusMap.set(taskId, aggregated);
-      }
-    },
-  );
-
-  return taskExecutionStatusMap;
-};
 
 const findExecutionIdAtPath = (
   path: string[],

--- a/src/routes/v2/pages/CompareView/hooks/useRunComparisonSide.ts
+++ b/src/routes/v2/pages/CompareView/hooks/useRunComparisonSide.ts
@@ -1,0 +1,62 @@
+import { usePipelineRunData } from "@/hooks/usePipelineRunData";
+import {
+  runDurationMs,
+  runOverallStatus,
+} from "@/routes/v2/pages/CompareView/utils/runExecutionFacts";
+import { useFetchPipelineRunMetadata } from "@/services/executionService";
+import type { ComponentSpec } from "@/utils/componentSpec";
+import { buildTaskExecutionStatusMap } from "@/utils/executionStatus";
+
+export interface RunComparisonSide {
+  runId: string;
+  spec: ComponentSpec | undefined;
+  taskStatusMap: Map<string, string>;
+  taskExecutionIdMap: Map<string, string>;
+  createdBy?: string;
+  createdAt?: string;
+  status?: string;
+  durationMs?: number;
+  runAnnotations?: Record<string, unknown>;
+  runArguments?: Record<string, unknown>;
+  isLoading: boolean;
+  error: Error | null;
+}
+
+/**
+ * Loads a single run's spec and per-task execution status for the comparison
+ * view. Safe to call twice in one component (once per side) because
+ * `usePipelineRunData` scopes all of its queries by id. Pass an empty string
+ * for an unselected side — the underlying queries stay disabled.
+ */
+export function useRunComparisonSide(runId: string): RunComparisonSide {
+  const { executionData, error } = usePipelineRunData(runId);
+  const { data: runMetadata } = useFetchPipelineRunMetadata(runId || undefined);
+
+  const details = executionData?.details;
+  const state = executionData?.state;
+
+  const spec =
+    (details?.task_spec.componentRef.spec as
+      ComponentSpec | null | undefined) ?? undefined;
+
+  const taskStatusMap = buildTaskExecutionStatusMap(details, state);
+
+  const taskExecutionIdMap = new Map<string, string>(
+    Object.entries(details?.child_task_execution_ids ?? {}),
+  );
+
+  return {
+    runId,
+    spec,
+    taskStatusMap,
+    taskExecutionIdMap,
+    createdBy: runMetadata?.created_by ?? undefined,
+    createdAt: runMetadata?.created_at ?? undefined,
+    status: runOverallStatus(state),
+    durationMs: runDurationMs(details),
+    runAnnotations: runMetadata?.annotations ?? undefined,
+    runArguments: details?.task_spec.arguments ?? undefined,
+    isLoading: Boolean(runId) && !executionData && !error,
+    error: error ?? null,
+  };
+}

--- a/src/routes/v2/pages/CompareView/utils/compareArtifacts.ts
+++ b/src/routes/v2/pages/CompareView/utils/compareArtifacts.ts
@@ -1,0 +1,26 @@
+import type { ArtifactNodeResponse } from "@/api/types.gen";
+import type { DiffStatus } from "@/utils/diffStatus";
+
+/**
+ * Compares two artifacts by what the backend reports about their contents, not
+ * by id: ids are minted per execution, so two runs that produced byte-identical
+ * output would always look different. Inline value, size and directory-ness are
+ * all the artifact listing carries about the content itself — a same-size file
+ * with different bytes reads as unchanged, which is the limit of this data.
+ */
+export function artifactDiffStatus(
+  a: ArtifactNodeResponse | undefined,
+  b: ArtifactNodeResponse | undefined,
+): DiffStatus {
+  if (a && !b) return "lost";
+  if (!a && b) return "new";
+  if (!a || !b) return "unchanged";
+
+  const same =
+    (a.artifact_data?.value ?? null) === (b.artifact_data?.value ?? null) &&
+    (a.artifact_data?.total_size ?? null) ===
+      (b.artifact_data?.total_size ?? null) &&
+    (a.artifact_data?.is_dir ?? null) === (b.artifact_data?.is_dir ?? null);
+
+  return same ? "unchanged" : "changed";
+}

--- a/src/routes/v2/pages/CompareView/utils/comparePipelines.test.ts
+++ b/src/routes/v2/pages/CompareView/utils/comparePipelines.test.ts
@@ -1,0 +1,562 @@
+import { describe, expect, test } from "vitest";
+
+import type {
+  ArtifactDataResponse,
+  ArtifactNodeResponse,
+} from "@/api/types.gen";
+import type {
+  ComponentSpec,
+  PredicateType,
+  TaskSpec,
+} from "@/utils/componentSpec";
+
+import {
+  buildPipelineComparison,
+  type ComparisonSide,
+  ioDisplayStatus,
+} from "./comparePipelines";
+
+const task = (digest: string, overrides: Partial<TaskSpec> = {}): TaskSpec => ({
+  componentRef: { name: "comp", digest },
+  ...overrides,
+});
+
+const graphSpec = (tasks: Record<string, TaskSpec>): ComponentSpec => ({
+  implementation: { graph: { tasks } },
+});
+
+const containerSpec = (): ComponentSpec => ({
+  implementation: { container: { image: "python:3.11" } },
+});
+
+const noStatus = new Map<string, string>();
+
+const enabledWhen: PredicateType = { "==": { op1: "mode", op2: "train" } };
+
+const side = (
+  spec: ComponentSpec | undefined,
+  taskStatusMap: Map<string, string> = noStatus,
+  taskExecutionIdMap?: Map<string, string>,
+): ComparisonSide => ({ spec, taskStatusMap, taskExecutionIdMap });
+
+const outputSpec = (): ComponentSpec => ({
+  outputs: [{ name: "model" }],
+  implementation: {
+    graph: {
+      tasks: { train: task("d1") },
+      outputValues: {
+        model: { taskOutput: { taskId: "train", outputName: "out" } },
+      },
+    },
+  },
+});
+
+const ioGraphSpec = (): ComponentSpec => ({
+  ...outputSpec(),
+  inputs: [{ name: "api_key" }],
+});
+
+const artifact = (
+  id: string,
+  data: Partial<ArtifactDataResponse>,
+): ArtifactNodeResponse => ({
+  id,
+  artifact_data: { total_size: 0, is_dir: false, ...data },
+});
+
+const sideWithArtifacts = (
+  spec: ComponentSpec,
+  outputArtifacts: Record<string, ArtifactNodeResponse>,
+): ComparisonSide => ({ spec, taskStatusMap: noStatus, outputArtifacts });
+
+describe("buildPipelineComparison()", () => {
+  test("flags added, removed, and unchanged tasks by id", () => {
+    const specA = graphSpec({ train: task("d1"), evaluate: task("d2") });
+    const specB = graphSpec({ train: task("d1"), deploy: task("d3") });
+
+    const { taskDiffs, counts } = buildPipelineComparison(
+      side(specA),
+      side(specB),
+    );
+
+    const byId = Object.fromEntries(taskDiffs.map((d) => [d.taskId, d.status]));
+    expect(byId).toEqual({
+      train: "unchanged",
+      evaluate: "lost",
+      deploy: "new",
+    });
+    expect(counts).toEqual({
+      added: 1,
+      removed: 1,
+      changed: 0,
+      unchanged: 1,
+      outcomeChanged: 0,
+      outputArtifactChanged: 0,
+    });
+  });
+
+  test("marks a task changed when the component digest differs", () => {
+    const specA = graphSpec({ train: task("d1") });
+    const specB = graphSpec({ train: task("d2") });
+
+    const [diff] = buildPipelineComparison(side(specA), side(specB)).taskDiffs;
+
+    expect(diff.status).toBe("changed");
+    expect(diff.componentChanged).toBe(true);
+  });
+
+  test("marks a task changed when arguments differ but the component is identical", () => {
+    const specA = graphSpec({
+      train: task("d1", { arguments: { epochs: "10" } }),
+    });
+    const specB = graphSpec({
+      train: task("d1", { arguments: { epochs: "20" } }),
+    });
+
+    const [diff] = buildPipelineComparison(side(specA), side(specB)).taskDiffs;
+
+    expect(diff.status).toBe("changed");
+    expect(diff.componentChanged).toBe(false);
+    const epochs = diff.argumentDiffs.find((a) => a.key === "epochs");
+    expect(epochs?.status).toBe("changed");
+  });
+
+  test("does not claim a component change when digests are absent and the refs match", () => {
+    const digestless = (args: Record<string, string>): TaskSpec => ({
+      componentRef: { name: "comp" },
+      arguments: args,
+    });
+    const specA = graphSpec({ train: digestless({ epochs: "10" }) });
+    const specB = graphSpec({ train: digestless({ epochs: "20" }) });
+
+    const [diff] = buildPipelineComparison(side(specA), side(specB)).taskDiffs;
+
+    expect(diff.status).toBe("changed");
+    expect(diff.componentChanged).toBe(false);
+  });
+
+  test("ignores frontend-only annotation changes", () => {
+    const specA = graphSpec({
+      train: task("d1", {
+        annotations: { "editor.position": "{x:0}", zIndex: "1" },
+      }),
+    });
+    const specB = graphSpec({
+      train: task("d1", {
+        annotations: { "editor.position": "{x:999}", zIndex: "5" },
+      }),
+    });
+
+    const [diff] = buildPipelineComparison(side(specA), side(specB)).taskDiffs;
+
+    expect(diff.status).toBe("unchanged");
+    expect(
+      diff.annotationDiffs.some((entry) => entry.status !== "unchanged"),
+    ).toBe(false);
+  });
+
+  test("flags a cache-only change as changed and carries per-run cache state", () => {
+    const specA = graphSpec({
+      train: task("d1", {
+        executionOptions: { cachingStrategy: { maxCacheStaleness: "P0D" } },
+      }),
+    });
+    const specB = graphSpec({ train: task("d1") });
+
+    const [diff] = buildPipelineComparison(side(specA), side(specB)).taskDiffs;
+
+    expect(diff.status).toBe("changed");
+    expect(diff.cacheChanged).toBe(true);
+    expect(diff.cacheDisabledA).toBe(true);
+    expect(diff.cacheDisabledB).toBe(false);
+  });
+
+  test("flags a cache staleness change that leaves caching enabled on both sides", () => {
+    const staleness = (maxCacheStaleness: string): Partial<TaskSpec> => ({
+      executionOptions: { cachingStrategy: { maxCacheStaleness } },
+    });
+    const specA = graphSpec({ train: task("d1", staleness("P7D")) });
+    const specB = graphSpec({ train: task("d1", staleness("P30D")) });
+
+    const [diff] = buildPipelineComparison(side(specA), side(specB)).taskDiffs;
+
+    expect(diff.status).toBe("changed");
+    expect(diff.cacheChanged).toBe(false);
+    expect(
+      diff.settingDiffs.find((entry) => entry.key === "cachingStrategy")
+        ?.status,
+    ).toBe("changed");
+  });
+
+  test("flags a retry strategy change", () => {
+    const specA = graphSpec({
+      train: task("d1", {
+        executionOptions: { retryStrategy: { maxRetries: 1 } },
+      }),
+    });
+    const specB = graphSpec({
+      train: task("d1", {
+        executionOptions: { retryStrategy: { maxRetries: 5 } },
+      }),
+    });
+
+    const [diff] = buildPipelineComparison(side(specA), side(specB)).taskDiffs;
+
+    expect(diff.status).toBe("changed");
+    expect(
+      diff.settingDiffs.find((entry) => entry.key === "retryStrategy")?.status,
+    ).toBe("changed");
+  });
+
+  test("flags a task guarded by a condition in one run only", () => {
+    const specA = graphSpec({ train: task("d1", { isEnabled: enabledWhen }) });
+    const specB = graphSpec({ train: task("d1") });
+
+    const [diff] = buildPipelineComparison(side(specA), side(specB)).taskDiffs;
+
+    expect(diff.status).toBe("changed");
+    expect(
+      diff.settingDiffs.find((entry) => entry.key === "isEnabled")?.status,
+    ).toBe("lost");
+  });
+
+  test("reports no setting differences when execution options match", () => {
+    const options: Partial<TaskSpec> = {
+      isEnabled: enabledWhen,
+      executionOptions: { retryStrategy: { maxRetries: 2 } },
+    };
+    const specA = graphSpec({ train: task("d1", options) });
+    const specB = graphSpec({ train: task("d1", { ...options }) });
+
+    const [diff] = buildPipelineComparison(side(specA), side(specB)).taskDiffs;
+
+    expect(diff.status).toBe("unchanged");
+    expect(
+      diff.settingDiffs.every((entry) => entry.status === "unchanged"),
+    ).toBe(true);
+  });
+
+  test("treats structurally equal object arguments as unchanged", () => {
+    const arg = { taskOutput: { taskId: "prep", outputName: "data" } };
+    const specA = graphSpec({ train: task("d1", { arguments: { in: arg } }) });
+    const specB = graphSpec({
+      train: task("d1", { arguments: { in: { ...arg } } }),
+    });
+
+    const [diff] = buildPipelineComparison(side(specA), side(specB)).taskDiffs;
+
+    expect(diff.status).toBe("unchanged");
+  });
+
+  test("carries per-run execution status onto each task diff", () => {
+    const specA = graphSpec({ train: task("d1") });
+    const specB = graphSpec({ train: task("d1") });
+
+    const [diff] = buildPipelineComparison(
+      side(specA, new Map([["train", "SUCCEEDED"]])),
+      side(specB, new Map([["train", "FAILED"]])),
+    ).taskDiffs;
+
+    expect(diff.statusA).toBe("SUCCEEDED");
+    expect(diff.statusB).toBe("FAILED");
+  });
+
+  test("carries per-run execution ids onto each task diff", () => {
+    const specA = graphSpec({ train: task("d1") });
+    const specB = graphSpec({ train: task("d1") });
+
+    const [diff] = buildPipelineComparison(
+      side(specA, noStatus, new Map([["train", "exec-a"]])),
+      side(specB, noStatus, new Map([["train", "exec-b"]])),
+    ).taskDiffs;
+
+    expect(diff.executionIdA).toBe("exec-a");
+    expect(diff.executionIdB).toBe("exec-b");
+  });
+
+  test("flags an outcome difference even when the task spec is unchanged", () => {
+    const specA = graphSpec({ train: task("d1") });
+    const specB = graphSpec({ train: task("d1") });
+
+    const { taskDiffs, counts } = buildPipelineComparison(
+      side(specA, new Map([["train", "SUCCEEDED"]])),
+      side(specB, new Map([["train", "FAILED"]])),
+    );
+
+    expect(taskDiffs[0].status).toBe("unchanged");
+    expect(taskDiffs[0].outcomeChanged).toBe(true);
+    expect(counts.outcomeChanged).toBe(1);
+  });
+
+  test("does not flag an outcome difference when both runs share a status", () => {
+    const specA = graphSpec({ train: task("d1") });
+    const specB = graphSpec({ train: task("d1") });
+
+    const { taskDiffs, counts } = buildPipelineComparison(
+      side(specA, new Map([["train", "SUCCEEDED"]])),
+      side(specB, new Map([["train", "SUCCEEDED"]])),
+    );
+
+    expect(taskDiffs[0].outcomeChanged).toBe(false);
+    expect(counts.outcomeChanged).toBe(0);
+  });
+
+  test("does not flag an outcome difference for added or removed tasks", () => {
+    const specA = graphSpec({ evaluate: task("d1") });
+    const specB = graphSpec({ deploy: task("d2") });
+
+    const { taskDiffs, counts } = buildPipelineComparison(
+      side(specA, new Map([["evaluate", "SUCCEEDED"]])),
+      side(specB, new Map([["deploy", "FAILED"]])),
+    );
+
+    const byId = Object.fromEntries(
+      taskDiffs.map((diff) => [diff.taskId, diff]),
+    );
+    expect(byId.evaluate.status).toBe("lost");
+    expect(byId.evaluate.outcomeChanged).toBe(false);
+    expect(byId.deploy.status).toBe("new");
+    expect(byId.deploy.outcomeChanged).toBe(false);
+    expect(counts.outcomeChanged).toBe(0);
+  });
+
+  test("reports no comparable graph for container-implementation specs", () => {
+    const { taskDiffs, hasComparableGraph } = buildPipelineComparison(
+      side(containerSpec()),
+      side(containerSpec()),
+    );
+
+    expect(taskDiffs).toHaveLength(0);
+    expect(hasComparableGraph).toBe(false);
+  });
+
+  test("treats unrelated pipelines as fully added/removed", () => {
+    const specA = graphSpec({ a1: task("d1"), a2: task("d2") });
+    const specB = graphSpec({ b1: task("d3") });
+
+    const { counts } = buildPipelineComparison(side(specA), side(specB));
+
+    expect(counts).toEqual({
+      added: 1,
+      removed: 2,
+      changed: 0,
+      unchanged: 0,
+      outcomeChanged: 0,
+      outputArtifactChanged: 0,
+    });
+  });
+
+  test("aligns pipeline inputs by name and flags value changes", () => {
+    const specA: ComponentSpec = {
+      inputs: [{ name: "epochs", value: "10" }, { name: "dropped" }],
+      implementation: { graph: { tasks: {} } },
+    };
+    const specB: ComponentSpec = {
+      inputs: [{ name: "epochs", value: "20" }, { name: "added" }],
+      implementation: { graph: { tasks: {} } },
+    };
+
+    const { inputDiffs } = buildPipelineComparison(side(specA), side(specB));
+    const byName = Object.fromEntries(
+      inputDiffs.map((d) => [d.name, d.status]),
+    );
+
+    expect(byName).toEqual({
+      epochs: "changed",
+      dropped: "lost",
+      added: "new",
+    });
+    const epochs = inputDiffs.find((d) => d.name === "epochs");
+    expect(epochs?.fieldDiffs.find((f) => f.key === "value")?.status).toBe(
+      "changed",
+    );
+  });
+
+  test("reports every task unchanged when both sides are the same spec", () => {
+    const spec = graphSpec({ train: task("d1"), evaluate: task("d2") });
+    const statuses = new Map([
+      ["train", "SUCCEEDED"],
+      ["evaluate", "FAILED"],
+    ]);
+
+    const { taskDiffs, counts, hasComparableGraph } = buildPipelineComparison(
+      side(spec, statuses),
+      side(spec, statuses),
+    );
+
+    expect(hasComparableGraph).toBe(true);
+    expect(taskDiffs.every((diff) => diff.status === "unchanged")).toBe(true);
+    expect(taskDiffs.every((diff) => !diff.outcomeChanged)).toBe(true);
+    expect(counts.changed).toBe(0);
+    expect(counts.added).toBe(0);
+    expect(counts.removed).toBe(0);
+    expect(counts.outcomeChanged).toBe(0);
+  });
+
+  test("reports no comparable graph when both specs are undefined", () => {
+    const { hasComparableGraph, taskDiffs } = buildPipelineComparison(
+      side(undefined),
+      side(undefined),
+    );
+
+    expect(hasComparableGraph).toBe(false);
+    expect(taskDiffs).toHaveLength(0);
+  });
+
+  test("flags an output whose producing task was rewired", () => {
+    const specA: ComponentSpec = {
+      outputs: [{ name: "model" }],
+      implementation: {
+        graph: {
+          tasks: { train: task("d1"), tune: task("d2") },
+          outputValues: {
+            model: { taskOutput: { taskId: "train", outputName: "out" } },
+          },
+        },
+      },
+    };
+    const specB: ComponentSpec = {
+      outputs: [{ name: "model" }],
+      implementation: {
+        graph: {
+          tasks: { train: task("d1"), tune: task("d2") },
+          outputValues: {
+            model: { taskOutput: { taskId: "tune", outputName: "out" } },
+          },
+        },
+      },
+    };
+
+    const { outputDiffs } = buildPipelineComparison(side(specA), side(specB));
+
+    const model = outputDiffs.find((d) => d.name === "model");
+    expect(model?.status).toBe("changed");
+    expect(model?.sourceTaskIdA).toBe("train");
+    expect(model?.sourceTaskIdB).toBe("tune");
+    expect(model?.fieldDiffs.find((f) => f.key === "source")?.status).toBe(
+      "changed",
+    );
+  });
+
+  test("flags an output whose artifact differs even though the spec matched", () => {
+    const spec = outputSpec();
+
+    const { outputDiffs, counts } = buildPipelineComparison(
+      sideWithArtifacts(spec, { model: artifact("a1", { total_size: 1_000 }) }),
+      sideWithArtifacts(spec, { model: artifact("b1", { total_size: 9_000 }) }),
+    );
+
+    const model = outputDiffs[0];
+    expect(model.status).toBe("unchanged");
+    expect(model.artifactStatus).toBe("changed");
+    expect(ioDisplayStatus(model)).toBe("changed");
+    expect(counts.outputArtifactChanged).toBe(1);
+  });
+
+  test("leaves an output unchanged when the artifacts match", () => {
+    const spec = outputSpec();
+    const data = { total_size: 1_000, value: "gs://bucket/model" };
+
+    const { outputDiffs, counts } = buildPipelineComparison(
+      sideWithArtifacts(spec, { model: artifact("a1", data) }),
+      sideWithArtifacts(spec, { model: artifact("b1", data) }),
+    );
+
+    expect(outputDiffs[0].artifactStatus).toBe("unchanged");
+    expect(ioDisplayStatus(outputDiffs[0])).toBe("unchanged");
+    expect(counts.outputArtifactChanged).toBe(0);
+  });
+
+  test("reports an artifact missing on one side as a value difference, not a removal", () => {
+    const spec = outputSpec();
+
+    const { outputDiffs, counts } = buildPipelineComparison(
+      sideWithArtifacts(spec, { model: artifact("a1", { total_size: 10 }) }),
+      sideWithArtifacts(spec, {}),
+    );
+
+    expect(outputDiffs[0].status).toBe("unchanged");
+    expect(outputDiffs[0].artifactStatus).toBe("lost");
+    expect(ioDisplayStatus(outputDiffs[0])).toBe("changed");
+    expect(counts.outputArtifactChanged).toBe(1);
+  });
+
+  test("does not count the artifact of an output only one run declares", () => {
+    const { outputDiffs, counts } = buildPipelineComparison(
+      sideWithArtifacts(outputSpec(), {
+        model: artifact("a1", { total_size: 10 }),
+      }),
+      side(graphSpec({})),
+    );
+
+    expect(outputDiffs[0].status).toBe("lost");
+    expect(ioDisplayStatus(outputDiffs[0])).toBe("lost");
+    expect(counts.outputArtifactChanged).toBe(0);
+  });
+
+  test("leaves the artifact axis undefined before artifact data arrives", () => {
+    const spec = outputSpec();
+
+    const { outputDiffs, counts } = buildPipelineComparison(
+      side(spec),
+      side(spec),
+    );
+
+    expect(outputDiffs[0].artifactStatus).toBeUndefined();
+    expect(ioDisplayStatus(outputDiffs[0])).toBe("unchanged");
+    expect(counts.outputArtifactChanged).toBe(0);
+  });
+
+  test("does not report a difference while only one side's artifacts are known", () => {
+    const spec = outputSpec();
+
+    const { outputDiffs, counts } = buildPipelineComparison(
+      sideWithArtifacts(spec, { model: artifact("a1", { total_size: 10 }) }),
+      side(spec),
+    );
+
+    expect(outputDiffs[0].artifactStatus).toBeUndefined();
+    expect(ioDisplayStatus(outputDiffs[0])).toBe("unchanged");
+    expect(counts.outputArtifactChanged).toBe(0);
+  });
+
+  test("tallies inputs and outputs alongside tasks", () => {
+    const spec = ioGraphSpec();
+
+    const { counts } = buildPipelineComparison(side(spec), side(spec));
+
+    expect(counts).toEqual({
+      added: 0,
+      removed: 0,
+      changed: 0,
+      unchanged: 3,
+      outcomeChanged: 0,
+      outputArtifactChanged: 0,
+    });
+  });
+
+  test("tallies an input only one run declares", () => {
+    const withInput = ioGraphSpec();
+    const withoutInput: ComponentSpec = { ...withInput, inputs: [] };
+
+    const { counts } = buildPipelineComparison(
+      side(withoutInput),
+      side(withInput),
+    );
+
+    expect(counts.added).toBe(1);
+    expect(counts.unchanged).toBe(2);
+  });
+
+  test("tallies an output whose artifact differs as changed", () => {
+    const spec = outputSpec();
+
+    const { counts } = buildPipelineComparison(
+      sideWithArtifacts(spec, { model: artifact("a1", { total_size: 1_000 }) }),
+      sideWithArtifacts(spec, { model: artifact("b1", { total_size: 9_000 }) }),
+    );
+
+    expect(counts.changed).toBe(1);
+    expect(counts.unchanged).toBe(1);
+  });
+});

--- a/src/routes/v2/pages/CompareView/utils/comparePipelines.ts
+++ b/src/routes/v2/pages/CompareView/utils/comparePipelines.ts
@@ -1,0 +1,475 @@
+import equal from "fast-deep-equal";
+
+import type { ArtifactNodeResponse } from "@/api/types.gen";
+import {
+  EDGE_CONDUITS_ANNOTATION,
+  EDITOR_COLLAPSED_ANNOTATION,
+  EDITOR_FLOW_DIRECTION_ANNOTATION,
+  EDITOR_POSITION_ANNOTATION,
+  FLEX_NODES_ANNOTATION,
+  SDK_ANNOTATION,
+  TASK_COLOR_ANNOTATION,
+  ZINDEX_ANNOTATION,
+} from "@/utils/annotationKeys";
+import { isCacheDisabled } from "@/utils/cache";
+import type {
+  ArgumentType,
+  ComponentSpec,
+  InputSpec,
+  OutputSpec,
+  TaskOutputArgument,
+  TaskSpec,
+} from "@/utils/componentSpec";
+import { isGraphImplementation } from "@/utils/componentSpec";
+import type { DiffStatus } from "@/utils/diffStatus";
+
+import { artifactDiffStatus } from "./compareArtifacts";
+
+export type { DiffStatus };
+
+/**
+ * Annotation keys the editor writes for layout/presentation only. They carry no
+ * technical meaning for a run comparison and would otherwise surface as noise,
+ * so they are stripped before diffing.
+ */
+const FRONTEND_ONLY_ANNOTATION_KEYS = new Set<string>([
+  EDITOR_POSITION_ANNOTATION,
+  EDITOR_COLLAPSED_ANNOTATION,
+  EDITOR_FLOW_DIRECTION_ANNOTATION,
+  ZINDEX_ANNOTATION,
+  FLEX_NODES_ANNOTATION,
+  SDK_ANNOTATION,
+  TASK_COLOR_ANNOTATION,
+  EDGE_CONDUITS_ANNOTATION,
+]);
+
+export function stripFrontendAnnotations<T>(
+  annotations: Record<string, T> | undefined,
+): Record<string, T> {
+  const result: Record<string, T> = {};
+  for (const [key, value] of Object.entries(annotations ?? {})) {
+    if (!FRONTEND_ONLY_ANNOTATION_KEYS.has(key)) result[key] = value;
+  }
+  return result;
+}
+
+export interface KeyedDiffEntry<T> {
+  key: string;
+  a?: T;
+  b?: T;
+  status: DiffStatus;
+}
+
+type IoKind = "input" | "output";
+
+export interface IoDiff {
+  name: string;
+  kind: IoKind;
+  status: DiffStatus;
+  fieldDiffs: KeyedDiffEntry<unknown>[];
+  sourceTaskIdA?: string;
+  sourceTaskIdB?: string;
+  artifactStatus?: DiffStatus;
+  artifactA?: ArtifactNodeResponse;
+  artifactB?: ArtifactNodeResponse;
+}
+
+/**
+ * The status an output should be shown as. What a pipeline declares and what it
+ * produced are separate axes: an output whose declaration matched but whose
+ * artifact differs is not "unchanged", and one whose artifact is missing on one
+ * side is not "removed" — the declaration is still on both sides — so a
+ * value-only difference reads as changed either way.
+ */
+export function ioDisplayStatus(diff: IoDiff): DiffStatus {
+  if (diff.status !== "unchanged") return diff.status;
+  return diff.artifactStatus && diff.artifactStatus !== "unchanged"
+    ? "changed"
+    : "unchanged";
+}
+
+export interface TaskDiff {
+  taskId: string;
+  status: DiffStatus;
+  a?: TaskSpec;
+  b?: TaskSpec;
+  digestA?: string;
+  digestB?: string;
+  componentChanged: boolean;
+  statusA?: string;
+  statusB?: string;
+  executionIdA?: string;
+  executionIdB?: string;
+  cacheDisabledA: boolean;
+  cacheDisabledB: boolean;
+  cacheChanged: boolean;
+  outcomeChanged: boolean;
+  argumentDiffs: KeyedDiffEntry<ArgumentType>[];
+  annotationDiffs: KeyedDiffEntry<unknown>[];
+  settingDiffs: KeyedDiffEntry<unknown>[];
+}
+
+interface ComparisonCounts {
+  added: number;
+  removed: number;
+  changed: number;
+  unchanged: number;
+  outcomeChanged: number;
+  outputArtifactChanged: number;
+}
+
+export interface PipelineComparison {
+  taskDiffs: TaskDiff[];
+  inputDiffs: IoDiff[];
+  outputDiffs: IoDiff[];
+  counts: ComparisonCounts;
+  hasComparableGraph: boolean;
+}
+
+/**
+ * One run's contribution to a comparison. Grouping the per-run inputs keeps the
+ * A and B sides impossible to transpose at the call site. `outputArtifacts` is
+ * the run's pipeline-level output artifacts keyed by output name, or `undefined`
+ * while they are unknown — one side loading must not read as a difference, so
+ * artifacts are compared only when both sides are known.
+ */
+export interface ComparisonSide {
+  spec: ComponentSpec | undefined;
+  taskStatusMap: Map<string, string>;
+  taskExecutionIdMap?: Map<string, string>;
+  outputArtifacts?: Record<string, ArtifactNodeResponse>;
+}
+
+export function countChanged(entries: { status: DiffStatus }[]): number {
+  return entries.filter((entry) => entry.status !== "unchanged").length;
+}
+
+/**
+ * Union of keys preserving `a`'s order first, then appending keys present only
+ * in `b` in `b`'s order. Mirrors the ordering of the editor's diff lists so the
+ * two features read consistently.
+ */
+export function unionKeysAFirst(
+  a: Record<string, unknown>,
+  b: Record<string, unknown>,
+): string[] {
+  const seen = new Set<string>();
+  const keys: string[] = [];
+  for (const key of Object.keys(a)) {
+    seen.add(key);
+    keys.push(key);
+  }
+  for (const key of Object.keys(b)) {
+    if (!seen.has(key)) keys.push(key);
+  }
+  return keys;
+}
+
+export function diffKeyedRecords<T>(
+  a: Record<string, T> | undefined,
+  b: Record<string, T> | undefined,
+): KeyedDiffEntry<T>[] {
+  const aRecord = a ?? {};
+  const bRecord = b ?? {};
+
+  return unionKeysAFirst(aRecord, bRecord).map((key) => {
+    const inA = key in aRecord;
+    const inB = key in bRecord;
+    const aValue = inA ? aRecord[key] : undefined;
+    const bValue = inB ? bRecord[key] : undefined;
+
+    let status: DiffStatus;
+    if (inA && !inB) status = "lost";
+    else if (!inA && inB) status = "new";
+    else status = equal(aValue, bValue) ? "unchanged" : "changed";
+
+    return { key, a: aValue, b: bValue, status };
+  });
+}
+
+function isComponentChanged(a: TaskSpec, b: TaskSpec): boolean {
+  const digestA = a.componentRef.digest;
+  const digestB = b.componentRef.digest;
+  if (digestA && digestB) return digestA !== digestB;
+  return !equal(a.componentRef, b.componentRef);
+}
+
+interface TaskSide {
+  spec?: TaskSpec;
+  status?: string;
+  executionId?: string;
+}
+
+function taskSettings(spec?: TaskSpec): Record<string, unknown> {
+  const settings: Record<string, unknown> = {};
+  if (spec?.isEnabled !== undefined) settings.isEnabled = spec.isEnabled;
+  const { retryStrategy, cachingStrategy } = spec?.executionOptions ?? {};
+  if (retryStrategy !== undefined) settings.retryStrategy = retryStrategy;
+  if (cachingStrategy !== undefined) settings.cachingStrategy = cachingStrategy;
+  return settings;
+}
+
+function buildTaskDiff(
+  taskId: string,
+  sideA: TaskSide,
+  sideB: TaskSide,
+): TaskDiff {
+  const { spec: a, status: statusA, executionId: executionIdA } = sideA;
+  const { spec: b, status: statusB, executionId: executionIdB } = sideB;
+
+  const argumentDiffs = diffKeyedRecords(a?.arguments, b?.arguments);
+  const annotationDiffs = diffKeyedRecords(
+    stripFrontendAnnotations(a?.annotations),
+    stripFrontendAnnotations(b?.annotations),
+  );
+  const settingDiffs = diffKeyedRecords(taskSettings(a), taskSettings(b));
+  const digestA = a?.componentRef.digest;
+  const digestB = b?.componentRef.digest;
+
+  const cacheDisabledA = isCacheDisabled(a);
+  const cacheDisabledB = isCacheDisabled(b);
+  const cacheChanged = Boolean(a && b && cacheDisabledA !== cacheDisabledB);
+  const componentChanged = Boolean(a && b && isComponentChanged(a, b));
+
+  let status: DiffStatus;
+  if (a && !b) status = "lost";
+  else if (!a && b) status = "new";
+  else if (a && b) {
+    const hasFieldChanges = [
+      ...argumentDiffs,
+      ...annotationDiffs,
+      ...settingDiffs,
+    ].some((entry) => entry.status !== "unchanged");
+    status =
+      componentChanged || hasFieldChanges || cacheChanged
+        ? "changed"
+        : "unchanged";
+  } else {
+    status = "unchanged";
+  }
+
+  return {
+    taskId,
+    status,
+    a,
+    b,
+    digestA,
+    digestB,
+    componentChanged,
+    statusA,
+    statusB,
+    executionIdA,
+    executionIdB,
+    cacheDisabledA,
+    cacheDisabledB,
+    cacheChanged,
+    outcomeChanged:
+      Boolean(a && b && statusA && statusB) && statusA !== statusB,
+    argumentDiffs,
+    annotationDiffs,
+    settingDiffs,
+  };
+}
+
+function getGraphTasks(
+  spec: ComponentSpec | undefined,
+): Record<string, TaskSpec> {
+  if (!spec || !isGraphImplementation(spec.implementation)) return {};
+  return spec.implementation.graph.tasks;
+}
+
+function getOutputValues(
+  spec: ComponentSpec | undefined,
+): Record<string, TaskOutputArgument> {
+  if (!spec || !isGraphImplementation(spec.implementation)) return {};
+  return spec.implementation.graph.outputValues ?? {};
+}
+
+function byName<T extends { name: string }>(
+  specs: T[] | undefined,
+): Record<string, T> {
+  const record: Record<string, T> = {};
+  for (const spec of specs ?? []) record[spec.name] = spec;
+  return record;
+}
+
+function inputFields(spec: InputSpec | undefined): Record<string, unknown> {
+  const fields: Record<string, unknown> = {};
+  if (!spec) return fields;
+  if (spec.type !== undefined) fields.type = spec.type;
+  if (spec.default !== undefined) fields.default = spec.default;
+  if (spec.value !== undefined) fields.value = spec.value;
+  if (spec.optional !== undefined) fields.optional = spec.optional;
+  if (spec.description !== undefined) fields.description = spec.description;
+  return fields;
+}
+
+function outputFields(
+  spec: OutputSpec | undefined,
+  source: TaskOutputArgument | undefined,
+): Record<string, unknown> {
+  const fields: Record<string, unknown> = {};
+  if (spec?.type !== undefined) fields.type = spec.type;
+  if (spec?.description !== undefined) fields.description = spec.description;
+  if (source) {
+    fields.source = `${source.taskOutput.taskId}.${source.taskOutput.outputName}`;
+  }
+  return fields;
+}
+
+function ioStatus(
+  inA: boolean,
+  inB: boolean,
+  fieldDiffs: KeyedDiffEntry<unknown>[],
+): DiffStatus {
+  if (inA && !inB) return "lost";
+  if (!inA && inB) return "new";
+  return fieldDiffs.some((entry) => entry.status !== "unchanged")
+    ? "changed"
+    : "unchanged";
+}
+
+function diffInputs(
+  specA: ComponentSpec | undefined,
+  specB: ComponentSpec | undefined,
+): IoDiff[] {
+  const aMap = byName(specA?.inputs);
+  const bMap = byName(specB?.inputs);
+
+  return unionKeysAFirst(aMap, bMap).map((name) => {
+    const inA = name in aMap;
+    const inB = name in bMap;
+    const fieldDiffs = diffKeyedRecords(
+      inputFields(aMap[name]),
+      inputFields(bMap[name]),
+    );
+    return {
+      name,
+      kind: "input" as const,
+      status: ioStatus(inA, inB, fieldDiffs),
+      fieldDiffs,
+    };
+  });
+}
+
+function diffOutputs(sideA: ComparisonSide, sideB: ComparisonSide): IoDiff[] {
+  const { spec: specA, outputArtifacts: artifactsA } = sideA;
+  const { spec: specB, outputArtifacts: artifactsB } = sideB;
+  const artifactsKnown = Boolean(artifactsA && artifactsB);
+  const aMap = byName(specA?.outputs);
+  const bMap = byName(specB?.outputs);
+  const aOut = getOutputValues(specA);
+  const bOut = getOutputValues(specB);
+
+  return unionKeysAFirst({ ...aMap, ...aOut }, { ...bMap, ...bOut }).map(
+    (name) => {
+      const inA = name in aMap || name in aOut;
+      const inB = name in bMap || name in bOut;
+      const fieldDiffs = diffKeyedRecords(
+        outputFields(aMap[name], aOut[name]),
+        outputFields(bMap[name], bOut[name]),
+      );
+      const artifactA = artifactsA?.[name];
+      const artifactB = artifactsB?.[name];
+      return {
+        name,
+        kind: "output" as const,
+        status: ioStatus(inA, inB, fieldDiffs),
+        fieldDiffs,
+        sourceTaskIdA: aOut[name]?.taskOutput.taskId,
+        sourceTaskIdB: bOut[name]?.taskOutput.taskId,
+        artifactStatus:
+          artifactsKnown && (artifactA || artifactB)
+            ? artifactDiffStatus(artifactA, artifactB)
+            : undefined,
+        artifactA,
+        artifactB,
+      };
+    },
+  );
+}
+
+/**
+ * Aligns two runs' pipeline specs by task id and produces a per-task diff of
+ * component version, arguments, annotations, and execution status. Task
+ * ordering follows run A first, with tasks only present in run B appended.
+ */
+export function buildPipelineComparison(
+  sideA: ComparisonSide,
+  sideB: ComparisonSide,
+): PipelineComparison {
+  const { spec: specA } = sideA;
+  const { spec: specB } = sideB;
+  const tasksA = getGraphTasks(specA);
+  const tasksB = getGraphTasks(specB);
+
+  const taskDiffs = unionKeysAFirst(tasksA, tasksB).map((taskId) =>
+    buildTaskDiff(
+      taskId,
+      {
+        spec: tasksA[taskId],
+        status: sideA.taskStatusMap.get(taskId),
+        executionId: sideA.taskExecutionIdMap?.get(taskId),
+      },
+      {
+        spec: tasksB[taskId],
+        status: sideB.taskStatusMap.get(taskId),
+        executionId: sideB.taskExecutionIdMap?.get(taskId),
+      },
+    ),
+  );
+
+  const inputDiffs = diffInputs(specA, specB);
+  const outputDiffs = diffOutputs(sideA, sideB);
+
+  const counts: ComparisonCounts = {
+    added: 0,
+    removed: 0,
+    changed: 0,
+    unchanged: 0,
+    outcomeChanged: 0,
+    outputArtifactChanged: 0,
+  };
+
+  // Each row is counted by the status its own badge shows.
+  const tally = (status: DiffStatus) => {
+    if (status === "new") counts.added += 1;
+    else if (status === "lost") counts.removed += 1;
+    else if (status === "changed") counts.changed += 1;
+    else counts.unchanged += 1;
+  };
+
+  for (const diff of taskDiffs) {
+    tally(diff.status);
+    if (diff.outcomeChanged) counts.outcomeChanged += 1;
+  }
+
+  for (const diff of [...inputDiffs, ...outputDiffs]) {
+    tally(ioDisplayStatus(diff));
+  }
+
+  /**
+   * An output only present on one side is already reported as added or removed,
+   * so its artifact adds nothing; the count is about outputs both runs declare
+   * but whose produced value differs.
+   */
+  for (const diff of outputDiffs) {
+    const bothSides = diff.status === "unchanged" || diff.status === "changed";
+    if (
+      bothSides &&
+      diff.artifactStatus &&
+      diff.artifactStatus !== "unchanged"
+    ) {
+      counts.outputArtifactChanged += 1;
+    }
+  }
+
+  return {
+    taskDiffs,
+    inputDiffs,
+    outputDiffs,
+    counts,
+    hasComparableGraph:
+      taskDiffs.length > 0 || inputDiffs.length > 0 || outputDiffs.length > 0,
+  };
+}

--- a/src/routes/v2/pages/CompareView/utils/runExecutionFacts.test.ts
+++ b/src/routes/v2/pages/CompareView/utils/runExecutionFacts.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "vitest";
+
+import type {
+  ExecutionStatusHistoryEntry,
+  GetExecutionInfoResponse,
+} from "@/api/types.gen";
+
+import { runDurationMs, runOverallStatus } from "./runExecutionFacts";
+
+const details = (
+  status_history: ExecutionStatusHistoryEntry[] | undefined,
+): GetExecutionInfoResponse =>
+  ({
+    id: "1",
+    child_task_execution_ids: {},
+    status_history,
+  }) as GetExecutionInfoResponse;
+
+const entry = (
+  status: string,
+  first_observed_at: string,
+): ExecutionStatusHistoryEntry => ({ status, first_observed_at });
+
+describe("runOverallStatus()", () => {
+  test("aggregates child stats by priority", () => {
+    const status = runOverallStatus({
+      child_execution_status_stats: {
+        e1: { SUCCEEDED: 2 },
+        e2: { FAILED: 1 },
+      },
+    });
+
+    expect(status).toBe("FAILED");
+  });
+
+  test("returns undefined without state", () => {
+    expect(runOverallStatus(undefined)).toBeUndefined();
+  });
+});
+
+describe("runDurationMs()", () => {
+  test("measures first to last observed status", () => {
+    const duration = runDurationMs(
+      details([
+        entry("PENDING", "2026-01-01T00:00:00Z"),
+        entry("RUNNING", "2026-01-01T00:00:10Z"),
+        entry("SUCCEEDED", "2026-01-01T00:02:30Z"),
+      ]),
+    );
+
+    expect(duration).toBe(150_000);
+  });
+
+  test("reports nothing while the run is still in progress", () => {
+    const duration = runDurationMs(
+      details([
+        entry("PENDING", "2026-01-01T00:00:00Z"),
+        entry("RUNNING", "2026-01-01T00:00:10Z"),
+      ]),
+    );
+
+    expect(duration).toBeUndefined();
+  });
+
+  test("reports nothing from a single entry or missing history", () => {
+    expect(
+      runDurationMs(details([entry("SUCCEEDED", "2026-01-01T00:00:00Z")])),
+    ).toBeUndefined();
+    expect(runDurationMs(details(undefined))).toBeUndefined();
+    expect(runDurationMs(undefined)).toBeUndefined();
+  });
+
+  test("reports nothing for unparseable timestamps", () => {
+    const duration = runDurationMs(
+      details([entry("PENDING", "not-a-date"), entry("SUCCEEDED", "also-not")]),
+    );
+
+    expect(duration).toBeUndefined();
+  });
+});

--- a/src/routes/v2/pages/CompareView/utils/runExecutionFacts.ts
+++ b/src/routes/v2/pages/CompareView/utils/runExecutionFacts.ts
@@ -1,0 +1,40 @@
+import type {
+  GetExecutionInfoResponse,
+  GetGraphExecutionStateResponse,
+} from "@/api/types.gen";
+import {
+  flattenExecutionStatusStats,
+  getOverallExecutionStatusFromStats,
+  isInProgressStatus,
+} from "@/utils/executionStatus";
+
+export function runOverallStatus(
+  state: GetGraphExecutionStateResponse | undefined,
+): string | undefined {
+  return getOverallExecutionStatusFromStats(
+    flattenExecutionStatusStats(state?.child_execution_status_stats),
+  );
+}
+
+/**
+ * Wall clock between the run's first and last observed status. The status
+ * history is the only run-level timing the backend reports — `started_at` and
+ * `ended_at` exist per container, not per run — and it only describes a duration
+ * once the run has stopped moving, so an in-flight run reports nothing rather
+ * than a figure that grows every poll.
+ */
+export function runDurationMs(
+  details: GetExecutionInfoResponse | undefined,
+): number | undefined {
+  const history = details?.status_history;
+  if (!history || history.length < 2) return undefined;
+
+  const last = history[history.length - 1];
+  if (isInProgressStatus(last.status)) return undefined;
+
+  const start = Date.parse(history[0].first_observed_at);
+  const end = Date.parse(last.first_observed_at);
+  if (Number.isNaN(start) || Number.isNaN(end) || end < start) return undefined;
+
+  return end - start;
+}

--- a/src/routes/v2/pages/Editor/components/UpgradeComponents/components/upgradePreviewConstants.ts
+++ b/src/routes/v2/pages/Editor/components/UpgradeComponents/components/upgradePreviewConstants.ts
@@ -1,5 +1,5 @@
 import type { IconName } from "@/components/ui/icon";
-import type { DiffStatus } from "@/routes/v2/pages/Editor/store/actions/task.utils";
+import type { DiffStatus } from "@/utils/diffStatus";
 
 export const DIFF_STATUS_CLASSES: Record<DiffStatus, string> = {
   unchanged: "bg-gray-200 text-gray-800",

--- a/src/routes/v2/pages/Editor/store/actions/task.utils.ts
+++ b/src/routes/v2/pages/Editor/store/actions/task.utils.ts
@@ -6,14 +6,13 @@ import type {
 import type { OutputSpec } from "@/models/componentSpec/entities/types";
 import { isInputRequired } from "@/models/componentSpec/validation/validateSpec";
 import type { LostBinding } from "@/routes/v2/pages/Editor/components/UpgradeComponents/types";
+import type { DiffStatus } from "@/utils/diffStatus";
 
 export interface EntityDiff<T> {
   lostEntities: T[];
   newEntities: T[];
   changedEntities: T[];
 }
-
-export type DiffStatus = "unchanged" | "lost" | "new" | "changed";
 
 export interface DiffEntry<T> {
   entry: T;

--- a/src/utils/annotationKeys.ts
+++ b/src/utils/annotationKeys.ts
@@ -1,0 +1,22 @@
+/**
+ * Annotation key names, deliberately kept in a module with no imports of its
+ * own. `@/utils/annotations` re-exports all of these alongside its helpers, but
+ * that module reaches into the components tree, which breaks vitest mock
+ * hoisting for pure utils — so leaf utils and their tests import from here.
+ */
+
+export const TASK_DISPLAY_NAME_ANNOTATION = "display_name";
+export const PIPELINE_NOTES_ANNOTATION = "notes";
+export const PIPELINE_RUN_NOTES_ANNOTATION = "notes";
+export const PIPELINE_TAGS_ANNOTATION = "tags";
+export const PIPELINE_CANONICAL_NAME_ANNOTATION = "canonical-pipeline-name";
+export const RUN_NAME_TEMPLATE_ANNOTATION = "run-name-template";
+export const RUN_SOURCE_ANNOTATION = "source";
+export const EDITOR_POSITION_ANNOTATION = "editor.position";
+export const EDITOR_COLLAPSED_ANNOTATION = "editor.collapsed";
+export const EDITOR_FLOW_DIRECTION_ANNOTATION = "editor.flow-direction";
+export const FLEX_NODES_ANNOTATION = "flex-nodes";
+export const ZINDEX_ANNOTATION = "zIndex";
+export const SDK_ANNOTATION = "sdk";
+export const TASK_COLOR_ANNOTATION = "tangleml.com/editor/task-color";
+export const EDGE_CONDUITS_ANNOTATION = "tangleml.com/editor/edge-conduits";

--- a/src/utils/annotations.ts
+++ b/src/utils/annotations.ts
@@ -3,24 +3,24 @@ import type { XYPosition } from "@xyflow/react";
 import { getNodeTypeZIndexDefault } from "@/components/shared/ReactFlow/FlowCanvas/utils/zIndex";
 import type { AnnotationConfig, Annotations } from "@/types/annotations";
 
+import {
+  EDGE_CONDUITS_ANNOTATION,
+  EDITOR_COLLAPSED_ANNOTATION,
+  EDITOR_FLOW_DIRECTION_ANNOTATION,
+  EDITOR_POSITION_ANNOTATION,
+  FLEX_NODES_ANNOTATION,
+  PIPELINE_NOTES_ANNOTATION,
+  PIPELINE_TAGS_ANNOTATION,
+  SDK_ANNOTATION,
+  TASK_COLOR_ANNOTATION,
+  TASK_DISPLAY_NAME_ANNOTATION,
+  ZINDEX_ANNOTATION,
+} from "./annotationKeys";
 import type { ComponentSpec } from "./componentSpec";
 
+export * from "./annotationKeys";
+
 export const DISPLAY_NAME_MAX_LENGTH = 100;
-export const TASK_DISPLAY_NAME_ANNOTATION = "display_name";
-export const PIPELINE_NOTES_ANNOTATION = "notes";
-export const PIPELINE_RUN_NOTES_ANNOTATION = "notes";
-export const PIPELINE_TAGS_ANNOTATION = "tags";
-export const PIPELINE_CANONICAL_NAME_ANNOTATION = "canonical-pipeline-name";
-export const RUN_NAME_TEMPLATE_ANNOTATION = "run-name-template";
-export const RUN_SOURCE_ANNOTATION = "source";
-export const EDITOR_POSITION_ANNOTATION = "editor.position";
-export const EDITOR_COLLAPSED_ANNOTATION = "editor.collapsed";
-export const EDITOR_FLOW_DIRECTION_ANNOTATION = "editor.flow-direction";
-export const FLEX_NODES_ANNOTATION = "flex-nodes";
-export const ZINDEX_ANNOTATION = "zIndex";
-export const SDK_ANNOTATION = "sdk";
-export const TASK_COLOR_ANNOTATION = "tangleml.com/editor/task-color";
-export const EDGE_CONDUITS_ANNOTATION = "tangleml.com/editor/edge-conduits";
 const PIPELINE_AGGREGATOR_ANNOTATION = "is_input_aggregator";
 
 export const SYSTEM_ANNOTATIONS = [

--- a/src/utils/componentSpec.ts
+++ b/src/utils/componentSpec.ts
@@ -456,9 +456,11 @@ export const isContainerImplementation = (
 ): implementation is ContainerImplementation => "container" in implementation;
 
 export const isGraphImplementation = (
-  implementation: ImplementationType | undefined,
+  implementation: ImplementationType | null | undefined,
 ): implementation is GraphImplementation =>
-  implementation !== undefined && "graph" in implementation;
+  implementation !== null &&
+  implementation !== undefined &&
+  "graph" in implementation;
 
 export const isGraphImplementationOutput = (
   implementation:

--- a/src/utils/diffStatus.ts
+++ b/src/utils/diffStatus.ts
@@ -1,0 +1,5 @@
+/**
+ * Membership of an entity in a before/after pair, shared by the editor's
+ * component upgrade preview and the run comparison view.
+ */
+export type DiffStatus = "unchanged" | "lost" | "new" | "changed";

--- a/src/utils/executionStatus.test.ts
+++ b/src/utils/executionStatus.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, test } from "vitest";
 
-import type { GetGraphExecutionStateResponse } from "@/api/types.gen";
+import type {
+  GetExecutionInfoResponse,
+  GetGraphExecutionStateResponse,
+} from "@/api/types.gen";
 import {
+  buildTaskExecutionStatusMap,
   countInProgressFromStats,
   flattenExecutionStatusStats,
   getExecutionStatusLabel,
@@ -208,5 +212,61 @@ describe("isExecutionComplete()", () => {
         SKIPPED: 2,
       }),
     ).toBe(true);
+  });
+});
+
+describe("buildTaskExecutionStatusMap()", () => {
+  const details = (
+    childTaskExecutionIds: Record<string, string>,
+  ): GetExecutionInfoResponse => ({
+    id: "root",
+    task_spec: { componentRef: {} },
+    child_task_execution_ids: childTaskExecutionIds,
+  });
+
+  const state = (
+    stats: NonNullable<
+      GetGraphExecutionStateResponse["child_execution_status_stats"]
+    >,
+  ): GetGraphExecutionStateResponse => ({
+    child_execution_status_stats: stats,
+  });
+
+  test("maps each task id to its aggregated execution status", () => {
+    const result = buildTaskExecutionStatusMap(
+      details({ train: "e1", evaluate: "e2" }),
+      state({ e1: { SUCCEEDED: 1 }, e2: { FAILED: 1, RUNNING: 2 } }),
+    );
+
+    expect(Object.fromEntries(result)).toEqual({
+      train: "SUCCEEDED",
+      evaluate: "FAILED",
+    });
+  });
+
+  test("returns an empty map when details are missing", () => {
+    expect(buildTaskExecutionStatusMap(undefined, state({})).size).toBe(0);
+  });
+
+  test("omits tasks whose execution has no stats", () => {
+    const result = buildTaskExecutionStatusMap(
+      details({ train: "e1", evaluate: "missing" }),
+      state({ e1: { SUCCEEDED: 1 } }),
+    );
+
+    expect(Object.fromEntries(result)).toEqual({ train: "SUCCEEDED" });
+  });
+
+  test("omits tasks whose stats are all zero", () => {
+    const result = buildTaskExecutionStatusMap(
+      details({ train: "e1" }),
+      state({ e1: { RUNNING: 0 } }),
+    );
+
+    expect(result.size).toBe(0);
+  });
+
+  test("omits every task when the run has no state yet", () => {
+    expect(buildTaskExecutionStatusMap(details({ train: "e1" })).size).toBe(0);
   });
 });

--- a/src/utils/executionStatus.ts
+++ b/src/utils/executionStatus.ts
@@ -1,5 +1,6 @@
 import type {
   ContainerExecutionStatus,
+  GetExecutionInfoResponse,
   GetGraphExecutionStateResponse,
 } from "@/api/types.gen";
 
@@ -152,6 +153,11 @@ export function getOverallExecutionStatusFromStats(
   return firstNonZero?.[0];
 }
 
+export function isInProgressStatus(status?: string): boolean {
+  if (!status) return false;
+  return IN_PROGRESS_STATUSES.has(status);
+}
+
 /**
  * Count the number of in-progress tasks from execution stats.
  */
@@ -169,4 +175,34 @@ export function countInProgressFromStats(stats: ExecutionStatusStats): number {
 export function isExecutionComplete(stats: ExecutionStatusStats): boolean {
   const total = Object.values(stats).reduce((sum, c) => sum + (c ?? 0), 0);
   return total > 0 && countInProgressFromStats(stats) === 0;
+}
+
+/**
+ * Build a map of task id → aggregated execution status by joining a run's
+ * task→execution id mapping against its per-execution status stats.
+ *
+ * @public
+ */
+export function buildTaskExecutionStatusMap(
+  details?: GetExecutionInfoResponse,
+  state?: GetGraphExecutionStateResponse,
+): Map<string, string> {
+  const taskExecutionStatusMap = new Map<string, string>();
+
+  if (!details?.child_task_execution_ids) {
+    return taskExecutionStatusMap;
+  }
+
+  for (const [taskId, executionId] of Object.entries(
+    details.child_task_execution_ids,
+  )) {
+    const statusStats = state?.child_execution_status_stats?.[executionId];
+    const aggregated = getOverallExecutionStatusFromStats(statusStats);
+
+    if (aggregated) {
+      taskExecutionStatusMap.set(taskId, aggregated);
+    }
+  }
+
+  return taskExecutionStatusMap;
 }


### PR DESCRIPTION
## Description

First PR in the **Compare Runs** stack. Adds the core engine that diffs two pipeline runs — no UI yet, just the logic everything else builds on.

Given two runs it aligns their tasks by id and works out, for each one, whether it was added, removed, changed, or unchanged. "Changed" covers a different component version, different arguments, different annotations, or a flipped cache setting. Pipeline inputs and outputs are compared the same way (including detecting when an output was rewired to a different task). Layout-only editor annotations (node positions, colours, etc.) are stripped out first so they don't show up as noise.

It also tracks per-task execution outcome, so a task whose spec is identical but that succeeded in one run and failed in the other is still flagged as "outcome differs".

A small helper for loading a single run's spec and execution status (`useRunComparisonSide`) and a shared `buildTaskExecutionStatusMap` util round out the PR.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

Part of the Compare Runs stack. Branches off `master`; the next PR (#2597) builds on this branch.

## Type of Change

- [x] New feature

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- No visual changes in this PR — it is logic only. -->

## Test Instructions

This PR is pure logic and ships behind the (not-yet-added) `compare-runs` flag, so there's nothing to click through on its own.

- Run the unit tests: `npm run test -- comparePipelines`
- The suite covers added/removed/changed/unchanged tasks, argument and annotation diffs, cache changes, outcome differences, input/output alignment and rewired outputs.

To exercise it in the real UI, check out the top of the stack (#2603), enable the **Compare runs** beta flag, and compare two runs.

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
