### PR TITLE
feat: run comparison - shared diff UI primitives

### DIFF
--- a/src/routes/v2/pages/CompareView/components/DiffCodeViewer.tsx
+++ b/src/routes/v2/pages/CompareView/components/DiffCodeViewer.tsx
@@ -1,0 +1,58 @@
+import { DiffEditor, Editor } from "@monaco-editor/react";
+
+/**
+ * Read-only Monaco surfaces for the comparison view, pinned to the dark theme
+ * regardless of the app theme so diffed code always renders on the same ground.
+ */
+const READ_ONLY_OPTIONS = {
+  readOnly: true,
+  minimap: { enabled: false },
+  scrollBeyondLastLine: false,
+  automaticLayout: true,
+  wordWrap: "on",
+  scrollbar: { verticalScrollbarSize: 10, horizontalScrollbarSize: 10 },
+} as const;
+
+const DIFF_OPTIONS = {
+  ...READ_ONLY_OPTIONS,
+  renderSideBySide: true,
+  renderOverviewRuler: false,
+} as const;
+
+interface DiffCodeViewerProps {
+  original: string;
+  modified: string;
+  language: string;
+}
+
+export function DiffCodeViewer({
+  original,
+  modified,
+  language,
+}: DiffCodeViewerProps) {
+  return (
+    <DiffEditor
+      original={original}
+      modified={modified}
+      language={language}
+      theme="vs-dark"
+      options={DIFF_OPTIONS}
+    />
+  );
+}
+
+interface CodeViewerProps {
+  value: string;
+  language: string;
+}
+
+export function CodeViewer({ value, language }: CodeViewerProps) {
+  return (
+    <Editor
+      value={value}
+      language={language}
+      theme="vs-dark"
+      options={READ_ONLY_OPTIONS}
+    />
+  );
+}

