### PR TITLE
feat: run comparison - compare page, run selection & routing

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -7,8 +7,7 @@
     "src/components/ui/**",
     "src/config/announcements.ts",
     "src/config/preSubmitHooks.ts",
-    "src/components/shared/BetaFeatureWrapper/BetaFeatureWrapper.tsx",
-    "src/routes/v2/pages/CompareView/**"
+    "src/components/shared/BetaFeatureWrapper/BetaFeatureWrapper.tsx"
   ],
   "ignoreDependencies": [
     "@tanstack/react-query-devtools",

--- a/react-compiler.config.js
+++ b/react-compiler.config.js
@@ -42,6 +42,7 @@ export const REACT_COMPILER_ENABLED_DIRS = [
   "src/hooks/useContainerLog.ts",
   "src/hooks/usePipelineRunList.ts",
   "src/components/shared/FavoriteToggle.tsx",
+  "src/components/shared/FloatingSelectionBar.tsx",
   "src/components/shared/ComponentLifecycleBadges.tsx",
   "src/components/shared/ComponentSearchEmptyStateSuggestions.tsx",
   "src/components/shared/EditorV2WelcomeSpotlight.tsx",

--- a/src/components/Home/PipelineSection/BulkActionsBar.tsx
+++ b/src/components/Home/PipelineSection/BulkActionsBar.tsx
@@ -1,7 +1,7 @@
 import { ConfirmationDialog } from "@/components/shared/Dialogs";
+import { FloatingSelectionBar } from "@/components/shared/FloatingSelectionBar";
 import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
-import { InlineStack } from "@/components/ui/layout";
 import useToastNotification from "@/hooks/useToastNotification";
 import { deletePipeline } from "@/services/pipelineService";
 import { getErrorMessage, pluralize } from "@/utils/string";
@@ -38,33 +38,24 @@ const BulkActionsBar = ({
   };
 
   return (
-    <div className="fixed bottom-4 left-1/2 transform -translate-x-1/2 bg-background border border-border rounded-lg shadow-lg p-4 z-50">
-      <InlineStack gap="4">
-        <span className="text-sm font-medium">
-          {selectedPipelines.length}{" "}
-          {pluralize(selectedPipelines.length, "pipeline")} selected
-        </span>
-
-        <InlineStack gap="2">
-          <ConfirmationDialog
-            trigger={
-              <Button variant="destructive" size="sm">
-                <Icon name="Trash2" />
-                Delete {selectedPipelines.length}{" "}
-                {pluralize(selectedPipelines.length, "item")}
-              </Button>
-            }
-            title={`Delete ${selectedPipelines.length} ${pluralize(selectedPipelines.length, "pipeline")}?`}
-            description={`Are you sure you want to delete ${selectedPipelines.length === 1 ? "this pipeline" : "these pipelines"}? Existing pipeline runs will not be impacted. This action cannot be undone.`}
-            onConfirm={handleBulkDelete}
-          />
-
-          <Button variant="ghost" size="sm" onClick={onClearSelection}>
-            <Icon name="X" />
+    <FloatingSelectionBar
+      count={selectedPipelines.length}
+      itemNoun="pipeline"
+      onClear={onClearSelection}
+    >
+      <ConfirmationDialog
+        trigger={
+          <Button variant="destructive" size="sm">
+            <Icon name="Trash2" />
+            Delete {selectedPipelines.length}{" "}
+            {pluralize(selectedPipelines.length, "item")}
           </Button>
-        </InlineStack>
-      </InlineStack>
-    </div>
+        }
+        title={`Delete ${selectedPipelines.length} ${pluralize(selectedPipelines.length, "pipeline")}?`}
+        description={`Are you sure you want to delete ${selectedPipelines.length === 1 ? "this pipeline" : "these pipelines"}? Existing pipeline runs will not be impacted. This action cannot be undone.`}
+        onConfirm={handleBulkDelete}
+      />
+    </FloatingSelectionBar>
   );
 };
 

--- a/src/components/Home/RunSection/RunBulkActionsBar.tsx
+++ b/src/components/Home/RunSection/RunBulkActionsBar.tsx
@@ -1,0 +1,49 @@
+import { useNavigate } from "@tanstack/react-router";
+
+import { FloatingSelectionBar } from "@/components/shared/FloatingSelectionBar";
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icon";
+import { APP_ROUTES } from "@/routes/appRoutes";
+import { tracking } from "@/utils/tracking";
+
+interface RunBulkActionsBarProps {
+  selectedRuns: string[];
+  onClearSelection: () => void;
+}
+
+const RunBulkActionsBar = ({
+  selectedRuns,
+  onClearSelection,
+}: RunBulkActionsBarProps) => {
+  const navigate = useNavigate();
+
+  const canCompare = selectedRuns.length === 2;
+
+  const handleCompare = () => {
+    if (!canCompare) return;
+    const [a, b] = selectedRuns;
+    navigate({ to: APP_ROUTES.COMPARE, search: { a, b } });
+  };
+
+  return (
+    <FloatingSelectionBar
+      count={selectedRuns.length}
+      itemNoun="run"
+      onClear={onClearSelection}
+    >
+      <Button
+        variant="default"
+        size="sm"
+        onClick={handleCompare}
+        disabled={!canCompare}
+        title={canCompare ? undefined : "Select exactly 2 runs to compare"}
+        {...tracking("compare_runs.dashboard.compare_selected")}
+      >
+        <Icon name="GitCompare" />
+        Compare
+      </Button>
+    </FloatingSelectionBar>
+  );
+};
+
+export default RunBulkActionsBar;

--- a/src/components/Home/RunSection/RunRow.tsx
+++ b/src/components/Home/RunSection/RunRow.tsx
@@ -10,6 +10,7 @@ import { RunSourceIcon } from "@/components/shared/RunSource";
 import { StatusBar, StatusIcon } from "@/components/shared/Status";
 import { TagList } from "@/components/shared/Tags/TagList";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Icon } from "@/components/ui/icon";
 import { InlineStack } from "@/components/ui/layout";
 import { TableCell, TableRow } from "@/components/ui/table";
@@ -37,9 +38,18 @@ import { tracking } from "@/utils/tracking";
 interface RunRowProps {
   run: PipelineRunResponse;
   onFilterByUser?: (createdBy: string) => void;
+  selectable?: boolean;
+  isSelected?: boolean;
+  onToggleSelected?: (runId: string) => void;
 }
 
-const RunRow = ({ run, onFilterByUser }: RunRowProps) => {
+const RunRow = ({
+  run,
+  onFilterByUser,
+  selectable = false,
+  isSelected = false,
+  onToggleSelected,
+}: RunRowProps) => {
   const navigate = useNavigate();
   const { backendUrl } = useBackend();
   const notify = useToastNotification();
@@ -122,6 +132,20 @@ const RunRow = ({ run, onFilterByUser }: RunRowProps) => {
       onClick={handleRowClick}
       className="cursor-pointer text-muted-foreground text-xs h-10"
     >
+      {selectable && (
+        <TableCell className="w-8">
+          <div
+            onClick={(e) => e.stopPropagation()}
+            className="flex items-center"
+          >
+            <Checkbox
+              checked={isSelected}
+              onCheckedChange={() => onToggleSelected?.(runId)}
+              aria-label={`Select run ${runId}`}
+            />
+          </div>
+        </TableCell>
+      )}
       <TableCell>
         <InlineStack gap="2" blockAlign="center" wrap="nowrap">
           <StatusIcon status={overallStatus} />

--- a/src/components/Home/RunSection/RunSection.tsx
+++ b/src/components/Home/RunSection/RunSection.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import { InfoBox } from "@/components/shared/InfoBox";
 import { useFlagValue } from "@/components/shared/Settings/useFlags";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Icon } from "@/components/ui/icon";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -27,6 +28,7 @@ import {
   parseFilterParam,
 } from "@/utils/pipelineRunFilterUtils";
 
+import RunBulkActionsBar from "./RunBulkActionsBar";
 import RunRow from "./RunRow";
 
 const CREATED_BY_ME_FILTER = "created_by:me";
@@ -51,8 +53,23 @@ export const RunSection = ({
   const { pathname } = useLocation();
   const search = useSearch({ strict: false }) as RunSectionSearch;
   const isCreatedByMeDefault = useFlagValue("created-by-me-default");
+  const compareEnabled = useFlagValue("compare-runs");
   const { setFilter } = useRunSearchParams();
   const dataVersion = useRef(0);
+
+  const [selectedRuns, setSelectedRuns] = useState<Set<string>>(new Set());
+
+  const toggleRun = (runId: string) => {
+    setSelectedRuns((prev) => {
+      const next = new Set(prev);
+      if (next.has(runId)) {
+        next.delete(runId);
+      } else {
+        next.add(runId);
+      }
+      return next;
+    });
+  };
 
   const onFilterByUser = forcedFilter
     ? undefined
@@ -258,12 +275,42 @@ export const RunSection = ({
     );
   }
 
+  const pageRuns = maxItems
+    ? data.pipeline_runs?.slice(0, maxItems)
+    : data.pipeline_runs;
+
+  const allPageRunsSelected =
+    !!pageRuns?.length &&
+    pageRuns.every((run) => selectedRuns.has(`${run.id}`));
+
+  const toggleSelectAll = () => {
+    setSelectedRuns((prev) => {
+      const next = new Set(prev);
+      const pageRunIds = pageRuns?.map((run) => `${run.id}`) ?? [];
+      if (allPageRunsSelected) {
+        pageRunIds.forEach((id) => next.delete(id));
+      } else {
+        pageRunIds.forEach((id) => next.add(id));
+      }
+      return next;
+    });
+  };
+
   return (
     <BlockStack gap="4">
       {searchMarkup}
       <Table>
         <TableHeader>
           <TableRow className="text-xs">
+            {compareEnabled && (
+              <TableHead className="w-8">
+                <Checkbox
+                  checked={allPageRunsSelected}
+                  onCheckedChange={toggleSelectAll}
+                  aria-label="Select all runs on this page"
+                />
+              </TableHead>
+            )}
             <TableHead className="w-1/4">Name</TableHead>
             <TableHead className="w-1/4">Status</TableHead>
             <TableHead className="w-3/20">Date</TableHead>
@@ -272,14 +319,25 @@ export const RunSection = ({
           </TableRow>
         </TableHeader>
         <TableBody>
-          {(maxItems
-            ? data.pipeline_runs?.slice(0, maxItems)
-            : data.pipeline_runs
-          )?.map((run) => (
-            <RunRow key={run.id} run={run} onFilterByUser={onFilterByUser} />
+          {pageRuns?.map((run) => (
+            <RunRow
+              key={run.id}
+              run={run}
+              onFilterByUser={onFilterByUser}
+              selectable={compareEnabled}
+              isSelected={selectedRuns.has(`${run.id}`)}
+              onToggleSelected={toggleRun}
+            />
           ))}
         </TableBody>
       </Table>
+
+      {compareEnabled && selectedRuns.size > 0 && (
+        <RunBulkActionsBar
+          selectedRuns={Array.from(selectedRuns)}
+          onClearSelection={() => setSelectedRuns(new Set())}
+        />
+      )}
 
       {(data.next_page_token || previousPageTokens.length > 0) && (
         <InlineStack

--- a/src/components/shared/FloatingSelectionBar.tsx
+++ b/src/components/shared/FloatingSelectionBar.tsx
@@ -1,0 +1,54 @@
+import type { ReactNode } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icon";
+import { InlineStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
+import { pluralize } from "@/utils/string";
+import { tracking } from "@/utils/tracking";
+
+interface FloatingSelectionBarProps {
+  count: number;
+  itemNoun: string;
+  onClear: () => void;
+  clearTrackingId?: string;
+  children: ReactNode;
+}
+
+/**
+ * The bar that floats over a table while rows are selected. Three tables grew
+ * their own copy of the same shell, so it lives here — the positioning, the
+ * "N selected" count and the clear button are identical everywhere, and only
+ * the actions differ.
+ */
+export function FloatingSelectionBar({
+  count,
+  itemNoun,
+  onClear,
+  clearTrackingId,
+  children,
+}: FloatingSelectionBarProps) {
+  if (count === 0) return null;
+
+  return (
+    <div className="fixed bottom-4 left-1/2 z-50 -translate-x-1/2 rounded-lg border border-border bg-background p-4 shadow-lg">
+      <InlineStack gap="4" blockAlign="center">
+        <Text size="sm" weight="semibold">
+          {count} {pluralize(count, itemNoun)} selected
+        </Text>
+        <InlineStack gap="2" blockAlign="center">
+          {children}
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onClear}
+            aria-label="Clear selection"
+            {...(clearTrackingId ? tracking(clearTrackingId) : {})}
+          >
+            <Icon name="X" />
+          </Button>
+        </InlineStack>
+      </InlineStack>
+    </div>
+  );
+}

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -78,4 +78,12 @@ export const ExistingFlags: ConfigFlags = {
     default: false,
     category: "beta",
   },
+
+  ["compare-runs"]: {
+    name: "Compare runs",
+    description:
+      "Select two runs to compare their pipeline structure and results side by side.",
+    default: false,
+    category: "beta",
+  },
 };

--- a/src/routes/appRoutes.ts
+++ b/src/routes/appRoutes.ts
@@ -46,4 +46,5 @@ export const APP_ROUTES = {
   PIPELINE_FOLDERS: "/pipeline-folders",
   PLAYGROUND: "/playground",
   ARTIFACT_PREVIEW: "/artifact/$artifactId",
+  COMPARE: "/compare",
 } as const;

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -44,6 +44,7 @@ import { BetaFeaturesSettings } from "./Settings/sections/BetaFeaturesSettings";
 import { PreferencesSettings } from "./Settings/sections/PreferencesSettings";
 import { SecretsSettings } from "./Settings/sections/SecretsSettings";
 import { SettingsLayout } from "./Settings/SettingsLayout";
+import { CompareView } from "./v2/pages/CompareView/CompareView";
 import { EditorV2 } from "./v2/pages/Editor/EditorV2";
 import { PipelineFoldersPage } from "./v2/pages/PipelineFolders/PipelineFoldersPage";
 import { RunViewV2 } from "./v2/pages/RunView/RunViewV2";
@@ -363,6 +364,17 @@ const runV2WithSubgraphRoute = createRoute({
   },
 });
 
+const compareRoute = createRoute({
+  getParentRoute: () => mainLayout,
+  path: APP_ROUTES.COMPARE,
+  component: CompareView,
+  beforeLoad: () => {
+    if (!isFlagEnabled("compare-runs")) {
+      throw redirect({ to: APP_ROUTES.DASHBOARD_RUNS });
+    }
+  },
+});
+
 const pipelineFoldersRoute = createRoute({
   getParentRoute: () => mainLayout,
   path: APP_ROUTES.PIPELINE_FOLDERS,
@@ -403,6 +415,7 @@ const appRouteTree = mainLayout.addChildren([
   editorV2PipelineRoute,
   runV2Route,
   runV2WithSubgraphRoute,
+  compareRoute,
   pipelineFoldersRoute,
   artifactPreviewRoute,
   tourRoute,

--- a/src/routes/v2/pages/CompareView/CompareView.tsx
+++ b/src/routes/v2/pages/CompareView/CompareView.tsx
@@ -1,0 +1,294 @@
+import { useNavigate, useSearch } from "@tanstack/react-router";
+import { type ReactNode, useEffect, useState } from "react";
+
+import { InfoBox } from "@/components/shared/InfoBox";
+import { RemoteAuthErrorView } from "@/components/shared/RemoteAuthErrorView";
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icon";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Spinner } from "@/components/ui/spinner";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Heading, Text } from "@/components/ui/typography";
+import useToastNotification from "@/hooks/useToastNotification";
+import { cn } from "@/lib/utils";
+import { useAnalytics } from "@/providers/AnalyticsProvider";
+import { APP_ROUTES } from "@/routes/appRoutes";
+import { RemoteAuthError } from "@/utils/fetchWithErrorHandling";
+import { copyToClipboard } from "@/utils/string";
+import { tracking } from "@/utils/tracking";
+
+import { GraphDiffView } from "./components/GraphDiffView";
+import { RunMetadataSection } from "./components/RunMetadataSection";
+import { RunSwitcher } from "./components/RunSwitcher";
+import { StructuredDiffView } from "./components/StructuredDiffView";
+import { YamlDiffView } from "./components/YamlDiffView";
+import { useRunComparisonSide } from "./hooks/useRunComparisonSide";
+import { compareMode } from "./utils/compareMode";
+import { buildPipelineComparison } from "./utils/comparePipelines";
+import {
+  type CompareSearch,
+  validateCompareSearch,
+} from "./utils/compareSearch";
+
+const LABEL_A = "A";
+const LABEL_B = "B";
+
+export function CompareView() {
+  const search = validateCompareSearch(useSearch({ strict: false }));
+  const navigate = useNavigate();
+  const { track } = useAnalytics();
+  const notify = useToastNotification();
+
+  const a = search.a ?? "";
+  const b = search.b ?? "";
+
+  const sideA = useRunComparisonSide(a);
+  const sideB = useRunComparisonSide(b);
+
+  const mode = compareMode(a, b);
+
+  const [activeTab, setActiveTab] = useState("structured");
+
+  useEffect(() => {
+    if (mode.kind === "both") {
+      track("compare_runs.comparison.impression", { run_a: a, run_b: b });
+    }
+  }, [mode.kind, a, b, track]);
+
+  // With one run selected we compare it against itself, so every task reads as
+  // unchanged and the views render that run's graph instead of an empty diff.
+  const selected = mode.kind === "single" && mode.side === "b" ? sideB : sideA;
+  const comparison =
+    mode.kind === "single"
+      ? buildPipelineComparison(selected, selected)
+      : buildPipelineComparison(sideA, sideB);
+
+  const nameA = a ? (sideA.spec?.name ?? `Run #${a}`) : undefined;
+  const nameB = b ? (sideB.spec?.name ?? `Run #${b}`) : undefined;
+
+  const setSide = (side: "a" | "b", id: string) => {
+    navigate({
+      to: APP_ROUTES.COMPARE,
+      search: (prev: CompareSearch) => ({ ...prev, [side]: id }),
+    });
+  };
+
+  const clearSide = (side: "a" | "b") => {
+    navigate({
+      to: APP_ROUTES.COMPARE,
+      search: (prev: CompareSearch) => {
+        const next = { ...prev };
+        delete next[side];
+        return next;
+      },
+    });
+  };
+
+  const authError = [sideA.error, sideB.error].find(
+    (candidate) => candidate instanceof RemoteAuthError,
+  );
+  if (authError) {
+    return <RemoteAuthErrorView />;
+  }
+
+  const contentError = sideA.error ?? sideB.error ?? null;
+  const contentLoading =
+    (Boolean(a) && sideA.isLoading) || (Boolean(b) && sideB.isLoading);
+
+  return (
+    <PageShell>
+      <InlineStack
+        align="space-between"
+        blockAlign="center"
+        gap="4"
+        className="w-full"
+      >
+        <InlineStack gap="3" blockAlign="center" wrap="wrap">
+          <Heading level={2}>Compare runs</Heading>
+          <RunSwitcher
+            label={LABEL_A}
+            side="a"
+            runId={a || undefined}
+            name={nameA}
+            excludeRunId={b || undefined}
+            onSelect={(id) => setSide("a", id)}
+            onClear={() => clearSide("a")}
+          />
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label="Swap runs"
+            disabled={mode.kind !== "both"}
+            onClick={() =>
+              navigate({
+                to: APP_ROUTES.COMPARE,
+                search: { a: b, b: a },
+              })
+            }
+            {...tracking("compare_runs.comparison.swap")}
+          >
+            <Icon name="ArrowLeftRight" size="sm" />
+          </Button>
+          <RunSwitcher
+            label={LABEL_B}
+            side="b"
+            runId={b || undefined}
+            name={nameB}
+            excludeRunId={a || undefined}
+            onSelect={(id) => setSide("b", id)}
+            onClear={() => clearSide("b")}
+          />
+        </InlineStack>
+        <InlineStack gap="1" blockAlign="center" wrap="nowrap">
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label="Copy link to this comparison"
+            onClick={() => {
+              copyToClipboard(window.location.href);
+              notify("Link copied to clipboard", "success");
+            }}
+            {...tracking("compare_runs.comparison.share")}
+          >
+            <Icon name="Share2" size="sm" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label="Close comparison"
+            onClick={() => navigate({ to: APP_ROUTES.DASHBOARD_RUNS })}
+            {...tracking("compare_runs.comparison.close")}
+          >
+            <Icon name="X" size="sm" />
+          </Button>
+        </InlineStack>
+      </InlineStack>
+
+      <RunMetadataSection
+        a={{
+          createdBy: sideA.createdBy,
+          createdAt: sideA.createdAt,
+          status: sideA.status,
+          durationMs: sideA.durationMs,
+          annotations: sideA.runAnnotations,
+          arguments: sideA.runArguments,
+        }}
+        b={{
+          createdBy: sideB.createdBy,
+          createdAt: sideB.createdAt,
+          status: sideB.status,
+          durationMs: sideB.durationMs,
+          annotations: sideB.runAnnotations,
+          arguments: sideB.runArguments,
+        }}
+        labelA={LABEL_A}
+        labelB={LABEL_B}
+        mode={mode}
+      />
+
+      {contentError ? (
+        <InfoBox title="Error loading runs" variant="error" width="full">
+          {contentError.message}
+        </InfoBox>
+      ) : contentLoading ? (
+        <InlineStack
+          align="center"
+          blockAlign="center"
+          gap="2"
+          className="w-full flex-1"
+        >
+          <Spinner /> <Text>Loading runs…</Text>
+        </InlineStack>
+      ) : (
+        <Tabs
+          value={activeTab}
+          onValueChange={setActiveTab}
+          className="flex-1 min-h-0 w-full"
+        >
+          <TabsList>
+            <TabsTrigger
+              value="structured"
+              {...tracking("compare_runs.tab.structured")}
+            >
+              Structured
+            </TabsTrigger>
+            <TabsTrigger value="yaml" {...tracking("compare_runs.tab.yaml")}>
+              YAML
+            </TabsTrigger>
+            <TabsTrigger value="graph" {...tracking("compare_runs.tab.graph")}>
+              Graph
+            </TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="structured" className="min-h-0 overflow-auto">
+            <StructuredDiffView
+              comparison={comparison}
+              labelA={LABEL_A}
+              labelB={LABEL_B}
+              nameA={nameA ?? LABEL_A}
+              nameB={nameB ?? LABEL_B}
+              mode={mode}
+            />
+          </TabsContent>
+
+          <LazyTabContent value="yaml" activeTab={activeTab}>
+            <YamlDiffView
+              specA={mode.kind === "single" ? selected.spec : sideA.spec}
+              specB={mode.kind === "single" ? undefined : sideB.spec}
+            />
+          </LazyTabContent>
+
+          <LazyTabContent value="graph" activeTab={activeTab}>
+            <GraphDiffView
+              comparison={comparison}
+              nameA={nameA ?? ""}
+              nameB={nameB ?? ""}
+              labelA={LABEL_A}
+              labelB={LABEL_B}
+              mode={mode}
+            />
+          </LazyTabContent>
+        </Tabs>
+      )}
+    </PageShell>
+  );
+}
+
+interface LazyTabContentProps {
+  value: string;
+  activeTab: string;
+  children: ReactNode;
+}
+
+/**
+ * Tab panel that mounts on first activation and stays mounted afterwards. The
+ * YAML and graph tabs each carry expensive state — a Monaco instance and a
+ * laid-out canvas — that should neither load before the tab is opened nor be
+ * rebuilt every time the user switches away and back.
+ */
+function LazyTabContent({ value, activeTab, children }: LazyTabContentProps) {
+  const active = activeTab === value;
+  const [mounted, setMounted] = useState(active);
+
+  useEffect(() => {
+    if (active) setMounted(true);
+  }, [active]);
+
+  return (
+    <TabsContent
+      value={value}
+      forceMount
+      className={cn("min-h-0", !active && "hidden")}
+    >
+      {mounted && children}
+    </TabsContent>
+  );
+}
+
+function PageShell({ children }: { children: ReactNode }) {
+  return (
+    <BlockStack gap="4" className="h-full w-full p-4">
+      {children}
+    </BlockStack>
+  );
+}

--- a/src/routes/v2/pages/CompareView/utils/compareMode.test.ts
+++ b/src/routes/v2/pages/CompareView/utils/compareMode.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { compareMode } from "./compareMode";
+
+describe("compareMode", () => {
+  it("is empty with no runs selected", () => {
+    expect(compareMode("", "")).toEqual({ kind: "empty" });
+  });
+
+  it("reports the filled side when only one run is selected", () => {
+    expect(compareMode("12", "")).toEqual({ kind: "single", side: "a" });
+    expect(compareMode("", "34")).toEqual({ kind: "single", side: "b" });
+  });
+
+  it("compares two distinct runs", () => {
+    expect(compareMode("12", "34")).toEqual({ kind: "both" });
+  });
+
+  it("treats the same run in both slots as a single selection", () => {
+    expect(compareMode("12", "12")).toEqual({ kind: "single", side: "a" });
+  });
+});

--- a/src/routes/v2/pages/CompareView/utils/compareMode.ts
+++ b/src/routes/v2/pages/CompareView/utils/compareMode.ts
@@ -4,3 +4,14 @@
  */
 export type CompareMode =
   { kind: "empty" } | { kind: "single"; side: "a" | "b" } | { kind: "both" };
+
+/**
+ * The same run in both slots counts as one selection, not a comparison: a run
+ * diffed against itself has nothing to show.
+ */
+export function compareMode(runIdA: string, runIdB: string): CompareMode {
+  if (runIdA && runIdB && runIdA !== runIdB) return { kind: "both" };
+  if (runIdA) return { kind: "single", side: "a" };
+  if (runIdB) return { kind: "single", side: "b" };
+  return { kind: "empty" };
+}

--- a/src/routes/v2/pages/CompareView/utils/compareSearch.test.ts
+++ b/src/routes/v2/pages/CompareView/utils/compareSearch.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "vitest";
+
+import { validateCompareSearch } from "./compareSearch";
+
+describe("validateCompareSearch()", () => {
+  test("passes string run ids through", () => {
+    expect(validateCompareSearch({ a: "run-1", b: "run-2" })).toEqual({
+      a: "run-1",
+      b: "run-2",
+    });
+  });
+
+  test("coerces numeric ids the router parsed out of the url", () => {
+    expect(validateCompareSearch({ a: 123, b: 456 })).toEqual({
+      a: "123",
+      b: "456",
+    });
+  });
+
+  test("drops values that cannot be a run id", () => {
+    expect(validateCompareSearch({ a: ["run-1"], b: { id: "run-2" } })).toEqual(
+      { a: undefined, b: undefined },
+    );
+  });
+
+  test("treats blank and whitespace-only ids as absent", () => {
+    expect(validateCompareSearch({ a: "", b: "   " })).toEqual({
+      a: undefined,
+      b: undefined,
+    });
+  });
+
+  test("tolerates a missing or non-object search object", () => {
+    expect(validateCompareSearch(undefined)).toEqual({
+      a: undefined,
+      b: undefined,
+    });
+    expect(validateCompareSearch({})).toEqual({ a: undefined, b: undefined });
+  });
+});

--- a/src/routes/v2/pages/CompareView/utils/compareSearch.ts
+++ b/src/routes/v2/pages/CompareView/utils/compareSearch.ts
@@ -1,0 +1,25 @@
+export interface CompareSearch {
+  a?: string;
+  b?: string;
+}
+
+/**
+ * Run ids arrive as search params, which the router JSON-parses: `?a=123`
+ * reaches the page as a number, and anything else can be an array or object. A
+ * run id is only ever a string here, so coerce what can be coerced and drop the
+ * rest rather than handing a non-string id to the run queries.
+ */
+function toRunId(value: unknown): string | undefined {
+  if (typeof value === "string") return value.trim() || undefined;
+  if (typeof value === "number" && Number.isFinite(value)) return String(value);
+  return undefined;
+}
+
+export function validateCompareSearch(search: unknown): CompareSearch {
+  const record =
+    typeof search === "object" && search !== null
+      ? (search as Record<string, unknown>)
+      : {};
+
+  return { a: toRunId(record.a), b: toRunId(record.b) };
+}

--- a/src/routes/v2/pages/PipelineFolders/components/FolderPipelineTable/components/SelectionToolbar.tsx
+++ b/src/routes/v2/pages/PipelineFolders/components/FolderPipelineTable/components/SelectionToolbar.tsx
@@ -1,8 +1,7 @@
 import { ConfirmationDialog } from "@/components/shared/Dialogs";
+import { FloatingSelectionBar } from "@/components/shared/FloatingSelectionBar";
 import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
-import { InlineStack } from "@/components/ui/layout";
-import { Text } from "@/components/ui/typography";
 import { pluralize } from "@/utils/string";
 import { tracking } from "@/utils/tracking";
 
@@ -23,54 +22,42 @@ export function SelectionToolbar({
   onClear,
   isDeleting,
 }: SelectionToolbarProps) {
-  if (totalSelected === 0) return null;
-
   return (
-    <div className="fixed bottom-4 left-1/2 z-50 -translate-x-1/2 rounded-lg border border-border bg-background p-4 shadow-lg">
-      <InlineStack gap="4" blockAlign="center">
-        <Text size="sm" weight="semibold">
-          {totalSelected} {pluralize(totalSelected, "item")} selected
-        </Text>
-        <InlineStack gap="2">
-          {canMove && (
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={onMove}
-              {...tracking("v2.pipeline_folders.table.selection_move")}
-            >
-              <Icon name="FolderInput" />
-              Move
-            </Button>
-          )}
-          <ConfirmationDialog
-            trigger={
-              <Button
-                variant="destructive"
-                size="sm"
-                disabled={isDeleting}
-                {...tracking(
-                  "v2.pipeline_folders.table.selection_bulk_delete_open",
-                )}
-              >
-                <Icon name="Trash2" />
-                Delete
-              </Button>
-            }
-            title={`Delete ${totalSelected} ${pluralize(totalSelected, "item")}?`}
-            description="Are you sure? Pipelines runs will not be impacted. Deleted folders will have their contents moved to root. This action cannot be undone."
-            onConfirm={onDelete}
-          />
+    <FloatingSelectionBar
+      count={totalSelected}
+      itemNoun="item"
+      onClear={onClear}
+      clearTrackingId="v2.pipeline_folders.table.selection_clear"
+    >
+      {canMove && (
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onMove}
+          {...tracking("v2.pipeline_folders.table.selection_move")}
+        >
+          <Icon name="FolderInput" />
+          Move
+        </Button>
+      )}
+      <ConfirmationDialog
+        trigger={
           <Button
-            variant="ghost"
+            variant="destructive"
             size="sm"
-            onClick={onClear}
-            {...tracking("v2.pipeline_folders.table.selection_clear")}
+            disabled={isDeleting}
+            {...tracking(
+              "v2.pipeline_folders.table.selection_bulk_delete_open",
+            )}
           >
-            <Icon name="X" />
+            <Icon name="Trash2" />
+            Delete
           </Button>
-        </InlineStack>
-      </InlineStack>
-    </div>
+        }
+        title={`Delete ${totalSelected} ${pluralize(totalSelected, "item")}?`}
+        description="Are you sure? Pipelines runs will not be impacted. Deleted folders will have their contents moved to root. This action cannot be undone."
+        onConfirm={onDelete}
+      />
+    </FloatingSelectionBar>
   );
 }

--- a/src/routes/v2/pages/RunView/components/RunViewMenuBar/components/RunMenu.tsx
+++ b/src/routes/v2/pages/RunView/components/RunViewMenuBar/components/RunMenu.tsx
@@ -1,4 +1,7 @@
+import { useNavigate } from "@tanstack/react-router";
+
 import ConfirmationDialog from "@/components/shared/Dialogs/ConfirmationDialog";
+import { useFlagValue } from "@/components/shared/Settings/useFlags";
 import TaskImplementation from "@/components/shared/TaskDetails/Implementation";
 import {
   DropdownMenu,
@@ -8,6 +11,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Icon } from "@/components/ui/icon";
+import { APP_ROUTES } from "@/routes/appRoutes";
 import { useCancelPipelineRun } from "@/routes/v2/pages/RunView/hooks/useCancelPipelineRun";
 import { useClonePipelineRun } from "@/routes/v2/pages/RunView/hooks/useClonePipelineRun";
 import { useExportPipelineYaml } from "@/routes/v2/pages/RunView/hooks/useExportPipelineYaml";
@@ -19,7 +23,9 @@ import { MenuTriggerButton } from "@/routes/v2/shared/components/MenuTriggerButt
 import { tracking } from "@/utils/tracking";
 
 export function RunMenu() {
+  const navigate = useNavigate();
   const actions = useRunViewActions();
+  const compareEnabled = useFlagValue("compare-runs");
   const componentSpec = actions.ready ? actions.componentSpec : undefined;
   const runId = actions.ready ? actions.runId : undefined;
   const pipelineName = actions.ready ? actions.pipelineName : undefined;
@@ -36,6 +42,12 @@ export function RunMenu() {
   } = useCancelPipelineRun(runId);
   const { inspect } = useInspectPipeline(pipelineName);
   const { exportYaml } = useExportPipelineYaml(componentSpec, pipelineName);
+
+  const handleCompare = () => {
+    if (runId) {
+      navigate({ to: APP_ROUTES.COMPARE, search: { a: runId } });
+    }
+  };
 
   if (!actions.ready) {
     return (
@@ -83,6 +95,16 @@ export function RunMenu() {
             <Icon name="FileCode" size="sm" />
             View YAML
           </DropdownMenuItem>
+
+          {compareEnabled && runId && (
+            <DropdownMenuItem
+              onSelect={handleCompare}
+              {...tracking("compare_runs.run_view.compare_with_another")}
+            >
+              <Icon name="GitCompare" size="sm" />
+              Compare with another run…
+            </DropdownMenuItem>
+          )}
 
           <DropdownMenuItem
             onSelect={clone}


### PR DESCRIPTION
## Description

Final PR in the **Compare Runs** stack — this is the one that turns all the previous pieces into a usable feature.

- Adds the **Compare** page (`/compare`) that ties everything together: a header with both runs (labelled A/B, swap, share-link and close), the run metadata bar, and the Structured / YAML / Graph tabs.
- Adds the ways to get there:
    - **Dashboard run list** — checkboxes on each row; selecting exactly two runs shows a "Compare" action bar.
    - **Run view menu** — a "Compare with another run…" item that pre-fills that run as side A.
- If you land on `/compare` without both runs chosen, it shows a run picker for the missing side (and guards against comparing a run with itself).
- Everything is gated behind a new **`compare-runs`** beta flag — the route redirects away and the entry points stay hidden when it's off.

Also moves the shared `buildTaskExecutionStatusMap` helper into `utils/executionStatus` (used by both the run view and the comparison).

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

Final PR in the Compare Runs stack. Builds on #2602 (#2596 → #2603).

## Type of Change

- [x] New feature

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

![image.png](https://app.graphite.com/user-attachments/assets/6dd06258-aa8c-47a7-b7f9-2832aec8461b.png)

![image.png](https://app.graphite.com/user-attachments/assets/f2409b91-ea97-4dbb-a71d-fce8e73f492c.png)

![image.png](https://app.graphite.com/user-attachments/assets/430bd40d-80b9-447e-9cef-66539b92fa65.png)

![image.png](https://app.graphite.com/user-attachments/assets/1e369a6a-f826-4318-aeb6-fa25721b71b8.png)

![image.png](https://app.graphite.com/user-attachments/assets/cd82a00c-7489-465a-b80b-fa354d5ef99a.png)

![image.png](https://app.graphite.com/user-attachments/assets/f2379c4a-40c1-4cf8-afea-3a98290e0f32.png)

![image.png](https://app.graphite.com/user-attachments/assets/a978918a-8d6a-4876-ac45-4c4f79985bd0.png)



<!-- Add screenshots of: the run list with checkboxes + compare bar, the run menu item, the run picker, and the full compare page. -->

## Test Instructions

1. Enable the **Compare runs** flag under Settings → Beta features.
2. **From the dashboard:** select exactly two runs with the row checkboxes — a Compare bar appears at the bottom. Click **Compare**.
3. **From a run:** open a run's menu and choose **Compare with another run…**, then pick a second run.
4. On the compare page, confirm:
    - The header shows both runs (A/B); **swap** flips them, **share** copies the URL, **close** returns to the run list.
    - The Structured, YAML and Graph tabs all work.
    - Opening the page URL directly (with `?a=…&b=…`) loads the same comparison; picking the same run twice is blocked.
5. **Flag off:** confirm the checkboxes, compare bar and run-menu item disappear, and visiting `/compare` redirects to the run list.
6. Regression: open a normal run view and confirm task statuses still render (the `buildTaskExecutionStatusMap` move).

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->