### PR TITLE
feat: Finalize Conditional Execution

### DIFF
--- a/src/components/shared/ComponentEditor/utils/buildPreviewTaskNodeViewProps.ts
+++ b/src/components/shared/ComponentEditor/utils/buildPreviewTaskNodeViewProps.ts
@@ -1,6 +1,7 @@
 import type { TaskNodeViewProps } from "@/routes/v2/shared/nodes/TaskNode/TaskNode";
 import { AggregatorOutputType } from "@/types/aggregator";
 import { isGraphImplementation } from "@/utils/componentSpec";
+import { CONDITION_LITERAL_LABELS } from "@/utils/conditionalExecution";
 import { componentSpecFromYaml } from "@/utils/yaml";
 
 const noop = () => {};
@@ -44,6 +45,8 @@ export function buildPreviewTaskNodeViewProps(
     annotations: [],
     taskColor: undefined,
     cacheDisabled: false,
+    isConditional: false,
+    conditionDisplayValue: CONDITION_LITERAL_LABELS.true,
     digest: undefined,
     inputDisplayValues: {},
     secretInputNames: new Set(),

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -88,10 +88,10 @@ export const ExistingFlags: ConfigFlags = {
   },
 
   ["conditional-execution"]: {
-    name: "Conditional Task Execution",
+    name: "Conditional task execution",
     description:
-      'Enable the "Enable task" setting in the task Config tab. Lets you disable a task or gate it on an upstream value connected to its "Is enabled?" port.',
-    default: true, //temp for demo purposes
+      'Adds a "Conditional execution" setting to the task Config tab. A conditional task gains a "Run when" port that decides whether it runs, either from a literal or from an upstream value.',
+    default: false,
     category: "beta",
   },
 };

--- a/src/models/componentSpec/__tests__/actions/createSubgraph.test.ts
+++ b/src/models/componentSpec/__tests__/actions/createSubgraph.test.ts
@@ -1,5 +1,10 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
+import {
+  IS_ENABLED_PORT_NAME,
+  RUN_CONDITION_INPUT_NAME,
+} from "@/utils/conditionalExecution";
+
 import { createSubgraph } from "../../actions/createSubgraph";
 import { Binding } from "../../entities/binding";
 import { ComponentSpec } from "../../entities/componentSpec";
