### PR TITLE
fix: prevent component editor from closing unexpectedly

### DIFF
--- a/src/components/Editor/PipelineEditor.tsx
+++ b/src/components/Editor/PipelineEditor.tsx
@@ -3,6 +3,7 @@ import "@/styles/editor.css";
 import { Background, MiniMap, type ReactFlowProps } from "@xyflow/react";
 import { useRef, useState } from "react";
 
+import { ComponentEditorProvider } from "@/components/shared/ComponentEditor/ComponentEditorProvider";
 import { CollapsibleContextPanel } from "@/components/shared/ContextPanel/CollapsibleContextPanel";
 import {
   FlowCanvas,
@@ -63,32 +64,34 @@ const PipelineEditor = () => {
         <ContextPanelProvider defaultContent={<PipelineDetails />}>
           <ForcedSearchProvider>
             <ComponentLibraryProvider>
-              <InlineStack fill>
-                <FlowSidebar />
-                <BlockStack fill className="flex-1 relative">
-                  <FlowCanvas ref={flowCanvasRef} {...flowConfig}>
-                    <MiniMap
-                      position="bottom-left"
-                      className="dark:rounded-md dark:border dark:border-border"
-                      pannable
-                    />
-                    <FlowControls
-                      className="ml-56! mb-3!"
-                      config={flowConfig}
-                      updateConfig={updateFlowConfig}
-                      onAutoLayout={handleAutoLayout}
-                      showInteractive={false}
-                      pageType="pipeline_editor"
-                    />
-                    <Background gap={GRID_SIZE} className="bg-canvas!" />
-                  </FlowCanvas>
+              <ComponentEditorProvider>
+                <InlineStack fill>
+                  <FlowSidebar />
+                  <BlockStack fill className="flex-1 relative">
+                    <FlowCanvas ref={flowCanvasRef} {...flowConfig}>
+                      <MiniMap
+                        position="bottom-left"
+                        className="dark:rounded-md dark:border dark:border-border"
+                        pannable
+                      />
+                      <FlowControls
+                        className="ml-56! mb-3!"
+                        config={flowConfig}
+                        updateConfig={updateFlowConfig}
+                        onAutoLayout={handleAutoLayout}
+                        showInteractive={false}
+                        pageType="pipeline_editor"
+                      />
+                      <Background gap={GRID_SIZE} className="bg-canvas!" />
+                    </FlowCanvas>
 
-                  <div className="absolute bottom-0 right-0 p-4">
-                    <UndoRedo />
-                  </div>
-                </BlockStack>
-                <CollapsibleContextPanel />
-              </InlineStack>
+                    <div className="absolute bottom-0 right-0 p-4">
+                      <UndoRedo />
+                    </div>
+                  </BlockStack>
+                  <CollapsibleContextPanel />
+                </InlineStack>
+              </ComponentEditorProvider>
             </ComponentLibraryProvider>
           </ForcedSearchProvider>
         </ContextPanelProvider>

--- a/src/components/shared/ComponentEditor/ComponentEditorProvider.test.tsx
+++ b/src/components/shared/ComponentEditor/ComponentEditorProvider.test.tsx
@@ -1,0 +1,72 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
+import { expect, test, vi } from "vitest";
+
+import {
+  ComponentEditorProvider,
+  useComponentEditor,
+} from "./ComponentEditorProvider";
+
+vi.mock("./ComponentEditorDialog", () => ({
+  ComponentEditorDialog: ({
+    text,
+    onClose,
+  }: {
+    text?: string;
+    onClose: () => void;
+  }) => (
+    <div data-testid="component-editor-dialog">
+      {text}
+      <button type="button" onClick={onClose}>
+        Close editor
+      </button>
+    </div>
+  ),
+}));
+
+function TransientEditorTrigger({ onOpen }: { onOpen: () => void }) {
+  const { openComponentEditor } = useComponentEditor();
+
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        openComponentEditor({ text: "name: draft" });
+        onOpen();
+      }}
+    >
+      Edit component
+    </button>
+  );
+}
+
+test("keeps the component editor open when its trigger unmounts", () => {
+  function TestHarness() {
+    const [showTrigger, setShowTrigger] = useState(true);
+
+    return (
+      <ComponentEditorProvider>
+        {showTrigger && (
+          <TransientEditorTrigger onOpen={() => setShowTrigger(false)} />
+        )}
+      </ComponentEditorProvider>
+    );
+  }
+
+  render(<TestHarness />);
+
+  fireEvent.click(screen.getByRole("button", { name: "Edit component" }));
+
+  expect(
+    screen.queryByRole("button", { name: "Edit component" }),
+  ).not.toBeInTheDocument();
+  expect(screen.getByTestId("component-editor-dialog")).toHaveTextContent(
+    "name: draft",
+  );
+
+  fireEvent.click(screen.getByRole("button", { name: "Close editor" }));
+
+  expect(
+    screen.queryByTestId("component-editor-dialog"),
+  ).not.toBeInTheDocument();
+});

