### PR TITLE
feat: run comparison - run metadata comparison

### DIFF
--- a/src/routes/v2/pages/CompareView/components/ExecutionStatusPill.tsx
+++ b/src/routes/v2/pages/CompareView/components/ExecutionStatusPill.tsx
@@ -1,0 +1,38 @@
+import { InlineStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
+import { cn } from "@/lib/utils";
+import {
+  EXECUTION_STATUS_BG_COLORS,
+  getExecutionStatusLabel,
+} from "@/utils/executionStatus";
+
+interface ExecutionStatusPillProps {
+  label?: string;
+  status: string | undefined;
+}
+
+export function ExecutionStatusPill({
+  label,
+  status,
+}: ExecutionStatusPillProps) {
+  if (!status) return null;
+
+  return (
+    <InlineStack gap="1" blockAlign="center" wrap="nowrap">
+      {label && (
+        <Text as="span" size="xs" tone="subdued">
+          {label}
+        </Text>
+      )}
+      <span
+        className={cn(
+          "h-2 w-2 rounded-full",
+          EXECUTION_STATUS_BG_COLORS[status] ?? "bg-muted",
+        )}
+      />
+      <Text as="span" size="xs">
+        {getExecutionStatusLabel(status)}
+      </Text>
+    </InlineStack>
+  );
+}

--- a/src/routes/v2/pages/CompareView/components/RunMetadataSection.tsx
+++ b/src/routes/v2/pages/CompareView/components/RunMetadataSection.tsx
@@ -1,0 +1,299 @@
+import type { ReactNode } from "react";
+import { useState } from "react";
+
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { Icon } from "@/components/ui/icon";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
+import { cn } from "@/lib/utils";
+import type { CompareMode } from "@/routes/v2/pages/CompareView/utils/compareMode";
+import type { KeyedDiffEntry } from "@/routes/v2/pages/CompareView/utils/comparePipelines";
+import {
+  buildRunMetadataComparison,
+  type RunMetadataInput,
+} from "@/routes/v2/pages/CompareView/utils/compareRunMetadata";
+import { formatDate, formatDurationMs } from "@/utils/date";
+import { getExecutionStatusLabel } from "@/utils/executionStatus";
+import { tracking } from "@/utils/tracking";
+
+import { DiffStatusBadge } from "./DiffStatusBadge";
+import { ExecutionStatusPill } from "./ExecutionStatusPill";
+import { FieldDiffRow } from "./FieldDiffRow";
+import { RunTag } from "./RunTag";
+
+interface RunMetadataSectionProps {
+  a: RunMetadataInput;
+  b: RunMetadataInput;
+  labelA: string;
+  labelB: string;
+  mode: CompareMode;
+}
+
+function MetadataBar({ children }: { children: ReactNode }) {
+  return (
+    <InlineStack
+      gap="3"
+      blockAlign="center"
+      wrap="wrap"
+      className="w-full rounded-lg border px-3 py-2"
+    >
+      <Text as="span" size="sm" weight="semibold">
+        Run metadata
+      </Text>
+      {children}
+    </InlineStack>
+  );
+}
+
+function scalarEntry(
+  key: string,
+  a: string | undefined,
+  b: string | undefined,
+  changed: boolean,
+): KeyedDiffEntry<unknown> {
+  return { key, a, b, status: changed ? "changed" : "unchanged" };
+}
+
+const statusText = (status: string | undefined) =>
+  status ? getExecutionStatusLabel(status) : undefined;
+
+const durationText = (durationMs: number | undefined) =>
+  durationMs === undefined ? undefined : formatDurationMs(durationMs);
+
+interface RunSummaryProps {
+  run: "a" | "b";
+  label: string;
+  author: string | undefined;
+  createdAt: string | undefined;
+  status: string | undefined;
+  durationMs: number | undefined;
+}
+
+function RunSummary({
+  run,
+  label,
+  author,
+  createdAt,
+  status,
+  durationMs,
+}: RunSummaryProps) {
+  return (
+    <InlineStack gap="2" blockAlign="center" wrap="nowrap" className="min-w-0">
+      <RunTag run={run} label={label} />
+      <Text as="span" size="xs" weight="semibold" className="truncate">
+        {author ?? "Unknown author"}
+      </Text>
+      <Text as="span" size="xs" tone="subdued" className="whitespace-nowrap">
+        {createdAt ? formatDate(createdAt) : "Unknown"}
+      </Text>
+      <ExecutionStatusPill status={status} />
+      {durationMs !== undefined && (
+        <Text as="span" size="xs" tone="subdued" className="whitespace-nowrap">
+          {formatDurationMs(durationMs)}
+        </Text>
+      )}
+    </InlineStack>
+  );
+}
+
+export function RunMetadataSection({
+  a,
+  b,
+  labelA,
+  labelB,
+  mode,
+}: RunMetadataSectionProps) {
+  if (mode.kind === "empty") {
+    return (
+      <MetadataBar>
+        <Text as="span" size="sm" tone="subdued">
+          Select runs to compare.
+        </Text>
+      </MetadataBar>
+    );
+  }
+
+  if (mode.kind === "single") {
+    const present = mode.side === "a" ? a : b;
+    return (
+      <MetadataBar>
+        <RunSummary
+          run={mode.side}
+          label={mode.side === "a" ? labelA : labelB}
+          author={present.createdBy}
+          createdAt={present.createdAt}
+          status={present.status}
+          durationMs={present.durationMs}
+        />
+      </MetadataBar>
+    );
+  }
+
+  return <RunMetadataComparison a={a} b={b} labelA={labelA} labelB={labelB} />;
+}
+
+function RunMetadataComparison({
+  a,
+  b,
+  labelA,
+  labelB,
+}: Omit<RunMetadataSectionProps, "mode">) {
+  const [open, setOpen] = useState(false);
+  const comparison = buildRunMetadataComparison(a, b);
+
+  const changedAnnotations = comparison.annotationDiffs.filter(
+    (entry) => entry.status !== "unchanged",
+  );
+  const changedArguments = comparison.argumentDiffs.filter(
+    (entry) => entry.status !== "unchanged",
+  );
+
+  const summary = (
+    <InlineStack gap="4" wrap="wrap" blockAlign="center">
+      <RunSummary
+        run="a"
+        label={labelA}
+        author={comparison.author.a}
+        createdAt={comparison.createdAt.a}
+        status={comparison.status.a}
+        durationMs={comparison.duration.a}
+      />
+      <RunSummary
+        run="b"
+        label={labelB}
+        author={comparison.author.b}
+        createdAt={comparison.createdAt.b}
+        status={comparison.status.b}
+        durationMs={comparison.duration.b}
+      />
+    </InlineStack>
+  );
+
+  if (!comparison.hasChanges) {
+    return <MetadataBar>{summary}</MetadataBar>;
+  }
+
+  return (
+    <Collapsible
+      open={open}
+      onOpenChange={setOpen}
+      className="w-full rounded-lg border"
+    >
+      <CollapsibleTrigger
+        className="flex w-full flex-wrap items-center gap-3 px-3 py-2"
+        {...tracking("compare_runs.run_metadata.toggle")}
+      >
+        <InlineStack gap="2" blockAlign="center" wrap="nowrap">
+          <Icon
+            name="ChevronRight"
+            size="sm"
+            className={cn("transition-transform", open && "rotate-90")}
+          />
+          <Text as="span" size="sm" weight="semibold">
+            Run metadata
+          </Text>
+          <InlineStack
+            as="span"
+            className="rounded-full bg-diff-changed/20 px-2 py-0.5 text-diff-changed"
+          >
+            <Text
+              as="span"
+              size="xs"
+              weight="semibold"
+              className="text-inherit"
+            >
+              {comparison.changeCount} changed
+            </Text>
+          </InlineStack>
+        </InlineStack>
+        {summary}
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        <BlockStack gap="2" className="px-3 pb-3">
+          <FieldDiffRow
+            entry={scalarEntry(
+              "author",
+              comparison.author.a,
+              comparison.author.b,
+              comparison.author.changed,
+            )}
+            labelA={labelA}
+            labelB={labelB}
+          />
+          <FieldDiffRow
+            entry={scalarEntry(
+              "created",
+              comparison.createdAt.a,
+              comparison.createdAt.b,
+              comparison.createdAt.changed,
+            )}
+            labelA={labelA}
+            labelB={labelB}
+          />
+          <FieldDiffRow
+            entry={scalarEntry(
+              "status",
+              statusText(comparison.status.a),
+              statusText(comparison.status.b),
+              comparison.status.changed,
+            )}
+            labelA={labelA}
+            labelB={labelB}
+          />
+          <FieldDiffRow
+            entry={scalarEntry(
+              "duration",
+              durationText(comparison.duration.a),
+              durationText(comparison.duration.b),
+              comparison.duration.changed,
+            )}
+            labelA={labelA}
+            labelB={labelB}
+          />
+
+          {changedAnnotations.length > 0 && (
+            <BlockStack gap="1">
+              <InlineStack gap="2" blockAlign="center">
+                <Text as="span" size="xs" weight="semibold" tone="subdued">
+                  Run annotations
+                </Text>
+                <DiffStatusBadge status="changed" />
+              </InlineStack>
+              {changedAnnotations.map((entry) => (
+                <FieldDiffRow
+                  key={entry.key}
+                  entry={entry}
+                  labelA={labelA}
+                  labelB={labelB}
+                />
+              ))}
+            </BlockStack>
+          )}
+
+          {changedArguments.length > 0 && (
+            <BlockStack gap="1">
+              <InlineStack gap="2" blockAlign="center">
+                <Text as="span" size="xs" weight="semibold" tone="subdued">
+                  Run arguments
+                </Text>
+                <DiffStatusBadge status="changed" />
+              </InlineStack>
+              {changedArguments.map((entry) => (
+                <FieldDiffRow
+                  key={entry.key}
+                  entry={entry}
+                  labelA={labelA}
+                  labelB={labelB}
+                />
+              ))}
+            </BlockStack>
+          )}
+        </BlockStack>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}

--- a/src/routes/v2/pages/CompareView/utils/compareMode.ts
+++ b/src/routes/v2/pages/CompareView/utils/compareMode.ts
@@ -1,0 +1,6 @@
+/**
+ * Which runs the comparison page currently has. `single` carries the side that
+ * is filled in, so views never have to guess it back out of the run data.
+ */
+export type CompareMode =
+  { kind: "empty" } | { kind: "single"; side: "a" | "b" } | { kind: "both" };

--- a/src/routes/v2/pages/CompareView/utils/compareRunMetadata.test.ts
+++ b/src/routes/v2/pages/CompareView/utils/compareRunMetadata.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test } from "vitest";
+
+import { buildRunMetadataComparison } from "./compareRunMetadata";
+
+describe("buildRunMetadataComparison()", () => {
+  test("flags an author change but ignores a differing timestamp", () => {
+    const result = buildRunMetadataComparison(
+      { createdBy: "alice", createdAt: "2026-01-01T00:00:00Z" },
+      { createdBy: "bob", createdAt: "2026-02-02T00:00:00Z" },
+    );
+
+    expect(result.author.changed).toBe(true);
+    expect(result.createdAt.changed).toBe(true);
+    expect(result.hasChanges).toBe(true);
+    expect(result.changeCount).toBe(1);
+  });
+
+  test("does not treat a differing timestamp alone as a change", () => {
+    const result = buildRunMetadataComparison(
+      { createdBy: "alice", createdAt: "2026-01-01T00:00:00Z" },
+      { createdBy: "alice", createdAt: "2026-02-02T00:00:00Z" },
+    );
+
+    expect(result.hasChanges).toBe(false);
+    expect(result.changeCount).toBe(0);
+  });
+
+  test("surfaces an arbitrary run-annotation key change generically", () => {
+    const result = buildRunMetadataComparison(
+      { annotations: { "run.serviceAccount": "svc-a@project" } },
+      { annotations: { "run.serviceAccount": "svc-b@project" } },
+    );
+
+    const entry = result.annotationDiffs.find(
+      (diff) => diff.key === "run.serviceAccount",
+    );
+    expect(entry?.status).toBe("changed");
+    expect(result.hasChanges).toBe(true);
+  });
+
+  test("excludes superficial and frontend-only annotations", () => {
+    const result = buildRunMetadataComparison(
+      {
+        annotations: {
+          notes: "first run",
+          tags: "a,b",
+          "editor.position": "{x:0}",
+        },
+      },
+      {
+        annotations: {
+          notes: "second run",
+          tags: "c,d",
+          "editor.position": "{x:9}",
+        },
+      },
+    );
+
+    expect(result.annotationDiffs).toHaveLength(0);
+    expect(result.hasChanges).toBe(false);
+  });
+
+  test("counts a differing run status", () => {
+    const result = buildRunMetadataComparison(
+      { status: "SUCCEEDED" },
+      { status: "FAILED" },
+    );
+
+    expect(result.status.changed).toBe(true);
+    expect(result.changeCount).toBe(1);
+  });
+
+  test("does not report a status difference while one side is still loading", () => {
+    const result = buildRunMetadataComparison({ status: "SUCCEEDED" }, {});
+
+    expect(result.status.changed).toBe(false);
+    expect(result.hasChanges).toBe(false);
+  });
+
+  test("counts a duration gap that is both large and proportionally big", () => {
+    const result = buildRunMetadataComparison(
+      { durationMs: 30_000 },
+      { durationMs: 120_000 },
+    );
+
+    expect(result.duration.changed).toBe(true);
+    expect(result.changeCount).toBe(1);
+  });
+
+  test("ignores a duration gap within scheduling noise", () => {
+    const proportionallyBigButTiny = buildRunMetadataComparison(
+      { durationMs: 1_000 },
+      { durationMs: 3_000 },
+    );
+    const absolutelyBigButProportionallySmall = buildRunMetadataComparison(
+      { durationMs: 600_000 },
+      { durationMs: 610_000 },
+    );
+
+    expect(proportionallyBigButTiny.duration.changed).toBe(false);
+    expect(absolutelyBigButProportionallySmall.duration.changed).toBe(false);
+  });
+
+  test("does not report a duration difference while one side is unknown", () => {
+    const result = buildRunMetadataComparison({ durationMs: 30_000 }, {});
+
+    expect(result.duration.changed).toBe(false);
+    expect(result.hasChanges).toBe(false);
+  });
+
+  test("diffs run arguments generically", () => {
+    const result = buildRunMetadataComparison(
+      { arguments: { epochs: "10", region: "us" } },
+      { arguments: { epochs: "20", region: "us" } },
+    );
+
+    const epochs = result.argumentDiffs.find((diff) => diff.key === "epochs");
+    const region = result.argumentDiffs.find((diff) => diff.key === "region");
+    expect(epochs?.status).toBe("changed");
+    expect(region?.status).toBe("unchanged");
+    expect(result.changeCount).toBe(1);
+  });
+});

--- a/src/routes/v2/pages/CompareView/utils/compareRunMetadata.ts
+++ b/src/routes/v2/pages/CompareView/utils/compareRunMetadata.ts
@@ -1,0 +1,144 @@
+import {
+  PIPELINE_RUN_NOTES_ANNOTATION,
+  PIPELINE_TAGS_ANNOTATION,
+} from "@/utils/annotationKeys";
+
+import {
+  countChanged,
+  diffKeyedRecords,
+  type KeyedDiffEntry,
+  stripFrontendAnnotations,
+} from "./comparePipelines";
+
+/**
+ * Free-text annotations a person edits on the run itself. They say nothing about
+ * what the run did, so a difference in them is not a difference worth reporting.
+ */
+const SUPERFICIAL_ANNOTATION_KEYS = new Set<string>([
+  PIPELINE_RUN_NOTES_ANNOTATION,
+  PIPELINE_TAGS_ANNOTATION,
+]);
+
+export interface RunMetadataInput {
+  createdBy?: string;
+  createdAt?: string;
+  status?: string;
+  durationMs?: number;
+  annotations?: Record<string, unknown>;
+  arguments?: Record<string, unknown>;
+}
+
+interface ScalarDiff {
+  a?: string;
+  b?: string;
+  changed: boolean;
+}
+
+interface DurationDiff {
+  a?: number;
+  b?: number;
+  changed: boolean;
+}
+
+export interface RunMetadataComparison {
+  author: ScalarDiff;
+  createdAt: ScalarDiff;
+  status: ScalarDiff;
+  duration: DurationDiff;
+  annotationDiffs: KeyedDiffEntry<unknown>[];
+  argumentDiffs: KeyedDiffEntry<unknown>[];
+  changeCount: number;
+  hasChanges: boolean;
+}
+
+/**
+ * Two runs of the same pipeline never take exactly the same time, so a duration
+ * counts as a difference only when the gap is both absolutely and
+ * proportionally large. Without the second test every long run would report a
+ * difference; without the first, every short one would.
+ */
+const DURATION_NOISE_MS = 5_000;
+const DURATION_NOISE_RATIO = 0.1;
+
+function stripComparableAnnotations(
+  annotations: Record<string, unknown> | undefined,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(
+    stripFrontendAnnotations(annotations),
+  )) {
+    if (!SUPERFICIAL_ANNOTATION_KEYS.has(key)) result[key] = value;
+  }
+  return result;
+}
+
+function scalarDiff(a: string | undefined, b: string | undefined): ScalarDiff {
+  return { a, b, changed: (a ?? "") !== (b ?? "") };
+}
+
+/**
+ * A side whose value has not arrived yet is not a difference — comparing a
+ * loaded run against a loading one would report a change that disappears a
+ * moment later.
+ */
+function knownScalarDiff(
+  a: string | undefined,
+  b: string | undefined,
+): ScalarDiff {
+  return a && b ? scalarDiff(a, b) : { a, b, changed: false };
+}
+
+function durationDiff(
+  a: number | undefined,
+  b: number | undefined,
+): DurationDiff {
+  if (a === undefined || b === undefined) return { a, b, changed: false };
+
+  const gap = Math.abs(a - b);
+  const changed =
+    gap >= DURATION_NOISE_MS && gap / Math.max(a, b) >= DURATION_NOISE_RATIO;
+
+  return { a, b, changed };
+}
+
+/**
+ * Compares run-level context between two runs. Annotation and argument keys are
+ * treated generically — the platform is agnostic about which keys exist, so
+ * whatever a deployment stores surfaces here. Superficial keys (notes, tags)
+ * and frontend-only annotations are excluded. `createdAt` is surfaced for
+ * context but does not count toward `hasChanges`, since two distinct runs
+ * always have different timestamps; how long they took and how they ended do
+ * count, because those describe what happened rather than when it started.
+ */
+export function buildRunMetadataComparison(
+  a: RunMetadataInput,
+  b: RunMetadataInput,
+): RunMetadataComparison {
+  const author = scalarDiff(a.createdBy, b.createdBy);
+  const createdAt = scalarDiff(a.createdAt, b.createdAt);
+  const status = knownScalarDiff(a.status, b.status);
+  const duration = durationDiff(a.durationMs, b.durationMs);
+  const annotationDiffs = diffKeyedRecords(
+    stripComparableAnnotations(a.annotations),
+    stripComparableAnnotations(b.annotations),
+  );
+  const argumentDiffs = diffKeyedRecords(a.arguments, b.arguments);
+
+  const changeCount =
+    (author.changed ? 1 : 0) +
+    (status.changed ? 1 : 0) +
+    (duration.changed ? 1 : 0) +
+    countChanged(annotationDiffs) +
+    countChanged(argumentDiffs);
+
+  return {
+    author,
+    createdAt,
+    status,
+    duration,
+    annotationDiffs,
+    argumentDiffs,
+    changeCount,
+    hasChanges: changeCount > 0,
+  };
+}

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -51,8 +51,18 @@ export const formatDate = (date: string | Date, format = defaultFormat) => {
 export const formatDuration = (startTime: string, endTime: string): string => {
   const startMs = new Date(startTime).getTime();
   const endMs = new Date(endTime).getTime();
-  const durationMs = endMs - startMs;
 
+  return formatDurationMs(endMs - startMs);
+};
+
+/**
+ * Format an already-measured duration
+ * @param durationMs - Elapsed milliseconds
+ * @returns Formatted duration string (e.g., "1h 23m 45s", "2m 30s", "45s")
+ * @public consumed by the run metadata section, which the compare page wires up
+ * later in this stack.
+ */
+export const formatDurationMs = (durationMs: number): string => {
   if (durationMs < 0) return "Invalid duration";
 
   const seconds = Math.floor(durationMs / 1000);


### PR DESCRIPTION
## Description

Fifth PR in the **Compare Runs** stack. Adds run-level metadata comparison — the context around the two runs, as opposed to their pipeline structure.

It compares who created each run, when, and any run-level annotations and arguments, and surfaces what changed. Two things are deliberately handled specially:

- **Created-at** is shown for context but never counts as a "change" on its own — two different runs always have different timestamps.
- Superficial keys (notes, tags) and layout-only editor annotations are ignored so they don't create noise.

Annotation and argument keys are treated generically, so whatever a given deployment stores shows up without needing hardcoded knowledge of the keys. Rendered as a compact summary bar that expands to show the details when something actually differs.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

Part of the Compare Runs stack. Builds on #2599; the next PR (#2601) builds on this branch.

## Type of Change

- [x] New feature

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Add screenshots of the collapsed summary bar and the expanded metadata diff. -->

## Test Instructions

- Run the unit tests: `npm run test -- compareRunMetadata`
  - Covers author changes, the created-at exception, generic annotation/argument diffing, and exclusion of superficial/frontend-only keys.
- End-to-end (via the top of the stack, #2603, with the **Compare runs** flag on):
  - Compare two runs by different authors and confirm the metadata bar flags the author change and expands to show details.
  - Confirm two runs by the same author with only different timestamps are reported as unchanged.

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
