### PR TITLE
fix: type Icon's name at the source instead of casting to any

### DIFF
--- a/src/components/shared/GitHubLibrary/components/LibraryList.tsx
+++ b/src/components/shared/GitHubLibrary/components/LibraryList.tsx
@@ -35,7 +35,7 @@ export const LibraryList = withSuspenseWrapper(
             >
               <InlineStack gap="1">
                 <Icon
-                  name={library.icon as any /** todo: fix this */}
+                  name={library.icon ?? "Folder"}
                   className="text-gray-400"
                 />
                 <Text>{library.name}</Text>

--- a/src/components/shared/ReactFlow/FlowSidebar/sections/GraphComponents.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/sections/GraphComponents.tsx
@@ -200,7 +200,7 @@ const GraphComponents = ({
                 <LibraryFolderItem
                   key={library.id}
                   library={getComponentLibrary(library.id)}
-                  icon={library.icon as any /** todo: fix this */}
+                  icon={library.icon}
                 />
               ))}
             </>

--- a/src/routes/v2/pages/Editor/components/ContextPanel/components/MultiSelectionDetails/SelectedNodesList.tsx
+++ b/src/routes/v2/pages/Editor/components/ContextPanel/components/MultiSelectionDetails/SelectedNodesList.tsx
@@ -30,7 +30,7 @@ export function SelectedNodesList({ nodes, spec }: SelectedNodesListProps) {
             className="text-xs py-1.5 px-2 bg-slate-50 rounded border border-slate-100 dark:bg-muted dark:border-border"
           >
             <Icon
-              name={getNodeIcon(registry, node.type) as any}
+              name={getNodeIcon(registry, node.type)}
               size="xs"
               className={`shrink-0 ${getNodeIconColor(registry, node.type)}`}
             />

--- a/src/routes/v2/pages/Editor/components/ContextPanel/components/MultiSelectionDetails/utils.ts
+++ b/src/routes/v2/pages/Editor/components/ContextPanel/components/MultiSelectionDetails/utils.ts
@@ -1,3 +1,4 @@
+import type { IconName } from "@/components/ui/icon";
 import type { ComponentSpec, Task, TypeSpecType } from "@/models/componentSpec";
 import type { NodeTypeRegistry } from "@/routes/v2/shared/nodes/registry";
 import type { SelectedNode } from "@/routes/v2/shared/store/editorStore";
@@ -107,7 +108,7 @@ export function getNodeDisplayName(
 export function getNodeIcon(
   registry: NodeTypeRegistry,
   type: SelectedNode["type"],
-): string {
+): IconName {
   return registry.get(type)?.icon ?? "Circle";
 }
 

--- a/src/routes/v2/shared/nodes/types.ts
+++ b/src/routes/v2/shared/nodes/types.ts
@@ -7,6 +7,7 @@ import type {
 } from "@xyflow/react";
 import type { ComponentType, MouseEvent } from "react";
 
+import type { IconName } from "@/components/ui/icon";
 import type { ComponentSpec } from "@/models/componentSpec";
 import type { GuidelineOrientation } from "@/models/componentSpec/annotations";
 import type { IdGenerator } from "@/models/componentSpec/factories/idGenerator";
@@ -186,7 +187,7 @@ export interface NodeTypeManifest {
   // -- Display metadata (multi-selection, etc.) -------------------------
 
   displayName?(spec: ComponentSpec, entityId: string): string;
-  readonly icon?: string;
+  readonly icon?: IconName;
   readonly iconColor?: string;
 
   // -- Interactions -----------------------------------------------------


### PR DESCRIPTION
Part of **B10** of #2626.

Three sites fed an icon name to `Icon` through `as any`, two of them tagged `/** todo: fix this */`. `Icon`'s own prop was already correct — `name: IconName` where `IconName = keyof typeof icons` — so every cast was hiding a **supply-side** problem. The issue proposed "introduce the icon-name union at the source"; the union largely already existed, and removing the casts showed three different causes:

| Site | What the cast was actually hiding |
|---|---|
| `GraphComponents.tsx:203` | **nothing.** `FolderItem` declares `icon?: ComponentProps<typeof Icon>["name"]` and `library.icon` is exactly that. Deleting the cast typechecks unchanged. |
| `LibraryList.tsx:38` | **nullability, not the union.** `StoredLibrary.icon` is already `keyof typeof icons` — the sole delta was `\| undefined`. |
| `SelectedNodesList.tsx:33` | **a real gap.** `NodeTypeManifest.icon` was `string`, so `getNodeIcon` returned `string`. |

The diagnosis came from deleting all three casts and reading what `tsc` said. The `LibraryList` error is the telling one — the two unions are character-for-character identical apart from `undefined`:

```
Type '"Menu" | … | 1735 more … | undefined' is not assignable to
type '"Menu" | … | 1734 more … | "ZoomOut"'.
```

## Fixes

- **`GraphComponents.tsx`** — cast removed, nothing else.
- **`LibraryList.tsx`** — `name={library.icon ?? "Folder"}`, matching the default [`FolderItem`](src/components/shared/ReactFlow/FlowSidebar/components/FolderItem.tsx#L50) already applies (`name={icon ? icon : "Folder"}`).
- **`NodeTypeManifest.icon`** `string` → `IconName`, and **`getNodeIcon`**'s return type to match; cast removed.

## A latent crash, not just a type smell

With `as any`, an icon-less library reached `icons[undefined]` → `undefined` → `<undefined />`, which React rejects with *"Element type is invalid"* — taking down the whole library list, not just the icon.

Not reachable from current code: `ensureGithubLibrary` is the only write path and always sets `icon: "CloudSync"`. But `icon` is optional on a **Dexie-persisted** record that outlives app versions, and `existingComponentLibraries` is just `component_libraries.toArray()`, so a record written by an older build would hit it. Worth a fallback rather than a cast.

## The narrowing has teeth

For a type-only change the compiler is the test, so I verified it enforces something. Setting a manifest icon to a name lucide doesn't export:

```
src/routes/v2/shared/nodes/TaskNode/taskManifestBase.ts(109,3): error TS2322:
  Type '"NotARealLucideIcon"' is not assignable to type '"Menu" | … | undefined'.
```

Previously that typechecked and rendered `<undefined />` at runtime. Reverted after probing. All four existing manifest icons (`Download`, `Upload`, `Workflow`, `StickyNote`) and the `"Circle"` fallback are valid, and no other `manifest.icon` consumer needed a change.

## Deliberately not done

- **`dynamicDataUtils.ts:92`** — `groupSchema.icon as IconName`. That value comes from an external JSON schema, so the honest fix is runtime validation (`icon in icons`), not a second type assertion. Different change; flagging rather than folding in.
- **Five sites spell `keyof typeof icons` inline** instead of importing `IconName`. Identical types — renaming is churn with no effect.
- **`StoredLibrary.icon` keeps `keyof typeof icons`** rather than importing `IconName`, so a storage module doesn't take a dependency on `components/ui`.

## Verification

`typecheck` · `lint` · `knip` · `prettier` clean; full suite **191 files / 1966 tests** passing. No new tests: two changes are cast removals with no runtime effect, one is a compile-time narrowing (probed above), and the `?? "Folder"` fallback would need the full `withSuspenseWrapper` + `useComponentLibrary` harness to exercise a one-line default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)