--- a/src/components/shared/ComponentEditor/ComponentEditorProvider.tsx
+++ b/src/components/shared/ComponentEditor/ComponentEditorProvider.tsx
@@ -1,0 +1,46 @@
+import { type ReactNode, useState } from "react";
+
+import {
+  createRequiredContext,
+  useRequiredContext,
+} from "@/hooks/useRequiredContext";
+
+import { ComponentEditorDialog } from "./ComponentEditorDialog";
+import type { SupportedTemplate } from "./types";
+
+interface ComponentEditorOptions {
+  text?: string;
+  templateName?: SupportedTemplate;
+}
+
+interface ComponentEditorContextValue {
+  openComponentEditor: (options: ComponentEditorOptions) => void;
+}
+
+const ComponentEditorContext =
+  createRequiredContext<ComponentEditorContextValue>("ComponentEditorContext");
+
+export function ComponentEditorProvider({ children }: { children: ReactNode }) {
+  const [options, setOptions] = useState<ComponentEditorOptions | null>(null);
+
+  const openComponentEditor = (nextOptions: ComponentEditorOptions) => {
+    setOptions(nextOptions);
+  };
+
+  return (
+    <ComponentEditorContext value={{ openComponentEditor }}>
+      {children}
+      {options && (
+        <ComponentEditorDialog
+          text={options.text}
+          templateName={options.templateName}
+          onClose={() => setOptions(null)}
+        />
+      )}
+    </ComponentEditorContext>
+  );
+}
+
+export function useComponentEditor() {
+  return useRequiredContext(ComponentEditorContext);
+}

--- a/src/components/shared/TaskDetails/Actions/EditComponentButton.tsx
+++ b/src/components/shared/TaskDetails/Actions/EditComponentButton.tsx
@@ -1,10 +1,8 @@
-import { useState } from "react";
-
 import type { HydratedComponentReference } from "@/utils/componentSpec";
 import { tracking } from "@/utils/tracking";
 
 import { ActionButton } from "../../Buttons/ActionButton";
