### PR TITLE
feat: run comparison - run picker & switcher

### DIFF
--- a/react-compiler.config.js
+++ b/react-compiler.config.js
@@ -40,6 +40,7 @@ export const REACT_COMPILER_ENABLED_DIRS = [
   "src/hooks/useDocsVisitTracking.ts",
   "src/hooks/useExecutionArtifacts.ts",
   "src/hooks/useContainerLog.ts",
+  "src/hooks/usePipelineRunList.ts",
   "src/components/shared/FavoriteToggle.tsx",
   "src/components/shared/ComponentLifecycleBadges.tsx",
   "src/components/shared/ComponentSearchEmptyStateSuggestions.tsx",

--- a/src/components/Home/RunSection/RunSection.tsx
+++ b/src/components/Home/RunSection/RunSection.tsx
@@ -1,8 +1,6 @@
-import { useQuery } from "@tanstack/react-query";
 import { useLocation, useNavigate, useSearch } from "@tanstack/react-router";
 import { useEffect, useRef, useState } from "react";
 
-import type { ListPipelineJobsResponse } from "@/api/types.gen";
 import { InfoBox } from "@/components/shared/InfoBox";
 import { useFlagValue } from "@/components/shared/Settings/useFlags";
 import { Button } from "@/components/ui/button";
@@ -20,10 +18,10 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Text } from "@/components/ui/typography";
+import { usePipelineRunList } from "@/hooks/usePipelineRunList";
 import { useRunSearchParams } from "@/hooks/useRunSearchParams";
 import { useBackend } from "@/providers/BackendProvider";
 import { getBackendStatusString } from "@/utils/backend";