--- a/src/routes/v2/pages/CompareView/components/DiffStatusBadge.tsx
+++ b/src/routes/v2/pages/CompareView/components/DiffStatusBadge.tsx
@@ -1,0 +1,47 @@
+import { Icon } from "@/components/ui/icon";
+import { InlineStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
+import { cn } from "@/lib/utils";
+import { DIFF_STATUS_ICON, type DiffStatus } from "@/utils/diffStatus";
+
+export const DIFF_STATUS_LABELS: Record<DiffStatus, string> = {
+  unchanged: "Unchanged",
+  lost: "Removed",
+  new: "Added",
+  changed: "Changed",
+};
+
+const DIFF_STATUS_TONE: Record<DiffStatus, string> = {
+  unchanged: "bg-diff-unchanged text-diff-unchanged-foreground",
+  lost: "bg-diff-lost text-diff-lost-foreground line-through",
+  new: "bg-diff-new text-diff-new-foreground",
+  changed: "bg-diff-changed text-diff-changed-foreground",
+};
+
+interface DiffStatusBadgeProps {
+  status: DiffStatus;
+  className?: string;
+}
+
+export function DiffStatusBadge({ status, className }: DiffStatusBadgeProps) {
+  const icon = DIFF_STATUS_ICON[status];
+
+  return (
+    <InlineStack
+      as="span"
+      gap="1"
+      blockAlign="center"
+      wrap="nowrap"
+      className={cn(
+        "rounded px-1.5 py-0.5",
+        DIFF_STATUS_TONE[status],
+        className,
+      )}
+    >
+      {icon && <Icon name={icon.name} size="xs" />}
+      <Text as="span" size="xs" weight="semibold" className="text-inherit">
+        {DIFF_STATUS_LABELS[status]}
+      </Text>
+    </InlineStack>
+  );
+}

--- a/src/routes/v2/pages/CompareView/components/FieldDiffRow.tsx
+++ b/src/routes/v2/pages/CompareView/components/FieldDiffRow.tsx
@@ -1,0 +1,77 @@
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
+import { cn } from "@/lib/utils";
+import type { KeyedDiffEntry } from "@/routes/v2/pages/CompareView/utils/comparePipelines";
+import { formatDiffValue } from "@/routes/v2/pages/CompareView/utils/formatDiffValue";
+
+import { DiffStatusBadge } from "./DiffStatusBadge";
+
+const LONG_VALUE_CHARS = 120;
+const LONG_VALUE_LINES = 3;
+
+interface ValueLineProps {
+  label: string;
+  value: unknown;
+}
+
+function ValueLine({ label, value }: ValueLineProps) {
+  const [expanded, setExpanded] = useState(false);
+  const text = formatDiffValue(value);
+  const isLong =
+    text.length > LONG_VALUE_CHARS ||
+    text.split("\n").length > LONG_VALUE_LINES;
+
+  return (
+    <InlineStack gap="2" blockAlign="start" wrap="nowrap">
+      <Text as="span" size="xs" tone="subdued" className="w-10 shrink-0">
+        {label}
+      </Text>
+      <BlockStack gap="0" className="min-w-0 flex-1">
+        <Text
+          as="span"
+          size="xs"
+          className={cn(
+            "font-mono break-all whitespace-pre-wrap",
+            isLong && !expanded && "line-clamp-3",
+          )}
+        >
+          {text}
+        </Text>
+        {isLong && (
+          <Button
+            variant="link"
+            size="sm"
+            className="h-auto w-fit p-0 text-xs"
+            onClick={() => setExpanded((prev) => !prev)}
+          >
+            {expanded ? "Show less" : "Show more"}
+          </Button>
+        )}
+      </BlockStack>
+    </InlineStack>
+  );
+}
+
+interface FieldDiffRowProps {
+  entry: KeyedDiffEntry<unknown>;
+  labelA: string;
+  labelB: string;
+}
+
+export function FieldDiffRow({ entry, labelA, labelB }: FieldDiffRowProps) {
+  return (
+    <BlockStack gap="1" className="rounded border border-border p-2">
+      <InlineStack gap="2" blockAlign="center">
+        <Text as="span" size="sm" weight="semibold" className="font-mono">
+          {entry.key}
+        </Text>
+        <DiffStatusBadge status={entry.status} />
+      </InlineStack>
+      {entry.status !== "new" && <ValueLine label={labelA} value={entry.a} />}
+      {entry.status !== "lost" && <ValueLine label={labelB} value={entry.b} />}
+    </BlockStack>
+  );
+}

--- a/src/routes/v2/pages/CompareView/components/RunTag.tsx
+++ b/src/routes/v2/pages/CompareView/components/RunTag.tsx
@@ -1,0 +1,52 @@
+import { InlineStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
+import { cn } from "@/lib/utils";
+import type { DiffStatus } from "@/routes/v2/pages/CompareView/utils/comparePipelines";
+import { RUN_TONE } from "@/routes/v2/pages/CompareView/utils/runTone";
+
+const STATUS_RUNS: Record<DiffStatus, ("a" | "b")[]> = {
+  lost: ["a"],
+  new: ["b"],
+  changed: ["a", "b"],
+  unchanged: ["a", "b"],
+};
+
+interface RunTagProps {
+  run: "a" | "b";
+  label: string;
+}
+
+export function RunTag({ run, label }: RunTagProps) {
+  return (
+    <Text
+      as="span"
+      size="xs"
+      weight="semibold"
+      className={cn(
+        "rounded border px-1.5 py-0.5 font-mono leading-none",
+        RUN_TONE[run],
+      )}
+      title={`In run ${label}`}
+    >
+      {label}
+    </Text>
+  );
+}
+
+interface RunTagsProps {
+  status: DiffStatus;
+  labelA: string;
+  labelB: string;
+}
+
+export function RunTags({ status, labelA, labelB }: RunTagsProps) {
+  const labels: Record<"a" | "b", string> = { a: labelA, b: labelB };
+
+  return (
+    <InlineStack gap="1" blockAlign="center" wrap="nowrap">
+      {STATUS_RUNS[status].map((run) => (
+        <RunTag key={run} run={run} label={labels[run]} />
+      ))}
+    </InlineStack>
+  );
+}

--- a/src/routes/v2/pages/CompareView/components/YamlDiffView.tsx
+++ b/src/routes/v2/pages/CompareView/components/YamlDiffView.tsx
@@ -1,0 +1,51 @@
+import { InfoBox } from "@/components/shared/InfoBox";
+import { InlineStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
+import type { ComponentSpec } from "@/utils/componentSpec";
+import { componentSpecToText } from "@/utils/yaml";
+
+import { CodeViewer, DiffCodeViewer } from "./DiffCodeViewer";
+
+interface YamlDiffViewProps {
+  specA?: ComponentSpec;
+  specB?: ComponentSpec;
+}
+
+export function YamlDiffView({ specA, specB }: YamlDiffViewProps) {
+  const yamlA = specA && componentSpecToText(specA);
+  const yamlB = specB && componentSpecToText(specB);
+
+  if (!yamlA && !yamlB) {
+    return (
+      <InfoBox title="Nothing to compare" variant="info" width="full">
+        Select two runs to compare their YAML specifications.
+      </InfoBox>
+    );
+  }
+
+  if (!yamlA || !yamlB) {
+    return (
+      <InlineStack
+        gap="0"
+        blockAlign="stretch"
+        wrap="nowrap"
+        className="h-full w-full"
+      >
+        <div className="min-w-0 flex-1">
+          <CodeViewer value={yamlA ?? yamlB ?? ""} language="yaml" />
+        </div>
+        <InlineStack
+          align="center"
+          blockAlign="center"
+          className="min-w-0 flex-1 border-l p-6"
+        >
+          <Text tone="subdued" className="text-center">
+            Select a second run to compare YAML side by side.
+          </Text>
+        </InlineStack>
+      </InlineStack>
+    );
+  }
+
+  return <DiffCodeViewer original={yamlA} modified={yamlB} language="yaml" />;
+}

--- a/src/routes/v2/pages/CompareView/utils/formatDiffValue.ts
+++ b/src/routes/v2/pages/CompareView/utils/formatDiffValue.ts
@@ -1,0 +1,11 @@
+const UNSET_LABEL = "(unset)";
+
+/**
+ * Renders one side of a diffed field as display text. Absent values read as
+ * `(unset)` rather than an empty gap, so a removed value stays visible.
+ */
+export function formatDiffValue(value: unknown): string {
+  if (value === undefined) return UNSET_LABEL;
+  if (typeof value === "string") return value;
+  return JSON.stringify(value);
+}

--- a/src/routes/v2/pages/CompareView/utils/runTone.ts
+++ b/src/routes/v2/pages/CompareView/utils/runTone.ts
@@ -1,0 +1,21 @@
+/**
+ * "Run A is blue, run B is emerald" — the single place that decides it. Every
+ * surface that carries a run's identity (tags, switcher chips, the graph
+ * spotlight panel) reads from here, so the two runs cannot drift apart a shade
+ * at a time as more surfaces are added.
+ */
+export const RUN_TONE: Record<"a" | "b", string> = {
+  a: "border-blue-400 bg-blue-50 text-blue-800 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-200",
+  b: "border-emerald-400 bg-emerald-50 text-emerald-800 dark:border-emerald-800 dark:bg-emerald-950 dark:text-emerald-200",
+};
+
+/**
+ * @public consumed by the run switcher, which lands later in this stack.
+ *
+ * The unfilled counterpart of {@link RUN_TONE}, for controls that only take on
+ * their run's colour on hover.
+ */
+export const RUN_OUTLINE_TONE: Record<"a" | "b", string> = {
+  a: "border-blue-400 text-blue-700 hover:bg-blue-50 dark:border-blue-800 dark:text-blue-300 dark:hover:bg-blue-950",
+  b: "border-emerald-400 text-emerald-700 hover:bg-emerald-50 dark:border-emerald-800 dark:text-emerald-300 dark:hover:bg-emerald-950",
+};

--- a/src/routes/v2/pages/Editor/components/UpgradeComponents/components/DiffInputRow.tsx
+++ b/src/routes/v2/pages/Editor/components/UpgradeComponents/components/DiffInputRow.tsx
@@ -5,15 +5,15 @@ import { InlineStack } from "@/components/ui/layout";
 import { cn } from "@/lib/utils";
 import type { DiffEntry } from "@/routes/v2/pages/Editor/store/actions/task.utils";
 import type { TaskNodeInput } from "@/routes/v2/shared/nodes/TaskNode/TaskNode";
+import { DIFF_STATUS_ICON } from "@/utils/diffStatus";
 
 import {
   DIFF_STATUS_CLASSES,
   HANDLE_STATUS_CLASSES,
-  STATUS_ICON,
 } from "./upgradePreviewConstants";
 
 export function DiffInputRow({ entry, status }: DiffEntry<TaskNodeInput>) {
-  const icon = STATUS_ICON[status];
+  const icon = DIFF_STATUS_ICON[status];
   return (
     <div className="relative w-full h-fit">
       <div className="absolute -translate-x-6 flex items-center h-3 w-3">

--- a/src/routes/v2/pages/Editor/components/UpgradeComponents/components/DiffOutputRow.tsx
+++ b/src/routes/v2/pages/Editor/components/UpgradeComponents/components/DiffOutputRow.tsx
@@ -5,15 +5,15 @@ import { InlineStack } from "@/components/ui/layout";
 import { cn } from "@/lib/utils";
 import type { DiffEntry } from "@/routes/v2/pages/Editor/store/actions/task.utils";
 import type { TaskNodeOutput } from "@/routes/v2/shared/nodes/TaskNode/TaskNode";
+import { DIFF_STATUS_ICON } from "@/utils/diffStatus";
 
 import {
   DIFF_STATUS_CLASSES,
   HANDLE_STATUS_CLASSES,
-  STATUS_ICON,
 } from "./upgradePreviewConstants";
 
 export function DiffOutputRow({ entry, status }: DiffEntry<TaskNodeOutput>) {
-  const icon = STATUS_ICON[status];
+  const icon = DIFF_STATUS_ICON[status];
   return (
     <InlineStack blockAlign="center" className="w-full justify-end">
       <InlineStack

--- a/src/routes/v2/pages/Editor/components/UpgradeComponents/components/upgradePreviewConstants.ts
+++ b/src/routes/v2/pages/Editor/components/UpgradeComponents/components/upgradePreviewConstants.ts
@@ -1,4 +1,3 @@
-import type { IconName } from "@/components/ui/icon";
 import type { DiffStatus } from "@/utils/diffStatus";
 
 export const DIFF_STATUS_CLASSES: Record<DiffStatus, string> = {
@@ -13,12 +12,4 @@ export const HANDLE_STATUS_CLASSES: Record<DiffStatus, string> = {
   lost: "!bg-red-400",
   new: "!bg-green-500",
   changed: "!bg-amber-500",
-};
-
-export const STATUS_ICON: Partial<
-  Record<DiffStatus, { name: IconName; className: string }>
-> = {
-  lost: { name: "Minus", className: "text-red-500" },
-  new: { name: "Plus", className: "text-green-600" },
-  changed: { name: "RefreshCw", className: "text-amber-600" },
 };

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -86,6 +86,18 @@ code {
   --status-cancelled: oklch(0.44 0.01 286);
   --status-cancelling: oklch(0.7 0.19 42);
   --status-uninitialized: oklch(0.85 0.16 90);
+
+  /* Run comparison diff colours — one fill per diff status (node borders,
+   * legend swatches, graph edge strokes, status badges) plus the foreground
+   * that stays legible on top of it. */
+  --diff-unchanged: oklch(0.87 0.01 286);
+  --diff-lost: oklch(0.7 0.19 22);
+  --diff-new: oklch(0.72 0.19 149);
+  --diff-changed: oklch(0.83 0.16 84);
+  --diff-unchanged-foreground: oklch(0.28 0.006 286);
+  --diff-lost-foreground: oklch(0.99 0 0);
+  --diff-new-foreground: oklch(0.99 0 0);
+  --diff-changed-foreground: oklch(0.28 0.02 84);
 }
 
 .dark {
@@ -150,6 +162,15 @@ code {
   --status-cancelled: oklch(0.52 0.01 286);
   --status-cancelling: oklch(0.6 0.13 42);
   --status-uninitialized: oklch(0.68 0.11 90);
+
+  --diff-unchanged: oklch(0.55 0.012 286);
+  --diff-lost: oklch(0.58 0.14 22);
+  --diff-new: oklch(0.58 0.12 149);
+  --diff-changed: oklch(0.68 0.11 84);
+  --diff-unchanged-foreground: oklch(0.98 0 0);
+  --diff-lost-foreground: oklch(0.99 0 0);
+  --diff-new-foreground: oklch(0.99 0 0);
+  --diff-changed-foreground: oklch(0.24 0.02 84);
 }
 
 /*
@@ -255,6 +276,14 @@ code {
   --color-status-cancelled: var(--status-cancelled);
   --color-status-cancelling: var(--status-cancelling);
   --color-status-uninitialized: var(--status-uninitialized);
+  --color-diff-unchanged: var(--diff-unchanged);
+  --color-diff-lost: var(--diff-lost);
+  --color-diff-new: var(--diff-new);
+  --color-diff-changed: var(--diff-changed);
+  --color-diff-unchanged-foreground: var(--diff-unchanged-foreground);
+  --color-diff-lost-foreground: var(--diff-lost-foreground);
+  --color-diff-new-foreground: var(--diff-new-foreground);
+  --color-diff-changed-foreground: var(--diff-changed-foreground);
 
   /* Custom animations */
   --animate-revert-copied: revert-copied 0.5s ease-in-out forwards;

--- a/src/utils/diffStatus.ts
+++ b/src/utils/diffStatus.ts
@@ -1,5 +1,15 @@
+import type { IconName } from "@/components/ui/icon";
+
 /**
  * Membership of an entity in a before/after pair, shared by the editor's
  * component upgrade preview and the run comparison view.
  */
 export type DiffStatus = "unchanged" | "lost" | "new" | "changed";
+
+export const DIFF_STATUS_ICON: Partial<
+  Record<DiffStatus, { name: IconName; className: string }>
+> = {
+  lost: { name: "Minus", className: "text-diff-lost" },
+  new: { name: "Plus", className: "text-diff-new" },
+  changed: { name: "RefreshCw", className: "text-diff-changed" },
+};


### PR DESCRIPTION
## Description

Third PR in the **Compare Runs** stack. Adds the small, shared UI building blocks that the later comparison views reuse, so they stay consistent. Nothing here is wired into a page yet.

- **CompareRunPicker** — a list of recent runs used to pick a run for either side of the comparison.
- **DiffStatusBadge** — the coloured Added / Removed / Changed / Unchanged badge.
- **RunTag / RunTags** — the small "A" / "B" pills that mark which run a value belongs to.
- **FieldDiffRow** — a single field's before/after values with expand-to-see-more for long values.
- **YamlDiffView** — a side-by-side YAML diff of the two run specs (Monaco diff editor).

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

Part of the Compare Runs stack. Builds on #2597; the next PR (#2599) builds on this branch.

## Type of Change

- [x] New feature

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Add screenshots of the diff badge, run tags, field diff row and YAML diff once wired up. -->

## Test Instructions

These are shared presentational components with no entry point of their own on this branch. They're exercised through the full feature.

- Check out the top of the stack (#2603) and enable the **Compare runs** beta flag (Settings → Beta features).
- Compare two runs and confirm the status badges, A/B run tags and field rows render correctly, and that the YAML tab shows a readable side-by-side diff.

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
