### PR TITLE
refactor(ui): success tone + Heading props, and migrate the colour/heading sites

### DIFF
--- a/src/components/shared/ComponentEditor/components/ComponentSpecErrorsList.tsx
+++ b/src/components/shared/ComponentEditor/components/ComponentSpecErrorsList.tsx
@@ -1,6 +1,6 @@
 import { Icon } from "@/components/ui/icon";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
-import { Text } from "@/components/ui/typography";
+import { Heading } from "@/components/ui/typography";
 
 export const ComponentSpecErrorsList = ({
   validationErrors,
@@ -15,9 +15,9 @@ export const ComponentSpecErrorsList = ({
     <BlockStack className="p-4 px-8 bg-destructive/10 border border-t-4 border-destructive/30 text-destructive">
       <InlineStack gap="2">
         <Icon name="OctagonAlert" size="lg" className="text-destructive" />
-        <Text tone="critical" as="h2" size="lg">
+        <Heading level={2} tone="critical" size="lg">
           Invalid component spec
-        </Text>
+        </Heading>
       </InlineStack>
       <ul className="list-disc list-inside space-y-1 p-4">
         {validationErrors.map((error, idx) => (

--- a/src/components/shared/ImportPipeline.tsx
+++ b/src/components/shared/ImportPipeline.tsx
@@ -18,6 +18,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
+import { Heading, Paragraph } from "@/components/ui/typography";
 import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { getDefaultEditorPath } from "@/routes/editorRoutes";
 import {
@@ -226,23 +227,37 @@ const ImportPipeline = ({
 
           {successMessage && (
             <div className="border border-green-200 bg-green-50 p-3 rounded-md mt-4 dark:border-green-500/30 dark:bg-green-500/10">
-              <h4 className="text-green-600 font-medium mb-1 dark:text-green-300">
+              <Heading
+                level={4}
+                tone="success"
+                size="md"
+                className="font-medium mb-1"
+              >
                 Import Successful
-              </h4>
-              <p className="text-green-500 text-sm dark:text-green-400">
+              </Heading>
+              <Paragraph tone="success" size="sm">
                 {successMessage}
-              </p>
+              </Paragraph>
             </div>
           )}
 
           {error && (
             <div className="border border-red-200 bg-red-50 p-3 rounded-md mt-4 dark:border-red-500/30 dark:bg-red-500/10">
-              <h4 className="text-red-600 font-medium mb-1 dark:text-red-300">
+              <Heading
+                level={4}
+                tone="critical"
+                size="md"
+                className="font-medium mb-1"
+              >
                 Import Failed
-              </h4>
-              <p className="text-red-500 text-sm whitespace-pre-wrap dark:text-red-400">
+              </Heading>
+              <Paragraph
+                tone="critical"
+                size="sm"
+                className="whitespace-pre-wrap"
+              >
                 {error}
-              </p>
+              </Paragraph>
             </div>
           )}
 

--- a/src/components/shared/ReactFlow/FlowSidebar/components/ImportComponent.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/components/ImportComponent.tsx
@@ -27,6 +27,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Spinner } from "@/components/ui/spinner";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Paragraph } from "@/components/ui/typography";
 import useToastNotification from "@/hooks/useToastNotification";
 import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { useComponentLibrary } from "@/providers/ComponentLibraryProvider";
@@ -225,12 +226,16 @@ const ImportComponent = ({
                         {!selectedFileName && (
                           <div className="flex flex-col items-center justify-center border-2 border-dashed rounded-lg p-6 text-center hover:border-primary/50 transition-colors">
                             <Upload className="h-8 w-8 text-gray-400 mb-2" />
-                            <p className="text-sm text-gray-600 dark:text-muted-foreground">
+                            <Paragraph tone="subdued" size="sm">
                               Drop your YAML file here or click to browse
-                            </p>
-                            <p className="text-xs text-gray-500 mt-1">
+                            </Paragraph>
+                            <Paragraph
+                              tone="subdued"
+                              size="xs"
+                              className="mt-1"
+                            >
                               Supports .yaml files
-                            </p>
+                            </Paragraph>
                           </div>
                         )}
                         {selectedFileName && (
@@ -262,9 +267,9 @@ const ImportComponent = ({
                         </Button>
                       )}
                     </div>
-                    <p className="text-sm text-gray-500">
+                    <Paragraph tone="subdued" size="sm">
                       Select a YAML file containing a pipeline component
-                    </p>
+                    </Paragraph>
                   </div>
                 </div>
               </TabsContent>
@@ -280,9 +285,9 @@ const ImportComponent = ({
                       onChange={handleUrlChange}
                       disabled={isPending}
                     />
-                    <p className="text-sm text-gray-500">
+                    <Paragraph tone="subdued" size="sm">
                       Enter the URL of a component YAML file
-                    </p>
+                    </Paragraph>
                   </div>
                 </div>
               </TabsContent>

--- a/src/components/shared/ReactFlow/FlowSidebar/components/SearchFilter.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/components/SearchFilter.tsx
@@ -8,6 +8,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import { Heading } from "@/components/ui/typography";
 import { type SearchFilterProps } from "@/types/componentLibrary";
 import { ComponentSearchFilter } from "@/utils/constants";
 
@@ -44,7 +45,9 @@ const SearchFilter = ({
       </PopoverTrigger>
       <PopoverContent className="w-40">
         <div className="grid gap-2">
-          <h4>Filter Search</h4>
+          <Heading level={4} size="md">
+            Filter Search
+          </Heading>
           <div className="space-y-2">
             {availableFilters.map((filter) => {
               if (filter === ComponentSearchFilter.EXACTMATCH) return;

--- a/src/components/shared/ReactFlow/FlowSidebar/components/SidebarSection.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/components/SidebarSection.tsx
@@ -1,7 +1,7 @@
 import { type ReactNode } from "react";
 
 import { BlockStack, InlineStack } from "@/components/ui/layout";
-import { Text } from "@/components/ui/typography";
+import { Heading } from "@/components/ui/typography";
 import { cn } from "@/lib/utils";
 
 interface SidebarSectionProps {
@@ -20,14 +20,14 @@ export const SidebarSection = ({
   return (
     <BlockStack gap="2" className={cn("p-2", className)}>
       <InlineStack align="space-between" className="w-full">
-        <Text
-          as="h3"
+        <Heading
+          level={3}
           size="sm"
           weight="medium"
           className="text-sidebar-foreground/70"
         >
           {title}
-        </Text>
+        </Heading>
         {headerAction}
       </InlineStack>
 

--- a/src/components/shared/TaskDetails/IO.tsx
+++ b/src/components/shared/TaskDetails/IO.tsx
@@ -1,4 +1,5 @@
 import { Badge } from "@/components/ui/badge";
+import { Heading } from "@/components/ui/typography";
 import type { ComponentSpec } from "@/utils/componentSpec";
 
 interface TaskIOProps {
@@ -10,7 +11,9 @@ const TaskIO = ({ componentSpec }: TaskIOProps) => {
     <div className="h-full overflow-auto hide-scrollbar">
       {componentSpec?.inputs && componentSpec.inputs.length > 0 && (
         <div className="mb-4">
-          <h4 className="text-sm font-medium mb-2">Inputs</h4>
+          <Heading level={4} size="sm" className="font-medium mb-2">
+            Inputs
+          </Heading>
           <div className="border rounded-md divide-y">
             {componentSpec.inputs.map((input, index) => (
               <div key={index} className="flex flex-col px-3 py-2 gap-2">
@@ -48,7 +51,9 @@ const TaskIO = ({ componentSpec }: TaskIOProps) => {
 
       {componentSpec?.outputs && componentSpec.outputs.length > 0 && (
         <div>
-          <h4 className="text-sm font-medium mb-2">Outputs</h4>
+          <Heading level={4} size="sm" className="font-medium mb-2">
+            Outputs
+          </Heading>
           <div className="border rounded-md divide-y">
             {componentSpec.outputs.map((output) => (
               <div key={output.name} className="flex flex-col px-3 py-2 gap-2">

--- a/src/components/ui/typography.tsx
+++ b/src/components/ui/typography.tsx
@@ -31,6 +31,7 @@ const textVariants = cva("", {
       inverted: "text-inverted",
       info: "text-foreground underline decoration-dotted",
       warning: "text-warning",
+      success: "text-success",
     },
     size: {
       xs: "text-xs",
@@ -125,12 +126,17 @@ Paragraph.displayName = "Paragraph";
 export const Heading = ({
   children,
   level = 1,
-}: PropsWithChildren<{ level: 1 | 2 | 3 | 4 | 5 | 6 }>) => {
+  size,
+  weight,
+  ...rest
+}: PropsWithChildren<{ level: 1 | 2 | 3 | 4 | 5 | 6 }> &
+  Omit<TextProps, "as" | "children">) => {
   return (
     <Text
+      {...rest}
       as={`h${level}`}
-      size={level === 1 ? "md" : "sm"}
-      weight={level < 3 ? "semibold" : "regular"}
+      size={size ?? (level === 1 ? "md" : "sm")}
+      weight={weight ?? (level < 3 ? "semibold" : "regular")}
       role="heading"
       aria-level={level}
     >

--- a/src/providers/ContextPanelProvider.tsx
+++ b/src/providers/ContextPanelProvider.tsx
@@ -8,6 +8,7 @@ import {
   useState,
 } from "react";
 
+import { Paragraph } from "@/components/ui/typography";
 import { deselectAllNodes } from "@/utils/flowUtils";
 
 import {
@@ -29,7 +30,7 @@ const ContextPanelContext = createRequiredContext<ContextPanelContextType>(
 
 const EMPTY_STATE = (
   <div className="flex items-center justify-center h-full">
-    <p className="text-gray-500">Select an element to see details</p>
+    <Paragraph tone="subdued">Select an element to see details</Paragraph>
   </div>
 );
 

--- a/src/routes/v2/pages/Editor/components/ArgumentRow/ArgumentRow.tsx
+++ b/src/routes/v2/pages/Editor/components/ArgumentRow/ArgumentRow.tsx
@@ -183,7 +183,7 @@ export const ArgumentRow = observer(function ArgumentRow({
           {inputSpec.name.replace(/_/g, " ")}
         </Text>
         {typeLabel && (
-          <Text size="xs" className="text-gray-400 shrink-0">
+          <Text size="xs" tone="subdued" className="shrink-0">
             ({typeLabel}
             {!inputSpec.optional ? "*" : ""})
           </Text>

--- a/src/routes/v2/pages/Editor/components/ArgumentRow/components/ThunderMenu/components/QuickConnectSubmenu.tsx
+++ b/src/routes/v2/pages/Editor/components/ArgumentRow/components/ThunderMenu/components/QuickConnectSubmenu.tsx
@@ -62,7 +62,7 @@ export function QuickConnectSubmenu({
                     {port.portName}
                   </Text>
                   {typeLabel && (
-                    <Text size="xs" className="text-gray-400 shrink-0 ml-auto">
+                    <Text size="xs" tone="subdued" className="shrink-0 ml-auto">
                       {typeLabel}
                     </Text>
                   )}

--- a/src/routes/v2/pages/Editor/components/ContextPanel/components/MultiSelectionDetails/components/BatchArgumentRow.tsx
+++ b/src/routes/v2/pages/Editor/components/ContextPanel/components/MultiSelectionDetails/components/BatchArgumentRow.tsx
@@ -197,17 +197,17 @@ export const BatchArgumentRow = observer(function BatchArgumentRow({
             {aggArg.name}
           </Text>
           {aggArg.typeLabel && (
-            <Text size="xs" className="text-gray-400 shrink-0">
+            <Text size="xs" tone="subdued" className="shrink-0">
               {aggArg.typeLabel}
             </Text>
           )}
           {!aggArg.optional && (
-            <Text size="xs" className="text-red-400 shrink-0">
+            <Text size="xs" tone="critical" className="shrink-0">
               *
             </Text>
           )}
         </InlineStack>
-        <Text size="xs" className="text-gray-400 shrink-0 mr-1">
+        <Text size="xs" tone="subdued" className="shrink-0 mr-1">
           {aggArg.taskIds.length} tasks
         </Text>
         <ThunderMenu

--- a/src/routes/v2/pages/Editor/components/ContextPanel/components/MultiSelectionDetails/components/BatchTaskColor.tsx
+++ b/src/routes/v2/pages/Editor/components/ContextPanel/components/MultiSelectionDetails/components/BatchTaskColor.tsx
@@ -31,7 +31,7 @@ export const BatchTaskColor = observer(function BatchTaskColor({
       <Separator />
       <InlineStack align="space-between" gap="2" className="w-full">
         <InlineStack gap="2" blockAlign="center">
-          <Text size="xs" className="text-gray-600 dark:text-muted-foreground">
+          <Text size="xs" tone="subdued">
             Task color
           </Text>
           {!allSame && (

--- a/src/routes/v2/pages/Editor/components/CreateSubgraphForm.tsx
+++ b/src/routes/v2/pages/Editor/components/CreateSubgraphForm.tsx
@@ -39,7 +39,7 @@ export function CreateSubgraphForm({
         <Label className="text-gray-600 dark:text-muted-foreground">
           Create Subgraph
         </Label>
-        <Text size="xs" className="text-gray-400">
+        <Text size="xs" tone="subdued">
           Group {selectedTaskCount} tasks into a reusable component
         </Text>
       </BlockStack>

--- a/src/routes/v2/pages/Editor/components/DriverPermissionGate.tsx
+++ b/src/routes/v2/pages/Editor/components/DriverPermissionGate.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
 import { BlockStack } from "@/components/ui/layout";
 import { Spinner } from "@/components/ui/spinner";
-import { Text } from "@/components/ui/typography";
+import { Heading, Text } from "@/components/ui/typography";
 import type { PipelineFolder } from "@/services/pipelineStorage/PipelineFolder";
 import { usePipelineStorage } from "@/services/pipelineStorage/PipelineStorageProvider";
 import type { PipelineStorageService } from "@/services/pipelineStorage/PipelineStorageService";
@@ -92,9 +92,9 @@ export function DriverPermissionGate({
   return (
     <BlockStack fill align="center" inlineAlign="center" gap="4">
       <Icon name="ShieldAlert" className="size-12 text-muted-foreground" />
-      <Text as="h2" size="lg" weight="semibold">
+      <Heading level={2} size="lg" weight="semibold">
         Permission Required
-      </Text>
+      </Heading>
       <Text tone="subdued" className="text-center max-w-md">
         This pipeline is stored in &ldquo;{data.folder?.name}&rdquo; which
         requires access permission.

--- a/src/routes/v2/pages/Editor/components/EditorMenuBar/components/RunsMenu.tsx
+++ b/src/routes/v2/pages/Editor/components/EditorMenuBar/components/RunsMenu.tsx
@@ -56,7 +56,7 @@ export const RunsMenu = observer(function RunsMenu() {
           <>
             <DropdownMenuSeparator />
             <div className="px-2 py-1.5">
-              <Text size="xs" className="text-red-500">
+              <Text size="xs" tone="critical">
                 {errorCount} validation {errorCount === 1 ? "issue" : "issues"}
               </Text>
             </div>

--- a/src/routes/v2/pages/Editor/components/EmptyEditorState.tsx
+++ b/src/routes/v2/pages/Editor/components/EmptyEditorState.tsx
@@ -3,7 +3,7 @@ import { useEffect } from "react";
 
 import { Icon } from "@/components/ui/icon";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
-import { Text } from "@/components/ui/typography";
+import { Heading } from "@/components/ui/typography";
 import { useAnalytics } from "@/providers/AnalyticsProvider";
 import { APP_ROUTES } from "@/routes/router";
 // TODO: extract PipelineFolders picker to shared or restructure via routing composition
@@ -38,9 +38,9 @@ export function EmptyEditorState() {
       >
         <InlineStack gap="2" blockAlign="center">
           <Icon name="FolderOpen" size="md" className="text-stone-500" />
-          <Text as="h2" size="lg" weight="semibold">
+          <Heading level={2} size="lg" weight="semibold">
             Open Pipeline
-          </Text>
+          </Heading>
         </InlineStack>
         <PipelineFolders onPipelineClick={handlePipelineClick} />
       </BlockStack>

--- a/src/routes/v2/pages/Editor/components/HistoryContent/components/InitialStateMarker.tsx
+++ b/src/routes/v2/pages/Editor/components/HistoryContent/components/InitialStateMarker.tsx
@@ -42,7 +42,7 @@ export function InitialStateMarker({
       >
         Initial state
         {isCurrent && (
-          <Text as="span" size="xs" className="text-green-500 ml-1">
+          <Text as="span" size="xs" tone="success" className="ml-1">
             ●
           </Text>
         )}

--- a/src/routes/v2/pages/Editor/components/PressedKeysList.tsx
+++ b/src/routes/v2/pages/Editor/components/PressedKeysList.tsx
@@ -2,7 +2,7 @@ import { autorun } from "mobx";
 import { useEffect, useState } from "react";
 
 import { BlockStack, InlineStack } from "@/components/ui/layout";
-import { Text } from "@/components/ui/typography";
+import { Heading, Text } from "@/components/ui/typography";
 import type { KeyConstant } from "@/routes/v2/shared/shortcuts/keys";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 
@@ -17,16 +17,9 @@ export const PressedKeysList = function PressedKeysList() {
 
   return (
     <BlockStack>
-      <Text
-        as="h3"
-        size="xs"
-        weight="semibold"
-        tone="subdued"
-        role="heading"
-        aria-level={3}
-      >
+      <Heading level={3} size="xs" weight="semibold" tone="subdued">
         Pressed Keys ({pressedKeys.length})
-      </Text>
+      </Heading>
       <InlineStack gap="2" blockAlign="center">
         {pressedKeys.map((key) => (
           <Text key={key} size="xs">

--- a/src/routes/v2/pages/Editor/components/StatComponents.tsx
+++ b/src/routes/v2/pages/Editor/components/StatComponents.tsx
@@ -11,7 +11,7 @@ interface StatItemProps {
 export function StatItem({ label, value }: StatItemProps) {
   return (
     <InlineStack blockAlign="center" className="justify-between py-1" gap="2">
-      <Text size="xs" className="text-gray-500 dark:text-muted-foreground">
+      <Text size="xs" tone="subdued">
         {label}
       </Text>
       <Text

--- a/src/routes/v2/pages/Editor/components/StatComponents.tsx
+++ b/src/routes/v2/pages/Editor/components/StatComponents.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 
 import { BlockStack, InlineStack } from "@/components/ui/layout";
-import { Text } from "@/components/ui/typography";
+import { Heading, Text } from "@/components/ui/typography";
 
 interface StatItemProps {
   label: string;
@@ -33,16 +33,9 @@ interface StatGroupProps {
 export function StatGroup({ title, children }: StatGroupProps) {
   return (
     <BlockStack gap="1">
-      <Text
-        as="h3"
-        size="xs"
-        weight="semibold"
-        tone="subdued"
-        role="heading"
-        aria-level={3}
-      >
+      <Heading level={3} size="xs" weight="semibold" tone="subdued">
         {title}
-      </Text>
+      </Heading>
       <BlockStack className="pl-2 border-l-2 border-gray-200 dark:border-border">
         {children}
       </BlockStack>

--- a/src/routes/v2/pages/Editor/nodes/IONode/context/InputDetails.tsx
+++ b/src/routes/v2/pages/Editor/nodes/IONode/context/InputDetails.tsx
@@ -149,7 +149,7 @@ export const InputDetails = observer(function InputDetails({
         </BlockStack>
 
         <InlineStack gap="2">
-          <Text size="xs" className="text-gray-400">
+          <Text size="xs" tone="subdued">
             Optional:
           </Text>
           <Text size="xs" weight="semibold" tone="subdued">

--- a/src/routes/v2/pages/Editor/nodes/IONode/context/OutputDetails.tsx
+++ b/src/routes/v2/pages/Editor/nodes/IONode/context/OutputDetails.tsx
@@ -65,7 +65,7 @@ export const OutputDetails = observer(function OutputDetails({
             >
               Type
             </InputLabel>
-            <Text size="xs" font="mono" className="text-gray-500">
+            <Text size="xs" font="mono" tone="subdued">
               {String(output.type)}
             </Text>
           </BlockStack>

--- a/src/routes/v2/shared/components/AiChat/components/renderMarkdown.tsx
+++ b/src/routes/v2/shared/components/AiChat/components/renderMarkdown.tsx
@@ -10,7 +10,7 @@ import remarkGfm from "remark-gfm";
 
 import { Link } from "@/components/ui/link";
 import { Separator } from "@/components/ui/separator";
-import { Paragraph, Text } from "@/components/ui/typography";
+import { Heading, Paragraph } from "@/components/ui/typography";
 import { getComponentQueryKey } from "@/hooks/useHydrateComponentReference";
 import type { ComponentRefData } from "@/routes/v2/shared/components/AiChat/types";
 import { CodeBlock } from "@/routes/v2/shared/components/CodeBlock";
@@ -137,24 +137,29 @@ function MarkdownCode({
 
 const markdownComponents = {
   h1: ({ children }: { children?: ReactNode }) => (
-    <Text as="h1" size="md" weight="bold" className="mt-3 mb-1 block">
+    <Heading level={1} size="md" weight="bold" className="mt-3 mb-1 block">
       {children}
-    </Text>
+    </Heading>
   ),
   h2: ({ children }: { children?: ReactNode }) => (
-    <Text as="h2" size="sm" weight="bold" className="mt-2 mb-1 block">
+    <Heading level={2} size="sm" weight="bold" className="mt-2 mb-1 block">
       {children}
-    </Text>
+    </Heading>
   ),
   h3: ({ children }: { children?: ReactNode }) => (
-    <Text as="h3" size="sm" weight="semibold" className="mt-2 mb-0.5 block">
+    <Heading
+      level={3}
+      size="sm"
+      weight="semibold"
+      className="mt-2 mb-0.5 block"
+    >
       {children}
-    </Text>
+    </Heading>
   ),
   h4: ({ children }: { children?: ReactNode }) => (
-    <Text as="h4" size="sm" weight="semibold" className="mt-1 block">
+    <Heading level={4} size="sm" weight="semibold" className="mt-1 block">
       {children}
-    </Text>
+    </Heading>
   ),
   p: ({ children }: { children?: ReactNode }) => (
     <Paragraph size="sm" className="my-1 leading-relaxed">


### PR DESCRIPTION
Resolves **B18** and **B19b** of #2626. Three commits: the primitive changes both items needed, then one migration commit each.

⚠️ **Needs a visual diff** — this changes rendered colour and adds heading semantics. Every site was migrated to preserve its exact size, weight and spacing, but that claim is worth checking against the running UI.

- [ ] Visually diffed the rendered output — no layout/spacing/colour regression

## Why the primitive had to change first

Both entries asked for call-site migrations that were **impossible** as the primitives stood:

| Blocker | Fix |
| --- | --- |
| No `tone` mapped to green, so success text had to use raw palette classes | Added `success: "text-success"`. `--success` and `--color-success` already existed in both palettes — only the variant was missing |
| `Heading` accepted only `children` and `level` and **dropped every other prop**, while its sibling `Paragraph` forwards rest props to `Text`. Any heading needing a tone, size, weight or className could not use it | `Heading` now forwards rest props, with the level-derived size/weight as overridable defaults |

`Heading`'s widening is deliberately conservative: `as` is omitted from the accepted props so the element can't be swapped, and `role="heading"` / `aria-level` are applied **after** the spread so a caller can't clobber the accessibility attributes.

## B18 — 19 colour sites across 13 files

`gray-*` → `subdued`, `red-*` → `critical`, `green-*` → `success`. 7 were raw `<p>`/`<h4>` and became `Paragraph`/`Heading`; 12 already used `Text` and only needed `className` swapped for a `tone`.

The entry claimed 20 sites; 19 is what is actually there. #2631 landed in the meantime and covered a different set — I re-derived the list rather than trusting the count.

This also fixes a real inconsistency at [ImportComponent.tsx:228](src/components/shared/ReactFlow/FlowSidebar/components/ImportComponent.tsx#L228), which read `text-sm text-gray-600 dark:text-muted-foreground` — the dark variant was already asking for `subdued` while the light half stayed raw palette.

**Deliberately out of scope**, since `tone` only covers text: container `border-*`/`bg-*` palette classes (e.g. the green/red callout boxes in `ImportPipeline`), lucide icon colours, and `Label`, which takes no `tone`.

## B19b — 13 heading sites across 9 files

10 `Text as="h*"` plus 3 raw `<h4>`. Every site keeps its exact `size`, `weight`, `tone` and `className`, so **the only rendering change is the `role="heading"` and `aria-level` that `Heading` adds** — which is the point of the migration.

Two sites were already hand-rolling exactly that: [PressedKeysList.tsx](src/routes/v2/pages/Editor/components/PressedKeysList.tsx) and [StatComponents.tsx](src/routes/v2/pages/Editor/components/StatComponents.tsx) both passed `role="heading"` and `aria-level={3}` to `Text` themselves. They now say `<Heading level={3}>`.

The entry counted "10 raw `<h1>`–`<h6>` in 5 files"; 5 of those are in `.test.tsx` fixtures and stay raw markup — they are asserting rendering, not product UI. The 5 real ones are the 2 in `ImportPipeline` (migrated in the B18 commit, since colour was the driver) and 3 here.

## Verified by compiling the theme, not by eye

`text-success` is a real utility only because `--color-success` is registered in `global.css`'s `@theme` block — in a stock Tailwind build it generates nothing. Rather than assume, I compiled the actual entry (`src/styles/global.css`) through Tailwind 4.3.3's `compile()` API and asked which candidates emit a rule:

```
text-success           GENERATED     ← the new tone renders
text-warning           GENERATED
text-destructive       GENERATED
text-muted-foreground  GENERATED
text-md                -- dead --
font-regular           -- dead --
text-inverted          -- dead --
```

## Three dead variant values, pre-existing — found, not fixed

`textVariants` emits three class names Tailwind never generates:

| Variant value | Emits | Should be | Used |
| --- | --- | --- | --- |
| `size="md"` | `text-md` | `text-base` | **the `Text` default** — every `Text` without an explicit size |
| `weight="regular"` | `font-regular` | `font-normal` | **the `Text` default** — every `Text` |
| `tone="inverted"` | `text-inverted` | no `--inverted` token exists at all | 0 sites |

The two defaults are why the codebase looks fine: emitting a dead class leaves the browser default in place, which is what `text-base` / `font-normal` would have given anyway. So this is latent, not a visible bug — but it does mean `size` and `weight` silently have no "reset to default" value, and `tone="inverted"` would render nothing if anyone used it.

It is also load-bearing in this PR in a benign way: `size="md"` is how a migrated raw element keeps the base font size it inherited, which is why `SearchFilter`'s `<h4>` and the two `ImportPipeline` headings pass it. Fixing the variants would change rendering at all 22 `size="md"` sites plus every defaulted `Text`, so it belongs in its own PR with its own visual diff. Worth filing separately.

## Validation

`typecheck` · `lint` · `knip` · `prettier` all clean — 191 files / 1,966 tests passing. No raw `<h1>`–`<h6>` and no `Text as="h*"` remain outside test fixtures and `typography.tsx` itself.

Once merged, the **B18** and **B19b** entries in #2626's Part B can be struck. **B19a** (the 27 `flex flex-col` → `BlockStack` sites) is untouched and still open — it needs a separate per-area ruling on `w-full`/`items-start`.
