### PR TITLE
feat: run comparison - structured diff view

### DIFF
--- a/react-compiler.config.js
+++ b/react-compiler.config.js
@@ -39,6 +39,7 @@ export const REACT_COMPILER_ENABLED_DIRS = [
   "src/hooks/useRecentlyViewed.ts",
   "src/hooks/useDocsVisitTracking.ts",
   "src/hooks/useExecutionArtifacts.ts",
+  "src/hooks/useContainerLog.ts",
   "src/components/shared/FavoriteToggle.tsx",
   "src/components/shared/ComponentLifecycleBadges.tsx",
   "src/components/shared/ComponentSearchEmptyStateSuggestions.tsx",

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/logs.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/logs.tsx
@@ -1,14 +1,13 @@
-import { useQuery } from "@tanstack/react-query";
 import { type ComponentPropsWithoutRef, useEffect, useState } from "react";
 
 import { CodeViewer } from "@/components/shared/CodeViewer";
 import { InfoBox } from "@/components/shared/InfoBox";
 import { Link } from "@/components/ui/link";
 import { Spinner } from "@/components/ui/spinner";
+import { useContainerLog } from "@/hooks/useContainerLog";
 import { useBackend } from "@/providers/BackendProvider";
-import { fetchContainerLog } from "@/services/executionService";
 import { getBackendStatusString } from "@/utils/backend";
-import { CONTAINER_STATUSES_PRE_LAUNCH } from "@/utils/executionStatus";
+import { shouldStatusHaveLogs } from "@/utils/executionStatus";
 
 const LogDisplay = ({
   logs,
@@ -54,31 +53,6 @@ const LogDisplay = ({
   );
 };
 
-/**
- * Statuses where the container is running and actively producing logs.
- * Used to decide whether to poll for new log content.
- */
-const isStatusActivelyLogging = (status?: string): boolean => {
-  switch (status) {
-    case "RUNNING":
-    case "PENDING":
-    case "CANCELLING":
-      return true;
-    default:
-      return false;
-  }
-};
-
-/**
- * Returns true if the container may have logs worth fetching.
- */
-export const shouldStatusHaveLogs = (status?: string): boolean => {
-  if (!status) {
-    return false;
-  }
-  return !CONTAINER_STATUSES_PRE_LAUNCH.has(status);
-};
-
 const Logs = ({
   executionId,
   status,
@@ -89,19 +63,15 @@ const Logs = ({
   const { backendUrl, configured, available } = useBackend();
 
   const shouldFetch = !!executionId && shouldStatusHaveLogs(status);
-  const shouldPoll = shouldFetch && isStatusActivelyLogging(status);
 
   const [logs, setLogs] = useState<{
     log_text?: string;
     system_error_exception_full?: string;
   }>();
-  const { data, isLoading, error, refetch } = useQuery({
-    queryKey: ["logs", executionId],
-    queryFn: () => fetchContainerLog(String(executionId), backendUrl),
-    enabled: shouldFetch,
-    refetchInterval: shouldPoll ? 5000 : false,
-    refetchIntervalInBackground: false,
-  });
+  const { data, isLoading, error, refetch } = useContainerLog(
+    executionId,
+    status,
+  );
 
   useEffect(() => {
     if (data && !error) {

--- a/src/hooks/useContainerLog.ts
+++ b/src/hooks/useContainerLog.ts
@@ -1,0 +1,35 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { useBackend } from "@/providers/BackendProvider";
+import { fetchContainerLog } from "@/services/executionService";
+import {
+  isStatusActivelyLogging,
+  shouldStatusHaveLogs,
+} from "@/utils/executionStatus";
+
+const LOG_POLL_INTERVAL_MS = 5000;
+
+interface UseContainerLogOptions {
+  enabled?: boolean;
+}
+
+export function useContainerLog(
+  executionId: string | number | undefined,
+  status: string | undefined,
+  { enabled = true }: UseContainerLogOptions = {},
+) {
+  const { backendUrl } = useBackend();
+
+  const shouldFetch = enabled && !!executionId && shouldStatusHaveLogs(status);
+
+  return useQuery({
+    queryKey: ["logs", backendUrl, executionId],
+    queryFn: () => fetchContainerLog(String(executionId), backendUrl),
+    enabled: shouldFetch,
+    refetchInterval:
+      shouldFetch && isStatusActivelyLogging(status)
+        ? LOG_POLL_INTERVAL_MS
+        : false,
+    refetchIntervalInBackground: false,
+  });
+}

--- a/src/routes/v2/pages/CompareView/components/IoDiffDetail.tsx
+++ b/src/routes/v2/pages/CompareView/components/IoDiffDetail.tsx
@@ -1,0 +1,82 @@
+import { Icon } from "@/components/ui/icon";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
+import type { IoDiff } from "@/routes/v2/pages/CompareView/utils/comparePipelines";
+import { ioDisplayStatus } from "@/routes/v2/pages/CompareView/utils/comparePipelines";
+
+import { ArtifactDiffRow } from "./ArtifactDiffRow";
+import { DiffStatusBadge } from "./DiffStatusBadge";
+import { FieldDiffRow } from "./FieldDiffRow";
+import { RunTags } from "./RunTag";
+
+interface IoDiffDetailProps {
+  diff: IoDiff;
+  labelA: string;
+  labelB: string;
+}
+
+export function IoDiffDetail({ diff, labelA, labelB }: IoDiffDetailProps) {
+  const isInput = diff.kind === "input";
+  const wholeChange = diff.status === "new" || diff.status === "lost";
+  const changedFields = diff.fieldDiffs.filter(
+    (entry) => entry.status !== "unchanged",
+  );
+  const hasArtifact = diff.artifactStatus !== undefined;
+
+  return (
+    <BlockStack gap="4">
+      <BlockStack gap="2">
+        <InlineStack gap="2" blockAlign="center" wrap="wrap">
+          <Icon
+            name={isInput ? "ArrowRightToLine" : "ArrowRightFromLine"}
+            size="xs"
+            className="text-muted-foreground"
+          />
+          <Text as="span" size="sm" weight="semibold" className="font-mono">
+            {diff.name}
+          </Text>
+          <DiffStatusBadge status={ioDisplayStatus(diff)} />
+          <RunTags status={diff.status} labelA={labelA} labelB={labelB} />
+        </InlineStack>
+        <Text as="span" size="xs" tone="subdued" className="uppercase">
+          {isInput ? "Pipeline input" : "Pipeline output"}
+        </Text>
+      </BlockStack>
+
+      {!wholeChange &&
+        (changedFields.length > 0 ? (
+          <BlockStack gap="1">
+            {changedFields.map((entry) => (
+              <FieldDiffRow
+                key={entry.key}
+                entry={entry}
+                labelA={labelA}
+                labelB={labelB}
+              />
+            ))}
+          </BlockStack>
+        ) : (
+          !hasArtifact && (
+            <Text as="span" size="sm" tone="subdued">
+              No differences in this {isInput ? "input" : "output"}.
+            </Text>
+          )
+        ))}
+
+      {hasArtifact && (
+        <BlockStack gap="1">
+          <Text as="span" size="xs" weight="semibold" tone="subdued">
+            Artifact
+          </Text>
+          <ArtifactDiffRow
+            name={diff.name}
+            a={diff.artifactA}
+            b={diff.artifactB}
+            labelA={labelA}
+            labelB={labelB}
+          />
+        </BlockStack>
+      )}
+    </BlockStack>
+  );
+}

--- a/src/routes/v2/pages/CompareView/components/IoDiffRow.tsx
+++ b/src/routes/v2/pages/CompareView/components/IoDiffRow.tsx
@@ -1,0 +1,18 @@
+import { BlockStack } from "@/components/ui/layout";
+import type { IoDiff } from "@/routes/v2/pages/CompareView/utils/comparePipelines";
+
+import { IoDiffDetail } from "./IoDiffDetail";
+
+interface IoDiffRowProps {
+  diff: IoDiff;
+  labelA: string;
+  labelB: string;
+}
+
+export function IoDiffRow({ diff, labelA, labelB }: IoDiffRowProps) {
+  return (
+    <BlockStack className="rounded-lg border border-border p-4">
+      <IoDiffDetail diff={diff} labelA={labelA} labelB={labelB} />
+    </BlockStack>
+  );
+}

--- a/src/routes/v2/pages/CompareView/components/StructuredDiffView.tsx
+++ b/src/routes/v2/pages/CompareView/components/StructuredDiffView.tsx
@@ -1,0 +1,220 @@
+import { type ReactNode, useState } from "react";
+
+import { InfoBox } from "@/components/shared/InfoBox";
+import { Label } from "@/components/ui/label";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Switch } from "@/components/ui/switch";
+import { Heading, Text } from "@/components/ui/typography";
+import type { CompareMode } from "@/routes/v2/pages/CompareView/utils/compareMode";
+import type { PipelineComparison } from "@/routes/v2/pages/CompareView/utils/comparePipelines";
+import { ioDisplayStatus } from "@/routes/v2/pages/CompareView/utils/comparePipelines";
+import { pluralize } from "@/utils/string";
+import { tracking } from "@/utils/tracking";
+
+import { IoDiffRow } from "./IoDiffRow";
+import { TaskDiffRow } from "./TaskDiffRow";
+
+interface SummaryCountProps {
+  label: string;
+  value: number;
+}
+
+function SummaryCount({ label, value }: SummaryCountProps) {
+  return (
+    <InlineStack gap="1" blockAlign="baseline">
+      <Text as="span" size="sm" weight="semibold">
+        {value}
+      </Text>
+      <Text as="span" size="sm" tone="subdued">
+        {label}
+      </Text>
+    </InlineStack>
+  );
+}
+
+function ChangeCount({ label, value }: SummaryCountProps) {
+  return (
+    <InlineStack gap="1" blockAlign="center">
+      <span className="h-2 w-2 rounded-full bg-diff-changed" />
+      <Text as="span" size="sm" weight="semibold">
+        {value}
+      </Text>
+      <Text as="span" size="sm" tone="subdued">
+        {label}
+      </Text>
+    </InlineStack>
+  );
+}
+
+interface StructuredDiffViewProps {
+  comparison: PipelineComparison;
+  labelA: string;
+  labelB: string;
+  nameA: string;
+  nameB: string;
+  mode: CompareMode;
+}
+
+export function StructuredDiffView({
+  comparison,
+  labelA,
+  labelB,
+  nameA,
+  nameB,
+  mode,
+}: StructuredDiffViewProps) {
+  const [showUnchanged, setShowUnchanged] = useState(false);
+
+  if (!comparison.hasComparableGraph) {
+    return (
+      <InfoBox title="Nothing to compare" variant="info" width="full">
+        {mode.kind === "empty"
+          ? "Select two runs to compare their inputs, tasks, and outputs."
+          : "Neither run has a graph pipeline, so there are no tasks, inputs, or outputs to align. Use the YAML tab to compare the raw specifications."}
+      </InfoBox>
+    );
+  }
+
+  const { counts } = comparison;
+
+  /**
+   * A single run is compared against itself, so every count is zero and every
+   * row is "unchanged" — revealing them would list the same run twice, with both
+   * pills naming it. There is no diff to control until a second run is picked.
+   */
+  const isSingleRun = mode.kind === "single";
+  const showUnchangedRows = showUnchanged && !isSingleRun;
+
+  const visibleInputs = showUnchangedRows
+    ? comparison.inputDiffs
+    : comparison.inputDiffs.filter((diff) => diff.status !== "unchanged");
+  const visibleOutputs = showUnchangedRows
+    ? comparison.outputDiffs
+    : comparison.outputDiffs.filter(
+        (diff) => ioDisplayStatus(diff) !== "unchanged",
+      );
+  const visibleTasks = showUnchangedRows
+    ? comparison.taskDiffs
+    : comparison.taskDiffs.filter(
+        (diff) => diff.status !== "unchanged" || diff.outcomeChanged,
+      );
+
+  const nothingVisible =
+    visibleInputs.length === 0 &&
+    visibleOutputs.length === 0 &&
+    visibleTasks.length === 0;
+
+  return (
+    <BlockStack gap="4" className="w-full">
+      {!isSingleRun && (
+        <InlineStack
+          align="space-between"
+          blockAlign="center"
+          gap="4"
+          className="w-full"
+        >
+          <InlineStack gap="4" blockAlign="center" wrap="wrap">
+            <SummaryCount label="added" value={counts.added} />
+            <SummaryCount label="removed" value={counts.removed} />
+            <SummaryCount label="changed" value={counts.changed} />
+            <SummaryCount label="unchanged" value={counts.unchanged} />
+            {counts.outcomeChanged > 0 && (
+              <ChangeCount
+                value={counts.outcomeChanged}
+                label="outcome differs"
+              />
+            )}
+            {counts.outputArtifactChanged > 0 && (
+              <ChangeCount
+                value={counts.outputArtifactChanged}
+                label={`output ${pluralize(counts.outputArtifactChanged, "artifact")} ${counts.outputArtifactChanged === 1 ? "differs" : "differ"}`}
+              />
+            )}
+          </InlineStack>
+          <InlineStack gap="2" blockAlign="center" wrap="nowrap">
+            <Switch
+              id="compare-show-unchanged"
+              checked={showUnchanged}
+              onCheckedChange={setShowUnchanged}
+              {...tracking("compare_runs.structured_diff.show_unchanged", {
+                new_value: !showUnchanged,
+              })}
+            />
+            <Label htmlFor="compare-show-unchanged">Show unchanged</Label>
+          </InlineStack>
+        </InlineStack>
+      )}
+
+      {nothingVisible ? (
+        isSingleRun ? (
+          <InfoBox title="One run selected" variant="info" width="full">
+            Select a second run to make a structured comparison.
+          </InfoBox>
+        ) : (
+          <InfoBox title="No differences" variant="success" width="full">
+            These two runs match on inputs, tasks, outcomes, and pipeline output
+            artifacts. Artifacts produced inside a task are compared when you
+            open that task — switch on Show unchanged to list them.
+          </InfoBox>
+        )
+      ) : (
+        <BlockStack gap="5" className="w-full">
+          {visibleInputs.length > 0 && (
+            <DiffSection title="Inputs">
+              {visibleInputs.map((diff) => (
+                <IoDiffRow
+                  key={diff.name}
+                  diff={diff}
+                  labelA={labelA}
+                  labelB={labelB}
+                />
+              ))}
+            </DiffSection>
+          )}
+          {visibleTasks.length > 0 && (
+            <DiffSection title="Tasks">
+              {visibleTasks.map((diff) => (
+                <TaskDiffRow
+                  key={diff.taskId}
+                  diff={diff}
+                  labelA={labelA}
+                  labelB={labelB}
+                  nameA={nameA}
+                  nameB={nameB}
+                />
+              ))}
+            </DiffSection>
+          )}
+          {visibleOutputs.length > 0 && (
+            <DiffSection title="Outputs">
+              {visibleOutputs.map((diff) => (
+                <IoDiffRow
+                  key={diff.name}
+                  diff={diff}
+                  labelA={labelA}
+                  labelB={labelB}
+                />
+              ))}
+            </DiffSection>
+          )}
+        </BlockStack>
+      )}
+    </BlockStack>
+  );
+}
+
+interface DiffSectionProps {
+  title: string;
+  children: ReactNode;
+}
+
+function DiffSection({ title, children }: DiffSectionProps) {
+  return (
+    <BlockStack gap="2" className="w-full">
+      <Heading level={3}>{title}</Heading>
+      <BlockStack gap="2" className="w-full">
+        {children}
+      </BlockStack>
+    </BlockStack>
+  );
+}

--- a/src/routes/v2/pages/CompareView/components/TaskDiffDetail.tsx
+++ b/src/routes/v2/pages/CompareView/components/TaskDiffDetail.tsx
@@ -1,0 +1,189 @@
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icon";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
+import type { TaskDiff } from "@/routes/v2/pages/CompareView/utils/comparePipelines";
+import { tracking } from "@/utils/tracking";
+
+import { ArtifactDiffSection } from "./ArtifactDiffSection";
+import { DiffStatusBadge } from "./DiffStatusBadge";
+import { ExecutionStatusPill } from "./ExecutionStatusPill";
+import { FieldDiffRow } from "./FieldDiffRow";
+import { RunTags } from "./RunTag";
+import {
+  taskHasComparableLogs,
+  TaskLogComparisonDialog,
+} from "./TaskLogComparisonDialog";
+
+interface TaskDiffDetailProps {
+  diff: TaskDiff;
+  labelA: string;
+  labelB: string;
+  nameA: string;
+  nameB: string;
+}
+
+export function TaskDiffDetail({
+  diff,
+  labelA,
+  labelB,
+  nameA,
+  nameB,
+}: TaskDiffDetailProps) {
+  const [logsOpen, setLogsOpen] = useState(false);
+  const wholeTaskChange = diff.status === "new" || diff.status === "lost";
+  const canCompareLogs = taskHasComparableLogs(diff);
+
+  const changedArguments = diff.argumentDiffs.filter(
+    (entry) => entry.status !== "unchanged",
+  );
+  const changedAnnotations = diff.annotationDiffs.filter(
+    (entry) => entry.status !== "unchanged",
+  );
+  const changedSettings = diff.settingDiffs.filter(
+    (entry) =>
+      entry.status !== "unchanged" &&
+      !(diff.cacheChanged && entry.key === "cachingStrategy"),
+  );
+
+  const hasFieldChanges =
+    diff.componentChanged ||
+    diff.cacheChanged ||
+    changedArguments.length > 0 ||
+    changedAnnotations.length > 0 ||
+    changedSettings.length > 0;
+
+  const cacheState = (disabled: boolean) => (disabled ? "disabled" : "enabled");
+
+  return (
+    <BlockStack gap="4">
+      <BlockStack gap="2">
+        <InlineStack gap="2" blockAlign="center" wrap="wrap">
+          <Text as="span" size="sm" weight="semibold" className="font-mono">
+            {diff.taskId}
+          </Text>
+          <DiffStatusBadge status={diff.status} />
+          <RunTags status={diff.status} labelA={labelA} labelB={labelB} />
+        </InlineStack>
+        <InlineStack gap="2" blockAlign="center" wrap="wrap">
+          <ExecutionStatusPill label={labelA} status={diff.statusA} />
+          {diff.outcomeChanged && diff.statusA && diff.statusB && (
+            <Icon
+              name="ArrowRight"
+              size="xs"
+              className="text-muted-foreground"
+            />
+          )}
+          <ExecutionStatusPill label={labelB} status={diff.statusB} />
+        </InlineStack>
+        {canCompareLogs && (
+          <InlineStack>
+            <Button
+              variant="outline"
+              size="xs"
+              onClick={() => setLogsOpen(true)}
+              {...tracking("compare_runs.task.compare_logs")}
+            >
+              <Icon name="ScrollText" size="xs" />
+              Compare logs
+            </Button>
+          </InlineStack>
+        )}
+      </BlockStack>
+
+      {diff.cacheChanged && (
+        <BlockStack gap="1">
+          <Text as="span" size="xs" weight="semibold" tone="subdued">
+            Cache
+          </Text>
+          <Text as="span" size="xs">
+            {cacheState(diff.cacheDisabledA)} →{" "}
+            {cacheState(diff.cacheDisabledB)}
+          </Text>
+        </BlockStack>
+      )}
+
+      {!wholeTaskChange && (
+        <>
+          {changedArguments.length > 0 && (
+            <BlockStack gap="1">
+              <Text as="span" size="xs" weight="semibold" tone="subdued">
+                Arguments
+              </Text>
+              {changedArguments.map((entry) => (
+                <FieldDiffRow
+                  key={entry.key}
+                  entry={entry}
+                  labelA={labelA}
+                  labelB={labelB}
+                />
+              ))}
+            </BlockStack>
+          )}
+
+          {changedSettings.length > 0 && (
+            <BlockStack gap="1">
+              <Text as="span" size="xs" weight="semibold" tone="subdued">
+                Execution settings
+              </Text>
+              {changedSettings.map((entry) => (
+                <FieldDiffRow
+                  key={entry.key}
+                  entry={entry}
+                  labelA={labelA}
+                  labelB={labelB}
+                />
+              ))}
+            </BlockStack>
+          )}
+
+          {changedAnnotations.length > 0 && (
+            <BlockStack gap="1">
+              <Text as="span" size="xs" weight="semibold" tone="subdued">
+                Annotations
+              </Text>
+              {changedAnnotations.map((entry) => (
+                <FieldDiffRow
+                  key={entry.key}
+                  entry={entry}
+                  labelA={labelA}
+                  labelB={labelB}
+                />
+              ))}
+            </BlockStack>
+          )}
+
+          {!hasFieldChanges && (
+            <Text as="span" size="sm" tone="subdued">
+              {diff.outcomeChanged
+                ? "No configuration changes - the execution outcome differs between runs."
+                : "Configuration and outcome match. Expand Artifacts to compare what each run produced."}
+            </Text>
+          )}
+        </>
+      )}
+
+      <ArtifactDiffSection
+        executionIdA={diff.executionIdA}
+        executionIdB={diff.executionIdB}
+        labelA={labelA}
+        labelB={labelB}
+      />
+
+      {canCompareLogs && (
+        <TaskLogComparisonDialog
+          open={logsOpen}
+          onOpenChange={setLogsOpen}
+          diff={diff}
+          taskName={diff.taskId}
+          labelA={labelA}
+          labelB={labelB}
+          nameA={nameA}
+          nameB={nameB}
+        />
+      )}
+    </BlockStack>
+  );
+}

--- a/src/routes/v2/pages/CompareView/components/TaskDiffRow.tsx
+++ b/src/routes/v2/pages/CompareView/components/TaskDiffRow.tsx
@@ -1,0 +1,38 @@
+import { BlockStack } from "@/components/ui/layout";
+import { cn } from "@/lib/utils";
+import type { TaskDiff } from "@/routes/v2/pages/CompareView/utils/comparePipelines";
+
+import { TaskDiffDetail } from "./TaskDiffDetail";
+
+interface TaskDiffRowProps {
+  diff: TaskDiff;
+  labelA: string;
+  labelB: string;
+  nameA: string;
+  nameB: string;
+}
+
+export function TaskDiffRow({
+  diff,
+  labelA,
+  labelB,
+  nameA,
+  nameB,
+}: TaskDiffRowProps) {
+  return (
+    <BlockStack
+      className={cn(
+        "rounded-lg border p-4",
+        diff.outcomeChanged ? "border-diff-changed" : "border-border",
+      )}
+    >
+      <TaskDiffDetail
+        diff={diff}
+        labelA={labelA}
+        labelB={labelB}
+        nameA={nameA}
+        nameB={nameB}
+      />
+    </BlockStack>
+  );
+}

--- a/src/routes/v2/pages/CompareView/components/TaskLogComparisonDialog.tsx
+++ b/src/routes/v2/pages/CompareView/components/TaskLogComparisonDialog.tsx
@@ -1,0 +1,231 @@
+import type { ReactNode } from "react";
+
+import type { GetContainerExecutionLogResponse } from "@/api/types.gen";
+import { InfoBox } from "@/components/shared/InfoBox";
+import { OpenLogsInNewWindowLink } from "@/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/logs";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Spinner } from "@/components/ui/spinner";
+import { Text } from "@/components/ui/typography";
+import { useContainerLog } from "@/hooks/useContainerLog";
+import type { TaskDiff } from "@/routes/v2/pages/CompareView/utils/comparePipelines";
+import { isGraphImplementation } from "@/utils/componentSpec";
+
+import { DiffCodeViewer } from "./DiffCodeViewer";
+import { RunTag } from "./RunTag";
+
+interface TaskLogSide {
+  executionId?: string;
+  status?: string;
+  canLog: boolean;
+}
+
+function toLogSide(
+  spec: TaskDiff["a"],
+  executionId: string | undefined,
+  status: string | undefined,
+): TaskLogSide {
+  const isSubgraph = isGraphImplementation(
+    spec?.componentRef.spec?.implementation,
+  );
+  return { executionId, status, canLog: Boolean(executionId) && !isSubgraph };
+}
+
+function taskLogSides(diff: TaskDiff): {
+  a: TaskLogSide;
+  b: TaskLogSide;
+} {
+  return {
+    a: toLogSide(diff.a, diff.executionIdA, diff.statusA),
+    b: toLogSide(diff.b, diff.executionIdB, diff.statusB),
+  };
+}
+
+/**
+ * Log comparison is only meaningful when both runs executed this task and the
+ * task changed or produced a different outcome. Added/removed tasks (present in
+ * only one run) have nothing to diff.
+ */
+export function taskHasComparableLogs(diff: TaskDiff): boolean {
+  const { a, b } = taskLogSides(diff);
+  return (
+    a.canLog && b.canLog && (diff.status === "changed" || diff.outcomeChanged)
+  );
+}
+
+function composeLogText(
+  data: GetContainerExecutionLogResponse | undefined,
+): string {
+  if (!data) return "";
+  const parts: string[] = [];
+  if (data.log_text) parts.push(data.log_text);
+  if (data.system_error_exception_full) {
+    parts.push(`=== System error ===\n${data.system_error_exception_full}`);
+  }
+  return parts.join("\n\n").trim();
+}
+
+interface LogHeaderSideProps {
+  run: "a" | "b";
+  label: string;
+  runName: string;
+  side: TaskLogSide;
+}
+
+function LogHeaderSide({ run, label, runName, side }: LogHeaderSideProps) {
+  return (
+    <InlineStack
+      gap="2"
+      blockAlign="center"
+      wrap="nowrap"
+      className="min-w-0 flex-1"
+    >
+      <RunTag run={run} label={label} />
+      <Text as="span" size="sm" weight="semibold" className="truncate">
+        {runName}
+      </Text>
+      {side.executionId && (
+        <OpenLogsInNewWindowLink
+          executionId={side.executionId}
+          status={side.status}
+        />
+      )}
+    </InlineStack>
+  );
+}
+
+function CenteredNotice({ children }: { children: ReactNode }) {
+  return (
+    <BlockStack
+      fill
+      align="center"
+      inlineAlign="center"
+      gap="2"
+      className="p-4"
+    >
+      {children}
+    </BlockStack>
+  );
+}
+
+interface LogComparisonBodyProps {
+  isLoading: boolean;
+  failedRuns: string[];
+  textA: string;
+  textB: string;
+}
+
+function LogComparisonBody({
+  isLoading,
+  failedRuns,
+  textA,
+  textB,
+}: LogComparisonBodyProps) {
+  if (isLoading) {
+    return (
+      <CenteredNotice>
+        <Spinner />
+        <Text as="span" size="sm" tone="subdued">
+          Loading logs…
+        </Text>
+      </CenteredNotice>
+    );
+  }
+
+  if (failedRuns.length > 0) {
+    return (
+      <CenteredNotice>
+        <InfoBox title="Logs unavailable" variant="error">
+          {`Could not load the logs for ${failedRuns.join(" and ")}. Retry from the run's own log view.`}
+        </InfoBox>
+      </CenteredNotice>
+    );
+  }
+
+  if (!textA && !textB) {
+    return (
+      <CenteredNotice>
+        <InfoBox title="No logs" variant="info">
+          Neither run produced container logs for this task.
+        </InfoBox>
+      </CenteredNotice>
+    );
+  }
+
+  return <DiffCodeViewer original={textA} modified={textB} language="text" />;
+}
+
+interface TaskLogComparisonDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  diff: TaskDiff;
+  taskName: string;
+  labelA: string;
+  labelB: string;
+  nameA: string;
+  nameB: string;
+}
+
+export function TaskLogComparisonDialog({
+  open,
+  onOpenChange,
+  diff,
+  taskName,
+  labelA,
+  labelB,
+  nameA,
+  nameB,
+}: TaskLogComparisonDialogProps) {
+  const { a, b } = taskLogSides(diff);
+
+  const queryA = useContainerLog(a.executionId, a.status, {
+    enabled: open && a.canLog,
+  });
+  const queryB = useContainerLog(b.executionId, b.status, {
+    enabled: open && b.canLog,
+  });
+
+  const textA = composeLogText(queryA.data);
+  const textB = composeLogText(queryB.data);
+
+  const isLoading =
+    (a.canLog && queryA.isLoading) || (b.canLog && queryB.isLoading);
+  const failedRuns: string[] = [];
+  if (queryA.error) failedRuns.push(labelA);
+  if (queryB.error) failedRuns.push(labelB);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="flex h-[90vh] w-[95vw] max-w-[95vw] flex-col sm:max-w-[95vw]">
+        <DialogHeader>
+          <DialogTitle>
+            <Text as="span" className="font-mono">
+              {taskName}
+            </Text>{" "}
+            · logs
+          </DialogTitle>
+        </DialogHeader>
+        <InlineStack gap="3" wrap="nowrap" className="w-full">
+          <LogHeaderSide run="a" label={labelA} runName={nameA} side={a} />
+          <LogHeaderSide run="b" label={labelB} runName={nameB} side={b} />
+        </InlineStack>
+        <BlockStack
+          align="stretch"
+          className="min-h-0 min-w-0 flex-1 overflow-hidden rounded-lg border"
+        >
+          <LogComparisonBody
+            isLoading={isLoading}
+            failedRuns={failedRuns}
+            textA={textA}
+            textB={textB}
+          />
+        </BlockStack>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/routes/v2/pages/RunView/nodes/TaskNode/useTaskRunStatus.test.ts
+++ b/src/routes/v2/pages/RunView/nodes/TaskNode/useTaskRunStatus.test.ts
@@ -6,13 +6,6 @@ const { useExecutionDataOptionalMock, useSpecMock } = vi.hoisted(() => ({
   useSpecMock: vi.fn(),
 }));
 
-vi.mock(
-  "@/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/logs",
-  () => ({
-    shouldStatusHaveLogs: (status: string | undefined) => status === "RUNNING",
-  }),
-);
-
 vi.mock("@/providers/ExecutionDataProvider", () => ({
   useExecutionDataOptional: useExecutionDataOptionalMock,
 }));

--- a/src/routes/v2/pages/RunView/nodes/TaskNode/useTaskRunStatus.ts
+++ b/src/routes/v2/pages/RunView/nodes/TaskNode/useTaskRunStatus.ts
@@ -1,9 +1,11 @@
-import { shouldStatusHaveLogs } from "@/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/logs";
 import type { Task } from "@/models/componentSpec";
 import { useExecutionDataOptional } from "@/providers/ExecutionDataProvider";
 import { useSpec } from "@/routes/v2/shared/providers/SpecContext";
 import { ISO8601_DURATION_ZERO_DAYS } from "@/utils/constants";
-import type { ExecutionStatusStats } from "@/utils/executionStatus";
+import {
+  type ExecutionStatusStats,
+  shouldStatusHaveLogs,
+} from "@/utils/executionStatus";
 
 interface TaskRunStatus {
   task: Task | undefined;

--- a/src/utils/executionStatus.ts
+++ b/src/utils/executionStatus.ts
@@ -61,6 +61,16 @@ export const CONTAINER_STATUSES_PRE_LAUNCH = new Set([
 ]);
 
 /**
+ * Statuses where the container is running and actively producing logs, so a log
+ * reader should keep polling.
+ */
+const CONTAINER_STATUSES_ACTIVELY_LOGGING = new Set([
+  "RUNNING",
+  "PENDING",
+  "CANCELLING",
+]);
+
+/**
  * Statuses considered "in progress" (not terminal).
  */
 const IN_PROGRESS_STATUSES = new Set([
@@ -106,6 +116,19 @@ export function isValidExecutionStatus(
   value: string,
 ): value is ContainerExecutionStatus {
   return value in EXECUTION_STATUS_LABELS;
+}
+
+/**
+ * Whether the container may have logs worth fetching at all.
+ */
+export function shouldStatusHaveLogs(status?: string): boolean {
+  if (!status) return false;
+  return !CONTAINER_STATUSES_PRE_LAUNCH.has(status);
+}
+
+export function isStatusActivelyLogging(status?: string): boolean {
+  if (!status) return false;
+  return CONTAINER_STATUSES_ACTIVELY_LOGGING.has(status);
 }
 
 /**


### PR DESCRIPTION
## Description

Sixth PR in the **Compare Runs** stack. Adds the **Structured** view — the main list-based way of reading a comparison.

It shows a summary line (how many tasks were added / removed / changed / unchanged, plus how many had a different outcome) and a **Show unchanged** toggle to hide the noise. Below that, inputs, tasks and outputs are listed in sections, each row showing exactly what changed:

- Per-task detail: diff status, per-run execution status (with an arrow when the outcome differs), changed arguments/annotations, cache changes, and the artifact comparison from the previous PR.
- A **Compare logs** button that opens a side-by-side log diff for tasks that ran in both runs and changed.
- Input/output detail rows with the same treatment.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

Part of the Compare Runs stack. Builds on #2600; the next PR (#2602) builds on this branch.

## Type of Change

- [x] New feature

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Add screenshots of the structured view: summary counts, a changed task row, and the log comparison dialog. -->

## Test Instructions

Reachable once the stack is wired up (#2603).

- Check out the top of the stack, enable the **Compare runs** beta flag, and compare two runs.
- On the **Structured** tab, confirm:
  - The summary counts (added / removed / changed / unchanged / outcome differs) look right, and **Show unchanged** hides/shows unchanged rows.
  - Tasks, inputs and outputs are grouped into sections, with changed fields listed on each row.
  - A task with a different outcome is highlighted and shows both runs' statuses.
  - **Compare logs** opens a side-by-side log diff for a task that ran in both runs.
  - Two identical runs show a "no differences" state.

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
