### PR TITLE
garden(refactor): weekly groundskeeping — 2026-W33

### DIFF
--- a/src/utils/validations.ts
+++ b/src/utils/validations.ts
@@ -356,7 +356,7 @@ const validateTaskOutputReference = (
     if (referencedTask.componentRef && referencedTask.componentRef.spec) {
       const referencedTaskSpec = referencedTask.componentRef.spec;
       const outputExists = referencedTaskSpec.outputs?.some(
-        (output: any) => output.name === referencedOutput,
+        (output) => output.name === referencedOutput,
       );
 
       if (!outputExists) {

--- a/src/utils/validations.ts
+++ b/src/utils/validations.ts
@@ -582,7 +582,7 @@ const validateCircularDependencies = (
           argValue !== null &&
           "taskOutput" in argValue
         ) {
-          const dependentTaskId = (argValue as any).taskOutput.taskId;
+          const dependentTaskId = argValue.taskOutput.taskId;
           if (hasCycle(dependentTaskId)) {
             return true;
           }


### PR DESCRIPTION
> 🤖 **Automated draft PR — opened by the `gardening` skill. Nothing here auto-merges.**
> First run of the `refactor` pillar, and it is **deliberately two lines**. This is the
> highest-subjectivity pillar, so the run leaned hard on the confidence gate: everything that would have
> been a judgment call about how code *should* look was routed to the decision queue instead of edited.

## What this is

Two `any` escapes removed in `src/utils/validations.ts` (fta score 72.1). Both are **type-level only** —
`any` annotations and `as any` assertions erase at compile time, so these are null transforms **by
construction**, not merely by passing tests.

- [ ] `validations.ts:359` — `(output: any) => …` → `(output) => …`.
      `referencedTaskSpec` is a `ComponentSpec`, so `outputs?.some()` already infers `OutputSpec`; the
      annotation only threw that inference away. `typescript-standards#core-rules`
- [ ] `validations.ts:585` — `(argValue as any).taskOutput.taskId` → `argValue.taskOutput.taskId`.
      The enclosing `typeof argValue === "object" && argValue !== null && "taskOutput" in argValue`
      guard already narrows the union — the assertion discarded narrowing the code had just earned.
      `typescript-standards#avoid-unsafe-type-casting`

These were the **only two `any` occurrences** in the file, and `tsc --noEmit` passes without them.

| | |
| --- | --- |
| Findings applied | **2** |
| Files | 1 (`+2 / −2`) |
| fta files scoring >60 | 85 (threshold `thresholds.refactorFtaScore: 60`) |
| Confidence threshold | `0.8` (config) |
| Validation | `pnpm run validate:test` ✅ — 191 test files / 1,966 tests |

## What the scan found and deliberately did not touch

This is the interesting half of this PR — three candidate classes were investigated and **rejected on
their merits**, not missed:

1. **`as unknown as ArgumentType`** (`arguments.actions.ts:57`, `BatchArgumentRow.tsx:138`) — the cast
   exists because the `ArgumentType` union does not include `DynamicDataArgument`, exactly as the
   in-code comment says. The correct fix widens a **`componentSpec` type**, which is a protected pattern
   requiring express permission → `touchesProtected: true`, decision queue.
2. **`PIPELINE_YAML_LOAD_OPTIONS … as unknown as yaml.LoadOptions`** (`utils/yaml.ts:8`) — verified
   against `node_modules/js-yaml@4.3.1`: `maxDepth` **is** a real runtime option
   (`js-yaml.js:1103`, enforced at `:2058`) that is simply missing from the shipped
   `LoadOptions` type. This is the "absolutely necessary" exception in the convention. **KEEP** — and
   worth stating, because a naive sweep would have "fixed" a working depth limit into a no-op.
3. **4 contexts hand-roll what `@/hooks/useRequiredContext` already does**
   (`useDialog.ts:8`, `NodeRegistryContext.tsx:22`, `SpecContext.tsx:41`,
   `ContentWindowStateContext.tsx:31`) while ~11 other providers use the canonical hook. Adopting it
   would change the thrown message text (`"useDialog must be used within DialogProvider"` →
   `"Required context … was not found"`) and switch the context default to `null`. Observable behavior →
   decision queue, not auto-apply.

Also checked and found clean: every `style={{…}}` hit holds computed layout values (legitimate per
`project-conventions#dont-do`), and the remaining ~33 `any` uses in non-test source are genuine escape
hatches (`window.gtag`, `catch (err: any)`, `obj is X` type-guard parameters).

## Reviewer checklist

- [ ] ⚠️ **Self-review was skipped (review skill unavailable) — review this diff manually.**
      The engine requires every PR to survive the `review` skill first, but that skill is
      `disable-model-invocation` and only a human can run it. No adversarial pass ran on this diff.
- [ ] Both removals are type-only — confirm no runtime semantics ride on them
- [ ] `validateCircularDependencies` still narrows correctly for every `ArgumentType` member
- [ ] If two findings feels too thin for the effort, the lever is
      `categories[refactor].confidenceThreshold` (currently `0.8`) — see the decision queue
