### PR TITLE
chore(gardening): standing v1↔v2 KEEP for dry + lower comments threshold to 0.75

### DIFF
--- a/.claude/skills/gardening/pillars/dry.md
+++ b/.claude/skills/gardening/pillars/dry.md
@@ -34,5 +34,14 @@ This pillar depends on the **global indexes** built in E3 — build them before 
   budget is spent) rather than shipping one sprawling PR — never a forgotten ticket.
 - Only consolidate genuine duplication of _behavior_. Superficially similar code with diverging intent
   (coincidental shape) is a KEEP — forcing it behind one helper couples unrelated concerns.
+- **Standing KEEP: v1 ↔ v2 parallel implementations.** A cluster whose participating files span the v1
+  canvas (`src/components/shared/ReactFlow/**`, and the v1 `src/routes/**` views it serves) and the v2
+  tree (`src/routes/v2/**`) is a **migration in progress**, not accidental duplication — v1 is slated for
+  removal, and coupling the two behind one helper mid-migration is the "diverging intent" case above.
+  Examples seen: `PipelineTags`/`TagsBlock`, `PipelineRun`/`RunViewV2`, `RunDetails`/`RunDetailsContent`,
+  `FlexNodeEditor`/`FlexNodeDetails`, `IONode`/`IONodeCard`.
+  Drop these clusters in E5 — do **not** file them as findings, and do **not** re-raise them as a
+  decision-queue item (#2626 B12 closed this; re-filing it every run is the noise this rule removes).
+  Duplication _within_ v1 or _within_ v2 is still in scope, as is a v1-only or v2-only cluster.
 - New helpers follow project structure: `@/` imports, no barrel exports, placed in the right
   `src/utils|hooks|lib` home with a proper TypeScript signature.

--- a/.github/gardening-config.json
+++ b/.github/gardening-config.json
@@ -17,7 +17,7 @@
       "id": "comments",
       "pillar": "comments",
       "enabled": true,
-      "confidenceThreshold": 0.85,
+      "confidenceThreshold": 0.75,
       "conventionSkill": "project-conventions",
       "description": "Remove or refine low-value narrating comments and commented-out code; keep comments that explain a non-obvious why."
     },


### PR DESCRIPTION
Resolves **B12** and **B20** of #2626. Two independent decisions, one commit each so either can be dropped.

## B12 — v1 ↔ v2 parallel implementations: leave them

Ruled **leave alone**, which is what #2621 already did — the entry existed only to stop the `dry` pillar re-finding the same ~12 clusters and re-filing the same decision item every week. `pillars/dry.md` now carries it as a standing KEEP: a cluster whose files span the v1 canvas and `src/routes/v2/**` is dropped in E5, not filed as a finding and not re-raised as a queue item. Duplication *within* v1 or *within* v2 is still in scope.

**Two mechanisms in the entry were not used, both deliberately.**

*Not `excludeGlobs`* (what the entry proposed): it is repo-global and **every** pillar drops it ([engine.md:153](.claude/skills/gardening/engine.md#L153), plus all seven pillar docs). Excluding v1 there would silence hygiene, comments, tests and the rest on still-live code in order to quiet one pillar about one thing.

*Not the ledger* (my own earlier recommendation — it was wrong): [.github/gardening-ledger.json](.github/gardening-ledger.json) is keyed by fingerprint, and these clusters have none. #2621 shipped **no `gardening-manifest` block**, the carry-over manifest in #2626 holds exactly one `dry` finding (`componentStore.ts`, unrelated), and the clusters appear only as prose pairs. For a DRY cluster the spec is `weakKey = sha1(category + "|" + <sorted file set + label>)` — the label is bot-generated and unrecorded, so any entry I wrote would hash differently from what next week's run computes and would **silently never match**, leaving the decision looking handled while the pillar kept re-finding it. The ledger's own `$comment` says fingerprints come from a PR manifest; there isn't one.

The pillar spec is the mechanism that both works and stays scoped to `dry`.

## B20 — `comments` threshold 0.85 → 0.75

One-line config edit. #2620 landed 115 findings across 25 files at 0.85 while a tail scoring 0.5–0.8 was dropped, and reviewer feedback on #2568 was that the sweep was too small.

| pillar | threshold |
| --- | --- |
| `react-compiler` | 0.95 |
| `hygiene`, `primitives` | 0.9 |
| `consistency`, `tests` | 0.85 |
| `dry`, `refactor` | 0.8 |
| **`comments`** | **0.75** ← was 0.85 |

This makes `comments` the most permissive pillar. That is the intended effect — it is also the most mechanical and most reviewable pillar, and `calibration.autoRaiseThreshold` is `false`, so the bot will never walk it back on its own. Expect a noticeably larger `comments` PR next run; if it overshoots, `0.8` is the obvious retreat.

## Validation

Config only — no source or test changes. JSON parses, `prettier --check` passes on both files. Nothing here changes behavior until the next gardening run.

Once this merges, the **B12** and **B20** entries in #2626's Part B can be struck (Part B is human-curated; I have not edited the issue).
