### PR TITLE
feat: URL Artifact Previews

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ArtifactPreviewContent.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ArtifactPreviewContent.tsx
@@ -5,12 +5,14 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { useBackend } from "@/providers/BackendProvider";
 import { getArtifactSignedUrl } from "@/services/executionService";
 import { HOURS } from "@/utils/constants";
+import { parseHttpUrl } from "@/utils/URL";
 
 import { CsvVisualizerRemote, CsvVisualizerValue } from "./CsvVisualizer";
 import ImageVisualizer from "./ImageVisualizer";
 import { JsonVisualizerRemote, JsonVisualizerValue } from "./JsonVisualizer";
 import ParquetVisualizer from "./ParquetVisualizer";
 import { TextVisualizerRemote, TextVisualizerValue } from "./TextVisualizer";
+import { UrlVisualizerRemote, UrlVisualizerValue } from "./UrlVisualizer";
 
 interface InlineContentProps {
   type: string;
@@ -44,9 +46,15 @@ export const InlineContent = ({
           isFullscreen={isFullscreen}
         />
       );
+    case "url":
+      return <UrlVisualizerValue value={value} />;
     case "text":
     default:
-      return <TextVisualizerValue value={value} isFullscreen={isFullscreen} />;
+      return parseHttpUrl(value) ? (
+        <UrlVisualizerValue value={value} />
+      ) : (
+        <TextVisualizerValue value={value} isFullscreen={isFullscreen} />
+      );
   }
 };
 
@@ -83,6 +91,8 @@ export const PreviewContent = ({
           isFullscreen={isFullscreen}
         />
       );
+    case "url":
+      return <UrlVisualizerRemote signedUrl={signedUrl} />;
     case "image":
       return <ImageVisualizer src={signedUrl} name={name} />;
     case "csv":

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ArtifactVisualizer.test.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ArtifactVisualizer.test.tsx
@@ -98,6 +98,15 @@ vi.mock("./JsonVisualizer", () => ({
   ),
 }));
 
