### PR TITLE
garden(dry): weekly groundskeeping — 2026-W33

### DIFF
--- a/src/components/shared/Submitters/GoogleCloud/compiler/vertexAiCompiler.ts
+++ b/src/components/shared/Submitters/GoogleCloud/compiler/vertexAiCompiler.ts
@@ -7,6 +7,7 @@ import {
   type StringOrPlaceholder,
   type TypeSpecType,
 } from "@/utils/componentSpec";
+import { makeNameUniqueByAddingIndex } from "@/utils/unique";
 
 import * as vertex from "./vertexPipelineSpec";
 
@@ -832,19 +833,6 @@ const buildVertexTaskSpecFromTaskSpec = (
   };
 
   return vertexTaskSpec;
-};
-
-const makeNameUniqueByAddingIndex = (
-  name: string,
-  existingNames: Set<string>,
-): string => {
-  let finalName = name;
-  let index = 1;
-  while (existingNames.has(finalName)) {
-    index++;
-    finalName = name + " " + index.toString();
-  }
-  return finalName;
 };
 
 const buildVertexPipelineSpecFromGraphComponentSpec = (

--- a/src/routes/Dashboard/DashboardComponentsV2View.tsx
+++ b/src/routes/Dashboard/DashboardComponentsV2View.tsx
@@ -64,6 +64,7 @@ import {
   type LexicalMatch,
   lexicalSearch,
   type MatchField,
+  mergeUniqueMatches,
   type SourcedReference,
 } from "@/services/componentSearchIndex";
 import { buildComponentSearchSuggestions } from "@/services/componentSearchSuggestions";
@@ -643,31 +644,6 @@ const ComponentDescriptionPanel = ({
     </BlockStack>
   );
 };
-
-/**
- * Merge every component source the rest of the app knows about into a single
- * deduped, source-attributed list.
- *
- * Order matters: the first occurrence of a digest wins. Priority is
- * `standard > published > registered > user` so the most canonical label
- * sticks when the same component appears in multiple places.
- */
-function mergeUniqueMatches(
-  primary: LexicalMatch[],
-  secondary: LexicalMatch[],
-  fallback: LexicalMatch[],
-  limit: number,
-): LexicalMatch[] {
-  const merged: LexicalMatch[] = [];
-  const seen = new Set<string>();
-  for (const match of [...primary, ...secondary, ...fallback]) {
-    if (seen.has(match.digest)) continue;
-    seen.add(match.digest);
-    merged.push(match);
-    if (merged.length >= limit) return merged;
-  }
-  return merged;
-}
 
 const AI_SEARCH_PROGRESS_VERBS = [
   "Scanning",

--- a/src/routes/v2/pages/Editor/hooks/useComponentSearchV2State.ts
+++ b/src/routes/v2/pages/Editor/hooks/useComponentSearchV2State.ts
@@ -39,6 +39,7 @@ import {
   buildSearchIndex,
   type IndexEntry,
   type LexicalMatch,
+  mergeUniqueMatches,
   type SourcedReference,
 } from "@/services/componentSearchIndex";
 import { buildComponentSearchSuggestions } from "@/services/componentSearchSuggestions";
@@ -52,23 +53,6 @@ import type { ComponentReference } from "@/utils/componentSpec";
 import { HOURS } from "@/utils/constants";
 
 const AI_EMBEDDING_FALLBACK_LIMIT = 20;
-
-function mergeUniqueMatches(
-  primary: LexicalMatch[],
-  secondary: LexicalMatch[],
-  fallback: LexicalMatch[],
-  limit: number,
-): LexicalMatch[] {
-  const merged: LexicalMatch[] = [];
-  const seen = new Set<string>();
-  for (const match of [...primary, ...secondary, ...fallback]) {
-    if (seen.has(match.digest)) continue;
-    seen.add(match.digest);
-    merged.push(match);
-    if (merged.length >= limit) return merged;
-  }
-  return merged;
-}
 
 export function useComponentSearchV2State(
   query: string,

--- a/src/services/componentSearchIndex.ts
+++ b/src/services/componentSearchIndex.ts
@@ -79,6 +79,27 @@ export function indexEntryToLexicalMatch(entry: IndexEntry): LexicalMatch {
   };
 }
 
+/**
+ * Concatenates match lists and drops repeats by digest, stopping at `limit`.
+ * The first occurrence of a digest wins, so pass the lists in priority order.
+ */
+export function mergeUniqueMatches(
+  primary: LexicalMatch[],
+  secondary: LexicalMatch[],
+  fallback: LexicalMatch[],
+  limit: number,
+): LexicalMatch[] {
+  const merged: LexicalMatch[] = [];
+  const seen = new Set<string>();
+  for (const match of [...primary, ...secondary, ...fallback]) {
+    if (seen.has(match.digest)) continue;
+    seen.add(match.digest);
+    merged.push(match);
+    if (merged.length >= limit) return merged;
+  }
+  return merged;
+}
+
 const ANNOTATION_KEYS_EXCLUDED_FROM_SEARCH = new Set([
   "editor.position",
   "editor.collapsed",

--- a/src/utils/unique.ts
+++ b/src/utils/unique.ts
@@ -1,6 +1,6 @@
 import type { ComponentSpec, GraphSpec } from "./componentSpec";
 
-const makeNameUniqueByAddingIndex = (
+export const makeNameUniqueByAddingIndex = (
   name: string,
   existingNames: Set<string>,
 ): string => {


### PR DESCRIPTION
> 🤖 **Automated draft PR — opened by the `gardening` skill. Nothing here auto-merges.**
> First run of the `dry` pillar. It is deliberately **small**: only clusters that are
> **byte-identical duplicate functions with an unambiguous canonical home** were applied. Everything
> else the scan found needs a human architectural call and is in the decision queue, not here.

## What this is

Two duplicated helpers consolidated. Both were **byte-identical** copies, so both changes are provable
null transforms — the only behavioral surface is module identity.

- [ ] **`makeNameUniqueByAddingIndex`** — 3 identical copies; canonical one already lived (private) in
      `src/utils/unique.ts`. Exported it and adopted it in
      `src/components/shared/Submitters/GoogleCloud/compiler/vertexAiCompiler.ts`.
      `action: adopt-existing` — `project-conventions#file-structure--imports`
- [ ] **`mergeUniqueMatches`** — 2 identical copies in `DashboardComponentsV2View.tsx` and
      `useComponentSearchV2State.ts`. Hoisted to `src/services/componentSearchIndex.ts`, which already
      owns `LexicalMatch` and which **both files already import from** — so no new coupling edge is
      created. `project-conventions#file-structure--imports`

| | |
| --- | --- |
| Findings applied | **2** (2 `adopt-existing`/hoist, 0 new modules) |
| Files | 5 (`+25 / −56`) |
| Multi-file duplicate clusters indexed | 238 (192 not test-only) |
| Confidence threshold | `0.8` (config) |
| Validation | `pnpm run validate:test` ✅ — 191 test files / 1,966 tests |

## Deliberately not done

- **A third copy of `makeNameUniqueByAddingIndex` remains** in `src/utils/componentStore.ts:285`. That
  file is claimed by the `comments` PR (#2620) in this same run, so editing it here would collide.
  It is in the carry-over manifest and will be swept next run.
- **v1 ↔ v2 parallel implementations were left alone** — `PipelineTags`/`TagsBlock`,
  `PipelineRun`/`RunViewV2`, `RunDetails`/`RunDetailsContent`, `FlexNodeEditor`/`FlexNodeDetails`,
  `IONode`/`IONodeCard` and others share 10–25 line blocks, but that is a **deliberate migration**, not
  accidental duplication. Coupling the old and new implementations mid-migration is exactly the
  "diverging intent" KEEP case. Recorded as one decision-queue item, not ten findings.
- **The Dashboard ↔ v2-editor search-logic overlap was not auto-fixed.**
  `DashboardComponentsV2View.tsx` re-declares `STANDARD_SOURCE`, `PUBLISHED_SOURCE`, `USER_SOURCE`,
  `registeredSource`, `registeredLibraryConfigurationFingerprint` and
  `createRegisteredLibrariesFingerprint`, all of which exist in
  `routes/v2/pages/Editor/components/componentSearchV2Logic.ts`. Adopting them directly would make
  `routes/Dashboard/**` import from another page's internals; the correct fix is to relocate that logic
  to `src/services/**` first. That is a multi-file architectural move → decision queue.
- **Repeated UI idioms that would need a *new* shared component** (the
  `useConfirmationDialog` + `<ConfirmationDialog>` boilerplate in 6 files; the Dashboard pagination
  control in 2; `RunActionsBar`/`RunMenu` sharing ~34 lines of menu items) are **proposals**, not
  findings. This pillar does not author new shared components.

## Reviewer checklist

- [ ] ⚠️ **Self-review was skipped (review skill unavailable) — review this diff manually.**
      The `gardening` engine requires every PR to survive the `review` skill before handoff, but that
      skill is marked `disable-model-invocation` and can only be run by a human typing `/review`.
      No automated adversarial pass ran on this diff.
- [ ] The two moved function bodies are **character-for-character** what they replaced (the only
      intended change is where they live)
- [ ] `mergeUniqueMatches` now carries a short doc stating the first-occurrence-wins contract; the
      Dashboard's old JSDoc claimed a `standard > published > registered > user` priority that did not
      describe its own arguments (it passes lexical/embedding/fallback lists) — confirm dropping that
      stale claim is right
- [ ] Exporting `makeNameUniqueByAddingIndex` from `@/utils/unique` is an acceptable widening of that
      module's surface

`requiresBehaviorReview` is not set for this pillar, but note the honest blast radius: **cross-file**.
`validate:test` proves the call graph still type-checks and every test passes; it cannot prove that two
identical-looking functions were *meant* to stay separate. Both here are pure and total, so they were not.