-import { ComponentEditorDialog } from "../../ComponentEditor/ComponentEditorDialog";
+import { useComponentEditor } from "../../ComponentEditor/ComponentEditorProvider";
 
 interface EditComponentButtonProps {
   componentRef: HydratedComponentReference;
@@ -13,22 +11,14 @@ interface EditComponentButtonProps {
 export const EditComponentButton = ({
   componentRef,
 }: EditComponentButtonProps) => {
-  const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
+  const { openComponentEditor } = useComponentEditor();
 
   return (
-    <>
-      <ActionButton
-        tooltip="Edit Component Definition"
-        icon="FilePenLine"
-        onClick={() => setIsEditDialogOpen(true)}
-        {...tracking("pipeline_editor.task_node.edit_component")}
-      />
-      {isEditDialogOpen && (
-        <ComponentEditorDialog
-          text={componentRef.text}
-          onClose={() => setIsEditDialogOpen(false)}
-        />
-      )}
-    </>
+    <ActionButton
+      tooltip="Edit Component Definition"
+      icon="FilePenLine"
+      onClick={() => openComponentEditor({ text: componentRef.text })}
+      {...tracking("pipeline_editor.task_node.edit_component")}
+    />
   );
 };

--- a/src/routes/v2/pages/Editor/EditorV2.tsx
+++ b/src/routes/v2/pages/Editor/EditorV2.tsx
@@ -6,6 +6,7 @@ import { ReactFlowProvider } from "@xyflow/react";
 import { observer } from "mobx-react-lite";
 import { type ReactNode, useEffect } from "react";
 
+import { ComponentEditorProvider } from "@/components/shared/ComponentEditor/ComponentEditorProvider";
 import { LoadingScreen } from "@/components/shared/LoadingScreen";
 import { useFlagValue } from "@/components/shared/Settings/useFlags";
 import { withSuspenseWrapper } from "@/components/shared/SuspenseWrapper";
@@ -164,13 +165,15 @@ function EditorV2Content({ pipelineRef }: { pipelineRef: PipelineRef | null }) {
 
   return (
     <ComponentLibraryProvider>
-      <ReactFlowProvider>
-        <EditorMenuBar />
-        <EditorTourBridge />
-        <TourSaveExploreDialog />
-        <TourSecretsDialog />
-        <ForcedSearchProvider>{body}</ForcedSearchProvider>
-      </ReactFlowProvider>
+      <ComponentEditorProvider>
+        <ReactFlowProvider>
+          <EditorMenuBar />
+          <EditorTourBridge />
+          <TourSaveExploreDialog />
+          <TourSecretsDialog />
+          <ForcedSearchProvider>{body}</ForcedSearchProvider>
+        </ReactFlowProvider>
+      </ComponentEditorProvider>
     </ComponentLibraryProvider>
   );
 }

--- a/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/components/ComponentRefBar.tsx
+++ b/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/components/ComponentRefBar.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 
 import { CodeViewer } from "@/components/shared/CodeViewer";
-import { ComponentEditorDialog } from "@/components/shared/ComponentEditor/ComponentEditorDialog";
+import { useComponentEditor } from "@/components/shared/ComponentEditor/ComponentEditorProvider";
 import ComponentDetailsDialog from "@/components/shared/Dialogs/ComponentDetailsDialog";
 import { TrimmedDigest } from "@/components/shared/ManageComponent/TrimmedDigest";
 import { Button } from "@/components/ui/button";
@@ -45,7 +45,7 @@ export function ComponentRefBar({
 }: ComponentRefBarProps) {
   const { track } = useAnalytics();
   const notify = useToastNotification();
-  const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
+  const { openComponentEditor } = useComponentEditor();
   const [showCodeViewer, setShowCodeViewer] = useState(false);
 
   const displayName = componentRef.name ?? getComponentName(componentRef);
@@ -180,7 +180,7 @@ export function ComponentRefBar({
               <DropdownMenuItem
                 onClick={() => {
                   track("v2.pipeline_editor.task_details.edit_component.click");
-                  setIsEditDialogOpen(true);
+                  openComponentEditor({ text: yamlText });
                 }}
               >
                 <Icon name="FilePenLine" size="sm" />
@@ -190,13 +190,6 @@ export function ComponentRefBar({
           </DropdownMenu>
         </InlineStack>
       </InlineStack>
-
-      {isEditDialogOpen && (
-        <ComponentEditorDialog
-          text={yamlText}
-          onClose={() => setIsEditDialogOpen(false)}
-        />
-      )}
 
       {showCodeViewer && (
         <CodeViewer


### PR DESCRIPTION
## Description

Prevents the fullscreen Component Editor from closing unexpectedly and losing unsaved changes when the UI that opened it unmounts.

The editor was portaled to `document.body`, but its open state was still owned by transient component-details and task-context UI. This change moves that state into a stable `ComponentEditorProvider`, mounts the provider in both editor versions, and routes existing-component edit actions through it.

## Related Issue and Pull requests

Fixes #2647

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

Not applicable; there are no visual changes.

## Test Instructions

1. Open a pipeline in the editor.
2. Click a component's info icon and select **Edit Component Definition**.
3. Make an unsaved change in the Component Editor.
4. Focus browser DevTools, then click back into the Component Editor.
5. Confirm the editor remains open and retains the unsaved change.
6. Repeat using **Edit Component** from a selected task's context panel.

Automated checks:

```bash
pnpm exec vitest run \
  src/components/shared/ComponentEditor/ComponentEditorProvider.test.tsx \
  src/components/shared/ComponentEditor/ComponentEditorDialog.test.tsx
pnpm run typecheck
```

## Additional Comments

The underlying component-details UI may still close or remount. The Component Editor is now owned by a stable ancestor, so its lifecycle and unsaved state no longer depend on the trigger remaining mounted.
