### PR TITLE
feat(notices): let a reader hide a banner without retiring it

### DIFF
--- a/react-compiler.config.js
+++ b/react-compiler.config.js
@@ -43,6 +43,7 @@ export const REACT_COMPILER_ENABLED_DIRS = [
   "src/hooks/usePipelineRunList.ts",
   "src/hooks/useNotices.ts",
   "src/hooks/useNoticeInbox.ts",
+  "src/hooks/useHiddenNotices.ts",
   "src/components/shared/FavoriteToggle.tsx",
   "src/components/shared/FloatingSelectionBar.tsx",
   "src/components/shared/ComponentLifecycleBadges.tsx",

--- a/src/components/shared/InfoBox.tsx
+++ b/src/components/shared/InfoBox.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 
 import { Button } from "@/components/ui/button";
-import { Icon } from "@/components/ui/icon";
+import { Icon, type IconName } from "@/components/ui/icon";
 import { InlineStack } from "@/components/ui/layout";
 import { Text } from "@/components/ui/typography";
 import { cn } from "@/lib/utils";
@@ -13,6 +13,8 @@ interface InfoBoxProps {
   children: ReactNode;
   variant?: "info" | "error" | "warning" | "success" | "ghost";
   onDismiss?: () => void;
+  dismissIcon?: IconName;
+  dismissLabel?: string;
 }
 
 const variantStyles: Record<
@@ -57,6 +59,8 @@ export const InfoBox = ({
   children,
   variant = "info",
   onDismiss,
+  dismissIcon = "X",
+  dismissLabel = "Dismiss",
 }: InfoBoxProps) => {
   const styles = variantStyles[variant];
   const widthClass = widthStyles[width];
@@ -81,9 +85,9 @@ export const InfoBox = ({
             onClick={onDismiss}
             variant="ghost"
             size="min"
-            aria-label="Dismiss"
+            aria-label={dismissLabel}
           >
-            <Icon name="X" size="sm" />
+            <Icon name={dismissIcon} size="sm" />
           </Button>
         )}
       </InlineStack>

--- a/src/components/shared/Notices/NoticeBanners.test.tsx
+++ b/src/components/shared/Notices/NoticeBanners.test.tsx
@@ -8,6 +8,7 @@ import {
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { installRawSource, installSource } from "@/config/noticeTestSource";
+import { resetHiddenNoticesForTests } from "@/hooks/useHiddenNotices";
 import { resetNoticeStateForTests } from "@/hooks/useNotices";
 
 import { NoticeBanners } from "./NoticeBanners";
@@ -19,6 +20,7 @@ describe("<NoticeBanners />", () => {
 
   afterEach(() => {
     cleanup();
+    resetHiddenNoticesForTests();
     resetNoticeStateForTests();
     delete window.__TANGLE_NOTICE_SOURCE__;
   });
@@ -102,15 +104,13 @@ describe("<NoticeBanners />", () => {
     expect(screen.getByTestId("info-box-error").className).toContain("w-full");
   });
 
-  it("leaves opening the full list to the header", () => {
-    installSource([
-      { id: "a", title: "Only notice", body: "", dismissible: true },
-    ]);
+  it("leaves clearing the banners and opening the full list to the header", () => {
+    installSource([{ id: "a", title: "Only notice", body: "" }]);
 
     render(<NoticeBanners />);
 
     expect(screen.getAllByRole("button")).toHaveLength(1);
-    expect(screen.getByLabelText("Dismiss")).toBeInTheDocument();
+    expect(screen.getByLabelText("Hide notice")).toBeInTheDocument();
   });
 
   it("renders a brief body inline as Markdown", () => {
@@ -203,7 +203,7 @@ describe("<NoticeBanners />", () => {
     expect(link).toHaveAttribute("rel", "noopener noreferrer");
   });
 
-  it("offers to dismiss only the notices the host allows", () => {
+  it("offers to hide any notice from the banners, but never to retire one", () => {
     installSource([
       { id: "a", title: "Scheduled maintenance", body: "", dismissible: true },
       { id: "b", title: "Mandatory notice", body: "" },
@@ -211,42 +211,47 @@ describe("<NoticeBanners />", () => {
 
     render(<NoticeBanners />);
 
-    expect(screen.getAllByLabelText("Dismiss")).toHaveLength(1);
+    expect(screen.getAllByLabelText("Hide notice")).toHaveLength(2);
+    expect(screen.queryByLabelText("Dismiss")).not.toBeInTheDocument();
   });
 
   it("takes one notice off the banners while leaving the rest in place", () => {
     installSource([
-      {
-        id: "a",
-        title: "First",
-        body: "",
-        variant: "error",
-        dismissible: true,
-      },
+      { id: "a", title: "First", body: "", variant: "error" },
       { id: "b", title: "Second", body: "", variant: "warning" },
     ]);
 
     render(<NoticeBanners />);
-    fireEvent.click(screen.getByLabelText("Dismiss"));
+    fireEvent.click(screen.getAllByLabelText("Hide notice")[0]!);
 
     expect(
       screen.getAllByTestId("info-box-title").map((el) => el.textContent),
     ).toEqual(["Second"]);
   });
 
-  it("keeps a dismissed notice off the banners across a remount", () => {
+  it("keeps a hidden dismissible notice off the banners across a remount", () => {
     installSource([
       { id: "a", title: "Scheduled maintenance", body: "", dismissible: true },
     ]);
 
     render(<NoticeBanners />);
-    fireEvent.click(screen.getByLabelText("Dismiss"));
+    fireEvent.click(screen.getByLabelText("Hide notice"));
 
     cleanup();
     const { container } = render(<NoticeBanners />);
 
     expect(container).toBeEmptyDOMElement();
-    expect(localStorage.getItem("dismissed-notices") ?? "").toContain("a");
+    expect(localStorage.getItem("hidden-notices") ?? "").toContain("a");
+  });
+
+  it("hides a non-dismissible notice without retiring it for good", () => {
+    installSource([{ id: "a", title: "Mandatory notice", body: "" }]);
+
+    render(<NoticeBanners />);
+    fireEvent.click(screen.getByLabelText("Hide notice"));
+
+    expect(screen.queryByTestId("notice-banners")).not.toBeInTheDocument();
+    expect(localStorage.getItem("hidden-notices") ?? "").not.toContain("a");
   });
 
   it("picks up a source installed after mount", () => {

--- a/src/components/shared/Notices/NoticeBanners.tsx
+++ b/src/components/shared/Notices/NoticeBanners.tsx
@@ -1,22 +1,26 @@
 import { NoticeCard } from "@/components/shared/Notices/NoticeCard";
+import { useHiddenNotices } from "@/hooks/useHiddenNotices";
 import { useNotices } from "@/hooks/useNotices";
 
 export const NoticeBanners = () => {
-  const { notices, dismiss } = useNotices();
+  const { notices } = useNotices();
+  const { hiddenIds, hide } = useHiddenNotices();
 
-  if (notices.length === 0) return null;
+  const banners = notices.filter((notice) => !hiddenIds.has(notice.id));
+
+  if (banners.length === 0) return null;
 
   return (
     <div
       className="w-full grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 items-start"
       data-testid="notice-banners"
     >
-      {notices.map((notice) => (
+      {banners.map((notice) => (
         <NoticeCard
           key={notice.id}
           notice={notice}
           clampBody
-          onDismiss={notice.dismissible ? () => dismiss(notice) : undefined}
+          onHide={() => hide(notice)}
         />
       ))}
     </div>

--- a/src/components/shared/Notices/NoticeCard.tsx
+++ b/src/components/shared/Notices/NoticeCard.tsx
@@ -9,12 +9,14 @@ import { cn } from "@/lib/utils";
 interface NoticeCardProps {
   notice: TangleNotice;
   clampBody?: boolean;
+  onHide?: () => void;
   onDismiss?: () => void;
 }
 
 export const NoticeCard = ({
   notice,
   clampBody = false,
+  onHide,
   onDismiss,
 }: NoticeCardProps) => {
   const hasBody = notice.body.trim().length > 0;
@@ -24,7 +26,9 @@ export const NoticeCard = ({
       title={notice.title}
       variant={notice.variant}
       width="full"
-      onDismiss={onDismiss}
+      onDismiss={onHide ?? onDismiss}
+      dismissIcon={onHide ? "EyeOff" : undefined}
+      dismissLabel={onHide ? "Hide notice" : undefined}
     >
       <BlockStack gap="2">
         {hasBody && (

--- a/src/components/shared/Notices/NoticeInbox.test.tsx
+++ b/src/components/shared/Notices/NoticeInbox.test.tsx
@@ -2,6 +2,7 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { installSource } from "@/config/noticeTestSource";
+import { resetHiddenNoticesForTests } from "@/hooks/useHiddenNotices";
 import { resetNoticeInboxForTests } from "@/hooks/useNoticeInbox";
 import { resetNoticeStateForTests } from "@/hooks/useNotices";
 
@@ -23,6 +24,7 @@ describe("<NoticeInbox />", () => {
   afterEach(() => {
     cleanup();
     delete window.__TANGLE_NOTICE_SOURCE__;
+    resetHiddenNoticesForTests();
     resetNoticeInboxForTests();
     resetNoticeStateForTests();
   });
@@ -193,6 +195,46 @@ describe("<NoticeInbox />", () => {
       "aria-label",
       "Notices, 12 unread",
     );
+  });
+
+  it("hides the banners from the centre, and offers to bring them back", () => {
+    installSource([{ id: "a", title: "One", body: "", dismissible: true }]);
+
+    render(<NoticeInbox />);
+    fireEvent.click(screen.getByTestId("notice-inbox-trigger"));
+
+    expect(screen.queryByTestId("notice-inbox-show")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("notice-inbox-hide"));
+
+    expect(screen.getByTestId("notice-inbox-show")).toBeInTheDocument();
+    expect(localStorage.getItem("hidden-notices")).toContain("a");
+  });
+
+  it("puts hidden notices back on the page", () => {
+    localStorage.setItem("hidden-notices", JSON.stringify(["a"]));
+    installSource([{ id: "a", title: "One", body: "", dismissible: true }]);
+
+    render(<NoticeInbox />);
+    fireEvent.click(screen.getByTestId("notice-inbox-trigger"));
+    fireEvent.click(screen.getByTestId("notice-inbox-show"));
+
+    expect(screen.queryByTestId("notice-inbox-show")).not.toBeInTheDocument();
+    expect(screen.getByTestId("notice-inbox-hide")).toBeInTheDocument();
+    expect(localStorage.getItem("hidden-notices")).toBe("[]");
+  });
+
+  it("keeps listing a hidden notice in full", () => {
+    localStorage.setItem("hidden-notices", JSON.stringify(["a"]));
+    installSource([
+      { id: "a", title: "Hidden", body: "", dismissible: true },
+      { id: "b", title: "Still a banner", body: "", dismissible: true },
+    ]);
+
+    render(<NoticeInbox />);
+    fireEvent.click(screen.getByTestId("notice-inbox-trigger"));
+
+    expect(screen.getByTestId("notice-inbox-show")).toBeInTheDocument();
+    expect(screen.getAllByTestId("info-box-title")).toHaveLength(2);
   });
 
   it("orders the list by severity", () => {

--- a/src/components/shared/Notices/NoticeInbox.tsx
+++ b/src/components/shared/Notices/NoticeInbox.tsx
@@ -3,14 +3,16 @@ import { useEffect } from "react";
 import TooltipButton from "@/components/shared/Buttons/TooltipButton";
 import { NoticeCard } from "@/components/shared/Notices/NoticeCard";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
-import { BlockStack } from "@/components/ui/layout";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { Text } from "@/components/ui/typography";
+import { useHiddenNotices } from "@/hooks/useHiddenNotices";
 import { closeNoticeInbox, useNoticeInbox } from "@/hooks/useNoticeInbox";
 import { tracking } from "@/utils/tracking";
 
@@ -24,10 +26,25 @@ function triggerLabel(unreadCount: number, total: number): string {
 
 export const NoticeInbox = () => {
   const { notices, unreadCount, isOpen, setOpen, dismiss } = useNoticeInbox();
+  const { hiddenIds, hideAll, showAll } = useHiddenNotices();
 
   useEffect(() => closeNoticeInbox, []);
 
   const label = triggerLabel(unreadCount, notices.length);
+
+  const bannerToggle = notices.some((notice) => hiddenIds.has(notice.id))
+    ? ({
+        icon: "Eye",
+        label: "Show notices",
+        onClick: showAll,
+        testId: "notice-inbox-show",
+      } as const)
+    : ({
+        icon: "EyeOff",
+        label: "Hide notices",
+        onClick: () => hideAll(notices),
+        testId: "notice-inbox-hide",
+      } as const);
 
   return (
     <Popover open={isOpen} onOpenChange={setOpen}>
@@ -61,9 +78,22 @@ export const NoticeInbox = () => {
         data-testid="notice-inbox"
       >
         <BlockStack gap="3">
-          <Text as="span" size="sm" weight="semibold">
-            Notices
-          </Text>
+          <InlineStack align="space-between" blockAlign="center" gap="2" fill>
+            <Text as="span" size="sm" weight="semibold">
+              Notices
+            </Text>
+            {notices.length > 0 && (
+              <Button
+                variant="link"
+                size="inline-xs"
+                onClick={bannerToggle.onClick}
+                data-testid={bannerToggle.testId}
+              >
+                <Icon name={bannerToggle.icon} size="xs" />
+                {bannerToggle.label}
+              </Button>
+            )}
+          </InlineStack>
           {notices.length === 0 ? (
             <Text
               as="span"

--- a/src/hooks/useHiddenNotices.test.ts
+++ b/src/hooks/useHiddenNotices.test.ts
@@ -1,0 +1,83 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { TangleNotice } from "@/config/notices";
+
+import {
+  resetHiddenNoticesForTests,
+  useHiddenNotices,
+} from "./useHiddenNotices";
+
+const HIDDEN_KEY = "hidden-notices";
+
+const notice = (id: string, dismissible?: true): TangleNotice => ({
+  id,
+  title: id,
+  body: "",
+  variant: "info",
+  ...(dismissible ? { dismissible } : {}),
+});
+
+afterEach(() => {
+  localStorage.clear();
+  resetHiddenNoticesForTests();
+});
+
+describe("useHiddenNotices", () => {
+  it("hides nothing until asked", () => {
+    const { result } = renderHook(() => useHiddenNotices());
+
+    expect(result.current.hiddenIds.size).toBe(0);
+  });
+
+  it("remembers a hidden notice only as long as the host allows", () => {
+    const { result } = renderHook(() => useHiddenNotices());
+
+    act(() => result.current.hide(notice("persisted", true)));
+    act(() => result.current.hide(notice("session-only")));
+
+    expect([...result.current.hiddenIds]).toEqual([
+      "persisted",
+      "session-only",
+    ]);
+
+    const stored = localStorage.getItem(HIDDEN_KEY) ?? "";
+    expect(stored).toContain("persisted");
+    expect(stored).not.toContain("session-only");
+  });
+
+  it("hides every notice in one go", () => {
+    const { result } = renderHook(() => useHiddenNotices());
+
+    act(() => result.current.hideAll([notice("a", true), notice("b")]));
+
+    expect(result.current.hiddenIds.size).toBe(2);
+  });
+
+  it("puts every hidden notice back at once", () => {
+    const { result } = renderHook(() => useHiddenNotices());
+
+    act(() => result.current.hideAll([notice("a", true), notice("b")]));
+    act(() => result.current.showAll());
+
+    expect(result.current.hiddenIds.size).toBe(0);
+    expect(localStorage.getItem(HIDDEN_KEY)).toBe("[]");
+  });
+
+  it("picks up a hide performed in another tab", () => {
+    const { result } = renderHook(() => useHiddenNotices());
+
+    act(() => {
+      localStorage.setItem(HIDDEN_KEY, JSON.stringify(["a"]));
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: HIDDEN_KEY,
+          newValue: JSON.stringify(["a"]),
+          storageArea: localStorage,
+        }),
+      );
+    });
+
+    expect(result.current.hiddenIds.has("a")).toBe(true);
+  });
+});

--- a/src/hooks/useHiddenNotices.ts
+++ b/src/hooks/useHiddenNotices.ts
@@ -1,0 +1,110 @@
+import { useSyncExternalStore } from "react";
+
+import type { TangleNotice } from "@/config/notices";
+import { getStorage } from "@/utils/typedStorage";
+
+const HIDDEN_KEY = "hidden-notices";
+
+const storage = getStorage<
+  typeof HIDDEN_KEY,
+  Record<typeof HIDDEN_KEY, string[]>
+>();
+
+const hiddenForThisSession = new Set<string>();
+
+let revision = 0;
+const listeners = new Set<() => void>();
+
+function publish() {
+  revision += 1;
+  listeners.forEach((listener) => listener());
+}
+
+function handleStorage(event: StorageEvent) {
+  // typedStorage re-dispatches a synthetic same-tab event on every write, which
+  // arrives without a storageArea. Those writes already publish themselves.
+  if (event.storageArea === null) return;
+  if (event.key === HIDDEN_KEY) publish();
+}
+
+function subscribe(listener: () => void): () => void {
+  if (listeners.size === 0) window.addEventListener("storage", handleStorage);
+  listeners.add(listener);
+
+  return () => {
+    listeners.delete(listener);
+    if (listeners.size === 0)
+      window.removeEventListener("storage", handleStorage);
+  };
+}
+
+function getRevision(): number {
+  return revision;
+}
+
+function readHiddenIds(): string[] {
+  const stored = storage.getItem(HIDDEN_KEY);
+  return Array.isArray(stored) ? stored : [];
+}
+
+let cachedHiddenIds: ReadonlySet<string> | null = null;
+let cachedRevision = -1;
+
+function getHiddenIds(revision: number): ReadonlySet<string> {
+  if (cachedHiddenIds && cachedRevision === revision) return cachedHiddenIds;
+
+  cachedRevision = revision;
+  cachedHiddenIds = new Set([...readHiddenIds(), ...hiddenForThisSession]);
+
+  return cachedHiddenIds;
+}
+
+function markHidden(notice: TangleNotice) {
+  if (notice.dismissible) {
+    const stored = readHiddenIds();
+    if (!stored.includes(notice.id))
+      storage.setItem(HIDDEN_KEY, [...stored, notice.id]);
+  }
+
+  if (!readHiddenIds().includes(notice.id)) hiddenForThisSession.add(notice.id);
+}
+
+function hideNotice(notice: TangleNotice) {
+  markHidden(notice);
+  publish();
+}
+
+function hideEvery(notices: readonly TangleNotice[]) {
+  notices.forEach(markHidden);
+  publish();
+}
+
+function showEvery() {
+  hiddenForThisSession.clear();
+  storage.setItem(HIDDEN_KEY, []);
+  publish();
+}
+
+export function resetHiddenNoticesForTests(): void {
+  hiddenForThisSession.clear();
+  cachedHiddenIds = null;
+  cachedRevision = -1;
+}
+
+export interface HiddenNotices {
+  hiddenIds: ReadonlySet<string>;
+  hide: (notice: TangleNotice) => void;
+  hideAll: (notices: readonly TangleNotice[]) => void;
+  showAll: () => void;
+}
+
+export function useHiddenNotices(): HiddenNotices {
+  const revision = useSyncExternalStore(subscribe, getRevision);
+
+  return {
+    hiddenIds: getHiddenIds(revision),
+    hide: hideNotice,
+    hideAll: hideEvery,
+    showAll: showEvery,
+  };
+}


### PR DESCRIPTION
## Why

With #2668 merged, dismissing a notice is the only way to clear it off the dashboard home — and dismissal is permanent and only offered on notices the host marked `dismissible`. That leaves two gaps:

- A mandatory notice (no `dismissible`) sits on the home page with no way to clear it, even for someone who has read it and wants their dashboard back.
- Clearing a dismissible one is a one-way door: there was no way to see it again short of clearing `localStorage`.

Now that the notices are also in the header popover, taking a banner off the home page doesn't lose it — so **hide** becomes safe to offer, on every notice.

## What you get

The banner's X becomes an eye-off, "Hide notice", present on every card:

- **Dismissible notice** → hidden for good, persisted under `hidden-notices`.
- **Mandatory notice** → hidden for this session only, back on the next load.

The reader always still has it in the header popover either way. The popover header gains one toggle that flips on state: **Hide notices** when any are showing, **Show notices** when any are hidden — so hiding is reversible without touching storage by hand.

Dismissal is unchanged and still lives in the popover: the X there still retires a dismissible notice permanently.

## Reviewer notes

`useHiddenNotices` is a separate store from `useNotices`, keyed on `hidden-notices`, and the banners compose the two. Hidden state deliberately doesn't live in `useNotices` — a hidden notice is still an active notice, and the popover has to keep listing it.

The persist-if-dismissible / session-only-if-mandatory rule is the same two-tier shape #2667 established for dismissal, and it's the reason `showAll` can restore everything: session hides clear on their own, and `hidden-notices` is emptied.

**One shared primitive changes: `InfoBox` gains `dismissIcon` and `dismissLabel`, both defaulting to today's values** (`X` / "Dismiss"), so every existing `InfoBox` renders identically. This is the only change to a design-system primitive in the notices stack, and it exists because a notice card needs the same affordance in the same slot with a different meaning — an eye-off in the banner, an X in the popover — and a second dismiss slot on `InfoBox` would be worse.

## How to test

Install a source with one dismissible and one mandatory notice (see `src/config/NOTICES.md`):

- Both banners on the dashboard home now show an eye-off, not an X.
- Hide the dismissible one → gone, and still gone after a reload. It's still listed in the header popover.
- Hide the mandatory one → gone, but back after a reload.
- Popover header shows **Show notices** once anything is hidden; clicking it brings both banners back.
- **Hide notices** clears the whole home region in one click.
- The X in the popover still permanently retires a dismissible notice.

## Where this sits

| | PR | |
| --- | --- | --- |
| 1 | #2664 | shared Markdown renderer |
| 2 | #2666 | validated host contract |
| 3 | #2667 | notice banners on the dashboard home — announcement parity |
| 4 | #2668 | notices button in the header |
| **5** | **#2681** | **hide a banner without retiring it** *(you are here)* |

Top of the stack, and the most droppable PR in it: #2667 alone is a complete announcements replacement, and #2668 adds the header surface. This is purely a reader affordance and depends on #2668 existing — hiding is only reasonable because the popover keeps the notice reachable.
