### PR TITLE
fix: Apply AI edits in the subgraph the entity lives in

### DIFF
--- a/src/agent/prompts/architect.md
+++ b/src/agent/prompts/architect.md
@@ -45,11 +45,26 @@ Every entity has a stable `$id`. Use these IDs when referencing entities in tool
 
 ## Active subgraph context
 
-`get_pipeline_state` may include an `activeSubgraphPath` field — a breadcrumb of subgraph task names from the root pipeline to whatever subgraph the user is currently viewing. Treat this as a hint about where the user's attention is, but remember: every CSOM mutation always applies to the root spec. When you build new structure, prefer extending the root pipeline (or an explicit subgraph the user named) rather than the nested view the user happens to be focused on.
+`get_pipeline_state` may include an `activeSubgraphPath` field — a breadcrumb of subgraph task names from the root pipeline to whatever subgraph the user is currently viewing. Use it to resolve what the user means by "here" or "this step" when they ask you to change something without saying where. New structure is always built at the top level.
 
 ## Looking inside a subgraph
 
 `get_pipeline_state` reports a subgraph task by its interface only — `isSubgraph: true` plus its input and output ports — so its inner tasks and bindings are not in that payload. Call `get_subgraph_state(taskEntityId)` when you need to know what a subgraph actually does before wiring into or around it. The result is the same shape as `get_pipeline_state`, and its inner tasks carry `isSubgraph` too, so call again with an inner `$id` to go deeper. Never assume a subgraph's contents from its name alone.
+
+The `$id`s you read from `get_subgraph_state` are valid mutation targets. Every edit tool resolves an `$id` to whichever subgraph it lives in, so renaming, deleting, connecting, or setting an argument on a nested entity works the same as at the top level — no need to unpack a subgraph first, and no need to ask permission you would not ask for a top-level edit.
+
+Two limits remain, and both are about structure rather than depth:
+
+- **A connection cannot cross a subgraph boundary.** `connect_nodes` requires both endpoints in the same graph. To move a value in or out of a subgraph, wire it to that subgraph task's own ports in the parent.
+- **`create_subgraph` cannot group across levels.** Every task you pass must already sit in the same graph.
+
+## Validation across subgraphs
+
+`validate_pipeline` reports issues from the whole pipeline including nested subgraphs, and each issue carries a `subgraphPath` locating it (`["root"]` means the top level). You can fix issues at any depth. Use the path to find the entity — `get_subgraph_state` down that chain gives you its `$id`.
+
+## Saying where a change landed
+
+The user's canvas does not follow you into a subgraph: after you edit something nested, they are still looking at wherever they were. So whenever you change something inside a subgraph, name that subgraph in your reply — "renamed it to `clean_rows` inside **Preprocessing**" — so the user knows where to look. Never describe a nested edit as though it happened on the graph in front of them.
 
 ## When to defer to another specialist
 

--- a/src/agent/prompts/architect.md
+++ b/src/agent/prompts/architect.md
@@ -51,7 +51,9 @@ Every entity has a stable `$id`. Use these IDs when referencing entities in tool
 
 `get_pipeline_state` reports a subgraph task by its interface only — `isSubgraph: true` plus its input and output ports — so its inner tasks and bindings are not in that payload. Call `get_subgraph_state(taskEntityId)` when you need to know what a subgraph actually does before wiring into or around it. The result is the same shape as `get_pipeline_state`, and its inner tasks carry `isSubgraph` too, so call again with an inner `$id` to go deeper. Never assume a subgraph's contents from its name alone.
 
-The `$id`s you read from `get_subgraph_state` are valid mutation targets. Every edit tool resolves an `$id` to whichever subgraph it lives in, so renaming, deleting, connecting, or setting an argument on a nested entity works the same as at the top level — no need to unpack a subgraph first, and no need to ask permission you would not ask for a top-level edit.
+The `$id`s you read from `get_subgraph_state` are valid mutation targets. Every edit tool that takes an `$id` resolves it to whichever subgraph the entity lives in, so renaming, deleting, connecting, or setting an argument on a nested entity works the same as at the top level — no need to unpack a subgraph first, and no need to ask permission you would not ask for a top-level edit.
+
+`add_task`, `add_input` and `add_output` take no entity `$id`, so they have nothing to resolve: they always add to the top-level pipeline. If the user asks for something new inside a subgraph, say that you can only add it at the top level rather than adding it there and describing it as nested.
 
 Two limits remain, and both are about structure rather than depth:
 
@@ -60,7 +62,7 @@ Two limits remain, and both are about structure rather than depth:
 
 ## Validation across subgraphs
 
-`validate_pipeline` reports issues from the whole pipeline including nested subgraphs, and each issue carries a `subgraphPath` locating it (`["root"]` means the top level). You can fix issues at any depth. Use the path to find the entity — `get_subgraph_state` down that chain gives you its `$id`.
+`validate_pipeline` reports issues from the whole pipeline including nested subgraphs, and each issue carries a `subgraphPath` locating it — the chain of subgraph task names from the top level, so `[]` means the top-level pipeline itself and it matches `activeSubgraphPath` segment for segment. You can fix issues at any depth. Use the path to find the entity — `get_subgraph_state` down that chain gives you its `$id`.
 
 ## Saying where a change landed
 

--- a/src/agent/prompts/pipelineRepair.md
+++ b/src/agent/prompts/pipelineRepair.md
@@ -66,11 +66,23 @@ Every entity has a stable `$id`. Use these IDs when referencing entities in tool
 
 ## Active subgraph context
 
-`get_pipeline_state` may include an `activeSubgraphPath` field — a breadcrumb of subgraph task names from the root pipeline to whatever subgraph the user is currently viewing. Treat this as a hint about what part of the pipeline the user cares about, but remember: every CSOM mutation always applies to the root spec. If a fix targets an entity inside a nested subgraph, point that out and ask the user before editing.
+`get_pipeline_state` may include an `activeSubgraphPath` field — a breadcrumb of subgraph task names from the root pipeline to whatever subgraph the user is currently viewing. Treat it as a hint about which part of the pipeline the user cares about. It does not limit what you can fix: a fix inside a subgraph needs no permission a top-level fix would not need.
 
 ## Looking inside a subgraph
 
 `get_pipeline_state` reports a subgraph task by its interface only — `isSubgraph: true` plus its input and output ports — so its inner tasks and bindings are not in that payload. When a validation issue or the user's question points inside a subgraph, call `get_subgraph_state(taskEntityId)` to get its contents in the same shape, and call it again with an inner `$id` for deeper nesting. Diagnose from the real contents rather than guessing from the subgraph's name.
