### PR TITLE
refactor(InfoBox): allow a body-only box

### DIFF
--- a/src/components/shared/InfoBox.tsx
+++ b/src/components/shared/InfoBox.tsx
@@ -7,7 +7,7 @@ import { Text } from "@/components/ui/typography";
 import { cn } from "@/lib/utils";
 
 interface InfoBoxProps {
-  title: string;
+  title?: string;
   width?: "full" | "fit" | "auto";
   className?: string;
   children: ReactNode;
@@ -67,15 +67,17 @@ export const InfoBox = ({
       className={cn("border rounded-md p-2", styles.container, widthClass)}
     >
       <InlineStack align="space-between" blockAlign="start" wrap="nowrap">
-        <Text
-          as="span"
-          size="sm"
-          weight="semibold"
-          className={cn("mb-1 min-w-0 wrap-break-word", styles.title)}
-          data-testid="info-box-title"
-        >
-          {title}
-        </Text>
+        {title && (
+          <Text
+            as="span"
+            size="sm"
+            weight="semibold"
+            className={cn("mb-1 min-w-0 wrap-break-word", styles.title)}
+            data-testid="info-box-title"
+          >
+            {title}
+          </Text>
+        )}
         {onDismiss && (
           <Button
             onClick={onDismiss}


### PR DESCRIPTION
## Why

A notice can carry a body with no title. `InfoBox` always rendered its title `Text`, so a body-only card opened with an empty semibold line and its `mb-1` above the content.

## What

`title` becomes optional and the `Text` renders only when there is one. Every existing caller passes a title and is unaffected.

## Reviewer notes

Previously this PR also introduced `contentHeight()` and a CSS variable for the notice strip to publish its height into. The banners now render inline on the dashboard home rather than as a strip above every route, so nothing publishes that variable — it has been removed. What was left of that change, the plain de-duplication of `calc(100vh - ${TOP_NAV_HEIGHT}px)` across six layouts, is now a standalone PR with no dependency on this stack.

The `safe-center` alignment and `tabIndex` prop this PR added to `BlockStack` / `InlineStack` existed only for the strip's horizontal scroller. That scroller is gone, so they have been dropped rather than left as unused surface.
