### PR TITLE
Adds notification center to the header

### DIFF
--- a/react-compiler.config.js
+++ b/react-compiler.config.js
@@ -80,6 +80,7 @@ export const REACT_COMPILER_ENABLED_DIRS = [
   "src/components/shared/HighlightText.tsx",
   "src/components/shared/AnnouncementBanners.tsx",
   "src/components/shared/AnnouncementMarkdown.tsx",
+  "src/components/shared/NoticeCenter.tsx",
   "src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection",
   "src/components/ui/typography.tsx",
 

--- a/src/components/layout/AppMenu.tsx
+++ b/src/components/layout/AppMenu.tsx
@@ -12,6 +12,7 @@ import { TopBarAuthentication } from "@/components/shared/Authentication/TopBarA
 import { CopyText } from "@/components/shared/CopyText/CopyText";
 import { EditorVersionToggle } from "@/components/shared/EditorVersionToggle";
 import ImportPipeline from "@/components/shared/ImportPipeline";
+import { NoticeCenter } from "@/components/shared/NoticeCenter";
 import { RunVersionToggle } from "@/components/shared/RunVersionToggle";
 import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
@@ -128,6 +129,7 @@ const DefaultAppMenu = () => {
 
           <EditorVersionToggle />
           <RunVersionToggle />
+          <NoticeCenter />
 
           {/* Settings & status */}
           {isOnSettingsRoute ? (

--- a/src/components/shared/NoticeCenter.test.tsx
+++ b/src/components/shared/NoticeCenter.test.tsx
@@ -1,0 +1,50 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { NoticeCenter } from "@/components/shared/NoticeCenter";
+
+beforeEach(() => {
+  delete window.__TANGLE_ANNOUNCEMENTS__;
+});
+
+afterEach(cleanup);
+
+describe("NoticeCenter", () => {
+  it("shows active notices in host order", () => {
+    window.__TANGLE_ANNOUNCEMENTS__ = [
+      {
+        id: "first",
+        title: "First notice",
+        body: "First body",
+        dismissible: true,
+      },
+      {
+        id: "second",
+        title: "Second notice",
+        body: "Second body",
+      },
+      {
+        id: "expired",
+        title: "Expired notice",
+        body: "Expired body",
+        expiresAt: "2000-01-01",
+      },
+    ];
+
+    render(<NoticeCenter />);
+    fireEvent.click(screen.getByLabelText("Notices, 2 active"));
+
+    expect(
+      screen.getAllByTestId("info-box-title").map((title) => title.textContent),
+    ).toEqual(["First notice", "Second notice"]);
+    expect(screen.queryByText("Expired notice")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Dismiss")).not.toBeInTheDocument();
+  });
+
+  it("shows an empty state", () => {
+    render(<NoticeCenter />);
+    fireEvent.click(screen.getByLabelText("Notices, none active"));
+
+    expect(screen.getByText("No active notices")).toBeVisible();
+  });
+});

--- a/src/components/shared/NoticeCenter.tsx
+++ b/src/components/shared/NoticeCenter.tsx
@@ -1,0 +1,72 @@
+import { AnnouncementMarkdown } from "@/components/shared/AnnouncementMarkdown";
+import TooltipButton from "@/components/shared/Buttons/TooltipButton";
+import { InfoBox } from "@/components/shared/InfoBox";
+import { Badge } from "@/components/ui/badge";
+import { Icon } from "@/components/ui/icon";
+import { BlockStack } from "@/components/ui/layout";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Heading, Text } from "@/components/ui/typography";
+import { getActiveAnnouncements } from "@/config/announcements";
+import { tracking } from "@/utils/tracking";
+
+function noticeLabel(count: number): string {
+  if (count === 0) return "Notices, none active";
+  return `Notices, ${count} active`;
+}
+
+export function NoticeCenter() {
+  const announcements = getActiveAnnouncements();
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild {...tracking("header.notices")}>
+        <TooltipButton
+          tooltip="Notices"
+          variant="header"
+          className="relative"
+          aria-label={noticeLabel(announcements.length)}
+        >
+          <Icon name="Megaphone" />
+          {announcements.length > 0 && (
+            <Badge
+              size="xs"
+              shape="rounded"
+              variant="destructive"
+              position="topright"
+            >
+              {announcements.length > 9 ? "9+" : announcements.length}
+            </Badge>
+          )}
+        </TooltipButton>
+      </PopoverTrigger>
+      <PopoverContent
+        align="end"
+        className="max-h-[calc(100vh-5rem)] w-96 max-w-[calc(100vw-2rem)] overflow-y-auto"
+      >
+        <BlockStack gap="3">
+          <Heading level={3}>Notices</Heading>
+          {announcements.length === 0 ? (
+            <Text as="span" size="sm" tone="subdued">
+              No active notices
+            </Text>
+          ) : (
+            announcements.map((announcement) => (
+              <InfoBox
+                key={announcement.id}
+                title={announcement.title}
+                variant={announcement.variant ?? "info"}
+                width="full"
+              >
+                <AnnouncementMarkdown>{announcement.body}</AnnouncementMarkdown>
+              </InfoBox>
+            ))
+          )}
+        </BlockStack>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/routes/v2/shared/components/AppMenuActions.tsx
+++ b/src/routes/v2/shared/components/AppMenuActions.tsx
@@ -6,6 +6,7 @@ import { isAuthorizationRequired } from "@/components/shared/Authentication/help
 import { TopBarAuthentication } from "@/components/shared/Authentication/TopBarAuthentication";
 import TooltipButton from "@/components/shared/Buttons/TooltipButton";
 import { EditorVersionToggle } from "@/components/shared/EditorVersionToggle";
+import { NoticeCenter } from "@/components/shared/NoticeCenter";
 import { RunVersionToggle } from "@/components/shared/RunVersionToggle";
 import { Icon } from "@/components/ui/icon";
 import { InlineStack } from "@/components/ui/layout";
@@ -30,6 +31,7 @@ export function AppMenuActions() {
       <AiModelQuickSelect />
       <EditorVersionToggle showWelcomeSpotlight />
       <RunVersionToggle showWelcomeSpotlight />
+      <NoticeCenter />
       {tourMode ? (
         <TooltipButton
           tooltip="Settings"


### PR DESCRIPTION
## Description

Adds a read-only Notices popover to the top-right of both application headers. It shows the active notice count and lists the same active announcements used by the homepage banners, preserving host order and rendering their Markdown content.

This intentionally does not add read/unread tracking, separate dismissal state, polling, or notification subscriptions.

## Related Pull Requests

- #2677

## Type of Change

- [x] New feature

## Test Instructions  
![image.png](https://app.graphite.com/user-attachments/assets/55ba7634-cf5e-4263-b73a-31ae84175d9d.png)





![image.png](https://app.graphite.com/user-attachments/assets/23488379-620a-472d-a06e-d6f9d12f730b.png)



1. Supply several announcements through `window.__TANGLE_ANNOUNCEMENTS__`.
2. Confirm the notice count appears in both header versions.
3. Open the popover and confirm active notices appear in host order with Markdown links.
4. Confirm expired notices are omitted and an empty source shows `No active notices`.
5. Confirm dismissing a homepage banner does not remove it from the read-only notice list.

Automated coverage:

```bash
pnpm exec vitest run src/components/shared/NoticeCenter.test.tsx
pnpm run typecheck
```