### PR TITLE
fix: correct generateDynamicNodeCallbacks return type

### DIFF
--- a/src/types/taskNode.ts
+++ b/src/types/taskNode.ts
@@ -25,7 +25,7 @@ export type NodeAndTaskId = {
 export type TaskType = "task" | "input" | "output";
 
 /* Note: Optional callbacks will cause TypeScript to break when applying the callbacks to the Nodes. */
-interface TaskNodeCallbacks {
+export interface TaskNodeCallbacks {
   setArguments: (args: Record<string, ArgumentType>) => void;
   setAnnotations: (annotations: Annotations) => void;
   setCacheStaleness: (cacheStaleness: string | undefined) => void;
@@ -48,7 +48,7 @@ export const DEFAULT_TASK_NODE_CALLBACKS: TaskNodeCallbacks = {
 };
 
 // Dynamic Node Callback types - every callback has a version with the node & task id added to it as an input parameter
-export type CallbackWithIds<K extends keyof TaskNodeCallbacks> =
+type CallbackWithIds<K extends keyof TaskNodeCallbacks> =
   TaskNodeCallbacks[K] extends (...args: infer A) => infer R
     ? (ids: NodeAndTaskId, ...args: A) => R
     : never;

--- a/src/utils/nodes/generateDynamicNodeCallbacks.test.ts
+++ b/src/utils/nodes/generateDynamicNodeCallbacks.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { NodeCallbacks } from "@/types/taskNode";
+import { DEFAULT_TASK_NODE_CALLBACKS } from "@/types/taskNode";
+import type { ComponentReference } from "@/utils/componentSpec";
+
+import { generateDynamicNodeCallbacks } from "./generateDynamicNodeCallbacks";
+
+const createNodeCallbacks = (): NodeCallbacks => ({
+  setArguments: vi.fn(),
+  setAnnotations: vi.fn(),
+  setCacheStaleness: vi.fn(),
+  onDelete: vi.fn(),
+  onDuplicate: vi.fn(),
+  onUpgrade: vi.fn(),
+  onSelect: vi.fn(),
+});
+
+const expectedIds = { taskId: "my-task", nodeId: "task_my-task" };
+
+describe("generateDynamicNodeCallbacks", () => {
+  it("returns the no-op callbacks when no node callbacks are given", () => {
+    expect(generateDynamicNodeCallbacks("task_my-task")).toBe(
+      DEFAULT_TASK_NODE_CALLBACKS,
+    );
+  });
+
+  it("derives the task id from the node id", () => {
+    const nodeCallbacks = createNodeCallbacks();
+
+    generateDynamicNodeCallbacks("task_my-task", nodeCallbacks).onSelect();
+
+    expect(nodeCallbacks.onSelect).toHaveBeenCalledWith(expectedIds);
+  });
+
+  it("injects the ids into callbacks that take no other arguments", () => {
+    const nodeCallbacks = createNodeCallbacks();
+    const callbacks = generateDynamicNodeCallbacks(
+      "task_my-task",
+      nodeCallbacks,
+    );
+
+    callbacks.onDelete();
+
+    expect(nodeCallbacks.onDelete).toHaveBeenCalledWith(expectedIds);
+  });
+
+  it("injects the ids ahead of the caller's arguments", () => {
+    const nodeCallbacks = createNodeCallbacks();
+    const callbacks = generateDynamicNodeCallbacks(
+      "task_my-task",
+      nodeCallbacks,
+    );
+    const componentRef: ComponentReference = { url: "https://example.com" };
+
+    callbacks.setArguments({ input1: "value1" });
+    callbacks.setAnnotations({ "editor.position": "{}" });
+    callbacks.setCacheStaleness("P30D");
+    callbacks.onDuplicate(true);
+    callbacks.onUpgrade(componentRef);
+
+    expect(nodeCallbacks.setArguments).toHaveBeenCalledWith(expectedIds, {
+      input1: "value1",
+    });
+    expect(nodeCallbacks.setAnnotations).toHaveBeenCalledWith(expectedIds, {
+      "editor.position": "{}",
+    });
+    expect(nodeCallbacks.setCacheStaleness).toHaveBeenCalledWith(
+      expectedIds,
+      "P30D",
+    );
+    expect(nodeCallbacks.onDuplicate).toHaveBeenCalledWith(expectedIds, true);
+    expect(nodeCallbacks.onUpgrade).toHaveBeenCalledWith(
+      expectedIds,
+      componentRef,
+    );
+  });
+
+  it("passes an undefined trailing argument through unchanged", () => {
+    const nodeCallbacks = createNodeCallbacks();
+
+    generateDynamicNodeCallbacks("task_my-task", nodeCallbacks).onDuplicate();
+
+    expect(nodeCallbacks.onDuplicate).toHaveBeenCalledWith(
+      expectedIds,
+      undefined,
+    );
+  });
+
+  it("does not invoke any callback until the returned wrapper is called", () => {
+    const nodeCallbacks = createNodeCallbacks();
+
+    generateDynamicNodeCallbacks("task_my-task", nodeCallbacks);
+
+    for (const callback of Object.values(nodeCallbacks)) {
+      expect(callback).not.toHaveBeenCalled();
+    }
+  });
+});

--- a/src/utils/nodes/generateDynamicNodeCallbacks.ts
+++ b/src/utils/nodes/generateDynamicNodeCallbacks.ts
@@ -1,42 +1,29 @@
-import type {
-  CallbackWithIds,
-  NodeAndTaskId,
-  NodeCallbacks,
-} from "@/types/taskNode";
+import type { NodeCallbacks, TaskNodeCallbacks } from "@/types/taskNode";
+import { DEFAULT_TASK_NODE_CALLBACKS } from "@/types/taskNode";
 
 import { nodeIdToTaskId } from "./nodeIdUtils";
-
-type ExcludeNodeAndTaskId<T> = T extends [NodeAndTaskId, ...infer Rest]
-  ? Rest
-  : never;
 
 // Utility function that adds the taskId and nodeId to the callbacks as the first argument
 export const generateDynamicNodeCallbacks = (
   nodeId: string,
   nodeCallbacks?: NodeCallbacks,
-): NodeCallbacks => {
+): TaskNodeCallbacks => {
   if (!nodeCallbacks) {
-    return {} as NodeCallbacks;
+    return DEFAULT_TASK_NODE_CALLBACKS;
   }
 
-  const taskId = nodeIdToTaskId(nodeId);
-  return Object.fromEntries(
-    (Object.keys(nodeCallbacks) as (keyof NodeCallbacks)[]).map(
-      (callbackName) => {
-        const callbackFn = nodeCallbacks[callbackName] as CallbackWithIds<
-          typeof callbackName
-        >;
-        return [
-          callbackName,
-          ((...args: any[]) =>
-            callbackFn(
-              { taskId, nodeId },
-              ...((args ?? []) as ExcludeNodeAndTaskId<
-                Parameters<typeof callbackFn>
-              >),
-            )) as NodeCallbacks[typeof callbackName],
-        ];
-      },
-    ),
-  ) as NodeCallbacks;
+  const ids = { taskId: nodeIdToTaskId(nodeId), nodeId };
+
+  return {
+    setArguments: (args) => nodeCallbacks.setArguments(ids, args),
+    setAnnotations: (annotations) =>
+      nodeCallbacks.setAnnotations(ids, annotations),
+    setCacheStaleness: (cacheStaleness) =>
+      nodeCallbacks.setCacheStaleness(ids, cacheStaleness),
+    onDelete: () => nodeCallbacks.onDelete(ids),
+    onDuplicate: (selected) => nodeCallbacks.onDuplicate(ids, selected),
+    onUpgrade: (newComponentRef) =>
+      nodeCallbacks.onUpgrade(ids, newComponentRef),
+    onSelect: () => nodeCallbacks.onSelect(ids),
+  };
 };


### PR DESCRIPTION
Part of **B3** of #2626.

## The bug

`generateDynamicNodeCallbacks` binds the node & task ids into each `NodeCallbacks` entry, so what it returns takes **one fewer argument** than what it received. It declared its return type as `NodeCallbacks` anyway — the *un-bound* shape — so every callback it handed back was typed as still needing an `ids` argument that the wrapper already supplies.

Nothing caught this because the only caller, `createTaskNode`, launders the result through `as Node`.

## The fix

Return `TaskNodeCallbacks`, the shape actually produced. Once the types line up, the reflective `Object.fromEntries` construction is no longer needed to satisfy the compiler, so the object is built explicitly. That removes:

- the `ExcludeNodeAndTaskId` helper type
- an `...args: any[]` spread
- all three `as` casts

and turns a missing or misordered argument into a compile error instead of something the casts absorb.

## Behaviour deltas

Two, both verified unreachable in production:

| Delta | Why it can't bite |
|---|---|
| No-callbacks branch returns `DEFAULT_TASK_NODE_CALLBACKS` instead of `{} as NodeCallbacks`, so consumers gating on callback *truthiness* (`TaskDetails/Actions.tsx:64,74,90`) now see no-ops rather than `undefined` | `FlowCanvas.tsx:394-404` always passes `nodeCallbacks`; the branch is never taken |
| The `ids` object is built once and shared by all seven wrappers rather than rebuilt per call | All seven `useNodeCallbacks` implementations only *read* `ids.taskId`/`ids.nodeId`; none mutates it |

`TaskNodeCallbacks` is exported for the annotation. `CallbackWithIds` is **un-exported** — it's used only inside `src/types/taskNode.ts`, and Knip fails CI on an export consumed solely within its own file.

## Tests

Adds `generateDynamicNodeCallbacks.test.ts` (6 tests) — the wrapper had no coverage. It pins id derivation, id injection ahead of caller args, `undefined` trailing args, laziness, and the no-callbacks branch.

Reverting *only* the type change makes the new test file fail to compile with 8 arity errors, so the test genuinely depends on the fix rather than merely accompanying it.

## Verification

`typecheck` · `lint` · `knip` · `prettier` clean; full suite **192 files / 1972 tests passing**.

Scope is v1-only: `NodeCallbacks` appears in 8 files, all under the v1 canvas. v2's single edge to this area is a type-only `TaskNodeContextType` import.

Left deliberately out of scope: `TaskNodeProvider.tsx:51` declares a *third*, structurally different local `TaskNodeCallbacks` (adds `setCollapsed`, makes four callbacks optional). Collapsing it is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)