### PR TITLE
fix: Do not allow conditional execution on Subgraph Nodes + Validations

### DIFF
--- a/src/models/componentSpec/__tests__/validation/validateSpec.test.ts
+++ b/src/models/componentSpec/__tests__/validation/validateSpec.test.ts
@@ -1,16 +1,22 @@
 import { describe, expect, it } from "vitest";
 
+import { IS_ENABLED_PORT_NAME } from "@/utils/conditionalExecution";
+
 import { Binding } from "../../entities/binding";
 import { ComponentSpec } from "../../entities/componentSpec";
 import { Input } from "../../entities/input";
 import { Output } from "../../entities/output";
 import { Task } from "../../entities/task";
-import type { ComponentSpecJson } from "../../entities/types";
+import type { ComponentSpecJson, TypeSpecType } from "../../entities/types";
 import { validateSpec } from "../../validation/validateSpec";
 
 function makeSpec(name = "TestPipeline"): ComponentSpec {
   return new ComponentSpec({ $id: "spec_1", name });
 }
+
+const containerComponentSpec: ComponentSpecJson = {
+  implementation: { container: { image: "python:3.11" } },
+};
 
 function makeTask(id: string, name: string, spec?: ComponentSpecJson): Task {
   return new Task({
@@ -501,6 +507,281 @@ describe("validateSpec", () => {
         i.message.includes("requiredInput"),
       );
       expect(missingInput).toBeUndefined();
+    });
+  });
+
+  describe("conditional execution rules", () => {
+    const graphComponentSpec: ComponentSpecJson = {
+      implementation: { graph: { tasks: {} } },
+    };
+
+    const conditionalIssues = (spec: ComponentSpec) =>
+      validateSpec(spec).filter(
+        (i) => i.issueCode === "CONDITIONAL_EXECUTION_UNSUPPORTED",
+      );
+
+    it("reports error for a subgraph gated on a literal", () => {
+      const spec = makeSpec();
+      const task = makeTask("t1", "Inner", graphComponentSpec);
+      task.setIsEnabled("false");
+      spec.addTask(task);
+
+      expect(conditionalIssues(spec)).toContainEqual(
+        expect.objectContaining({
+          type: "task",
+          message: "Conditional execution is not supported on subgraphs",
+          entityId: "t1",
+          severity: "error",
+        }),
+      );
+    });
+
+    it("reports error for a subgraph gated on a connected condition", () => {
+      const spec = makeSpec();
+      spec.addTask(makeTask("t1", "Flag"));
+      spec.addTask(makeTask("t2", "Inner", graphComponentSpec));
+      spec.addBinding(
+        makeBinding("b1", "t1", "flag", "t2", IS_ENABLED_PORT_NAME),
+      );
+
+      expect(conditionalIssues(spec)).toHaveLength(1);
+    });
+
+    it("allows a container task to be conditional", () => {
+      const spec = makeSpec();
+      const task = makeTask("t1", "Greet");
+      task.setIsEnabled("false");
+      spec.addTask(task);
+
+      expect(conditionalIssues(spec)).toHaveLength(0);
+    });
+
+    it("allows a subgraph with no run condition", () => {
+      const spec = makeSpec();
+      spec.addTask(makeTask("t1", "Inner", graphComponentSpec));
+
+      expect(conditionalIssues(spec)).toHaveLength(0);
+    });
+
+    it("is the error that blocks submission", () => {
+      const spec = makeSpec();
+      const task = makeTask("t1", "Inner", graphComponentSpec);
+      task.setIsEnabled("false");
+      spec.addTask(task);
+
+      expect(spec.isValid).toBe(false);
+
+      task.setIsEnabled(undefined);
+
+      expect(spec.isValid).toBe(true);
+    });
+  });
+
+  describe("reserved input name rules", () => {
+    const componentDeclaringReservedInput: ComponentSpecJson = {
+      ...containerComponentSpec,
+      inputs: [{ name: IS_ENABLED_PORT_NAME, optional: true }],
+    };
+
+    const reservedNameIssues = (spec: ComponentSpec) =>
+      validateSpec(spec).filter((i) => i.issueCode === "RESERVED_INPUT_NAME");
+
+    it("warns when a component declares the reserved input", () => {
+      const spec = makeSpec();
+      spec.addTask(makeTask("t1", "Greet", componentDeclaringReservedInput));
+
+      expect(reservedNameIssues(spec)).toContainEqual(
+        expect.objectContaining({
+          type: "task",
+          entityId: "t1",
+          severity: "warning",
+          argumentName: IS_ENABLED_PORT_NAME,
+        }),
+      );
+    });
+
+    it("does not block submission while the reserved input is unconnected", () => {
+      const spec = makeSpec();
+      spec.addTask(makeTask("t1", "Greet", componentDeclaringReservedInput));
+
+      expect(spec.isValid).toBe(true);
+    });
+
+    it("errors once connected, because saving would drop the argument", () => {
+      const spec = makeSpec();
+      spec.addTask(makeTask("t1", "Flag", containerComponentSpec));
+      spec.addTask(makeTask("t2", "Greet", componentDeclaringReservedInput));
+      spec.addBinding(
+        makeBinding("b1", "t1", "flag", "t2", IS_ENABLED_PORT_NAME),
+      );
+
+      expect(reservedNameIssues(spec)).toContainEqual(
+        expect.objectContaining({ entityId: "t2", severity: "error" }),
+      );
+      expect(spec.isValid).toBe(false);
+    });
+
+    it("ignores components with ordinary input names", () => {
+      const spec = makeSpec();
+      spec.addTask(
+        makeTask("t1", "Greet", {
+          ...containerComponentSpec,
+          inputs: [{ name: "name", optional: true }],
+        }),
+      );
+
+      expect(reservedNameIssues(spec)).toHaveLength(0);
+    });
+  });
+
+  describe("condition source type rules", () => {
+    const componentWithFlagOutput = (
+      type?: TypeSpecType,
+    ): ComponentSpecJson => ({
+      ...containerComponentSpec,
+      outputs: [{ name: "flag", type }],
+    });
+
+    const typeIssues = (spec: ComponentSpec) =>
+      validateSpec(spec).filter(
+        (i) => i.issueCode === "CONDITION_SOURCE_TYPE_MISMATCH",
+      );
+
+    const gateOnTaskOutput = (type?: TypeSpecType) => {
+      const spec = makeSpec();
+      spec.addTask(makeTask("t1", "Flag", componentWithFlagOutput(type)));
+      spec.addTask(makeTask("t2", "Greet", containerComponentSpec));
+      spec.addBinding(
+        makeBinding("b1", "t1", "flag", "t2", IS_ENABLED_PORT_NAME),
+      );
+      return spec;
+    };
+
+    it("blocks submission when the condition comes from a numeric output", () => {
+      const spec = gateOnTaskOutput("Integer");
+
+      expect(typeIssues(spec)).toContainEqual(
+        expect.objectContaining({
+          type: "task",
+          entityId: "t2",
+          severity: "error",
+          referencedName: "Integer",
+        }),
+      );
+      expect(spec.isValid).toBe(false);
+    });
+
+    it("accepts the types a condition can actually be read from", () => {
+      expect(typeIssues(gateOnTaskOutput("String"))).toHaveLength(0);
+      expect(typeIssues(gateOnTaskOutput("Boolean"))).toHaveLength(0);
+      expect(typeIssues(gateOnTaskOutput("boolean"))).toHaveLength(0);
+      expect(typeIssues(gateOnTaskOutput("Any"))).toHaveLength(0);
+      expect(typeIssues(gateOnTaskOutput(undefined))).toHaveLength(0);
+      expect(typeIssues(gateOnTaskOutput({ Enum: "yes/no" }))).toHaveLength(0);
+    });
+
+    it("accepts the aliases a hand-written component might use", () => {
+      expect(typeIssues(gateOnTaskOutput("bool"))).toHaveLength(0);
+      expect(typeIssues(gateOnTaskOutput("str"))).toHaveLength(0);
+      expect(typeIssues(gateOnTaskOutput("Text"))).toHaveLength(0);
+    });
+
+    it("errors when the condition comes from a numeric pipeline input", () => {
+      const spec = makeSpec();
+      spec.addInput(
+        new Input({ $id: "i1", name: "threshold", type: "Integer" }),
+      );
+      spec.addTask(makeTask("t1", "Greet"));
+      spec.addBinding(
+        makeBinding("b1", "i1", "threshold", "t1", IS_ENABLED_PORT_NAME),
+      );
+
+      expect(typeIssues(spec)).toHaveLength(1);
+    });
+
+    it("stays quiet for a fixed condition, which has no source", () => {
+      const spec = makeSpec();
+      const task = makeTask("t1", "Greet");
+      task.setIsEnabled("false");
+      spec.addTask(task);
+
+      expect(typeIssues(spec)).toHaveLength(0);
+    });
+
+    it("defers to the unsupported error on subgraphs", () => {
+      const spec = makeSpec();
+      spec.addTask(makeTask("t1", "Flag", componentWithFlagOutput("Integer")));
+      spec.addTask(
+        makeTask("t2", "Inner", { implementation: { graph: { tasks: {} } } }),
+      );
+      spec.addBinding(
+        makeBinding("b1", "t1", "flag", "t2", IS_ENABLED_PORT_NAME),
+      );
+
+      expect(typeIssues(spec)).toHaveLength(0);
+    });
+  });
+
+  describe("fixed run condition rules", () => {
+    const conditionIssues = (spec: ComponentSpec) =>
+      validateSpec(spec).filter((i) => i.issueCode === "INVALID_RUN_CONDITION");
+
+    const gateOnLiteral = (condition: string) => {
+      const spec = makeSpec();
+      const task = makeTask("t1", "Greet", containerComponentSpec);
+      task.setIsEnabled(condition);
+      spec.addTask(task);
+      return spec;
+    };
+
+    it("blocks submission on a condition the runtime cannot read", () => {
+      const spec = gateOnLiteral("yes");
+
+      expect(conditionIssues(spec)).toContainEqual(
+        expect.objectContaining({
+          type: "task",
+          entityId: "t1",
+          severity: "error",
+          referencedName: "yes",
+        }),
+      );
+      expect(spec.isValid).toBe(false);
+    });
+
+    it("accepts the canonical literals however they were written", () => {
+      expect(conditionIssues(gateOnLiteral("true"))).toHaveLength(0);
+      expect(conditionIssues(gateOnLiteral("false"))).toHaveLength(0);
+      expect(conditionIssues(gateOnLiteral("False"))).toHaveLength(0);
+      expect(conditionIssues(gateOnLiteral(" TRUE\n"))).toHaveLength(0);
+    });
+
+    it("stays quiet for a task with no run condition", () => {
+      const spec = makeSpec();
+      spec.addTask(makeTask("t1", "Greet", containerComponentSpec));
+
+      expect(conditionIssues(spec)).toHaveLength(0);
+    });
+
+    it("stays quiet for a connected condition, whose value is not known yet", () => {
+      const spec = makeSpec();
+      const task = makeTask("t1", "Greet", containerComponentSpec);
+      task.setIsEnabled({
+        taskOutput: { taskId: "Flag", outputName: "flag" },
+      });
+      spec.addTask(task);
+
+      expect(conditionIssues(spec)).toHaveLength(0);
+    });
+
+    it("defers to the unsupported error on subgraphs", () => {
+      const spec = makeSpec();
+      const task = makeTask("t1", "Inner", {
+        implementation: { graph: { tasks: {} } },
+      });
+      task.setIsEnabled("yes");
+      spec.addTask(task);
+
+      expect(conditionIssues(spec)).toHaveLength(0);
     });
   });
 

