### PR TITLE
feat: run comparison - graph diff view

### DIFF
--- a/react-compiler.config.js
+++ b/react-compiler.config.js
@@ -65,6 +65,7 @@ export const REACT_COMPILER_ENABLED_DIRS = [
   "src/components/shared/TaskDetails/Actions/UnpackSubgraphButton.tsx",
   "src/components/shared/ReactFlow/FlowSidebar/components/ComponentHoverPopover.tsx",
   "src/components/shared/ReactFlow/FlowControls/StackingControls.tsx",
+  "src/components/shared/ReactFlow/FlowCanvas/TaskNode/StatusIndicator.tsx",
   "src/components/shared/ReactFlow/FlowCanvas/FlexNode",
   "src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/ZIndexEditor.tsx",
   "src/components/Editor/IOEditor/IOZIndexEditor.tsx",

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/StatusIndicator.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/StatusIndicator.tsx
@@ -14,6 +14,34 @@ import {
   getExecutionStatusLabel,
 } from "@/utils/executionStatus";
 
+type StatusTabProps = {
+  status: string;
+  label?: string;
+  className?: string;
+};
+
+/** @public consumed by the run comparison graph, landed later in this stack. */
+export const StatusTab = ({ status, label, className }: StatusTabProps) => {
+  const { style, text, icon } = getStatusMetadata(status);
+
+  return (
+    <div
+      title={label ? `${label} · ${text}` : text}
+      className={cn(
+        "h-8.75 overflow-hidden rounded-t-md px-2.5 py-1 text-[10px]",
+        style,
+        className,
+      )}
+    >
+      <div className="flex min-w-0 items-center gap-1 font-mono whitespace-nowrap text-white">
+        {label && <span className="shrink-0 font-semibold">{label}</span>}
+        <span className="shrink-0">{icon}</span>
+        <span className="truncate">{text}</span>
+      </div>
+    </div>
+  );
+};
+
 type StatusIndicatorProps = {
   status: string;
   disabledCache?: boolean;
@@ -23,20 +51,12 @@ export const StatusIndicator = ({
   status,
   disabledCache = false,
 }: StatusIndicatorProps) => {
-  const { style, text, icon } = getStatusMetadata(status);
-
   return (
     <div className="absolute -z-1 -top-5 left-0 flex items-start">
-      <div
-        className={cn("h-8.75 rounded-t-md px-2.5 py-1 text-[10px]", style, {
-          "rounded-tr-none": disabledCache,
-        })}
-      >
-        <div className="flex items-center gap-1 font-mono text-white">
-          {icon}
-          {text}
-        </div>
-      </div>
+      <StatusTab
+        status={status}
+        className={cn({ "rounded-tr-none": disabledCache })}
+      />
       {disabledCache && (
         <div className="h-5.5 bg-status-cancelling rounded-tr-md flex items-center px-1.5">
           <QuickTooltip content="Cache Disabled" className="whitespace-nowrap">

--- a/src/routes/v2/pages/CompareView/components/DiffStatusBadge.tsx
+++ b/src/routes/v2/pages/CompareView/components/DiffStatusBadge.tsx
@@ -2,29 +2,56 @@ import { Icon } from "@/components/ui/icon";
 import { InlineStack } from "@/components/ui/layout";
 import { Text } from "@/components/ui/typography";
 import { cn } from "@/lib/utils";
+import type { SpotlightMode } from "@/routes/v2/pages/CompareView/utils/buildMergedGraph";
 import { DIFF_STATUS_ICON, type DiffStatus } from "@/utils/diffStatus";
 
-export const DIFF_STATUS_LABELS: Record<DiffStatus, string> = {
+const DIFF_STATUS_LABELS: Record<DiffStatus, string> = {
   unchanged: "Unchanged",
   lost: "Removed",
   new: "Added",
   changed: "Changed",
 };
 
+const SPOTLIGHT_STATUS_LABELS: Partial<Record<DiffStatus, string>> = {
+  lost: "Only in A",
+  new: "Only in B",
+};
+
+/**
+ * "Added" and "Removed" describe a move from A to B, which only makes sense
+ * while both runs are on screen. With one run spotlighted the reader is standing
+ * inside it, so a task being highlighted *and* called removed contradicts
+ * itself — name the run it belongs to instead.
+ */
+export function diffStatusLabel(
+  status: DiffStatus,
+  spotlight: SpotlightMode = "both",
+): string {
+  const sideLabel =
+    spotlight === "both" ? undefined : SPOTLIGHT_STATUS_LABELS[status];
+  return sideLabel ?? DIFF_STATUS_LABELS[status];
+}
+
 const DIFF_STATUS_TONE: Record<DiffStatus, string> = {
   unchanged: "bg-diff-unchanged text-diff-unchanged-foreground",
-  lost: "bg-diff-lost text-diff-lost-foreground line-through",
+  lost: "bg-diff-lost text-diff-lost-foreground",
   new: "bg-diff-new text-diff-new-foreground",
   changed: "bg-diff-changed text-diff-changed-foreground",
 };
 
 interface DiffStatusBadgeProps {
   status: DiffStatus;
+  spotlight?: SpotlightMode;
   className?: string;
 }
 
-export function DiffStatusBadge({ status, className }: DiffStatusBadgeProps) {
+export function DiffStatusBadge({
+  status,
+  spotlight = "both",
+  className,
+}: DiffStatusBadgeProps) {
   const icon = DIFF_STATUS_ICON[status];
+  const label = diffStatusLabel(status, spotlight);
 
   return (
     <InlineStack
@@ -35,12 +62,13 @@ export function DiffStatusBadge({ status, className }: DiffStatusBadgeProps) {
       className={cn(
         "rounded px-1.5 py-0.5",
         DIFF_STATUS_TONE[status],
+        status === "lost" && spotlight === "both" && "line-through",
         className,
       )}
     >
       {icon && <Icon name={icon.name} size="xs" />}
       <Text as="span" size="xs" weight="semibold" className="text-inherit">
-        {DIFF_STATUS_LABELS[status]}
+        {label}
       </Text>
     </InlineStack>
   );

--- a/src/routes/v2/pages/CompareView/components/GraphDiffView.tsx
+++ b/src/routes/v2/pages/CompareView/components/GraphDiffView.tsx
@@ -1,0 +1,452 @@
+import "@xyflow/react/dist/style.css";
+
+import {
+  Background,
+  Controls,
+  Panel,
+  ReactFlow,
+  ReactFlowProvider,
+  useNodesInitialized,
+  useNodesState,
+  useReactFlow,
+  useViewport,
+} from "@xyflow/react";
+import equal from "fast-deep-equal";
+import { useEffect, useState } from "react";
+
+import { InfoBox } from "@/components/shared/InfoBox";
+import { autoLayoutNodes } from "@/components/shared/ReactFlow/FlowCanvas/utils/autolayout";
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icon";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import {
+  Popover,
+  PopoverAnchor,
+  PopoverContent,
+} from "@/components/ui/popover";
+import { Text } from "@/components/ui/typography";
+import { cn } from "@/lib/utils";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
+import {
+  buildMergedGraph,
+  type MergedNode,
+  type SpotlightMode,
+} from "@/routes/v2/pages/CompareView/utils/buildMergedGraph";
+import type { CompareMode } from "@/routes/v2/pages/CompareView/utils/compareMode";
+import type {
+  DiffStatus,
+  PipelineComparison,
+  TaskDiff,
+} from "@/routes/v2/pages/CompareView/utils/comparePipelines";
+import { RUN_TONE } from "@/routes/v2/pages/CompareView/utils/runTone";
+import { FLOW_CANVAS_DEFAULT_PROPS } from "@/routes/v2/shared/flowCanvasDefaults";
+import { tracking } from "@/utils/tracking";
+
+import { diffStatusLabel } from "./DiffStatusBadge";
+import { IoDiffDetail } from "./IoDiffDetail";
+import { MergedIoNode } from "./MergedIoNode";
+import { MergedTaskNode } from "./MergedTaskNode";
+import { TaskDiffDetail } from "./TaskDiffDetail";
+
+const taskDisplayName = (diff: TaskDiff) =>
+  diff.a?.componentRef.spec?.name ??
+  diff.b?.componentRef.spec?.name ??
+  diff.taskId;
+
+const NODE_TYPES = { mergedTask: MergedTaskNode, mergedIo: MergedIoNode };
+
+const EDGE_STROKE: Record<DiffStatus, string> = {
+  unchanged: "var(--diff-unchanged)",
+  lost: "var(--diff-lost)",
+  new: "var(--diff-new)",
+  changed: "var(--diff-changed)",
+};
+
+const SWATCH: Record<DiffStatus, string> = {
+  unchanged: "bg-diff-unchanged",
+  lost: "bg-diff-lost",
+  new: "bg-diff-new",
+  changed: "bg-diff-changed",
+};
+
+const LEGEND_ORDER: DiffStatus[] = ["new", "lost", "changed", "unchanged"];
+
+const nodeInRun = (status: DiffStatus, run: "a" | "b") =>
+  run === "a" ? status !== "new" : status !== "lost";
+
+const edgeInRun = (membership: DiffStatus, run: "a" | "b") =>
+  run === "a" ? membership !== "new" : membership !== "lost";
+
+interface GraphDiffViewProps {
+  comparison: PipelineComparison;
+  nameA: string;
+  nameB: string;
+  labelA: string;
+  labelB: string;
+  mode: CompareMode;
+}
+
+export function GraphDiffView(props: GraphDiffViewProps) {
+  if (!props.comparison.hasComparableGraph) {
+    return (
+      <InfoBox title="No graph to compare" variant="info" width="full">
+        {props.mode.kind === "empty"
+          ? "Select two runs to compare their pipeline graphs."
+          : "Neither run has a graph pipeline, so there are no tasks to lay out. Use the YAML tab to compare the raw specifications."}
+      </InfoBox>
+    );
+  }
+
+  return (
+    <ReactFlowProvider>
+      <MergedGraphCanvas {...props} />
+    </ReactFlowProvider>
+  );
+}
+
+function MergedGraphCanvas({
+  comparison,
+  nameA,
+  nameB,
+  labelA,
+  labelB,
+  mode,
+}: GraphDiffViewProps) {
+  const { track } = useAnalytics();
+  const singleRun = mode.kind === "single";
+
+  const { nodes: base, edges: baseEdges } = buildMergedGraph(comparison);
+  const topology = base.map((node) => node.id).join("|");
+
+  const [nodes, setNodes, onNodesChange] = useNodesState(base);
+  const [spotlight, setSpotlight] = useState<SpotlightMode>("both");
+  const [laidOut, setLaidOut] = useState(false);
+  const [seededTopology, setSeededTopology] = useState(topology);
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+
+  const selectedNode = selectedNodeId
+    ? (base.find((node) => node.id === selectedNodeId) ?? null)
+    : null;
+
+  const initialized = useNodesInitialized();
+  const { fitView } = useReactFlow();
+
+  /**
+   * The comparison is refetched every few seconds while either run is still
+   * going, so the rebuilt model has to be pushed back into node state — seeding
+   * `useNodesState` only covers first paint, and the graph would otherwise keep
+   * showing the statuses it was born with. Diffs are swapped in place so
+   * positions survive a status-only refresh; a changed node set reseeds and
+   * re-runs layout instead.
+   */
+  useEffect(() => {
+    if (topology !== seededTopology) {
+      setNodes(base);
+      setSeededTopology(topology);
+      setLaidOut(false);
+      return;
+    }
+
+    setNodes((current) => {
+      const rebuilt = new Map(base.map((node) => [node.id, node.data.diff]));
+      let changed = false;
+
+      const next = current.map((node) => {
+        const diff = rebuilt.get(node.id);
+        if (!diff || equal(diff, node.data.diff)) return node;
+        changed = true;
+        return { ...node, data: { ...node.data, diff } } as MergedNode;
+      });
+
+      return changed ? next : current;
+    });
+  }, [base, topology, seededTopology, setNodes]);
+
+  const sizeSignature = nodes
+    .map(
+      (node) => `${node.id}@${node.measured?.width}x${node.measured?.height}`,
+    )
+    .join("|");
+  const [layoutSignature, setLayoutSignature] = useState("");
+
+  /**
+   * Node height is content-driven — spotlighting a run adds its side values, a
+   * status arriving adds a status tab — so positions computed for the previous
+   * heights leave nodes overlapping each other. Laying out again whenever a
+   * measured size changes keeps them apart, and since positions never feed back
+   * into sizes it settles in one pass.
+   */
+  useEffect(() => {
+    if (!initialized || sizeSignature === layoutSignature) return;
+    setNodes((current) => autoLayoutNodes(current, baseEdges) as MergedNode[]);
+    setLayoutSignature(sizeSignature);
+    setLaidOut(true);
+  }, [initialized, sizeSignature, layoutSignature, baseEdges, setNodes]);
+
+  useEffect(() => {
+    if (laidOut) {
+      fitView({ padding: 0.2, maxZoom: 1 });
+    }
+  }, [laidOut, fitView]);
+
+  /**
+   * Nodes outside the spotlighted run fade into the background. Where layout puts
+   * two of them on top of each other, a faded node winning the stack would hide
+   * the run the reader asked to see, so the spotlighted ones are lifted a layer.
+   */
+  const displayNodes: MergedNode[] = nodes.map((node) => {
+    const dimmed =
+      spotlight !== "both" && !nodeInRun(node.data.diff.status, spotlight);
+    return {
+      ...node,
+      data: { ...node.data, spotlight, singleRun },
+      zIndex: dimmed ? 0 : 1,
+      style: { ...node.style, opacity: dimmed ? 0.35 : 1 },
+    } as MergedNode;
+  });
+
+  const displayEdges = baseEdges.map((edge) => {
+    const membership = edge.data?.membership ?? "unchanged";
+    const dimmed = spotlight !== "both" && !edgeInRun(membership, spotlight);
+    return {
+      ...edge,
+      style: {
+        ...edge.style,
+        stroke: EDGE_STROKE[membership],
+        strokeWidth: 2,
+        opacity: dimmed ? 0.15 : 1,
+      },
+    };
+  });
+
+  const spotlightModes: {
+    value: SpotlightMode;
+    label: string;
+    title: string;
+  }[] = [
+    { value: "both", label: "Both", title: "Show both runs" },
+    { value: "a", label: "A", title: `Highlight run A · ${nameA}` },
+    { value: "b", label: "B", title: `Highlight run B · ${nameB}` },
+  ];
+
+  return (
+    <BlockStack gap="2" className="h-full w-full">
+      <InlineStack
+        align="space-between"
+        blockAlign="center"
+        gap="4"
+        wrap="wrap"
+        className="w-full"
+      >
+        <InlineStack gap="3" blockAlign="center" wrap="wrap">
+          {!singleRun && (
+            <InlineStack gap="1" blockAlign="center">
+              <Text as="span" size="sm" tone="subdued">
+                Highlight
+              </Text>
+              {spotlightModes.map(({ value, label, title }) => (
+                <Button
+                  key={value}
+                  size="sm"
+                  variant={spotlight === value ? "default" : "outline"}
+                  aria-pressed={spotlight === value}
+                  title={title}
+                  onClick={() => setSpotlight(value)}
+                  {...tracking("compare_runs.graph.highlight", { run: value })}
+                >
+                  {label}
+                </Button>
+              ))}
+            </InlineStack>
+          )}
+          <Text as="span" size="xs" tone="subdued">
+            {singleRun ? nameA || nameB : `A · ${nameA} vs B · ${nameB}`}
+          </Text>
+        </InlineStack>
+
+        {!singleRun && (
+          <InlineStack gap="3" blockAlign="center" wrap="wrap">
+            {LEGEND_ORDER.map((status) => (
+              <InlineStack key={status} gap="1" blockAlign="center">
+                <span
+                  className={cn("h-2.5 w-2.5 rounded-sm", SWATCH[status])}
+                />
+                <Text as="span" size="xs" tone="subdued">
+                  {diffStatusLabel(status, spotlight)}
+                </Text>
+              </InlineStack>
+            ))}
+          </InlineStack>
+        )}
+      </InlineStack>
+
+      <BlockStack
+        gap="0"
+        className="min-h-0 w-full flex-1 overflow-hidden rounded-lg border"
+      >
+        <ReactFlow
+          {...FLOW_CANVAS_DEFAULT_PROPS}
+          nodes={displayNodes}
+          edges={displayEdges}
+          nodeTypes={NODE_TYPES}
+          onNodesChange={onNodesChange}
+          onNodeClick={(_, node) => {
+            setSelectedNodeId(node.id);
+            track("compare_runs.graph.node.inspect", {
+              diff_status: base.find((candidate) => candidate.id === node.id)
+                ?.data.diff.status,
+            });
+          }}
+          nodesConnectable={false}
+          nodesDraggable={false}
+          edgesFocusable={false}
+          deleteKeyCode={null}
+          onPaneClick={() => setSelectedNodeId(null)}
+        >
+          <Background />
+          <Controls showInteractive={false} />
+          {singleRun && (
+            <Panel position="top-center">
+              <InlineStack
+                gap="2"
+                blockAlign="center"
+                wrap="nowrap"
+                className="rounded-full border bg-background/95 px-3 py-1 shadow-sm"
+              >
+                <Icon
+                  name="GitCompare"
+                  size="xs"
+                  className="text-muted-foreground"
+                />
+                <Text as="span" size="xs" tone="subdued">
+                  Select a second run to see what changed.
+                </Text>
+              </InlineStack>
+            </Panel>
+          )}
+          {spotlight !== "both" && (
+            <Panel position="top-left">
+              <InlineStack
+                gap="2"
+                blockAlign="center"
+                wrap="nowrap"
+                className={cn(
+                  "max-w-80 rounded-md border px-2 py-1 shadow-sm",
+                  RUN_TONE[spotlight],
+                )}
+              >
+                <Text
+                  as="span"
+                  size="xs"
+                  weight="bold"
+                  className="text-inherit"
+                >
+                  {spotlight === "a" ? labelA : labelB}
+                </Text>
+                <Text
+                  as="span"
+                  size="sm"
+                  weight="semibold"
+                  className="truncate text-inherit"
+                >
+                  {spotlight === "a" ? nameA : nameB}
+                </Text>
+              </InlineStack>
+            </Panel>
+          )}
+        </ReactFlow>
+      </BlockStack>
+
+      <Popover
+        open={selectedNode != null}
+        onOpenChange={(open) => {
+          if (!open) setSelectedNodeId(null);
+        }}
+      >
+        {selectedNodeId && <NodeScreenAnchor nodeId={selectedNodeId} />}
+        {selectedNode && (
+          <PopoverContent
+            side="top"
+            align="center"
+            sideOffset={12}
+            collisionPadding={12}
+            onOpenAutoFocus={(event) => event.preventDefault()}
+            className="max-h-96 w-80 overflow-y-auto overscroll-contain"
+          >
+            <BlockStack gap="3">
+              <InlineStack
+                align="space-between"
+                blockAlign="start"
+                gap="2"
+                className="w-full"
+              >
+                <Text as="span" size="sm" weight="semibold">
+                  {selectedNode.type === "mergedTask"
+                    ? taskDisplayName(selectedNode.data.diff)
+                    : selectedNode.data.diff.name}
+                </Text>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  aria-label="Close details"
+                  onClick={() => setSelectedNodeId(null)}
+                  className="-mt-2 -mr-2 size-7 shrink-0"
+                  {...tracking("compare_runs.graph.node.close")}
+                >
+                  <Icon name="X" size="sm" />
+                </Button>
+              </InlineStack>
+              {selectedNode.type === "mergedTask" ? (
+                <TaskDiffDetail
+                  diff={selectedNode.data.diff}
+                  labelA={labelA}
+                  labelB={labelB}
+                  nameA={nameA}
+                  nameB={nameB}
+                />
+              ) : (
+                <IoDiffDetail
+                  diff={selectedNode.data.diff}
+                  labelA={labelA}
+                  labelB={labelB}
+                />
+              )}
+            </BlockStack>
+          </PopoverContent>
+        )}
+      </Popover>
+    </BlockStack>
+  );
+}
+
+/**
+ * Mirrors a node's on-screen box as a fixed, invisible popover anchor, so the
+ * detail panel can be portalled to the body and overlay the page. A
+ * `NodeToolbar` can't: it portals inside the canvas, whose `overflow-hidden`
+ * clips it. Kept a separate component so the per-frame viewport subscription
+ * re-renders only the anchor while panning, not the canvas.
+ */
+function NodeScreenAnchor({ nodeId }: { nodeId: string }) {
+  const { zoom } = useViewport();
+  const { flowToScreenPosition, getInternalNode } = useReactFlow();
+
+  const node = getInternalNode(nodeId);
+  if (!node) return null;
+
+  const { x, y } = flowToScreenPosition(node.internals.positionAbsolute);
+
+  return (
+    <PopoverAnchor asChild>
+      <div
+        aria-hidden
+        className="pointer-events-none fixed"
+        style={{
+          left: x,
+          top: y,
+          width: (node.measured.width ?? 0) * zoom,
+          height: (node.measured.height ?? 0) * zoom,
+        }}
+      />
+    </PopoverAnchor>
+  );
+}

--- a/src/routes/v2/pages/CompareView/components/MergedIoNode.tsx
+++ b/src/routes/v2/pages/CompareView/components/MergedIoNode.tsx
@@ -1,0 +1,163 @@
+import { Handle, type Node, type NodeProps, Position } from "@xyflow/react";
+
+import { Icon } from "@/components/ui/icon";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
+import { cn } from "@/lib/utils";
+import type { MergedIoNodeData } from "@/routes/v2/pages/CompareView/utils/buildMergedGraph";
+import type { KeyedDiffEntry } from "@/routes/v2/pages/CompareView/utils/comparePipelines";
+import { ioDisplayStatus } from "@/routes/v2/pages/CompareView/utils/comparePipelines";
+import { formatDiffValue } from "@/routes/v2/pages/CompareView/utils/formatDiffValue";
+import { summarizeIoChange } from "@/routes/v2/pages/CompareView/utils/summarizeChange";
+
+import { DiffStatusBadge } from "./DiffStatusBadge";
+import { MEMBERSHIP_BORDER } from "./mergedNodeStyles";
+import { SideValues } from "./SideValues";
+
+/**
+ * Slight background tint hinting at the node's kind, echoing the blue inputs /
+ * violet outputs of the editor and run views so they read at a glance.
+ */
+const KIND_TINT: Record<"input" | "output", string> = {
+  input: "bg-blue-50 dark:bg-blue-950/40",
+  output: "bg-violet-50 dark:bg-violet-950/40",
+};
+
+const MAX_IO_FIELDS = 2;
+const LONG_IO_VALUE = 22;
+
+function ioFieldLabel(key: string): string {
+  return key === "default" || key === "value" ? "value" : key;
+}
+
+/**
+ * Compact rendering of what changed on an input/output between the two runs.
+ * Short scalar changes are shown as a `before → after` transition (before
+ * struck through); anything too long collapses to a "<field> changed" label.
+ */
+function IoFieldChanges({ fields }: { fields: KeyedDiffEntry<unknown>[] }) {
+  const shown = fields.slice(0, MAX_IO_FIELDS);
+  const remaining = fields.length - shown.length;
+
+  return (
+    <BlockStack gap="0" className="w-full">
+      {shown.map((entry) => {
+        const before = formatDiffValue(entry.a);
+        const after = formatDiffValue(entry.b);
+        const label = ioFieldLabel(entry.key);
+        const fits = before.length + after.length <= LONG_IO_VALUE;
+        return (
+          <Text
+            key={entry.key}
+            as="span"
+            size="xs"
+            tone="subdued"
+            className={cn("w-full truncate", fits && "font-mono")}
+            title={`${label}: ${before} → ${after}`}
+          >
+            {fits ? (
+              <>
+                <span className="line-through opacity-70">{before}</span> →{" "}
+                {after}
+              </>
+            ) : (
+              `${label} changed`
+            )}
+          </Text>
+        );
+      })}
+      {remaining > 0 && (
+        <Text as="span" size="xs" tone="subdued">
+          +{remaining} more
+        </Text>
+      )}
+    </BlockStack>
+  );
+}
+
+type MergedIoNodeType = Node<MergedIoNodeData, "mergedIo">;
+
+export function MergedIoNode({ data }: NodeProps<MergedIoNodeType>) {
+  const { diff, spotlight, singleRun } = data;
+  const isInput = diff.kind === "input";
+  const changedFields = diff.fieldDiffs.filter(
+    (entry) => entry.status !== "unchanged",
+  );
+  const side = spotlight === "b" ? "b" : "a";
+  const displayStatus = ioDisplayStatus(diff);
+  const showSideValues = spotlight !== "both" && changedFields.length > 0;
+  const changeSummary =
+    displayStatus === "changed" ? summarizeIoChange(diff) : "";
+  const showFieldChanges =
+    !showSideValues &&
+    diff.status === "changed" &&
+    changedFields.length > 0 &&
+    changeSummary !== "source rewired";
+
+  return (
+    <BlockStack
+      gap="1"
+      className={cn(
+        "relative w-44 rounded-2xl border-2 px-4 py-2",
+        KIND_TINT[isInput ? "input" : "output"],
+        MEMBERSHIP_BORDER[displayStatus],
+      )}
+    >
+      <InlineStack
+        align="space-between"
+        blockAlign="center"
+        gap="2"
+        className="w-full"
+      >
+        <InlineStack gap="1" blockAlign="center" wrap="nowrap">
+          <Icon
+            name={isInput ? "ArrowRightToLine" : "ArrowRightFromLine"}
+            size="xs"
+            className="text-muted-foreground"
+          />
+          <Text
+            as="span"
+            size="xs"
+            tone="subdued"
+            weight="semibold"
+            className="uppercase"
+          >
+            {isInput ? "Input" : "Output"}
+          </Text>
+        </InlineStack>
+        {!singleRun && (
+          <DiffStatusBadge status={displayStatus} spotlight={spotlight} />
+        )}
+      </InlineStack>
+
+      <Text as="span" size="sm" weight="semibold" className="wrap-break-word">
+        {diff.name}
+      </Text>
+      {showSideValues ? (
+        <SideValues fields={changedFields} side={side} />
+      ) : showFieldChanges ? (
+        <IoFieldChanges fields={changedFields} />
+      ) : (
+        changeSummary && (
+          <Text as="span" size="xs" tone="subdued">
+            {changeSummary}
+          </Text>
+        )
+      )}
+
+      {isInput ? (
+        <Handle
+          type="source"
+          position={Position.Right}
+          className="border-0! bg-gray-500!"
+        />
+      ) : (
+        <Handle
+          type="target"
+          position={Position.Left}
+          className="border-0! bg-gray-500!"
+        />
+      )}
+    </BlockStack>
+  );
+}

--- a/src/routes/v2/pages/CompareView/components/MergedTaskNode.tsx
+++ b/src/routes/v2/pages/CompareView/components/MergedTaskNode.tsx
@@ -1,0 +1,187 @@
+import { Handle, type Node, type NodeProps, Position } from "@xyflow/react";
+import type { ReactNode } from "react";
+
+import { trimDigest } from "@/components/shared/ManageComponent/utils/digest";
+import { StatusTab } from "@/components/shared/ReactFlow/FlowCanvas/TaskNode/StatusIndicator";
+import { Icon } from "@/components/ui/icon";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { QuickTooltip } from "@/components/ui/tooltip";
+import { Text } from "@/components/ui/typography";
+import { cn } from "@/lib/utils";
+import type { MergedTaskNodeData } from "@/routes/v2/pages/CompareView/utils/buildMergedGraph";
+import { summarizeTaskChange } from "@/routes/v2/pages/CompareView/utils/summarizeChange";
+
+import { DiffStatusBadge } from "./DiffStatusBadge";
+import { MEMBERSHIP_BORDER } from "./mergedNodeStyles";
+import { SideValues } from "./SideValues";
+
+function StatusTabRow({ children }: { children: ReactNode }) {
+  return (
+    <InlineStack
+      gap="1"
+      blockAlign="start"
+      wrap="nowrap"
+      className="absolute -top-5 left-0 right-0 w-full -z-1"
+    >
+      {children}
+    </InlineStack>
+  );
+}
+
+type MergedTaskNodeType = Node<MergedTaskNodeData, "mergedTask">;
+
+export function MergedTaskNode({ data }: NodeProps<MergedTaskNodeType>) {
+  const { diff, spotlight, singleRun } = data;
+
+  const spotlightSide = spotlight === "b" ? "b" : "a";
+  const side = spotlight === "b" ? diff.b : diff.a;
+  const name =
+    side?.componentRef.spec?.name ??
+    diff.a?.componentRef.spec?.name ??
+    diff.b?.componentRef.spec?.name ??
+    diff.taskId;
+
+  const changeSummary =
+    diff.status === "changed" ? summarizeTaskChange(diff) : "";
+
+  const changedArgs = diff.argumentDiffs.filter(
+    (entry) => entry.status !== "unchanged",
+  );
+  const showSideValues = spotlight !== "both" && changedArgs.length > 0;
+
+  const { componentChanged } = diff;
+  const sideDigest =
+    (spotlight === "b" ? diff.digestB : diff.digestA) ??
+    diff.digestA ??
+    diff.digestB;
+  const digestFull =
+    componentChanged && diff.digestA && diff.digestB
+      ? `A: ${diff.digestA}\nB: ${diff.digestB}`
+      : sideDigest;
+  const digestDisplay =
+    componentChanged && diff.digestA && diff.digestB
+      ? `${trimDigest(diff.digestA)} → ${trimDigest(diff.digestB)}`
+      : sideDigest
+        ? trimDigest(sideDigest)
+        : undefined;
+
+  const cacheDisabled =
+    spotlight === "b" ? diff.cacheDisabledB : diff.cacheDisabledA;
+  const showCacheIcon = cacheDisabled || diff.cacheChanged;
+  const cacheTooltip = diff.cacheChanged
+    ? `Caching ${diff.cacheDisabledA ? "off" : "on"} in A, ${diff.cacheDisabledB ? "off" : "on"} in B`
+    : "Caching disabled";
+
+  const statusA = spotlight === "b" ? undefined : diff.statusA;
+  const statusB = spotlight === "a" ? undefined : diff.statusB;
+  const singleStatus = diff.statusA ?? diff.statusB;
+
+  return (
+    <BlockStack
+      gap="1"
+      className={cn(
+        "relative w-64 rounded-lg border-2 bg-background px-3 py-2",
+        MEMBERSHIP_BORDER[diff.status],
+      )}
+    >
+      {singleRun
+        ? singleStatus && (
+            <StatusTabRow>
+              <StatusTab status={singleStatus} className="min-w-0" />
+            </StatusTabRow>
+          )
+        : (statusA || statusB) && (
+            <StatusTabRow>
+              {statusA ? (
+                <StatusTab
+                  status={statusA}
+                  label="A"
+                  className="min-w-0 flex-1"
+                />
+              ) : (
+                <div className="flex-1" />
+              )}
+              {statusB ? (
+                <StatusTab
+                  status={statusB}
+                  label="B"
+                  className="min-w-0 flex-1"
+                />
+              ) : (
+                <div className="flex-1" />
+              )}
+            </StatusTabRow>
+          )}
+
+      <InlineStack
+        align="space-between"
+        blockAlign="center"
+        gap="1"
+        wrap="nowrap"
+        className="w-full"
+      >
+        <InlineStack
+          gap="1"
+          blockAlign="center"
+          wrap="nowrap"
+          className="shrink-0"
+        >
+          {!singleRun && (
+            <DiffStatusBadge status={diff.status} spotlight={spotlight} />
+          )}
+          {showCacheIcon && (
+            <QuickTooltip content={cacheTooltip}>
+              <Icon
+                name="ZapOff"
+                size="xs"
+                className={cn(
+                  "shrink-0",
+                  diff.cacheChanged ? "text-diff-changed" : "text-orange-400",
+                )}
+              />
+            </QuickTooltip>
+          )}
+        </InlineStack>
+        {digestDisplay && (
+          <QuickTooltip content={digestFull ?? digestDisplay}>
+            <Text
+              as="span"
+              size="xs"
+              tone="subdued"
+              className="max-w-[60%] truncate font-mono"
+            >
+              {digestDisplay}
+            </Text>
+          </QuickTooltip>
+        )}
+      </InlineStack>
+
+      <Text as="span" size="sm" weight="semibold" className="wrap-break-word">
+        {name}
+      </Text>
+      <Text as="span" size="xs" tone="subdued" className="font-mono break-all">
+        {diff.taskId}
+      </Text>
+      {showSideValues ? (
+        <SideValues fields={changedArgs} side={spotlightSide} />
+      ) : (
+        changeSummary && (
+          <Text as="span" size="xs" tone="subdued">
+            {changeSummary}
+          </Text>
+        )
+      )}
+
+      <Handle
+        type="target"
+        position={Position.Left}
+        className="border-0! bg-gray-500!"
+      />
+      <Handle
+        type="source"
+        position={Position.Right}
+        className="border-0! bg-gray-500!"
+      />
+    </BlockStack>
+  );
+}

--- a/src/routes/v2/pages/CompareView/components/SideValues.tsx
+++ b/src/routes/v2/pages/CompareView/components/SideValues.tsx
@@ -1,0 +1,46 @@
+import { BlockStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
+import type { KeyedDiffEntry } from "@/routes/v2/pages/CompareView/utils/comparePipelines";
+import { formatDiffValue } from "@/routes/v2/pages/CompareView/utils/formatDiffValue";
+
+const MAX_SIDE_VALUES = 4;
+
+interface SideValuesProps {
+  fields: KeyedDiffEntry<unknown>[];
+  side: "a" | "b";
+}
+
+/**
+ * Compact, single-line-per-field rendering of one run's values, used when the
+ * graph is spotlighting run A or B so nodes show that side's actual values
+ * instead of an aggregate "N fields changed" summary.
+ */
+export function SideValues({ fields, side }: SideValuesProps) {
+  const shown = fields.slice(0, MAX_SIDE_VALUES);
+  const remaining = fields.length - shown.length;
+
+  return (
+    <BlockStack gap="0" className="w-full">
+      {shown.map((entry) => {
+        const value = formatDiffValue(side === "b" ? entry.b : entry.a);
+        return (
+          <Text
+            key={entry.key}
+            as="span"
+            size="xs"
+            tone="subdued"
+            className="w-full truncate font-mono"
+            title={`${entry.key}: ${value}`}
+          >
+            <span className="font-semibold">{entry.key}:</span> {value}
+          </Text>
+        );
+      })}
+      {remaining > 0 && (
+        <Text as="span" size="xs" tone="subdued">
+          +{remaining} more
+        </Text>
+      )}
+    </BlockStack>
+  );
+}

--- a/src/routes/v2/pages/CompareView/components/mergedNodeStyles.ts
+++ b/src/routes/v2/pages/CompareView/components/mergedNodeStyles.ts
@@ -1,0 +1,8 @@
+import type { DiffStatus } from "@/utils/diffStatus";
+
+export const MEMBERSHIP_BORDER: Record<DiffStatus, string> = {
+  unchanged: "border-diff-unchanged",
+  lost: "border-diff-lost",
+  new: "border-diff-new",
+  changed: "border-diff-changed",
+};

--- a/src/routes/v2/pages/CompareView/utils/buildMergedGraph.ts
+++ b/src/routes/v2/pages/CompareView/utils/buildMergedGraph.ts
@@ -24,6 +24,7 @@ export interface MergedTaskNodeData extends Record<string, unknown> {
 export interface MergedIoNodeData extends Record<string, unknown> {
   diff: IoDiff;
   spotlight: SpotlightMode;
+  singleRun?: boolean;
 }
 
 type MergedTaskNode = Node<MergedTaskNodeData, "mergedTask">;


### PR DESCRIPTION
## Description

Seventh PR in the **Compare Runs** stack. Adds the **Graph** view — a visual, side-by-side-in-one-canvas take on the comparison.

It renders the merged graph (from #2597) with colour-coded nodes and edges: green for added, red for removed, amber for changed, grey for unchanged, plus a legend. Nodes show each task's status, digest and a short change summary; clicking one opens a detail popover reusing the same task/IO diff detail from the Structured view. A **Highlight A / B / Both** control dims everything not present in the chosen run and switches nodes to show that run's actual values.

Also refactors the run view's status indicator to extract a reusable `StatusTab` so the merged task nodes can show per-run (A/B) status tabs.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

Part of the Compare Runs stack. Builds on #2601; the final PR (#2603) builds on this branch.

## Type of Change

- [x] New feature
- [x] Cleanup/Refactor

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Add screenshots of the graph tab: the merged graph with legend, a node detail popover, and the A/B highlight modes. -->

## Test Instructions

Reachable once the stack is wired up (#2603).

- Check out the top of the stack, enable the **Compare runs** beta flag, and compare two runs.
- On the **Graph** tab, confirm:
  - The merged graph lays out and node/edge colours match the legend (added / removed / changed / unchanged).
  - Clicking a node opens its detail popover; clicking the background closes it.
  - **Highlight A / B / Both** dims the other run and shows the highlighted run's values.
- Regression check the refactor: open a normal run's graph and confirm task status indicators (including the cache-disabled state) still render as before.

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
