### PR TITLE
fix: Conflict between Artifact Preview buttons

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ArtifactPreviewHeader.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ArtifactPreviewHeader.tsx
@@ -1,6 +1,6 @@
 import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
-import { InlineStack } from "@/components/ui/layout";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Heading, Text } from "@/components/ui/typography";
 import { tracking } from "@/utils/tracking";
 
@@ -22,27 +22,36 @@ export const ArtifactPreviewHeader = ({
   isDir,
   shareUrl,
   onShareClick,
-}: ArtifactPreviewHeaderProps) => (
-  <InlineStack gap="4" blockAlign="center">
-    <Heading level={2}>{name}</Heading>
-    {!!type && (
-      <Text size="xs" tone="subdued" weight="light" className="-ml-2">
-        {type}
-      </Text>
-    )}
-    <InlineStack gap="3" wrap="nowrap" blockAlign="center">
-      {!!artifactUri && <ArtifactURI uri={artifactUri} isDir={!!isDir} />}
-      {shareUrl && onShareClick && (
-        <Button
-          variant="ghost"
-          size="xs"
-          onClick={onShareClick}
-          {...tracking("pipeline_run.artifact_preview.share")}
-        >
-          Share
-          <Icon name="Share2" size="xs" />
-        </Button>
+}: ArtifactPreviewHeaderProps) => {
+  const showShare = !!shareUrl && !!onShareClick;
+
+  return (
+    <BlockStack gap="1">
+      <InlineStack gap="2" blockAlign="center">
+        <Heading level={2}>{name}</Heading>
+        {!!type && (
+          <Text size="xs" tone="subdued" weight="light">
+            {type}
+          </Text>
+        )}
+      </InlineStack>
+
+      {(!!artifactUri || showShare) && (
+        <InlineStack gap="3" wrap="nowrap" blockAlign="center">
+          {!!artifactUri && <ArtifactURI uri={artifactUri} isDir={!!isDir} />}
+          {showShare && (
+            <Button
+              variant="ghost"
+              size="xs"
+              onClick={onShareClick}
+              {...tracking("pipeline_run.artifact_preview.share")}
+            >
+              Share
+              <Icon name="Share2" size="xs" />
+            </Button>
+          )}
+        </InlineStack>
       )}
-    </InlineStack>
-  </InlineStack>
-);
+    </BlockStack>
+  );
+};


### PR DESCRIPTION
## Description

Moves the `raw data`, `copy uri` and `share`buttons onto a new line so they no longer conflict with the dialog's `close` and `maximise` buttons.

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix
- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

before

![image.png](https://app.graphite.com/user-attachments/assets/2616b02e-ea71-4215-96b7-752960284d9d.png)

after

![image.png](https://app.graphite.com/user-attachments/assets/06f1dac2-42b6-4fa7-8669-0ad1520ad706.png)



<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->