### PR TITLE
chore: various fixes and improvements for v2 runs

### DIFF
--- a/src/components/PipelineRun/components/InspectPipelineButton.tsx
+++ b/src/components/PipelineRun/components/InspectPipelineButton.tsx
@@ -50,7 +50,7 @@ export const InspectPipelineButton = ({
       data-testid="inspect-pipeline-button"
       {...rest}
     >
-      <Icon name="Network" className="rotate-270" />
+      <Icon name="Binoculars" />
       {displayLabel ?? (showLabel ? "Inspect" : null)}
     </TooltipButton>
   );

--- a/src/components/PipelineRun/components/SharePipelineButton.test.tsx
+++ b/src/components/PipelineRun/components/SharePipelineButton.test.tsx
@@ -1,0 +1,30 @@
+import { screen } from "@testing-library/dom";
+import { act, fireEvent, render } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+
+import { SharePipelineButton } from "./SharePipelineButton";
+
+const mockNotify = vi.fn();
+
+vi.mock("@/hooks/useToastNotification", () => ({
+  default: () => mockNotify,
+}));
+
+describe("<SharePipelineButton/>", () => {
+  test("copies the current URL to the clipboard on click", () => {
+    const writeText = vi.fn();
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+
+    render(<SharePipelineButton />);
+    act(() => fireEvent.click(screen.getByTestId("share-pipeline-button")));
+
+    expect(writeText).toHaveBeenCalledWith(window.location.href);
+    expect(mockNotify).toHaveBeenCalledWith(
+      "Run URL copied to clipboard",
+      "success",
+    );
+  });
+});

--- a/src/components/PipelineRun/components/SharePipelineButton.tsx
+++ b/src/components/PipelineRun/components/SharePipelineButton.tsx
@@ -1,0 +1,42 @@
+import { type ComponentPropsWithoutRef, useCallback } from "react";
+
+import TooltipButton from "@/components/shared/Buttons/TooltipButton";
+import { Icon } from "@/components/ui/icon";
+import useToastNotification from "@/hooks/useToastNotification";
+import { copyToClipboard } from "@/utils/string";
+
+type SharePipelineButtonProps = {
+  showLabel?: boolean;
+  displayLabel?: string;
+  showTooltip?: boolean;
+} & Omit<
+  ComponentPropsWithoutRef<typeof TooltipButton>,
+  "onClick" | "tooltip" | "variant" | "children"
+>;
+
+export const SharePipelineButton = ({
+  showLabel,
+  displayLabel,
+  showTooltip = true,
+  ...rest
+}: SharePipelineButtonProps) => {
+  const notify = useToastNotification();
+
+  const handleShare = useCallback(() => {
+    copyToClipboard(window.location.href);
+    notify("Run URL copied to clipboard", "success");
+  }, [notify]);
+
+  return (
+    <TooltipButton
+      variant="outline"
+      onClick={handleShare}
+      tooltip={showTooltip ? "Share run" : undefined}
+      data-testid="share-pipeline-button"
+      {...rest}
+    >
+      <Icon name="Share2" />
+      {displayLabel ?? (showLabel ? "Share" : null)}
+    </TooltipButton>
+  );
+};

--- a/src/components/shared/CodeViewer/CodeViewer.tsx
+++ b/src/components/shared/CodeViewer/CodeViewer.tsx
@@ -13,6 +13,7 @@ interface CodeViewerProps {
   filename?: string;
   fullscreen?: boolean;
   scrollToBottom?: boolean;
+  allowFullscreen?: boolean;
   onClose?: () => void;
 }
 
@@ -24,6 +25,7 @@ const CodeViewer = ({
   filename = "",
   fullscreen = false,
   scrollToBottom = false,
+  allowFullscreen = true,
   onClose,
 }: CodeViewerProps) => {
   const [isFullscreen, setIsFullscreen] = useState(fullscreen);
@@ -65,17 +67,19 @@ const CodeViewer = ({
               (Read Only)
             </Text>
           </div>
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            onClick={handleToggleFullscreen}
-            className="text-muted-foreground hover:text-foreground"
-            title={isFullscreen ? "Exit fullscreen" : "View fullscreen"}
-            aria-label={isFullscreen ? "Exit fullscreen" : "View fullscreen"}
-          >
-            {isFullscreen ? <Icon name="X" /> : <Icon name="Maximize2" />}
-          </Button>
+          {allowFullscreen && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              onClick={handleToggleFullscreen}
+              className="text-muted-foreground hover:text-foreground"
+              title={isFullscreen ? "Exit fullscreen" : "View fullscreen"}
+              aria-label={isFullscreen ? "Exit fullscreen" : "View fullscreen"}
+            >
+              {isFullscreen ? <Icon name="X" /> : <Icon name="Maximize2" />}
+            </Button>
+          )}
         </div>
         <div className="flex-1 relative">
           <div

--- a/src/components/shared/CopyText/CopyText.tsx
+++ b/src/components/shared/CopyText/CopyText.tsx
@@ -64,7 +64,7 @@ export const CopyText = ({
 
   return (
     <div
-      className="group cursor-pointer"
+      className="group max-w-full min-w-0 cursor-pointer"
       onClick={handleCopy}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}

--- a/src/components/shared/InfoBox.tsx
+++ b/src/components/shared/InfoBox.tsx
@@ -66,12 +66,12 @@ export const InfoBox = ({
       data-testid={`info-box-${variant}`}
       className={cn("border rounded-md p-2", styles.container, widthClass)}
     >
-      <InlineStack align="space-between" blockAlign="start">
+      <InlineStack align="space-between" blockAlign="start" wrap="nowrap">
         <Text
           as="span"
           size="sm"
           weight="semibold"
-          className={cn("mb-1", styles.title)}
+          className={cn("mb-1 min-w-0 wrap-break-word", styles.title)}
           data-testid="info-box-title"
         >
           {title}
@@ -87,7 +87,11 @@ export const InfoBox = ({
           </Button>
         )}
       </InlineStack>
-      <div className={cn("text-sm", className)}>{children}</div>
+      <div
+        className={cn("text-sm wrap-break-word whitespace-normal", className)}
+      >
+        {children}
+      </div>
     </div>
   );
 };

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCollapsibleSection.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCollapsibleSection.tsx
@@ -1,0 +1,53 @@
+import type { ReactNode } from "react";
+import { useState } from "react";
+
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { Icon } from "@/components/ui/icon";
+import { BlockStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
+
+interface IOCollapsibleSectionProps {
+  title: string;
+  count: number;
+  children: ReactNode;
+}
+
+const IOCollapsibleSection = ({
+  title,
+  count,
+  children,
+}: IOCollapsibleSectionProps) => {
+  const [open, setOpen] = useState(true);
+
+  return (
+    <Collapsible open={open} onOpenChange={setOpen} className="w-full">
+      <CollapsibleTrigger className="flex w-full cursor-pointer items-center gap-1 rounded-sm py-0.5 hover:bg-muted/50">
+        <Icon
+          name={open ? "ChevronDown" : "ChevronRight"}
+          size="xs"
+          className="text-muted-foreground"
+        />
+        <Text size="md" weight="semibold">
+          {title}
+        </Text>
+        {count > 0 && (
+          <Text size="xs" tone="subdued">
+            {count}
+          </Text>
+        )}
+      </CollapsibleTrigger>
+
+      <CollapsibleContent>
+        <BlockStack gap="1" className="w-full pt-1">
+          {children}
+        </BlockStack>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+};
+
+export default IOCollapsibleSection;

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOExtras.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOExtras.tsx
@@ -1,9 +1,8 @@
 import type { GetExecutionArtifactsResponse } from "@/api/types.gen";
-import { BlockStack } from "@/components/ui/layout";
-import { Heading } from "@/components/ui/typography";
 import type { InputSpec, OutputSpec } from "@/utils/componentSpec";
 
 import IOCell from "./IOCell/IOCell";
+import IOCollapsibleSection from "./IOCollapsibleSection";
 
 interface IOExtrasProps {
   inputs?: InputSpec[];
@@ -27,21 +26,25 @@ const IOExtras = ({ inputs, outputs, artifacts }: IOExtrasProps) => {
   return (
     <>
       {additionalInputs.length > 0 && (
-        <BlockStack gap="1" className="w-full">
-          <Heading level={1}>Additional Input Artifacts</Heading>
+        <IOCollapsibleSection
+          title="Additional Input Artifacts"
+          count={additionalInputs.length}
+        >
           {additionalInputs.map(([key, artifact]) => (
             <IOCell key={key} name={key} artifact={artifact} />
           ))}
-        </BlockStack>
+        </IOCollapsibleSection>
       )}
 
       {additionalOutputs.length > 0 && (
-        <BlockStack gap="1" className="w-full">
-          <Heading level={1}>Additional Output Artifacts</Heading>
+        <IOCollapsibleSection
+          title="Additional Output Artifacts"
+          count={additionalOutputs.length}
+        >
           {additionalOutputs.map(([key, artifact]) => (
             <IOCell key={key} name={key} artifact={artifact} />
           ))}
-        </BlockStack>
+        </IOCollapsibleSection>
       )}
     </>
   );

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOInputs.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOInputs.tsx
@@ -1,9 +1,9 @@
 import type { GetExecutionArtifactsResponse } from "@/api/types.gen";
-import { BlockStack } from "@/components/ui/layout";
-import { Heading, Paragraph } from "@/components/ui/typography";
+import { Paragraph } from "@/components/ui/typography";
 import type { InputSpec } from "@/utils/componentSpec";
 
 import IOCell from "./IOCell/IOCell";
+import IOCollapsibleSection from "./IOCollapsibleSection";
 
 interface IOInputsProps {
   inputs?: InputSpec[];
@@ -12,9 +12,7 @@ interface IOInputsProps {
 
 const IOInputs = ({ inputs, artifacts }: IOInputsProps) => {
   return (
-    <BlockStack gap="1" className="w-full">
-      <Heading level={1}>Inputs</Heading>
-
+    <IOCollapsibleSection title="Inputs" count={inputs?.length ?? 0}>
       {(!inputs || inputs.length === 0) && (
         <Paragraph tone="subdued" size="xs">
           No inputs defined
@@ -33,7 +31,7 @@ const IOInputs = ({ inputs, artifacts }: IOInputsProps) => {
           />
         );
       })}
-    </BlockStack>
+    </IOCollapsibleSection>
   );
 };
 

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOOutputs.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOOutputs.tsx
@@ -1,9 +1,9 @@
 import type { GetExecutionArtifactsResponse } from "@/api/types.gen";
-import { BlockStack } from "@/components/ui/layout";
-import { Heading, Paragraph } from "@/components/ui/typography";
+import { Paragraph } from "@/components/ui/typography";
 import type { OutputSpec } from "@/utils/componentSpec";
 
 import IOCell from "./IOCell/IOCell";
+import IOCollapsibleSection from "./IOCollapsibleSection";
 
 interface IOOutputsProps {
   outputs?: OutputSpec[];
@@ -12,9 +12,7 @@ interface IOOutputsProps {
 
 const IOOutputs = ({ outputs, artifacts }: IOOutputsProps) => {
   return (
-    <BlockStack gap="1" className="w-full">
-      <Heading level={1}>Outputs</Heading>
-
+    <IOCollapsibleSection title="Outputs" count={outputs?.length ?? 0}>
       {(!outputs || outputs.length === 0) && (
         <Paragraph tone="subdued" size="xs">
           No outputs defined
@@ -33,7 +31,7 @@ const IOOutputs = ({ outputs, artifacts }: IOOutputsProps) => {
           />
         );
       })}
-    </BlockStack>
+    </IOCollapsibleSection>
   );
 };
 

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/logs.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/logs.tsx
@@ -11,11 +11,13 @@ import { shouldStatusHaveLogs } from "@/utils/executionStatus";
 
 const LogDisplay = ({
   logs,
+  allowFullscreen,
 }: {
   logs: {
     log_text?: string;
     system_error_exception_full?: string;
   };
+  allowFullscreen?: boolean;
 }) => {
   if (!logs.log_text && !logs.system_error_exception_full) {
     return <div>No logs available</div>;
@@ -36,6 +38,7 @@ const LogDisplay = ({
             language="text"
             filename="Execution Logs"
             scrollToBottom
+            allowFullscreen={allowFullscreen}
           />
         </div>
       )}
@@ -46,6 +49,7 @@ const LogDisplay = ({
             language="text"
             filename="System Error Logs"
             scrollToBottom
+            allowFullscreen={allowFullscreen}
           />
         </div>
       )}
@@ -56,9 +60,11 @@ const LogDisplay = ({
 const Logs = ({
   executionId,
   status,
+  allowFullscreen = true,
 }: {
   executionId?: string | number;
   status?: string;
+  allowFullscreen?: boolean;
 }) => {
   const { backendUrl, configured, available } = useBackend();
 
@@ -132,7 +138,7 @@ const Logs = ({
   return (
     <div className="space-y-4 h-full">
       <div className="font-mono text-sm whitespace-pre-wrap bg-gray-50 dark:bg-muted p-4 rounded-lg h-full min-h-0 flex-1">
-        {logs && <LogDisplay logs={logs} />}
+        {logs && <LogDisplay logs={logs} allowFullscreen={allowFullscreen} />}
       </div>
     </div>
   );

--- a/src/components/shared/RunSource.tsx
+++ b/src/components/shared/RunSource.tsx
@@ -11,27 +11,31 @@ interface SourceConfig {
   icon: IconName;
   label: string;
   tooltip: string;
+  message: string;
 }
 
 const SOURCE_BUCKETS: Record<RunSourceBucket, SourceConfig> = {
   "web-app": {
     icon: "AppWindow",
     label: "Web app",
-    tooltip: "Submitted via Tangle web app",
+    tooltip: "Submitted via the Tangle web app",
+    message: "Submitted via the Tangle web app",
   },
   programmatic: {
     icon: "Bot",
     label: "Programmatic",
-    tooltip: "Submitted by AI or via CLI",
+    tooltip: "Submitted via AI or CLI",
+    message: "Submitted via AI or CLI",
   },
   unknown: {
     icon: "CircleQuestionMark",
     label: "Unknown",
     tooltip: "Source unknown",
+    message: "Source unknown",
   },
 };
 
-const getRunSourceBucket = (source?: string | null): RunSourceBucket => {
+export const getRunSourceBucket = (source?: string | null): RunSourceBucket => {
   if (!source) return "unknown";
   if (source === "web-app") return "web-app";
   return "programmatic";
@@ -39,6 +43,10 @@ const getRunSourceBucket = (source?: string | null): RunSourceBucket => {
 
 const getRunSourceConfig = (source?: string | null): SourceConfig =>
   SOURCE_BUCKETS[getRunSourceBucket(source)];
+
+/** Human-readable message describing how a run was submitted. */
+export const getRunSourceMessage = (source?: string | null): string =>
+  getRunSourceConfig(source).message;
 
 interface RunSourceIconProps {
   source?: string | null;

--- a/src/routes/v2/pages/Editor/components/EditorMenuBar/components/QuickRunButton.tsx
+++ b/src/routes/v2/pages/Editor/components/EditorMenuBar/components/QuickRunButton.tsx
@@ -66,6 +66,7 @@ export const QuickRunButton = observer(function QuickRunButton({
   const errorCount = allIssues.filter((i) => i.severity === "error").length;
   const hasErrors = errorCount > 0;
   const onlyWarnings = allIssues.length > 0 && errorCount === 0;
+  const hasConfigurableInputs = (rootSpec?.inputs?.length ?? 0) > 0;
 
   let serializedPipelineSpec:
     ReturnType<typeof serializeComponentSpec> | undefined;
@@ -85,25 +86,54 @@ export const QuickRunButton = observer(function QuickRunButton({
     triggerSubmitRun();
   };
 
+  const handleSubmitWithArgumentsClick = (
+    event: MouseEvent<HTMLButtonElement>,
+  ) => {
+    event.stopPropagation();
+    triggerSubmitWithArguments();
+  };
+
+  const showMiniArgumentsButton = isMini && hasConfigurableInputs && !hasErrors;
+
   return (
     <>
-      <TooltipButton
-        {...tooltipButtonProps}
-        tooltip={tooltip}
-        variant={isMini ? "outline" : "header"}
-        size={isMini ? "icon" : undefined}
-        className={isMini ? "relative size-8 shrink-0 rounded-md" : undefined}
-        aria-label={isMini ? tooltip : undefined}
-        disabled={hasErrors}
-        onClick={handleClick}
-        {...tracking(trackingKey)}
-      >
-        <Icon
-          name="Play"
-          size={isMini ? "sm" : undefined}
-          className={quickRunIconVariants({ variant, hasErrors, onlyWarnings })}
-        />
-      </TooltipButton>
+      {!showMiniArgumentsButton && (
+        <TooltipButton
+          {...tooltipButtonProps}
+          tooltip={tooltip}
+          variant={isMini ? "outline" : "header"}
+          size={isMini ? "icon" : undefined}
+          className={isMini ? "relative size-8 shrink-0 rounded-md" : undefined}
+          aria-label={isMini ? tooltip : undefined}
+          disabled={hasErrors}
+          onClick={handleClick}
+          {...tracking(trackingKey)}
+        >
+          <Icon
+            name="Play"
+            size={isMini ? "sm" : undefined}
+            className={quickRunIconVariants({
+              variant,
+              hasErrors,
+              onlyWarnings,
+            })}
+          />
+        </TooltipButton>
+      )}
+      {showMiniArgumentsButton && (
+        <TooltipButton
+          {...tooltipButtonProps}
+          tooltip="Submit run with arguments"
+          variant="outline"
+          size="icon"
+          className="relative size-8 shrink-0 rounded-md"
+          aria-label="Submit run with arguments"
+          onClick={handleSubmitWithArgumentsClick}
+          {...tracking(`${trackingKey}_with_arguments`)}
+        >
+          <Icon name="Split" size="sm" className="rotate-90" />
+        </TooltipButton>
+      )}
       {renderSubmitter && serializedPipelineSpec && isAuthorized && (
         <div data-quick-run className="sr-only">
           <TangleSubmitter

--- a/src/routes/v2/pages/RunView/components/RunDetailsContent.tsx
+++ b/src/routes/v2/pages/RunView/components/RunDetailsContent.tsx
@@ -1,3 +1,4 @@
+import { useQuery } from "@tanstack/react-query";
 import { observer } from "mobx-react-lite";
 
 import type {
@@ -12,21 +13,30 @@ import { TextBlock } from "@/components/shared/ContextPanel/Blocks/TextBlock";
 import PipelineIO from "@/components/shared/Execution/PipelineIO";
 import { InfoBox } from "@/components/shared/InfoBox";
 import { LoadingScreen } from "@/components/shared/LoadingScreen";
+import {
+  getRunSourceBucket,
+  getRunSourceMessage,
+  RunSourceIcon,
+} from "@/components/shared/RunSource";
 import { TagList } from "@/components/shared/Tags/TagList";
-import { BlockStack } from "@/components/ui/layout";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Separator } from "@/components/ui/separator";
-import { Paragraph } from "@/components/ui/typography";
+import { Paragraph, Text } from "@/components/ui/typography";
 import { useUserDetails } from "@/hooks/useUserDetails";
 import type { ComponentSpec } from "@/models/componentSpec";
 import { useBackend } from "@/providers/BackendProvider";
 import { useExecutionData } from "@/providers/ExecutionDataProvider";
 import { PipelineDetailsCollapsibleSection } from "@/routes/v2/shared/components/PipelineDetailsCollapsibleSection";
 import { useSpec } from "@/routes/v2/shared/providers/SpecContext";
+import { fetchRunAnnotations } from "@/services/pipelineRunService";
 import {
+  getAnnotationValue,
   PIPELINE_NOTES_ANNOTATION,
   PIPELINE_TAGS_ANNOTATION,
+  RUN_SOURCE_ANNOTATION,
   SYSTEM_ANNOTATIONS,
 } from "@/utils/annotations";
+import { TWENTY_FOUR_HOURS_IN_MS } from "@/utils/constants";
 import {
   flattenExecutionStatusStats,
   getExecutionStatusLabel,
@@ -184,20 +194,45 @@ function RunDetailsContentLoaded({
 }
 
 function RunInfoSection({ metadata }: { metadata: PipelineRunResponse }) {
+  const { backendUrl } = useBackend();
+  const runId = metadata.id;
+
+  const { data: runAnnotations } = useQuery({
+    queryKey: ["pipeline-run-annotations", backendUrl, runId],
+    queryFn: () => fetchRunAnnotations(runId, backendUrl),
+    enabled: !!runId,
+    refetchOnWindowFocus: false,
+    staleTime: TWENTY_FOUR_HOURS_IN_MS,
+  });
+
+  const runSource = getAnnotationValue(runAnnotations, RUN_SOURCE_ANNOTATION);
+  const hasKnownSource = getRunSourceBucket(runSource) !== "unknown";
+
   return (
-    <KeyValueList
-      items={[
-        { label: "Run Id", value: metadata.id },
-        { label: "Execution Id", value: metadata.root_execution_id },
-        { label: "Created by", value: metadata.created_by ?? undefined },
-        {
-          label: "Created at",
-          value: metadata.created_at
-            ? new Date(metadata.created_at).toLocaleString()
-            : undefined,
-        },
-      ]}
-    />
+    <BlockStack gap="2">
+      <KeyValueList
+        items={[
+          { label: "Run Id", value: metadata.id },
+          { label: "Execution Id", value: metadata.root_execution_id },
+          { label: "Created by", value: metadata.created_by ?? undefined },
+          {
+            label: "Created at",
+            value: metadata.created_at
+              ? new Date(metadata.created_at).toLocaleString()
+              : undefined,
+          },
+        ]}
+      />
+
+      {hasKnownSource && (
+        <InlineStack gap="1" blockAlign="center" wrap="nowrap">
+          <RunSourceIcon source={runSource} size="xs" />
+          <Text size="xs" tone="subdued">
+            {getRunSourceMessage(runSource)}
+          </Text>
+        </InlineStack>
+      )}
+    </BlockStack>
   );
 }
 

--- a/src/routes/v2/pages/RunView/components/RunToolsContent.tsx
+++ b/src/routes/v2/pages/RunView/components/RunToolsContent.tsx
@@ -4,6 +4,7 @@ import { CancelPipelineRunButton } from "@/components/PipelineRun/components/Can
 import { ClonePipelineButton } from "@/components/PipelineRun/components/ClonePipelineButton";
 import { InspectPipelineButton } from "@/components/PipelineRun/components/InspectPipelineButton";
 import { RerunPipelineButton } from "@/components/PipelineRun/components/RerunPipelineButton";
+import { SharePipelineButton } from "@/components/PipelineRun/components/SharePipelineButton";
 import { ViewYamlButton } from "@/components/shared/Buttons/ViewYamlButton";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { useRunViewActions } from "@/routes/v2/pages/RunView/hooks/useRunViewActions";
@@ -11,14 +12,25 @@ import { useOptionalWindowContext } from "@/routes/v2/shared/windows/ContentWind
 import { tracking } from "@/utils/tracking";
 
 const RUN_TOOL_CLASS_NAME =
-  "h-10 w-full justify-start gap-3 border-transparent bg-transparent px-3 shadow-none hover:border-border hover:bg-muted";
-const RUN_TOOL_WRAPPER_CLASS_NAME = "w-full";
+  "h-10 w-48 justify-start gap-3 border-transparent bg-transparent px-3 shadow-none hover:border-border hover:bg-muted";
+const RUN_TOOL_WRAPPER_CLASS_NAME = "w-fit";
+
+const CANCEL_TOOL_CLASS_NAME =
+  "text-destructive hover:text-destructive dark:text-red-400 dark:hover:text-red-400 border-destructive/50 dark:border-red-400/30 hover:bg-destructive/10 dark:hover:bg-red-400/10";
 
 const ROW_TOOL_CLASS_NAME =
   "h-10 justify-start gap-3 px-3 shadow-none hover:border-border hover:bg-muted border";
 const ROW_TOOL_WRAPPER_CLASS_NAME = "shrink-0";
 
-export const RunToolsContent = observer(function RunToolsContent() {
+const RAIL_TOOL_CLASS_NAME = "size-8 shrink-0 p-0";
+
+interface RunToolsContentProps {
+  layout?: "rail";
+}
+
+export const RunToolsContent = observer(function RunToolsContent({
+  layout,
+}: RunToolsContentProps) {
   const actions = useRunViewActions();
   const windowContext = useOptionalWindowContext();
   const isFloatingPanel =
@@ -37,6 +49,66 @@ export const RunToolsContent = observer(function RunToolsContent() {
     pipelineName,
   } = actions;
 
+  if (layout === "rail") {
+    return (
+      <BlockStack gap="1" align="center" className="w-full">
+        <ViewYamlButton
+          componentSpec={componentSpec}
+          aria-label="View YAML"
+          className={RAIL_TOOL_CLASS_NAME}
+          tooltipSide="right"
+          {...tracking("v2.run_view.tools.view_yaml")}
+        />
+
+        <SharePipelineButton
+          aria-label="Share run"
+          className={RAIL_TOOL_CLASS_NAME}
+          tooltipSide="right"
+          {...tracking("v2.run_view.tools.share_pipeline")}
+        />
+
+        {canAccessEditorSpec && pipelineName && (
+          <InspectPipelineButton
+            pipelineName={pipelineName}
+            aria-label="Inspect pipeline"
+            className={RAIL_TOOL_CLASS_NAME}
+            tooltipSide="right"
+            {...tracking("v2.run_view.tools.inspect_pipeline")}
+          />
+        )}
+
+        <ClonePipelineButton
+          componentSpec={componentSpec}
+          runId={runId}
+          aria-label="Clone pipeline"
+          className={RAIL_TOOL_CLASS_NAME}
+          tooltipSide="right"
+          {...tracking("v2.run_view.tools.clone_pipeline")}
+        />
+
+        {isInProgress && isRunCreator && (
+          <CancelPipelineRunButton
+            runId={runId}
+            aria-label="Cancel run"
+            className={`${RAIL_TOOL_CLASS_NAME} bg-transparent ${CANCEL_TOOL_CLASS_NAME}`}
+            tooltipSide="right"
+            {...tracking("v2.run_view.tools.cancel_run")}
+          />
+        )}
+
+        {isComplete && (
+          <RerunPipelineButton
+            componentSpec={componentSpec}
+            aria-label="Rerun pipeline"
+            className={RAIL_TOOL_CLASS_NAME}
+            tooltipSide="right"
+            {...tracking("v2.run_view.tools.rerun_pipeline")}
+          />
+        )}
+      </BlockStack>
+    );
+  }
+
   const toolClassName = isFloatingPanel
     ? ROW_TOOL_CLASS_NAME
     : RUN_TOOL_CLASS_NAME;
@@ -53,6 +125,14 @@ export const RunToolsContent = observer(function RunToolsContent() {
         className={toolClassName}
         wrapperClassName={wrapperClassName}
         {...tracking("v2.run_view.tools.view_yaml")}
+      />
+
+      <SharePipelineButton
+        displayLabel="Share run"
+        showTooltip={false}
+        className={toolClassName}
+        wrapperClassName={wrapperClassName}
+        {...tracking("v2.run_view.tools.share_pipeline")}
       />
 
       {canAccessEditorSpec && pipelineName && (
@@ -81,7 +161,7 @@ export const RunToolsContent = observer(function RunToolsContent() {
           runId={runId}
           displayLabel="Cancel run"
           showTooltip={false}
-          className={`${toolClassName} bg-transparent border-destructive/50 hover:bg-destructive/10 text-destructive hover:text-destructive`}
+          className={`${toolClassName} bg-transparent ${CANCEL_TOOL_CLASS_NAME}`}
           wrapperClassName={wrapperClassName}
           {...tracking("v2.run_view.tools.cancel_run")}
         />

--- a/src/routes/v2/pages/RunView/components/RunViewMenuBar/RunViewMenuBar.tsx
+++ b/src/routes/v2/pages/RunView/components/RunViewMenuBar/RunViewMenuBar.tsx
@@ -55,7 +55,7 @@ export const RunViewMenuBar = observer(function RunViewMenuBar() {
               as="span"
               size="sm"
               weight="semibold"
-              className="text-white truncate max-w-64 lg:max-w-md leading-tight ml-1"
+              className="text-white truncate max-w-64 lg:max-w-md leading-tight ml-1 select-text cursor-text"
             >
               {pipelineName}
             </Text>

--- a/src/routes/v2/pages/RunView/hooks/useAiChatWindow.test.ts
+++ b/src/routes/v2/pages/RunView/hooks/useAiChatWindow.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import { getRunSuggestedPrompts } from "./useAiChatWindow";
+
+const labelsFor = (status: string | undefined) =>
+  getRunSuggestedPrompts(status).map((prompt) => prompt.label);
+
+describe("getRunSuggestedPrompts", () => {
+  it("always offers the summarize prompt first", () => {
+    const statuses = [
+      undefined,
+      "RUNNING",
+      "SUCCEEDED",
+      "FAILED",
+      "CANCELLED",
+      "SKIPPED",
+    ];
+
+    for (const status of statuses) {
+      expect(labelsFor(status)[0]).toBe("Summarize this run");
+    }
+  });
+
+  it.each(["FAILED", "SYSTEM_ERROR", "INVALID"])(
+    "offers failure prompts for %s",
+    (status) => {
+      expect(labelsFor(status)).toEqual([
+        "Summarize this run",
+        "Why did this run fail?",
+        "Which tasks failed and why?",
+      ]);
+    },
+  );
+
+  it.each([
+    "RUNNING",
+    "PENDING",
+    "QUEUED",
+    "WAITING_FOR_UPSTREAM",
+    "CANCELLING",
+    "UNINITIALIZED",
+  ])("offers in-progress prompts for %s", (status) => {
+    expect(labelsFor(status)).toEqual([
+      "Summarize this run",
+      "What's happening in this run right now?",
+      "Which tasks are still running?",
+    ]);
+  });
+
+  it.each(["CANCELLED", "SKIPPED"])(
+    "offers halted-run prompts for %s",
+    (status) => {
+      expect(labelsFor(status)).toEqual([
+        "Summarize this run",
+        "What completed before this run stopped?",
+        "Which tasks did not run?",
+      ]);
+    },
+  );
+
+  it("falls back to outcome prompts for succeeded and unknown statuses", () => {
+    const expected = [
+      "Summarize this run",
+      "Explain the outputs of this run",
+      "Did anything unexpected happen?",
+    ];
+
+    expect(labelsFor("SUCCEEDED")).toEqual(expected);
+    expect(labelsFor(undefined)).toEqual(expected);
+  });
+});

--- a/src/routes/v2/pages/RunView/hooks/useAiChatWindow.tsx
+++ b/src/routes/v2/pages/RunView/hooks/useAiChatWindow.tsx
@@ -1,18 +1,78 @@
+import { observer } from "mobx-react-lite";
 import { useEffect } from "react";
 
+import { useExecutionDataOptional } from "@/providers/ExecutionDataProvider";
 import { RUN_AI_ASSISTANT_WINDOW_ID } from "@/routes/v2/pages/RunView/runViewWindowPresets";
 import { createRunViewToolBridge } from "@/routes/v2/pages/RunView/toolBridge/runViewToolBridge";
 import { AiChatContent } from "@/routes/v2/shared/components/AiChat/AiChatContent";
 import type { SuggestedPrompt } from "@/routes/v2/shared/components/AiChat/types";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 import { WindowMiniButton } from "@/routes/v2/shared/windows/WindowMiniButton";
+import {
+  flattenExecutionStatusStats,
+  getOverallExecutionStatusFromStats,
+  IN_PROGRESS_STATUSES,
+} from "@/utils/executionStatus";
 
-const SUGGESTED_PROMPTS_RUN: SuggestedPrompt[] = [
-  { label: "Summarize this run", icon: "FileText" },
-  { label: "Why did this run fail?", icon: "CircleAlert" },
-  { label: "Which tasks failed and why?", icon: "ListChecks" },
-  { label: "Explain the outputs of this run", icon: "ArrowUpFromLine" },
-];
+const SUMMARIZE_PROMPT: SuggestedPrompt = {
+  label: "Summarize this run",
+  icon: "FileText",
+};
+
+const FAILED_STATUSES = new Set(["FAILED", "SYSTEM_ERROR", "INVALID"]);
+const HALTED_STATUSES = new Set(["CANCELLED", "SKIPPED"]);
+
+export function getRunSuggestedPrompts(
+  status: string | undefined,
+): SuggestedPrompt[] {
+  if (status && FAILED_STATUSES.has(status)) {
+    return [
+      SUMMARIZE_PROMPT,
+      { label: "Why did this run fail?", icon: "CircleAlert" },
+      { label: "Which tasks failed and why?", icon: "ListChecks" },
+    ];
+  }
+
+  if (status && IN_PROGRESS_STATUSES.has(status)) {
+    return [
+      SUMMARIZE_PROMPT,
+      { label: "What's happening in this run right now?", icon: "Activity" },
+      { label: "Which tasks are still running?", icon: "LoaderCircle" },
+    ];
+  }
+
+  if (status && HALTED_STATUSES.has(status)) {
+    return [
+      SUMMARIZE_PROMPT,
+      { label: "What completed before this run stopped?", icon: "ListChecks" },
+      { label: "Which tasks did not run?", icon: "CircleSlash" },
+    ];
+  }
+
+  return [
+    SUMMARIZE_PROMPT,
+    { label: "Explain the outputs of this run", icon: "ArrowUpFromLine" },
+    { label: "Did anything unexpected happen?", icon: "Search" },
+  ];
+}
+
+const RunAiChatContent = observer(function RunAiChatContent() {
+  const executionData = useExecutionDataOptional();
+
+  const stats =
+    executionData?.metadata?.execution_status_stats ??
+    flattenExecutionStatusStats(
+      executionData?.rootState?.child_execution_status_stats,
+    );
+  const overallStatus = getOverallExecutionStatusFromStats(stats);
+
+  return (
+    <AiChatContent
+      createBridge={createRunViewToolBridge}
+      suggestedPrompts={getRunSuggestedPrompts(overallStatus)}
+    />
+  );
+});
 
 export function useAiChatWindow(enabled: boolean) {
   const { windows } = useSharedStores();
@@ -24,28 +84,22 @@ export function useAiChatWindow(enabled: boolean) {
     }
     if (windows.getWindowById(RUN_AI_ASSISTANT_WINDOW_ID)) return;
 
-    windows.openWindow(
-      <AiChatContent
-        createBridge={createRunViewToolBridge}
-        suggestedPrompts={SUGGESTED_PROMPTS_RUN}
-      />,
-      {
-        id: RUN_AI_ASSISTANT_WINDOW_ID,
-        title: "AI Assistant",
-        position: { x: 100, y: 80 },
-        size: { width: 380, height: 520 },
-        disabledActions: ["close"],
-        defaultVisible: true,
-        defaultDockState: "left",
-        persisted: true,
-        miniContent: (
-          <WindowMiniButton
-            tooltip="Open AI Assistant"
-            label="AI Assistant"
-            icon="Sparkles"
-          />
-        ),
-      },
-    );
+    windows.openWindow(<RunAiChatContent />, {
+      id: RUN_AI_ASSISTANT_WINDOW_ID,
+      title: "AI Assistant",
+      position: { x: 100, y: 80 },
+      size: { width: 380, height: 520 },
+      disabledActions: ["close"],
+      defaultVisible: true,
+      defaultDockState: "left",
+      persisted: true,
+      miniContent: (
+        <WindowMiniButton
+          tooltip="Open AI Assistant"
+          label="AI Assistant"
+          icon="Sparkles"
+        />
+      ),
+    });
   }, [enabled, windows]);
 }

--- a/src/routes/v2/pages/RunView/hooks/useRunViewSelectionSync.tsx
+++ b/src/routes/v2/pages/RunView/hooks/useRunViewSelectionSync.tsx
@@ -33,6 +33,7 @@ export function useRunViewSelectionSync() {
               persisted: true,
               fillDockHeight: true,
               defaultDockState: "right",
+              onClose: () => editor.clearSelection(),
               miniContent: (
                 <WindowMiniButton
                   tooltip="View Properties"

--- a/src/routes/v2/pages/RunView/hooks/useRunViewWindows.tsx
+++ b/src/routes/v2/pages/RunView/hooks/useRunViewWindows.tsx
@@ -28,13 +28,8 @@ export function useRunViewWindows() {
         minSize: { width: 240, height: 180 },
         defaultDockState: "left",
         persisted: true,
-        miniContent: (
-          <WindowMiniButton
-            tooltip="View Run Tools"
-            label="Run Tools"
-            icon="Wrench"
-          />
-        ),
+        renderMiniInline: true,
+        miniContent: <RunToolsContent layout="rail" />,
       });
     }
 

--- a/src/routes/v2/pages/RunView/nodes/TaskNode/RunViewTaskNode.tsx
+++ b/src/routes/v2/pages/RunView/nodes/TaskNode/RunViewTaskNode.tsx
@@ -2,7 +2,6 @@ import { type Node, type NodeProps } from "@xyflow/react";
 import { observer } from "mobx-react-lite";
 
 import { StatusIndicator } from "@/components/shared/ReactFlow/FlowCanvas/TaskNode/StatusIndicator";
-import Logs from "@/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/logs";
 import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
 import { TaskNode } from "@/routes/v2/shared/nodes/TaskNode/TaskNode";
@@ -18,23 +17,19 @@ export const RunViewTaskNode = observer(function RunViewTaskNode(
   props: NodeProps<TaskNodeType>,
 ) {
   const { entityId } = props.data;
-  const { windows } = useSharedStores();
+  const { editor } = useSharedStores();
   const {
     task,
     status,
     disabledCache,
-    executionId,
     showLogsButton,
     subgraphExecutionStats,
   } = useTaskRunStatus(entityId);
 
   const handleOpenLogs = () => {
-    if (!task || !executionId) return;
-    windows.openWindow(<Logs executionId={executionId} status={status} />, {
-      id: `task-logs-${task.name}`,
-      title: `Logs: ${task.name}`,
-      size: { width: 500, height: 400 },
-    });
+    if (!task || task.subgraphSpec) return;
+    editor.selectNode(entityId, "task");
+    editor.setPendingTaskDetailTab("logs");
   };
 
   return (

--- a/src/routes/v2/pages/RunView/nodes/TaskNode/context/RunViewTaskDetails.tsx
+++ b/src/routes/v2/pages/RunView/nodes/TaskNode/context/RunViewTaskDetails.tsx
@@ -1,6 +1,7 @@
 import { useParams } from "@tanstack/react-router";
 import { AmphoraIcon, InfoIcon, LogsIcon } from "lucide-react";
 import { observer } from "mobx-react-lite";
+import { useEffect, useState } from "react";
 
 import type { ContainerExecutionStatus } from "@/api/types.gen";
 import IOSection from "@/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOSection";
@@ -11,6 +12,7 @@ import { LogsEventsOverlaySection } from "@/components/shared/ReactFlow/FlowCanv
 import { RemoteTroubleshootButton } from "@/components/shared/RemoteTroubleshootAction/RemoteTroubleshootButton";
 import { StatusIcon } from "@/components/shared/Status";
 import TaskDetails from "@/components/shared/TaskDetails/Details";
+import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -18,11 +20,16 @@ import { Text } from "@/components/ui/typography";
 import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { useExecutionDataOptional } from "@/providers/ExecutionDataProvider";
 import { useSpec } from "@/routes/v2/shared/providers/SpecContext";
+import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 import type { TaskSpec } from "@/utils/componentSpec";
 import { tracking } from "@/utils/tracking";
 
 import { RunViewTaskActions } from "./RunViewTaskActions";
 import { getTaskAnnotationSections } from "./RunViewTaskAnnotations";
+
+const DEFAULT_TAB = "artifacts";
+
+const LOGS_MIN_DOCKED_HEIGHT = 280;
 
 interface RunViewTaskDetailsProps {
   entityId: string;
@@ -34,11 +41,29 @@ export const RunViewTaskDetails = observer(function RunViewTaskDetails({
   const { track } = useAnalytics();
   const spec = useSpec();
   const executionData = useExecutionDataOptional();
+  const { editor, windows } = useSharedStores();
   const params = useParams({ strict: false });
   const runId =
     "id" in params && typeof params.id === "string" ? params.id : undefined;
 
   const task = spec?.tasks.find((t) => t.$id === entityId);
+  const isSubgraphTask = task?.subgraphSpec !== undefined;
+  const hasLogsTab = !!task && !isSubgraphTask;
+
+  const [activeTab, setActiveTab] = useState(DEFAULT_TAB);
+
+  useEffect(() => {
+    setActiveTab(DEFAULT_TAB);
+  }, [entityId]);
+
+  const pendingTab = editor.pendingTaskDetailTab;
+  useEffect(() => {
+    if (!pendingTab) return;
+    if (pendingTab !== "logs" || hasLogsTab) {
+      setActiveTab(pendingTab);
+    }
+    editor.setPendingTaskDetailTab(null);
+  }, [pendingTab, hasLogsTab, editor]);
 
   if (!task) {
     return (
@@ -55,9 +80,25 @@ export const RunViewTaskDetails = observer(function RunViewTaskDetails({
     executionData?.details?.child_task_execution_ids?.[task.name];
 
   const componentRef = task.resolvedComponentRef;
-  const isSubgraphTask = task.subgraphSpec !== undefined;
 
   const taskSpecForIO = { componentRef } as TaskSpec;
+
+  const handlePopOutLogs = () => {
+    if (!executionId) return;
+    windows.openWindow(
+      <Logs
+        executionId={executionId}
+        status={status}
+        allowFullscreen={false}
+      />,
+      {
+        id: `task-logs-${task.name}`,
+        title: `Logs: ${task.name}`,
+        size: { width: 500, height: 400 },
+        minDockedHeight: LOGS_MIN_DOCKED_HEIGHT,
+      },
+    );
+  };
 
   return (
     <BlockStack
@@ -86,13 +127,14 @@ export const RunViewTaskDetails = observer(function RunViewTaskDetails({
 
       <div className="overflow-y-auto pb-4 h-full w-full">
         <Tabs
-          defaultValue="artifacts"
+          value={activeTab}
           className="h-full"
-          onValueChange={(activeTab) =>
+          onValueChange={(nextTab) => {
+            setActiveTab(nextTab);
             track("v2.run_view.context_panel.task_detail_tab.select", {
-              active_tab: activeTab,
-            })
-          }
+              active_tab: nextTab,
+            });
+          }}
         >
           <TabsList className="mb-2 w-full">
             <TabsTrigger value="artifacts" className="flex-1">
@@ -133,19 +175,37 @@ export const RunViewTaskDetails = observer(function RunViewTaskDetails({
           {!isSubgraphTask && (
             <TabsContent value="logs">
               {!!executionId && (
-                <div className="flex w-full justify-end pr-4">
+                <InlineStack
+                  gap="2"
+                  blockAlign="center"
+                  align="end"
+                  className="w-full pr-4"
+                >
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={handlePopOutLogs}
+                    {...tracking("v2.run_view.context_panel.logs_pop_out")}
+                  >
+                    <Icon name="PictureInPicture2" size="xs" />
+                    Pop out
+                  </Button>
                   <OpenLogsInNewWindowLink
                     executionId={executionId}
                     status={status}
                     {...tracking("v2.run_view.context_panel.open_logs_new_tab")}
                   />
-                </div>
+                </InlineStack>
               )}
               <LogsEventsOverlaySection
                 executionId={executionId}
                 status={status as ContainerExecutionStatus}
               />
-              <Logs executionId={executionId} status={status} />
+              <Logs
+                executionId={executionId}
+                status={status}
+                allowFullscreen={false}
+              />
             </TabsContent>
           )}
         </Tabs>

--- a/src/routes/v2/pages/RunView/nodes/TaskNode/useTaskRunStatus.test.ts
+++ b/src/routes/v2/pages/RunView/nodes/TaskNode/useTaskRunStatus.test.ts
@@ -73,4 +73,36 @@ describe("useTaskRunStatus", () => {
 
     expect(result.current.subgraphExecutionStats).toBeNull();
   });
+
+  it("shows the logs button for a container task with logs", () => {
+    useSpecMock.mockReturnValue({
+      tasks: [
+        {
+          $id: "task-1",
+          name: "subgraph-task",
+          subgraphSpec: undefined,
+        },
+      ],
+    });
+
+    const { result } = renderHook(() => useTaskRunStatus("task-1"));
+
+    expect(result.current.showLogsButton).toBe(true);
+  });
+
+  it("hides the logs button for a subgraph task", () => {
+    useSpecMock.mockReturnValue({
+      tasks: [
+        {
+          $id: "task-1",
+          name: "subgraph-task",
+          subgraphSpec: {},
+        },
+      ],
+    });
+
+    const { result } = renderHook(() => useTaskRunStatus("task-1"));
+
+    expect(result.current.showLogsButton).toBe(false);
+  });
 });

--- a/src/routes/v2/pages/RunView/nodes/TaskNode/useTaskRunStatus.ts
+++ b/src/routes/v2/pages/RunView/nodes/TaskNode/useTaskRunStatus.ts
@@ -54,7 +54,8 @@ export function useTaskRunStatus(entityId: string): TaskRunStatus {
     ISO8601_DURATION_ZERO_DAYS;
 
   const executionId = resolveExecutionId(task, executionData);
-  const showLogsButton = !!executionId && shouldStatusHaveLogs(status);
+  const showLogsButton =
+    !!executionId && !task?.subgraphSpec && shouldStatusHaveLogs(status);
   const subgraphExecutionStats = resolveSubgraphExecutionStats(
     task,
     executionId,

--- a/src/routes/v2/shared/store/editorStore.ts
+++ b/src/routes/v2/shared/store/editorStore.ts
@@ -19,6 +19,7 @@ export class EditorStore {
   @observable accessor focusedArgumentName: string | null = null;
   @observable accessor hoveredEntityId: string | null = null;
   @observable accessor pendingFocusNodeId: string | null = null;
+  @observable accessor pendingTaskDetailTab: string | null = null;
   @observable.ref accessor selectedValidationIssue: ValidationIssue | null =
     null;
 
@@ -35,6 +36,7 @@ export class EditorStore {
     this.focusedArgumentName = null;
     this.hoveredEntityId = null;
     this.pendingFocusNodeId = null;
+    this.pendingTaskDetailTab = null;
     this.selectedValidationIssue = null;
   }
 
@@ -70,7 +72,12 @@ export class EditorStore {
     this.multiSelection = [];
     this.focusedArgumentName = null;
     this.hoveredEntityId = null;
+    this.pendingTaskDetailTab = null;
     this.selectedValidationIssue = null;
+  }
+
+  @action setPendingTaskDetailTab(tab: string | null) {
+    this.pendingTaskDetailTab = tab;
   }
 
   @computed get hasAnySelection(): boolean {

--- a/src/routes/v2/shared/windows/DockArea.tsx
+++ b/src/routes/v2/shared/windows/DockArea.tsx
@@ -138,13 +138,19 @@ export const DockArea = observer(function DockArea({ side }: DockAreaProps) {
           align="center"
           className="relative z-20 min-h-0 flex-1 overflow-y-auto overflow-x-hidden hide-scrollbar py-1 px-0.5"
         >
-          {visibleWindowsWithMini.map((windowId) => (
-            <CollapsedDockWindowMini
-              key={windowId}
-              windowId={windowId}
-              dockSide={side}
-            />
-          ))}
+          {visibleWindowsWithMini.map((windowId) =>
+            windows.getWindowById(windowId)?.renderMiniInline ? (
+              <div key={windowId} className="w-full shrink-0">
+                {windows.getWindowMiniContent(windowId)}
+              </div>
+            ) : (
+              <CollapsedDockWindowMini
+                key={windowId}
+                windowId={windowId}
+                dockSide={side}
+              />
+            ),
+          )}
         </BlockStack>
         <VerticalResizeHandle
           side={handleSide}

--- a/src/routes/v2/shared/windows/components/DockedWindow.tsx
+++ b/src/routes/v2/shared/windows/components/DockedWindow.tsx
@@ -17,7 +17,6 @@ import { SnapPreview } from "@/routes/v2/shared/windows/SnapPreview";
 import {
   DEFAULT_DOCKED_HEIGHT,
   DOCKED_HEADER_HEIGHT as HEADER_HEIGHT,
-  MIN_DOCKED_HEIGHT,
 } from "@/routes/v2/shared/windows/types";
 
 import { WindowActions } from "./WindowActions";
@@ -71,7 +70,7 @@ export const DockedWindow = observer(function DockedWindow() {
 
     const onMouseMove = (moveE: MouseEvent) => {
       const newHeight = Math.max(
-        MIN_DOCKED_HEIGHT,
+        model.minDockedHeight,
         startHeight + (moveE.clientY - startY),
       );
       model.updateDockedHeight(newHeight);
@@ -196,7 +195,7 @@ export const DockedWindow = observer(function DockedWindow() {
             isDragging && "opacity-50",
           )}
           style={{
-            minHeight: MIN_DOCKED_HEIGHT,
+            minHeight: model.minDockedHeight,
             // fillDockHeight => grow to fill the dock column; otherwise an
             // undefined height fits content and a concrete value fixes the
             // height with the inner content area scrolling.

--- a/src/routes/v2/shared/windows/types.ts
+++ b/src/routes/v2/shared/windows/types.ts
@@ -62,10 +62,12 @@ export interface WindowOptions {
   defaultDockState?: "left" | "right";
   variant?: "window" | "panel";
   fillDockHeight?: boolean;
+  minDockedHeight?: number;
   onClose?: () => void;
   // Without miniContent a window is filtered out of the collapsed dock strip, so
   // it is unreachable until the user expands the dock area again.
   miniContent?: ReactNode;
+  renderMiniInline?: boolean;
 }
 
 // All dimensions below are CSS pixels. See src/routes/v2/WINDOWS.md for what each one drives.

--- a/src/routes/v2/shared/windows/windowModel.ts
+++ b/src/routes/v2/shared/windows/windowModel.ts
@@ -44,6 +44,8 @@ export interface WindowModelInit {
   persisted: boolean;
   variant: "window" | "panel";
   fillDockHeight?: boolean;
+  minDockedHeight?: number;
+  renderMiniInline?: boolean;
   onClose?: () => void;
 }
 
@@ -73,6 +75,8 @@ export class WindowModel {
 
   /** Static config: when docked, fill remaining dock-area height. */
   readonly fillDockHeight: boolean;
+  readonly minDockedHeight: number;
+  readonly renderMiniInline: boolean;
   readonly onClose: (() => void) | undefined;
   private readonly store: WindowStoreRef;
 
@@ -95,6 +99,8 @@ export class WindowModel {
     this.persisted = init.persisted;
     this.variant = init.variant;
     this.fillDockHeight = init.fillDockHeight ?? false;
+    this.minDockedHeight = init.minDockedHeight ?? MIN_DOCKED_HEIGHT;
+    this.renderMiniInline = init.renderMiniInline ?? false;
     this.onClose = init.onClose;
     this.store = store;
     makeObservable(this);
@@ -216,7 +222,7 @@ export class WindowModel {
   }
 
   @action updateDockedHeight(height: number): void {
-    this.dockedHeight = Math.max(MIN_DOCKED_HEIGHT, height);
+    this.dockedHeight = Math.max(this.minDockedHeight, height);
   }
 
   /** Clears the explicit height so the window returns to fit-to-content sizing. */

--- a/src/routes/v2/shared/windows/windowStore.utils.test.ts
+++ b/src/routes/v2/shared/windows/windowStore.utils.test.ts
@@ -184,3 +184,25 @@ describe("resolveGeometry viewport clamping (via buildWindowModelInit)", () => {
     expect(init.position).toEqual(optionPosition);
   });
 });
+
+describe("minDockedHeight (via buildWindowModelInit)", () => {
+  it("passes the option through to the model init", () => {
+    const init = buildWindowModelInit(
+      "logs-window",
+      baseOptions({ minDockedHeight: 280 }),
+      DEFAULT_POSITION,
+    );
+
+    expect(init.minDockedHeight).toBe(280);
+  });
+
+  it("leaves the value unset when the option is omitted", () => {
+    const init = buildWindowModelInit(
+      "plain-window",
+      baseOptions(),
+      DEFAULT_POSITION,
+    );
+
+    expect(init.minDockedHeight).toBeUndefined();
+  });
+});

--- a/src/routes/v2/shared/windows/windowStore.utils.ts
+++ b/src/routes/v2/shared/windows/windowStore.utils.ts
@@ -50,6 +50,8 @@ export function buildWindowModelInit(
     persisted: !!options.persisted,
     variant: options.variant ?? "window",
     fillDockHeight: options.fillDockHeight,
+    minDockedHeight: options.minDockedHeight,
+    renderMiniInline: options.renderMiniInline,
     onClose: options.onClose,
   };
 }

--- a/src/utils/executionStatus.ts
+++ b/src/utils/executionStatus.ts
@@ -73,7 +73,7 @@ const CONTAINER_STATUSES_ACTIVELY_LOGGING = new Set([
 /**
  * Statuses considered "in progress" (not terminal).
  */
-const IN_PROGRESS_STATUSES = new Set([
+export const IN_PROGRESS_STATUSES = new Set([
   "RUNNING",
   "PENDING",
   "QUEUED",


### PR DESCRIPTION
## Description

This PR is a round of small polish fixes and quality-of-life improvements for the new (v2) runs view. None of them are big new features — they're the little things that make inspecting a run feel smoother and less confusing. In short:

- **Run info now tells you how a run was started** — a friendly note shows whether it came from the Tangle app or was kicked off via AI/CLI (this existed in the old view but had gone missing here).
- **The AI assistant is smarter about what it offers** — instead of always suggesting "Why did this run fail?", the quick prompts now match what actually happened (still running, succeeded, or failed).
- **Getting to logs is easier** — clicking "Open Logs" on a task now opens the properties panel straight to the Logs tab instead of spawning a separate window, and there's a "pop out" option if you do want logs in their own floating window. (Popped-out log windows are intentionally left out of the top-level Windows menu for now — closing one no longer leaves a stale entry behind.)
- **The properties panel behaves as expected** — if you close it and then click a task, it reopens (previously nothing happened).
- **A handful of visual fixes** — dark-mode colours that were too harsh or hard to read, text that got cut off or overflowed in narrow panels, and buttons that were stretched full-width now sit at a sensible fixed size.
- **The collapsed Run Tools sidebar shows real buttons** — when the run-tools dock is collapsed, the actions (view YAML, inspect, clone, cancel, rerun) now appear as a compact vertical strip of icon buttons instead of hiding behind a popover. Also adds a "Share Run" button to the toolbar, similar to the share button in v1.
- **You can submit a run with arguments from the compact view** — previously the collapsed submit button couldn't do this. In the compact editor bar exactly one submit button now shows: "run with arguments" when the pipeline has configurable inputs, otherwise the normal run button.

The goal is simply to make the v2 runs view feel more consistent, more polished, and closer to (or better than) the old view it's replacing.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix
- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

![](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADYAAADhCAYAAACDfkZKAAABTGlDQ1BJQ0MgUHJvZmlsZQAAKJF9kD9LQmEUhx/LEOKCDg0NQQ7RZGEm/RnVIgIHsYRqu15NA72+XK9EW0PtQi1tYUufoJaGvkFB0BARza2RS8ntXK20os7L4ffwe885HA70abpSJS9QNm0rvRQPrq1vBH1P+BglgIZfN6oqlkolpYRP/R7NWzyu3ky4s37//xuDuXzVEH2TjBrKssETFk5t28rlXeEhS5YSPnS50OFTl7MdvmjXrKYTwtfCAaOo54QfhUPZHr/Qw+VSzfjYwd1ey5uZFdFhyREWWCQpL0iGCLNMMS9e4o+eaLsnQQXFDhZbFChiS3dMHEWJvPAyJgaThIQjhCVn3Fv/vGHXqzRg7gX6610vewTn+7LmXdcbOwb/HpxdKd3Svy7raXqrm9ORDmtxGHhwnOdx8B1Aq+44rw3HaZ3I/Hu4NN8BNt1ctRWLZ54AAABWZVhJZk1NACoAAAAIAAGHaQAEAAAAAQAAABoAAAAAAAOShgAHAAAAEgAAAESgAgAEAAAAAQAAADagAwAEAAAAAQAAAOEAAAAAQVNDSUkAAABTY3JlZW5zaG908pDpVAAAAdVpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IlhNUCBDb3JlIDYuMC4wIj4KICAgPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4KICAgICAgPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIKICAgICAgICAgICAgeG1sbnM6ZXhpZj0iaHR0cDovL25zLmFkb2JlLmNvbS9leGlmLzEuMC8iPgogICAgICAgICA8ZXhpZjpQaXhlbFlEaW1lbnNpb24+MjI1PC9leGlmOlBpeGVsWURpbWVuc2lvbj4KICAgICAgICAgPGV4aWY6UGl4ZWxYRGltZW5zaW9uPjU0PC9leGlmOlBpeGVsWERpbWVuc2lvbj4KICAgICAgICAgPGV4aWY6VXNlckNvbW1lbnQ+U2NyZWVuc2hvdDwvZXhpZjpVc2VyQ29tbWVudD4KICAgICAgPC9yZGY6RGVzY3JpcHRpb24+CiAgIDwvcmRmOlJERj4KPC94OnhtcG1ldGE+CjA7x/wAABBWSURBVHgB7V1rbB3FFZ5rJ7bjxHbsOA5JIMTqDyLUPERRgYIC4SX6h6pVAZGmASrRUqkqgaRUqlootEUU8awqtVWlNjggJPoLVKq2anikCaQVbQMCSn+0MeFpx078fsXX7nxzc9a7szO7M/fO7t6Ldpyb3Z3HOeebM3Nmds7ubOGaq6+af+ONN1hSocAaWEfD51lTXTdnUfDYFOdH2NCp/WxqrteLc3myyCUxFa15NsMGZ55VJSUaV5co9QyJ58AyrPyyWOcaK6vaMiyUayzDyi+Lda6xsqotw0K5xjKs/LJYL2rvXMu6Vo+WVTiJQoMDfeySSy5mBw8eqoh83hQrqj4HhTtWdGqptLW1sfr6+kB6zWhsbFTfXSYmJtjc3FwAmPZ+rFAosLpCHeMHfn+4cIMYKG17MT/P+D82Nz/Hj/zEIszMTGtznzp1KpSmBFZXV89BFQTzOSFJsDZCVEwjOE381XP6oDs3VzQtaZ0vBAxMcQefCFMORvxxZRXq6gTAYkLgAn0MmgKoeam9WleXQQHBg/MSPA3y22bxgJX6FG9+KYAiIcELTR68XQcPGAyFbYd2IQx4gndcaGlp1WZpbl7KNR+k4V2h0tD+0w7gaaKwqEpXyS2AiUICWfrAhP3nvKMER2WPjenHsUmbcSxKc5u3bNImv34kucVXLVNFQsjcK/IEom66aSfbuXNHIE6+uHP3HpY1QGtgANXT8yR74omeAB5o8ZGHH2JHuMZwzBqcZzwCUsZcHHn9iDbHbq4tAhfVZLUEHCWUBSyKN8D07OsR4HZ+dWdUVqu0xqYmbf6GhobQWGjdFHXU0adIU7o8lcQ3Nzez6akpJYmmpiWsWCyKH2VwBgwE0QwpUJ+j60qPJ0+c0JIYGRkOpTlviiEOGUVYA4NFzNqUm9SVNTDZzJswySKPNTAM0A/zcQoB5/hVY7ACRrMO8lljPMOATUCTBCjP3v28VLc9xsBg5eRZB/oaZhhbeFrSmlvZ1eXHEjhv7+jgq1RBA28MjMYpgPPPKGgQlmcjWzZvCTCv9KLv44+1JE4MDvIxbDaQbgwMpWi6RGCgJWiL5oW43r//z+JH2g1wS/GicOP2m+fffvvfbPHixWyOj94mARrTmXy/NnV5ZB51fLETS2joK66WuIMNU+aouY4SOCpNQy6R6IWmiPVDk3t012IkdOfuARO4sPaWcsACKni7DgIY2jYWSFXjgWuGMj3wxKJpHO+1Z54lF/Wuu7pWsUWLgr3Ku8KScwE/voyV1toieIEvFnLigH3w/nseEPmkv79PjmJeU0RKscgX99HVpDW6UCkHEYIH5yV4OqAnk/CAlWqswGY5OF6BYum5gIVMlwaF0wJNLGuDB3hhTT1OW7LQJtdeU0RmMABD1OIcFwAOCixBc0lMaMXn4cRLgGb5ER6cZEBBkAAwRBA4tHvSHuJdhVIDgPVNDhRkDQFD5ELTgABchQ7DAm2HRBWkYtsYBHH5U8hgFAWTrgul2X3QB63UmI5AlvGDgwNa9sNDwyFHpRYYtFRNPmgsr+mCyvuqBJb7oHVVqIuHuccft0cYoDGc5D5oXWVp4j2rWOpTuQ9aU0/20ZgImPigl7e3a4m3tLTUrg9a55AA2pmZGd5vgxMJ0RRFJOY6UqK2ilwmCEsS74OenJzUcp2eng4BU5p7LQWDhK5VXWzDhg1ezuHhYb7w87p3ndaJc2C/+uUvWGtrS0D+O3d/J3VwzoDRshtA3Xvfj9mBlw8IcFhnxPOEaQcnwGhNP23ho/h541hUpri0TZs2CTftFVdc7WXdeulWhp+r0Lx0qZZU05IlIXNvpbEdO77C1qxd7TF466232fO//4N3jZNnn3uO3XP39724kZFRhpXmSoO8CuWnJz82izRjYFu3XsJuueUm9vLpvoPCd96xKwTsZ4//nOHnOoxw66oL42NjoSRjYHzWKgrfxw0DwnXXX8cu5U3tru/uYd3d69jEhH6cEQVS/q/sPlYvLfDII3/KOELszDUmVpUYu9vXf0DtwZ8+lIpHMyR5TIQxsAMHDrK9e3vY6jVneCQfffRx75xOvn37t9gXrr2WLhmMx223fZP19fV7cWmcGAODMPv2PRkrE0BhgKYAC3kOn2JVCgz+O9Vj6OADi4mlA393KLuPkeA44tkpeDYxy0BYf/Z6MfOg2YeIrPC/trblWgrLloVvW6w0pqMMZx/ctQh4pK/33V5x7vK/gYHjWnJDQydDaU6AgSp5MtGn/AM00jDDTzs4A0aC3/r1b7Bzzz2XLgWoT8Rty8DxAW9m76HL4GTBeJy+k01dhoTu3D1gAhf3gKQduGcgkRUJAQxLb9Xug169Zq22zjtXrqxdH/RHH36gBTZwPDwUeE0RpXIftLbuYhJ4k8990DF1FJccGqBhSGAhMaHMfdBx1edLR8WlEQLGQ8UQgrj8qXiYxK1evUabrbMzwtxrS1VJwkcffaiVRDXzD/UxKg0tVZMPmuQyPSqB5T5o0+qjfNzS5j5oqowyjwGrKF7D/6S9B41HE/yrPGVWlHUx8DTxQa/o7NTSblu+XL/tBcZNtP+0A3iajNmjIyNa0cbHx/ltFx4TXAiiKQpNCWTpAxPzN847rrXAga4Ls/yZfbm80tzrCCCePJe6PLRapUtPK94KGN46wsJoVMB7mv5XGqPyJplmDAyaAii/11IlGFaDkTdrzRkDU4FQxcUBV5VJIq4iYIv5+8cXXXgBnrVVy8ZN+auvHtY6E9SF1LGtra3cc6O2jEu5fxoPuPgtY9nA4P147LGH2IZzFh5WUYn0zn/eYbtu310xuGIxaM79vPyAKL5sYBdddKEAFdf00OeQ98CBvxLPso7j42E/MxFSPY4UmFJRRqOjovldz/3S+IWCIm8oj+OIsjWmkmN999mq6EzinACDlgBq48ZPCxB4kqD36LvsmWd+lwkoMDVuihiXMPjSOJWZxIaMrTSGGQUNvv7HiUgz0BQCniRwHbADxNSU+lmShsZGdkp6GNMKGISNmlGg+SUVlvDnpXTAGjmw2VN4EWjh2XxrYJ7gfPCVA2lOjhcz+FCkXcTJk/ptL1S3NGUDw4wCgy89KaATE3lePfw3XXJi8WUDwzMXu3btSW1KZVsDZQMDI3TYSmcUtgKb5l8w9+gzGcwQBE9FfzUFoMvnARO4qtgHHbVdoWpLDAEMy9nV7oOGn1kXli9vD61SeX2s2t+D7u+L2PbixGAIs9cUkZL7oEP1YxjBm3zugzasK102r49RBhgSWEgsQOY+aKoVgyMqLo0QMB4qhhDE5U/FwyTuzLPWabN1rYrY9kJbqkoS3n/vmFaS/r7wthehPkaloaXcB021EXdEs+Z/8MWlvhc35l3o36q3wePkjk3nljYzHzSaYBpbywgevAKjJrexFRWRIWAVcx90RE3ZJmEiYOKD7lq18OqJzKOjY0Vodu9pDP2qmn3QqqdICSBeKJB3jxDAhP9WIAuvPFHhxI6Yv6Ff4xgRooyZytviaSyCZk0maQdoFRpyrNOiKV1jW0LaJbNa9ji1Akb7Ku4+skfsgIk9FBGwpo83a+Gjpn0VswZoBYy0SE8P0IaRFI8jvRMNoFk+PWDdx6AV/FSgAAyaQhryAKSr0N7eoSXVwv3T8kBvBYz6ETjgPTHdbrPog9goWd7vVCuZQcLk5IQ21/QUdocI+qitmiK0Ydp3kI/6oFYii4QpzQbjIKH6Co+VxmAFyRKayASjQgbHJL/LPFYaIyFhFU0C3t3MKlhpjF4yNRUWfY3GPNMyrvJZASOmUdYOBgU+M/pF5SV6SRytgJlYO4xd9IYtBMZ45iIsXbZMSwZuXNkxYQUMlGHtYBRg7lXagHFBGvLg5yrIgvvpqtKsjAcRg1YACuYcPwKAQRmBPn+iG+eIjs1R5Wem8nh0Vg5lAQMRGtNIa2hy1ATJYGRpFcsGRjUUNWATQMqb5tG6j6UpXCW8FoCdvpOthFhZZRO6c/eACVxV7IPG13R0YRF/KBTLhv4ggCGy2n3QuDXRBTw6K5t8z3hUuw96cCBqc9ahEGavKSIl90GH6scwgjf53AdtWFe6bF4fowzCKZH7oKk6zI+yWTYvaZczYDxURSGIy5+Kh0lc/h706VpS9jHnvmdZJXyag5lOOd+FlknprgPAEnv/WeaO5p2wL9oDhikJ55eM71kGBo3hDx6khPbkFsYDmhJmXnqBU5YnieukfNElYFxVaTjUdRUD3q6/C12HDSDjvIk6gVzGx/mirXc5Qr9Ce886QAbxKRWNIGXscgRk2QMrWZLgzaIGo1F07MzDiEoVZsqBVaFSIkVKTGPnn//ZkPs0UhLHiU6A3fuj+xl+67u7hXg4XnX1NeyCCy50Bs72hYKKgW27/EoB5ujRo+LY0NDIrr9hO8PLapdtu4Kdd95nnOhieCi8YEOEx8ZG+VQw6IOuGBiIv/TiC4JHd/enhD/4wQd+wia4M/zpp/ex1177O/Gv6KjbShdEZ2fxtl9wyKoY2NnrS83v3d6jjM7B7JGHH+Rv1pa0iOu0gze7N2VM/QjaAZBu3p/2/ubXon9dtu1ydvPXbmUAifDiC38xJes8n7XGbuGCX7btSgEKAH7LQSFAO/f84HseKICEQckqWAODoNASacXf3Eib0CQZk6yA1W/efN4Pjyu2ytQJ9NKL+8W9G9IB4Itf+jLr7f0fG+JW647dd4npNEAf+dc/+O+fIl5HS47HTec4t3Dr1q1jx44FPy/Zyj+4ge+zqAL800XJgFj3MRA+fPgVNjlRegQIfQr9DT9oCf0tiQDLpwvFWb7BuJRoBQwfpdi+fYfQ1CuHDrE//fF50SShOWiJmqfEw8nlhMLPTIRVL35b9bGNGzfzlSX+yv0D97PPXXwxW9LczLX0X0EfxqKaghWwPv7p1DV8A8frbrhRaIeaI4wJQpbmXa5Uq6Z4jDe3p57qYfhC4ptvlp7hgFWEma+2YAUMwifdl1xVkFVTdMW0HDp4rEgXMOHG8qE/1AywxsYmv9yBczjeZWDWTTFAMcUL1ecViP3o6CidekeuMW6/JTV6qWmeQAbp1qMS9nVi/ZwF22clBMstW+AyOMTF6nDnKbfPcoWrpBxkcPmxUK6xefFaofhUeCWSVVAWvOnb6xWQCRQVVjHN5zsC3PmFqFDezYUMcqLvWvWNMUquqw9+MhnxJacYb9/0lnrJpcTxJmlQOG3b5z1WrIjYnJXf0sjAhblH+0bHRa0l8q11qlo6cmbgN1s0//Z6P5+n6sLJE+EdkLxxjMChz5H2dIRcxJcaBKwxtOfeKnvAIOwCAzDiVZpgWOCVDJMAMD+LpBn7eSVxXjNzRVvwOTDbGnOdf+2ZZ2lJruQ3vvJ3NrV9TEslo4QP3g8ux/nFOK4YCvKm6K+hWjjPNVYLWvLLmGvMXxtZnK86I2LbixXhbS9qxtwf79d/Ehaze+eu2rS0JzvP/XxlUEjL+5i/hmrhPNdYLWjJL2PNaAw7GelCa2sbk1eqagaY6pVgAgpXrfxMc82MY9PTU4QjdFR9hadmNBZCExORA4upoKpLzjWWtUqWLWvRioDnTeTXhWtGY1Gr4HAayuH/q3/VnEUxdw0AAAAASUVORK5CYII=)

![image.png](https://app.graphite.com/user-attachments/assets/1d3eb8b9-a088-4b60-9236-0e9accd93022.png)

![image.png](https://app.graphite.com/user-attachments/assets/7e9db520-b347-416b-b349-6d4683cccb53.png)

![image.png](https://app.graphite.com/user-attachments/assets/1be1a979-5630-474b-a393-e5c05e73cf03.png)





<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

Open a v2 run and check the fixes above feel right:

1. **Run info** — the source note appears and reads correctly for a run started from the app vs. programmatically.
2. **AI assistant** — the suggested prompts match the run's outcome (a passed run should not ask "why did it fail?").
3. **Logs** — "Open Logs" on a task opens the properties panel on the Logs tab; the "pop out" option opens a floating logs window. Close a popped-out log window and confirm it does not linger in the Windows menu.
4. **Properties panel** — close it, then click a task; it should reopen.
5. **Dark mode** — the cancel button red and the selected-prompt header both look right.
6. **Narrow panels** — long values and the artifact-expiry warning wrap instead of getting cut off or overflowing.
7. **Collapsed Run Tools** — collapse the Run Tools dock and confirm the actions render as icon buttons in the sidebar rail (not behind a popover), each with a tooltip.
8. **Compact submit** — collapse the editor menu bar and confirm exactly one submit button shows: "run with arguments" for a pipeline with inputs, otherwise the plain run button — never both at once.

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->