+
+The `$id`s you read from `get_subgraph_state` are valid mutation targets. Every edit tool resolves an `$id` to whichever subgraph it lives in, so a nested fix is applied exactly like a top-level one — never unpack a subgraph just to reach inside it.
+
+Two structural limits remain: `connect_nodes` needs both endpoints in the same graph (to route a value across a subgraph boundary, wire it to that subgraph task's own ports in the parent), and `create_subgraph` cannot group tasks that live at different levels.
+
+## Validation across subgraphs
+
+`validate_pipeline` reports issues from the whole pipeline including nested subgraphs, and each issue carries a `subgraphPath` locating it (`["root"]` means the top level). Fix issues at any depth. To reach a nested one, follow its path with `get_subgraph_state` to get the entity's `$id`, then apply the normal fix.
+
+## Saying where a fix landed
+
+The user's canvas does not follow you into a subgraph, so after a nested fix they are still looking at wherever they were. Whenever a fix lands inside a subgraph, name that subgraph in your summary so the user knows where to look. Never describe a nested fix as though it happened on the graph in front of them.
 
 ## Response Formatting
 

--- a/src/agent/prompts/pipelineRepair.md
+++ b/src/agent/prompts/pipelineRepair.md
@@ -72,13 +72,15 @@ Every entity has a stable `$id`. Use these IDs when referencing entities in tool
 
 `get_pipeline_state` reports a subgraph task by its interface only — `isSubgraph: true` plus its input and output ports — so its inner tasks and bindings are not in that payload. When a validation issue or the user's question points inside a subgraph, call `get_subgraph_state(taskEntityId)` to get its contents in the same shape, and call it again with an inner `$id` for deeper nesting. Diagnose from the real contents rather than guessing from the subgraph's name.
 
-The `$id`s you read from `get_subgraph_state` are valid mutation targets. Every edit tool resolves an `$id` to whichever subgraph it lives in, so a nested fix is applied exactly like a top-level one — never unpack a subgraph just to reach inside it.
+The `$id`s you read from `get_subgraph_state` are valid mutation targets. Every edit tool that takes an `$id` resolves it to whichever subgraph the entity lives in, so a nested fix is applied exactly like a top-level one — never unpack a subgraph just to reach inside it.
+
+`add_task`, `add_input` and `add_output` take no entity `$id`, so they have nothing to resolve: they always add to the top-level pipeline. If clearing an issue inside a subgraph would need a new task or port in that subgraph, report that rather than adding it at the top level, where it cannot be connected to anything inside.
 
 Two structural limits remain: `connect_nodes` needs both endpoints in the same graph (to route a value across a subgraph boundary, wire it to that subgraph task's own ports in the parent), and `create_subgraph` cannot group tasks that live at different levels.
 
 ## Validation across subgraphs
 
-`validate_pipeline` reports issues from the whole pipeline including nested subgraphs, and each issue carries a `subgraphPath` locating it (`["root"]` means the top level). Fix issues at any depth. To reach a nested one, follow its path with `get_subgraph_state` to get the entity's `$id`, then apply the normal fix.
+`validate_pipeline` reports issues from the whole pipeline including nested subgraphs, and each issue carries a `subgraphPath` locating it — the chain of subgraph task names from the top level, so `[]` means the top-level pipeline itself and it matches `activeSubgraphPath` segment for segment. Fix issues at any depth. To reach a nested one, follow its path with `get_subgraph_state` to get the entity's `$id`, then apply the normal fix.
 
 ## Saying where a fix landed
 

--- a/src/agent/toolBridgeApi.ts
+++ b/src/agent/toolBridgeApi.ts
@@ -25,13 +25,20 @@ interface ValidationIssue {
   severity: string;
   message: string;
   entityId?: string;
+  entityName?: string;
   issueCode?: string;
+  subgraphPath: string[];
 }
 
 export interface ValidationResult {
   valid: boolean;
   issueCount: number;
   issues: ValidationIssue[];
+}
+
+interface BridgeResult {
+  success: boolean;
+  error?: string;
 }
 
 export interface ConnectArgs {
@@ -113,17 +120,15 @@ export interface ToolBridgeApi {
   getPipelineState(): Promise<AiSpec>;
   getSubgraphState(taskEntityId: string): Promise<SubgraphStateResult>;
 
-  setPipelineName(name: string): Promise<{ success: boolean }>;
-  setPipelineDescription(description: string): Promise<{ success: boolean }>;
+  setPipelineName(name: string): Promise<BridgeResult>;
+  setPipelineDescription(description: string): Promise<BridgeResult>;
 
-  addTask(args: { name: string; componentRef: ComponentReference }): Promise<{
-    success: boolean;
-    taskId?: string;
-    name?: string;
-    error?: string;
-  }>;
-  deleteTask(entityId: string): Promise<{ success: boolean }>;
-  renameTask(entityId: string, newName: string): Promise<{ success: boolean }>;
+  addTask(args: {
+    name: string;
+    componentRef: ComponentReference;
+  }): Promise<BridgeResult & { taskId?: string; name?: string }>;
+  deleteTask(entityId: string): Promise<BridgeResult>;
+  renameTask(entityId: string, newName: string): Promise<BridgeResult>;
 
   addInput(args: {
     name: string;
@@ -131,37 +136,34 @@ export interface ToolBridgeApi {
     description?: string;
     defaultValue?: string;
     optional?: boolean;
-  }): Promise<{ success: boolean; inputId: string; name: string }>;
-  deleteInput(entityId: string): Promise<{ success: boolean }>;
-  renameInput(entityId: string, newName: string): Promise<{ success: boolean }>;
+  }): Promise<BridgeResult & { inputId?: string; name?: string }>;
+  deleteInput(entityId: string): Promise<BridgeResult>;
+  renameInput(entityId: string, newName: string): Promise<BridgeResult>;
 
   addOutput(args: {
     name: string;
     type?: string;
     description?: string;
-  }): Promise<{ success: boolean; outputId: string; name: string }>;
-  deleteOutput(entityId: string): Promise<{ success: boolean }>;
-  renameOutput(
-    entityId: string,
-    newName: string,
-  ): Promise<{ success: boolean }>;
+  }): Promise<BridgeResult & { outputId?: string; name?: string }>;
+  deleteOutput(entityId: string): Promise<BridgeResult>;
+  renameOutput(entityId: string, newName: string): Promise<BridgeResult>;
 
   connectNodes(
     args: ConnectArgs,
-  ): Promise<{ success: boolean; bindingId?: string; error?: string }>;
-  deleteEdge(entityId: string): Promise<{ success: boolean }>;
+  ): Promise<BridgeResult & { bindingId?: string }>;
+  deleteEdge(entityId: string): Promise<BridgeResult>;
 
   setTaskArgument(
     taskEntityId: string,
     inputName: string,
     value: ArgumentType,
-  ): Promise<{ success: boolean; error?: string }>;
+  ): Promise<BridgeResult>;
 
   createSubgraph(
     taskEntityIds: string[],
     subgraphName: string,
-  ): Promise<{ success: boolean; subgraphTaskId?: string; error?: string }>;
-  unpackSubgraph(taskEntityId: string): Promise<{ success: boolean }>;
+  ): Promise<BridgeResult & { subgraphTaskId?: string }>;
+  unpackSubgraph(taskEntityId: string): Promise<BridgeResult>;
 
   validatePipeline(): Promise<ValidationResult>;
 

