### PR TITLE
Enable AI Assistant and remove its feature flag

### DIFF
--- a/src/components/layout/AiModelQuickSelect.test.tsx
+++ b/src/components/layout/AiModelQuickSelect.test.tsx
@@ -4,12 +4,6 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { AiModelQuickSelect } from "./AiModelQuickSelect";
 
 const STORAGE_KEY = "tangle.aiProvider.config";
-const FLAGS_STORAGE_KEY = "betaFlags";
-
-function enableFlags(flags: Record<string, boolean>) {
-  window.localStorage.setItem(FLAGS_STORAGE_KEY, JSON.stringify(flags));
-}
-
 describe("AiModelQuickSelect", () => {
   beforeEach(() => {
     window.localStorage.clear();
@@ -22,31 +16,12 @@ describe("AiModelQuickSelect", () => {
   });
 
   it("does not render until AI provider settings are configured", () => {
-    enableFlags({ "ai-assistant": true });
-
     render(<AiModelQuickSelect />);
 
     expect(screen.queryByRole("combobox", { name: "AI model" })).toBeNull();
   });
 
-  it("does not render when both AI features are disabled", () => {
-    enableFlags({ "ai-assistant": false, "component-search-v2": false });
-    window.localStorage.setItem(
-      STORAGE_KEY,
-      JSON.stringify({
-        apiBase: "https://api.example.com/v1",
-        apiKey: "",
-        model: "gpt-4.1-mini",
-      }),
-    );
-
-    render(<AiModelQuickSelect />);
-
-    expect(screen.queryByRole("combobox", { name: "AI model" })).toBeNull();
-  });
-
-  it("shows configured model choices when component search is enabled", () => {
-    enableFlags({ "component-search-v2": true });
+  it("shows configured model choices", () => {
     window.localStorage.setItem(
       STORAGE_KEY,
       JSON.stringify({
@@ -66,24 +41,6 @@ describe("AiModelQuickSelect", () => {
     expect(screen.getByRole("option", { name: "GPT-5.5" })).toBeInTheDocument();
     expect(
       screen.getByRole("option", { name: "GPT-4.1 mini" }),
-    ).toBeInTheDocument();
-  });
-
-  it("shows configured model choices when the AI assistant is enabled", () => {
-    enableFlags({ "ai-assistant": true });
-    window.localStorage.setItem(
-      STORAGE_KEY,
-      JSON.stringify({
-        apiBase: "https://api.example.com/v1",
-        apiKey: "",
-        model: "gpt-4.1-mini",
-      }),
-    );
-
-    render(<AiModelQuickSelect />);
-
-    expect(
-      screen.getByRole("combobox", { name: "AI model" }),
     ).toBeInTheDocument();
   });
 });

--- a/src/components/layout/AiModelQuickSelect.tsx
+++ b/src/components/layout/AiModelQuickSelect.tsx
@@ -1,4 +1,3 @@
-import { useFlagValue } from "@/components/shared/Settings/useFlags";
 import {
   Select,
   SelectContent,
@@ -16,8 +15,6 @@ import {
 import { useAiProviderSettings } from "@/hooks/useAiProviderSettings";
 
 export function AiModelQuickSelect() {
-  const componentSearchEnabled = useFlagValue("component-search-v2");
-  const aiAssistantEnabled = useFlagValue("ai-assistant");
   const { config, update, isConfigured } = useAiProviderSettings();
   const configuredModel = config.model.trim();
   const options = getAiModelOptions();
@@ -28,9 +25,7 @@ export function AiModelQuickSelect() {
     update({ model: value });
   };
 
-  if ((!componentSearchEnabled && !aiAssistantEnabled) || !isConfigured) {
-    return null;
-  }
+  if (!isConfigured) return null;
 
   return (
     <Select value={selectedValue} onValueChange={handleValueChange}>

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -55,14 +55,6 @@ export const ExistingFlags: ConfigFlags = {
     category: "beta",
   },
 
-  ["ai-assistant"]: {
-    name: "AI Assistant",
-    description:
-      "Enable the AI Assistant panel in the V2 editor. Lets you chat with an assistant about your pipeline.",
-    default: false,
-    category: "beta",
-  },
-
   ["component-search-v2"]: {
     name: "Component Search",
     description:

--- a/src/routes/Settings/SettingsLayout.tsx
+++ b/src/routes/Settings/SettingsLayout.tsx
@@ -1,6 +1,5 @@
 import { Link, Outlet, useRouter } from "@tanstack/react-router";
 
-import { useFlagValue } from "@/components/shared/Settings/useFlags";
 import { Button } from "@/components/ui/button";
 import { Icon, type IconName } from "@/components/ui/icon";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
@@ -41,23 +40,16 @@ const SIDEBAR_ITEMS: SidebarItem[] = [
     icon: "Lock",
     testId: "settings-nav-secrets",
   },
+  {
+    to: "/settings/agent",
+    label: "AI Configuration",
+    icon: "Bot",
+    testId: "settings-nav-agent",
+  },
 ];
-
-const AGENT_ITEM: SidebarItem = {
-  to: "/settings/agent",
-  label: "AI Configuration",
-  icon: "Bot",
-  testId: "settings-nav-agent",
-};
 
 export function SettingsLayout() {
   const router = useRouter();
-  const componentSearchEnabled = useFlagValue("component-search-v2");
-  const aiAssistantEnabled = useFlagValue("ai-assistant");
-  const sidebarItems =
-    componentSearchEnabled || aiAssistantEnabled
-      ? [...SIDEBAR_ITEMS, AGENT_ITEM]
-      : SIDEBAR_ITEMS;
 
   const handleGoBack = () => {
     router.history.back();
@@ -90,7 +82,7 @@ export function SettingsLayout() {
               gap="1"
               className="w-48 shrink-0 border-r border-border pr-4"
             >
-              {sidebarItems.map((item) => (
+              {SIDEBAR_ITEMS.map((item) => (
                 <Link
                   key={item.to}
                   to={item.to}

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -217,14 +217,6 @@ const settingsAgentRoute = createRoute({
   getParentRoute: () => settingsLayoutRoute,
   path: "/agent",
   component: AgentSettings,
-  beforeLoad: () => {
-    if (
-      !isFlagEnabled("component-search-v2") &&
-      !isFlagEnabled("ai-assistant")
-    ) {
-      throw redirect({ to: APP_ROUTES.SETTINGS_BACKEND });
-    }
-  },
 });
 
 const settingsSecretsRoute = createRoute({

--- a/src/routes/v2/pages/Editor/EditorV2.tsx
+++ b/src/routes/v2/pages/Editor/EditorV2.tsx
@@ -101,8 +101,7 @@ const PipelineEditor = withSuspenseWrapper(
     useDebugPanelWindow();
     useTipOfTheDayWindow();
 
-    const aiEnabled = useFlagValue("ai-assistant");
-    useAiChatWindow(aiEnabled);
+    useAiChatWindow();
 
     useComponentSearchV2Window(componentSearchV2Enabled);
     useSeedInitialDockLayoutFromPreset(componentSearchV2Enabled);

--- a/src/routes/v2/pages/Editor/hooks/useAiChatWindow.tsx
+++ b/src/routes/v2/pages/Editor/hooks/useAiChatWindow.tsx
@@ -19,15 +19,11 @@ const SUGGESTED_PROMPTS_EDITOR: SuggestedPrompt[] = [
   },
 ];
 
-export function useAiChatWindow(enabled: boolean) {
+export function useAiChatWindow() {
   const { windows } = useSharedStores();
   const editorSession = useEditorSession();
 
   useEffect(() => {
-    if (!enabled) {
-      windows.closeWindow(AI_CHAT_WINDOW_ID);
-      return;
-    }
     if (windows.getWindowById(AI_CHAT_WINDOW_ID)) return;
 
     windows.openWindow(
@@ -55,5 +51,5 @@ export function useAiChatWindow(enabled: boolean) {
         ),
       },
     );
-  }, [enabled, windows, editorSession]);
+  }, [windows, editorSession]);
 }

--- a/src/routes/v2/pages/RunView/RunViewV2.tsx
+++ b/src/routes/v2/pages/RunView/RunViewV2.tsx
@@ -9,7 +9,6 @@ import { useEffect, useRef } from "react";
 import { InfoBox } from "@/components/shared/InfoBox";
 import { LoadingScreen } from "@/components/shared/LoadingScreen";
 import { RemoteAuthErrorView } from "@/components/shared/RemoteAuthErrorView";
-import { useFlagValue } from "@/components/shared/Settings/useFlags";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Paragraph } from "@/components/ui/typography";
 import { useTrackRecentlyViewedRun } from "@/hooks/useTrackRecentlyViewedRun";
@@ -176,8 +175,7 @@ const RunViewLayout = observer(function RunViewLayout({
   useFocusTaskFromUrl(spec);
   useCanvasControlsWindow("v2.run_view");
 
-  const aiEnabled = useFlagValue("ai-assistant");
-  useAiChatWindow(aiEnabled);
+  useAiChatWindow();
 
   const { navigation } = useSharedStores();
   const activeSpec = navigation.activeSpec;

--- a/src/routes/v2/pages/RunView/hooks/runWindowVisibilityPersistence.test.tsx
+++ b/src/routes/v2/pages/RunView/hooks/runWindowVisibilityPersistence.test.tsx
@@ -49,7 +49,7 @@ const RUN_WINDOW_IDS = [
 function renderRunWindowHooks() {
   return renderHook(() => {
     useRunViewWindows();
-    useAiChatWindow(true);
+    useAiChatWindow();
   });
 }
 

--- a/src/routes/v2/pages/RunView/hooks/useAiChatWindow.tsx
+++ b/src/routes/v2/pages/RunView/hooks/useAiChatWindow.tsx
@@ -74,14 +74,10 @@ const RunAiChatContent = observer(function RunAiChatContent() {
   );
 });
 
-export function useAiChatWindow(enabled: boolean) {
+export function useAiChatWindow() {
   const { windows } = useSharedStores();
 
   useEffect(() => {
-    if (!enabled) {
-      windows.closeWindow(RUN_AI_ASSISTANT_WINDOW_ID);
-      return;
-    }
     if (windows.getWindowById(RUN_AI_ASSISTANT_WINDOW_ID)) return;
 
     windows.openWindow(<RunAiChatContent />, {
@@ -101,5 +97,5 @@ export function useAiChatWindow(enabled: boolean) {
         />
       ),
     });
-  }, [enabled, windows]);
+  }, [windows]);
 }


### PR DESCRIPTION
## Description

The AI Assistant is ready to be enabled for all users, so this removes the `ai-assistant` feature flag and its conditional code paths.

The AI Assistant window is now always registered in the V2 editor and Run View. AI Configuration is always available in Settings, and the model selector is shown whenever an AI provider is configured. Tests that covered the retired flag states have been simplified accordingly.

## Related Issue and Pull requests

None.

## Type of Change

- [x] Improvement
- [x] Cleanup/Refactor

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

Not applicable.

## Test Instructions

1. Open **Settings → Beta Features** and confirm **AI Assistant** is no longer listed.
2. Open the V2 editor and confirm **Sidekick** is available.
3. Open a pipeline run and confirm **AI Assistant** is available.
4. Open Settings and confirm **AI Configuration** is always visible and accessible.
5. Configure an AI provider and confirm the AI model selector appears in the application header.

Run the focused tests:

```bash
pnpm exec vitest run src/components/layout/AiModelQuickSelect.test.tsx src/routes/v2/pages/RunView/hooks/runWindowVisibilityPersistence.test.tsx
```

## Additional Comments

Existing `ai-assistant` values in local storage are ignored after this change.
