### PR TITLE
Enhance search results to display additional components

### DIFF
--- a/src/routes/v2/pages/Editor/components/ComponentSearchResults.test.tsx
+++ b/src/routes/v2/pages/Editor/components/ComponentSearchResults.test.tsx
@@ -150,6 +150,80 @@ describe("ComponentSearchResults", () => {
     expect(screen.getByText("source Published")).toBeInTheDocument();
   });
 
+  it("renders matches in a vertically scrollable list", () => {
+    const results: ComponentSearchV2Result[] = [
+      {
+        reference: { digest: "digest", name: "Load CSV" },
+        source: { kind: "standard", id: "standard", label: "Standard" },
+      },
+    ];
+
+    render(
+      <ComponentSearchResults {...baseProps} query="csv" results={results} />,
+    );
+
+    expect(screen.getByTestId("search-results-list")).toHaveClass(
+      "overflow-y-auto",
+    );
+  });
+
+  it("shows large result sets progressively", () => {
+    const results: ComponentSearchV2Result[] = Array.from(
+      { length: 25 },
+      (_, index) => ({
+        reference: { digest: `digest-${index}`, name: `Component ${index}` },
+        source: { kind: "standard", id: "standard", label: "Standard" },
+      }),
+    );
+
+    render(
+      <ComponentSearchResults
+        {...baseProps}
+        query="component"
+        results={results}
+      />,
+    );
+
+    expect(screen.getByTestId("search-results-header")).toHaveTextContent(
+      "Search Results (10 of 25)",
+    );
+    expect(screen.getAllByRole("listitem")).toHaveLength(10);
+
+    const showMoreButton = screen.getByRole("button", {
+      name: "Show 10 more",
+    });
+    expect(showMoreButton).toHaveAttribute(
+      "data-tracking-id",
+      "component_library.search.show_more",
+    );
+    expect(showMoreButton).toHaveAttribute(
+      "data-tracking-metadata",
+      JSON.stringify({
+        surface: "editor_component_search_v2",
+        shown_count: 10,
+        result_count: 25,
+        ai_ranked: false,
+      }),
+    );
+
+    fireEvent.click(showMoreButton);
+
+    expect(screen.getByTestId("search-results-header")).toHaveTextContent(
+      "Search Results (20 of 25)",
+    );
+    expect(screen.getAllByRole("listitem")).toHaveLength(20);
+
+    fireEvent.click(screen.getByRole("button", { name: "Show 5 more" }));
+
+    expect(screen.getByTestId("search-results-header")).toHaveTextContent(
+      "Search Results (25)",
+    );
+    expect(screen.getAllByRole("listitem")).toHaveLength(25);
+    expect(
+      screen.queryByRole("button", { name: /Show .* more/ }),
+    ).not.toBeInTheDocument();
+  });
+
   it("passes matched fields through for result explanations", () => {
     const results: ComponentSearchV2Result[] = [
       {

--- a/src/routes/v2/pages/Editor/components/ComponentSearchResults.tsx
+++ b/src/routes/v2/pages/Editor/components/ComponentSearchResults.tsx
@@ -1,3 +1,5 @@
+import { useState } from "react";
+
 import { ComponentSearchEmptyStateSuggestions } from "@/components/shared/ComponentSearchEmptyStateSuggestions";
 import {
   ComponentMarkup,
@@ -13,8 +15,12 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Paragraph, Text } from "@/components/ui/typography";
 import type { ComponentSearchSuggestion } from "@/services/componentSearchSuggestions";
 import type { UIComponentFolder } from "@/types/componentLibrary";
+import { tracking } from "@/utils/tracking";
 
 import type { ComponentSearchV2Result } from "./componentSearchV2Logic";
+
+const INITIAL_VISIBLE_RESULT_COUNT = 10;
+const RESULT_PAGE_SIZE = 10;
 
 interface ComponentSearchResultsProps {
   query: string;
@@ -83,6 +89,12 @@ export function ComponentSearchResults({
   onSuggestedSearch,
 }: ComponentSearchResultsProps) {
   const isEmptyQuery = query.trim().length === 0;
+  const [visibleResultCount, setVisibleResultCount] = useState(
+    INITIAL_VISIBLE_RESULT_COUNT,
+  );
+  const visibleResults = results.slice(0, visibleResultCount);
+  const remainingResultCount = results.length - visibleResults.length;
+  const nextPageSize = Math.min(RESULT_PAGE_SIZE, remainingResultCount);
 
   if (!isEmptyQuery && (isLoading || isSearching)) {
     return <ComponentSearchResultsSkeleton />;
@@ -125,9 +137,18 @@ export function ComponentSearchResults({
       data-testid="search-results-container"
     >
       <InlineStack align="space-between" blockAlign="center" gap="2">
-        <Text tone="subdued" size="sm" data-testid="search-results-header">
+        <Text
+          tone="subdued"
+          size="sm"
+          role="status"
+          aria-live="polite"
+          data-testid="search-results-header"
+        >
           {isRerankActive ? "AI-ranked results" : "Search Results"} (
-          {results.length})
+          {remainingResultCount > 0
+            ? `${visibleResults.length} of ${results.length}`
+            : results.length}
+          )
         </Text>
         {isRerankActive && (
           <Button
@@ -141,23 +162,51 @@ export function ComponentSearchResults({
         )}
       </InlineStack>
       <Separator />
-      <BlockStack className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden scrollbar-thin">
+      <BlockStack
+        className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden scrollbar-thin"
+        data-testid="search-results-list"
+      >
         {results.length > 0 ? (
-          <BlockStack
-            as="ul"
-            className="[&_li]:marker:hidden [&_li]:before:content-none [&_li]:list-none"
-          >
-            {results.map((result) => (
-              <ComponentMarkup
-                key={`${result.reference.digest}-${result.reference.name ?? result.reference.url ?? "component"}`}
-                component={result.reference}
-                matchedFields={result.matchedFields}
-                rerankScore={result.rerankScore}
-                rerankReason={result.rerankReason}
-                showOutdatedBadge={false}
-                source={result.source}
-              />
-            ))}
+          <BlockStack>
+            <BlockStack
+              as="ul"
+              className="[&_li]:marker:hidden [&_li]:before:content-none [&_li]:list-none"
+            >
+              {visibleResults.map((result) => (
+                <ComponentMarkup
+                  key={`${result.reference.digest}-${result.reference.name ?? result.reference.url ?? "component"}`}
+                  component={result.reference}
+                  matchedFields={result.matchedFields}
+                  rerankScore={result.rerankScore}
+                  rerankReason={result.rerankReason}
+                  showOutdatedBadge={false}
+                  source={result.source}
+                />
+              ))}
+            </BlockStack>
+            {remainingResultCount > 0 && (
+              <div className="px-2 pb-2 pt-1">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="w-full"
+                  onClick={() =>
+                    setVisibleResultCount(
+                      (current) => current + RESULT_PAGE_SIZE,
+                    )
+                  }
+                  {...tracking("component_library.search.show_more", {
+                    surface: "editor_component_search_v2",
+                    shown_count: visibleResults.length,
+                    result_count: results.length,
+                    ai_ranked: isRerankActive,
+                  })}
+                >
+                  Show {nextPageSize} more
+                </Button>
+              </div>
+            )}
           </BlockStack>
         ) : (
           <BlockStack gap="2">

--- a/src/routes/v2/pages/Editor/components/ComponentSearchV2Content.tsx
+++ b/src/routes/v2/pages/Editor/components/ComponentSearchV2Content.tsx
@@ -230,6 +230,11 @@ export function ComponentSearchV2Content() {
         />
       </BlockStack>
       <ComponentSearchResults
+        key={JSON.stringify([
+          deferredQuery,
+          [...disabledSourceKeys].sort(),
+          isRerankActive ? "ai" : "lexical",
+        ])}
         query={deferredQuery}
         results={results}
         browseFolders={browseFolders}

--- a/src/routes/v2/pages/Editor/components/componentSearchV2Logic.test.ts
+++ b/src/routes/v2/pages/Editor/components/componentSearchV2Logic.test.ts
@@ -22,7 +22,6 @@ import {
   buildResults,
   buildSourcedHydratedReferences,
   collectAllSourcedReferences,
-  LEXICAL_RESULT_LIMIT,
   mergeSearchIndexes,
   PUBLISHED_SOURCE,
   registeredLibrariesFingerprint,
@@ -330,20 +329,18 @@ describe("buildLexicalMatches / buildAiCandidateMatches", () => {
     expect(buildAiCandidateMatches(index, "")).toEqual([]);
   });
 
-  it("caps displayed lexical results below the AI candidate pool", () => {
+  it("returns every lexical match while keeping the AI candidate pool bounded", () => {
     const broadIndex = buildSearchIndex(
-      Array.from({ length: 20 }, (_, i) => ({
+      Array.from({ length: 100 }, (_, i) => ({
         reference: ref(`train-${i}`, `train_${i}`),
         source: source("standard"),
       })),
     );
 
-    expect(buildLexicalMatches(broadIndex, "train")).toHaveLength(
-      LEXICAL_RESULT_LIMIT,
-    );
-    expect(buildAiCandidateMatches(broadIndex, "train").length).toBeGreaterThan(
-      LEXICAL_RESULT_LIMIT,
-    );
+    expect(buildLexicalMatches(broadIndex, "train")).toHaveLength(100);
+    expect(
+      buildAiCandidateMatches(broadIndex, "train").length,
+    ).toBeLessThanOrEqual(80);
   });
 
   it("returns no AI candidates when literal search finds nothing", () => {

--- a/src/routes/v2/pages/Editor/components/componentSearchV2Logic.ts
+++ b/src/routes/v2/pages/Editor/components/componentSearchV2Logic.ts
@@ -29,8 +29,6 @@ import type {
   HydratedComponentReference,
 } from "@/utils/componentSpec";
 
-/** How many hits to show by default before the user asks for AI judgment. */
-export const LEXICAL_RESULT_LIMIT = 10;
 const AI_CANDIDATE_LIMIT = 80;
 const AI_LEXICAL_CANDIDATE_LIMIT = 60;
 const AI_SOURCE_DIVERSITY_CANDIDATES_PER_SOURCE = 8;
@@ -326,7 +324,7 @@ export function buildResultFolders({
 
 /**
  * Matches to display: an alphabetical browse list for an empty query, otherwise
- * the top lexical hits.
+ * every lexical hit in relevance order. The results panel owns scrolling.
  */
 export function buildLexicalMatches(
   index: IndexEntry[],
@@ -338,7 +336,7 @@ export function buildLexicalMatches(
       .map(indexEntryToLexicalMatch);
   }
   return lexicalSearch(index, trimmedQuery, {
-    limit: LEXICAL_RESULT_LIMIT,
+    limit: index.length,
     minLength: 1,
   });
 }

--- a/src/routes/v2/pages/Editor/hooks/useComponentSearchV2State.ts
+++ b/src/routes/v2/pages/Editor/hooks/useComponentSearchV2State.ts
@@ -29,7 +29,6 @@ import {
   buildResults,
   collectAllSourcedReferences,
   type ComponentSearchV2State,
-  LEXICAL_RESULT_LIMIT,
   mergeSearchIndexes,
   registeredLibrariesFingerprint,
   registeredSource,
@@ -51,6 +50,8 @@ import { componentReferenceToCandidate } from "@/services/naturalLanguageCompone
 import type { ComponentFolder } from "@/types/componentLibrary";
 import type { ComponentReference } from "@/utils/componentSpec";
 import { HOURS } from "@/utils/constants";
+
+const AI_EMBEDDING_FALLBACK_LIMIT = 20;
 
 function mergeUniqueMatches(
   primary: LexicalMatch[],
@@ -262,11 +263,14 @@ export function useComponentSearchV2State(
     !isEmbeddingSearchPending &&
     (rerankData?.matches.length ?? 0) > 0;
 
-  const displayedMatches = (
-    isRerankActive
-      ? rerankedMatches(rerankData, rerankBaseMatches)
-      : lexicalMatches
-  ).slice(0, LEXICAL_RESULT_LIMIT);
+  const displayedMatches = isRerankActive
+    ? mergeUniqueMatches(
+        rerankedMatches(rerankData, rerankBaseMatches),
+        [],
+        lexicalMatches,
+        rerankBaseMatches.length + lexicalMatches.length,
+      )
+    : lexicalMatches;
 
   const buildEmbeddingMatches = async ({
     sourceIndex,
@@ -318,7 +322,7 @@ export function useComponentSearchV2State(
     const canUseEmbeddings = useEmbeddings && canUseEmbeddingSearch;
     if (matches.length === 0 && !canUseEmbeddings) return;
 
-    const effectiveLimit = limit || LEXICAL_RESULT_LIMIT;
+    const effectiveLimit = limit || AI_EMBEDDING_FALLBACK_LIMIT;
     const embeddingMatches = canUseEmbeddings
       ? await buildEmbeddingMatches({
           sourceIndex: filteredIndex,
@@ -359,7 +363,7 @@ export function useComponentSearchV2State(
     void startRerank(aiCandidateMatches, {
       scoreAllCandidates: true,
       useEmbeddings: true,
-      limit: aiCandidateMatches.length || LEXICAL_RESULT_LIMIT,
+      limit: aiCandidateMatches.length || AI_EMBEDDING_FALLBACK_LIMIT,
     });
   };
 


### PR DESCRIPTION
## Description

Updates Editor V2 component search so valid matches are no longer silently excluded by the 10-result search cap.

Search now retains all lexical matches while rendering them progressively:

- Shows the first 10 results by default.
- Displays the visible and total counts, such as `Search Results (10 of 25)`.
- Provides a scrollable, full-width “Show 10 more” action.
- Adjusts the final increment when fewer than 10 results remain.
- Resets the visible count when the query, source filters, or AI-ranking mode changes.
- Keeps AI re-ranking bounded to 80 candidates to control latency and model usage, while preserving access to the remaining lexical matches.
- Tracks “Show more” interactions without including search-query text.

This fixes cases where an exact component match exists but ranks below the first 10 results, making it appear unavailable in the editor.

## Related Issue and Pull requests

- [#687](https://github.com/Shopify/oasis-frontend/issues/687)

## Type of Change

- [x] Bug fix
- [x] Improvement

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

Recommended screenshots:

<img width="506" height="305" alt="image" src="https://github.com/user-attachments/assets/131764d7-5403-486f-8007-2a62a0b77da7" />
<img width="511" height="391" alt="image" src="https://github.com/user-attachments/assets/df80f3b6-8914-49ab-9d50-fefa9bf0d7f4" />

## Test Instructions

1. Open a pipeline in Editor V2.
2. Open Component Search.
3. Search for a term with more than 10 matching components, such as `comp`.
4. Confirm that:
   - The first 10 results appear.
   - The header shows `Search Results (10 of N)`.
   - The results area remains vertically scrollable.
   - A full-width “Show 10 more” button appears after the results.
5. Select “Show 10 more” and confirm:
   - The next 10 results appear in relevance order.
   - The header updates to `20 of N`.
   - Previously visible results retain their ordering.
6. Continue expanding until all results are visible.
7. Confirm the final button reflects the remaining count, such as “Show 5 more.”
8. Change the search query and confirm the visible count resets to 10.
9. Toggle a component-source filter and confirm the visible count resets to 10.
10. Trigger AI re-ranking and confirm:
    - The visible count resets to 10.
    - AI-ranked candidates appear first.
    - Additional lexical matches remain available through “Show more.”
11. Clear the query and confirm the normal component browsing experience remains unchanged.
12. Search for a term with no matches and confirm the existing empty-state guidance appears.

Automated verification completed:

- 111 component-search tests pass.
- TypeScript type checking passes.
- ESLint passes, aside from the existing React-version configuration warning.
- Prettier and `git diff --check` pass.

## Additional Comments

The result list intentionally uses progressive rendering instead of immediately rendering every matching component. This keeps the editor responsive for broad searches containing hundreds of matches while ensuring that no valid lexical result is inaccessible.

The existing results panel remains the only scrolling boundary; this avoids nested scrolling and preserves keyboard and trackpad behavior.