+vi.mock("./UrlVisualizer", () => ({
+  UrlVisualizerValue: ({ value }: { value: string }) => (
+    <div data-testid="url-visualizer" data-value={value} />
+  ),
+  UrlVisualizerRemote: ({ signedUrl }: { signedUrl: string }) => (
+    <div data-testid="url-visualizer" data-signed-url={signedUrl} />
+  ),
+}));
+
 vi.mock("./ParquetVisualizer", () => ({
   default: ({ signedUrl }: { signedUrl: string }) => (
     <div data-testid="parquet-visualizer" data-signed-url={signedUrl} />
@@ -224,6 +233,42 @@ describe("ArtifactVisualizer", () => {
       });
     });
 
+    it("renders UrlVisualizerValue for url type", async () => {
+      renderWithQuery(
+        <ArtifactVisualizer
+          artifact={makeArtifact()}
+          name="output"
+          type="URL"
+          value="https://example.com"
+        />,
+      );
+
+      await userEvent.click(screen.getByRole("button"));
+
+      await waitFor(() => {
+        const viz = screen.getByTestId("url-visualizer");
+        expect(viz).toHaveAttribute("data-value", "https://example.com");
+      });
+    });
+
+    it("renders UrlVisualizerValue when a text value is a URL", async () => {
+      renderWithQuery(
+        <ArtifactVisualizer
+          artifact={makeArtifact()}
+          name="output"
+          type="text"
+          value="https://example.com/report"
+        />,
+      );
+
+      await userEvent.click(screen.getByRole("button"));
+
+      await waitFor(() => {
+        expect(screen.getByTestId("url-visualizer")).toBeInTheDocument();
+      });
+      expect(screen.queryByTestId("text-visualizer")).not.toBeInTheDocument();
+    });
+
     it("renders JsonVisualizerValue for jsonobject type", async () => {
       renderWithQuery(
         <ArtifactVisualizer
@@ -254,6 +299,21 @@ describe("ArtifactVisualizer", () => {
       await waitFor(() => {
         const viz = screen.getByTestId("text-visualizer");
         expect(viz).toHaveAttribute(
+          "data-signed-url",
+          "https://storage.example.com/signed",
+        );
+      });
+    });
+
+    it("renders UrlVisualizerRemote for url type", async () => {
+      renderWithQuery(
+        <ArtifactVisualizer artifact={makeArtifact()} name="link" type="URL" />,
+      );
+
+      await userEvent.click(screen.getByText("Preview"));
+
+      await waitFor(() => {
+        expect(screen.getByTestId("url-visualizer")).toHaveAttribute(
           "data-signed-url",
           "https://storage.example.com/signed",
         );

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/UrlVisualizer.test.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/UrlVisualizer.test.tsx
@@ -1,0 +1,62 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { UrlVisualizerValue } from "./UrlVisualizer";
+
+const mockNotify = vi.hoisted(() => vi.fn());
+
+vi.mock("@/hooks/useToastNotification", () => ({
+  default: () => mockNotify,
+}));
+
+beforeEach(() => {
+  mockNotify.mockClear();
+});
+
+describe("UrlVisualizerValue", () => {
+  it("renders the value as an external link", () => {
+    render(<UrlVisualizerValue value="https://example.com/report" />);
+
+    const link = screen.getByRole("link", {
+      name: /https:\/\/example\.com\/report/,
+    });
+    expect(link).toHaveAttribute("href", "https://example.com/report");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("copies the URL and notifies on copy click", () => {
+    const writeText = vi.fn();
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+
+    render(<UrlVisualizerValue value="https://example.com/report" />);
+    fireEvent.click(screen.getByRole("button", { name: "Copy URL" }));
+
+    expect(writeText).toHaveBeenCalledWith("https://example.com/report");
+    expect(mockNotify).toHaveBeenCalledWith(
+      "URL copied to clipboard",
+      "success",
+    );
+  });
+
+  it("shows the raw value instead of a link when it is not a valid URL", () => {
+    render(<UrlVisualizerValue value="not a url" />);
+
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+    expect(screen.getByText("Not a valid URL")).toBeInTheDocument();
+    expect(screen.getByText("not a url")).toBeInTheDocument();
+  });
+
+  it("does not link a javascript: value", () => {
+    render(<UrlVisualizerValue value="javascript:alert(1)" />);
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+
+  it("shows 'No data' for an empty value", () => {
+    render(<UrlVisualizerValue value="   " />);
+    expect(screen.getByText("No data")).toBeInTheDocument();
+  });
+});

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/UrlVisualizer.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/UrlVisualizer.tsx
@@ -1,0 +1,98 @@
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icon";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Link } from "@/components/ui/link";
+import { Paragraph, Text } from "@/components/ui/typography";
+import useToastNotification from "@/hooks/useToastNotification";
+import { copyToClipboard } from "@/utils/string";
+import { parseHttpUrl } from "@/utils/URL";
+
+import { useArtifactFetch } from "./useArtifactFetch";
+
+interface UrlValueProps {
+  url: string;
+  size?: "xs" | "sm";
+}
+
+export const UrlValue = ({ url, size = "sm" }: UrlValueProps) => {
+  const notify = useToastNotification();
+
+  const handleCopy = () => {
+    copyToClipboard(url);
+    notify("URL copied to clipboard", "success");
+  };
+
+  return (
+    <InlineStack gap="1" blockAlign="center" wrap="nowrap" className="min-w-0">
+      <Link
+        href={url}
+        external
+        size={size}
+        title={url}
+        className="min-w-0"
+        variant="primary"
+      >
+        <Text size={size} font="mono" className="min-w-0 truncate">
+          {url}
+        </Text>
+      </Link>
+
+      <Button
+        size="xs"
+        variant="ghost"
+        onClick={handleCopy}
+        aria-label="Copy URL"
+      >
+        <Icon name="Copy" size="xs" />
+      </Button>
+    </InlineStack>
+  );
+};
+
+const UrlContent = ({ content }: { content: string }) => {
+  const trimmed = content.trim();
+
+  if (trimmed.length === 0) {
+    return (
+      <Paragraph tone="subdued" size="xs">
+        No data
+      </Paragraph>
+    );
+  }
+
+  const url = parseHttpUrl(trimmed);
+
+  if (!url) {
+    return (
+      <BlockStack gap="1">
+        <Paragraph tone="subdued" size="xs">
+          Not a valid URL
+        </Paragraph>
+        <Text size="sm" font="mono" className="break-all">
+          {trimmed}
+        </Text>
+      </BlockStack>
+    );
+  }
+
+  return <UrlValue url={url} />;
+};
+
+interface UrlVisualizerValueProps {
+  value: string;
+}
+
+interface UrlVisualizerRemoteProps {
+  signedUrl: string;
+}
+
+export const UrlVisualizerValue = ({ value }: UrlVisualizerValueProps) => (
+  <UrlContent content={value} />
+);
+
+export const UrlVisualizerRemote = ({
+  signedUrl,
+}: UrlVisualizerRemoteProps) => {
+  const content = useArtifactFetch("url", signedUrl, (r) => r.text());
+  return <UrlContent content={content} />;
+};

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/artifactType.test.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/artifactType.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  inferTypeFromUri,
+  isVisualizableType,
+  normalizeRawType,
+  resolveArtifactType,
+} from "./artifactType";
+
+describe("resolveArtifactType", () => {
+  it("resolves URL aliases", () => {
+    expect(resolveArtifactType(normalizeRawType("URL"))).toBe("url");
+    expect(resolveArtifactType(normalizeRawType("URI"))).toBe("url");
+    expect(resolveArtifactType(normalizeRawType("Link"))).toBe("url");
+  });
+});
+
+describe("isVisualizableType", () => {
+  it("treats url as visualizable", () => {
+    expect(isVisualizableType("url")).toBe(true);
+  });
+});
+
+describe("inferTypeFromUri", () => {
+  it("infers url from a .uri extension", () => {
+    expect(inferTypeFromUri("gs://bucket/output.uri")).toBe("url");
+  });
+});

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/artifactType.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/artifactType.ts
@@ -1,5 +1,6 @@
 const VISUALIZABLE_TYPES = [
   "text",
+  "url",
   "image",
   "jsonobject",
   "jsonarray",
@@ -16,6 +17,8 @@ const TYPE_ALIASES: Record<string, VisualizableType> = {
   yaml: "text",
   yml: "text",
   xml: "text",
+  uri: "url",
+  link: "url",
   png: "image",
   jpg: "image",
   jpeg: "image",

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/IOCell.test.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/IOCell.test.tsx
@@ -160,6 +160,65 @@ describe("IOCell", () => {
     expect(screen.getByText("some inline value")).toBeInTheDocument();
   });
 
+  it("renders an inline URL value as an external link", () => {
+    renderWithQuery(
+      <IOCell
+        name="output"
+        type="URL"
+        artifact={makeArtifact({
+          artifact_data: {
+            total_size: 30,
+            is_dir: false,
+            value: "https://example.com/report",
+          },
+        })}
+      />,
+    );
+
+    const link = screen.getByRole("link", {
+      name: /https:\/\/example\.com\/report/,
+    });
+    expect(link).toHaveAttribute("href", "https://example.com/report");
+    expect(link).toHaveAttribute("target", "_blank");
+  });
+
+  it("links an inline URL value even when the declared type is text", () => {
+    renderWithQuery(
+      <IOCell
+        name="output"
+        type="text"
+        artifact={makeArtifact({
+          artifact_data: {
+            total_size: 30,
+            is_dir: false,
+            value: "https://example.com/report",
+          },
+        })}
+      />,
+    );
+
+    expect(screen.getByRole("link")).toBeInTheDocument();
+  });
+
+  it("does not link an inline value that is not a web URL", () => {
+    renderWithQuery(
+      <IOCell
+        name="output"
+        type="text"
+        artifact={makeArtifact({
+          artifact_data: {
+            total_size: 20,
+            is_dir: false,
+            value: "javascript:alert(1)",
+          },
+        })}
+      />,
+    );
+
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+    expect(screen.getByText("javascript:alert(1)")).toBeInTheDocument();
+  });
+
   it("does not render inline value for whitespace-only strings", () => {
     renderWithQuery(
       <IOCell

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/IOCell.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/IOCell.tsx
@@ -3,6 +3,7 @@ import { CopyText } from "@/components/shared/CopyText/CopyText";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Text } from "@/components/ui/typography";
 import { formatBytes } from "@/utils/string";
+import { parseHttpUrl } from "@/utils/URL";
 
 import ArtifactURI from "./ArtifactURI";
 import {
@@ -11,6 +12,7 @@ import {
   resolveArtifactType,
 } from "./ArtifactVisualizer/artifactType";
 import ArtifactVisualizer from "./ArtifactVisualizer/ArtifactVisualizer";
+import { UrlValue } from "./ArtifactVisualizer/UrlVisualizer";
 import { MAX_VISUALIZABLE_SIZE_BYTES } from "./ArtifactVisualizer/utils";
 
 interface IOCellProps {
@@ -23,6 +25,7 @@ const IOCell = ({ name, type, artifact }: IOCellProps) => {
   const artifactData = artifact?.artifact_data;
   const inlineValue = artifactData?.value;
   const hasInlineValue = canShowInlineValue(inlineValue);
+  const inlineUrl = parseHttpUrl(inlineValue);
   const hasDetails = Boolean(artifactData?.uri || hasInlineValue);
 
   const artifactType =
@@ -71,15 +74,18 @@ const IOCell = ({ name, type, artifact }: IOCellProps) => {
         className="w-full"
         wrap="nowrap"
       >
-        {hasInlineValue && (
-          <CopyText
-            size="xs"
-            compact
-            className="font-mono text-success line-clamp-2 break-all"
-          >
-            {inlineValue}
-          </CopyText>
-        )}
+        {hasInlineValue &&
+          (inlineUrl ? (
+            <UrlValue url={inlineUrl} size="xs" />
+          ) : (
+            <CopyText
+              size="xs"
+              compact
+              className="font-mono text-success line-clamp-2 break-all"
+            >
+              {inlineValue}
+            </CopyText>
+          ))}
 
         {!artifactData?.uri &&
           artifact &&

--- a/src/routes/v2/pages/CompareView/utils/artifactTextDiff.ts
+++ b/src/routes/v2/pages/CompareView/utils/artifactTextDiff.ts
@@ -1,5 +1,6 @@
 const DIFF_LANGUAGES: Record<string, string> = {
   text: "plaintext",
+  url: "plaintext",
   csv: "plaintext",
   tsv: "plaintext",
   jsonobject: "json",

--- a/src/utils/URL.test.ts
+++ b/src/utils/URL.test.ts
@@ -8,13 +8,13 @@ import {
   downloadYamlFromComponentText,
   getIdOrTitleFromPath,
   normalizeUrl,
+  parseHttpUrl,
 } from "./URL";
 
 vi.mock("@/routes/router", () => ({
   RUNS_BASE_PATH: "/runs",
 }));
 
-// normalizeUrl tests
 describe("normalizeUrl", () => {
   it("returns empty string for empty input", () => {
     expect(normalizeUrl("")).toBe("");
@@ -50,7 +50,52 @@ describe("normalizeUrl", () => {
   });
 });
 
-// convertGcsUrlToBrowserUrl tests
+describe("parseHttpUrl", () => {
+  it.each([
+    "https://example.com",
+    "http://example.com/path?q=1#frag",
+    "https://example.com:8080/a/b",
+  ])("accepts %s", (value) => {
+    expect(parseHttpUrl(value)).toBe(value);
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(parseHttpUrl("  https://example.com\n")).toBe("https://example.com");
+  });
+
+  it.each([
+    ["javascript:alert(1)"],
+    ["data:text/html,<script>alert(1)</script>"],
+    ["file:///etc/passwd"],
+    ["gs://bucket/object"],
+    ["ftp://example.com"],
+  ])("rejects the non-web scheme %s", (value) => {
+    expect(parseHttpUrl(value)).toBeUndefined();
+  });
+
+  it.each([
+    ["plain text"],
+    ["example.com"],
+    ["https://example.com and more text"],
+    ["https://example.com\nhttps://other.com"],
+    [""],
+    ["   "],
+  ])("rejects %j", (value) => {
+    expect(parseHttpUrl(value)).toBeUndefined();
+  });
+
+  it("rejects null and undefined", () => {
+    expect(parseHttpUrl(null)).toBeUndefined();
+    expect(parseHttpUrl(undefined)).toBeUndefined();
+  });
+
+  it("rejects URLs beyond the length cap", () => {
+    expect(
+      parseHttpUrl(`https://example.com/${"a".repeat(2048)}`),
+    ).toBeUndefined();
+  });
+});
+
 describe("convertGcsUrlToBrowserUrl", () => {
   it("returns unchanged if not a gs:// url", () => {
     expect(convertGcsUrlToBrowserUrl("http://example.com", false)).toBe(
@@ -99,7 +144,6 @@ describe("buildComponentSourceUrl", () => {
   });
 });
 
-// convertGithubUrlToDirectoryUrl tests
 describe("convertGithubUrlToDirectoryUrl", () => {
   it("converts raw github url to directory url", () => {
     const rawUrl =
@@ -168,7 +212,6 @@ describe("getIdOrTitleFromPath", () => {
   });
 });
 
-// downloadYamlFromComponentText tests
 describe("downloadYamlFromComponentText", () => {
   beforeAll(() => {
     // @ts-expect-error: global.URL may not exist in the test environment, so we mock it for testing purposes
@@ -224,7 +267,6 @@ describe("downloadYamlFromComponentText", () => {
   });
 });
 
-// converHfUrlToDirectoryUrl tests
 describe("converHfUrlToDirectoryUrl", () => {
   describe("non-hf URLs", () => {
     it("returns unchanged for URLs that don't start with hf://", () => {

--- a/src/utils/URL.ts
+++ b/src/utils/URL.ts
@@ -179,6 +179,22 @@ const getIdOrTitleFromPath = (
   };
 };
 
+const MAX_URL_LENGTH = 2048;
+
+const parseHttpUrl = (value?: string | null): string | undefined => {
+  const trimmed = value?.trim();
+  if (!trimmed || trimmed.length > MAX_URL_LENGTH || /\s/.test(trimmed)) {
+    return undefined;
+  }
+
+  try {
+    const { protocol } = new URL(trimmed);
+    return protocol === "http:" || protocol === "https:" ? trimmed : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
 const normalizeUrl = (url: string) => {
   if (url.trim() === "") {
     return "";
@@ -223,4 +239,5 @@ export {
   getIdOrTitleFromPath,
   isGithubUrl,
   normalizeUrl,
+  parseHttpUrl,
 };


### PR DESCRIPTION
## Description

Renders URL type output artifacts as clickable hyperlinks in artifact previews

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

- [x] New feature

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

![image.png](https://app.graphite.com/user-attachments/assets/524fb870-1704-4cd3-a676-6dac760efaae.png)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

Use this pipeline:

```
name: URL Artifact Type Test
description: >
  Single task that echoes the `url` pipeline input into an output artifact
  typed `URL`. Change the input, re-run, inspect how the run view renders a
  url-typed artifact.

inputs:
  - name: url
    type: String
    description: URL to emit as a url-typed artifact.
    default: https://oasis-project.docs.shopify.io
    annotations:
      editor.position: '{"x": 0, "y": 0}'

outputs:
  - name: url_artifact
    type: URL
    description: The input url, written out as a url-typed artifact.
    annotations:
      editor.position: '{"x": 640, "y": 0}'

implementation:
  graph:
    tasks:
      Emit URL:
        componentRef:
          spec:
            name: Emit URL
            description: Writes the given url string to a url-typed output artifact.
            inputs:
              - name: url
                type: String
                description: URL to write.
            outputs:
              - name: url_artifact
                type: URL
                description: File containing the url.
            implementation:
              container:
                image: python:3.11-slim
                command:
                  - python3
                  - '-c'
                  - |
                    import os, sys

                    url, output_path = sys.argv[1], sys.argv[2]
                    os.makedirs(os.path.dirname(output_path), exist_ok=True)
                    with open(output_path, "w") as f:
                        f.write(url)
                    print(f"wrote url artifact -> {output_path}: {url}")
                  - inputValue: url
                  - outputPath: url_artifact
        arguments:
          url:
            graphInput:
              inputName: url
        executionOptions:
          cachingStrategy:
            maxCacheStaleness: P0D
        annotations:
          editor.position: '{"x": 320, "y": 0}'

    outputValues:
      url_artifact:
        taskOutput:
          taskId: Emit URL
          outputName: url_artifact
```

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->