### PR TITLE
chore: v2 runview  - split task annotations into user and system section

### DIFF
--- a/src/routes/v2/pages/RunView/nodes/TaskNode/context/RunViewTaskAnnotations.tsx
+++ b/src/routes/v2/pages/RunView/nodes/TaskNode/context/RunViewTaskAnnotations.tsx
@@ -6,6 +6,7 @@ import { BlockStack } from "@/components/ui/layout";
 import { Text } from "@/components/ui/typography";
 import type { Annotation } from "@/models/componentSpec";
 import type { Annotations } from "@/models/componentSpec/annotations";
+import { SYSTEM_ANNOTATIONS } from "@/utils/annotations";
 
 interface TaskAnnotationSection {
   title: string;
@@ -27,13 +28,36 @@ function formatAnnotationValue(value: unknown): string {
 export function getTaskAnnotationSections(
   annotations: Annotations,
 ): TaskAnnotationSection[] {
-  return [
-    {
+  const systemKeys = new Set<string>(SYSTEM_ANNOTATIONS);
+  const userAnnotations: Annotation[] = [];
+  const systemAnnotations: Annotation[] = [];
+
+  for (const annotation of annotations) {
+    if (systemKeys.has(annotation.key)) {
+      systemAnnotations.push(annotation);
+    } else {
+      userAnnotations.push(annotation);
+    }
+  }
+
+  const sections: TaskAnnotationSection[] = [];
+
+  if (userAnnotations.length > 0) {
+    sections.push({
       title: "Task Annotations",
-      component: <AnnotationList annotations={annotations.items} />,
+      component: <AnnotationList annotations={userAnnotations} />,
+    });
+  }
+
+  if (systemAnnotations.length > 0) {
+    sections.push({
+      title: "System annotations",
+      component: <AnnotationList annotations={systemAnnotations} />,
       isCollapsed: true,
-    },
-  ];
+    });
+  }
+
+  return sections;
 }
 
 interface AnnotationRowProps {


### PR DESCRIPTION
## Description

Task annotations in the Run View are now split into two distinct sections: **Task Annotations** (user-defined) and **System Annotations** (system-defined, based on the `SYSTEM_ANNOTATIONS` list). User annotations are shown expanded by default, while system annotations are collapsed. Either section is only rendered if it contains at least one annotation.

## Screenshots (if applicable)

| Before | After |
| --- | --- |
| ![image.png](https://app.graphite.com/user-attachments/assets/47a37a7e-14eb-4c46-85bc-42ca44a27f96.png)<br> | ![image.png](https://app.graphite.com/user-attachments/assets/a163efec-311f-42e8-979e-4df8287ea24f.png)<br> |

## Test Instructions

1. Open a run in the Run View that has task nodes with annotations.
2. Verify that user-defined annotations appear under the **Task Annotations** section.
3. Verify that system-defined annotations (keys matching `SYSTEM_ANNOTATIONS`) appear under the **System annotations** section, collapsed by default.
4. Verify that if only one type of annotation exists, only the relevant section is rendered.

## Additional Comments

UX is consistent with the Editor counter part