@@ -86,6 +91,52 @@ describe("createSubgraph", () => {
     expect(result).not.toBeNull();
     expect(result!.subgraphSpec.inputs.length).toBe(1);
     expect(result!.subgraphSpec.inputs.at(0)?.name).toBe("data");
+  });
+
+  it("promotes an external run condition to a readable input instead of the sentinel", () => {
+    const spec = new ComponentSpec({
+      $id: idGen.next("spec"),
+      name: "Main",
+    });
+    const input = new Input({
+      $id: idGen.next("input"),
+      name: "should_run",
+    });
+    const task = new Task({
+      $id: idGen.next("task"),
+      name: "InnerTask",
+      componentRef: {},
+    });
+    spec.addInput(input);
+    spec.addTask(task);
+    spec.addBinding(
+      new Binding({
+        $id: idGen.next("binding"),
+        sourceEntityId: input.$id,
+        sourcePortName: "should_run",
+        targetEntityId: task.$id,
+        targetPortName: IS_ENABLED_PORT_NAME,
+      }),
+    );
+
+    const result = createSubgraph({
+      spec,
+      selectedTaskIds: [task.$id],
+      subgraphName: "Sub",
+      idGen,
+    });
+
+    const subgraphInput = result!.subgraphSpec.inputs.at(0);
+    expect(subgraphInput?.name).toBe(RUN_CONDITION_INPUT_NAME);
+
+    const innerBinding = result!.subgraphSpec.bindings.find(
+      (b) => b.sourceEntityId === subgraphInput?.$id,
+    );
+    expect(innerBinding?.targetPortName).toBe(IS_ENABLED_PORT_NAME);
+
+    const outerBinding = spec.bindings.at(0);
+    expect(outerBinding?.targetEntityId).toBe(result!.replacementTask.$id);
+    expect(outerBinding?.targetPortName).toBe(RUN_CONDITION_INPUT_NAME);
   });
 
   it("moves internal bindings to subgraph", () => {

--- a/src/models/componentSpec/__tests__/actions/unpackSubgraph.test.ts
+++ b/src/models/componentSpec/__tests__/actions/unpackSubgraph.test.ts
@@ -1,5 +1,10 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
+import {
+  IS_ENABLED_PORT_NAME,
+  RUN_CONDITION_INPUT_NAME,
+} from "@/utils/conditionalExecution";
+
 import { createSubgraph } from "../../actions/createSubgraph";
 import { unpackSubgraph } from "../../actions/unpackSubgraph";
 import { Annotations } from "../../annotations";
@@ -330,6 +335,76 @@ describe("unpackSubgraph roundtrip", () => {
     const restored = spec.tasks.find((t) => t.name === "ConditionalTask");
     expect(restored).toBeDefined();
     expect(restored?.isEnabled).toEqual(predicate);
+  });
+
+  it("connected run condition preserved after roundtrip", () => {
+    const spec = new ComponentSpec({
+      $id: idGen.next("spec"),
+      name: "Main",
+    });
+    const input = new Input({ $id: idGen.next("input"), name: "should_run" });
+    const task = makeTask(idGen, "ConditionalTask");
+    spec.addInput(input);
+    spec.addTask(task);
+    spec.addBinding(
+      makeBinding(
+        idGen,
+        input.$id,
+        "should_run",
+        task.$id,
+        IS_ENABLED_PORT_NAME,
+      ),
+    );
+
+    expect(roundtrip(spec, [task.$id], idGen)).toBe(true);
+
+    const restored = spec.tasks.find((t) => t.name === "ConditionalTask");
+    const binding = spec.bindings.find(
+      (b) => b.targetEntityId === restored?.$id,
+    );
+    expect(binding?.sourceEntityId).toBe(input.$id);
+    expect(binding?.targetPortName).toBe(IS_ENABLED_PORT_NAME);
+  });
+
+  it("a literal on the promoted run condition port lands back on isEnabled", () => {
+    const spec = new ComponentSpec({
+      $id: idGen.next("spec"),
+      name: "Main",
+    });
+    const input = new Input({ $id: idGen.next("input"), name: "should_run" });
+    const task = makeTask(idGen, "ConditionalTask");
+    spec.addInput(input);
+    spec.addTask(task);
+    spec.addBinding(
+      makeBinding(
+        idGen,
+        input.$id,
+        "should_run",
+        task.$id,
+        IS_ENABLED_PORT_NAME,
+      ),
+    );
+
+    const created = createSubgraph({
+      spec,
+      selectedTaskIds: [task.$id],
+      subgraphName: "Subgraph",
+      idGen,
+    });
+    spec.removeBindingBy(
+      (b) => b.targetEntityId === created!.replacementTask.$id,
+    );
+    created!.replacementTask.setArgument(RUN_CONDITION_INPUT_NAME, "false");
+
+    expect(
+      unpackSubgraph({ spec, taskId: created!.replacementTask.$id, idGen }),
+    ).toBe(true);
+
+    const restored = spec.tasks.find((t) => t.name === "ConditionalTask");
+    expect(restored?.isEnabled).toBe("false");
+    expect(
+      restored?.arguments.some((a) => a.name === IS_ENABLED_PORT_NAME),
+    ).toBe(false);
   });
 
   it("static arguments preserved after roundtrip", () => {

--- a/src/models/componentSpec/__tests__/serialization/yamlDeserializer.test.ts
+++ b/src/models/componentSpec/__tests__/serialization/yamlDeserializer.test.ts
@@ -140,6 +140,32 @@ describe("YamlDeserializer", () => {
     expect(binding?.sourcePortName).toBe("flag");
   });
 
+  it("keeps an unresolvable isEnabled reference rather than leaving the task ungated", () => {
+    const yaml = {
+      name: "Pipeline",
+      implementation: {
+        graph: {
+          tasks: {
+            Consumer: {
+              componentRef: {},
+              isEnabled: {
+                taskOutput: { taskId: "Missing", outputName: "flag" },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const spec = deserializer.deserialize(yaml);
+    const consumer = spec.tasks.at(0);
+
+    expect(consumer?.isEnabled).toEqual({
+      taskOutput: { taskId: "Missing", outputName: "flag" },
+    });
+    expect(spec.bindings.length).toBe(0);
+  });
+
   it("keeps literal isEnabled 'false' without a binding", () => {
     const yaml = {
       name: "Pipeline",

--- a/src/models/componentSpec/actions/createSubgraph.ts
+++ b/src/models/componentSpec/actions/createSubgraph.ts
@@ -1,3 +1,7 @@
+import {
+  IS_ENABLED_PORT_NAME,
+  RUN_CONDITION_INPUT_NAME,
+} from "@/utils/conditionalExecution";
 import { deepClone } from "@/utils/deepClone";
 
 import { Annotations } from "../annotations";
@@ -128,7 +132,12 @@ export function createSubgraph({
   const usedInputNames = new Set<string>();
   for (const [, bindings] of Object.entries(incomingBySource)) {
     const first = bindings[0];
-    const inputName = deduplicatePortName(first.targetPortName, usedInputNames);
+    const inputName = deduplicatePortName(
+      first.targetPortName === IS_ENABLED_PORT_NAME
+        ? RUN_CONDITION_INPUT_NAME
+        : first.targetPortName,
+      usedInputNames,
+    );
     const input = new Input({
       $id: idGen.next("input"),
       name: inputName,

--- a/src/models/componentSpec/actions/unpackSubgraph.ts
+++ b/src/models/componentSpec/actions/unpackSubgraph.ts
@@ -1,3 +1,4 @@
+import { IS_ENABLED_PORT_NAME } from "@/utils/conditionalExecution";
 import { deepClone } from "@/utils/deepClone";
 
 import { Annotations, deserializeAnnotationValue } from "../annotations";
@@ -267,6 +268,11 @@ function transferStaticArguments(
 
       const newTask = spec.tasks.find((t) => t.$id === newTaskId);
       if (!newTask) continue;
+
+      if (innerBinding.targetPortName === IS_ENABLED_PORT_NAME) {
+        newTask.setIsEnabled(arg.value);
+        continue;
+      }
 
       newTask.setArgument(innerBinding.targetPortName, arg.value);
     }

--- a/src/models/componentSpec/bindingReference.ts
+++ b/src/models/componentSpec/bindingReference.ts
@@ -1,0 +1,30 @@
+import type { Binding } from "./entities/binding";
+import type { ComponentSpec } from "./entities/componentSpec";
+import type { ArgumentType } from "./entities/types";
+
+/**
+ * Resolves a binding's source into the reference shape it serializes to. The
+ * serializer and the editor both need this, and they have to agree: the shape
+ * written to the user's file is the shape the editor reads back.
+ */
+export function bindingToArgumentReference(
+  binding: Binding,
+  spec: ComponentSpec,
+): ArgumentType | undefined {
+  const sourceTask = spec.tasks.find((t) => t.$id === binding.sourceEntityId);
+  if (sourceTask) {
+    return {
+      taskOutput: {
+        taskId: sourceTask.name,
+        outputName: binding.sourcePortName,
+      },
+    };
+  }
+
+  const sourceInput = spec.inputs.find((i) => i.$id === binding.sourceEntityId);
+  if (sourceInput) {
+    return { graphInput: { inputName: sourceInput.name } };
+  }
+
+  return undefined;
+}

--- a/src/models/componentSpec/entities/componentSpec.ts
+++ b/src/models/componentSpec/entities/componentSpec.ts
@@ -108,14 +108,14 @@ export class ComponentSpec extends Model({
   }
 
   /**
-   * Unlike an ordinary argument, whose literal is retained and resurfaces when a
-   * connection is removed, the conditional gate has no meaningful "previous
-   * value": resurfacing `"false"` would silently keep the task disabled after
-   * the user deleted the condition. Dropping a gate binding resets it to enabled,
-   * which also keeps the task conditional so the port stays put.
+   * An argument keeps its literal while connected and resurfaces it when the
+   * connection goes away; a run condition must not, because resurfacing
+   * `"false"` would leave the task silently disabled after the user deleted the
+   * condition. Resetting to `"true"` also keeps the task conditional, so the
+   * port stays where the user left it.
    */
   @modelAction
-  private resetGateLiteral(binding: Binding | undefined) {
+  private resetRunCondition(binding: Binding | undefined) {
     if (!binding || binding.targetPortName !== IS_ENABLED_PORT_NAME) return;
     const task = this.tasks.find((t) => t.$id === binding.targetEntityId);
     task?.setIsEnabled("true");
@@ -124,7 +124,7 @@ export class ComponentSpec extends Model({
   @modelAction
   removeBinding(index: number) {
     const removed = this.bindings.splice(index, 1)[0];
-    this.resetGateLiteral(removed);
+    this.resetRunCondition(removed);
     return removed;
   }
 
@@ -133,7 +133,7 @@ export class ComponentSpec extends Model({
     const idx = this.bindings.findIndex(predicate);
     if (idx >= 0) {
       const removed = this.bindings.splice(idx, 1)[0];
-      this.resetGateLiteral(removed);
+      this.resetRunCondition(removed);
       return removed;
     }
     return undefined;
@@ -153,7 +153,7 @@ export class ComponentSpec extends Model({
       }
     }
     for (const binding of removed) {
-      this.resetGateLiteral(binding);
+      this.resetRunCondition(binding);
     }
     return removed;
   }
@@ -227,7 +227,7 @@ export class ComponentSpec extends Model({
   deleteEdgeById(bindingId: string): boolean {
     const idx = this.bindings.findIndex((b) => b.$id === bindingId);
     if (idx < 0) return false;
-    this.resetGateLiteral(this.bindings.splice(idx, 1)[0]);
+    this.resetRunCondition(this.bindings.splice(idx, 1)[0]);
     return true;
   }
 

--- a/src/models/componentSpec/serialization/jsonSerializer.ts
+++ b/src/models/componentSpec/serialization/jsonSerializer.ts
@@ -2,6 +2,7 @@ import { IS_ENABLED_PORT_NAME } from "@/utils/conditionalExecution";
 
 import type { Annotations } from "../annotations";
 import { serializeAnnotationValue } from "../annotations";
+import { bindingToArgumentReference } from "../bindingReference";
 import type { Binding } from "../entities/binding";
 import type { ComponentSpec } from "../entities/componentSpec";
 import type { Input } from "../entities/input";
@@ -86,13 +87,11 @@ export class JsonSerializer {
       (b) => b.targetEntityId === task.$id,
     );
 
-    // A connection to the reserved "Is enabled?" port is serialized to
-    // `isEnabled` rather than to `arguments`.
-    const conditionalBinding = taskBindings.find(
+    const runConditionBinding = taskBindings.find(
       (b) => b.targetPortName === IS_ENABLED_PORT_NAME,
     );
     const argumentBindings = taskBindings.filter(
-      (b) => b !== conditionalBinding,
+      (b) => b !== runConditionBinding,
     );
     const args = this.serializeArguments(
       task.arguments,
@@ -112,11 +111,11 @@ export class JsonSerializer {
       result.arguments = args;
     }
 
-    const conditionalArgument = conditionalBinding
-      ? this.bindingToArgument(conditionalBinding, spec)
+    const runConditionReference = runConditionBinding
+      ? bindingToArgumentReference(runConditionBinding, spec)
       : undefined;
-    if (conditionalArgument !== undefined) {
-      result.isEnabled = conditionalArgument;
+    if (runConditionReference !== undefined) {
+      result.isEnabled = runConditionReference;
     } else if (task.isEnabled !== undefined) {
       result.isEnabled = task.isEnabled;
     }
@@ -141,7 +140,7 @@ export class JsonSerializer {
     const result: Record<string, ArgumentType> = {};
 
     for (const binding of bindings) {
-      const argument = this.bindingToArgument(binding, spec);
+      const argument = bindingToArgumentReference(binding, spec);
       if (argument !== undefined) {
         result[binding.targetPortName] = argument;
       }
@@ -154,39 +153,6 @@ export class JsonSerializer {
     }
 
     return result;
-  }
-
-  /**
-   * Resolve a binding's source into the argument reference it serializes to:
-   * a task output or a graph input. Returns undefined when the source entity
-   * cannot be resolved.
-   */
-  private bindingToArgument(
-    binding: Binding,
-    spec: ComponentSpec,
-  ): ArgumentType | undefined {
-    const sourceTask = spec.tasks.find((t) => t.$id === binding.sourceEntityId);
-    if (sourceTask) {
-      return {
-        taskOutput: {
-          taskId: sourceTask.name,
-          outputName: binding.sourcePortName,
-        },
-      };
-    }
-
-    const sourceInput = spec.inputs.find(
-      (i) => i.$id === binding.sourceEntityId,
-    );
-    if (sourceInput) {
-      return {
-        graphInput: {
-          inputName: sourceInput.name,
-        },
-      };
-    }
-
-    return undefined;
   }
 
   private serializeInput(input: Input): InputSpec {

--- a/src/models/componentSpec/serialization/yamlDeserializer.ts
+++ b/src/models/componentSpec/serialization/yamlDeserializer.ts
@@ -1,3 +1,4 @@
+import { GRAPH_INPUT_REGEX, TASK_OUTPUT_REGEX } from "@/utils/componentSpec";
 import {
   IS_ENABLED_PORT_NAME,
   isConditionalArgument,
@@ -24,9 +25,6 @@ import type {
 } from "../entities/types";
 import { isGraphImplementation } from "../entities/types";
 import type { IdGenerator } from "../factories/idGenerator";
-
-const GRAPH_INPUT_REGEX = /^\{\{inputs\.([^}]+)\}\}$/;
-const TASK_OUTPUT_REGEX = /^\{\{tasks\.([^.]+)\.outputs\.([^}]+)\}\}$/;
 
 function getGraph(implementation?: ImplementationType): GraphSpec | undefined {
   if (!implementation) return undefined;
@@ -128,11 +126,6 @@ export class YamlDeserializer {
         }
       }
 
-      // A reference-valued `isEnabled` becomes a binding to the reserved port
-      // (see buildBindings) and the entity keeps `isEnabled` empty. Literal
-      // values (e.g. "false") stay on the entity.
-      const conditionalEnabled = isConditionalArgument(taskJson.isEnabled);
-
       const args: Argument[] = [];
       if (taskJson.arguments) {
         for (const [argName, argValue] of Object.entries(taskJson.arguments)) {
@@ -159,7 +152,7 @@ export class YamlDeserializer {
         name: taskName,
         componentRef,
         subgraphSpec,
-        isEnabled: conditionalEnabled ? undefined : taskJson.isEnabled,
+        isEnabled: taskJson.isEnabled,
         executionOptions: taskJson.executionOptions,
         annotations: Annotations.from(annotationItems),
         arguments: args,
@@ -190,7 +183,6 @@ export class YamlDeserializer {
       const targetTask = tasks.find((t) => t.name === taskName);
       if (!targetTask) continue;
 
-      // A reference-valued `isEnabled` connects to the reserved port.
       if (isConditionalArgument(taskJson.isEnabled)) {
         const binding = this.createBindingFromArgument(
           inputs,
@@ -199,7 +191,13 @@ export class YamlDeserializer {
           IS_ENABLED_PORT_NAME,
           taskJson.isEnabled,
         );
-        if (binding) bindings.push(binding);
+        // The binding is the representation of a reference-valued condition, so
+        // the raw value is only dropped once one exists. An unresolvable
+        // reference keeps its value instead of leaving the task ungated.
+        if (binding) {
+          bindings.push(binding);
+          targetTask.setIsEnabled(undefined);
+        }
       }
 
       if (!taskJson.arguments) continue;

--- a/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/components/ConfigurationSection.tsx
+++ b/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/components/ConfigurationSection.tsx
@@ -1,5 +1,5 @@
 import { observer } from "mobx-react-lite";
-import { useEffect, useState } from "react";
+import { useEffect, useId, useState } from "react";
 
 import { ComputeResourcesEditor } from "@/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/ComputeResourcesEditor";
 import {
@@ -10,13 +10,19 @@ import {
 } from "@/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/utils";
 import { useFlagValue } from "@/components/shared/Settings/useFlags";
 import { ColorPicker } from "@/components/ui/color";
+import { Label } from "@/components/ui/label";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Separator } from "@/components/ui/separator";
 import { Switch } from "@/components/ui/switch";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Heading, Paragraph } from "@/components/ui/typography";
+import { Heading, Paragraph, Text } from "@/components/ui/typography";
+import { cn } from "@/lib/utils";
 import type { Task } from "@/models/componentSpec";
 import { useAnalytics } from "@/providers/AnalyticsProvider";
+import {
+  CONDITION_LABEL_CLASSES,
+  CONDITION_SURFACE_CLASSES,
+} from "@/routes/v2/shared/conditionalExecution.styles";
 import { useSpec } from "@/routes/v2/shared/providers/SpecContext";
 import type { AnnotationConfig, Annotations } from "@/types/annotations";
 import {
@@ -24,8 +30,12 @@ import {
   TASK_COLOR_ANNOTATION,
 } from "@/utils/annotations";
 import {
+  CONDITION_LITERAL_LABELS,
+  describeConditionSource,
   isTaskConditional,
   resolveConditionalReference,
+  RUN_CONDITION_LABEL,
+  toConditionLiteral,
 } from "@/utils/conditionalExecution";
 import { ISO8601_DURATION_ZERO_DAYS } from "@/utils/constants";
 
@@ -47,26 +57,30 @@ export const ConfigurationSection = observer(function ConfigurationSection({
     setTaskColor,
     clearProviderAnnotations,
     setCollapsed,
-    setTaskConditional,
-    setTaskCondition,
+    setConditionalExecution,
+    setRunCondition,
   } = useTaskConfigActions();
   const isSubgraph = task.subgraphSpec !== undefined;
+  const conditionalSwitchId = useId();
+  const runConditionLabelId = useId();
 
   const isConditional = isTaskConditional(task, spec);
-  const conditionReference = resolveConditionalReference(task, spec);
+  const conditionSource = describeConditionSource(
+    resolveConditionalReference(task, spec) ?? task.isEnabled,
+  );
 
   const handleConditionalChange = (checked: boolean) => {
     if (!spec) return;
-    setTaskConditional(spec, task, checked);
-    track("v2.pipeline_editor.task_details.conditional_task.toggle", {
+    setConditionalExecution(spec, task, checked);
+    track("v2.pipeline_editor.task_details.conditional_execution.toggle", {
       conditional: checked,
     });
   };
 
-  const handleConditionChange = (value: string) => {
-    const enabled = value === "true";
-    setTaskCondition(task, enabled);
-    track("v2.pipeline_editor.task_details.task_condition.change", { enabled });
+  const handleRunConditionChange = (value: string) => {
+    const literal = toConditionLiteral(value);
+    setRunCondition(task, literal);
+    track("v2.pipeline_editor.task_details.run_condition.change", { literal });
   };
 
   const cacheDisabled =
@@ -187,37 +201,52 @@ export const ConfigurationSection = observer(function ConfigurationSection({
         <>
           <Separator />
 
-          <BlockStack gap="3">
+          <BlockStack
+            gap="3"
+            className={cn("rounded-lg p-3", CONDITION_SURFACE_CLASSES)}
+          >
             <InlineStack align="space-between" gap="2" className="w-full">
-              <Paragraph size="xs" tone="subdued">
-                Conditional task
-              </Paragraph>
+              <Label
+                htmlFor={conditionalSwitchId}
+                className={cn("text-xs font-medium", CONDITION_LABEL_CLASSES)}
+              >
+                Conditional execution
+              </Label>
               <Switch
+                id={conditionalSwitchId}
                 checked={isConditional}
                 onCheckedChange={handleConditionalChange}
               />
             </InlineStack>
 
             {isConditional && (
-              <InlineStack align="space-between" gap="2" className="w-full">
-                <Paragraph size="xs" tone="subdued">
-                  Condition
+              <InlineStack
+                align="space-between"
+                blockAlign="center"
+                gap="2"
+                className="w-full"
+              >
+                <Paragraph size="xs" tone="subdued" id={runConditionLabelId}>
+                  {RUN_CONDITION_LABEL}
                 </Paragraph>
-                {conditionReference ? (
-                  <code className="text-2xs font-mono bg-muted rounded px-1.5 py-0.5 overflow-x-auto whitespace-nowrap max-w-50">
-                    {JSON.stringify(conditionReference)}
-                  </code>
+                {conditionSource ? (
+                  <Text size="xs" className="min-w-0 truncate">
+                    {conditionSource}
+                  </Text>
                 ) : (
                   <Tabs
-                    value={task.isEnabled === "false" ? "false" : "true"}
-                    onValueChange={handleConditionChange}
+                    value={toConditionLiteral(task.isEnabled)}
+                    onValueChange={handleRunConditionChange}
                   >
-                    <TabsList className="h-6">
+                    <TabsList
+                      className="h-6"
+                      aria-labelledby={runConditionLabelId}
+                    >
                       <TabsTrigger value="true" className="text-xs px-2.5">
-                        True
+                        {CONDITION_LITERAL_LABELS.true}
                       </TabsTrigger>
                       <TabsTrigger value="false" className="text-xs px-2.5">
-                        False
+                        {CONDITION_LITERAL_LABELS.false}
                       </TabsTrigger>
                     </TabsList>
                   </Tabs>

--- a/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/components/taskConfig.actions.test.ts
+++ b/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/components/taskConfig.actions.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+
+import { Binding, ComponentSpec, Input, Task } from "@/models/componentSpec";
+import { IS_ENABLED_PORT_NAME } from "@/utils/conditionalExecution";
+
+import { setConditionalExecution, setRunCondition } from "./taskConfig.actions";
+
+const noopUndo = {
+  withGroup: <T>(_label: string, fn: () => T): T => fn(),
+};
+
+function makeSpecWithTask() {
+  const task = new Task({ $id: "task_1", name: "Greet", componentRef: {} });
+  const spec = new ComponentSpec({
+    $id: "spec_1",
+    name: "Pipeline",
+    tasks: [task],
+  });
+  return { spec, task };
+}
+
+describe("setConditionalExecution", () => {
+  it("enabling defaults the run condition to the always literal", () => {
+    const { spec, task } = makeSpecWithTask();
+
+    setConditionalExecution(noopUndo, spec, task, true);
+
+    expect(task.isEnabled).toBe("true");
+  });
+
+  it("disabling clears both the literal and any connected condition", () => {
+    const task = new Task({ $id: "task_1", name: "Greet", componentRef: {} });
+    const flag = new Input({ $id: "input_1", name: "run_greeting" });
+    const spec = new ComponentSpec({
+      $id: "spec_1",
+      name: "Pipeline",
+      tasks: [task],
+      inputs: [flag],
+      bindings: [
+        new Binding({
+          $id: "binding_1",
+          sourceEntityId: flag.$id,
+          sourcePortName: "run_greeting",
+          targetEntityId: task.$id,
+          targetPortName: IS_ENABLED_PORT_NAME,
+        }),
+      ],
+    });
+
+    setConditionalExecution(noopUndo, spec, task, false);
+
+    expect(task.isEnabled).toBeUndefined();
+    expect(spec.bindings).toHaveLength(0);
+  });
+
+  it("leaves other bindings of the same task alone", () => {
+    const task = new Task({ $id: "task_1", name: "Greet", componentRef: {} });
+    const name = new Input({ $id: "input_1", name: "name" });
+    const spec = new ComponentSpec({
+      $id: "spec_1",
+      name: "Pipeline",
+      tasks: [task],
+      inputs: [name],
+      bindings: [
+        new Binding({
+          $id: "binding_1",
+          sourceEntityId: name.$id,
+          sourcePortName: "name",
+          targetEntityId: task.$id,
+          targetPortName: "name",
+        }),
+      ],
+    });
+
+    setConditionalExecution(noopUndo, spec, task, false);
+
+    expect(spec.bindings).toHaveLength(1);
+  });
+
+  it("groups the change for undo", () => {
+    const labels: string[] = [];
+    const undo = {
+      withGroup: <T>(label: string, fn: () => T): T => {
+        labels.push(label);
+        return fn();
+      },
+    };
+    const { spec, task } = makeSpecWithTask();
+
+    setConditionalExecution(undo, spec, task, true);
+
+    expect(labels).toEqual(["Toggle conditional execution"]);
+  });
+});
+
+describe("setRunCondition", () => {
+  it("writes the chosen literal", () => {
+    const { task } = makeSpecWithTask();
+
+    setRunCondition(noopUndo, task, "false");
+    expect(task.isEnabled).toBe("false");
+
+    setRunCondition(noopUndo, task, "true");
+    expect(task.isEnabled).toBe("true");
+  });
+});

--- a/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/components/taskConfig.actions.ts
+++ b/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/components/taskConfig.actions.ts
@@ -5,6 +5,7 @@ import {
   EDITOR_COLLAPSED_ANNOTATION,
   TASK_COLOR_ANNOTATION,
 } from "@/utils/annotations";
+import type { ConditionLiteral } from "@/utils/conditionalExecution";
 import { IS_ENABLED_PORT_NAME } from "@/utils/conditionalExecution";
 import { ISO8601_DURATION_ZERO_DAYS } from "@/utils/constants";
 
@@ -57,13 +58,13 @@ export function setCollapsed(
   });
 }
 
-export function setTaskConditional(
+export function setConditionalExecution(
   undo: UndoGroupable,
   spec: ComponentSpec,
   task: Task,
   conditional: boolean,
 ) {
-  undo.withGroup("Toggle conditional task", () => {
+  undo.withGroup("Toggle conditional execution", () => {
     if (conditional) {
       task.setIsEnabled("true");
       return;
@@ -78,13 +79,13 @@ export function setTaskConditional(
   });
 }
 
-export function setTaskCondition(
+export function setRunCondition(
   undo: UndoGroupable,
   task: Task,
-  enabled: boolean,
+  literal: ConditionLiteral,
 ) {
-  undo.withGroup("Set task condition", () => {
-    task.setIsEnabled(enabled ? "true" : "false");
+  undo.withGroup("Set run condition", () => {
+    task.setIsEnabled(literal);
   });
 }
 

--- a/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/components/useTaskConfigActions.ts
+++ b/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/components/useTaskConfigActions.ts
@@ -4,9 +4,9 @@ import {
   clearProviderAnnotations,
   saveAnnotation,
   setCollapsed,
+  setConditionalExecution,
+  setRunCondition,
   setTaskColor,
-  setTaskCondition,
-  setTaskConditional,
   toggleCacheDisable,
 } from "./taskConfig.actions";
 
@@ -18,8 +18,8 @@ export function useTaskConfigActions() {
     saveAnnotation: saveAnnotation.bind(null, undo),
     setTaskColor: setTaskColor.bind(null, undo),
     setCollapsed: setCollapsed.bind(null, undo),
-    setTaskConditional: setTaskConditional.bind(null, undo),
-    setTaskCondition: setTaskCondition.bind(null, undo),
+    setConditionalExecution: setConditionalExecution.bind(null, undo),
+    setRunCondition: setRunCondition.bind(null, undo),
     clearProviderAnnotations: clearProviderAnnotations.bind(null, undo),
   };
 }

--- a/src/routes/v2/pages/Editor/store/actions/__tests__/io.actions.test.ts
+++ b/src/routes/v2/pages/Editor/store/actions/__tests__/io.actions.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+
+import { ComponentSpec, Task } from "@/models/componentSpec";
+import { createConnectedIONode } from "@/routes/v2/pages/Editor/store/actions/io.actions";
+import { IS_ENABLED_PORT_NAME } from "@/utils/conditionalExecution";
+
+const noopUndo = {
+  withGroup: <T>(_label: string, fn: () => T): T => fn(),
+};
+
+const position = { x: 0, y: 0 };
+
+function makeSpecWithTask() {
+  const task = new Task({
+    $id: "task_1",
+    name: "Greet",
+    componentRef: {
+      spec: {
+        name: "Say hello",
+        inputs: [{ name: "name", type: "String" }],
+        implementation: { container: { image: "alpine" } },
+      },
+    },
+  });
+  const spec = new ComponentSpec({
+    $id: "spec_1",
+    name: "Pipeline",
+    tasks: [task],
+  });
+  return { spec, task };
+}
+
+describe("createConnectedIONode", () => {
+  it("names a graph input after the port it was dragged from", () => {
+    const { spec } = makeSpecWithTask();
+
+    createConnectedIONode(
+      noopUndo,
+      spec,
+      "task_1",
+      "input_name",
+      position,
+      "input",
+    );
+
+    expect(spec.inputs.map((i) => i.name)).toEqual(["name"]);
+    expect(spec.inputs[0].type).toBe("String");
+  });
+
+  it("gives the run condition port a readable input name instead of the sentinel", () => {
+    const { spec } = makeSpecWithTask();
+
+    createConnectedIONode(
+      noopUndo,
+      spec,
+      "task_1",
+      `input_${IS_ENABLED_PORT_NAME}`,
+      position,
+      "input",
+    );
+
+    expect(spec.inputs.map((i) => i.name)).toEqual(["run_condition"]);
+    expect(spec.inputs[0].type).toBe("String");
+    expect(spec.bindings).toHaveLength(1);
+    expect(spec.bindings[0].targetPortName).toBe(IS_ENABLED_PORT_NAME);
+  });
+
+  it("carries a Never condition onto the input it creates", () => {
+    const { spec, task } = makeSpecWithTask();
+    task.setIsEnabled("false");
+
+    createConnectedIONode(
+      noopUndo,
+      spec,
+      "task_1",
+      `input_${IS_ENABLED_PORT_NAME}`,
+      position,
+      "input",
+    );
+
+    expect(spec.inputs[0].defaultValue).toBe("false");
+  });
+
+  it("gives the input a condition even when the task was set to Always", () => {
+    const { spec, task } = makeSpecWithTask();
+    task.setIsEnabled("true");
+
+    createConnectedIONode(
+      noopUndo,
+      spec,
+      "task_1",
+      `input_${IS_ENABLED_PORT_NAME}`,
+      position,
+      "input",
+    );
+
+    expect(spec.inputs[0].defaultValue).toBe("true");
+  });
+});

--- a/src/routes/v2/pages/Editor/store/actions/io.actions.ts
+++ b/src/routes/v2/pages/Editor/store/actions/io.actions.ts
@@ -13,6 +13,12 @@ import {
 import type { UndoGroupable } from "@/routes/v2/shared/nodes/types";
 import type { ParentContext } from "@/routes/v2/shared/store/navigationStore";
 import { EDITOR_POSITION_ANNOTATION } from "@/utils/annotations";
+import {
+  IS_ENABLED_PORT_NAME,
+  RUN_CONDITION_INPUT_NAME,
+  RUN_CONDITION_INPUT_TYPE,
+  toConditionLiteral,
+} from "@/utils/conditionalExecution";
 
 import {
   propagateInputDelete,
@@ -215,6 +221,7 @@ export function createConnectedIONode(
 
   undo.withGroup("Create connected IO node", () => {
     if (ioType === "input") {
+      const isRunCondition = portName === IS_ENABLED_PORT_NAME;
       const inputSpec = taskComponentSpec?.inputs?.find(
         (i) => i.name === portName,
       );
@@ -223,11 +230,24 @@ export function createConnectedIONode(
       )?.value;
       const literalArgValue =
         typeof existingArgValue === "string" ? existingArgValue : undefined;
-      const defaultValue = literalArgValue ?? inputSpec?.default;
 
-      const newInput = addInput(undo, spec, position, portName);
+      // The run condition keeps its literal on the task rather than in
+      // `arguments`, so without this the new input starts empty — and an empty
+      // condition reads as enabled, silently ungating a task set to Never.
+      const defaultValue = isRunCondition
+        ? toConditionLiteral(task.isEnabled)
+        : (literalArgValue ?? inputSpec?.default);
 
-      if (inputSpec?.type) {
+      const newInput = addInput(
+        undo,
+        spec,
+        position,
+        isRunCondition ? RUN_CONDITION_INPUT_NAME : portName,
+      );
+
+      if (isRunCondition) {
+        newInput.setType(RUN_CONDITION_INPUT_TYPE);
+      } else if (inputSpec?.type) {
         newInput.setType(inputSpec.type);
       }
       if (defaultValue !== undefined) {

--- a/src/routes/v2/shared/conditionalExecution.styles.ts
+++ b/src/routes/v2/shared/conditionalExecution.styles.ts
@@ -1,0 +1,20 @@
+import type { IconName } from "@/components/ui/icon";
+
+export const CONDITION_ICON_NAME: IconName = "Split";
+
+/**
+ * Violet is the fixed identity of conditional execution, deliberately outside the
+ * per-task colour palette: the run-condition row sits next to the palette-tinted
+ * inputs section, and tinting it too would make the two indistinguishable.
+ */
+export const CONDITION_SURFACE_CLASSES =
+  "border border-violet-200 bg-violet-50/80 dark:border-violet-500/40 dark:bg-violet-500/15";
+
+export const CONDITION_CHIP_CLASSES =
+  "bg-violet-100 text-violet-800 dark:bg-violet-500/20 dark:text-violet-200";
+
+export const CONDITION_LABEL_CLASSES = "text-violet-800 dark:text-violet-200";
+
+export const CONDITION_ICON_CLASSES = "text-violet-600 dark:text-violet-300";
+
+export const CONDITION_HANDLE_CLASSES = "bg-violet-500! border-0!";

--- a/src/routes/v2/shared/nodes/TaskNode/TaskNode.tsx
+++ b/src/routes/v2/shared/nodes/TaskNode/TaskNode.tsx
@@ -28,9 +28,11 @@ import {
 } from "@/utils/annotations";
 import { isSecretArgument } from "@/utils/componentSpec";
 import {
-  IS_ENABLED_INPUT_LABEL,
+  CONDITION_LITERAL_LABELS,
+  describeConditionSource,
   IS_ENABLED_PORT_NAME,
   isTaskConditional,
+  toConditionLiteral,
 } from "@/utils/conditionalExecution";
 import { ISO8601_DURATION_ZERO_DAYS } from "@/utils/constants";
 import type { ExecutionStatusStats } from "@/utils/executionStatus";
@@ -49,8 +51,6 @@ export interface TaskNodeInput {
   type?: TypeSpecType;
   optional?: boolean;
   default?: string;
-  /** Human-readable label; falls back to the (prettified) name when unset. */
-  label?: string;
 }
 
 export interface TaskNodeOutput {
@@ -74,6 +74,8 @@ export interface TaskNodeViewProps {
   annotations: { key: string }[];
   taskColor?: string;
   cacheDisabled: boolean;
+  isConditional: boolean;
+  conditionDisplayValue: string;
   componentRef?: ComponentReference;
   digest?: string;
   publishedComponentBadgeReadOnly?: boolean;
@@ -306,28 +308,7 @@ export const TaskNode = observer(function TaskNode({
   const connectedPorts = resolveConnectedPortNames(entityId, spec);
   const inputDisplayData = resolveInputDisplayData(task, entityId, spec);
 
-  // A conditional task exposes a virtual "Is enabled?" input so the user can
-  // connect an upstream value that gates it. A connection is an ordinary binding
-  // to the reserved port, so its display value and connected state are already
-  // resolved above; a literal lives on the entity and is filled in here.
-  const isConditionalExecution = isTaskConditional(task, spec);
-  const displayInputs: TaskNodeInput[] = isConditionalExecution
-    ? [
-        ...inputs,
-        {
-          name: IS_ENABLED_PORT_NAME,
-          label: IS_ENABLED_INPUT_LABEL,
-          type: "Boolean",
-        },
-      ]
-    : inputs;
-  const inputDisplayValues =
-    isConditionalExecution && typeof task.isEnabled === "string"
-      ? {
-          [IS_ENABLED_PORT_NAME]: task.isEnabled,
-          ...inputDisplayData.values,
-        }
-      : inputDisplayData.values;
+  const conditionReferenceLabel = inputDisplayData.values[IS_ENABLED_PORT_NAME];
 
   const isSelected = isEditorVisualNodeSelected(editor, id, !!selected);
 
@@ -344,7 +325,7 @@ export const TaskNode = observer(function TaskNode({
     isSubgraph: isTaskSubgraph(componentSpec),
     collapsed: isManuallyCollapsed,
     description,
-    inputs: displayInputs,
+    inputs,
     outputs,
     connectedInputNames: connectedPorts.inputs,
     connectedOutputNames: connectedPorts.outputs,
@@ -353,6 +334,11 @@ export const TaskNode = observer(function TaskNode({
     cacheDisabled:
       task.executionOptions?.cachingStrategy?.maxCacheStaleness ===
       ISO8601_DURATION_ZERO_DAYS,
+    isConditional: isTaskConditional(task, spec),
+    conditionDisplayValue:
+      conditionReferenceLabel ??
+      describeConditionSource(task.isEnabled) ??
+      CONDITION_LITERAL_LABELS[toConditionLiteral(task.isEnabled)],
     componentRef: publishedComponentBadgeEnabled
       ? task.resolvedComponentRef
       : undefined,
@@ -362,7 +348,7 @@ export const TaskNode = observer(function TaskNode({
     subgraphExecutionStats,
     onOutputTypeChange: handleOutputTypeChange,
     digest: task.componentRef.digest,
-    inputDisplayValues,
+    inputDisplayValues: inputDisplayData.values,
     secretInputNames: inputDisplayData.secretInputNames,
     onNodeClick: handleClick,
     onInputClick: handleInputClick,

--- a/src/routes/v2/shared/nodes/TaskNode/TaskNodeCard.test.tsx
+++ b/src/routes/v2/shared/nodes/TaskNode/TaskNodeCard.test.tsx
@@ -35,6 +35,8 @@ const buildProps = (
   connectedOutputNames: new Set(),
   annotations: [],
   cacheDisabled: false,
+  isConditional: false,
+  conditionDisplayValue: "Always",
   inputDisplayValues: {},
   secretInputNames: new Set(),
   isAggregator: false,
@@ -205,6 +207,81 @@ describe("TaskNodeCard", () => {
         expect.anything(),
       );
       expect(props.onInputClick).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("run condition", () => {
+    const renderConditional = (overrides: Partial<TaskNodeViewProps> = {}) => {
+      const props = buildProps({
+        isSubgraph: false,
+        inputs: [{ name: "name", type: "String" }],
+        isConditional: true,
+        onHandleClick: vi.fn((_handleId, event) => event.stopPropagation()),
+        ...overrides,
+      });
+
+      render(
+        <ReactFlowProvider>
+          <TaskNodeCard {...props} />
+        </ReactFlowProvider>,
+      );
+
+      return props;
+    };
+
+    it("is hidden for a task that is not conditional", () => {
+      renderConditional({ isConditional: false });
+
+      expect(screen.queryByText("Run when")).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId("run-condition-handle"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("shows the literal for a task with no connected condition", () => {
+      renderConditional({ conditionDisplayValue: "Never" });
+
+      expect(screen.getByText("Run when")).toBeInTheDocument();
+      expect(screen.getByText("Never")).toBeInTheDocument();
+    });
+
+    it("shows the upstream reference when the condition is connected", () => {
+      renderConditional({ conditionDisplayValue: "→ Flag.flag" });
+
+      expect(screen.getByText("→ Flag.flag")).toBeInTheDocument();
+    });
+
+    it("stays out of the collapsed inputs count", () => {
+      renderConditional({
+        collapsed: true,
+        inputs: [{ name: "name" }, { name: "greeting" }, { name: "locale" }],
+      });
+
+      expect(screen.getByText("+2 more inputs")).toBeInTheDocument();
+      expect(screen.getByText("Run when")).toBeInTheDocument();
+    });
+
+    it("stays visible when the collapsed inputs are expanded", async () => {
+      renderConditional({
+        collapsed: true,
+        inputs: [{ name: "name" }, { name: "greeting" }, { name: "locale" }],
+      });
+
+      await userEvent.click(screen.getByText("+2 more inputs"));
+
+      expect(screen.getByTestId("input-label-locale")).toBeInTheDocument();
+      expect(screen.getByText("Run when")).toBeInTheDocument();
+    });
+
+    it("selects the connected edges when its handle is clicked", async () => {
+      const props = renderConditional();
+
+      await userEvent.click(screen.getByTestId("run-condition-handle"));
+
+      expect(props.onHandleClick).toHaveBeenCalledWith(
+        "input___is_enabled__",
+        expect.anything(),
+      );
     });
   });
 

--- a/src/routes/v2/shared/nodes/TaskNode/TaskNodeCard.tsx
+++ b/src/routes/v2/shared/nodes/TaskNode/TaskNodeCard.tsx
@@ -16,11 +16,22 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { Text } from "@/components/ui/typography";
 import { cn } from "@/lib/utils";
 import { useTheme } from "@/providers/ThemeProvider";
+import {
+  CONDITION_CHIP_CLASSES,
+  CONDITION_HANDLE_CLASSES,
+  CONDITION_ICON_CLASSES,
+  CONDITION_ICON_NAME,
+  CONDITION_SURFACE_CLASSES,
+} from "@/routes/v2/shared/conditionalExecution.styles";
 import { useSpec } from "@/routes/v2/shared/providers/SpecContext";
 import { AGGREGATOR_ADD_INPUT_HANDLE_ID } from "@/utils/aggregatorInputs";
-import { IS_ENABLED_PORT_NAME } from "@/utils/conditionalExecution";
+import {
+  IS_ENABLED_PORT_NAME,
+  RUN_CONDITION_LABEL,
+} from "@/utils/conditionalExecution";
 import { pluralize } from "@/utils/string";
 
 import { deriveColorPalette } from "./color.utils";
@@ -32,8 +43,7 @@ const AGGREGATOR_INTERNAL_INPUTS = new Set([
   "output_type",
 ]);
 
-/** The conditional gate stays visible while the rest of the inputs condense. */
-const isGatePort = (inputName: string) => inputName === IS_ENABLED_PORT_NAME;
+const RUN_CONDITION_HANDLE_ID = `input_${IS_ENABLED_PORT_NAME}`;
 
 const cardVariants = cva(
   "min-w-[300px] max-w-[350px] rounded-2xl border-2 p-0 drop-shadow-none cursor-pointer select-none gap-2 transition-shadow",
@@ -172,12 +182,12 @@ const ClassicInputHandle = observer(function ClassicInputHandle({
                   ? "text-gray-100 bg-white/10 hover:bg-white/15 dark:hover:bg-white/15 hover:text-gray-100"
                   : "text-gray-800 bg-black/5 hover:bg-black/10 dark:hover:bg-black/10 hover:text-gray-800",
             )}
-            title={`${input.label ?? input.name}${input.type ? `: ${input.type}` : ""}`}
+            title={`${input.name}${input.type ? `: ${input.type}` : ""}`}
             onClick={onLabelClick}
             data-input-control
             data-testid={`input-label-${input.name}`}
           >
-            {input.label ?? input.name.replace(/_/g, " ")}
+            {input.name.replace(/_/g, " ")}
           </Button>
         </div>
         {showValueDisplay && (
@@ -216,6 +226,56 @@ const ClassicInputHandle = observer(function ClassicInputHandle({
   );
 });
 
+interface RunConditionHandleProps {
+  displayValue: string;
+  onHandleClick: (event: ReactMouseEvent) => void;
+}
+
+function RunConditionHandle({
+  displayValue,
+  onHandleClick,
+}: RunConditionHandleProps) {
+  return (
+    <div className={cn("relative p-2 rounded-lg", CONDITION_SURFACE_CLASSES)}>
+      <div className="absolute top-1/2 -translate-x-6 -translate-y-1/2 flex items-center h-3 w-3">
+        <Handle
+          type="target"
+          position={Position.Left}
+          id={RUN_CONDITION_HANDLE_ID}
+          aria-label={`Connect ${RUN_CONDITION_LABEL}`}
+          className={cn(
+            "h-full! w-full! transform-none!",
+            CONDITION_HANDLE_CLASSES,
+          )}
+          onClick={onHandleClick}
+          data-input-control
+          data-testid="run-condition-handle"
+        />
+      </div>
+      <InlineStack
+        align="space-between"
+        blockAlign="center"
+        gap="2"
+        className="w-full"
+      >
+        <Text
+          size="xs"
+          weight="medium"
+          className={cn(
+            "shrink-0 rounded-md px-2 py-1",
+            CONDITION_CHIP_CLASSES,
+          )}
+        >
+          {RUN_CONDITION_LABEL}
+        </Text>
+        <Text size="xs" className="min-w-0 truncate pr-2 text-right">
+          {displayValue}
+        </Text>
+      </InlineStack>
+    </div>
+  );
+}
+
 export const TaskNodeCard = observer(function TaskNodeCard({
   entityId,
   taskName,
@@ -235,6 +295,8 @@ export const TaskNodeCard = observer(function TaskNodeCard({
   onHandleClick,
   taskColor,
   cacheDisabled,
+  isConditional,
+  conditionDisplayValue,
   componentRef,
   digest,
   publishedComponentBadgeReadOnly,
@@ -266,23 +328,16 @@ export const TaskNodeCard = observer(function TaskNodeCard({
     ? inputs.filter((input) => !AGGREGATOR_INTERNAL_INPUTS.has(input.name))
     : inputs;
 
-  const gateInputs = filteredInputs.filter((input) => isGatePort(input.name));
-  const regularInputs = filteredInputs.filter(
-    (input) => !isGatePort(input.name),
-  );
-
-  const condensedInputs = regularInputs.some((input) =>
+  const condensedInputs = filteredInputs.some((input) =>
     connectedInputNames.has(input.name),
   )
-    ? regularInputs.filter((input) => connectedInputNames.has(input.name))
-    : regularInputs.slice(0, 1);
-  const hiddenInputCount = regularInputs.length - condensedInputs.length;
+    ? filteredInputs.filter((input) => connectedInputNames.has(input.name))
+    : filteredInputs.slice(0, 1);
+  const hiddenInputCount = filteredInputs.length - condensedInputs.length;
   const inputsSectionToggles =
     !isAggregator && collapsed && hiddenInputCount > 0;
   const showCondensedInputs = inputsSectionToggles && !inputsExpanded;
-  const visibleInputs = showCondensedInputs
-    ? [...condensedInputs, ...gateInputs]
-    : filteredInputs;
+  const visibleInputs = showCondensedInputs ? condensedInputs : filteredInputs;
   const showInputsSection = filteredInputs.length > 0 || isAggregator;
 
   const openInputProperties =
@@ -356,6 +411,22 @@ export const TaskNodeCard = observer(function TaskNodeCard({
                   <TooltipContent side="top">Subgraph</TooltipContent>
                 </Tooltip>
               )}
+              {isConditional && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span>
+                      <Icon
+                        name={CONDITION_ICON_NAME}
+                        size="sm"
+                        className={CONDITION_ICON_CLASSES}
+                      />
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent side="top">
+                    Conditional execution
+                  </TooltipContent>
+                </Tooltip>
+              )}
               {cacheDisabled && (
                 <Tooltip>
                   <TooltipTrigger asChild>
@@ -398,6 +469,12 @@ export const TaskNodeCard = observer(function TaskNodeCard({
         {isSubgraph && subgraphExecutionStats && (
           <TaskStatusBar executionStatusStats={subgraphExecutionStats} />
         )}
+        {isConditional && (
+          <RunConditionHandle
+            displayValue={conditionDisplayValue}
+            onHandleClick={(e) => onHandleClick(RUN_CONDITION_HANDLE_ID, e)}
+          />
+        )}
         {showInputsSection && (
           <div
             className={cn(
@@ -420,40 +497,31 @@ export const TaskNodeCard = observer(function TaskNodeCard({
           >
             <BlockStack gap="3">
               {isAggregator && <InputAggregatorHandle />}
-              {visibleInputs.map((input, index) => {
-                const condensedAway =
-                  showCondensedInputs && !isGatePort(input.name);
-                const hiddenCountLabel =
-                  condensedAway && index === 0
-                    ? `+${hiddenInputCount} more ${pluralize(hiddenInputCount, "input")}`
-                    : undefined;
-
-                return (
-                  <ClassicInputHandle
-                    key={input.name}
-                    input={input}
-                    entityId={entityId}
-                    themed={!palette}
-                    isDark={isDark}
-                    displayValue={
-                      condensedAway
-                        ? hiddenCountLabel
-                        : inputDisplayValues[input.name]
-                    }
-                    hideValue={condensedAway && !hiddenCountLabel}
-                    isSecret={secretInputNames.has(input.name)}
-                    onRowClick={
-                      inputsSectionToggles
-                        ? undefined
-                        : openInputProperties(input.name)
-                    }
-                    onLabelClick={openInputProperties(input.name)}
-                    onHandleClick={(e) =>
-                      onHandleClick(`input_${input.name}`, e)
-                    }
-                  />
-                );
-              })}
+              {visibleInputs.map((input, index) => (
+                <ClassicInputHandle
+                  key={input.name}
+                  input={input}
+                  entityId={entityId}
+                  themed={!palette}
+                  isDark={isDark}
+                  displayValue={
+                    showCondensedInputs
+                      ? index === 0
+                        ? `+${hiddenInputCount} more ${pluralize(hiddenInputCount, "input")}`
+                        : undefined
+                      : inputDisplayValues[input.name]
+                  }
+                  hideValue={showCondensedInputs && index !== 0}
+                  isSecret={secretInputNames.has(input.name)}
+                  onRowClick={
+                    inputsSectionToggles
+                      ? undefined
+                      : openInputProperties(input.name)
+                  }
+                  onLabelClick={openInputProperties(input.name)}
+                  onHandleClick={(e) => onHandleClick(`input_${input.name}`, e)}
+                />
+              ))}
               {collapsed && inputsExpanded && hiddenInputCount > 0 && (
                 <span
                   className={cn(

--- a/src/routes/v2/shared/nodes/TaskNode/TaskNodePublishedComponentBadge.test.tsx
+++ b/src/routes/v2/shared/nodes/TaskNode/TaskNodePublishedComponentBadge.test.tsx
@@ -53,6 +53,8 @@ const buildProps = (
   connectedOutputNames: new Set(),
   annotations: [],
   cacheDisabled: false,
+  isConditional: false,
+  conditionDisplayValue: "Always",
   componentRef,
   digest: componentRef.digest,
   inputDisplayValues: {},

--- a/src/routes/v2/shared/nodes/TaskNode/TaskNodeSimplified.tsx
+++ b/src/routes/v2/shared/nodes/TaskNode/TaskNodeSimplified.tsx
@@ -10,8 +10,17 @@ import {
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { useTheme } from "@/providers/ThemeProvider";
+import {
+  CONDITION_HANDLE_CLASSES,
+  CONDITION_ICON_CLASSES,
+  CONDITION_ICON_NAME,
+} from "@/routes/v2/shared/conditionalExecution.styles";
 import { deriveColorPalette } from "@/routes/v2/shared/nodes/TaskNode/color.utils";
 import { AGGREGATOR_ADD_INPUT_HANDLE_ID } from "@/utils/aggregatorInputs";
+import {
+  IS_ENABLED_PORT_NAME,
+  RUN_CONDITION_LABEL,
+} from "@/utils/conditionalExecution";
 
 import type { TaskNodeViewProps } from "./TaskNode";
 import { createTaskNodeCardVariants } from "./taskNode.variants";
@@ -37,6 +46,7 @@ export function TaskNodeSimplified({
   isHovered,
   taskColor,
   isAggregator,
+  isConditional,
   subgraphExecutionStats,
   onNodeClick,
 }: TaskNodeViewProps) {
@@ -71,6 +81,21 @@ export function TaskNodeSimplified({
       data-tour-card="task"
       data-tour-card-name={taskName}
     >
+      {isConditional && (
+        <Handle
+          type="target"
+          position={Position.Left}
+          id={`input_${IS_ENABLED_PORT_NAME}`}
+          aria-label={`Connect ${RUN_CONDITION_LABEL}`}
+          style={{
+            top: "25%",
+            width: `calc(${s} * 12px)`,
+            height: `calc(${s} * 12px)`,
+            left: `calc(${s} * -4px)`,
+          }}
+          className={CONDITION_HANDLE_CLASSES}
+        />
+      )}
       {visibleInputs.map((input) => (
         <Handle
           key={input.name}
@@ -143,6 +168,16 @@ export function TaskNodeSimplified({
           </TooltipTrigger>
           <TooltipContent side="top">{taskName}</TooltipContent>
         </Tooltip>
+        {isConditional && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className={cn("shrink-0", CONDITION_ICON_CLASSES)}>
+                <Icon name={CONDITION_ICON_NAME} size="sm" />
+              </span>
+            </TooltipTrigger>
+            <TooltipContent side="top">Conditional execution</TooltipContent>
+          </Tooltip>
+        )}
       </div>
 
       {showSubgraphProgress && (

--- a/src/utils/componentSpec.ts
+++ b/src/utils/componentSpec.ts
@@ -409,9 +409,6 @@ type PredicateType =
       not: PredicateType;
     };
 
-/**
- * Optional configuration that specifies how the task should be retried if it fails.
- */
 interface RetryStrategySpec {
   maxRetries?: number;
 }
@@ -477,6 +474,13 @@ export const isGraphImplementationOutput = (
   "graph" in implementation &&
   implementation.graph !== null &&
   implementation.graph !== undefined;
+
+/**
+ * The template forms an argument reference takes in hand-written YAML, which the
+ * deserializer converts into the structured `graphInput` / `taskOutput` shapes.
+ */
+export const GRAPH_INPUT_REGEX = /^\{\{inputs\.([^}]+)\}\}$/;
+export const TASK_OUTPUT_REGEX = /^\{\{tasks\.([^.]+)\.outputs\.([^}]+)\}\}$/;
 
 export const isTaskOutputArgument = (
   arg?: ArgumentType,

--- a/src/utils/conditionalExecution.test.ts
+++ b/src/utils/conditionalExecution.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from "vitest";
+
+import { Binding, ComponentSpec, Input, Task } from "@/models/componentSpec";
+
+import {
+  CONDITION_LITERAL_LABELS,
+  describeConditionSource,
+  IS_ENABLED_PORT_NAME,
+  isConditionalArgument,
+  isTaskConditional,
+  resolveConditionalReference,
+  toConditionLiteral,
+} from "./conditionalExecution";
+
+function makeTask(id: string, name: string) {
+  return new Task({ $id: id, name, componentRef: {} });
+}
+
+function makeSpec(
+  tasks: Task[],
+  inputs: Input[] = [],
+  bindings: Binding[] = [],
+) {
+  return new ComponentSpec({
+    $id: "spec_1",
+    name: "Pipeline",
+    tasks,
+    inputs,
+    bindings,
+  });
+}
+
+function bindToRunCondition(
+  sourceEntityId: string,
+  sourcePortName: string,
+  taskId: string,
+) {
+  return new Binding({
+    $id: "binding_1",
+    sourceEntityId,
+    sourcePortName,
+    targetEntityId: taskId,
+    targetPortName: IS_ENABLED_PORT_NAME,
+  });
+}
+
+describe("toConditionLiteral", () => {
+  it("treats anything other than the false literal as always", () => {
+    expect(toConditionLiteral(undefined)).toBe("true");
+    expect(toConditionLiteral("true")).toBe("true");
+    expect(toConditionLiteral({ graphInput: { inputName: "flag" } })).toBe(
+      "true",
+    );
+    expect(toConditionLiteral("false")).toBe("false");
+  });
+
+  it("recognises the shapes a hand-authored pipeline can produce", () => {
+    expect(toConditionLiteral(false)).toBe("false");
+    expect(toConditionLiteral("False")).toBe("false");
+    expect(toConditionLiteral("FALSE\n")).toBe("false");
+    expect(toConditionLiteral(true)).toBe("true");
+    expect(toConditionLiteral("True")).toBe("true");
+  });
+
+  it("labels the literals for display", () => {
+    expect(CONDITION_LITERAL_LABELS.true).toBe("Always");
+    expect(CONDITION_LITERAL_LABELS.false).toBe("Never");
+  });
+});
+
+describe("isConditionalArgument", () => {
+  it("accepts upstream references in both object and template form", () => {
+    expect(isConditionalArgument({ graphInput: { inputName: "flag" } })).toBe(
+      true,
+    );
+    expect(
+      isConditionalArgument({
+        taskOutput: { taskId: "Flag", outputName: "flag" },
+      }),
+    ).toBe(true);
+    expect(isConditionalArgument("{{inputs.flag}}")).toBe(true);
+    expect(isConditionalArgument("{{tasks.Flag.outputs.flag}}")).toBe(true);
+  });
+
+  it("rejects literals and absent values", () => {
+    expect(isConditionalArgument(undefined)).toBe(false);
+    expect(isConditionalArgument("false")).toBe(false);
+    expect(isConditionalArgument("true")).toBe(false);
+  });
+});
+
+describe("isTaskConditional", () => {
+  it("is false for a task with no run condition", () => {
+    const task = makeTask("task_1", "Greet");
+    expect(isTaskConditional(task, makeSpec([task]))).toBe(false);
+  });
+
+  it("is true for a literal run condition", () => {
+    const task = makeTask("task_1", "Greet");
+    task.setIsEnabled("false");
+    expect(isTaskConditional(task, makeSpec([task]))).toBe(true);
+  });
+
+  it("is true for a connected run condition even without a literal", () => {
+    const task = makeTask("task_1", "Greet");
+    const flag = new Input({ $id: "input_1", name: "run_greeting" });
+    const spec = makeSpec(
+      [task],
+      [flag],
+      [bindToRunCondition(flag.$id, "run_greeting", task.$id)],
+    );
+
+    expect(task.isEnabled).toBeUndefined();
+    expect(isTaskConditional(task, spec)).toBe(true);
+  });
+
+  it("ignores bindings to other ports", () => {
+    const task = makeTask("task_1", "Greet");
+    const flag = new Input({ $id: "input_1", name: "name" });
+    const spec = makeSpec(
+      [task],
+      [flag],
+      [
+        new Binding({
+          $id: "binding_1",
+          sourceEntityId: flag.$id,
+          sourcePortName: "name",
+          targetEntityId: task.$id,
+          targetPortName: "name",
+        }),
+      ],
+    );
+
+    expect(isTaskConditional(task, spec)).toBe(false);
+  });
+});
+
+describe("resolveConditionalReference", () => {
+  it("resolves a task output source by task name", () => {
+    const upstream = makeTask("task_1", "Flag");
+    const task = makeTask("task_2", "Greet");
+    const spec = makeSpec(
+      [upstream, task],
+      [],
+      [bindToRunCondition(upstream.$id, "flag", task.$id)],
+    );
+
+    expect(resolveConditionalReference(task, spec)).toEqual({
+      taskOutput: { taskId: "Flag", outputName: "flag" },
+    });
+  });
+
+  it("resolves a graph input source by input name", () => {
+    const task = makeTask("task_1", "Greet");
+    const flag = new Input({ $id: "input_1", name: "run_greeting" });
+    const spec = makeSpec(
+      [task],
+      [flag],
+      [bindToRunCondition(flag.$id, "run_greeting", task.$id)],
+    );
+
+    expect(resolveConditionalReference(task, spec)).toEqual({
+      graphInput: { inputName: "run_greeting" },
+    });
+  });
+
+  it("is undefined when the run condition is a literal", () => {
+    const task = makeTask("task_1", "Greet");
+    task.setIsEnabled("false");
+
+    expect(resolveConditionalReference(task, makeSpec([task]))).toBeUndefined();
+  });
+});
+
+describe("describeConditionSource", () => {
+  it("matches the arrow form the node card uses for bound inputs", () => {
+    expect(
+      describeConditionSource({
+        taskOutput: { taskId: "Flag", outputName: "flag" },
+      }),
+    ).toBe("→ Flag.flag");
+    expect(
+      describeConditionSource({ graphInput: { inputName: "run_greeting" } }),
+    ).toBe("→ run_greeting");
+  });
+
+  it("describes the template form an unresolved reference keeps", () => {
+    expect(describeConditionSource("{{inputs.run_greeting}}")).toBe(
+      "→ run_greeting",
+    );
+    expect(describeConditionSource("{{tasks.Flag.outputs.flag}}")).toBe(
+      "→ Flag.flag",
+    );
+  });
+
+  it("is undefined for literals and absent references", () => {
+    expect(describeConditionSource(undefined)).toBeUndefined();
+    expect(describeConditionSource("false")).toBeUndefined();
+  });
+});

--- a/src/utils/conditionalExecution.ts
+++ b/src/utils/conditionalExecution.ts
@@ -1,24 +1,51 @@
 import type { ArgumentType, ComponentSpec, Task } from "@/models/componentSpec";
+import { bindingToArgumentReference } from "@/models/componentSpec/bindingReference";
 
-import { isGraphInputArgument, isTaskOutputArgument } from "./componentSpec";
+import {
+  GRAPH_INPUT_REGEX,
+  isGraphInputArgument,
+  isTaskOutputArgument,
+  TASK_OUTPUT_REGEX,
+} from "./componentSpec";
 
 /**
- * Reserved binding port name used to model the virtual "Is enabled?" input on a
- * task node. A connection to this port is serialized to `TaskSpec.isEnabled`
- * instead of `TaskSpec.arguments[...]`. The sentinel is intentionally unlikely
- * to collide with a real component input name.
+ * Reserved binding port name for a task's run condition. A connection to this
+ * port serializes to `TaskSpec.isEnabled` instead of `TaskSpec.arguments[...]`.
+ * The sentinel is intentionally unlikely to collide with a component input name.
  */
 export const IS_ENABLED_PORT_NAME = "__is_enabled__";
 
-/** Human-readable label shown for the virtual "Is enabled?" input. */
-export const IS_ENABLED_INPUT_LABEL = "Is enabled?";
+export const RUN_CONDITION_LABEL = "Run when";
 
-const GRAPH_INPUT_REGEX = /^\{\{inputs\.([^}]+)\}\}$/;
-const TASK_OUTPUT_REGEX = /^\{\{tasks\.([^.]+)\.outputs\.([^}]+)\}\}$/;
+export const RUN_CONDITION_INPUT_NAME = "run_condition";
 
 /**
- * True when an `isEnabled` value is a reference to an upstream value (a graph
- * input or a sibling task output) rather than a plain literal such as `"false"`.
+ * The runtime contract for `isEnabled` is the strings `"true"` / `"false"`, and
+ * port compatibility is an exact type-name match — a `Boolean` input would not
+ * be offered for the `String` arguments components actually declare.
+ */
+export const RUN_CONDITION_INPUT_TYPE = "String";
+
+export type ConditionLiteral = "true" | "false";
+
+export const CONDITION_LITERAL_LABELS: Record<ConditionLiteral, string> = {
+  true: "Always",
+  false: "Never",
+};
+
+/**
+ * The editor only ever writes the canonical strings, but a hand-authored or
+ * SDK-generated pipeline can carry an unquoted YAML `false` (a JS boolean at
+ * runtime, whatever the declared type says) or `"False"` — both of which the
+ * backend honours, so both have to read as the negative literal here.
+ */
+export function toConditionLiteral(value: unknown): ConditionLiteral {
+  return String(value).trim().toLowerCase() === "false" ? "false" : "true";
+}
+
+/**
+ * True when an `isEnabled` value points at an upstream value (a graph input or a
+ * sibling task output) rather than holding a literal such as `"false"`.
  */
 export function isConditionalArgument(
   value: ArgumentType | undefined,
@@ -55,10 +82,7 @@ export function isTaskConditional(
   );
 }
 
-/**
- * The upstream reference a task is gated on, in the shape it serializes to, or
- * undefined when the task is gated on a literal.
- */
+/** The upstream reference a task is gated on, in the shape it serializes to. */
 export function resolveConditionalReference(
   task: Task,
   spec: ComponentSpec | null | undefined,
@@ -66,20 +90,31 @@ export function resolveConditionalReference(
   const binding = findConditionalBinding(spec, task.$id);
   if (!binding || !spec) return undefined;
 
-  const sourceTask = spec.tasks.find((t) => t.$id === binding.sourceEntityId);
-  if (sourceTask) {
-    return {
-      taskOutput: {
-        taskId: sourceTask.name,
-        outputName: binding.sourcePortName,
-      },
-    };
-  }
+  return bindingToArgumentReference(binding, spec);
+}
 
-  const sourceInput = spec.inputs.find((i) => i.$id === binding.sourceEntityId);
-  if (sourceInput) {
-    return { graphInput: { inputName: sourceInput.name } };
+/**
+ * Handles the raw template form as well as the structured one, because a task
+ * whose reference could not be resolved to a binding on load still holds the
+ * template — and without it a dangling reference would fall back to the literal
+ * label and read as "Always".
+ */
+export function describeConditionSource(
+  reference: ArgumentType | undefined,
+): string | undefined {
+  if (isTaskOutputArgument(reference)) {
+    const { taskId, outputName } = reference.taskOutput;
+    return `→ ${taskId}.${outputName}`;
   }
+  if (isGraphInputArgument(reference)) {
+    return `→ ${reference.graphInput.inputName}`;
+  }
+  if (typeof reference === "string") {
+    const graphInput = reference.match(GRAPH_INPUT_REGEX);
+    if (graphInput) return `→ ${graphInput[1]}`;
 
+    const taskOutput = reference.match(TASK_OUTPUT_REGEX);
+    if (taskOutput) return `→ ${taskOutput[1]}.${taskOutput[2]}`;
+  }
   return undefined;
 }


### PR DESCRIPTION
## Description

Final pass over conditional execution. Nothing changes about what gets sent to the backend — this is UI, vocabulary and test coverage. The visual direction is borrowed from the exploration in #2649.

**"Run when", not "isEnabled".** `isEnabled` is spec jargon. The UI now says **Run when**, and the two literal choices read **Always** / **Never** rather than true/false.

**Conditional execution gets its own purple box in the Config tab.** A single switch turns it on for a task. When it's on, the **Run when** control appears inside the box — either the Always/Never toggle, or, if something is wired into it, the upstream source it follows (`→ Flag.flag`), formatted the same way bound inputs are formatted everywhere else in the editor.

**On the node, the condition is separate from the inputs.** It used to be injected into the task's input list as a fake input, which meant the list had to know about it in every place it did anything (splitting, condensing, counting). It's now its own purple row above the inputs with its own handle, which means:

- it stays visible when a node's inputs are condensed, instead of being counted into "+3 more"
- the input-list code went back to exactly what it is on master — the whole special case is gone
- collapsed nodes get the same treatment: a purple handle plus a branch icon

**Dragging off the "Run when" handle no longer creates a graph input called** **`__is_enabled__`.** The editor names an auto-created input after the port you dragged from, and the reserved port name was leaking into the user's pipeline. It now creates an input called `run_condition`, typed `String` — that's the form the condition is actually read in, and it's what lets the input connect to the ports components declare.

**Naming and comments.** Internal names now say what they are (`resetRunCondition`, `runConditionBinding`, `setRunCondition`, …). Comments that narrated the code were deleted; the ones left explain a decision the code can't.

**Tests.** New coverage for the shared helpers, the enable/disable actions (including that switching conditional execution off clears both the literal and the connection while leaving other connections alone), the node rendering, the auto-created input, and each of the fixes below.

### Fixes from review

- **A hand-written or SDK-generated pipeline can set the condition to an unquoted `false`.** That now reads as **Never**; before, it showed as **Always** while the backend skipped the task — the display and the behaviour disagreed.
- **A condition pointing at something that no longer exists** now shows what it pointed at, instead of quietly falling back to **Always**. Loading such a pipeline also keeps the condition rather than leaving the task ungated.
- **Grouping tasks into a subgraph, and ungrouping them again, no longer leaks the internal port name into the pipeline.** A promoted condition becomes a readable `run_condition` input, and a fixed condition survives the round trip.
- **Dragging off the handle of a task set to Never no longer ungates it.** The auto-created input now starts out holding the task's own condition, so the task keeps running when it was set to.
- **The Run when control is now properly labelled for screen readers.**
- One violet palette, one icon and one stated reason for both, so the condition row can't drift apart between the full and collapsed node.

## Related Issue and Pull requests

Stacked on #2651. UI direction borrowed from #2649. Followed by #2658, which stops conditional execution being set where the backend won't honour it.

## Type of Change

- [x] Improvement

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

![image.png](https://app.graphite.com/user-attachments/assets/867473a8-dde6-490d-b617-311386ab3a2f.png)

![image.png](https://app.graphite.com/user-attachments/assets/29830e75-b968-45dc-8052-8b3903daa8dc.png)

![image.png](https://app.graphite.com/user-attachments/assets/4b780085-7d4a-4f78-97da-504426663f52.png)

![image.png](https://app.graphite.com/user-attachments/assets/dbdeaf0d-4da1-45c9-b7fe-3f641e6a2cd9.png)



## Test Instructions

The `conditional-execution` flag is off by default — turn it on in Settings first.

1. Select a task → **Config** tab → toggle **Conditional execution**. The purple box expands to show **Run when**, and the node grows a purple row.
2. Flip **Run when** between Always and Never; the node's row should follow.
3. Condense the node's inputs — the condition row stays visible.
4. Drag from the node's purple handle onto empty canvas. You should get a `run_condition` String graph input, **not** one named `__is_enabled__`.
5. Set a task to **Never**, then drag off its handle. The new input should already hold `false`, and the task should still read as gated off — not silently switch to running.
6. Wire a task output into the handle. Both the node and the Config panel should read `→ Task.output`.
7. Delete that edge. The task stays conditional and resets to **Always** rather than silently staying Never.
8. Export the pipeline YAML and re-import it — the condition should survive the round trip.
9. Hand-edit a pipeline's YAML to set a task's condition to a bare `false` (no quotes), then open it. The task should read **Never**.
10. Select a conditional task and a neighbour, group them into a subgraph, then ungroup them. The condition should come back intact, and no input named `__is_enabled__` should appear anywhere.

## Additional Comments

Turning conditional execution off deliberately clears the condition (both the literal and any connection) rather than remembering it, so re-enabling starts from Always. That's the trade discussed in #2651.

