### PR TITLE
docs: make Icon the canonical icon entrypoint (actions B17)

### DIFF
--- a/.claude/skills/gardening/canon-registry.md
+++ b/.claude/skills/gardening/canon-registry.md
@@ -55,6 +55,41 @@ Each entry provides:
 
 ---
 
+## icon-usage — rendering an icon glyph
+
+- **conceptId:** `icon-usage`
+- **canonical:** `Icon` from `@/components/ui/icon` — `<Icon name="ChevronRight" size="lg" />`. It maps a
+  Lucide name to the component and applies the shared size scale, so call sites never hand-size an icon.
+- **detector (`.tsx`/`.ts` under `src`):** any of an import from `lucide-react`, an import of `Icon` from
+  `@/components/ui/icon`, an import from `react-icons/*`, or a literal `<svg`.
+- **deviations (migrate onto canonical):**
+  - a direct `lucide-react` import whose JSX carries a size class **on the `Icon` scale**
+    (`size-3`/`3.5`/`4`/`5`/`6`, or the `w-*`/`h-*` pair) — move the size to the `size` prop
+    (`xs`/`sm`/`md`/`lg`/`xl`) and keep the remaining classes — **apply: yes**, identical computed size;
+  - a direct `lucide-react` import with **no** size class — Lucide's own default is 24px, so this needs
+    `size="xl"` to stay put; `size="md"` (the default) would silently shrink it to 16px — **apply: yes**
+    with `size="xl"`, never a bare swap;
+  - a size class **off** the scale (`w-2`, `h-8`, `w-12`) — **apply: flag.** No variant matches, and
+    `iconVariants` emits `!w-*`/`!h-*` (`!important`, which `twMerge` does not dedupe against a later
+    `size-*`), so the class cannot win. Migrating needs either a new scale step or an accepted size
+    change — a human's call;
+  - a **computed** `className` (`className={cn(…)}`) around a Lucide icon — **apply: flag**; the size
+    cannot be read statically, so preservation cannot be proven.
+- **conventionRef:** `ui-primitives#icons`
+- **exceptions:**
+  - **Non-Lucide glyphs.** `Icon`'s `name` is `keyof typeof icons` from `lucide-react`, so it structurally
+    cannot render anything else. Brand and language logos come from `react-icons` (`FaPython`,
+    `SiGnubash`, `SiRuby`, `TbBrandJavascript`, `FaGoogleDrive`) and Lucide has no equivalent. KEEP, and
+    do not re-flag them as unmigrated icons.
+  - **`src/components/ui/**`.** shadcn/ui primitives (`dialog`, `select`, `sheet`, `command`, `calendar`,
+    `checkbox`, `breadcrumb`, `date-picker`) import their own Lucide glyphs and are CLI-regenerable — a
+    hand edit is overwritten by the next `shadcn add`. `icon.tsx` **is** the primitive. KEEP.
+  - **Raw `<svg>` that is not an icon.** `<defs>`/`<marker>` arrowhead definitions
+    (`FlowCanvas/Edges/*.tsx`), the `Spinner` primitive's own markup, and bespoke glyphs with no library
+    equivalent (the resize grip in `windows/components/FloatingWindow.tsx`). KEEP.
+
+---
+
 <!--
 Candidates a run may PROPOSE (flag-only) until a human blesses them here. Do NOT pre-declare these
 canonical — only add an entry once one implementation is actually dominant AND a convention-skill
@@ -63,5 +98,4 @@ rule authorizes it:
   - confirm / destructive-action dialogs
   - toast / notification calls
   - date & number formatting entrypoints
-  - icon usage (raw lucide import vs the `Icon` primitive)
 -->

--- a/.claude/skills/gardening/canon-registry.md
+++ b/.claude/skills/gardening/canon-registry.md
@@ -64,8 +64,14 @@ Each entry provides:
   `@/components/ui/icon`, an import from `react-icons/*`, or a literal `<svg`.
 - **deviations (migrate onto canonical):**
   - a direct `lucide-react` import whose JSX carries a size class **on the `Icon` scale**
-    (`size-3`/`3.5`/`4`/`5`/`6`, or the `w-*`/`h-*` pair) — move the size to the `size` prop
-    (`xs`/`sm`/`md`/`lg`/`xl`) and keep the remaining classes — **apply: yes**, identical computed size;
+    (`size-3`/`3.5`/`4`/`5`/`6`, or a matched `w-*`/`h-*` pair at the same step) — move the size to the
+    `size` prop (`xs`/`sm`/`md`/`lg`/`xl`) and keep the remaining classes — **apply: yes**, identical
+    computed size;
+  - a **lone** `w-*` or `h-*` without its partner, or a mismatched pair (`w-4 h-5`) — **apply: flag.**
+    Only the constrained axis comes from the class; the other falls back to Lucide's own 24px attribute,
+    so `<ChevronRight className="w-4" />` renders 16×24 and any `size` prop would change it (`size="md"`
+    → 16×16). No such usage exists today, so this bucket should be empty — but it must not be swept in
+    with the matched pair above;
   - a direct `lucide-react` import with **no** size class — Lucide's own default is 24px, so this needs
     `size="xl"` to stay put; `size="md"` (the default) would silently shrink it to 16px — **apply: yes**
     with `size="xl"`, never a bare swap;

--- a/.claude/skills/ui-primitives/SKILL.md
+++ b/.claude/skills/ui-primitives/SKILL.md
@@ -41,7 +41,24 @@ Use `Button` from `@/components/ui/button`
 
 ## Icons
 
