### PR TITLE
fix: Missing Hydration in Run View Subgraphs

### DIFF
--- a/src/hooks/useHydrateComponentReference.test.tsx
+++ b/src/hooks/useHydrateComponentReference.test.tsx
@@ -387,3 +387,75 @@ describe("useGuaranteedHydrateComponentReference", () => {
     });
   });
 });
+
+describe("digest key collisions between stripped and content-bearing references", () => {
+  const DIGEST = "8f0380c9807ac38866a922c847b75dff";
+
+  const spec: ComponentReference["spec"] = {
+    name: "Transform Batch",
+    implementation: { graph: { tasks: {} } },
+  };
+
+  const hydrated: HydratedComponentReference = {
+    digest: DIGEST,
+    name: "Transform Batch",
+    spec: spec!,
+    text: "name: Transform Batch",
+  };
+
+  const sharedWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const Wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    Wrapper.displayName = "SharedQueryClientWrapper";
+    return Wrapper;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(hydrateComponentReference).mockReset();
+  });
+
+  it("does not let an unresolvable digest-only reference poison the same digest carrying a spec", async () => {
+    vi.mocked(hydrateComponentReference).mockImplementation(async (ref) =>
+      ref.spec ? hydrated : null,
+    );
+
+    const wrapper = sharedWrapper();
+
+    const stripped = renderHook(
+      () => useHydrateComponentReference({ digest: DIGEST }),
+      { wrapper },
+    );
+    await waitFor(() => expect(stripped.result.current).toBeNull());
+
+    const resolved = renderHook(
+      () => useHydrateComponentReference({ digest: DIGEST, spec }),
+      { wrapper },
+    );
+    await waitFor(() => expect(resolved.result.current).toEqual(hydrated));
+  });
+
+  it("still shares one cache entry between content-bearing references with the same digest", async () => {
+    vi.mocked(hydrateComponentReference).mockResolvedValue(hydrated);
+
+    const wrapper = sharedWrapper();
+
+    const first = renderHook(
+      () => useHydrateComponentReference({ digest: DIGEST, spec }),
+      { wrapper },
+    );
+    await waitFor(() => expect(first.result.current).toEqual(hydrated));
+
+    const second = renderHook(
+      () => useHydrateComponentReference({ digest: DIGEST, spec }),
+      { wrapper },
+    );
+    await waitFor(() => expect(second.result.current).toEqual(hydrated));
+
+    expect(hydrateComponentReference).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/useHydrateComponentReference.ts
+++ b/src/hooks/useHydrateComponentReference.ts
@@ -11,7 +11,9 @@ import { componentSpecToText } from "@/utils/yaml";
  */
 export function getComponentQueryKey(component: ComponentReference): string {
   if (component.digest) {
-    return `digest:${component.digest}`;
+    return component.spec || component.text
+      ? `digest:${component.digest}:content`
+      : `digest:${component.digest}`;
   }
 
   if (component.url) {

--- a/src/models/componentSpec/__tests__/entities/task.test.ts
+++ b/src/models/componentSpec/__tests__/entities/task.test.ts
@@ -1,3 +1,4 @@
+import yaml from "js-yaml";
 import { describe, expect, it } from "vitest";
 
 import { Task } from "../../entities/task";
@@ -156,6 +157,74 @@ describe("Task", () => {
 
     expect(task.executionOptions).toEqual({
       retryStrategy: { maxRetries: 3 },
+    });
+  });
+
+  describe("resolvedComponentRef", () => {
+    const subgraphRef = {
+      name: "Subgraph",
+      digest: "digest123",
+      spec: {
+        name: "Subgraph",
+        inputs: [{ name: "page", type: "String" }],
+        implementation: {
+          graph: {
+            tasks: {
+              Inner: {
+                componentRef: {
+                  name: "Inner",
+                  spec: {
+                    name: "Inner",
+                    implementation: { container: { image: "inner:latest" } },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    it("returns the reference unchanged for a container task", () => {
+      const componentRef = {
+        name: "Container",
+        digest: "digest456",
+        spec: {
+          name: "Container",
+          implementation: { container: { image: "container:latest" } },
+        },
+      };
+      const task = new Task({ $id: "task_1", name: "T", componentRef });
+
+      expect(task.resolvedComponentRef).toBe(task.componentRef);
+      expect(task.resolvedComponentRef.spec).toEqual(componentRef.spec);
+    });
+
+    it("re-attaches the spec that setComponentRef stripped from a subgraph task", () => {
+      const task = new Task({ $id: "task_1", name: "T", componentRef: {} });
+      task.setComponentRef(subgraphRef);
+
+      expect(task.componentRef.spec).toBeUndefined();
+      expect(task.resolvedComponentRef.name).toBe("Subgraph");
+      expect(task.resolvedComponentRef.digest).toBe("digest123");
+      expect(task.resolvedComponentRef.spec?.implementation).toHaveProperty(
+        "graph",
+      );
+      expect(task.resolvedComponentRef.spec?.inputs).toEqual([
+        expect.objectContaining({ name: "page", type: "String" }),
+      ]);
+    });
+
+    it("yields a spec that survives yaml.dump, unlike resolvedComponentSpec", () => {
+      const task = new Task({ $id: "task_1", name: "T", componentRef: {} });
+      task.setComponentRef(subgraphRef);
+
+      const dumped = yaml.load(
+        yaml.dump(task.resolvedComponentRef.spec),
+      ) as Record<string, unknown>;
+
+      expect(dumped).toHaveProperty("implementation");
+      expect(yaml.dump(task.resolvedComponentSpec)).toBe("{}\n");
     });
   });
 });

--- a/src/models/componentSpec/entities/task.ts
+++ b/src/models/componentSpec/entities/task.ts
@@ -2,6 +2,7 @@ import { computed } from "mobx";
 import { idProp, Model, model, modelAction, prop } from "mobx-keystone";
 
 import { Annotations } from "../annotations";
+import { serializeComponentSpec } from "../serialization/serialize";
 import type { ComponentSpec } from "./componentSpec";
 import { createComponentSpecProxy } from "./componentSpecProxy";
 import { deserializeSubgraphSpec } from "./taskSubgraphHelper";
@@ -62,6 +63,18 @@ export class Task extends Model({
       return createComponentSpecProxy(this.subgraphSpec);
     }
     return this.componentRef.spec;
+  }
+
+  @computed
+  get resolvedComponentRef(): ComponentReference {
+    if (!this.subgraphSpec) {
+      return this.componentRef;
+    }
+
+    return {
+      ...this.componentRef,
+      spec: serializeComponentSpec(this.subgraphSpec),
+    };
   }
 
   @modelAction

--- a/src/routes/v2/pages/RunView/nodes/TaskNode/context/RunViewTaskDetails.tsx
+++ b/src/routes/v2/pages/RunView/nodes/TaskNode/context/RunViewTaskDetails.tsx
@@ -54,7 +54,7 @@ export const RunViewTaskDetails = observer(function RunViewTaskDetails({
   const executionId =
     executionData?.details?.child_task_execution_ids?.[task.name];
 
-  const componentRef = task.componentRef;
+  const componentRef = task.resolvedComponentRef;
   const isSubgraphTask = task.subgraphSpec !== undefined;
 
   const taskSpecForIO = { componentRef } as TaskSpec;

--- a/src/routes/v2/shared/nodes/TaskNode/TaskNode.tsx
+++ b/src/routes/v2/shared/nodes/TaskNode/TaskNode.tsx
@@ -321,7 +321,7 @@ export const TaskNode = observer(function TaskNode({
       task.executionOptions?.cachingStrategy?.maxCacheStaleness ===
       ISO8601_DURATION_ZERO_DAYS,
     componentRef: publishedComponentBadgeEnabled
-      ? task.componentRef
+      ? task.resolvedComponentRef
       : undefined,
     publishedComponentBadgeReadOnly,
     isAggregator,

--- a/src/services/hydrateComponentReference.test.ts
+++ b/src/services/hydrateComponentReference.test.ts
@@ -2,6 +2,10 @@ import { waitFor } from "@testing-library/dom";
 import yaml from "js-yaml";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import {
+  IncrementingIdGenerator,
+  YamlDeserializer,
+} from "@/models/componentSpec";
 import type { ComponentSpec } from "@/utils/componentSpec";
 import * as localforage from "@/utils/localforage";
 
@@ -1167,6 +1171,53 @@ describe("hydrateComponentReference()", () => {
         expect(result?.spec?.description).toBe(largeDescription);
       });
     });
+  });
+});
+
+describe("subgraph task references", () => {
+  it("hydrates a deserialized subgraph task via resolvedComponentRef", async () => {
+    mockGetComponentById(null);
+
+    const subgraphRef = {
+      name: "Lock Scrape Complete",
+      digest: "d8eee904e935",
+      spec: {
+        name: "Lock Scrape Complete",
+        inputs: [{ name: "page", type: "String" }],
+        implementation: {
+          graph: {
+            tasks: {
+              Scrape: {
+                componentRef: {
+                  name: "Scrape",
+                  spec: createComponentSpec("Scrape", "scrape:latest"),
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const spec = new YamlDeserializer(
+      new IncrementingIdGenerator(),
+    ).deserialize({
+      name: "parent",
+      implementation: {
+        graph: { tasks: { "Lock Scrape 108": { componentRef: subgraphRef } } },
+      },
+    });
+    const task = spec.tasks[0];
+
+    expect(task.componentRef.spec).toBeUndefined();
+    expect(await hydrateComponentReference(task.componentRef)).toBeNull();
+
+    const hydrated = await hydrateComponentReference(task.resolvedComponentRef);
+
+    expect(hydrated).not.toBeNull();
+    expect(hydrated?.name).toBe("Lock Scrape Complete");
+    expect(hydrated?.spec.implementation).toHaveProperty("graph");
+    expect(hydrated?.text).toContain("Scrape");
   });
 });
 


### PR DESCRIPTION
## Description

Fixes an issue where tasks nested within subgraphs were no longer being given their component spec and were thus failing to hydrate. This made the tasks render incorrectly, the console fill with errors and the task details UI to fail to load.

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

![image.png](https://app.graphite.com/user-attachments/assets/3981b61d-4eff-4fb4-b04c-e2a816fe5e3b.png)



<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

Use this pipeline to test: https://oasis-staging.shopify.io/runs-v2/01a01b3c9e5217132e6c

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->