-import { fetchWithErrorHandling } from "@/utils/fetchWithErrorHandling";
 import {
   filtersToFilterQuery,
   parseFilterParam,
@@ -31,12 +29,7 @@ import {
 
 import RunRow from "./RunRow";
 
-const PIPELINE_RUNS_QUERY_URL = "/api/pipeline_runs/";
-const PAGE_TOKEN_QUERY_KEY = "page_token";
-const FILTER_QUERY_PARAM_KEY = "filter_query";
 const CREATED_BY_ME_FILTER = "created_by:me";
-const INCLUDE_PIPELINE_NAME_QUERY_KEY = "include_pipeline_names";
-const INCLUDE_EXECUTION_STATS_QUERY_KEY = "include_execution_stats";
 
 type RunSectionSearch = { page_token?: string; filter?: string };
 
@@ -53,7 +46,7 @@ export const RunSection = ({
   forcedFilter,
   maxItems,
 }: RunSectionProps) => {
-  const { backendUrl, configured, available, ready } = useBackend();
+  const { configured, available, ready } = useBackend();
   const navigate = useNavigate();
   const { pathname } = useLocation();
   const search = useSearch({ strict: false }) as RunSectionSearch;
@@ -81,29 +74,13 @@ export const RunSection = ({
   const pageToken = search.page_token;
   const [previousPageTokens, setPreviousPageTokens] = useState<string[]>([]);
 
-  const { data, isLoading, isFetching, error, isFetched } =
-    useQuery<ListPipelineJobsResponse>({
-      queryKey: ["runs", backendUrl, pageToken, apiFilterQuery],
-      refetchOnWindowFocus: false,
-      enabled: configured && available,
-      queryFn: async () => {
-        const url = new URL(PIPELINE_RUNS_QUERY_URL, backendUrl);
-        if (pageToken) url.searchParams.set(PAGE_TOKEN_QUERY_KEY, pageToken);
-        if (apiFilterQuery)
-          url.searchParams.set(FILTER_QUERY_PARAM_KEY, apiFilterQuery);
-
-        url.searchParams.set(INCLUDE_PIPELINE_NAME_QUERY_KEY, "true");
-        url.searchParams.set(INCLUDE_EXECUTION_STATS_QUERY_KEY, "true");
-
-        if (!available) {
-          throw new Error("Backend is not available");
-        }
-
-        dataVersion.current++;
-
-        return fetchWithErrorHandling(url.toString());
-      },
-    });
+  const { data, isLoading, isFetching, error, isFetched } = usePipelineRunList({
+    pageToken,
+    filterQuery: apiFilterQuery,
+    onFetch: () => {
+      dataVersion.current++;
+    },
+  });
 
   const handleFilterChange = (value: boolean) => {
     const nextSearch: RunSectionSearch = { ...search };

--- a/src/hooks/usePipelineRunList.ts
+++ b/src/hooks/usePipelineRunList.ts
@@ -1,0 +1,54 @@
+import { useQuery } from "@tanstack/react-query";
+
+import type { ListPipelineJobsResponse } from "@/api/types.gen";
+import { useBackend } from "@/providers/BackendProvider";
+import { fetchWithErrorHandling } from "@/utils/fetchWithErrorHandling";
+
+const PIPELINE_RUNS_QUERY_URL = "/api/pipeline_runs/";
+const PAGE_TOKEN_QUERY_KEY = "page_token";
+const FILTER_QUERY_PARAM_KEY = "filter_query";
+const INCLUDE_PIPELINE_NAME_QUERY_KEY = "include_pipeline_names";
+const INCLUDE_EXECUTION_STATS_QUERY_KEY = "include_execution_stats";
+
+interface UsePipelineRunListOptions {
+  pageToken?: string;
+  filterQuery?: string;
+  onFetch?: () => void;
+}
+
+/**
+ * Sole owner of the `["runs", backendUrl, pageToken, filterQuery]` cache entry.
+ * The runs dashboard and the comparison run picker read the same list, so the URL
+ * they build has to be the same one — otherwise adding a query param on one side
+ * leaves the other silently reading a payload that lacks it.
+ */
+export function usePipelineRunList({
+  pageToken,
+  filterQuery,
+  onFetch,
+}: UsePipelineRunListOptions = {}) {
+  const { backendUrl, configured, available } = useBackend();
+
+  return useQuery<ListPipelineJobsResponse>({
+    queryKey: ["runs", backendUrl, pageToken, filterQuery],
+    refetchOnWindowFocus: false,
+    enabled: configured && available,
+    queryFn: async () => {
+      if (!available) {
+        throw new Error("Backend is not available");
+      }
+
+      const url = new URL(PIPELINE_RUNS_QUERY_URL, backendUrl);
+      if (pageToken) url.searchParams.set(PAGE_TOKEN_QUERY_KEY, pageToken);
+      if (filterQuery) {
+        url.searchParams.set(FILTER_QUERY_PARAM_KEY, filterQuery);
+      }
+      url.searchParams.set(INCLUDE_PIPELINE_NAME_QUERY_KEY, "true");
+      url.searchParams.set(INCLUDE_EXECUTION_STATS_QUERY_KEY, "true");
+
+      onFetch?.();
+
+      return fetchWithErrorHandling(url.toString());
+    },
+  });
+}

--- a/src/routes/v2/pages/CompareView/components/RunPickerDialog.tsx
+++ b/src/routes/v2/pages/CompareView/components/RunPickerDialog.tsx
@@ -1,0 +1,170 @@
+import { type ReactNode, useState } from "react";
+
+import { CreatedByFilter } from "@/components/shared/CreatedByFilter/CreatedByFilter";
+import { InfoBox } from "@/components/shared/InfoBox";
+import { Button } from "@/components/ui/button";
+import { DatePickerWithRange } from "@/components/ui/date-picker";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Icon } from "@/components/ui/icon";
+import { Input } from "@/components/ui/input";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Spinner } from "@/components/ui/spinner";
+import { Text } from "@/components/ui/typography";
+import { useDebouncedSearchValue } from "@/hooks/useDebouncedSearchValue";
+import { usePipelineRunList } from "@/hooks/usePipelineRunList";
+import type { PipelineRunFilters } from "@/types/pipelineRunFilters";
+import {
+  parseUTCAsLocalDate,
+  toEndOfDayUTC,
+  toStartOfDayUTC,
+} from "@/utils/date";
+import { filtersToFilterQuery } from "@/utils/pipelineRunFilterUtils";
+
+import { RunPickerRow } from "./RunPickerRow";
+
+interface RunPickerDialogProps {
+  side: "a" | "b";
+  excludeRunId?: string;
+  onSelect: (runId: string) => void;
+  trigger: ReactNode;
+}
+
+export function RunPickerDialog({
+  side,
+  excludeRunId,
+  onSelect,
+  trigger,
+}: RunPickerDialogProps) {
+  const [open, setOpen] = useState(false);
+  const [filters, setFilters] = useState<PipelineRunFilters>({});
+  const [nameInput, setNameInput] = useDebouncedSearchValue((value) =>
+    setFilters((prev) => ({
+      ...prev,
+      pipeline_name: value.trim() || undefined,
+    })),
+  );
+
+  const { data, isLoading, error } = usePipelineRunList({
+    filterQuery: filtersToFilterQuery(filters),
+  });
+
+  const dateRange =
+    filters.created_after || filters.created_before
+      ? {
+          from: filters.created_after
+            ? parseUTCAsLocalDate(filters.created_after)
+            : undefined,
+          to: filters.created_before
+            ? parseUTCAsLocalDate(filters.created_before)
+            : undefined,
+        }
+      : undefined;
+
+  const runs = (data?.pipeline_runs ?? []).filter(
+    (run) => `${run.id}` !== excludeRunId,
+  );
+
+  const handleSelect = (runId: string) => {
+    onSelect(runId);
+    setOpen(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>{trigger}</DialogTrigger>
+      <DialogContent className="flex max-h-[80vh] w-[90vw] flex-col sm:max-w-280">
+        <DialogHeader>
+          <DialogTitle>Select run {side === "a" ? "A" : "B"}</DialogTitle>
+          <DialogDescription>
+            Choose a run to add to the comparison.
+          </DialogDescription>
+        </DialogHeader>
+
+        <InlineStack gap="2" blockAlign="center" wrap="wrap" className="w-full">
+          <div className="relative min-w-60 flex-1">
+            <Icon
+              name="Search"
+              size="sm"
+              className="absolute top-1/2 left-3 -translate-y-1/2 text-muted-foreground"
+            />
+            <Input
+              aria-label="Search runs by pipeline name"
+              placeholder="Search by pipeline name..."
+              value={nameInput}
+              onChange={(event) => setNameInput(event.target.value)}
+              className="w-full pr-8 pl-9"
+            />
+            {nameInput && (
+              <Button
+                variant="ghost"
+                size="icon"
+                aria-label="Clear search"
+                onClick={() => setNameInput("")}
+                className="absolute top-1/2 right-2 size-6 -translate-y-1/2"
+              >
+                <Icon name="X" size="sm" />
+              </Button>
+            )}
+          </div>
+          <CreatedByFilter
+            value={filters.created_by}
+            onChange={(value) =>
+              setFilters((prev) => ({ ...prev, created_by: value }))
+            }
+            onClear={() =>
+              setFilters((prev) => ({ ...prev, created_by: undefined }))
+            }
+          />
+          <DatePickerWithRange
+            value={dateRange}
+            placeholder="Date range (UTC)"
+            onChange={(range) =>
+              setFilters((prev) => ({
+                ...prev,
+                created_after: range?.from
+                  ? toStartOfDayUTC(range.from)
+                  : undefined,
+                created_before: range?.to ? toEndOfDayUTC(range.to) : undefined,
+              }))
+            }
+          />
+        </InlineStack>
+
+        <BlockStack gap="1" className="min-h-0 flex-1 overflow-auto">
+          {isLoading && (
+            <InlineStack gap="2" blockAlign="center">
+              <Spinner /> <Text>Loading runs…</Text>
+            </InlineStack>
+          )}
+          {error && (
+            <InfoBox title="Error loading runs" variant="error" width="full">
+              {error.message}
+            </InfoBox>
+          )}
+          {data && runs.length === 0 && (
+            <Text tone="subdued" size="sm">
+              No runs match your filters.
+            </Text>
+          )}
+          {runs.map((run) => (
+            <RunPickerRow key={run.id} run={run} onSelect={handleSelect} />
+          ))}
+        </BlockStack>
+
+        {data?.next_page_token && (
+          <Text tone="subdued" size="xs">
+            Showing the first {runs.length} runs. Narrow the search or filters
+            to find others.
+          </Text>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/routes/v2/pages/CompareView/components/RunPickerRow.tsx
+++ b/src/routes/v2/pages/CompareView/components/RunPickerRow.tsx
@@ -1,0 +1,62 @@
+import type { PipelineRunResponse } from "@/api/types.gen";
+import { StatusBar, StatusIcon } from "@/components/shared/Status";
+import { Button } from "@/components/ui/button";
+import { InlineStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
+import { formatDate } from "@/utils/date";
+import { getOverallExecutionStatusFromStats } from "@/utils/executionStatus";
+import { tracking } from "@/utils/tracking";
+
+interface RunPickerRowProps {
+  run: PipelineRunResponse;
+  onSelect: (runId: string) => void;
+}
+
+export function RunPickerRow({ run, onSelect }: RunPickerRowProps) {
+  const runId = `${run.id}`;
+  const status = getOverallExecutionStatusFromStats(
+    run.execution_status_stats ?? undefined,
+  );
+
+  return (
+    <Button
+      variant="ghost"
+      className="h-auto w-full justify-start py-2"
+      onClick={() => onSelect(runId)}
+      {...tracking("compare_runs.run_picker.select_run")}
+    >
+      <InlineStack gap="3" blockAlign="center" wrap="nowrap" className="w-full">
+        <StatusIcon status={status} />
+        <Text
+          as="span"
+          size="sm"
+          className="min-w-48 flex-1 truncate text-left"
+        >
+          {run.pipeline_name ?? "Unknown pipeline"}
+        </Text>
+        <Text as="span" size="xs" tone="subdued" className="shrink-0">
+          #{runId}
+        </Text>
+        <div className="w-32 shrink-0">
+          <StatusBar executionStatusStats={run.execution_status_stats} />
+        </div>
+        <Text
+          as="span"
+          size="xs"
+          tone="subdued"
+          className="w-28 shrink-0 whitespace-nowrap text-right"
+        >
+          {run.created_at ? formatDate(run.created_at) : ""}
+        </Text>
+        <Text
+          as="span"
+          size="xs"
+          tone="subdued"
+          className="w-36 shrink-0 truncate text-right"
+        >
+          {run.created_by ?? ""}
+        </Text>
+      </InlineStack>
+    </Button>
+  );
+}

--- a/src/routes/v2/pages/CompareView/components/RunSwitcher.tsx
+++ b/src/routes/v2/pages/CompareView/components/RunSwitcher.tsx
@@ -1,0 +1,124 @@
+import { Link } from "@tanstack/react-router";
+
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icon";
+import { InlineStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
+import { cn } from "@/lib/utils";
+import { APP_ROUTES } from "@/routes/appRoutes";
+import {
+  RUN_OUTLINE_TONE,
+  RUN_TONE,
+} from "@/routes/v2/pages/CompareView/utils/runTone";
+import { tracking } from "@/utils/tracking";
+
+import { RunPickerDialog } from "./RunPickerDialog";
+
+interface RunSwitcherProps {
+  label: string;
+  side: "a" | "b";
+  runId?: string;
+  name?: string;
+  excludeRunId?: string;
+  onSelect: (runId: string) => void;
+  onClear: () => void;
+}
+
+export function RunSwitcher({
+  label,
+  side,
+  runId,
+  name,
+  excludeRunId,
+  onSelect,
+  onClear,
+}: RunSwitcherProps) {
+  if (!runId) {
+    return (
+      <RunPickerDialog
+        side={side}
+        excludeRunId={excludeRunId}
+        onSelect={onSelect}
+        trigger={
+          <Button
+            variant="outline"
+            size="sm"
+            className={cn("border-dashed", RUN_OUTLINE_TONE[side])}
+            aria-label={`Select run ${label}`}
+            {...tracking("compare_runs.comparison.select_run", { side: label })}
+          >
+            <Icon name="Plus" size="xs" />
+            Select run {label}
+          </Button>
+        }
+      />
+    );
+  }
+
+  return (
+    <InlineStack
+      gap="1"
+      blockAlign="center"
+      wrap="nowrap"
+      className={cn("rounded border px-2 py-1", RUN_TONE[side])}
+    >
+      <Link
+        to={APP_ROUTES.RUN_DETAIL}
+        params={{ id: runId }}
+        target="_blank"
+        rel="noopener noreferrer"
+        title={`Open ${name ?? runId} in a new tab`}
+        className="group min-w-0"
+        {...tracking("compare_runs.comparison.open_run", { side: label })}
+      >
+        <InlineStack
+          gap="2"
+          blockAlign="center"
+          wrap="nowrap"
+          className="min-w-0"
+        >
+          <Text as="span" size="sm" weight="semibold" className="text-inherit">
+            {label}
+          </Text>
+          <Text as="span" size="sm" className="max-w-48 truncate text-inherit">
+            {name ?? `Run #${runId}`}
+          </Text>
+          <Text as="span" size="xs" className="text-inherit opacity-70">
+            #{runId}
+          </Text>
+          <Icon
+            name="ExternalLink"
+            size="xs"
+            className="opacity-40 group-hover:opacity-80"
+          />
+        </InlineStack>
+      </Link>
+      <RunPickerDialog
+        side={side}
+        excludeRunId={excludeRunId}
+        onSelect={onSelect}
+        trigger={
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-6 text-inherit"
+            aria-label={`Change run ${label}`}
+            {...tracking("compare_runs.comparison.change_run", { side: label })}
+          >
+            <Icon name="Replace" size="xs" />
+          </Button>
+        }
+      />
+      <Button
+        variant="ghost"
+        size="icon"
+        className="size-6 text-inherit"
+        aria-label={`Clear run ${label}`}
+        onClick={onClear}
+        {...tracking("compare_runs.comparison.clear_run", { side: label })}
+      >
+        <Icon name="X" size="xs" />
+      </Button>
+    </InlineStack>
+  );
+}


### PR DESCRIPTION
## Description

The **Compare Runs** stack needs a way to actually choose the two runs you're comparing. This PR adds that: the run chips in the page header, and the dialog behind them.

- **Run chips (A and B)** — each side of the comparison is a small coloured chip: blue for A, green for B. The chip shows the pipeline name and run number, and gives you three things: click the name to open that run in a new tab, a **swap-in** button to replace it with a different run, and an **✕** to clear the slot. An empty slot is a dashed **"Select run A / B"** button instead.
- **Run picker dialog** — opens from either chip. It's a searchable list of recent runs with:
  - search by pipeline name (debounced, with a clear button),
  - a **created by** filter,
  - a **date range** filter (UTC),
  - one row per run showing status icon, pipeline name, run number, the task status bar, when it ran and who ran it.
- The run already selected on the *other* side is filtered out of the list, so you can't accidentally compare a run with itself.

Two small things worth knowing:

- The picker reuses the **same cached run list as the runs dashboard**, so opening it with no filters applied is instant rather than a fresh fetch.
- Nothing in this PR is rendered yet — these are the pieces the compare page in #2603 mounts. Reviewing this on its own is a component read; to see it on screen, use #2603.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

Part of the Compare Runs stack. Builds on #2602, consumed by #2603 (#2596 → #2603).

## Type of Change

- [x] New feature

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Add screenshots of: the header with both chips filled, an empty "Select run" chip, and the run picker dialog with filters. -->

## Test Instructions

These components are only visible once #2603 is in, so test from the tip of the stack:

1. Enable the **Compare runs** flag under Settings → Beta features and open the compare page.
2. Click **Select run A** — the picker opens. Try each filter: type a pipeline name, pick a **created by** value, set a **date range**. Confirm the list narrows and shows "No runs match your filters." when nothing matches.
3. Pick a run — the dialog closes and the chip fills in with the pipeline name and run number.
4. Repeat for **B**, and confirm the run you picked for A is **not** in B's list.
5. On a filled chip: click the name (opens that run in a new tab), the swap-in icon (reopens the picker), and **✕** (clears the slot).
6. Confirm the runs dashboard still lists and filters runs as before — the picker shares its query cache.

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->

No existing behaviour changes; everything here is new and scoped to the compare page.
