### PR TITLE
Adds markdown support for banners

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -5,7 +5,6 @@
   "ignore": [
     "src/api/**",
     "src/components/ui/**",
-    "src/config/announcements.ts",
     "src/config/preSubmitHooks.ts",
     "src/components/shared/BetaFeatureWrapper/BetaFeatureWrapper.tsx"
   ],

--- a/react-compiler.config.js
+++ b/react-compiler.config.js
@@ -79,6 +79,7 @@ export const REACT_COMPILER_ENABLED_DIRS = [
   "src/components/shared/SecretsManagement/components/SecretsBackendUnavailable.tsx",
   "src/components/shared/HighlightText.tsx",
   "src/components/shared/AnnouncementBanners.tsx",
+  "src/components/shared/AnnouncementMarkdown.tsx",
   "src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection",
   "src/components/ui/typography.tsx",
 

--- a/src/components/shared/AnnouncementBanners.test.tsx
+++ b/src/components/shared/AnnouncementBanners.test.tsx
@@ -1,0 +1,49 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { AnnouncementBanners } from "@/components/shared/AnnouncementBanners";
+
+beforeEach(() => {
+  delete window.__TANGLE_ANNOUNCEMENTS__;
+  localStorage.clear();
+});
+
+afterEach(cleanup);
+
+describe("AnnouncementBanners", () => {
+  it("dismisses a configured announcement from the dashboard", () => {
+    window.__TANGLE_ANNOUNCEMENTS__ = [
+      {
+        id: "notice",
+        title: "Active notification",
+        body: "Notification body",
+        dismissible: true,
+      },
+    ];
+
+    render(<AnnouncementBanners />);
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+
+    expect(screen.queryByText("Active notification")).not.toBeInTheDocument();
+    expect(
+      JSON.parse(localStorage.getItem("dismissed-announcements") ?? "[]"),
+    ).toEqual(["notice"]);
+  });
+
+  it("does not dismiss an announcement unless configured", () => {
+    window.__TANGLE_ANNOUNCEMENTS__ = [
+      {
+        id: "notice",
+        title: "Required notification",
+        body: "Notification body",
+      },
+    ];
+
+    render(<AnnouncementBanners />);
+
+    expect(screen.getByText("Required notification")).toBeVisible();
+    expect(
+      screen.queryByRole("button", { name: "Dismiss" }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/components/shared/AnnouncementBanners.tsx
+++ b/src/components/shared/AnnouncementBanners.tsx
@@ -1,9 +1,9 @@
-import "@/config/announcements";
-
 import { useState } from "react";
 
+import { AnnouncementMarkdown } from "@/components/shared/AnnouncementMarkdown";
 import { InfoBox } from "@/components/shared/InfoBox";
 import { BlockStack } from "@/components/ui/layout";
+import { getActiveAnnouncements } from "@/config/announcements";
 import { getStorage } from "@/utils/typedStorage";
 
 interface DismissedAnnouncementsStorage {
@@ -21,44 +21,37 @@ function getDismissedIds(): string[] {
 
 export const AnnouncementBanners = () => {
   const [dismissedIds, setDismissedIds] = useState(getDismissedIds);
-
-  const announcements = window.__TANGLE_ANNOUNCEMENTS__ ?? [];
-  const now = new Date();
-  const visible = announcements.filter(
-    (a) =>
-      !dismissedIds.includes(a.id) &&
-      (!a.expiresAt || new Date(a.expiresAt) > now),
+  const announcements = getActiveAnnouncements().filter(
+    (announcement) => !dismissedIds.includes(announcement.id),
   );
 
-  if (visible.length === 0) {
+  if (announcements.length === 0) {
     return null;
   }
 
-  const handleDismiss = (id: string) => {
-    const updated = [...dismissedIds, id];
-    storage.setItem("dismissed-announcements", updated);
-    setDismissedIds(updated);
+  const dismiss = (id: string) => {
+    const nextDismissedIds = [...dismissedIds, id];
+    storage.setItem("dismissed-announcements", nextDismissedIds);
+    setDismissedIds(nextDismissedIds);
   };
 
   return (
     <BlockStack gap="2">
-      {visible.map((announcement) => {
-        const onDismiss = announcement.dismissible
-          ? () => handleDismiss(announcement.id)
-          : undefined;
-
-        return (
-          <InfoBox
-            key={announcement.id}
-            title={announcement.title}
-            variant={announcement.variant ?? "info"}
-            width="full"
-            onDismiss={onDismiss}
-          >
-            {announcement.body}
-          </InfoBox>
-        );
-      })}
+      {announcements.map((announcement) => (
+        <InfoBox
+          key={announcement.id}
+          title={announcement.title}
+          variant={announcement.variant ?? "info"}
+          width="full"
+          onDismiss={
+            announcement.dismissible
+              ? () => dismiss(announcement.id)
+              : undefined
+          }
+        >
+          <AnnouncementMarkdown>{announcement.body}</AnnouncementMarkdown>
+        </InfoBox>
+      ))}
     </BlockStack>
   );
 };

--- a/src/components/shared/AnnouncementMarkdown.test.tsx
+++ b/src/components/shared/AnnouncementMarkdown.test.tsx
@@ -1,0 +1,34 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { AnnouncementMarkdown } from "@/components/shared/AnnouncementMarkdown";
+
+afterEach(cleanup);
+
+describe("AnnouncementMarkdown", () => {
+  it("renders formatting and absolute HTTP links", () => {
+    render(
+      <AnnouncementMarkdown>
+        {
+          "Read the **important** [migration guide](https://example.com/migration)."
+        }
+      </AnnouncementMarkdown>,
+    );
+
+    expect(screen.getByText("important").tagName).toBe("STRONG");
+    expect(
+      screen.getByRole("link", { name: /migration guide/i }),
+    ).toHaveAttribute("href", "https://example.com/migration");
+  });
+
+  it("does not render unsafe or relative links", () => {
+    render(
+      <AnnouncementMarkdown>
+        {"[Unsafe](javascript:alert(1)) [Relative](/settings)"}
+      </AnnouncementMarkdown>,
+    );
+
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+    expect(screen.getByText("Unsafe Relative")).toBeVisible();
+  });
+});

--- a/src/components/shared/AnnouncementMarkdown.tsx
+++ b/src/components/shared/AnnouncementMarkdown.tsx
@@ -1,0 +1,78 @@
+import type { ComponentProps, ReactNode } from "react";
+import Markdown from "react-markdown";
+
+import { Link } from "@/components/ui/link";
+import { Paragraph } from "@/components/ui/typography";
+
+const ALLOWED_ELEMENTS = [
+  "p",
+  "a",
+  "strong",
+  "em",
+  "ul",
+  "ol",
+  "li",
+  "code",
+  "br",
+];
+
+function isAbsoluteHttpUrl(value: string | undefined): value is string {
+  if (!value) return false;
+
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function MarkdownLink({ href, children }: ComponentProps<"a">) {
+  if (!isAbsoluteHttpUrl(href)) return children;
+
+  return (
+    <Link href={href} size="sm" variant="primary" external>
+      {children}
+    </Link>
+  );
+}
+
+const components = {
+  p: ({ children }: { children?: ReactNode }) => (
+    <Paragraph size="sm" className="my-1 leading-relaxed">
+      {children}
+    </Paragraph>
+  ),
+  a: MarkdownLink,
+  ul: ({ children }: { children?: ReactNode }) => (
+    <ul className="my-1 list-disc pl-4">{children}</ul>
+  ),
+  ol: ({ children }: { children?: ReactNode }) => (
+    <ol className="my-1 list-decimal pl-4">{children}</ol>
+  ),
+  li: ({ children }: { children?: ReactNode }) => (
+    <li className="my-0.5">{children}</li>
+  ),
+  code: ({ children }: { children?: ReactNode }) => (
+    <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">
+      {children}
+    </code>
+  ),
+};
+
+interface AnnouncementMarkdownProps {
+  children: string;
+}
+
+export function AnnouncementMarkdown({ children }: AnnouncementMarkdownProps) {
+  return (
+    <Markdown
+      allowedElements={ALLOWED_ELEMENTS}
+      components={components}
+      skipHtml
+      unwrapDisallowed
+    >
+      {children}
+    </Markdown>
+  );
+}

--- a/src/config/announcements.ts
+++ b/src/config/announcements.ts
@@ -4,11 +4,18 @@ export interface Announcement {
   body: string;
   variant?: "warning" | "info" | "success" | "error";
   dismissible?: boolean;
-  expiresAt?: string; // ISO date string, e.g. "2026-04-01"
+  expiresAt?: string;
 }
 
 declare global {
   interface Window {
     __TANGLE_ANNOUNCEMENTS__?: Announcement[];
   }
+}
+
+export function getActiveAnnouncements(now = new Date()): Announcement[] {
+  return (window.__TANGLE_ANNOUNCEMENTS__ ?? []).filter(
+    (announcement) =>
+      !announcement.expiresAt || new Date(announcement.expiresAt) > now,
+  );
 }


### PR DESCRIPTION
## Description

Adds safe Markdown rendering to the existing homepage announcement banners. Banner bodies now support basic formatting and absolute HTTP(S) links while raw HTML, relative links, and unsafe URL schemes remain non-interactive.

This keeps the existing `window.__TANGLE_ANNOUNCEMENTS__` contract, expiry filtering, and local dismissal behavior unchanged.

## Type of Change

- [x] Improvement

## Test Instructions

1. Supply an announcement with bold text and a Markdown link through `window.__TANGLE_ANNOUNCEMENTS__`.
2. Open the dashboard home and confirm the formatting and external link render correctly.
3. Confirm dismissible announcements still remain dismissed after reloading.
4. Confirm relative and `javascript:` links render as text rather than clickable links.

Automated coverage:

```bash
pnpm exec vitest run src/components/shared/AnnouncementBanners.test.tsx src/components/shared/AnnouncementMarkdown.test.tsx
pnpm run typecheck
```