-Use `Icon` from `@/components/ui/icon`
+Use `Icon` from `@/components/ui/icon` instead of importing from `lucide-react` directly:
+
+- `<Icon name="ChevronRight" size="lg" />` instead of `<ChevronRight className="size-5" />`
+- `name` is any Lucide icon name; `size` is `xs` `sm` `md` `lg` `xl` `fill` (12/14/16/20/24/100%,
+  default `md`)
+- Size comes from the `size` prop, **not** a `className`. The variant emits `!w-* !h-*`, so a width or
+  height class on `className` loses to it — `<Icon name="X" className="size-5" />` renders at 16px, not
+  20px. Reserve `className` for colour, margin, and transforms.
+
+**Icons Lucide does not have** — brand and language logos (Python, Ruby, Bash, JavaScript, Google
+Drive, …) — come from `react-icons` and are used directly, because `Icon` only accepts Lucide names:
+
+- `<FaPython />` from `react-icons/fa` — correct, not a deviation to migrate
+- Match the surrounding icons' rendered size by hand (`size={n}` or a Tailwind size class); these do not
+  get the `Icon` size scale
+
+Draw a raw `<svg>` only for something that is not an icon from a set — SVG `<defs>`/`<marker>`
+definitions, or a bespoke glyph with no library equivalent.
 
 ## Styling
 


### PR DESCRIPTION
Actions **B17** in the gardening queue (#2626): blesses `Icon` as the canonical way to render an icon, so
the `consistency` pillar is allowed to migrate the stragglers instead of only proposing.

Two files, docs only. **No `src` changes** — the migration itself is a later, reviewable PR.

## Why it needed a human

The empirical bar was already met — **222** files import `Icon`, **30** still import `lucide-react`
directly (88.1%, over `supermajorityRatio: 0.75`), and **10 of the 30 do both**, which reads as drift
rather than intent. But `pillars/consistency.md` forbids migrating on measurement alone: without a
registry entry that would be the bot inventing a convention and enforcing it repo-wide. Hence the entry.

## Non-Lucide icons are exceptions, not stragglers

`Icon`'s `name` is `keyof typeof icons` from `lucide-react`, so it **structurally cannot** render anything
else. Recorded as KEEP so no future run "fixes" them:

- **`react-icons` brand/language logos** — `FaPython` ×2, `SiGnubash`, `SiRuby`, `TbBrandJavascript`,
  `FaGoogleDrive` across 3 files. Lucide dropped brand logos; there is no equivalent to migrate to.
- **`src/components/ui/**`** — 9 files. shadcn primitives (`dialog`, `select`, `sheet`, `command`,
  `calendar`, `checkbox`, `breadcrumb`, `date-picker`) import their own glyphs and are CLI-regenerable, so
  a hand edit is overwritten by the next `shadcn add`. `icon.tsx` *is* the primitive.
- **Raw `<svg>` that isn't an icon** — `<defs>`/`<marker>` arrowheads in `FlowCanvas/Edges/*`, the
  `Spinner` primitive's own markup, and the bespoke resize grip in `FloatingWindow.tsx`.

## The swap is not size-neutral, so the entry is not blanket `apply: yes`

Worth reading before approving, because it contradicts the "mechanical swap" framing in #2623:

`iconVariants` emits `!w-4 !h-4`. Leading-`!` **still compiles to `!important`** in Tailwind v4.3.3
(verified by compiling `!w-4` with the project's own Tailwind: `.\!w-4 { width: …; !important }`), and
`twMerge@3.6.0` does **not** dedupe `!w-4` against a later `size-5` — it emits both, so `!important` wins.
A blind `<ChevronRight className="size-5" />` → `<Icon name="ChevronRight" className="size-5" />` renders
**16px instead of 20px**.

Across the 30 files there are **59** Lucide JSX usages:

| Bucket | Count | Disposition |
| --- | --- | --- |
| Size class on the scale (`size-4`, `w-5 h-5`, …) | 37 | `apply: yes` — size moves to the `size` prop |
| **No** size class | 9 | `apply: yes` **as `size="xl"`** — Lucide's own default is `width: 24` (`lucide-react.js:39`), so `size="md"` would shrink them |
| Off-scale (`w-2 h-2` ×6, `h-8 w-8`, `w-12 h-12`) | 8 | `apply: flag` — no variant matches and `className` can't beat `!important` |
| Computed `className={cn(…)}` | 5 | `apply: flag` — size not statically readable |

So ~46 of 59 usages are provably size-identical; the other 13 need a human. The off-scale ones are mostly
`StatusIndicator.tsx` at `w-2 h-2` (8px, below `xs`) — if you'd rather they migrate too, the `Icon` scale
needs a step, which is a primitive change and deliberately not in this PR.

## Also fixes a claim I got wrong

#2623 said there was "no `canon-registry.md` entry **and** no convention-skill rule naming `Icon` as
canonical." The registry entry was indeed missing; the convention rule was not — `ui-primitives#icons`
already said "Use `Icon` from `@/components/ui/icon`". That line was one sentence with no `size` guidance,
which is how the `!important` interaction went unnoticed, so this PR fills it in: the size scale, the
warning that a size `className` loses to the variant, and the `react-icons` escape hatch.

## Checks

`prettier --check` passes on both files. No `src`, test, or config changes, so `lint`/`typecheck`/`test`
are unaffected — I did not run the full `validate:test` gate because its `fix` step rewrites the working
tree, and there is no code here for it to validate.
