### PR TITLE
fix: treat conditional skips as successful runs

### DIFF
--- a/src/utils/executionStatus.test.ts
+++ b/src/utils/executionStatus.test.ts
@@ -130,6 +130,19 @@ describe("getOverallExecutionStatusFromStats()", () => {
     ).toBe("RUNNING");
   });
 
+  test("returns succeeded when completed tasks include intentional skips", () => {
+    expect(
+      getOverallExecutionStatusFromStats({
+        SUCCEEDED: 2,
+        SKIPPED: 1,
+      }),
+    ).toBe("SUCCEEDED");
+  });
+
+  test("returns skipped when every task was skipped", () => {
+    expect(getOverallExecutionStatusFromStats({ SKIPPED: 3 })).toBe("SKIPPED");
+  });
+
   test("returns raw status values (use getExecutionStatusLabel for display)", () => {
     expect(
       getOverallExecutionStatusFromStats({

--- a/src/utils/executionStatus.ts
+++ b/src/utils/executionStatus.ts
@@ -98,8 +98,8 @@ const EXECUTION_STATUS_PRIORITY = [
   "WAITING_FOR_UPSTREAM",
   "QUEUED",
   "UNINITIALIZED",
-  "SKIPPED",
   "SUCCEEDED",
+  "SKIPPED",
 ] as const;
 
 export type ExecutionStatusStats = Record<string, number>;


### PR DESCRIPTION
## Description

Updates the aggregate run status shown in the runs list for pipelines with conditional execution.

Tangle currently assigns `SKIPPED` only to a task whose `isEnabled` condition resolves to false and to tasks downstream of that conditionally skipped task. A successful run can therefore contain both `SUCCEEDED` and `SKIPPED` task counts.

This PR changes the terminal status priority so that:

- `SUCCEEDED` with conditionally skipped tasks is displayed as **Succeeded**.
- A run where every task is skipped is still displayed as **Skipped**.
- Failures, cancellations, and in-progress statuses continue to take priority.
- Individual skipped tasks remain displayed as **Skipped** in run details.

## Related Issue and Pull requests

- Conditional execution UI: #2649
- Backend conditional execution: https://github.com/TangleML/tangle/pull/301

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

Not applicable.

## Test Instructions

1. Create a pipeline with at least one task that succeeds and one conditional branch whose condition resolves to `false`.
2. Run the pipeline.
3. Confirm the runs list displays the run as **Succeeded**.
4. Open the run and confirm the conditional task and its downstream tasks remain **Skipped**.
5. Verify a run containing only skipped tasks is displayed as **Skipped**.
6. Verify failed, cancelled, and in-progress tasks continue to determine the overall run status.

Automated checks:

```bash
pnpm vitest run src/utils/executionStatus.test.ts
pnpm exec eslint src/utils/executionStatus.ts src/utils/executionStatus.test.ts
pnpm exec tsc --noEmit --pretty false
```

## Additional Comments

The runs-list API returns aggregate status counts rather than task-level skip reasons. This behavior relies on the current Tangle contract that `SKIPPED` is only produced by conditional execution and its downstream propagation. If another skip reason is introduced, the backend should expose distinct skip reasons or an authoritative overall run status.
