### PR TITLE
fix: v2 runview  - add task annotations section

### DIFF
--- a/src/components/shared/CopyText/CopyText.tsx
+++ b/src/components/shared/CopyText/CopyText.tsx
@@ -1,4 +1,9 @@
-import { type MouseEvent, useEffect, useState } from "react";
+import {
+  type ComponentProps,
+  type MouseEvent,
+  useEffect,
+  useState,
+} from "react";
 
 import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
@@ -15,6 +20,8 @@ interface CopyTextProps {
   alwaysShowButton?: boolean;
   compact?: boolean;
   size?: "xs" | "sm" | "md" | "lg" | "xl";
+  tone?: ComponentProps<typeof Text>["tone"];
+  font?: ComponentProps<typeof Text>["font"];
   copyTrackingAction?: string;
 }
 
@@ -25,6 +32,8 @@ export const CopyText = ({
   alwaysShowButton = false,
   compact = false,
   size = "md",
+  tone,
+  font,
   copyTrackingAction,
 }: CopyTextProps) => {
   const { track } = useAnalytics();
@@ -64,6 +73,8 @@ export const CopyText = ({
       <InlineStack gap="1" blockAlign="center" wrap="nowrap">
         <Text
           size={size}
+          tone={tone}
+          font={font}
           className={cn(
             "min-w-0 transition-all duration-150",
             className,

--- a/src/routes/v2/pages/RunView/nodes/TaskNode/context/RunViewTaskAnnotations.tsx
+++ b/src/routes/v2/pages/RunView/nodes/TaskNode/context/RunViewTaskAnnotations.tsx
@@ -1,0 +1,93 @@
+import { observer } from "mobx-react-lite";
+import type { ReactNode } from "react";
+
+import { CopyText } from "@/components/shared/CopyText/CopyText";
+import { BlockStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
+import type { Annotation } from "@/models/componentSpec";
+import type { Annotations } from "@/models/componentSpec/annotations";
+
+interface TaskAnnotationSection {
+  title: string;
+  component: ReactNode;
+  isCollapsed?: boolean;
+}
+
+function formatAnnotationValue(value: unknown): string {
+  if (value === undefined || value === null) return "";
+  if (typeof value === "object") return JSON.stringify(value);
+  return String(value);
+}
+
+/**
+ * Builds annotation sections shaped for `TaskDetails`'s `additionalSection` prop
+ * so they render inside the shared details card (matching legacy layout) rather
+ * than as a detached block. User and system annotations are kept separate.
+ */
+export function getTaskAnnotationSections(
+  annotations: Annotations,
+): TaskAnnotationSection[] {
+  return [
+    {
+      title: "Task Annotations",
+      component: <AnnotationList annotations={annotations.items} />,
+      isCollapsed: true,
+    },
+  ];
+}
+
+interface AnnotationRowProps {
+  annotation: Annotation;
+}
+
+const AnnotationRow = observer(function AnnotationRow({
+  annotation,
+}: AnnotationRowProps) {
+  const value = formatAnnotationValue(annotation.value);
+
+  return (
+    <BlockStack align="stretch" className="min-w-0 w-full">
+      {annotation.key ? (
+        <CopyText
+          size="xs"
+          compact
+          tone="subdued"
+          font="mono"
+          className="truncate"
+        >
+          {annotation.key}
+        </CopyText>
+      ) : (
+        <Text size="xs" font="mono" tone="subdued">
+          (empty key)
+        </Text>
+      )}
+      {value ? (
+        <CopyText size="xs" compact font="mono" className="truncate">
+          {value}
+        </CopyText>
+      ) : (
+        <Text size="xs" font="mono" tone="subdued">
+          (empty value)
+        </Text>
+      )}
+    </BlockStack>
+  );
+});
+
+interface AnnotationListProps {
+  annotations: Annotation[];
+}
+
+function AnnotationList({ annotations }: AnnotationListProps) {
+  return (
+    <BlockStack gap="1">
+      {annotations.map((annotation, index) => (
+        <AnnotationRow
+          key={`${annotation.key}-${index}`}
+          annotation={annotation}
+        />
+      ))}
+    </BlockStack>
+  );
+}

--- a/src/routes/v2/pages/RunView/nodes/TaskNode/context/RunViewTaskDetails.tsx
+++ b/src/routes/v2/pages/RunView/nodes/TaskNode/context/RunViewTaskDetails.tsx
@@ -22,6 +22,7 @@ import type { TaskSpec } from "@/utils/componentSpec";
 import { tracking } from "@/utils/tracking";
 
 import { RunViewTaskActions } from "./RunViewTaskActions";
+import { getTaskAnnotationSections } from "./RunViewTaskAnnotations";
 
 interface RunViewTaskDetailsProps {
   entityId: string;
@@ -125,6 +126,7 @@ export const RunViewTaskDetails = observer(function RunViewTaskDetails({
               status={status}
               readOnly
               options={{ descriptionExpanded: true }}
+              additionalSection={getTaskAnnotationSections(task.annotations)}
             />
           </TabsContent>
 


### PR DESCRIPTION
## Description

Adds task annotation display to the Run View task details panel. Annotations are rendered inside the existing details card as a collapsible "Task Annotations" section, showing each annotation's key and value in a monospace font with copy-to-clipboard support. Empty keys or values are indicated with placeholder text rather than being silently omitted.

To support styled rendering of annotation text, `CopyText` now accepts `tone` and `font` props, which are forwarded directly to the underlying `Text` component.

## Screenshots (if applicable)

![image.png](https://app.graphite.com/user-attachments/assets/ecdce5f1-f536-4d9a-884a-4d1e9a519c36.png)



## Test Instructions

1. Open a run that has tasks with annotations attached.
2. Navigate to a task node and open its details panel.
3. Expand the "Task Annotations" section and verify each annotation's key and value are displayed correctly.
4. Click the copy button on a key or value and confirm the correct text is copied to the clipboard.
5. Verify that tasks with empty annotation keys or values show the appropriate placeholder text.

## Additional Comments