### PR TITLE
feat: run comparison - artifact comparison

### DIFF
--- a/react-compiler.config.js
+++ b/react-compiler.config.js
@@ -38,6 +38,7 @@ export const REACT_COMPILER_ENABLED_DIRS = [
   "src/hooks/useFavorites.ts",
   "src/hooks/useRecentlyViewed.ts",
   "src/hooks/useDocsVisitTracking.ts",
+  "src/hooks/useExecutionArtifacts.ts",
   "src/components/shared/FavoriteToggle.tsx",
   "src/components/shared/ComponentLifecycleBadges.tsx",
   "src/components/shared/ComponentSearchEmptyStateSuggestions.tsx",

--- a/src/components/shared/ReactFlow/FlowCanvas/IONode/IONode.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/IONode/IONode.tsx
@@ -1,4 +1,3 @@
-import { useQuery } from "@tanstack/react-query";
 import { Handle, Position, useEdges, useReactFlow } from "@xyflow/react";
 import type { MouseEvent } from "react";
 import { memo, useCallback, useEffect, useMemo } from "react";
@@ -12,13 +11,12 @@ import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { QuickTooltip } from "@/components/ui/tooltip";
 import { Paragraph } from "@/components/ui/typography";
 import { useEdgeSelectionHighlight } from "@/hooks/useEdgeSelectionHighlight";
+import { useExecutionArtifacts } from "@/hooks/useExecutionArtifacts";
 import { useIsMultiSelect } from "@/hooks/useIsMultiSelect";
 import { cn } from "@/lib/utils";
-import { useBackend } from "@/providers/BackendProvider";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 import { useContextPanel } from "@/providers/ContextPanelProvider";
 import { useExecutionDataOptional } from "@/providers/ExecutionDataProvider";
-import { getExecutionArtifacts } from "@/services/executionService";
 import type { OutputSpec } from "@/utils/componentSpec";
 import { getArgumentValue } from "@/utils/nodes/taskArguments";
 import { isViewingSubgraph } from "@/utils/subgraphUtils";
@@ -46,7 +44,6 @@ const IONode = ({ id, type, data, selected = false }: IONodeProps) => {
   const { currentGraphSpec, currentSubgraphSpec, currentSubgraphPath } =
     useComponentSpec();
 
-  const { backendUrl } = useBackend();
   const executionData = useExecutionDataOptional();
   const taskArguments = executionData?.rootDetails?.task_spec.arguments;
   const rootExecutionId = executionData?.rootExecutionId;
@@ -156,7 +153,6 @@ const IONode = ({ id, type, data, selected = false }: IONodeProps) => {
             key={output.name}
             disabled={readOnly}
             rootExecutionId={rootExecutionId}
-            backendUrl={backendUrl}
           />,
         );
       }
@@ -284,7 +280,6 @@ interface OutputNodeContentProps {
   connectedDetails: OutputConnectedDetails;
   disabled: boolean;
   rootExecutionId: string | undefined;
-  backendUrl: string;
 }
 
 const OutputNodeContent = ({
@@ -292,13 +287,8 @@ const OutputNodeContent = ({
   connectedDetails,
   disabled,
   rootExecutionId,
-  backendUrl,
 }: OutputNodeContentProps) => {
-  const { data: artifacts } = useQuery({
-    queryKey: ["artifacts", rootExecutionId],
-    queryFn: () => getExecutionArtifacts(String(rootExecutionId), backendUrl),
-    enabled: !!rootExecutionId,
-  });
+  const { data: artifacts } = useExecutionArtifacts(rootExecutionId);
 
   const artifact = artifacts?.output_artifacts?.[output.name];
 

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ArtifactPreviewContent.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ArtifactPreviewContent.tsx
@@ -37,7 +37,13 @@ export const InlineContent = ({
       );
     case "jsonobject":
     case "jsonarray":
-      return <JsonVisualizerValue value={value} name={name} />;
+      return (
+        <JsonVisualizerValue
+          value={value}
+          name={name}
+          isFullscreen={isFullscreen}
+        />
+      );
     case "text":
     default:
       return <TextVisualizerValue value={value} isFullscreen={isFullscreen} />;
@@ -94,7 +100,13 @@ export const PreviewContent = ({
       );
     case "jsonobject":
     case "jsonarray":
-      return <JsonVisualizerRemote signedUrl={signedUrl} name={name} />;
+      return (
+        <JsonVisualizerRemote
+          signedUrl={signedUrl}
+          name={name}
+          isFullscreen={isFullscreen}
+        />
+      );
     default:
       return null;
   }

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/JsonVisualizer.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/JsonVisualizer.tsx
@@ -4,22 +4,30 @@ import { useArtifactFetch } from "./useArtifactFetch";
 interface JsonVisualizerValueProps {
   name: string;
   value: string;
+  isFullscreen?: boolean;
 }
 
 interface JsonVisualizerRemoteProps {
   name: string;
   signedUrl: string;
+  isFullscreen?: boolean;
 }
 
 export const JsonVisualizerValue = ({
   name,
   value,
-}: JsonVisualizerValueProps) => <IOCodeViewer title={name} value={value} />;
+  isFullscreen,
+}: JsonVisualizerValueProps) => (
+  <IOCodeViewer title={name} value={value} fillContainer={isFullscreen} />
+);
 
 export const JsonVisualizerRemote = ({
   name,
   signedUrl,
+  isFullscreen,
 }: JsonVisualizerRemoteProps) => {
   const content = useArtifactFetch("json", signedUrl, (r) => r.text());
-  return <IOCodeViewer title={name} value={content} />;
+  return (
+    <IOCodeViewer title={name} value={content} fillContainer={isFullscreen} />
+  );
 };

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/IOCodeViewer.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/IOCodeViewer.tsx
@@ -1,4 +1,5 @@
 import { CodeViewer } from "@/components/shared/CodeViewer";
+import { cn } from "@/lib/utils";
 import { safeJsonParse } from "@/utils/string";
 
 const MAX_LINES = 10;
@@ -8,14 +9,20 @@ const HEADER_HEIGHT = 55;
 interface IOCodeViewerProps {
   title: string;
   value: string;
+  fillContainer?: boolean;
 }
 
-const IOCodeViewer = ({ title, value }: IOCodeViewerProps) => {
+const IOCodeViewer = ({ title, value, fillContainer }: IOCodeViewerProps) => {
   const { parsed, isValidJson } = safeJsonParse(value);
 
   if (!isValidJson) {
     return (
-      <pre className="w-full font-mono text-xs whitespace-pre-line wrap-break-word">
+      <pre
+        className={cn(
+          "w-full font-mono text-xs whitespace-pre-line wrap-break-word",
+          fillContainer && "h-full overflow-auto",
+        )}
+      >
         {value || "No value"}
       </pre>
     );
@@ -28,7 +35,10 @@ const IOCodeViewer = ({ title, value }: IOCodeViewerProps) => {
   const lineHeight = `${maxLines * JSON_CODE_LINE_HEIGHT + HEADER_HEIGHT}px`;
 
   return (
-    <div style={{ height: lineHeight }}>
+    <div
+      className={fillContainer ? "h-full min-h-0 w-full" : undefined}
+      style={fillContainer ? undefined : { height: lineHeight }}
+    >
       <CodeViewer code={codeString} language="json" filename={title} />
     </div>
   );

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOSection.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOSection.tsx
@@ -1,12 +1,10 @@
-import { useQuery } from "@tanstack/react-query";
-
 import { InfoBox } from "@/components/shared/InfoBox";
 import { BlockStack } from "@/components/ui/layout";
 import { Spinner } from "@/components/ui/spinner";
 import { Paragraph } from "@/components/ui/typography";
+import { useExecutionArtifacts } from "@/hooks/useExecutionArtifacts";
 import { useBackend } from "@/providers/BackendProvider";
 import { useExecutionData } from "@/providers/ExecutionDataProvider";
-import { getExecutionArtifacts } from "@/services/executionService";
 import { getBackendStatusString } from "@/utils/backend";
 import type { TaskSpec } from "@/utils/componentSpec";
 import { addDays, formatDate, isOlderThanDays } from "@/utils/date";
@@ -24,7 +22,7 @@ interface IOSectionProps {
 }
 
 const IOSection = ({ taskSpec, executionId, readOnly }: IOSectionProps) => {
-  const { backendUrl, configured, available } = useBackend();
+  const { configured, available } = useBackend();
   const { metadata } = useExecutionData();
 
   const {
@@ -32,11 +30,7 @@ const IOSection = ({ taskSpec, executionId, readOnly }: IOSectionProps) => {
     isLoading,
     isFetching,
     error,
-  } = useQuery({
-    queryKey: ["artifacts", executionId],
-    queryFn: () => getExecutionArtifacts(String(executionId), backendUrl),
-    enabled: !!executionId,
-  });
+  } = useExecutionArtifacts(executionId);
 
   if (!configured) {
     return (

--- a/src/hooks/useExecutionArtifacts.ts
+++ b/src/hooks/useExecutionArtifacts.ts
@@ -1,0 +1,16 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { useBackend } from "@/providers/BackendProvider";
+import { getExecutionArtifacts } from "@/services/executionService";
+
+export function useExecutionArtifacts(
+  executionId: string | number | undefined,
+) {
+  const { backendUrl } = useBackend();
+
+  return useQuery({
+    queryKey: ["artifacts", backendUrl, executionId],
+    queryFn: () => getExecutionArtifacts(String(executionId), backendUrl),
+    enabled: !!executionId,
+  });
+}

--- a/src/routes/v2/pages/CompareView/components/ArtifactComparisonDialog.tsx
+++ b/src/routes/v2/pages/CompareView/components/ArtifactComparisonDialog.tsx
@@ -1,0 +1,183 @@
+import type { ArtifactNodeResponse } from "@/api/types.gen";
+import {
+  PreviewContent,
+  PreviewSkeleton,
+} from "@/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ArtifactPreviewContent";
+import {
+  isVisualizableType,
+  normalizeRawType,
+  resolveArtifactType,
+} from "@/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/artifactType";
+import { SuspenseWrapper } from "@/components/shared/SuspenseWrapper";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
+import { artifactDiffLanguage } from "@/routes/v2/pages/CompareView/utils/artifactTextDiff";
+
+import { ArtifactTextDiff } from "./ArtifactTextDiff";
+import { RunTag } from "./RunTag";
+
+interface ArtifactComparisonSide {
+  run: "a" | "b";
+  label: string;
+  artifact: ArtifactNodeResponse | undefined;
+  type: string | undefined;
+}
+
+function PaneHeader({
+  run,
+  label,
+  type,
+}: Pick<ArtifactComparisonSide, "run" | "label" | "type">) {
+  return (
+    <InlineStack
+      gap="2"
+      blockAlign="center"
+      wrap="nowrap"
+      className="min-w-0 flex-1"
+    >
+      <RunTag run={run} label={label} />
+      <Text as="span" size="xs" tone="subdued" className="truncate">
+        {type ?? "unknown"}
+      </Text>
+    </InlineStack>
+  );
+}
+
+function ComparisonPane({
+  run,
+  label,
+  artifact,
+  type,
+}: ArtifactComparisonSide) {
+  const normalizedType = resolveArtifactType(
+    normalizeRawType(type ?? undefined),
+  );
+
+  return (
+    <BlockStack
+      align="stretch"
+      gap="2"
+      className="min-h-0 min-w-0 flex-1 overflow-hidden rounded-lg border p-2"
+    >
+      <PaneHeader run={run} label={label} type={type} />
+      <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
+        {!artifact ? (
+          <Text as="span" size="sm" tone="subdued">
+            Not produced in run {label}.
+          </Text>
+        ) : !isVisualizableType(normalizedType) ? (
+          <Text as="span" size="sm" tone="subdued">
+            This artifact type cannot be previewed.
+          </Text>
+        ) : (
+          <SuspenseWrapper
+            fallback={<PreviewSkeleton />}
+            errorFallback={() => (
+              <Text as="span" size="sm" tone="subdued">
+                Failed to load artifact.
+              </Text>
+            )}
+          >
+            <PreviewContent
+              name={`${label}:${artifact.id}`}
+              artifactId={artifact.id}
+              type={normalizedType}
+              isFullscreen
+            />
+          </SuspenseWrapper>
+        )}
+      </div>
+    </BlockStack>
+  );
+}
+
+interface ArtifactComparisonDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  name: string;
+  labelA: string;
+  labelB: string;
+  artifactA: ArtifactNodeResponse | undefined;
+  artifactB: ArtifactNodeResponse | undefined;
+  typeA: string | undefined;
+  typeB: string | undefined;
+}
+
+export function ArtifactComparisonDialog({
+  open,
+  onOpenChange,
+  name,
+  labelA,
+  labelB,
+  artifactA,
+  artifactB,
+  typeA,
+  typeB,
+}: ArtifactComparisonDialogProps) {
+  const diffLanguage = artifactDiffLanguage(
+    resolveArtifactType(normalizeRawType(typeA ?? undefined)),
+    resolveArtifactType(normalizeRawType(typeB ?? undefined)),
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="flex h-[90vh] w-[95vw] max-w-[95vw] flex-col sm:max-w-[95vw]">
+        <DialogHeader>
+          <DialogTitle>
+            <Text as="span" className="font-mono">
+              {name}
+            </Text>{" "}
+            · artifact comparison
+          </DialogTitle>
+        </DialogHeader>
+        {artifactA && artifactB && diffLanguage ? (
+          <BlockStack
+            align="stretch"
+            gap="2"
+            className="min-h-0 w-full flex-1 overflow-hidden rounded-lg border p-2"
+          >
+            <InlineStack gap="3" blockAlign="center" wrap="nowrap">
+              <PaneHeader run="a" label={labelA} type={typeA} />
+              <PaneHeader run="b" label={labelB} type={typeB} />
+            </InlineStack>
+            <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
+              <ArtifactTextDiff
+                artifactIdA={artifactA.id}
+                artifactIdB={artifactB.id}
+                labelA={labelA}
+                labelB={labelB}
+                language={diffLanguage}
+              />
+            </div>
+          </BlockStack>
+        ) : (
+          <InlineStack
+            gap="3"
+            blockAlign="stretch"
+            wrap="nowrap"
+            className="min-h-0 w-full flex-1"
+          >
+            <ComparisonPane
+              run="a"
+              label={labelA}
+              artifact={artifactA}
+              type={typeA}
+            />
+            <ComparisonPane
+              run="b"
+              label={labelB}
+              artifact={artifactB}
+              type={typeB}
+            />
+          </InlineStack>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/routes/v2/pages/CompareView/components/ArtifactDiffRow.tsx
+++ b/src/routes/v2/pages/CompareView/components/ArtifactDiffRow.tsx
@@ -1,0 +1,180 @@
+import { useState } from "react";
+
+import type { ArtifactNodeResponse } from "@/api/types.gen";
+import {
+  isVisualizableType,
+  normalizeRawType,
+  resolveArtifactType,
+} from "@/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/artifactType";
+import { MAX_VISUALIZABLE_SIZE_BYTES } from "@/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/utils";
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icon";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
+import { artifactDiffStatus } from "@/routes/v2/pages/CompareView/utils/compareArtifacts";
+import { formatBytes } from "@/utils/string";
+import { tracking } from "@/utils/tracking";
+
+import { ArtifactComparisonDialog } from "./ArtifactComparisonDialog";
+import { DiffStatusBadge } from "./DiffStatusBadge";
+import { RunTag } from "./RunTag";
+
+function inlineValue(
+  artifact: ArtifactNodeResponse | undefined,
+): string | undefined {
+  const value = artifact?.artifact_data?.value;
+  return value && value.trim() !== "" ? value : undefined;
+}
+
+function artifactTypeLabel(
+  artifact: ArtifactNodeResponse | undefined,
+): string | undefined {
+  if (!artifact) return undefined;
+  return (
+    artifact.type_name ?? (artifact.artifact_data?.is_dir ? "Directory" : "Any")
+  );
+}
+
+function isPreviewable(artifact: ArtifactNodeResponse | undefined): boolean {
+  if (!artifact) return false;
+  const totalSize = artifact.artifact_data?.total_size;
+  if (totalSize && totalSize > MAX_VISUALIZABLE_SIZE_BYTES) return false;
+  const type = resolveArtifactType(
+    normalizeRawType(artifactTypeLabel(artifact) ?? undefined),
+  );
+  return isVisualizableType(type);
+}
+
+interface InlineValueLineProps {
+  run: "a" | "b";
+  label: string;
+  value: string | undefined;
+  present: boolean;
+}
+
+function InlineValueLine({ run, label, value, present }: InlineValueLineProps) {
+  return (
+    <InlineStack gap="2" blockAlign="start" wrap="nowrap" className="min-w-0">
+      <RunTag run={run} label={label} />
+      <Text
+        as="span"
+        size="xs"
+        font="mono"
+        tone={present ? "inherit" : "subdued"}
+        className="break-all whitespace-pre-wrap"
+      >
+        {present ? (value ?? "(none)") : "absent"}
+      </Text>
+    </InlineStack>
+  );
+}
+
+interface MetadataLineProps {
+  run: "a" | "b";
+  label: string;
+  artifact: ArtifactNodeResponse | undefined;
+}
+
+function MetadataLine({ run, label, artifact }: MetadataLineProps) {
+  const totalSize = artifact?.artifact_data?.total_size;
+  return (
+    <InlineStack gap="2" blockAlign="center" wrap="nowrap" className="min-w-0">
+      <RunTag run={run} label={label} />
+      {!artifact ? (
+        <Text as="span" size="xs" tone="subdued">
+          absent
+        </Text>
+      ) : (
+        <>
+          <Text as="span" size="xs" tone="subdued" className="truncate">
+            {artifactTypeLabel(artifact)}
+          </Text>
+          {!!totalSize && (
+            <Text as="span" size="xs" tone="subdued" font="mono">
+              ({formatBytes(totalSize)})
+            </Text>
+          )}
+        </>
+      )}
+    </InlineStack>
+  );
+}
+
+interface ArtifactDiffRowProps {
+  name: string;
+  a: ArtifactNodeResponse | undefined;
+  b: ArtifactNodeResponse | undefined;
+  labelA: string;
+  labelB: string;
+}
+
+export function ArtifactDiffRow({
+  name,
+  a,
+  b,
+  labelA,
+  labelB,
+}: ArtifactDiffRowProps) {
+  const [compareOpen, setCompareOpen] = useState(false);
+
+  const aVal = inlineValue(a);
+  const bVal = inlineValue(b);
+  const hasInline = aVal !== undefined || bVal !== undefined;
+  const canCompare = isPreviewable(a) || isPreviewable(b);
+
+  return (
+    <BlockStack gap="1" className="rounded-md border p-2">
+      <InlineStack
+        gap="2"
+        blockAlign="center"
+        align="space-between"
+        wrap="wrap"
+        className="w-full"
+      >
+        <InlineStack gap="2" blockAlign="center" wrap="wrap">
+          <Text as="span" size="xs" weight="semibold" className="font-mono">
+            {name}
+          </Text>
+          <DiffStatusBadge status={artifactDiffStatus(a, b)} />
+        </InlineStack>
+        {!hasInline && canCompare && (
+          <Button
+            variant="outline"
+            size="xs"
+            onClick={() => setCompareOpen(true)}
+            {...tracking("compare_runs.task.compare_artifact")}
+          >
+            <Icon name="Columns2" size="xs" />
+            Compare
+          </Button>
+        )}
+      </InlineStack>
+
+      {hasInline ? (
+        <BlockStack gap="1">
+          <InlineValueLine run="a" label={labelA} value={aVal} present={!!a} />
+          <InlineValueLine run="b" label={labelB} value={bVal} present={!!b} />
+        </BlockStack>
+      ) : (
+        <InlineStack gap="4" wrap="wrap">
+          <MetadataLine run="a" label={labelA} artifact={a} />
+          <MetadataLine run="b" label={labelB} artifact={b} />
+        </InlineStack>
+      )}
+
+      {!hasInline && canCompare && (
+        <ArtifactComparisonDialog
+          open={compareOpen}
+          onOpenChange={setCompareOpen}
+          name={name}
+          labelA={labelA}
+          labelB={labelB}
+          artifactA={a}
+          artifactB={b}
+          typeA={artifactTypeLabel(a)}
+          typeB={artifactTypeLabel(b)}
+        />
+      )}
+    </BlockStack>
+  );
+}

--- a/src/routes/v2/pages/CompareView/components/ArtifactDiffSection.tsx
+++ b/src/routes/v2/pages/CompareView/components/ArtifactDiffSection.tsx
@@ -1,0 +1,125 @@
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { Icon } from "@/components/ui/icon";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Spinner } from "@/components/ui/spinner";
+import { Text } from "@/components/ui/typography";
+import { useExecutionArtifacts } from "@/hooks/useExecutionArtifacts";
+import { cn } from "@/lib/utils";
+import { useBackend } from "@/providers/BackendProvider";
+import { outputArtifactsOf } from "@/routes/v2/pages/CompareView/utils/compareArtifacts";
+import { unionKeysAFirst } from "@/routes/v2/pages/CompareView/utils/comparePipelines";
+import { tracking } from "@/utils/tracking";
+
+import { ArtifactDiffRow } from "./ArtifactDiffRow";
+
+interface ArtifactDiffSectionProps {
+  executionIdA?: string;
+  executionIdB?: string;
+  labelA: string;
+  labelB: string;
+}
+
+function ArtifactDiffList({
+  executionIdA,
+  executionIdB,
+  labelA,
+  labelB,
+}: ArtifactDiffSectionProps) {
+  const queryA = useExecutionArtifacts(executionIdA);
+  const queryB = useExecutionArtifacts(executionIdB);
+
+  const isLoading =
+    (queryA.isFetching && !queryA.data) || (queryB.isFetching && !queryB.data);
+
+  if (isLoading) {
+    return (
+      <InlineStack gap="2" blockAlign="center">
+        <Spinner />
+        <Text as="span" size="xs" tone="subdued">
+          Loading artifacts…
+        </Text>
+      </InlineStack>
+    );
+  }
+
+  const artifactsA = outputArtifactsOf(queryA.data);
+  const artifactsB = outputArtifactsOf(queryB.data);
+  const names = unionKeysAFirst(artifactsA, artifactsB);
+
+  if (names.length === 0) {
+    return (
+      <Text as="span" size="xs" tone="subdued">
+        No output artifacts.
+      </Text>
+    );
+  }
+
+  return (
+    <BlockStack gap="2">
+      {names.map((name) => (
+        <ArtifactDiffRow
+          key={name}
+          name={name}
+          a={artifactsA[name]}
+          b={artifactsB[name]}
+          labelA={labelA}
+          labelB={labelB}
+        />
+      ))}
+    </BlockStack>
+  );
+}
+
+/**
+ * A section is rendered per compared task, so keeping the two artifact queries
+ * in a child that Radix only mounts once expanded is what stops a wide pipeline
+ * from firing two requests per task the moment the tab opens.
+ */
+export function ArtifactDiffSection({
+  executionIdA,
+  executionIdB,
+  labelA,
+  labelB,
+}: ArtifactDiffSectionProps) {
+  const { configured } = useBackend();
+  const [open, setOpen] = useState(false);
+
+  if (!configured || (!executionIdA && !executionIdB)) return null;
+
+  return (
+    <Collapsible open={open} onOpenChange={setOpen}>
+      <CollapsibleTrigger asChild>
+        <Button
+          variant="ghost"
+          size="xs"
+          className="-ml-1 gap-1 px-1"
+          {...tracking("compare_runs.task.toggle_artifacts")}
+        >
+          <Icon
+            name="ChevronRight"
+            size="xs"
+            className={cn("transition-transform", open && "rotate-90")}
+          />
+          <Text as="span" size="xs" weight="semibold" tone="subdued">
+            Artifacts
+          </Text>
+        </Button>
+      </CollapsibleTrigger>
+      <CollapsibleContent className="pt-2">
+        <ArtifactDiffList
+          executionIdA={executionIdA}
+          executionIdB={executionIdB}
+          labelA={labelA}
+          labelB={labelB}
+        />
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}

--- a/src/routes/v2/pages/CompareView/components/ArtifactTextDiff.tsx
+++ b/src/routes/v2/pages/CompareView/components/ArtifactTextDiff.tsx
@@ -1,0 +1,50 @@
+import { InfoBox } from "@/components/shared/InfoBox";
+import { PreviewSkeleton } from "@/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ArtifactPreviewContent";
+import { useArtifactText } from "@/routes/v2/pages/CompareView/hooks/useArtifactText";
+import { normalizeForDiff } from "@/routes/v2/pages/CompareView/utils/artifactTextDiff";
+
+import { DiffCodeViewer } from "./DiffCodeViewer";
+
+interface ArtifactTextDiffProps {
+  artifactIdA: string;
+  artifactIdB: string;
+  labelA: string;
+  labelB: string;
+  language: string;
+}
+
+export function ArtifactTextDiff({
+  artifactIdA,
+  artifactIdB,
+  labelA,
+  labelB,
+  language,
+}: ArtifactTextDiffProps) {
+  const a = useArtifactText(artifactIdA);
+  const b = useArtifactText(artifactIdB);
+
+  const failedRuns: string[] = [];
+  if (a.isError) failedRuns.push(labelA);
+  if (b.isError) failedRuns.push(labelB);
+
+  if (failedRuns.length > 0) {
+    return (
+      <InfoBox title="Artifact unavailable" variant="error" width="full">
+        Could not load the artifact for {failedRuns.join(" and ")}. Open it from
+        the run&apos;s own output to retry.
+      </InfoBox>
+    );
+  }
+
+  if (a.text === undefined || b.text === undefined) {
+    return <PreviewSkeleton />;
+  }
+
+  return (
+    <DiffCodeViewer
+      original={normalizeForDiff(a.text, language)}
+      modified={normalizeForDiff(b.text, language)}
+      language={language}
+    />
+  );
+}

--- a/src/routes/v2/pages/CompareView/hooks/useArtifactText.ts
+++ b/src/routes/v2/pages/CompareView/hooks/useArtifactText.ts
@@ -1,0 +1,41 @@
+import { skipToken, useQuery } from "@tanstack/react-query";
+
+import { fetchArtifactOrThrow } from "@/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/useArtifactFetch";
+import { useBackend } from "@/providers/BackendProvider";
+import { getArtifactSignedUrl } from "@/services/executionService";
+import { HOURS } from "@/utils/constants";
+
+interface ArtifactText {
+  text: string | undefined;
+  isError: boolean;
+}
+
+export function useArtifactText(artifactId: string): ArtifactText {
+  const { backendUrl } = useBackend();
+
+  const signedUrlQuery = useQuery({
+    queryKey: ["artifact-signed-url", backendUrl, artifactId],
+    queryFn: () => getArtifactSignedUrl(artifactId, backendUrl),
+    staleTime: 24 * HOURS,
+    retry: false,
+  });
+
+  const signedUrl = signedUrlQuery.data?.signed_url;
+
+  const textQuery = useQuery({
+    queryKey: ["artifact-text", signedUrl],
+    queryFn: signedUrl
+      ? async () => (await fetchArtifactOrThrow(signedUrl)).text()
+      : skipToken,
+    staleTime: 24 * HOURS,
+    retry: false,
+  });
+
+  return {
+    text: textQuery.data,
+    isError:
+      signedUrlQuery.isError ||
+      textQuery.isError ||
+      (signedUrlQuery.isSuccess && !signedUrl),
+  };
+}

--- a/src/routes/v2/pages/CompareView/hooks/useRunComparisonSide.ts
+++ b/src/routes/v2/pages/CompareView/hooks/useRunComparisonSide.ts
@@ -1,4 +1,8 @@
+import type { ArtifactNodeResponse } from "@/api/types.gen";
+import { useExecutionArtifacts } from "@/hooks/useExecutionArtifacts";
 import { usePipelineRunData } from "@/hooks/usePipelineRunData";
+import { useBackend } from "@/providers/BackendProvider";
+import { outputArtifactsOf } from "@/routes/v2/pages/CompareView/utils/compareArtifacts";
 import {
   runDurationMs,
   runOverallStatus,
@@ -12,6 +16,7 @@ export interface RunComparisonSide {
   spec: ComponentSpec | undefined;
   taskStatusMap: Map<string, string>;
   taskExecutionIdMap: Map<string, string>;
+  outputArtifacts: Record<string, ArtifactNodeResponse> | undefined;
   createdBy?: string;
   createdAt?: string;
   status?: string;
@@ -23,14 +28,24 @@ export interface RunComparisonSide {
 }
 
 /**
- * Loads a single run's spec and per-task execution status for the comparison
- * view. Safe to call twice in one component (once per side) because
- * `usePipelineRunData` scopes all of its queries by id. Pass an empty string
- * for an unselected side — the underlying queries stay disabled.
+ * Loads a single run's spec, per-task execution status and pipeline-level output
+ * artifacts for the comparison view. Safe to call twice in one component (once
+ * per side) because `usePipelineRunData` scopes all of its queries by id. Pass
+ * an empty string for an unselected side — the underlying queries stay disabled.
+ *
+ * Only the root execution's artifacts are fetched, which is one request per run
+ * however wide the pipeline is. Per-task artifacts stay behind the task rows
+ * that ask for them. `outputArtifacts` stays `undefined` until that request
+ * succeeds, so a side that is still loading or failed is never mistaken for a
+ * run that produced nothing.
  */
 export function useRunComparisonSide(runId: string): RunComparisonSide {
-  const { executionData, error } = usePipelineRunData(runId);
+  const { configured } = useBackend();
+  const { executionData, rootExecutionId, error } = usePipelineRunData(runId);
   const { data: runMetadata } = useFetchPipelineRunMetadata(runId || undefined);
+  const { data: artifacts, isSuccess: artifactsLoaded } = useExecutionArtifacts(
+    configured ? rootExecutionId : undefined,
+  );
 
   const details = executionData?.details;
   const state = executionData?.state;
@@ -50,6 +65,7 @@ export function useRunComparisonSide(runId: string): RunComparisonSide {
     spec,
     taskStatusMap,
     taskExecutionIdMap,
+    outputArtifacts: artifactsLoaded ? outputArtifactsOf(artifacts) : undefined,
     createdBy: runMetadata?.created_by ?? undefined,
     createdAt: runMetadata?.created_at ?? undefined,
     status: runOverallStatus(state),

--- a/src/routes/v2/pages/CompareView/utils/artifactTextDiff.test.ts
+++ b/src/routes/v2/pages/CompareView/utils/artifactTextDiff.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "vitest";
+
+import { artifactDiffLanguage, normalizeForDiff } from "./artifactTextDiff";
+
+describe("artifactDiffLanguage()", () => {
+  test("diffs json artifacts as json", () => {
+    expect(artifactDiffLanguage("jsonobject", "jsonobject")).toBe("json");
+    expect(artifactDiffLanguage("jsonarray", "jsonarray")).toBe("json");
+  });
+
+  test("diffs text and delimited artifacts as plain text", () => {
+    expect(artifactDiffLanguage("text", "text")).toBe("plaintext");
+    expect(artifactDiffLanguage("csv", "csv")).toBe("plaintext");
+    expect(artifactDiffLanguage("tsv", "tsv")).toBe("plaintext");
+  });
+
+  test("falls back to plain text when the two runs produced different types", () => {
+    expect(artifactDiffLanguage("jsonobject", "text")).toBe("plaintext");
+    expect(artifactDiffLanguage("csv", "tsv")).toBe("plaintext");
+  });
+
+  test("cannot diff types without a line-oriented form", () => {
+    expect(artifactDiffLanguage("image", "image")).toBeUndefined();
+    expect(
+      artifactDiffLanguage("apacheparquet", "apacheparquet"),
+    ).toBeUndefined();
+    expect(artifactDiffLanguage("text", "image")).toBeUndefined();
+    expect(artifactDiffLanguage("any", "any")).toBeUndefined();
+  });
+});
+
+describe("normalizeForDiff()", () => {
+  test("re-prints minified json so the diff lands on changed fields", () => {
+    expect(normalizeForDiff('{"a":1,"b":[2,3]}', "json")).toBe(
+      '{\n  "a": 1,\n  "b": [\n    2,\n    3\n  ]\n}',
+    );
+  });
+
+  test("leaves unparseable json untouched", () => {
+    expect(normalizeForDiff("{not json", "json")).toBe("{not json");
+  });
+
+  test("leaves plain text untouched", () => {
+    const text = '{"a":1}';
+    expect(normalizeForDiff(text, "plaintext")).toBe(text);
+  });
+});

--- a/src/routes/v2/pages/CompareView/utils/artifactTextDiff.ts
+++ b/src/routes/v2/pages/CompareView/utils/artifactTextDiff.ts
@@ -1,0 +1,36 @@
+const DIFF_LANGUAGES: Record<string, string> = {
+  text: "plaintext",
+  csv: "plaintext",
+  tsv: "plaintext",
+  jsonobject: "json",
+  jsonarray: "json",
+};
+
+/**
+ * Monaco language for diffing a pair of artifacts, or `undefined` when the pair
+ * cannot be diffed as text — images and parquet have no line-oriented form, so
+ * those keep their side-by-side previews. Takes resolved artifact types.
+ */
+export function artifactDiffLanguage(
+  typeA: string,
+  typeB: string,
+): string | undefined {
+  const languageA = DIFF_LANGUAGES[typeA];
+  const languageB = DIFF_LANGUAGES[typeB];
+  if (!languageA || !languageB) return undefined;
+  return languageA === languageB ? languageA : "plaintext";
+}
+
+/**
+ * Minified JSON lands on a single line, where a line diff reports the whole
+ * artifact as changed. Re-print it so the diff lands on the fields that
+ * actually differ, leaving anything unparseable as it came.
+ */
+export function normalizeForDiff(text: string, language: string): string {
+  if (language !== "json") return text;
+  try {
+    return JSON.stringify(JSON.parse(text), null, 2);
+  } catch {
+    return text;
+  }
+}

--- a/src/routes/v2/pages/CompareView/utils/compareArtifacts.ts
+++ b/src/routes/v2/pages/CompareView/utils/compareArtifacts.ts
@@ -1,5 +1,14 @@
-import type { ArtifactNodeResponse } from "@/api/types.gen";
+import type {
+  ArtifactNodeResponse,
+  GetExecutionArtifactsResponse,
+} from "@/api/types.gen";
 import type { DiffStatus } from "@/utils/diffStatus";
+
+export function outputArtifactsOf(
+  data: GetExecutionArtifactsResponse | null | undefined,
+): Record<string, ArtifactNodeResponse> {
+  return data?.output_artifacts ?? {};
+}
 
 /**
  * Compares two artifacts by what the backend reports about their contents, not

--- a/src/routes/v2/pages/RunView/nodes/IONode/context/RunViewOutputDetails.tsx
+++ b/src/routes/v2/pages/RunView/nodes/IONode/context/RunViewOutputDetails.tsx
@@ -1,4 +1,3 @@
-import { useQuery } from "@tanstack/react-query";
 import { observer } from "mobx-react-lite";
 
 import { LinkNodeButton } from "@/components/shared/Buttons/LinkNodeButton";
@@ -9,10 +8,9 @@ import { Icon } from "@/components/ui/icon";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Spinner } from "@/components/ui/spinner";
 import { Text } from "@/components/ui/typography";
-import { useBackend } from "@/providers/BackendProvider";
+import { useExecutionArtifacts } from "@/hooks/useExecutionArtifacts";
 import { useExecutionDataOptional } from "@/providers/ExecutionDataProvider";
 import { useSpec } from "@/routes/v2/shared/providers/SpecContext";
-import { getExecutionArtifacts } from "@/services/executionService";
 import { tracking } from "@/utils/tracking";
 
 interface RunViewOutputDetailsProps {
@@ -24,15 +22,11 @@ export const RunViewOutputDetails = observer(function RunViewOutputDetails({
 }: RunViewOutputDetailsProps) {
   const spec = useSpec();
   const executionData = useExecutionDataOptional();
-  const { backendUrl } = useBackend();
   const output = spec?.outputs.find((o) => o.$id === entityId);
 
   const rootExecutionId = executionData?.rootExecutionId;
-  const { data: artifacts, isLoading: isLoadingArtifacts } = useQuery({
-    queryKey: ["artifacts", rootExecutionId],
-    queryFn: () => getExecutionArtifacts(String(rootExecutionId), backendUrl),
-    enabled: !!rootExecutionId,
-  });
+  const { data: artifacts, isLoading: isLoadingArtifacts } =
+    useExecutionArtifacts(rootExecutionId);
 
   if (!output) {
     return (


### PR DESCRIPTION
## Description

Fourth PR in the **Compare Runs** stack. Adds artifact comparison — the ability to see how a task's output artifacts differ between the two runs.

For each output artifact it shows whether it was added, removed, changed or unchanged. Small inline values are shown directly side by side; larger artifacts show their type and size, with a **Compare** button that opens a full-screen dialog previewing both runs' versions next to each other (reusing the existing artifact preview components). Artifacts that are too large or can't be previewed are handled gracefully.

Not wired into a page yet — the later task diff view consumes this.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

Part of the Compare Runs stack. Builds on #2598; the next PR (#2600) builds on this branch.

## Type of Change

- [x] New feature

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Add screenshots of the artifact diff rows and the side-by-side comparison dialog. -->

## Test Instructions

Reachable once the stack is wired up (#2603).

- Check out the top of the stack, enable the **Compare runs** beta flag, and compare two runs that both produced output artifacts on the same task.
- Expand a task and confirm:
  - Artifacts show the correct Added / Removed / Changed / Unchanged status.
  - Small inline values are shown side by side for both runs.
  - Larger/previewable artifacts show a **Compare** button that opens the dialog with both runs' previews.
  - Non-previewable or oversized artifacts show a sensible message instead of erroring.

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