--- a/src/agent/tools/csomTools.ts
+++ b/src/agent/tools/csomTools.ts
@@ -50,7 +50,11 @@ const argumentValueSchema = z.union([
   }),
   z.object({
     taskOutput: z.object({
-      taskId: z.string(),
+      taskId: z
+        .string()
+        .describe(
+          "The source task's $id or its name — both are accepted. The referenced task must live in the same graph as the task being written to.",
+        ),
       outputName: z.string(),
       type: z.string().nullable().optional(),
     }),
@@ -382,7 +386,7 @@ export function createCsomTools(bridge: ToolBridgeApi) {
   const validatePipeline = tool({
     name: "validate_pipeline",
     description:
-      "Validate the whole pipeline — including everything inside every subgraph — for schema errors, missing inputs, orphaned bindings, and cycles. Each issue carries a subgraphPath saying where it is. Always call before finalizing.",
+      "Validate the whole pipeline — including everything inside every subgraph — for schema errors, missing inputs, orphaned bindings, and cycles. Each issue carries a subgraphPath saying where it is: the chain of subgraph task names from the top level, empty for the top-level pipeline itself. Always call before finalizing.",
     parameters: z.object({}),
     execute: async () => asJson(await bridge.validatePipeline()),
   });

--- a/src/agent/tools/csomTools.ts
+++ b/src/agent/tools/csomTools.ts
@@ -105,14 +105,16 @@ export function createCsomTools(bridge: ToolBridgeApi) {
 
   const setPipelineName = tool({
     name: "set_pipeline_name",
-    description: "Set the pipeline name.",
+    description:
+      "Set the name of the top-level pipeline. To rename a subgraph, use rename_task on the subgraph task instead.",
     parameters: z.object({ name: z.string().describe("New pipeline name") }),
     execute: async ({ name }) => asJson(await bridge.setPipelineName(name)),
   });
 
   const setPipelineDescription = tool({
     name: "set_pipeline_description",
-    description: "Set the pipeline description.",
+    description:
+      "Set the description of the top-level pipeline (not of a subgraph).",
     parameters: z.object({
       description: z.string().describe("New pipeline description"),
     }),
@@ -232,7 +234,8 @@ export function createCsomTools(bridge: ToolBridgeApi) {
 
   const deleteInput = tool({
     name: "delete_input",
-    description: "Delete a pipeline input and its connections.",
+    description:
+      "Delete a graph input and its connections. Works on inputs inside a subgraph too: the matching input port disappears from the subgraph task and any connection feeding it in the parent is removed.",
     parameters: z.object({
       entityId: z.string().describe("The $id of the input to delete"),
     }),
@@ -241,7 +244,8 @@ export function createCsomTools(bridge: ToolBridgeApi) {
 
   const renameInput = tool({
     name: "rename_input",
-    description: "Rename a pipeline input.",
+    description:
+      "Rename a graph input. Works on inputs inside a subgraph too: the matching input port on the subgraph task is renamed with it, so connections in the parent survive.",
     parameters: z.object({
       entityId: z.string().describe("The $id of the input"),
       newName: z.string().describe("New input name"),
@@ -270,7 +274,8 @@ export function createCsomTools(bridge: ToolBridgeApi) {
 
   const deleteOutput = tool({
     name: "delete_output",
-    description: "Delete a pipeline output and its connections.",
+    description:
+      "Delete a graph output and its connections. Works on outputs inside a subgraph too: the matching output port disappears from the subgraph task and any connection drawing from it in the parent is removed.",
     parameters: z.object({
       entityId: z.string().describe("The $id of the output to delete"),
     }),
@@ -280,7 +285,8 @@ export function createCsomTools(bridge: ToolBridgeApi) {
 
   const renameOutput = tool({
     name: "rename_output",
-    description: "Rename a pipeline output.",
+    description:
+      "Rename a graph output. Works on outputs inside a subgraph too: the matching output port on the subgraph task is renamed with it, so connections in the parent survive.",
     parameters: z.object({
       entityId: z.string().describe("The $id of the output"),
       newName: z.string().describe("New output name"),
@@ -292,7 +298,7 @@ export function createCsomTools(bridge: ToolBridgeApi) {
   const connectNodes = tool({
     name: "connect_nodes",
     description:
-      "Connect an output port of one entity to an input port of another. Replaces any existing connection to the target port.",
+      "Connect an output port of one entity to an input port of another. Replaces any existing connection to the target port. Both entities must live in the same pipeline or the same subgraph — a connection cannot cross a subgraph boundary. To get a value into or out of a subgraph, wire it to that subgraph task's own ports in the parent.",
     parameters: z.object({
       sourceEntityId: z
         .string()
@@ -321,7 +327,8 @@ export function createCsomTools(bridge: ToolBridgeApi) {
 
   const deleteEdge = tool({
     name: "delete_edge",
-    description: "Delete a binding/edge by its $id.",
+    description:
+      "Delete a binding/edge by its $id, wherever it lives — top-level pipeline or inside a subgraph.",
     parameters: z.object({
       entityId: z.string().describe("The $id of the binding to delete"),
     }),
@@ -331,7 +338,7 @@ export function createCsomTools(bridge: ToolBridgeApi) {
   const setTaskArgument = tool({
     name: "set_task_argument",
     description:
-      "Set a value for a task input. Removes any existing connection to that port. Accepts a literal string or a graph-input, task-output, or dynamic-data (secret or system) reference object.",
+      "Set a value for a task input, for a task anywhere in the pipeline including inside a subgraph. Removes any existing connection to that port. Accepts a literal string or a graph-input, task-output, or dynamic-data (secret or system) reference object.",
     parameters: z.object({
       taskEntityId: z.string().describe("$id of the task"),
       inputName: z.string().describe("Name of the input port"),
@@ -352,7 +359,7 @@ export function createCsomTools(bridge: ToolBridgeApi) {
   const createSubgraph = tool({
     name: "create_subgraph",
     description:
-      "Group 2 or more related tasks into a subgraph. NEVER use for a single task — only group tasks that form a logical unit of work together.",
+      "Group 2 or more related tasks into a subgraph. NEVER use for a single task — only group tasks that form a logical unit of work together. Every task passed must already live in the same pipeline or the same subgraph; tasks from different levels cannot be grouped.",
     parameters: z.object({
       taskEntityIds: z.array(z.string()).describe("$ids of tasks to group"),
       subgraphName: z.string().describe("Name for the subgraph"),
@@ -364,7 +371,7 @@ export function createCsomTools(bridge: ToolBridgeApi) {
   const unpackSubgraph = tool({
     name: "unpack_subgraph",
     description:
-      "Inline a subgraph task back into the parent pipeline, expanding its inner tasks.",
+      "Inline a subgraph task back into the graph that contains it, expanding its inner tasks. Works on a nested subgraph too — its contents are inlined into the subgraph that held it, not into the top-level pipeline.",
     parameters: z.object({
       taskEntityId: z.string().describe("$id of the subgraph task to unpack"),
     }),
@@ -375,7 +382,7 @@ export function createCsomTools(bridge: ToolBridgeApi) {
   const validatePipeline = tool({
     name: "validate_pipeline",
     description:
-      "Validate the current pipeline for schema errors, missing inputs, orphaned bindings, and cycles. Always call before finalizing.",
+      "Validate the whole pipeline — including everything inside every subgraph — for schema errors, missing inputs, orphaned bindings, and cycles. Each issue carries a subgraphPath saying where it is. Always call before finalizing.",
     parameters: z.object({}),
     execute: async () => asJson(await bridge.validatePipeline()),
   });

--- a/src/models/componentSpec/validation/collectIssues.ts
+++ b/src/models/componentSpec/validation/collectIssues.ts
@@ -2,7 +2,7 @@ import type { ComponentSpec } from "../entities/componentSpec";
 import type { ComponentValidationIssue, ValidationIssue } from "./types";
 import { validateSpec } from "./validateSpec";
 
-const ROOT_PATH_ID = "root";
+export const ROOT_PATH_ID = "root";
 
 /**
  * Recursively collect validation issues across the entire pipeline,

--- a/src/routes/v2/pages/Editor/components/AiChat/toolBridge.test.ts
+++ b/src/routes/v2/pages/Editor/components/AiChat/toolBridge.test.ts
@@ -460,8 +460,11 @@ describe("createEditorToolBridge", () => {
 
   describe("subgraphs", () => {
     it("createSubgraph returns the new subgraph task id", async () => {
-      const { bridge, spec } = makeBridge();
-      const result = await bridge.createSubgraph(["task_1"], "Group");
+      const { bridge, spec } = makeNestedBridge();
+      const result = await bridge.createSubgraph(
+        [taskId(spec, "Preprocess"), taskId(spec, "Train")],
+        "Group",
+      );
       expect(result.success).toBe(true);
       expect(result.subgraphTaskId).toBeDefined();
       expect(spec.tasks.some((t) => t.$id === result.subgraphTaskId)).toBe(
@@ -473,7 +476,23 @@ describe("createEditorToolBridge", () => {
       const { bridge } = makeBridge();
       const result = await bridge.createSubgraph([], "Group");
       expect(result.success).toBe(false);
-      expect(result.error).toMatch(/Could not create subgraph/);
+      expect(result.error).toMatch(/at least two distinct tasks/);
+    });
+
+    it("createSubgraph refuses to wrap a single task", async () => {
+      const { bridge, spec } = makeBridge();
+      const result = await bridge.createSubgraph(["task_1"], "Group");
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/at least two distinct tasks/);
+      expect(spec.tasks).toHaveLength(1);
+    });
+
+    it("createSubgraph refuses the same task id passed twice", async () => {
+      const { bridge, spec } = makeBridge();
+      const result = await bridge.createSubgraph(["task_1", "task_1"], "Group");
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/at least two distinct tasks/);
+      expect(spec.tasks).toHaveLength(1);
     });
   });
 
@@ -666,6 +685,67 @@ describe("createEditorToolBridge", () => {
       expect(result.success).toBe(false);
       expect(result.error).toContain('refers to task "Train", not a binding');
     });
+
+    it("refuses an argument referencing a graph input from another graph", async () => {
+      const { bridge, spec, inner } = makeNestedBridge();
+
+      const result = await bridge.setTaskArgument(
+        taskId(inner, "DropNulls"),
+        "path",
+        { graphInput: { inputName: "raw_path" } },
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('has no input named "raw_path"');
+      expect(inner.tasks[0].arguments).toEqual([]);
+      expect(spec.inputs.map((i) => i.name)).toEqual(["raw_path"]);
+    });
+
+    it("accepts a task output referenced by $id and stores it by name", async () => {
+      const { bridge, spec } = makeNestedBridge();
+
+      const result = await bridge.setTaskArgument(
+        taskId(spec, "Train"),
+        "table",
+        {
+          taskOutput: {
+            taskId: taskId(spec, "Preprocess"),
+            outputName: "table",
+          },
+        },
+      );
+
+      expect(result).toEqual({ success: true });
+      expect(spec.tasks.find((t) => t.name === "Train")?.arguments).toEqual([
+        {
+          name: "table",
+          value: { taskOutput: { taskId: "Preprocess", outputName: "table" } },
+        },
+      ]);
+    });
+
+    it("explains a rename that collides instead of failing generically", async () => {
+      const { bridge, spec } = makeNestedBridge();
+
+      const result = await bridge.renameTask(
+        taskId(spec, "Train"),
+        "Preprocess",
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("already taken in that graph");
+      expect(spec.tasks.map((t) => t.name)).toEqual(["Preprocess", "Train"]);
+    });
+
+    it("explains unpacking something that is not a subgraph", async () => {
+      const { bridge, spec } = makeNestedBridge();
+
+      const result = await bridge.unpackSubgraph(taskId(spec, "Train"));
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("is not a subgraph");
+      expect(result.error).not.toContain("could not be applied");
+    });
   });
 
   describe("validatePipeline", () => {
@@ -712,7 +792,7 @@ describe("createEditorToolBridge", () => {
         expect(typeof issue.type).toBe("string");
         expect(typeof issue.severity).toBe("string");
         expect(typeof issue.message).toBe("string");
-        expect(issue.subgraphPath).toEqual(["root"]);
+        expect(issue.subgraphPath).toEqual([]);
       }
     });
 
@@ -720,10 +800,10 @@ describe("createEditorToolBridge", () => {
       const { bridge } = makeNestedBridge();
 
       const result = await bridge.validatePipeline();
-      const nested = result.issues.filter((i) => i.subgraphPath.length > 1);
+      const nested = result.issues.filter((i) => i.subgraphPath.length > 0);
 
       expect(nested.length).toBeGreaterThan(0);
-      expect(nested[0].subgraphPath).toEqual(["root", "Preprocess"]);
+      expect(nested[0].subgraphPath).toEqual(["Preprocess"]);
       expect(result.issueCount).toBe(result.issues.length);
     });
   });

--- a/src/routes/v2/pages/Editor/components/AiChat/toolBridge.test.ts
+++ b/src/routes/v2/pages/Editor/components/AiChat/toolBridge.test.ts
@@ -8,6 +8,8 @@ import {
   Output,
   Task,
 } from "@/models/componentSpec";
+import { IncrementingIdGenerator } from "@/models/componentSpec/factories/idGenerator";
+import { YamlDeserializer } from "@/models/componentSpec/serialization/yamlDeserializer";
 import { ONBOARDING_MY_RUN_COUNT_KEY } from "@/providers/OnboardingProvider/onboardingQueryKeys";
 import type { UndoGroupable } from "@/routes/v2/shared/nodes/types";
 
@@ -98,6 +100,91 @@ function makeBridge() {
     undo,
   });
   return { bridge, undo, spec };
+}
+
+const containerComponent = (
+  name: string,
+  image: string,
+  inputName: string,
+  outputName: string,
+) => ({
+  name,
+  spec: {
+    name,
+    inputs: [{ name: inputName, type: "String" }],
+    outputs: [{ name: outputName, type: "String" }],
+    implementation: { container: { image } },
+  },
+});
+
+const nestedPipelineYaml = (extraInnerTasks: Record<string, unknown> = {}) => ({
+  name: "RootPipeline",
+  inputs: [{ name: "raw_path", type: "String" }],
+  implementation: {
+    graph: {
+      tasks: {
+        Preprocess: {
+          componentRef: {
+            name: "Preprocess",
+            spec: {
+              name: "Preprocess",
+              inputs: [{ name: "path", type: "String" }],
+              outputs: [{ name: "table", type: "String" }],
+              implementation: {
+                graph: {
+                  tasks: {
+                    DropNulls: {
+                      componentRef: containerComponent(
+                        "DropNulls",
+                        "clean:1",
+                        "path",
+                        "table",
+                      ),
+                      arguments: {
+                        path: { graphInput: { inputName: "path" } },
+                      },
+                    },
+                    ...extraInnerTasks,
+                  },
+                },
+              },
+            },
+          },
+        },
+        Train: {
+          componentRef: containerComponent(
+            "Train",
+            "train:1",
+            "table",
+            "model",
+          ),
+        },
+      },
+    },
+  },
+});
+
+function makeNestedBridge(extraInnerTasks?: Record<string, unknown>) {
+  const spec = new YamlDeserializer(new IncrementingIdGenerator()).deserialize(
+    nestedPipelineYaml(extraInnerTasks),
+  );
+  const undo = new RecordingUndo();
+  const bridge = createEditorToolBridge({
+    getSpec: () => spec,
+    getActiveSubgraphPath: () => [],
+    undo,
+  });
+  const preprocess = spec.tasks.find((t) => t.name === "Preprocess");
+  if (!preprocess?.subgraphSpec) {
+    throw new Error("Preprocess did not deserialize as a subgraph");
+  }
+  return { bridge, spec, undo, inner: preprocess.subgraphSpec };
+}
+
+function taskId(spec: ComponentSpec, name: string): string {
+  const task = spec.tasks.find((t) => t.name === name);
+  if (!task) throw new Error(`No task named ${name}`);
+  return task.$id;
 }
 
 function makeEmptyBridge() {
@@ -192,10 +279,22 @@ describe("createEditorToolBridge", () => {
       expect(undo.labels.filter((l) => l === "Add task")).toHaveLength(1);
     });
 
-    it("deleteTask returns success false for unknown id", async () => {
+    it("deleteTask reports an unknown id rather than a bare failure", async () => {
       const { bridge } = makeBridge();
       const result = await bridge.deleteTask("does-not-exist");
-      expect(result).toEqual({ success: false });
+      expect(result.success).toBe(false);
+      expect(result.error).toBe(
+        'No task with $id "does-not-exist" exists in this pipeline.',
+      );
+    });
+
+    it("deleteTask reports when the id belongs to another kind of entity", async () => {
+      const { bridge } = makeBridge();
+      const result = await bridge.deleteTask("input_1");
+      expect(result.success).toBe(false);
+      expect(result.error).toBe(
+        '$id "input_1" refers to input "data", not a task.',
+      );
     });
 
     it("deleteTask removes an existing task", async () => {
@@ -335,6 +434,28 @@ describe("createEditorToolBridge", () => {
       const task = spec.tasks.find((t) => t.$id === "task_1");
       expect(task?.arguments).toEqual([{ name: "input", value: "hello" }]);
     });
+
+    it("accepts an input declared by a top-level subgraph task", async () => {
+      const { bridge, spec } = makeNestedBridge();
+      const preprocessId = taskId(spec, "Preprocess");
+
+      const result = await bridge.setTaskArgument(
+        preprocessId,
+        "path",
+        "/data.csv",
+      );
+
+      expect(result).toEqual({ success: true });
+      const task = spec.tasks.find((t) => t.$id === preprocessId);
+      expect(task?.arguments).toEqual([{ name: "path", value: "/data.csv" }]);
+    });
+
+    it("reports an input the task does not declare", async () => {
+      const { bridge } = makeBridge();
+      const result = await bridge.setTaskArgument("task_1", "nope", "hello");
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('no input named "nope"');
+    });
   });
 
   describe("subgraphs", () => {
@@ -353,6 +474,197 @@ describe("createEditorToolBridge", () => {
       const result = await bridge.createSubgraph([], "Group");
       expect(result.success).toBe(false);
       expect(result.error).toMatch(/Could not create subgraph/);
+    });
+  });
+
+  describe("subgraph mutations", () => {
+    it("deletes a task inside a subgraph rather than failing", async () => {
+      const { bridge, spec, inner } = makeNestedBridge();
+
+      const result = await bridge.deleteTask(taskId(inner, "DropNulls"));
+
+      expect(result).toEqual({ success: true });
+      expect(inner.tasks).toHaveLength(0);
+      expect(spec.tasks.map((t) => t.name)).toEqual(["Preprocess", "Train"]);
+    });
+
+    it("renames a task inside a subgraph without touching the top level", async () => {
+      const { bridge, spec, inner } = makeNestedBridge();
+
+      const result = await bridge.renameTask(
+        taskId(inner, "DropNulls"),
+        "CleanRows",
+      );
+
+      expect(result).toEqual({ success: true });
+      expect(inner.tasks[0].name).toBe("CleanRows");
+      expect(spec.tasks.map((t) => t.name)).toEqual(["Preprocess", "Train"]);
+    });
+
+    it("sets an argument on a task inside a subgraph", async () => {
+      const { bridge, inner } = makeNestedBridge();
+
+      const result = await bridge.setTaskArgument(
+        taskId(inner, "DropNulls"),
+        "path",
+        "/inner.csv",
+      );
+
+      expect(result).toEqual({ success: true });
+      expect(inner.tasks[0].arguments).toEqual([
+        { name: "path", value: "/inner.csv" },
+      ]);
+    });
+
+    it("renaming a subgraph input renames the port the parent binds to", async () => {
+      const { bridge, spec, inner } = makeNestedBridge();
+      const preprocessId = taskId(spec, "Preprocess");
+      await bridge.setTaskArgument(preprocessId, "path", "/data.csv");
+
+      const result = await bridge.renameInput(inner.inputs[0].$id, "src_path");
+
+      expect(result).toEqual({ success: true });
+      expect(inner.inputs[0].name).toBe("src_path");
+      const parentTask = spec.tasks.find((t) => t.$id === preprocessId);
+      expect(parentTask?.arguments).toEqual([
+        { name: "src_path", value: "/data.csv" },
+      ]);
+      expect(
+        parentTask?.resolvedComponentSpec?.inputs?.map((i) => i.name),
+      ).toEqual(["src_path"]);
+    });
+
+    it("deleting a subgraph input drops the parent's argument for that port", async () => {
+      const { bridge, spec, inner } = makeNestedBridge();
+      const preprocessId = taskId(spec, "Preprocess");
+      await bridge.setTaskArgument(preprocessId, "path", "/data.csv");
+
+      const result = await bridge.deleteInput(inner.inputs[0].$id);
+
+      expect(result).toEqual({ success: true });
+      expect(inner.inputs).toHaveLength(0);
+      expect(spec.tasks.find((t) => t.$id === preprocessId)?.arguments).toEqual(
+        [],
+      );
+    });
+
+    it("connects two entities that both live inside a subgraph", async () => {
+      const { bridge, spec, inner } = makeNestedBridge();
+      const before = inner.bindings.length;
+
+      const result = await bridge.connectNodes({
+        sourceEntityId: taskId(inner, "DropNulls"),
+        sourcePortName: "table",
+        targetEntityId: inner.outputs[0].$id,
+        targetPortName: inner.outputs[0].$id,
+      });
+
+      expect(result.success).toBe(true);
+      expect(inner.bindings.length).toBe(before + 1);
+      expect(spec.bindings).toHaveLength(0);
+    });
+
+    it("deletes a binding that lives inside a subgraph", async () => {
+      const { bridge, spec, inner } = makeNestedBridge();
+      expect(inner.bindings.length).toBeGreaterThan(0);
+
+      const result = await bridge.deleteEdge(inner.bindings[0].$id);
+
+      expect(result).toEqual({ success: true });
+      expect(inner.bindings).toHaveLength(0);
+      expect(spec.bindings).toHaveLength(0);
+    });
+
+    it("unpacks a subgraph nested inside another subgraph into its own parent", async () => {
+      const { bridge, spec, inner } = makeNestedBridge({
+        Dedupe: {
+          componentRef: containerComponent(
+            "Dedupe",
+            "dedupe:1",
+            "path",
+            "table",
+          ),
+        },
+      });
+      const grouped = await bridge.createSubgraph(
+        [taskId(inner, "DropNulls"), taskId(inner, "Dedupe")],
+        "Cleanup",
+      );
+      expect(grouped.success).toBe(true);
+      expect(inner.tasks.map((t) => t.name)).toEqual(["Cleanup"]);
+
+      const result = await bridge.unpackSubgraph(grouped.subgraphTaskId!);
+
+      expect(result).toEqual({ success: true });
+      expect(inner.tasks.map((t) => t.name).sort()).toEqual([
+        "Dedupe",
+        "DropNulls",
+      ]);
+      expect(spec.tasks.map((t) => t.name)).toEqual(["Preprocess", "Train"]);
+    });
+
+    it("refuses a connection that would cross a subgraph boundary", async () => {
+      const { bridge, spec, inner } = makeNestedBridge();
+
+      const result = await bridge.connectNodes({
+        sourceEntityId: taskId(spec, "Train"),
+        sourcePortName: "model",
+        targetEntityId: taskId(inner, "DropNulls"),
+        targetPortName: "path",
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("cannot cross a subgraph boundary");
+      expect(spec.bindings).toHaveLength(0);
+      expect(inner.bindings).toHaveLength(1);
+    });
+
+    it("refuses to group tasks that live at different levels", async () => {
+      const { bridge, spec, inner } = makeNestedBridge();
+
+      const result = await bridge.createSubgraph(
+        [taskId(spec, "Train"), taskId(inner, "DropNulls")],
+        "Group",
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("must already live in the same");
+      expect(result.error).toContain('task "DropNulls" inside subgraph');
+    });
+
+    it("reports an unknown connection endpoint instead of writing a dangling binding", async () => {
+      const { bridge, spec } = makeNestedBridge();
+
+      const result = await bridge.connectNodes({
+        sourceEntityId: "nope",
+        sourcePortName: "model",
+        targetEntityId: taskId(spec, "Train"),
+        targetPortName: "table",
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('"nope"');
+      expect(spec.bindings).toHaveLength(0);
+    });
+
+    it("deleteEdge reports an unknown binding instead of claiming success", async () => {
+      const { bridge } = makeNestedBridge();
+
+      const result = await bridge.deleteEdge("not-a-binding");
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe(
+        'No binding with $id "not-a-binding" exists in this pipeline.',
+      );
+    });
+
+    it("deleteEdge reports when the id is a task rather than a binding", async () => {
+      const { bridge, spec } = makeNestedBridge();
+
+      const result = await bridge.deleteEdge(taskId(spec, "Train"));
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('refers to task "Train", not a binding');
     });
   });
 
@@ -400,7 +712,19 @@ describe("createEditorToolBridge", () => {
         expect(typeof issue.type).toBe("string");
         expect(typeof issue.severity).toBe("string");
         expect(typeof issue.message).toBe("string");
+        expect(issue.subgraphPath).toEqual(["root"]);
       }
+    });
+
+    it("reports issues from inside subgraphs with their path", async () => {
+      const { bridge } = makeNestedBridge();
+
+      const result = await bridge.validatePipeline();
+      const nested = result.issues.filter((i) => i.subgraphPath.length > 1);
+
+      expect(nested.length).toBeGreaterThan(0);
+      expect(nested[0].subgraphPath).toEqual(["root", "Preprocess"]);
+      expect(result.issueCount).toBe(result.issues.length);
     });
   });
 

--- a/src/routes/v2/pages/Editor/components/AiChat/toolBridge/csomBridge.ts
+++ b/src/routes/v2/pages/Editor/components/AiChat/toolBridge/csomBridge.ts
@@ -14,7 +14,6 @@ import type {
   ValidationResult,
 } from "@/agent/toolBridgeApi";
 import type { EntityLocationOf } from "@/models/componentSpec/queries/locateEntity";
-import { collectValidationIssues } from "@/models/componentSpec/validation/collectIssues";
 import {
   connectNodes,
   deleteSelectedEdgesByEdgeIds,
@@ -47,6 +46,7 @@ import type { BridgeDeps } from "@/routes/v2/shared/components/AiChat/toolBridge
 import {
   computeNextPosition,
   requireSpec,
+  toValidationResult,
 } from "@/routes/v2/shared/components/AiChat/toolBridge/utils";
 import type { UndoGroupable } from "@/routes/v2/shared/nodes/types";
 import { hydrateComponentReference } from "@/services/componentService";
@@ -54,6 +54,9 @@ import { hydrateComponentReference } from "@/services/componentService";
 import {
   applyToTarget,
   describeEntityLocation,
+  explainNameCollision,
+  explainNotASubgraph,
+  resolveArgumentValue,
   resolveConnectable,
   resolveTarget,
 } from "./mutationTarget";
@@ -136,8 +139,18 @@ export function createCsomBridgeHandlers(deps: CsomBridgeDeps): CsomHandlers {
 
     async renameTask(entityId, newName) {
       const root = requireSpec(deps);
-      return applyToTarget(root, entityId, "task", (location) =>
-        renameTask(deps.undo, location.spec, entityId, newName),
+      return applyToTarget(
+        root,
+        entityId,
+        "task",
+        (location) => renameTask(deps.undo, location.spec, entityId, newName),
+        (location) =>
+          explainNameCollision(
+            location.spec.tasks,
+            entityId,
+            newName,
+            location,
+          ),
       );
     },
 
@@ -166,14 +179,25 @@ export function createCsomBridgeHandlers(deps: CsomBridgeDeps): CsomHandlers {
 
     async renameInput(entityId, newName) {
       const root = requireSpec(deps);
-      return applyToTarget(root, entityId, "input", (location) =>
-        renameInput(
-          deps.undo,
-          location.spec,
-          entityId,
-          newName,
-          location.parentContext,
-        ),
+      return applyToTarget(
+        root,
+        entityId,
+        "input",
+        (location) =>
+          renameInput(
+            deps.undo,
+            location.spec,
+            entityId,
+            newName,
+            location.parentContext,
+          ),
+        (location) =>
+          explainNameCollision(
+            location.spec.inputs,
+            entityId,
+            newName,
+            location,
+          ),
       );
     },
 
@@ -207,14 +231,25 @@ export function createCsomBridgeHandlers(deps: CsomBridgeDeps): CsomHandlers {
 
     async renameOutput(entityId, newName) {
       const root = requireSpec(deps);
-      return applyToTarget(root, entityId, "output", (location) =>
-        renameOutput(
-          deps.undo,
-          location.spec,
-          entityId,
-          newName,
-          location.parentContext,
-        ),
+      return applyToTarget(
+        root,
+        entityId,
+        "output",
+        (location) =>
+          renameOutput(
+            deps.undo,
+            location.spec,
+            entityId,
+            newName,
+            location.parentContext,
+          ),
+        (location) =>
+          explainNameCollision(
+            location.spec.outputs,
+            entityId,
+            newName,
+            location,
+          ),
       );
     },
 
@@ -289,8 +324,14 @@ export function createCsomBridgeHandlers(deps: CsomBridgeDeps): CsomHandlers {
           error: `Task "${location.entity.name}" has no input named "${inputName}"`,
         };
       }
+
+      const resolved = resolveArgumentValue(location, value);
+      if (!resolved.ok) {
+        return { success: false, error: resolved.error };
+      }
+
       deps.undo.withGroup("Set task argument", () => {
-        location.spec.setTaskArgument(taskEntityId, inputName, value);
+        location.spec.setTaskArgument(taskEntityId, inputName, resolved.value);
       });
       return { success: true };
     },
@@ -298,11 +339,20 @@ export function createCsomBridgeHandlers(deps: CsomBridgeDeps): CsomHandlers {
     async createSubgraph(taskEntityIds, subgraphName) {
       const root = requireSpec(deps);
 
+      const distinctIds = [...new Set(taskEntityIds)];
+      if (distinctIds.length < 2) {
+        return {
+          success: false,
+          error:
+            "Could not create subgraph — pass the $ids of at least two distinct tasks to group. Wrapping a single task in a subgraph is not useful.",
+        };
+      }
+
       const locations: Array<{
         id: string;
         location: EntityLocationOf<"task">;
       }> = [];
-      for (const taskEntityId of taskEntityIds) {
+      for (const taskEntityId of distinctIds) {
         const target = resolveTarget(root, taskEntityId, "task");
         if (!target.ok) {
           return { success: false, error: target.error };
@@ -315,7 +365,7 @@ export function createCsomBridgeHandlers(deps: CsomBridgeDeps): CsomHandlers {
         return {
           success: false,
           error:
-            "Could not create subgraph — pass the $ids of at least two tasks to group.",
+            "Could not create subgraph — pass the $ids of at least two distinct tasks to group.",
         };
       }
       const stray = locations.find(
@@ -332,7 +382,7 @@ export function createCsomBridgeHandlers(deps: CsomBridgeDeps): CsomHandlers {
       const subgraphTask = createSubgraph(
         deps.undo,
         spec,
-        taskEntityIds,
+        distinctIds,
         subgraphName,
         computeNextPosition(spec),
       );
@@ -340,7 +390,7 @@ export function createCsomBridgeHandlers(deps: CsomBridgeDeps): CsomHandlers {
         return {
           success: false,
           error:
-            "Could not create subgraph — pass the $ids of at least two tasks that can be grouped together.",
+            "Could not create subgraph — pass the $ids of at least two distinct tasks that can be grouped together.",
         };
       }
       return { success: true, subgraphTaskId: subgraphTask.$id };
@@ -348,26 +398,18 @@ export function createCsomBridgeHandlers(deps: CsomBridgeDeps): CsomHandlers {
 
     async unpackSubgraph(taskEntityId) {
       const root = requireSpec(deps);
-      return applyToTarget(root, taskEntityId, "task", (location) =>
-        unpackSubgraphTask(deps.undo, location.spec, taskEntityId),
+      return applyToTarget(
+        root,
+        taskEntityId,
+        "task",
+        (location) =>
+          unpackSubgraphTask(deps.undo, location.spec, taskEntityId),
+        (location) => explainNotASubgraph(location, taskEntityId),
       );
     },
 
     async validatePipeline(): Promise<ValidationResult> {
-      const issues = collectValidationIssues(requireSpec(deps));
-      return {
-        valid: issues.length === 0,
-        issueCount: issues.length,
-        issues: issues.map((i) => ({
-          type: i.type,
-          severity: i.severity,
-          message: i.message,
-          entityId: i.entityId,
-          entityName: i.entityName,
-          issueCode: i.issueCode,
-          subgraphPath: i.subgraphPath,
-        })),
-      };
+      return toValidationResult(requireSpec(deps));
     },
   };
 }

--- a/src/routes/v2/pages/Editor/components/AiChat/toolBridge/csomBridge.ts
+++ b/src/routes/v2/pages/Editor/components/AiChat/toolBridge/csomBridge.ts
@@ -1,17 +1,20 @@
 /**
  * CSOM bridge handlers — the spec-mutation slice of `ToolBridgeApi`.
  *
- * Each handler mutates the live MobX `ComponentSpec` from `deps.getSpec()`
- * inside `deps.undo.withGroup(...)` so the agent's edits are user-visible
- * immediately and undoable as a single user step. Mirrors the worker-side
- * `csomTools.ts` tool surface one-to-one.
+ * Each handler resolves which spec in the tree owns the `$id` it was given
+ * (`mutationTarget.ts`) and mutates that spec inside `deps.undo.withGroup(...)`,
+ * so an edit lands in the subgraph the entity actually lives in. The undo
+ * manager and autosave are both anchored at the root spec and traverse the whole
+ * document, so nested edits are undoable and persisted without extra wiring.
+ * Mirrors the worker-side `csomTools.ts` tool surface one-to-one.
  */
 import type {
   ConnectArgs,
   ToolBridgeApi,
   ValidationResult,
 } from "@/agent/toolBridgeApi";
-import { validateSpec } from "@/models/componentSpec/validation/validateSpec";
+import type { EntityLocationOf } from "@/models/componentSpec/queries/locateEntity";
+import { collectValidationIssues } from "@/models/componentSpec/validation/collectIssues";
 import {
   connectNodes,
   deleteSelectedEdgesByEdgeIds,
@@ -47,6 +50,13 @@ import {
 } from "@/routes/v2/shared/components/AiChat/toolBridge/utils";
 import type { UndoGroupable } from "@/routes/v2/shared/nodes/types";
 import { hydrateComponentReference } from "@/services/componentService";
+
+import {
+  applyToTarget,
+  describeEntityLocation,
+  resolveConnectable,
+  resolveTarget,
+} from "./mutationTarget";
 
 /**
  * CSOM handlers need the Editor's undo store to make the agent's spec
@@ -102,8 +112,12 @@ export function createCsomBridgeHandlers(deps: CsomBridgeDeps): CsomHandlers {
       const spec = requireSpec(deps);
       const hydrated =
         (await hydrateComponentReference(componentRef)) ?? componentRef;
-      const position = computeNextPosition(spec);
-      const task = addTask(deps.undo, spec, hydrated, position);
+      const task = addTask(
+        deps.undo,
+        spec,
+        hydrated,
+        computeNextPosition(spec),
+      );
       if (!task) {
         return { success: false, error: "addTask returned no task" };
       }
@@ -114,19 +128,22 @@ export function createCsomBridgeHandlers(deps: CsomBridgeDeps): CsomHandlers {
     },
 
     async deleteTask(entityId) {
-      const spec = requireSpec(deps);
-      return { success: deleteTask(deps.undo, spec, entityId) };
+      const root = requireSpec(deps);
+      return applyToTarget(root, entityId, "task", (location) =>
+        deleteTask(deps.undo, location.spec, entityId),
+      );
     },
 
     async renameTask(entityId, newName) {
-      const spec = requireSpec(deps);
-      return { success: renameTask(deps.undo, spec, entityId, newName) };
+      const root = requireSpec(deps);
+      return applyToTarget(root, entityId, "task", (location) =>
+        renameTask(deps.undo, location.spec, entityId, newName),
+      );
     },
 
     async addInput({ name, type, description, defaultValue, optional }) {
       const spec = requireSpec(deps);
-      const position = computeNextPosition(spec);
-      const input = addInput(deps.undo, spec, position, name);
+      const input = addInput(deps.undo, spec, computeNextPosition(spec), name);
       if (type) setInputType(deps.undo, spec, input.$id, type);
       if (description)
         setInputDescription(deps.undo, spec, input.$id, description);
@@ -141,19 +158,33 @@ export function createCsomBridgeHandlers(deps: CsomBridgeDeps): CsomHandlers {
     },
 
     async deleteInput(entityId) {
-      const spec = requireSpec(deps);
-      return { success: deleteInput(deps.undo, spec, entityId) };
+      const root = requireSpec(deps);
+      return applyToTarget(root, entityId, "input", (location) =>
+        deleteInput(deps.undo, location.spec, entityId, location.parentContext),
+      );
     },
 
     async renameInput(entityId, newName) {
-      const spec = requireSpec(deps);
-      return { success: renameInput(deps.undo, spec, entityId, newName) };
+      const root = requireSpec(deps);
+      return applyToTarget(root, entityId, "input", (location) =>
+        renameInput(
+          deps.undo,
+          location.spec,
+          entityId,
+          newName,
+          location.parentContext,
+        ),
+      );
     },
 
     async addOutput({ name, type, description }) {
       const spec = requireSpec(deps);
-      const position = computeNextPosition(spec);
-      const output = addOutput(deps.undo, spec, position, name);
+      const output = addOutput(
+        deps.undo,
+        spec,
+        computeNextPosition(spec),
+        name,
+      );
       if (type) {
         deps.undo.withGroup("Set output type", () => output.setType(type));
       }
@@ -163,17 +194,46 @@ export function createCsomBridgeHandlers(deps: CsomBridgeDeps): CsomHandlers {
     },
 
     async deleteOutput(entityId) {
-      const spec = requireSpec(deps);
-      return { success: deleteOutput(deps.undo, spec, entityId) };
+      const root = requireSpec(deps);
+      return applyToTarget(root, entityId, "output", (location) =>
+        deleteOutput(
+          deps.undo,
+          location.spec,
+          entityId,
+          location.parentContext,
+        ),
+      );
     },
 
     async renameOutput(entityId, newName) {
-      const spec = requireSpec(deps);
-      return { success: renameOutput(deps.undo, spec, entityId, newName) };
+      const root = requireSpec(deps);
+      return applyToTarget(root, entityId, "output", (location) =>
+        renameOutput(
+          deps.undo,
+          location.spec,
+          entityId,
+          newName,
+          location.parentContext,
+        ),
+      );
     },
 
     async connectNodes(args: ConnectArgs) {
-      const spec = requireSpec(deps);
+      const root = requireSpec(deps);
+
+      const source = resolveConnectable(root, args.sourceEntityId);
+      if (!source.ok) return { success: false, error: source.error };
+      const target = resolveConnectable(root, args.targetEntityId);
+      if (!target.ok) return { success: false, error: target.error };
+
+      if (source.location.spec !== target.location.spec) {
+        return {
+          success: false,
+          error: `Cannot connect ${describeEntityLocation(source.location, args.sourceEntityId)} to ${describeEntityLocation(target.location, args.targetEntityId)} — a connection cannot cross a subgraph boundary. Route the value through the subgraph's own inputs and outputs instead.`,
+        };
+      }
+
+      const spec = source.location.spec;
       const ok = connectNodes(deps.undo, spec, {
         sourceNodeId: args.sourceEntityId,
         sourceHandleId: `output_${args.sourcePortName}`,
@@ -204,55 +264,97 @@ export function createCsomBridgeHandlers(deps: CsomBridgeDeps): CsomHandlers {
     },
 
     async deleteEdge(entityId) {
-      const spec = requireSpec(deps);
-      deleteSelectedEdgesByEdgeIds(deps.undo, spec, [`edge_${entityId}`]);
-      return { success: true };
+      const root = requireSpec(deps);
+      return applyToTarget(root, entityId, "binding", (location) => {
+        deleteSelectedEdgesByEdgeIds(deps.undo, location.spec, [
+          `edge_${entityId}`,
+        ]);
+        return !location.spec.bindings.some((b) => b.$id === entityId);
+      });
     },
 
     async setTaskArgument(taskEntityId, inputName, value) {
-      const spec = requireSpec(deps);
-      const task = spec.tasks.find((t) => t.$id === taskEntityId);
-      if (!task) {
-        return { success: false, error: `No task with id ${taskEntityId}` };
+      const target = resolveTarget(requireSpec(deps), taskEntityId, "task");
+      if (!target.ok) {
+        return { success: false, error: target.error };
       }
-      const hasInput = task.componentRef.spec?.inputs?.some(
+      const { location } = target;
+
+      const hasInput = location.entity.resolvedComponentSpec?.inputs?.some(
         (i) => i.name === inputName,
       );
       if (!hasInput) {
         return {
           success: false,
-          error: `Task has no input named "${inputName}"`,
+          error: `Task "${location.entity.name}" has no input named "${inputName}"`,
         };
       }
       deps.undo.withGroup("Set task argument", () => {
-        spec.setTaskArgument(taskEntityId, inputName, value);
+        location.spec.setTaskArgument(taskEntityId, inputName, value);
       });
       return { success: true };
     },
 
     async createSubgraph(taskEntityIds, subgraphName) {
-      const spec = requireSpec(deps);
-      const position = computeNextPosition(spec);
+      const root = requireSpec(deps);
+
+      const locations: Array<{
+        id: string;
+        location: EntityLocationOf<"task">;
+      }> = [];
+      for (const taskEntityId of taskEntityIds) {
+        const target = resolveTarget(root, taskEntityId, "task");
+        if (!target.ok) {
+          return { success: false, error: target.error };
+        }
+        locations.push({ id: taskEntityId, location: target.location });
+      }
+
+      const first = locations[0];
+      if (!first) {
+        return {
+          success: false,
+          error:
+            "Could not create subgraph — pass the $ids of at least two tasks to group.",
+        };
+      }
+      const stray = locations.find(
+        (l) => l.location.spec !== first.location.spec,
+      );
+      if (stray) {
+        return {
+          success: false,
+          error: `Cannot group ${describeEntityLocation(first.location, first.id)} with ${describeEntityLocation(stray.location, stray.id)} — every task in a new subgraph must already live in the same pipeline or subgraph.`,
+        };
+      }
+
+      const spec = first.location.spec;
       const subgraphTask = createSubgraph(
         deps.undo,
         spec,
         taskEntityIds,
         subgraphName,
-        position,
+        computeNextPosition(spec),
       );
       if (!subgraphTask) {
-        return { success: false, error: "Could not create subgraph" };
+        return {
+          success: false,
+          error:
+            "Could not create subgraph — pass the $ids of at least two tasks that can be grouped together.",
+        };
       }
       return { success: true, subgraphTaskId: subgraphTask.$id };
     },
 
     async unpackSubgraph(taskEntityId) {
-      const spec = requireSpec(deps);
-      return { success: unpackSubgraphTask(deps.undo, spec, taskEntityId) };
+      const root = requireSpec(deps);
+      return applyToTarget(root, taskEntityId, "task", (location) =>
+        unpackSubgraphTask(deps.undo, location.spec, taskEntityId),
+      );
     },
 
     async validatePipeline(): Promise<ValidationResult> {
-      const issues = validateSpec(requireSpec(deps));
+      const issues = collectValidationIssues(requireSpec(deps));
       return {
         valid: issues.length === 0,
         issueCount: issues.length,
@@ -261,7 +363,9 @@ export function createCsomBridgeHandlers(deps: CsomBridgeDeps): CsomHandlers {
           severity: i.severity,
           message: i.message,
           entityId: i.entityId,
+          entityName: i.entityName,
           issueCode: i.issueCode,
+          subgraphPath: i.subgraphPath,
         })),
       };
     },

--- a/src/routes/v2/pages/RunView/toolBridge/runViewToolBridge.ts
+++ b/src/routes/v2/pages/RunView/toolBridge/runViewToolBridge.ts
@@ -9,7 +9,7 @@
  * the Editor's spec-mutation actions or an undo store.
  */
 import type { ToolBridgeApi, ValidationResult } from "@/agent/toolBridgeApi";
-import { validateSpec } from "@/models/componentSpec/validation/validateSpec";
+import { collectValidationIssues } from "@/models/componentSpec/validation/collectIssues";
 import { serializeSpecForAi } from "@/routes/v2/shared/components/AiChat/serializeSpecForAi";
 import { createDebugBridgeHandlers } from "@/routes/v2/shared/components/AiChat/toolBridge/debugBridge";
 import { createRunBridgeHandlers } from "@/routes/v2/shared/components/AiChat/toolBridge/runBridge";
@@ -52,7 +52,7 @@ function createReadOnlyCsomHandlers(deps: BridgeDeps): ReadOnlyCsomHandlers {
     },
 
     async validatePipeline(): Promise<ValidationResult> {
-      const issues = validateSpec(requireSpec(deps));
+      const issues = collectValidationIssues(requireSpec(deps));
       return {
         valid: issues.length === 0,
         issueCount: issues.length,
@@ -61,7 +61,9 @@ function createReadOnlyCsomHandlers(deps: BridgeDeps): ReadOnlyCsomHandlers {
           severity: i.severity,
           message: i.message,
           entityId: i.entityId,
+          entityName: i.entityName,
           issueCode: i.issueCode,
+          subgraphPath: i.subgraphPath,
         })),
       };
     },
@@ -75,43 +77,43 @@ function createReadOnlyCsomHandlers(deps: BridgeDeps): ReadOnlyCsomHandlers {
     },
 
     async setPipelineName() {
-      return { success: false };
+      return { success: false, error: READ_ONLY_ERROR };
     },
     async setPipelineDescription() {
-      return { success: false };
+      return { success: false, error: READ_ONLY_ERROR };
     },
     async addTask() {
       return { success: false, error: READ_ONLY_ERROR };
     },
     async deleteTask() {
-      return { success: false };
+      return { success: false, error: READ_ONLY_ERROR };
     },
     async renameTask() {
-      return { success: false };
+      return { success: false, error: READ_ONLY_ERROR };
     },
     async addInput() {
-      return { success: false, inputId: "", name: "" };
+      return { success: false, error: READ_ONLY_ERROR };
     },
     async deleteInput() {
-      return { success: false };
+      return { success: false, error: READ_ONLY_ERROR };
     },
     async renameInput() {
-      return { success: false };
+      return { success: false, error: READ_ONLY_ERROR };
     },
     async addOutput() {
-      return { success: false, outputId: "", name: "" };
+      return { success: false, error: READ_ONLY_ERROR };
     },
     async deleteOutput() {
-      return { success: false };
+      return { success: false, error: READ_ONLY_ERROR };
     },
     async renameOutput() {
-      return { success: false };
+      return { success: false, error: READ_ONLY_ERROR };
     },
     async connectNodes() {
       return { success: false, error: READ_ONLY_ERROR };
     },
     async deleteEdge() {
-      return { success: false };
+      return { success: false, error: READ_ONLY_ERROR };
     },
     async setTaskArgument() {
       return { success: false, error: READ_ONLY_ERROR };
@@ -120,7 +122,7 @@ function createReadOnlyCsomHandlers(deps: BridgeDeps): ReadOnlyCsomHandlers {
       return { success: false, error: READ_ONLY_ERROR };
     },
     async unpackSubgraph() {
-      return { success: false };
+      return { success: false, error: READ_ONLY_ERROR };
     },
   };
 }

--- a/src/routes/v2/pages/RunView/toolBridge/runViewToolBridge.ts
+++ b/src/routes/v2/pages/RunView/toolBridge/runViewToolBridge.ts
@@ -9,13 +9,15 @@
  * the Editor's spec-mutation actions or an undo store.
  */
 import type { ToolBridgeApi, ValidationResult } from "@/agent/toolBridgeApi";
-import { collectValidationIssues } from "@/models/componentSpec/validation/collectIssues";
 import { serializeSpecForAi } from "@/routes/v2/shared/components/AiChat/serializeSpecForAi";
 import { createDebugBridgeHandlers } from "@/routes/v2/shared/components/AiChat/toolBridge/debugBridge";
 import { createRunBridgeHandlers } from "@/routes/v2/shared/components/AiChat/toolBridge/runBridge";
 import { createSubgraphBridgeHandlers } from "@/routes/v2/shared/components/AiChat/toolBridge/subgraphBridge";
 import type { BridgeDeps } from "@/routes/v2/shared/components/AiChat/toolBridge/utils";
-import { requireSpec } from "@/routes/v2/shared/components/AiChat/toolBridge/utils";
+import {
+  requireSpec,
+  toValidationResult,
+} from "@/routes/v2/shared/components/AiChat/toolBridge/utils";
 
 const READ_ONLY_ERROR =
   "This is a read-only run view — the pipeline spec cannot be edited here.";
@@ -52,20 +54,7 @@ function createReadOnlyCsomHandlers(deps: BridgeDeps): ReadOnlyCsomHandlers {
     },
 
     async validatePipeline(): Promise<ValidationResult> {
-      const issues = collectValidationIssues(requireSpec(deps));
-      return {
-        valid: issues.length === 0,
-        issueCount: issues.length,
-        issues: issues.map((i) => ({
-          type: i.type,
-          severity: i.severity,
-          message: i.message,
-          entityId: i.entityId,
-          entityName: i.entityName,
-          issueCode: i.issueCode,
-          subgraphPath: i.subgraphPath,
-        })),
-      };
+      return toValidationResult(requireSpec(deps));
     },
 
     async searchComponents() {

--- a/src/routes/v2/shared/components/AiChat/serializeSpecForAi.ts
+++ b/src/routes/v2/shared/components/AiChat/serializeSpecForAi.ts
@@ -7,8 +7,9 @@
  * subgraph tasks are flagged with `isSubgraph: true`, and the active
  * subgraph breadcrumb (`activeSubgraphPath`) is surfaced so the model
  * can disambiguate "fix the pipeline" vs "fix this subgraph" without a
- * separate bridge call. Edits always target the root spec; the path is
- * a hint, not a target.
+ * separate bridge call. Edits land in whichever spec owns the `$id` they
+ * name, so the breadcrumb tells the model where the user is looking
+ * rather than where an edit will go.
  */
 import type {
   Binding,

--- a/src/routes/v2/shared/components/AiChat/toolBridge/utils.ts
+++ b/src/routes/v2/shared/components/AiChat/toolBridge/utils.ts
@@ -13,7 +13,12 @@
  */
 import type { QueryClient } from "@tanstack/react-query";
 
+import type { ValidationResult } from "@/agent/toolBridgeApi";
 import type { ComponentSpec } from "@/models/componentSpec";
+import {
+  collectValidationIssues,
+  ROOT_PATH_ID,
+} from "@/models/componentSpec/validation/collectIssues";
 import { EDITOR_POSITION_ANNOTATION } from "@/utils/annotations";
 
 const DEFAULT_POSITION = { x: 250, y: 250 };
@@ -55,6 +60,33 @@ export function errorMessage(error: unknown): string {
   if (error instanceof Error) return error.message;
   if (typeof error === "string") return error;
   return "An unknown error occurred";
+}
+
+/**
+ * The `"root"` segment that `collectValidationIssues` prefixes is dropped on the
+ * way out: `activeSubgraphPath` — the only other path the model ever sees — is
+ * the bare chain of subgraph task names, and a model correlating "where is this
+ * issue" against "where am I" cannot match the two otherwise, or tries to
+ * descend into a subgraph literally named "root".
+ */
+export function toValidationResult(spec: ComponentSpec): ValidationResult {
+  const issues = collectValidationIssues(spec);
+  return {
+    valid: issues.length === 0,
+    issueCount: issues.length,
+    issues: issues.map((i) => ({
+      type: i.type,
+      severity: i.severity,
+      message: i.message,
+      entityId: i.entityId,
+      entityName: i.entityName,
+      issueCode: i.issueCode,
+      subgraphPath:
+        i.subgraphPath[0] === ROOT_PATH_ID
+          ? i.subgraphPath.slice(1)
+          : i.subgraphPath,
+    })),
+  };
 }
 
 export function computeNextPosition(spec: ComponentSpec): {


### PR DESCRIPTION
## Description

When you asked the AI assistant to change something inside a subgraph, it applied
the change to the top-level pipeline instead — whatever depth the thing you named
actually lived at. One cause, four ways of showing up:

- **Nothing happened.** The edit went looking at the top level, found nothing, and
  quietly did nothing — or worse, hit an unrelated top-level step that happened to
  match.
- **Connections could corrupt the pipeline.** Asked to wire something across a
  subgraph boundary, it wrote a connection pointing at a step that isn't in that
  graph. The pipeline format has no such connection, so the result was broken.
- **Deleting a connection lied.** It reported success while deleting nothing.
- **Nine tools couldn't explain a failure.** They could only answer "that didn't
  work", with no way to say whether the thing didn't exist or was a different kind
  of thing than expected — so the assistant guessed, and often told you something
  untrue.

Each edit now works out which graph owns the thing you named and changes that
graph. This turned out to be mostly plumbing that was already in place: every
editing operation already took the graph to act on as an argument, and the editor
itself has always used that to let you edit inside a subgraph. The assistant was
the only caller that always handed over the top-level pipeline.

The layer that answers "which graph, and is this the kind of thing you asked
for" — along with the wording of every refusal — now lives in #2687, directly
below. This PR is the rewiring: swapping each handler onto it, and the knock-on
fixes below.

Also fixed here, because they're the same underlying thing:

- **Renaming or deleting a subgraph's input no longer breaks the wiring above it.**
  The matching port on the subgraph step is renamed or removed with it, so the
  connection feeding it in the parent survives.
- **Validation reports where issues are.** Issues found inside subgraphs now carry
  the name and the trail to the subgraph they're in, so the assistant can act on
  them instead of reporting a problem it can't locate.
- **Setting a value can't reach across a subgraph boundary either.** Same
  corruption as the connection case above, through a different door: asked to set
  a step's input to a value coming from another graph, it used to write it and
  produce a pipeline that no longer loads. It's refused now, with the way round
  it.
- **Grouping needs at least two steps.** Asked to make a subgraph out of one step
  — or the same step named twice — it used to do it, despite saying elsewhere
  that it wouldn't.

Two refusals remain, and both are about structure rather than depth, so they're
correct rather than missing. Both now say what to do instead:

- A connection can't cross a subgraph boundary.
- A new subgraph can't be made from steps that live at different levels.

Where a refusal has a knowable cause, it now names it — a rename that collides
with an existing name, or being asked to unpack something that isn't a subgraph.
The vague "couldn't do that" is what's left when there's genuinely nothing to
say, rather than the standard answer.

**The canvas doesn't follow the assistant into a subgraph.** A single request can
produce several edits across several subgraphs, and yanking the view around for
each one would lose wherever you were. The assistant is told to name the subgraph
it changed, so you're told where to look rather than being taken there.

## Related Issue and Pull requests

Stacked on #2687 → #2686 → #2685 → #2655.

This PR and #2684 were re-cut. Previously the two split this fix down the middle:
the lower one described the failures and refused them, the upper one rewrote it to
actually fix them. Since all four symptoms above share one cause and one fix, that
seam meant ~635 lines were written twice and reviewed twice to net zero. The stack
is now split by concern instead: shared resolver (#2685), an unrelated chip bug
(#2686), this fix, then the new capability on top (#2684).

## Type of Change

- [x] Bug fix

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

1. Open a pipeline with a subgraph in it (nested subgraphs are a better test) and
   ask the AI chat for edits inside it: "rename the second step in \<subgraph
   name>", "delete the connection between X and Y in \<subgraph name>", "set the
   input file on \<nested step>". Each should apply, and the reply should say which
   subgraph it changed.
2. Open the subgraph afterwards and confirm the change is there and looks right.
3. Undo (Cmd/Ctrl+Z) — a nested edit should undo like any other, and the pipeline
   should still save normally.
4. Rename an input inside a subgraph that the parent feeds a value to, then check
   the parent: the port should be renamed and still connected, not orphaned.
5. Ask for something genuinely impossible — "connect \<top-level step> straight to
   \<a step inside a subgraph>" — and it should explain that a connection can't
   cross a subgraph boundary and offer the way round it. Same for asking it to
   group a top-level step together with a nested one.
6. Ask it to change something that doesn't exist, and something of the wrong kind
   ("delete the connection \<id of a step>"). It should say what's actually wrong
   rather than inventing a reason. Same for renaming a step to a name already
   taken in that graph, and for "unpack \<a step that isn't a subgraph>".
7. Ask it to set an input on a nested step to a value that comes from the
   top-level pipeline — it should refuse and explain, not write it. Then ask it
   to group a single step into a subgraph, which it should also refuse.
8. Ask it to validate a pipeline that has problems inside a subgraph — it should
   report them and say where they are.
9. Sanity check that ordinary top-level editing through the chat is unchanged.

## Additional Comments

Nothing new was needed for undo or saving: both already watch the whole pipeline
including everything nested, which the editor has always relied on.

One pre-existing quirk left alone: renaming a subgraph step doesn't update the
name stored on the subgraph's own contents. Nothing depends on it, and the same
thing happens when you rename a subgraph step by hand in the editor, so it's not
new here — but it's worth a separate look at some point.


