### PR TITLE
refactor(layout): centralise content-area height in contentHeight()

### DIFF
--- a/src/components/shared/ComponentDetail/ComponentDetail.tsx
+++ b/src/components/shared/ComponentDetail/ComponentDetail.tsx
@@ -16,8 +16,8 @@ import type {
   InputSpec,
   OutputSpec,
 } from "@/utils/componentSpec";
-import { TOP_NAV_HEIGHT } from "@/utils/constants";
 import { getComponentName } from "@/utils/getComponentName";
+import { contentHeight } from "@/utils/layout";
 import { buildComponentSourceUrl } from "@/utils/URL";
 
 // Repeated label style used for "Inputs"/"Outputs"/"Source" headings — small,
@@ -337,8 +337,7 @@ export const ComponentDetail = ({
   }
 
   // ── Split layout (V1 default) ─────────────────────────────────────────
-  const splitSourceHeight =
-    sourcePanelHeight ?? `calc(100vh - ${TOP_NAV_HEIGHT + 48}px)`;
+  const splitSourceHeight = sourcePanelHeight ?? contentHeight(48);
   return (
     <InlineStack gap="6" blockAlign="start">
       <BlockStack gap="4" className="flex-2 min-w-0">

--- a/src/components/shared/ContextPanel/ContextPanel.tsx
+++ b/src/components/shared/ContextPanel/ContextPanel.tsx
@@ -1,5 +1,6 @@
 import { useContextPanel } from "@/providers/ContextPanelProvider";
-import { BOTTOM_FOOTER_HEIGHT, TOP_NAV_HEIGHT } from "@/utils/constants";
+import { BOTTOM_FOOTER_HEIGHT } from "@/utils/constants";
+import { contentHeight } from "@/utils/layout";
 
 export const ContextPanel = () => {
   const { content } = useContextPanel();
@@ -8,7 +9,7 @@ export const ContextPanel = () => {
       data-testid="context-panel-container"
       className="h-full p-2 bg-sidebar text-sidebar-foreground overflow-y-auto"
       style={{
-        maxHeight: `calc(100vh - ${TOP_NAV_HEIGHT}px - ${BOTTOM_FOOTER_HEIGHT}px)`,
+        maxHeight: contentHeight(BOTTOM_FOOTER_HEIGHT),
       }}
     >
       {content}

--- a/src/components/shared/ReactFlow/FlowSidebar/FlowSidebar.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/FlowSidebar.tsx
@@ -1,6 +1,7 @@
 import { BlockStack } from "@/components/ui/layout";
 import { VerticalResizeHandle } from "@/components/ui/resize-handle";
-import { BOTTOM_FOOTER_HEIGHT, TOP_NAV_HEIGHT } from "@/utils/constants";
+import { BOTTOM_FOOTER_HEIGHT } from "@/utils/constants";
+import { contentHeight } from "@/utils/layout";
 
 import FileActions from "./sections/FileActions";
 import GraphComponents from "./sections/GraphComponents";
@@ -19,7 +20,7 @@ const FlowSidebar = () => {
         width: `${DEFAULT_WIDTH}px`,
         minWidth: `${MIN_WIDTH}px`,
         maxWidth: `${MAX_WIDTH}px`,
-        maxHeight: `calc(100vh - ${TOP_NAV_HEIGHT}px - ${BOTTOM_FOOTER_HEIGHT}px)`,
+        maxHeight: contentHeight(BOTTOM_FOOTER_HEIGHT),
       }}
     >
       <BlockStack fill gap="2">

--- a/src/routes/Dashboard/DashboardComponentsV2View.tsx
+++ b/src/routes/Dashboard/DashboardComponentsV2View.tsx
@@ -81,8 +81,9 @@ import {
 import type { ComponentFolder } from "@/types/componentLibrary";
 import type { ComponentReference } from "@/utils/componentSpec";
 import { componentMetadata } from "@/utils/componentTracking";
-import { HOURS, TOP_NAV_HEIGHT } from "@/utils/constants";
+import { HOURS } from "@/utils/constants";
 import { getComponentName } from "@/utils/getComponentName";
+import { contentHeight } from "@/utils/layout";
 import { tracking } from "@/utils/tracking";
 
 import { APP_ROUTES } from "../router";
@@ -1564,7 +1565,7 @@ export const DashboardComponentsV2View = () => {
     // `min-height: auto` defaults fight against that flex chain.
     <div
       className="flex flex-col -mt-4 -mb-6 -mx-8 overflow-hidden"
-      style={{ height: `calc(100vh - ${TOP_NAV_HEIGHT}px)` }}
+      style={{ height: contentHeight() }}
     >
       {/* Header zone: page title, description, search input. shrink-0 so it
           never gets squeezed by the body below. */}

--- a/src/routes/Dashboard/DashboardComponentsView.tsx
+++ b/src/routes/Dashboard/DashboardComponentsView.tsx
@@ -31,9 +31,9 @@ import { fetchAndStoreComponentLibrary } from "@/services/componentService";
 import type { ComponentFolder } from "@/types/componentLibrary";
 import type { ComponentReference } from "@/utils/componentSpec";
 import { componentMetadata } from "@/utils/componentTracking";
-import { TOP_NAV_HEIGHT } from "@/utils/constants";
 import { fetchWithErrorHandling } from "@/utils/fetchWithErrorHandling";
 import { getComponentName } from "@/utils/getComponentName";
+import { contentHeight } from "@/utils/layout";
 import { tracking } from "@/utils/tracking";
 
 import { readSelectedComponentDigest } from "./searchParams";
@@ -389,7 +389,7 @@ export function DashboardComponentsView() {
   return (
     <div
       className="flex -mt-4 -mb-6 -mx-8 overflow-hidden border-t border-border"
-      style={{ height: `calc(100vh - ${TOP_NAV_HEIGHT}px)` }}
+      style={{ height: contentHeight() }}
     >
       {/* Left: component list */}
       <div className="w-64 shrink-0 border-r border-border flex flex-col overflow-hidden">

--- a/src/routes/Dashboard/DashboardLayout.tsx
+++ b/src/routes/Dashboard/DashboardLayout.tsx
@@ -18,8 +18,8 @@ import {
   GIT_REPO_URL,
   GIVE_FEEDBACK_URL,
   PRIVACY_POLICY_URL,
-  TOP_NAV_HEIGHT,
 } from "@/utils/constants";
+import { contentHeight } from "@/utils/layout";
 
 interface SidebarItem {
   to: string;
@@ -84,7 +84,7 @@ export function DashboardLayout() {
   return (
     <div
       className="flex w-full overflow-hidden"
-      style={{ height: `calc(100vh - ${TOP_NAV_HEIGHT}px)` }}
+      style={{ height: contentHeight() }}
     >
       {/* Sidebar — fixed height, independent scroll */}
       <div className="w-56 shrink-0 border-r border-border flex flex-col overflow-y-auto">

--- a/src/utils/layout.test.ts
+++ b/src/utils/layout.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import { TOP_NAV_HEIGHT } from "./constants";
+import { contentHeight } from "./layout";
+
+describe("contentHeight", () => {
+  it("subtracts the top nav from the viewport height", () => {
+    expect(contentHeight()).toBe(`calc(100vh - ${TOP_NAV_HEIGHT}px - 0px)`);
+  });
+
+  it("subtracts an additional fixed amount on top of the nav", () => {
+    expect(contentHeight(48)).toBe(`calc(100vh - ${TOP_NAV_HEIGHT}px - 48px)`);
+  });
+
+  it("treats an explicit zero the same as no argument", () => {
+    expect(contentHeight(0)).toBe(contentHeight());
+  });
+});

--- a/src/utils/layout.ts
+++ b/src/utils/layout.ts
@@ -1,0 +1,5 @@
+import { TOP_NAV_HEIGHT } from "@/utils/constants";
+
+export function contentHeight(subtractPx = 0): string {
+  return `calc(100vh - ${TOP_NAV_HEIGHT}px - ${subtractPx}px)`;
+}


### PR DESCRIPTION
## Why

Six layouts each hardcode the same expression to fill the space under the top nav:

```tsx
style={{ height: `calc(100vh - ${TOP_NAV_HEIGHT}px)` }}
```

Three of them subtract a second fixed amount on top of it (`BOTTOM_FOOTER_HEIGHT`, or a bare `48`). Adding anything above the content area means finding and editing all six.

## What

One helper, `contentHeight(subtractPx?)`, in `src/utils/layout.ts`. Every call site now reads what it means rather than restating the arithmetic:

```tsx
style={{ height: contentHeight() }}
style={{ maxHeight: contentHeight(BOTTOM_FOOTER_HEIGHT) }}
```

Call sites updated: `ComponentDetail`, `ContextPanel`, `FlowSidebar`, `DashboardComponentsView`, `DashboardComponentsV2View`, `DashboardLayout`.

**Behaviour is unchanged at every call site** — the emitted string is identical to what each one produced before, including the `- 0px` term that CSS `calc()` folds away. This is a pure de-duplication; it is not a prerequisite for anything and can be merged or dropped independently.
