### PR TITLE
feat: Conditional Execution - Option 1

### DIFF
--- a/src/models/componentSpec/__tests__/serialization/yamlDeserializer.test.ts
+++ b/src/models/componentSpec/__tests__/serialization/yamlDeserializer.test.ts
@@ -1,6 +1,5 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
-import { EDITOR_CONDITIONAL_EXECUTION_ANNOTATION } from "@/utils/annotations";
 import { IS_ENABLED_PORT_NAME } from "@/utils/conditionalExecution";
 
 import { IncrementingIdGenerator } from "../../factories/idGenerator";
@@ -127,11 +126,8 @@ describe("YamlDeserializer", () => {
     const consumer = spec.tasks.find((t) => t.name === "Consumer");
     const producer = spec.tasks.find((t) => t.name === "Producer");
 
-    // Conditional mode: entity value cleared, mode annotation set.
+    // The binding is the sole record of the reference.
     expect(consumer?.isEnabled).toBeUndefined();
-    expect(
-      consumer?.annotations.get(EDITOR_CONDITIONAL_EXECUTION_ANNOTATION),
-    ).toBe("true");
 
     // A binding to the reserved port drives the connection.
     const binding = spec.bindings.find(
@@ -160,9 +156,6 @@ describe("YamlDeserializer", () => {
     const task = spec.tasks.at(0);
 
     expect(task?.isEnabled).toBe("false");
-    expect(
-      task?.annotations.get(EDITOR_CONDITIONAL_EXECUTION_ANNOTATION),
-    ).toBeUndefined();
     expect(spec.bindings.length).toBe(0);
   });
 

--- a/src/models/componentSpec/entities/componentSpec.ts
+++ b/src/models/componentSpec/entities/componentSpec.ts
@@ -1,6 +1,8 @@
 import { computed } from "mobx";
 import { idProp, Model, model, modelAction, prop } from "mobx-keystone";
 
+import { IS_ENABLED_PORT_NAME } from "@/utils/conditionalExecution";
+
 import { Annotations } from "../annotations";
 import { collectValidationIssues } from "../validation/collectIssues";
 import type {
@@ -105,15 +107,35 @@ export class ComponentSpec extends Model({
     this.bindings.push(binding);
   }
 
+  /**
+   * Unlike an ordinary argument, whose literal is retained and resurfaces when a
+   * connection is removed, the conditional gate has no meaningful "previous
+   * value": resurfacing `"false"` would silently keep the task disabled after
+   * the user deleted the condition. Dropping a gate binding resets it to enabled,
+   * which also keeps the task conditional so the port stays put.
+   */
+  @modelAction
+  private resetGateLiteral(binding: Binding | undefined) {
+    if (!binding || binding.targetPortName !== IS_ENABLED_PORT_NAME) return;
+    const task = this.tasks.find((t) => t.$id === binding.targetEntityId);
+    task?.setIsEnabled("true");
+  }
+
   @modelAction
   removeBinding(index: number) {
-    return this.bindings.splice(index, 1)[0];
+    const removed = this.bindings.splice(index, 1)[0];
+    this.resetGateLiteral(removed);
+    return removed;
   }
 
   @modelAction
   removeBindingBy(predicate: (b: Binding) => boolean): Binding | undefined {
     const idx = this.bindings.findIndex(predicate);
-    if (idx >= 0) return this.bindings.splice(idx, 1)[0];
+    if (idx >= 0) {
+      const removed = this.bindings.splice(idx, 1)[0];
+      this.resetGateLiteral(removed);
+      return removed;
+    }
     return undefined;
   }
 
@@ -129,6 +151,9 @@ export class ComponentSpec extends Model({
       if (predicate(this.bindings[i])) {
         removed.push(this.bindings.splice(i, 1)[0]);
       }
+    }
+    for (const binding of removed) {
+      this.resetGateLiteral(binding);
     }
     return removed;
   }
@@ -202,7 +227,7 @@ export class ComponentSpec extends Model({
   deleteEdgeById(bindingId: string): boolean {
     const idx = this.bindings.findIndex((b) => b.$id === bindingId);
     if (idx < 0) return false;
-    this.bindings.splice(idx, 1);
+    this.resetGateLiteral(this.bindings.splice(idx, 1)[0]);
     return true;
   }
 

--- a/src/models/componentSpec/serialization/yamlDeserializer.ts
+++ b/src/models/componentSpec/serialization/yamlDeserializer.ts
@@ -1,5 +1,4 @@
 import {
-  EDITOR_CONDITIONAL_EXECUTION_ANNOTATION,
   IS_ENABLED_PORT_NAME,
   isConditionalArgument,
 } from "@/utils/conditionalExecution";
@@ -129,21 +128,10 @@ export class YamlDeserializer {
         }
       }
 
-      // A reference-valued `isEnabled` is the "Conditional" mode: it becomes a
-      // binding to the reserved port (see buildBindings) and the entity keeps
-      // `isEnabled` empty. Literal values (e.g. "false") stay on the entity.
+      // A reference-valued `isEnabled` becomes a binding to the reserved port
+      // (see buildBindings) and the entity keeps `isEnabled` empty. Literal
+      // values (e.g. "false") stay on the entity.
       const conditionalEnabled = isConditionalArgument(taskJson.isEnabled);
-      if (
-        conditionalEnabled &&
-        !annotationItems.some(
-          (a) => a.key === EDITOR_CONDITIONAL_EXECUTION_ANNOTATION,
-        )
-      ) {
-        annotationItems.push({
-          key: EDITOR_CONDITIONAL_EXECUTION_ANNOTATION,
-          value: "true",
-        });
-      }
 
       const args: Argument[] = [];
       if (taskJson.arguments) {
@@ -209,7 +197,7 @@ export class YamlDeserializer {
           tasks,
           targetTask.$id,
           IS_ENABLED_PORT_NAME,
-          taskJson.isEnabled as ArgumentType,
+          taskJson.isEnabled,
         );
         if (binding) bindings.push(binding);
       }

--- a/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/components/ConfigurationSection.tsx
+++ b/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/components/ConfigurationSection.tsx
@@ -11,15 +11,9 @@ import {
 import { useFlagValue } from "@/components/shared/Settings/useFlags";
 import { ColorPicker } from "@/components/ui/color";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { Separator } from "@/components/ui/separator";
 import { Switch } from "@/components/ui/switch";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Heading, Paragraph } from "@/components/ui/typography";
 import type { Task } from "@/models/componentSpec";
 import { useAnalytics } from "@/providers/AnalyticsProvider";
@@ -27,13 +21,14 @@ import { useSpec } from "@/routes/v2/shared/providers/SpecContext";
 import type { AnnotationConfig, Annotations } from "@/types/annotations";
 import {
   EDITOR_COLLAPSED_ANNOTATION,
-  EDITOR_CONDITIONAL_EXECUTION_ANNOTATION,
   TASK_COLOR_ANNOTATION,
 } from "@/utils/annotations";
-import { IS_ENABLED_PORT_NAME } from "@/utils/conditionalExecution";
+import {
+  isTaskConditional,
+  resolveConditionalReference,
+} from "@/utils/conditionalExecution";
 import { ISO8601_DURATION_ZERO_DAYS } from "@/utils/constants";
 
-import type { EnableTaskMode } from "./taskConfig.actions";
 import { useTaskConfigActions } from "./useTaskConfigActions";
 
 interface ConfigurationSectionProps {
@@ -52,30 +47,26 @@ export const ConfigurationSection = observer(function ConfigurationSection({
     setTaskColor,
     clearProviderAnnotations,
     setCollapsed,
-    setEnableTaskMode,
+    setTaskConditional,
+    setTaskCondition,
   } = useTaskConfigActions();
   const isSubgraph = task.subgraphSpec !== undefined;
 
-  const isConditionalConnected =
-    spec?.bindings.some(
-      (b) =>
-        b.targetEntityId === task.$id &&
-        b.targetPortName === IS_ENABLED_PORT_NAME,
-    ) ?? false;
-  const isConditional =
-    task.annotations.get(EDITOR_CONDITIONAL_EXECUTION_ANNOTATION) === "true" ||
-    isConditionalConnected;
-  const enableMode: EnableTaskMode = isConditional
-    ? "conditional"
-    : task.isEnabled === "false"
-      ? "false"
-      : "true";
+  const isConditional = isTaskConditional(task, spec);
+  const conditionReference = resolveConditionalReference(task, spec);
 
-  const handleEnableModeChange = (value: string) => {
+  const handleConditionalChange = (checked: boolean) => {
     if (!spec) return;
-    const mode = value as EnableTaskMode;
-    setEnableTaskMode(spec, task, mode);
-    track("v2.pipeline_editor.task_details.enable_task.change", { mode });
+    setTaskConditional(spec, task, checked);
+    track("v2.pipeline_editor.task_details.conditional_task.toggle", {
+      conditional: checked,
+    });
+  };
+
+  const handleConditionChange = (value: string) => {
+    const enabled = value === "true";
+    setTaskCondition(task, enabled);
+    track("v2.pipeline_editor.task_details.task_condition.change", { enabled });
   };
 
   const cacheDisabled =
@@ -196,33 +187,42 @@ export const ConfigurationSection = observer(function ConfigurationSection({
         <>
           <Separator />
 
-          <BlockStack gap="1">
+          <BlockStack gap="3">
             <InlineStack align="space-between" gap="2" className="w-full">
               <Paragraph size="xs" tone="subdued">
-                Enable task
+                Conditional task
               </Paragraph>
-              <Select value={enableMode} onValueChange={handleEnableModeChange}>
-                <SelectTrigger className="h-6 text-xs px-2 py-0 min-w-25">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="true" className="text-xs">
-                    True
-                  </SelectItem>
-                  <SelectItem value="false" className="text-xs">
-                    False
-                  </SelectItem>
-                  <SelectItem value="conditional" className="text-xs">
-                    Conditional
-                  </SelectItem>
-                </SelectContent>
-              </Select>
+              <Switch
+                checked={isConditional}
+                onCheckedChange={handleConditionalChange}
+              />
             </InlineStack>
-            {isConditional && !isConditionalConnected && (
-              <Paragraph size="xs" tone="subdued">
-                Connect a task output or pipeline input to the “Is enabled?”
-                port on the node.
-              </Paragraph>
+
+            {isConditional && (
+              <InlineStack align="space-between" gap="2" className="w-full">
+                <Paragraph size="xs" tone="subdued">
+                  Condition
+                </Paragraph>
+                {conditionReference ? (
+                  <code className="text-2xs font-mono bg-muted rounded px-1.5 py-0.5 overflow-x-auto whitespace-nowrap max-w-50">
+                    {JSON.stringify(conditionReference)}
+                  </code>
+                ) : (
+                  <Tabs
+                    value={task.isEnabled === "false" ? "false" : "true"}
+                    onValueChange={handleConditionChange}
+                  >
+                    <TabsList className="h-6">
+                      <TabsTrigger value="true" className="text-xs px-2.5">
+                        True
+                      </TabsTrigger>
+                      <TabsTrigger value="false" className="text-xs px-2.5">
+                        False
+                      </TabsTrigger>
+                    </TabsList>
+                  </Tabs>
+                )}
+              </InlineStack>
             )}
           </BlockStack>
         </>

--- a/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/components/taskConfig.actions.ts
+++ b/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/components/taskConfig.actions.ts
@@ -3,14 +3,10 @@ import type { UndoGroupable } from "@/routes/v2/shared/nodes/types";
 import type { AnnotationConfig } from "@/types/annotations";
 import {
   EDITOR_COLLAPSED_ANNOTATION,
-  EDITOR_CONDITIONAL_EXECUTION_ANNOTATION,
   TASK_COLOR_ANNOTATION,
 } from "@/utils/annotations";
 import { IS_ENABLED_PORT_NAME } from "@/utils/conditionalExecution";
 import { ISO8601_DURATION_ZERO_DAYS } from "@/utils/constants";
-
-/** The three "Enable task" choices exposed in the Config tab. */
-export type EnableTaskMode = "true" | "false" | "conditional";
 
 export function toggleCacheDisable(
   undo: UndoGroupable,
@@ -61,30 +57,34 @@ export function setCollapsed(
   });
 }
 
-export function setEnableTaskMode(
+export function setTaskConditional(
   undo: UndoGroupable,
   spec: ComponentSpec,
   task: Task,
-  mode: EnableTaskMode,
+  conditional: boolean,
 ) {
-  undo.withGroup("Set enable task", () => {
-    if (mode === "conditional") {
-      // The connection is modelled as a binding the user draws to the virtual
-      // "Is enabled?" port; here we just enter conditional mode so the port
-      // shows. `isEnabled` is derived from that binding at serialize time.
-      task.annotations.set(EDITOR_CONDITIONAL_EXECUTION_ANNOTATION, "true");
-      task.setIsEnabled(undefined);
+  undo.withGroup("Toggle conditional task", () => {
+    if (conditional) {
+      task.setIsEnabled("true");
       return;
     }
 
-    // Leaving conditional mode: drop any connection to the reserved port.
     spec.removeAllBindingsBy(
       (b) =>
         b.targetEntityId === task.$id &&
         b.targetPortName === IS_ENABLED_PORT_NAME,
     );
-    task.annotations.remove(EDITOR_CONDITIONAL_EXECUTION_ANNOTATION);
-    task.setIsEnabled(mode === "false" ? "false" : undefined);
+    task.setIsEnabled(undefined);
+  });
+}
+
+export function setTaskCondition(
+  undo: UndoGroupable,
+  task: Task,
+  enabled: boolean,
+) {
+  undo.withGroup("Set task condition", () => {
+    task.setIsEnabled(enabled ? "true" : "false");
   });
 }
 

--- a/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/components/useTaskConfigActions.ts
+++ b/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/components/useTaskConfigActions.ts
@@ -4,8 +4,9 @@ import {
   clearProviderAnnotations,
   saveAnnotation,
   setCollapsed,
-  setEnableTaskMode,
   setTaskColor,
+  setTaskCondition,
+  setTaskConditional,
   toggleCacheDisable,
 } from "./taskConfig.actions";
 
@@ -17,7 +18,8 @@ export function useTaskConfigActions() {
     saveAnnotation: saveAnnotation.bind(null, undo),
     setTaskColor: setTaskColor.bind(null, undo),
     setCollapsed: setCollapsed.bind(null, undo),
-    setEnableTaskMode: setEnableTaskMode.bind(null, undo),
+    setTaskConditional: setTaskConditional.bind(null, undo),
+    setTaskCondition: setTaskCondition.bind(null, undo),
     clearProviderAnnotations: clearProviderAnnotations.bind(null, undo),
   };
 }

--- a/src/routes/v2/shared/nodes/TaskNode/TaskNode.tsx
+++ b/src/routes/v2/shared/nodes/TaskNode/TaskNode.tsx
@@ -23,7 +23,6 @@ import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 import { AggregatorOutputType } from "@/types/aggregator";
 import {
   EDITOR_COLLAPSED_ANNOTATION,
-  EDITOR_CONDITIONAL_EXECUTION_ANNOTATION,
   isPipelineAggregator,
   TASK_COLOR_ANNOTATION,
 } from "@/utils/annotations";
@@ -31,6 +30,7 @@ import { isSecretArgument } from "@/utils/componentSpec";
 import {
   IS_ENABLED_INPUT_LABEL,
   IS_ENABLED_PORT_NAME,
+  isTaskConditional,
 } from "@/utils/conditionalExecution";
 import { ISO8601_DURATION_ZERO_DAYS } from "@/utils/constants";
 import type { ExecutionStatusStats } from "@/utils/executionStatus";
@@ -306,13 +306,11 @@ export const TaskNode = observer(function TaskNode({
   const connectedPorts = resolveConnectedPortNames(entityId, spec);
   const inputDisplayData = resolveInputDisplayData(task, entityId, spec);
 
-  // In "Conditional" execution mode a virtual "Is enabled?" input is exposed so
-  // the user can connect an upstream value that gates the task. The connection
-  // itself is an ordinary binding to the reserved port, so its display value and
-  // connected state are already resolved above.
-  const isConditionalExecution =
-    task.annotations.get(EDITOR_CONDITIONAL_EXECUTION_ANNOTATION) === "true" ||
-    connectedPorts.inputs.has(IS_ENABLED_PORT_NAME);
+  // A conditional task exposes a virtual "Is enabled?" input so the user can
+  // connect an upstream value that gates it. A connection is an ordinary binding
+  // to the reserved port, so its display value and connected state are already
+  // resolved above; a literal lives on the entity and is filled in here.
+  const isConditionalExecution = isTaskConditional(task, spec);
   const displayInputs: TaskNodeInput[] = isConditionalExecution
     ? [
         ...inputs,
@@ -323,6 +321,13 @@ export const TaskNode = observer(function TaskNode({
         },
       ]
     : inputs;
+  const inputDisplayValues =
+    isConditionalExecution && typeof task.isEnabled === "string"
+      ? {
+          [IS_ENABLED_PORT_NAME]: task.isEnabled,
+          ...inputDisplayData.values,
+        }
+      : inputDisplayData.values;
 
   const isSelected = isEditorVisualNodeSelected(editor, id, !!selected);
 
@@ -357,7 +362,7 @@ export const TaskNode = observer(function TaskNode({
     subgraphExecutionStats,
     onOutputTypeChange: handleOutputTypeChange,
     digest: task.componentRef.digest,
-    inputDisplayValues: inputDisplayData.values,
+    inputDisplayValues,
     secretInputNames: inputDisplayData.secretInputNames,
     onNodeClick: handleClick,
     onInputClick: handleInputClick,

--- a/src/utils/annotations.ts
+++ b/src/utils/annotations.ts
@@ -19,7 +19,6 @@ import {
 import type { ComponentSpec } from "./componentSpec";
 
 export * from "./annotationKeys";
-export { EDITOR_CONDITIONAL_EXECUTION_ANNOTATION } from "./conditionalExecution";
 
 export const DISPLAY_NAME_MAX_LENGTH = 100;
 const PIPELINE_AGGREGATOR_ANNOTATION = "is_input_aggregator";

--- a/src/utils/conditionalExecution.ts
+++ b/src/utils/conditionalExecution.ts
@@ -1,4 +1,5 @@
-import type { ArgumentType } from "./componentSpec";
+import type { ArgumentType, ComponentSpec, Task } from "@/models/componentSpec";
+
 import { isGraphInputArgument, isTaskOutputArgument } from "./componentSpec";
 
 /**
@@ -12,29 +13,73 @@ export const IS_ENABLED_PORT_NAME = "__is_enabled__";
 /** Human-readable label shown for the virtual "Is enabled?" input. */
 export const IS_ENABLED_INPUT_LABEL = "Is enabled?";
 
-/**
- * Annotation key marking that a task is in "Conditional" enable mode. Lives here
- * (rather than in the UI-oriented `@/utils/annotations` module) so the model
- * serializers can reference it without pulling the React component tree into the
- * `@/models/componentSpec` barrel's module graph.
- */
-export const EDITOR_CONDITIONAL_EXECUTION_ANNOTATION =
-  "editor.conditional-execution";
-
 const GRAPH_INPUT_REGEX = /^\{\{inputs\.([^}]+)\}\}$/;
 const TASK_OUTPUT_REGEX = /^\{\{tasks\.([^.]+)\.outputs\.([^}]+)\}\}$/;
 
 /**
  * True when an `isEnabled` value is a reference to an upstream value (a graph
- * input or a sibling task output) — i.e. the "Conditional" mode — rather than a
- * plain literal such as `"false"`.
+ * input or a sibling task output) rather than a plain literal such as `"false"`.
  */
 export function isConditionalArgument(
   value: ArgumentType | undefined,
-): boolean {
+): value is ArgumentType {
   if (value === undefined) return false;
   if (typeof value === "string") {
     return GRAPH_INPUT_REGEX.test(value) || TASK_OUTPUT_REGEX.test(value);
   }
   return isGraphInputArgument(value) || isTaskOutputArgument(value);
+}
+
+function findConditionalBinding(
+  spec: ComponentSpec | null | undefined,
+  taskId: string,
+) {
+  return spec?.bindings.find(
+    (b) =>
+      b.targetEntityId === taskId && b.targetPortName === IS_ENABLED_PORT_NAME,
+  );
+}
+
+/**
+ * A task is conditional when it carries an `isEnabled` value — either a literal
+ * on the entity or a connection to the reserved port. There is no separate flag:
+ * the presence of the value is what exposes the port and the condition control.
+ */
+export function isTaskConditional(
+  task: Task,
+  spec: ComponentSpec | null | undefined,
+): boolean {
+  return (
+    task.isEnabled !== undefined ||
+    findConditionalBinding(spec, task.$id) !== undefined
+  );
+}
+
+/**
+ * The upstream reference a task is gated on, in the shape it serializes to, or
+ * undefined when the task is gated on a literal.
+ */
+export function resolveConditionalReference(
+  task: Task,
+  spec: ComponentSpec | null | undefined,
+): ArgumentType | undefined {
+  const binding = findConditionalBinding(spec, task.$id);
+  if (!binding || !spec) return undefined;
+
+  const sourceTask = spec.tasks.find((t) => t.$id === binding.sourceEntityId);
+  if (sourceTask) {
+    return {
+      taskOutput: {
+        taskId: sourceTask.name,
+        outputName: binding.sourcePortName,
+      },
+    };
+  }
+
+  const sourceInput = spec.inputs.find((i) => i.$id === binding.sourceEntityId);
+  if (sourceInput) {
+    return { graphInput: { inputName: sourceInput.name } };
+  }
+
+  return undefined;
 }


### PR DESCRIPTION
## Description

Implements **Option 1 — Derived**. Two alternatives were prototyped alongside it (#2652, #2654); this is the one we settled on. Also a general pass over the UI, UX and frontend architecture of the feature.

### The question these options were answering

`TaskSpec.isEnabled` decides whether a task runs. It either holds a literal (`"false"`) or points at an upstream value — a graph input, or another task's output.

The editor needs to know one thing the spec doesn't record: whether the user wants the conditional UI on this task at all — the extra handle on the node, the condition control in the Config panel. A task with no `isEnabled` looks exactly like a task that was never meant to be conditional, so where does that piece of state live?

### The three answers

- **Option 2 — Annotation (#2652):** keep an `isConditional` annotation on the task, fully decoupled from `isEnabled`. The annotation controls the UI; `isEnabled` controls the backend.
- **Option 4 — Always-on (#2654):** don't track it. Show the conditional UI on every task, always.
- **Option 1 — Derived (this PR):** don't track it either, but infer it. A task is conditional when it *has* an `isEnabled` value — a literal on the task, or a connection to the reserved port.

### Why derived

**Two sources of truth drift, and this one drifts immediately.** Pipelines don't only come from our editor — they come from the SDK, from other tools, from hand-written YAML. Those have `isEnabled` set and no annotation, so the annotation version opens them showing no condition and no edge: the connection is right there in the file and invisible on the canvas. The fix would be to backfill the annotation on import, which is deriving it anyway, one round trip late.

**It keeps editor state out of the user's pipeline.** Conditional-ness is already expressed by `isEnabled`. An annotation would write a second copy of it into the file for something we can compute.

**Most tasks aren't conditional.** Always-on avoids the state problem, but it spends vertical space on every node and adds a concept to every task for the benefit of the few that use it. A switch keeps it opt-in and keeps ordinary nodes looking ordinary.

**One question, one answer.** `isTaskConditional(task, spec)` is what the node, the panel and serialization all ask, so they can't disagree.

The honest cost: deriving couples the switch to the value. Turning it on has to write something (`"true"` — Always), and turning it off has to clear it, so "conditional but not configured yet" isn't a state we can represent. We think that's fine — Always is a sensible starting point, and the alternative was the drift above.

### Also in here

- **The condition control was a three-way dropdown** (*Enable task*: True / False / Conditional), which folded two different questions into one control — "should this be conditional" and "what's the condition". It's now a switch for the first and a toggle for the second.
- **Deleting the condition edge resets the task to enabled** instead of resurfacing the previous literal. For an ordinary input, bringing back the old literal when you disconnect it is helpful. For a condition it isn't: resurfacing `"false"` would leave the task silently disabled after the user deliberately removed the condition.

## Related Issue and Pull requests

Stacked on #2574. Alternatives: #2652 (annotation), #2654 (always-on). Followed by #2657, which finishes the UI.

## Type of Change

- [x] New feature

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

The `conditional-execution` flag gates all of this.

1. Select a task → **Config** tab → toggle **Conditional task** on, then set the condition to False and confirm the task's `isEnabled` follows in the YAML.
2. Toggle it back off and confirm `isEnabled` is cleared and no stray annotation is written.
3. Connect a graph input or an upstream task output to the condition handle, then delete that edge — the task should stay conditional and reset to enabled.
4. Import a pipeline whose YAML sets `isEnabled` to a reference (e.g. one produced by the SDK) and confirm the editor shows both the conditional UI and the edge without us having written anything into the file first.

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
