### PR TITLE
chore(gardening): adopt UI primitives + tone prop where the class delta is provably zero (18 swaps)

### DIFF
--- a/src/components/Home/PipelineSection/PipelineRow.tsx
+++ b/src/components/Home/PipelineSection/PipelineRow.tsx
@@ -27,7 +27,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { Paragraph } from "@/components/ui/typography";
+import { Paragraph, Text } from "@/components/ui/typography";
 import { cn } from "@/lib/utils";
 import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { getDefaultEditorPath } from "@/routes/editorRoutes";
@@ -215,7 +215,9 @@ const PipelineRow = withSuspenseWrapper(
           </div>
         </TableCell>
         <TableCell>
-          <span className="text-xs text-muted-foreground">{formattedDate}</span>
+          <Text size="xs" tone="subdued">
+            {formattedDate}
+          </Text>
         </TableCell>
         <TableCell className="max-w-64">
           {tags && tags.length > 0 && <TagList tags={tags} />}

--- a/src/components/Learn/DocsQuickLinks.tsx
+++ b/src/components/Learn/DocsQuickLinks.tsx
@@ -78,7 +78,7 @@ function QuickLinkPill({ link }: { link: QuickLink }) {
 export function DocsQuickLinks() {
   return (
     <BlockStack gap="1">
-      <Text size="sm" weight="semibold" className="text-muted-foreground">
+      <Text size="sm" weight="semibold" tone="subdued">
         Quick links
       </Text>
       <InlineStack gap="2">

--- a/src/components/shared/CodeViewer/CodeViewer.tsx
+++ b/src/components/shared/CodeViewer/CodeViewer.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
+import { Text } from "@/components/ui/typography";
 
 import { FullscreenElement } from "../FullscreenElement";
 import CodeSyntaxHighlighter from "./CodeSyntaxHighlighter";
@@ -60,7 +61,9 @@ const CodeViewer = ({
             <span className="font-semibold text-base text-foreground">
               {filename}
             </span>
-            <span className="text-sm text-muted-foreground">(Read Only)</span>
+            <Text size="sm" tone="subdued">
+              (Read Only)
+            </Text>
           </div>
           <Button
             type="button"

--- a/src/components/shared/GitHubLibrary/components/AddGitHubLibraryDialogContent.tsx
+++ b/src/components/shared/GitHubLibrary/components/AddGitHubLibraryDialogContent.tsx
@@ -39,7 +39,7 @@ const ComponentList = ({
 
             <BlockStack align="start">
               <Text className="truncate max-w-106.25">{component.name}</Text>
-              <Text size="xs" tone="subdued" className="font-mono">
+              <Text size="xs" tone="subdued" font="mono">
                 Ver: {trimDigest(component.digest)}
               </Text>
             </BlockStack>

--- a/src/components/shared/ReactFlow/FlowCanvas/ConfirmationDialogs/shared.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/ConfirmationDialogs/shared.tsx
@@ -1,7 +1,8 @@
+import { Paragraph } from "@/components/ui/typography";
 import type { ArgumentType } from "@/utils/componentSpec";
 
 export const thisCannotBeUndone = (
-  <p className="text-muted-foreground">This cannot be undone.</p>
+  <Paragraph tone="subdued">This cannot be undone.</Paragraph>
 );
 
 export function getArgumentDetails(

--- a/src/components/shared/ReactFlow/FlowCanvas/Subgraphs/create/NodeListItem.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/Subgraphs/create/NodeListItem.tsx
@@ -64,7 +64,7 @@ export function NodeListItem({
         {isOrphaned && (
           <InlineStack gap="1" wrap="nowrap">
             <Icon name="TriangleAlert" className="text-destructive" />
-            <Paragraph size="xs" className="text-destructive">
+            <Paragraph size="xs" tone="critical">
               Orphaned
             </Paragraph>
           </InlineStack>

--- a/src/routes/Dashboard/DashboardComponentsView.tsx
+++ b/src/routes/Dashboard/DashboardComponentsView.tsx
@@ -68,7 +68,7 @@ const CollapsibleSection = ({
       >
         {label}
       </Text>
-      <Text size="xs" className="text-muted-foreground tabular-nums">
+      <Text size="xs" tone="subdued" className="tabular-nums">
         {count}
       </Text>
     </CollapsibleTrigger>
@@ -150,7 +150,7 @@ const FolderNode = ({
         className="text-muted-foreground transition-transform shrink-0 group-data-[state=open]:rotate-90"
         size="sm"
       />
-      <Text size="xs" className="text-muted-foreground font-medium truncate">
+      <Text size="xs" tone="subdued" className="font-medium truncate">
         {folder.name}
       </Text>
     </CollapsibleTrigger>

--- a/src/routes/Dashboard/DashboardFavoritesView.tsx
+++ b/src/routes/Dashboard/DashboardFavoritesView.tsx
@@ -148,7 +148,7 @@ export function DashboardFavoritesView() {
               >
                 <Icon name="ChevronLeft" />
               </Button>
-              <Text size="sm" className="text-muted-foreground">
+              <Text size="sm" tone="subdued">
                 {safePage + 1} / {totalPages}
               </Text>
               <Button

--- a/src/routes/Dashboard/DashboardHomeView.tsx
+++ b/src/routes/Dashboard/DashboardHomeView.tsx
@@ -62,7 +62,7 @@ const RecentlyViewedPreviewRow = ({ item }: { item: RecentItem }) => (
         </TooltipTrigger>
         <TooltipContent>{item.name}</TooltipContent>
       </Tooltip>
-      <Text size="xs" className="text-muted-foreground shrink-0">
+      <Text size="xs" tone="subdued" className="shrink-0">
         {formatRelativeTime(new Date(item.timestamp))}
       </Text>
     </Link>
@@ -144,7 +144,7 @@ const RecentComponentPreviewRow = ({
           </TooltipTrigger>
           <TooltipContent>{item.name}</TooltipContent>
         </Tooltip>
-        <Text size="xs" className="text-muted-foreground shrink-0">
+        <Text size="xs" tone="subdued" className="shrink-0">
           {formatRelativeTime(new Date(item.timestamp))}
         </Text>
       </Link>

--- a/src/routes/Dashboard/DashboardRecentlyViewedView.tsx
+++ b/src/routes/Dashboard/DashboardRecentlyViewedView.tsx
@@ -20,7 +20,7 @@ const RecentlyViewedCardBody = ({ item }: { item: RecentItem }) => (
   >
     <InlineStack blockAlign="center" align="space-between" gap="2">
       <TypePill type={item.type} />
-      <Text size="xs" className="text-muted-foreground">
+      <Text size="xs" tone="subdued">
         {formatRelativeTime(new Date(item.timestamp))}
       </Text>
     </InlineStack>
@@ -97,7 +97,7 @@ export function DashboardRecentlyViewedView() {
               >
                 <Icon name="ChevronLeft" />
               </Button>
-              <Text size="sm" className="text-muted-foreground">
+              <Text size="sm" tone="subdued">
                 {safePage + 1} / {totalPages}
               </Text>
               <Button

--- a/src/routes/v2/pages/Editor/components/IssueResolution/resolutions/MissingPipelineInputValueResolution.tsx
+++ b/src/routes/v2/pages/Editor/components/IssueResolution/resolutions/MissingPipelineInputValueResolution.tsx
@@ -76,7 +76,7 @@ export const MissingPipelineInputValueResolution = observer(
                 size="sm"
                 className="text-muted-foreground"
               />
-              <Text size="xs" className="text-muted-foreground">
+              <Text size="xs" tone="subdued">
                 Use as default
               </Text>
             </InlineStack>

--- a/src/routes/v2/pages/Editor/nodes/ConduitNode/context/ConduitDetails.tsx
+++ b/src/routes/v2/pages/Editor/nodes/ConduitNode/context/ConduitDetails.tsx
@@ -106,7 +106,7 @@ export const ConduitDetails = observer(function ConduitDetails({
                   >
                     <Icon name="X" size="xs" />
                   </Button>
-                  <Text size="xs" className="truncate flex-1 font-mono">
+                  <Text size="xs" font="mono" className="truncate flex-1">
                     {edgeLabel(
                       binding.sourceEntityId,
                       binding.sourcePortName,

--- a/src/routes/v2/pages/Editor/nodes/IONode/context/InputDetails.tsx
+++ b/src/routes/v2/pages/Editor/nodes/IONode/context/InputDetails.tsx
@@ -129,7 +129,7 @@ export const InputDetails = observer(function InputDetails({
                 size="sm"
                 className="text-muted-foreground"
               />
-              <Text size="xs" className="text-muted-foreground">
+              <Text size="xs" tone="subdued">
                 Use as default
               </Text>
             </InlineStack>
@@ -152,7 +152,7 @@ export const InputDetails = observer(function InputDetails({
           <Text size="xs" className="text-gray-400">
             Optional:
           </Text>
-          <Text size="xs" weight="semibold" className="text-muted-foreground">
+          <Text size="xs" weight="semibold" tone="subdued">
             {input.optional ? "Yes" : "No"}
           </Text>
         </InlineStack>

--- a/src/routes/v2/pages/Editor/nodes/IONode/context/OutputDetails.tsx
+++ b/src/routes/v2/pages/Editor/nodes/IONode/context/OutputDetails.tsx
@@ -65,7 +65,7 @@ export const OutputDetails = observer(function OutputDetails({
             >
               Type
             </InputLabel>
-            <Text size="xs" className="font-mono text-gray-500">
+            <Text size="xs" font="mono" className="text-gray-500">
               {String(output.type)}
             </Text>
           </BlockStack>


### PR DESCRIPTION
> 🤖 **Automated draft PR — opened by the `gardening` skill. Nothing here auto-merges.**
> 18 swaps in 14 files, every one **provably identical computed CSS**. The `primitives` category is
> `requiresVisualReview: true`, so this PR deliberately applies *only* exact mappings and leaves every
> judgement call to the decision queue. PR #2569's lesson — a `<p>` → `<Paragraph>` swap is **not**
> automatically null — is honoured by proving the class delta from source before touching anything.

## The proof this run is built on

Read from source, not assumed:

1. **`textVariants` fills in defaults.** `src/components/ui/typography.tsx:21` — `Text` defaults to
   `tone="inherit" size="md" weight="regular" font="default"`, which emit
   `text-foreground` / `text-md` / `font-regular` / `""`.
2. **`text-md` and `font-regular` emit no CSS.** Neither `--text-md` nor `--font-weight-regular` exists
   in the `@theme inline` block (`src/styles/global.css:194`), and neither is a Tailwind default
   (v4 ships `text-base`, `font-normal`). `tailwind.config.js` extends `fontSize` with only `2xs`/`3xs`.
   So the *only* class a primitive adds with real CSS behind it is the `tone` colour.
3. **`cn` is `twMerge(clsx(...))`** (`src/lib/utils.ts:4`), so a trailing `className="text-muted-foreground"`
   already **overrode** the `text-foreground` that `tone="inherit"` injects. Moving that colour into
   `tone="subdued"` therefore produces the identical computed colour *and* removes a conflicting
   class pair.

That is what makes each swap below an exact mapping rather than a hopeful one.

## Findings applied

**Raw HTML → primitive (3)** — `ui-primitives#typography`

- [ ] `ConfirmationDialogs/shared.tsx:4` — `<p className="text-muted-foreground">` →
      `<Paragraph tone="subdued">`. Renders `<p>` either way; classes identical.
- [ ] `PipelineRow.tsx:218` — `<span className="text-xs text-muted-foreground">` →
      `<Text size="xs" tone="subdued">`. `Text` renders a `<span>` by default.
- [ ] `CodeViewer.tsx:63` — `<span className="text-sm text-muted-foreground">` →
      `<Text size="sm" tone="subdued">`.

**Hardcoded colour className → `tone` (12)** — `ui-primitives#typography`

- [ ] `DocsQuickLinks.tsx:81`, `InputDetails.tsx:132`, `InputDetails.tsx:155`,
      `MissingPipelineInputValueResolution.tsx:79`, `DashboardFavoritesView.tsx:151`,
      `DashboardRecentlyViewedView.tsx:23`, `DashboardRecentlyViewedView.tsx:100` —
      `className="text-muted-foreground"` → `tone="subdued"`
- [ ] `NodeListItem.tsx:67` — `className="text-destructive"` → `tone="critical"`
- [ ] `DashboardHomeView.tsx:65`, `:147` — → `tone="subdued" className="shrink-0"`
- [ ] `DashboardComponentsView.tsx:71` — → `tone="subdued" className="tabular-nums"`
- [ ] `DashboardComponentsView.tsx:153` — → `tone="subdued" className="font-medium truncate"`

Non-mappable classes (`shrink-0`, `tabular-nums`, `font-medium truncate`) stay in `className` untouched.

**`className="font-mono"` → `font="mono"` (3)** — `ui-primitives#typography` names this rule verbatim

- [ ] `AddGitHubLibraryDialogContent.tsx:42`
- [ ] `ConduitDetails.tsx:109` — `truncate flex-1` retained in `className`
- [ ] `OutputDetails.tsx:68` — the hardcoded `text-gray-500` retained (no `tone` maps to it)

These three are class-equivalent **only because `font-regular` is dead**, and it is worth being explicit
about that dependency, because it is not the same argument as the other 15 swaps:

```
before: twMerge("text-foreground text-xs font-regular", "font-mono text-gray-500")
     → "text-xs font-mono text-gray-500"                   ← font-regular DROPPED
after:  twMerge("text-foreground text-xs font-regular !font-mono", "text-gray-500")
     → "text-xs font-regular !font-mono text-gray-500"     ← font-regular SURVIVES
```

`twMerge` drops `font-regular` against a later `font-mono` but does **not** dedupe it against
`!font-mono`, so the emitted class set genuinely changed here — only `font-regular` compiling to nothing
keeps the pixels equal. If `--font-weight-regular` is ever added to the theme, these three sites gain a
weight the raw `className` versions never had. `font="mono"` also introduces `!important` where the
`className` had none.

| | |
| --- | --- |
| Findings applied | **18** |
| Files | 14 (`+25 / −19`) |
| `.tsx` files scanned | 1,331 |
| Exact-mapping candidates found | 18 of 18 applied |
| Confidence threshold | `0.9` (`primitives`, config) |
| Validation | `pnpm run validate:test` ✅ — 191 test files / 1,966 tests |
| React Compiler edits | **0** (`flagOnly: true`; `--promote-compiler` not passed) |

## Reviewer checklist

- [ ] **Visually diffed the rendered output — no layout/spacing regression**
      (mandatory: `requiresVisualReview: true` for `primitives`)
- [ ] ⚠️ **Self-review was skipped (review skill unavailable) — review this diff manually.**
      The engine requires every PR to survive the `review` skill first, but that skill is
      `disable-model-invocation` and only a human can run it.
- [ ] Spot-check one `tone="subdued"` site in **both** light and dark mode — the whole argument rests on
      `text-muted-foreground` being emitted identically, and `tone` is the only real class delta.
- [ ] Confirm you agree `text-md` / `font-regular` are dead classes. The three `font="mono"` swaps
      **depend** on `font-regular` being dead (see above); the other 15 do not. **If they are supposed to work**,
      that is a separate (and more interesting) bug in `typography.tsx` — every `<Text>` in the app is
      currently rendering at inherited size and weight. This PR does not change that either way.

## Deliberately not applied

Each of these is a real convention gap, but none is an *exact* mapping, so all are queued for a human.

- **4 raw `<p className="text-sm font-semibold">`** (`RegionInput.tsx:36`, `ConfigInput.tsx:67`,
  `GoogleCloudSubmitter.tsx:42`, `:58`). `<Paragraph size="sm" weight="semibold">` would add
  `text-foreground`. `body` does set `text-foreground` (`global.css:294`), so the computed colour is
  *probably* unchanged — but proving no intermediate ancestor recolours these four sites is exactly the
  ancestor-chain reasoning `requiresVisualReview` exists to send to a human. **Not applied.**
- **`FlexNodeCard.tsx:54`, `:97`** — the code says why: a user-configurable `fontSize` needs an inline
  `style`, which `Text` does not accept. **KEEP** (documented, correct).
- **Raw `<p>` with hardcoded palette colours** — `ContextPanelProvider.tsx:32` (`text-gray-500`),
  `ImportPipeline.tsx:232`/`:243` (`text-green-500 dark:text-green-400`, `text-red-500 dark:…`),
  `ImportComponent.tsx:228`/`:231`/`:265`/`:283` (`text-gray-500/600` + `dark:` pairs). No `tone` maps to
  a raw palette colour or a `dark:` variant pair. Needs a design-token decision first.
- **13 `Text`/`Paragraph` sites in 11 files with `text-gray-*` / `dark:` pairs** — same reason. The IDE
  already flags several as `cssConflict` (e.g. `MissingPipelineInputValueResolution.tsx:55`,
  `ConduitDetails.tsx:81`); those warnings are pre-existing, not introduced here.
- **27 `className="flex flex-col"` in 19 files → `BlockStack`.** `blockStackVariants`
  (`layout.tsx:13`) bases on `flex flex-col w-full` and defaults to `items-start justify-start gap-0`.
  `w-full` and `items-start` are **real** layout changes (a plain flex-col column stretches its children;
  `items-start` shrinks them to content width). Per-site visual review required.
- **14 bare `<p>` (no `className`) in non-test source, 13 of them in `ConfirmationDialogs/*`**
  (`ReplaceConfirmation.tsx`, `BulkUpdateConfirmationDialog.tsx`, `UpgradeComponent.tsx`).
  `<Paragraph>` would add `text-foreground`, and dialog bodies commonly *inherit* a muted colour from
  the shadcn `DialogDescription` wrapper — so this swap could visibly darken dialog copy. This is the
  single largest raw-`<p>` bucket and the one most likely to regress; it needs a look at the rendered
  dialogs, not a grep.
- **10 raw `<h1>`–`<h6>` in 5 files, 6 `<Text as="h*">` in 3 files** → `Heading`. `Heading`
  (`typography.tsx:124`) accepts only `children` and `level` — it forces its own `size`/`weight` and
  accepts **no `className`**. Every site here carries classes it would drop. Not mappable.
- **`src/components/ui/date-picker.tsx:42`** — a genuinely exact `<span className="text-muted-foreground">`
  → `<Text tone="subdued">`, but it lives *inside* a shadcn-derived primitive. Making one
  `components/ui` primitive depend on another is a design call, and this file is regenerable by the
  shadcn CLI. **KEEP.**

## React Compiler — flag-only, nothing edited

`flagOnly: true` and `promotionEnabled: false` in `.github/gardening-config.json`, and
`--promote-compiler` was not passed. Reporting only:

- **Coverage: 783 / 1,331 `src` files (58.8%)** across 75 enabled entries.
- **Promotion candidates: 0.** Every directory annotated `0 useCallback/useMemo - ready to enable` in
  `react-compiler.config.js` is already *uncommented*, i.e. already enabled. The remaining commented-out
  entries carry 12–190 `useCallback`/`useMemo` each and are explicitly *not* marked ready.
- **Largest coverage gaps** (uncovered files by area): `src/components/shared` 206, `src/utils` 61,
  `src/hooks` 45, `src/components/ui` 37, `src/services` 22,
  `src/providers/ComponentLibraryProvider` 18, `src/components/PipelineRun` 16, `src/agent` 26 (incl.
  `tools`, `agents`).
  (`src/models/**` is in `excludeGlobs` and is excluded from that ranking.)
- **Manual-memoization removal candidates: 0 real ones.** Only 6 call sites survive inside enabled dirs,
  and all 6 look load-bearing rather than redundant: 3 × `useMemo` wrapping a **debounce factory**
  (`PipelineNotesEditor.tsx:20`, `PipelineDescriptionEditor.tsx:21`, `useSelectionBehavior.ts:41`) where
  a fresh instance per render would break debouncing outright, and 3 × `memo()` on components whose
  referential stability matters to React Flow / syntax highlighting (`GhostNode.tsx:25`,
  `CodeSyntaxHighlighter.tsx:18`, `CodeBlock.tsx:34`). The compiler does not guarantee identity
  stability, so these are **KEEPs**, not cleanup debt.

## New primitives

**None proposed, none authored.** Per the pillar spec, new primitives are flag-only and never written
without express permission — and nothing in this scan showed a recurring shape with no existing
primitive to cover it. The gaps found were all *adoption* gaps, not *coverage* gaps.

## Method deviations, disclosed

- **Commits are one-per-file (14), not one-per-finding (18).** Four files hold two findings of the same
  category; `DashboardHomeView.tsx`'s two sites are byte-identical and were replaced together.
- All 18 edits went through the `Edit` tool. No scripted applier was used in this pillar.

<!-- gardening-pillar: react -->
<!-- gardening-week: 2026-W33 -->