--- a/src/models/componentSpec/entities/task.ts
+++ b/src/models/componentSpec/entities/task.ts
@@ -65,6 +65,11 @@ export class Task extends Model({
   }
 
   @computed
+  get isSubgraph(): boolean {
+    return isGraphImplementation(this.resolvedComponentSpec?.implementation);
+  }
+
+  @computed
   get resolvedComponentRef(): ComponentReference {
     if (!this.subgraphSpec) {
       return this.componentRef;

--- a/src/models/componentSpec/validation/types.ts
+++ b/src/models/componentSpec/validation/types.ts
@@ -22,7 +22,11 @@ export type ValidationIssueCode =
   | "EMPTY_COMPONENT_NAME"
   | "NO_TASKS"
   | "ORPHANED_BINDING_SOURCE"
-  | "ORPHANED_BINDING_TARGET";
+  | "ORPHANED_BINDING_TARGET"
+  | "CONDITIONAL_EXECUTION_UNSUPPORTED"
+  | "RESERVED_INPUT_NAME"
+  | "INVALID_RUN_CONDITION"
+  | "CONDITION_SOURCE_TYPE_MISMATCH";
 
 export interface ValidationIssue {
   type: ValidationIssueType;

--- a/src/models/componentSpec/validation/validateSpec.ts
+++ b/src/models/componentSpec/validation/validateSpec.ts
@@ -6,13 +6,19 @@ import {
   parseSchemaToAnnotationConfig,
 } from "@/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/utils";
 import { isInvalidComponentReference } from "@/utils/componentSpec";
+import {
+  IS_ENABLED_PORT_NAME,
+  isConditionalArgument,
+  isConditionalExecutionSupported,
+  isTaskConditional,
+} from "@/utils/conditionalExecution";
 
 import type { Binding } from "../entities/binding";
 import type { ComponentSpec } from "../entities/componentSpec";
 import type { Input } from "../entities/input";
 import type { Output } from "../entities/output";
 import type { Task } from "../entities/task";
-import type { InputSpec } from "../entities/types";
+import type { InputSpec, TypeSpecType } from "../entities/types";
 import { isGraphInputArgument, isTaskOutputArgument } from "../entities/types";
 import { isPipelineInputMissingConfiguredValue } from "./pipelineInputValue";
 import type { ValidationIssue } from "./types";
@@ -228,8 +234,167 @@ function validateSingleTask(
   issues.push(...validateTaskArguments(task, spec));
   issues.push(...validateTaskRequiredInputs(task, spec));
   issues.push(...validateLauncherTaskAnnotations(task));
+  issues.push(...validateConditionalExecution(task, spec));
+  issues.push(...validateReservedInputName(task, spec));
+  issues.push(...validateRunConditionLiteral(task));
+  issues.push(...validateConditionSourceType(task, spec));
 
   return issues;
+}
+
+/**
+ * The editor hides the condition controls for subgraphs, so this only fires on
+ * externally-authored pipelines — where it has to block submission rather than
+ * let run creation fail with a raw backend error.
+ */
+function validateConditionalExecution(
+  task: Task,
+  spec: ComponentSpec,
+): ValidationIssue[] {
+  if (isConditionalExecutionSupported(task)) return [];
+  if (!isTaskConditional(task, spec)) return [];
+
+  return [
+    {
+      type: "task",
+      message: "Conditional execution is not supported on subgraphs",
+      entityId: task.$id,
+      severity: "error",
+      issueCode: "CONDITIONAL_EXECUTION_UNSUPPORTED",
+    },
+  ];
+}
+
+function findConditionBinding(task: Task, spec: ComponentSpec) {
+  return spec.bindings.find(
+    (b) =>
+      b.targetEntityId === task.$id &&
+      b.targetPortName === IS_ENABLED_PORT_NAME,
+  );
+}
+
+/**
+ * A run condition is a binding to a reserved pseudo-port, which shares the
+ * `targetPortName` namespace with real input ports. A component declaring an
+ * input under that name is therefore indistinguishable from a gated task: on
+ * save the connection serializes to `isEnabled` and the argument is dropped.
+ */
+function validateReservedInputName(
+  task: Task,
+  spec: ComponentSpec,
+): ValidationIssue[] {
+  const declaresReservedInput = task.resolvedComponentSpec?.inputs?.some(
+    (input) => input.name === IS_ENABLED_PORT_NAME,
+  );
+  if (!declaresReservedInput) return [];
+
+  const isConnected = findConditionBinding(task, spec) !== undefined;
+
+  return [
+    {
+      type: "task",
+      message: `Component input "${IS_ENABLED_PORT_NAME}" is reserved for run conditions`,
+      entityId: task.$id,
+      severity: isConnected ? "error" : "warning",
+      issueCode: "RESERVED_INPUT_NAME",
+      argumentName: IS_ENABLED_PORT_NAME,
+    },
+  ];
+}
+
+function isRunConditionLiteral(value: unknown): boolean {
+  if (typeof value === "boolean") return true;
+  return (
+    typeof value === "string" &&
+    ["true", "false"].includes(value.trim().toLowerCase())
+  );
+}
+
+/**
+ * The orchestrator rejects a condition that does not resolve to `true` or
+ * `false`, and it does so once it reaches the task — after everything upstream
+ * has already run. A fixed condition can be checked before submission, so it is.
+ */
+function validateRunConditionLiteral(task: Task): ValidationIssue[] {
+  if (!isConditionalExecutionSupported(task)) return [];
+
+  const condition = task.isEnabled;
+  if (condition === undefined) return [];
+  if (isConditionalArgument(condition)) return [];
+  if (isRunConditionLiteral(condition)) return [];
+
+  const shown = typeof condition === "string" ? condition : undefined;
+
+  return [
+    {
+      type: "task",
+      message: shown
+        ? `Run condition "${shown}" must be true or false`
+        : "Run condition must be true or false",
+      entityId: task.$id,
+      severity: "error",
+      issueCode: "INVALID_RUN_CONDITION",
+      referencedName: shown,
+    },
+  ];
+}
+
+/**
+ * The aliases matter: this blocks submission, so a hand-written `bool` or `str`
+ * must not be mistaken for a mismatch.
+ */
+const CONDITION_SOURCE_TYPES = [
+  "string",
+  "str",
+  "text",
+  "boolean",
+  "bool",
+  "any",
+];
+
+/**
+ * A condition that resolves to anything but `true` or `false` fails the run at
+ * the point the task is reached, so a declared type that cannot produce either
+ * is worth blocking up front. Structured and absent types make no claim about
+ * the value, and a declared type is only a claim — a `String` source can still
+ * carry something unusable, which no static check will catch.
+ */
+function validateConditionSourceType(
+  task: Task,
+  spec: ComponentSpec,
+): ValidationIssue[] {
+  if (!isConditionalExecutionSupported(task)) return [];
+
+  const binding = findConditionBinding(task, spec);
+  if (!binding) return [];
+
+  const sourceType = resolveBindingSourceType(binding, spec);
+  if (typeof sourceType !== "string") return [];
+  if (CONDITION_SOURCE_TYPES.includes(sourceType.toLowerCase())) return [];
+
+  return [
+    {
+      type: "task",
+      message: `Run condition is connected to a ${sourceType} value, which cannot be read as true or false`,
+      entityId: task.$id,
+      severity: "error",
+      issueCode: "CONDITION_SOURCE_TYPE_MISMATCH",
+      referencedName: sourceType,
+    },
+  ];
+}
+
+function resolveBindingSourceType(
+  binding: Binding,
+  spec: ComponentSpec,
+): TypeSpecType | undefined {
+  const sourceInput = spec.inputs.find((i) => i.$id === binding.sourceEntityId);
+  if (sourceInput) return sourceInput.type;
+
+  const sourceTask = spec.tasks.find((t) => t.$id === binding.sourceEntityId);
+  return sourceTask?.resolvedComponentSpec?.outputs?.find(
+    (output) => output.name === binding.sourcePortName,
+  )?.type;
 }
 
 function taskAnnotationsAsStringRecord(task: Task): Record<string, string> {

--- a/src/routes/v2/pages/Editor/components/IssueResolution/ValidationIssueResolutionCard.tsx
+++ b/src/routes/v2/pages/Editor/components/IssueResolution/ValidationIssueResolutionCard.tsx
@@ -10,8 +10,10 @@ import type {
   ValidationIssueCode,
 } from "@/models/componentSpec";
 import { useSpec } from "@/routes/v2/shared/providers/SpecContext";
+import { IS_ENABLED_PORT_NAME } from "@/utils/conditionalExecution";
 
 import { BadReferenceResolution } from "./resolutions/BadReferenceResolution";
+import { ConditionalExecutionResolution } from "./resolutions/ConditionalExecutionResolution";
 import { DeleteEntityResolution } from "./resolutions/DeleteEntityResolution";
 import { DuplicateNameResolution } from "./resolutions/DuplicateNameResolution";
 import { InfoOnlyResolution } from "./resolutions/InfoOnlyResolution";
@@ -192,6 +194,21 @@ const RESOLUTION_MAP: Record<ValidationIssueCode, ResolutionResolver> = {
   NO_TASKS: () =>
     renderInfoResolution(
       "Add tasks to the pipeline from the component library.",
+    ),
+  CONDITIONAL_EXECUTION_UNSUPPORTED: (p) => (
+    <ConditionalExecutionResolution issue={p.issue} spec={p.spec} />
+  ),
+  RESERVED_INPUT_NAME: () =>
+    renderInfoResolution(
+      `The editor reserves "${IS_ENABLED_PORT_NAME}" for run conditions, so an input of that name cannot be connected — its value would be saved as the task's run condition instead. Rename the input in the component definition, or use a component that does not declare it.`,
+    ),
+  INVALID_RUN_CONDITION: () =>
+    renderInfoResolution(
+      "A run condition has to be true or false. Set it from the task's Config tab, or connect it to a value that resolves to true or false.",
+    ),
+  CONDITION_SOURCE_TYPE_MISMATCH: () =>
+    renderInfoResolution(
+      "A run condition is read as the text true or false. Connect the condition to a String or Boolean value, or gate the task on a fixed condition instead.",
     ),
 };
 

--- a/src/routes/v2/pages/Editor/components/IssueResolution/resolutions/ConditionalExecutionResolution.tsx
+++ b/src/routes/v2/pages/Editor/components/IssueResolution/resolutions/ConditionalExecutionResolution.tsx
@@ -1,0 +1,79 @@
+import { observer } from "mobx-react-lite";
+
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icon";
+import { BlockStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
+import type { ComponentSpec, ValidationIssue } from "@/models/componentSpec";
+import { useValidationResolutionActions } from "@/routes/v2/pages/Editor/components/IssueResolution/useValidationResolutionActions";
+import { findTaskById } from "@/routes/v2/pages/Editor/components/IssueResolution/validationResolution.utils";
+import {
+  describeConditionSource,
+  resolveConditionalReference,
+} from "@/utils/conditionalExecution";
+import { tracking } from "@/utils/tracking";
+
+import { InfoOnlyResolution } from "./InfoOnlyResolution";
+
+export const ConditionalExecutionResolution = observer(
+  function ConditionalExecutionResolution({
+    issue,
+    spec,
+  }: {
+    issue: ValidationIssue;
+    spec: ComponentSpec;
+  }) {
+    const { removeConditionalExecution } = useValidationResolutionActions();
+
+    if (!issue.entityId) {
+      return (
+        <InfoOnlyResolution message="Cannot resolve: missing task information." />
+      );
+    }
+
+    const task = findTaskById(spec, issue.entityId);
+    if (!task) {
+      return (
+        <InfoOnlyResolution message="Task not found in the current graph." />
+      );
+    }
+
+    const conditionSource = describeConditionSource(
+      resolveConditionalReference(task, spec),
+    );
+
+    return (
+      <BlockStack gap="3">
+        <BlockStack gap="2">
+          <Text
+            size="xs"
+            weight="semibold"
+            className="text-gray-700 dark:text-foreground"
+          >
+            Remove the run condition from &ldquo;{task.name}&rdquo;
+          </Text>
+          <Text size="xs" tone="subdued">
+            Runs cannot be submitted while a subgraph is gated on a condition.
+          </Text>
+          {conditionSource && (
+            <Text size="xs" tone="subdued">
+              Current condition: {conditionSource}
+            </Text>
+          )}
+        </BlockStack>
+
+        <Button
+          variant="outline"
+          size="sm"
+          {...tracking(
+            "v2.pipeline_editor.pipeline_tree.resolution.remove_conditional_execution",
+          )}
+          onClick={() => removeConditionalExecution(spec, task)}
+        >
+          <Icon name="Unlink" size="xs" />
+          Remove Condition
+        </Button>
+      </BlockStack>
+    );
+  },
+);

--- a/src/routes/v2/pages/Editor/components/IssueResolution/useValidationResolutionActions.ts
+++ b/src/routes/v2/pages/Editor/components/IssueResolution/useValidationResolutionActions.ts
@@ -5,6 +5,7 @@ import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 import {
   deleteDuplicate,
   deleteEntity,
+  removeConditionalExecution,
   renameDuplicate,
   renameEntity,
   unsetBadReference,
@@ -61,6 +62,10 @@ export function useValidationResolutionActions() {
       argumentName: string,
     ) => {
       unsetBadReference(undo, task, spec, argumentName);
+      clearIssue();
+    },
+    removeConditionalExecution: (spec: ComponentSpec, task: Task) => {
+      removeConditionalExecution(undo, spec, task);
       clearIssue();
     },
   };

--- a/src/routes/v2/pages/Editor/components/IssueResolution/validationResolution.actions.ts
+++ b/src/routes/v2/pages/Editor/components/IssueResolution/validationResolution.actions.ts
@@ -1,5 +1,6 @@
 import type { ComponentSpec, Task } from "@/models/componentSpec";
 import type { UndoGroupable } from "@/routes/v2/shared/nodes/types";
+import { clearConditionalExecution } from "@/utils/conditionalExecution";
 
 export function deleteEntity(
   undo: UndoGroupable,
@@ -80,6 +81,16 @@ export function deleteDuplicate(
     } else {
       spec.removeOutputById(entityId);
     }
+  });
+}
+
+export function removeConditionalExecution(
+  undo: UndoGroupable,
+  spec: ComponentSpec,
+  task: Task,
+) {
+  undo.withGroup("Remove conditional execution", () => {
+    clearConditionalExecution(spec, task);
   });
 }
 

--- a/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/components/ConfigurationSection.tsx
+++ b/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/components/ConfigurationSection.tsx
@@ -32,6 +32,7 @@ import {
 import {
   CONDITION_LITERAL_LABELS,
   describeConditionSource,
+  isConditionalExecutionSupported,
   isTaskConditional,
   resolveConditionalReference,
   RUN_CONDITION_LABEL,
@@ -60,7 +61,7 @@ export const ConfigurationSection = observer(function ConfigurationSection({
     setConditionalExecution,
     setRunCondition,
   } = useTaskConfigActions();
-  const isSubgraph = task.subgraphSpec !== undefined;
+  const isSubgraph = task.isSubgraph;
   const conditionalSwitchId = useId();
   const runConditionLabelId = useId();
 
@@ -197,7 +198,7 @@ export const ConfigurationSection = observer(function ConfigurationSection({
         />
       </InlineStack>
 
-      {conditionalExecutionEnabled && (
+      {conditionalExecutionEnabled && isConditionalExecutionSupported(task) && (
         <>
           <Separator />
 

--- a/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/components/taskConfig.actions.ts
+++ b/src/routes/v2/pages/Editor/nodes/TaskNode/context/TaskDetails/components/taskConfig.actions.ts
@@ -6,7 +6,7 @@ import {
   TASK_COLOR_ANNOTATION,
 } from "@/utils/annotations";
 import type { ConditionLiteral } from "@/utils/conditionalExecution";
-import { IS_ENABLED_PORT_NAME } from "@/utils/conditionalExecution";
+import { clearConditionalExecution } from "@/utils/conditionalExecution";
 import { ISO8601_DURATION_ZERO_DAYS } from "@/utils/constants";
 
 export function toggleCacheDisable(
@@ -70,12 +70,7 @@ export function setConditionalExecution(
       return;
     }
 
-    spec.removeAllBindingsBy(
-      (b) =>
-        b.targetEntityId === task.$id &&
-        b.targetPortName === IS_ENABLED_PORT_NAME,
-    );
-    task.setIsEnabled(undefined);
+    clearConditionalExecution(spec, task);
   });
 }
 

--- a/src/routes/v2/shared/nodes/TaskNode/TaskNode.tsx
+++ b/src/routes/v2/shared/nodes/TaskNode/TaskNode.tsx
@@ -31,6 +31,7 @@ import {
   CONDITION_LITERAL_LABELS,
   describeConditionSource,
   IS_ENABLED_PORT_NAME,
+  isConditionalExecutionSupported,
   isTaskConditional,
   toConditionLiteral,
 } from "@/utils/conditionalExecution";
@@ -89,14 +90,6 @@ export interface TaskNodeViewProps {
   onInputClick: (inputName: string, event: MouseEvent | KeyboardEvent) => void;
   onOutputClick: (outputName: string, event: MouseEvent) => void;
   onHandleClick: (handleId: string, event: MouseEvent) => void;
-}
-
-function isTaskSubgraph(componentSpec: ComponentSpecJson | undefined): boolean {
-  const implementation = componentSpec?.implementation;
-  if (!implementation || typeof implementation !== "object") {
-    return false;
-  }
-  return "graph" in implementation;
 }
 
 interface InputDisplayData {
@@ -322,7 +315,7 @@ export const TaskNode = observer(function TaskNode({
     taskName: task.name,
     selected: isSelected,
     isHovered: editor.hoveredEntityId === entityId,
-    isSubgraph: isTaskSubgraph(componentSpec),
+    isSubgraph: task.isSubgraph,
     collapsed: isManuallyCollapsed,
     description,
     inputs,
@@ -334,7 +327,8 @@ export const TaskNode = observer(function TaskNode({
     cacheDisabled:
       task.executionOptions?.cachingStrategy?.maxCacheStaleness ===
       ISO8601_DURATION_ZERO_DAYS,
-    isConditional: isTaskConditional(task, spec),
+    isConditional:
+      isConditionalExecutionSupported(task) && isTaskConditional(task, spec),
     conditionDisplayValue:
       conditionReferenceLabel ??
       describeConditionSource(task.isEnabled) ??

--- a/src/utils/conditionalExecution.test.ts
+++ b/src/utils/conditionalExecution.test.ts
@@ -3,10 +3,12 @@ import { describe, expect, it } from "vitest";
 import { Binding, ComponentSpec, Input, Task } from "@/models/componentSpec";
 
 import {
+  clearConditionalExecution,
   CONDITION_LITERAL_LABELS,
   describeConditionSource,
   IS_ENABLED_PORT_NAME,
   isConditionalArgument,
+  isConditionalExecutionSupported,
   isTaskConditional,
   resolveConditionalReference,
   toConditionLiteral,
@@ -14,6 +16,20 @@ import {
 
 function makeTask(id: string, name: string) {
   return new Task({ $id: id, name, componentRef: {} });
+}
+
+function makeGraphComponentTask(id: string, name: string) {
+  return new Task({
+    $id: id,
+    name,
+    componentRef: { spec: { implementation: { graph: { tasks: {} } } } },
+  });
+}
+
+function makeEmbeddedSubgraphTask(id: string, name: string) {
+  const task = new Task({ $id: id, name, componentRef: {} });
+  task.setSubgraphSpec(new ComponentSpec({ $id: "spec_sub", name: "Inner" }));
+  return task;
 }
 
 function makeSpec(
@@ -132,6 +148,73 @@ describe("isTaskConditional", () => {
     );
 
     expect(isTaskConditional(task, spec)).toBe(false);
+  });
+});
+
+describe("isConditionalExecutionSupported", () => {
+  it("is true for a container-component task", () => {
+    expect(isConditionalExecutionSupported(makeTask("task_1", "Greet"))).toBe(
+      true,
+    );
+  });
+
+  it("is false for an embedded subgraph", () => {
+    expect(
+      isConditionalExecutionSupported(
+        makeEmbeddedSubgraphTask("task_1", "Inner"),
+      ),
+    ).toBe(false);
+  });
+
+  it("is false for a referenced graph component", () => {
+    expect(
+      isConditionalExecutionSupported(
+        makeGraphComponentTask("task_1", "Published"),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("clearConditionalExecution", () => {
+  it("removes both the literal and the reserved-port binding", () => {
+    const task = makeTask("task_1", "Greet");
+    task.setIsEnabled("false");
+    const flag = new Input({ $id: "input_1", name: "run_greeting" });
+    const spec = makeSpec(
+      [task],
+      [flag],
+      [bindToRunCondition(flag.$id, "run_greeting", task.$id)],
+    );
+
+    clearConditionalExecution(spec, task);
+
+    expect(task.isEnabled).toBeUndefined();
+    expect(isTaskConditional(task, spec)).toBe(false);
+    expect(spec.bindings).toHaveLength(0);
+  });
+
+  it("leaves bindings to other ports alone", () => {
+    const task = makeTask("task_1", "Greet");
+    task.setIsEnabled("true");
+    const name = new Input({ $id: "input_1", name: "name" });
+    const spec = makeSpec(
+      [task],
+      [name],
+      [
+        new Binding({
+          $id: "binding_1",
+          sourceEntityId: name.$id,
+          sourcePortName: "name",
+          targetEntityId: task.$id,
+          targetPortName: "name",
+        }),
+      ],
+    );
+
+    clearConditionalExecution(spec, task);
+
+    expect(task.isEnabled).toBeUndefined();
+    expect(spec.bindings).toHaveLength(1);
   });
 });
 

--- a/src/utils/conditionalExecution.ts
+++ b/src/utils/conditionalExecution.ts
@@ -82,6 +82,29 @@ export function isTaskConditional(
   );
 }
 
+/**
+ * The backend only honours `isEnabled` on container-component tasks — a graph
+ * task carrying a run condition is rejected at run creation — so the condition
+ * controls are hidden for subgraphs and the state is flagged as a validation
+ * error where it already exists.
+ */
+export function isConditionalExecutionSupported(task: Task): boolean {
+  return !task.isSubgraph;
+}
+
+/**
+ * A run condition lives in two places: the literal on the task and the binding
+ * to the reserved port. Clearing one without the other leaves the task gated.
+ */
+export function clearConditionalExecution(spec: ComponentSpec, task: Task) {
+  spec.removeAllBindingsBy(
+    (b) =>
+      b.targetEntityId === task.$id &&
+      b.targetPortName === IS_ENABLED_PORT_NAME,
+  );
+  task.setIsEnabled(undefined);
+}
+
 /** The upstream reference a task is gated on, in the shape it serializes to. */
 export function resolveConditionalReference(
   task: Task,


### PR DESCRIPTION
## Description

Conditional execution only works on tasks that run a container. The backend rejects it on subgraphs, so a pipeline that gates one fails at submission with a raw error the user can't act on.

**The control is hidden for subgraphs.** The Conditional execution box no longer appears when the selected node is a subgraph, so it can't be switched on by accident.

**Validation covers what hiding the control can't.** A pipeline can arrive with the condition already set — from the SDK, from hand-written YAML, or from an earlier version of the editor. A subgraph with a run condition is now flagged as an error that blocks submission, with a **Remove Condition** fix offered in the issue panel.

Three related checks, since the same panel was already open:

- **A component that declares an input named `__is_enabled__`** collides with the name the editor reserves for run conditions. Connecting such an input would silently save it as the task's run condition and drop the argument. It's a warning as soon as the component is used, and an error once the input is actually connected.
- **A condition wired to a value that can't be read as true or false** — a number, say — is an error. Anything else blocks submission too, and for the same reason: the run doesn't fail up front, it fails at the moment the task is reached, after everything upstream has already spent its compute. Catching it before submission is worth doing.
- **A fixed condition that isn't true or false** — someone's hand-written `yes`, or a value the editor can't make sense of — is an error, and the message quotes the offending value. Casing and stray whitespace are fine. A condition that's wired up rather than fixed is left alone, since its value isn't known until the run.

## Related Issue and Pull requests

Stacked on #2657.

## Type of Change

- [x] Bug fix

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

The `conditional-execution` flag is off by default — turn it on in Settings first.

1. Select a subgraph node → **Config** tab. There should be no Conditional execution box. Select an ordinary task and confirm it's still there.
2. Hand-edit a pipeline's YAML so a subgraph task is gated on a condition, then open it. The issue panel should show an error, submission should be blocked, and **Remove Condition** should clear it.
3. Gate an ordinary task on a number-typed output. You should get an error explaining the value can't be read as a condition, and submission should be blocked. Re-wire it to a String or Boolean output and the error should clear.
4. Hand-edit a task's condition to something like `yes`. You should get an error quoting that value. Change it to `TRUE` or ` false ` and it should be accepted.

## Additional Comments

The reserved-name check is a guard against a name collision rather than something a user is likely to hit — a component would have to declare an input called `__is_enabled__`. It's here because the failure is silent: the argument disappears on save with nothing to indicate why.

The type check accepts `str`, `bool` and `text` alongside the canonical type names. Since it blocks submission, a hand-written component using a lowercase alias shouldn't be caught by it.

One thing deliberately not done: the accepted conditions aren't normalized on load. The checks read leniently but write nothing — quietly rewriting a value in someone's pipeline is worse than reporting it.

