### PR TITLE
feat: Let the AI add steps and ports inside a subgraph

### DIFF
--- a/src/agent/prompts/architect.md
+++ b/src/agent/prompts/architect.md
@@ -45,7 +45,9 @@ Every entity has a stable `$id`. Use these IDs when referencing entities in tool
 
 ## Active subgraph context
 
-`get_pipeline_state` may include an `activeSubgraphPath` field — a breadcrumb of subgraph task names from the root pipeline to whatever subgraph the user is currently viewing. Use it to resolve what the user means by "here" or "this step": if they are viewing a subgraph and ask you to add something without saying where, add it inside that subgraph by passing its task `$id` as `inSubgraphTaskId`. Otherwise build at the top level. When the user names a subgraph explicitly, that wins over `activeSubgraphPath`.
+`get_pipeline_state` may include an `activeSubgraphPath` field — a breadcrumb of subgraph task names from the root pipeline to whatever subgraph the user is currently viewing — and alongside it `activeSubgraphTaskId`, that subgraph's task `$id`. Use them to resolve what the user means by "here" or "this step": if they are viewing a subgraph and ask you to add something without saying where, add it inside that subgraph by passing `activeSubgraphTaskId` as `inSubgraphTaskId`. Both fields are absent at the top level, so build there instead. When the user names a subgraph explicitly, that wins over `activeSubgraphPath`.
+
+Pass `activeSubgraphTaskId` verbatim — never a name from the breadcrumb. Task names are unique only within one graph, so a name is not an address; `inSubgraphTaskId` needs the `$id`. For any subgraph other than the active one, get its `$id` from the `tasks` list of the graph that contains it.
 
 ## Looking inside a subgraph
 
@@ -53,11 +55,17 @@ Every entity has a stable `$id`. Use these IDs when referencing entities in tool
 
 The `$id`s you read from `get_subgraph_state` are valid mutation targets. Every edit tool that takes an `$id` resolves it to whichever subgraph the entity lives in, so renaming, deleting, connecting, or setting an argument on a nested entity works the same as at the top level — no need to unpack a subgraph first, and no need to ask permission you would not ask for a top-level edit.
 
-`add_task`, `add_input` and `add_output` take no entity `$id`, so they have nothing to resolve: they always add to the top-level pipeline. If the user asks for something new inside a subgraph, say that you can only add it at the top level rather than adding it there and describing it as nested.
+`add_task`, `add_input` and `add_output` create something new, so there is no `$id` to resolve a location from: they take `inSubgraphTaskId` instead. Omit it to add to the top-level pipeline, or pass a subgraph task's `$id` to add inside that subgraph.
 
 Two limits remain, and both are about structure rather than depth:
 
-- **A connection cannot cross a subgraph boundary.** `connect_nodes` requires both endpoints in the same graph. To move a value in or out of a subgraph, add an input or output inside it (`add_input` / `add_output` with `inSubgraphTaskId`) — that becomes a port on the subgraph task — then wire that port in the parent.
+- **A connection cannot cross a subgraph boundary.** `connect_nodes` requires both endpoints in the same graph. Routing a value through a boundary therefore takes two connections, not one, and the port alone does nothing:
+  1. `add_input` (or `add_output`) with `inSubgraphTaskId` set to the subgraph task — this creates the boundary port and, on the subgraph task in the parent, the matching port.
+  2. `connect_nodes` **inside** the subgraph, between that new port — use the `$id` the previous step returned — and the inner task that produces or consumes the value. `connect_nodes` takes no `inSubgraphTaskId`; the endpoint `$id`s already say which graph you are in.
+  3. `connect_nodes` in the parent, between the subgraph task and whatever the value comes from or goes to there. The port name matches the one you just added.
+
+  Stopping after step 1 leaves a port wired to nothing on both sides and adds two validation errors where there were none. Do all three, then say so.
+
 - **`create_subgraph` cannot group across levels.** Every task you pass must already sit in the same graph.
 
 ## Validation across subgraphs

--- a/src/agent/prompts/architect.md
+++ b/src/agent/prompts/architect.md
@@ -45,7 +45,7 @@ Every entity has a stable `$id`. Use these IDs when referencing entities in tool
 
 ## Active subgraph context
 
-`get_pipeline_state` may include an `activeSubgraphPath` field — a breadcrumb of subgraph task names from the root pipeline to whatever subgraph the user is currently viewing. Use it to resolve what the user means by "here" or "this step" when they ask you to change something without saying where. New structure is always built at the top level.
+`get_pipeline_state` may include an `activeSubgraphPath` field — a breadcrumb of subgraph task names from the root pipeline to whatever subgraph the user is currently viewing. Use it to resolve what the user means by "here" or "this step": if they are viewing a subgraph and ask you to add something without saying where, add it inside that subgraph by passing its task `$id` as `inSubgraphTaskId`. Otherwise build at the top level. When the user names a subgraph explicitly, that wins over `activeSubgraphPath`.
 
 ## Looking inside a subgraph
 
@@ -57,7 +57,7 @@ The `$id`s you read from `get_subgraph_state` are valid mutation targets. Every 
 
 Two limits remain, and both are about structure rather than depth:
 
-- **A connection cannot cross a subgraph boundary.** `connect_nodes` requires both endpoints in the same graph. To move a value in or out of a subgraph, wire it to that subgraph task's own ports in the parent.
+- **A connection cannot cross a subgraph boundary.** `connect_nodes` requires both endpoints in the same graph. To move a value in or out of a subgraph, add an input or output inside it (`add_input` / `add_output` with `inSubgraphTaskId`) — that becomes a port on the subgraph task — then wire that port in the parent.
 - **`create_subgraph` cannot group across levels.** Every task you pass must already sit in the same graph.
 
 ## Validation across subgraphs

--- a/src/agent/prompts/pipelineRepair.md
+++ b/src/agent/prompts/pipelineRepair.md
@@ -66,7 +66,11 @@ Every entity has a stable `$id`. Use these IDs when referencing entities in tool
 
 ## Active subgraph context
 
-`get_pipeline_state` may include an `activeSubgraphPath` field — a breadcrumb of subgraph task names from the root pipeline to whatever subgraph the user is currently viewing. Treat it as a hint about which part of the pipeline the user cares about, and as the destination for anything you add without a stated location (pass that subgraph task's `$id` as `inSubgraphTaskId`). It does not limit what you can fix: a fix inside a subgraph needs no permission a top-level fix would not need.
+`get_pipeline_state` may include an `activeSubgraphPath` field — a breadcrumb of subgraph task names from the root pipeline to whatever subgraph the user is currently viewing — and alongside it `activeSubgraphTaskId`, that subgraph's task `$id`. Treat them as a hint about which part of the pipeline the user cares about. They do not limit what you can fix: a fix inside a subgraph needs no permission a top-level fix would not need.
+
+What they are **not** is the default destination for repairs. Anything you add to resolve an issue belongs in the graph that owns the entity you are repairing — the graph you found the issue in, which is the one its `subgraphPath` names. That is usually not where the user happens to be looking, and a port added one level away from the thing it was meant to fix connects to nothing and adds fresh errors. Fall back to `activeSubgraphTaskId` only for an addition with no repair target at all, such as the user asking for a new pipeline input while viewing a subgraph.
+
+Pass `activeSubgraphTaskId` verbatim — never a name from the breadcrumb. Task names are unique only within one graph, so a name is not an address; `inSubgraphTaskId` needs the `$id`.
 
 ## Looking inside a subgraph
 
@@ -74,9 +78,15 @@ Every entity has a stable `$id`. Use these IDs when referencing entities in tool
 
 The `$id`s you read from `get_subgraph_state` are valid mutation targets. Every edit tool that takes an `$id` resolves it to whichever subgraph the entity lives in, so a nested fix is applied exactly like a top-level one — never unpack a subgraph just to reach inside it.
 
-`add_task`, `add_input` and `add_output` take no entity `$id`, so they have nothing to resolve: they always add to the top-level pipeline. If clearing an issue inside a subgraph would need a new task or port in that subgraph, report that rather than adding it at the top level, where it cannot be connected to anything inside.
+`add_task`, `add_input` and `add_output` create something new, so there is no `$id` to resolve a location from: they take `inSubgraphTaskId` instead. Omit it to add to the top-level pipeline, or pass a subgraph task's `$id` to add inside that subgraph — for a repair, the subgraph that owns the entity you are fixing.
 
-Two structural limits remain: `connect_nodes` needs both endpoints in the same graph (to route a value through a subgraph boundary, add an input or output inside the subgraph with `inSubgraphTaskId` and wire the resulting port in the parent), and `create_subgraph` cannot group tasks that live at different levels.
+Two structural limits remain. `create_subgraph` cannot group tasks that live at different levels. And `connect_nodes` needs both endpoints in the same graph, so routing a value through a subgraph boundary takes three calls, not one:
+
+1. `add_input` (or `add_output`) with `inSubgraphTaskId` set to the subgraph task — this creates the boundary port and the matching port on the subgraph task in the parent.
+2. `connect_nodes` **inside** the subgraph, between that new port — use the `$id` the previous step returned — and the inner task that produces or consumes the value.
+3. `connect_nodes` in the parent, between the subgraph task and whatever the value comes from or goes to there.
+
+A port added without steps 2 and 3 is wired to nothing on either side, which turns one issue into three. Finish the chain before you re-run `validate_pipeline`.
 
 ## Validation across subgraphs
 

--- a/src/agent/prompts/pipelineRepair.md
+++ b/src/agent/prompts/pipelineRepair.md
@@ -66,7 +66,7 @@ Every entity has a stable `$id`. Use these IDs when referencing entities in tool
 
 ## Active subgraph context
 
-`get_pipeline_state` may include an `activeSubgraphPath` field — a breadcrumb of subgraph task names from the root pipeline to whatever subgraph the user is currently viewing. Treat it as a hint about which part of the pipeline the user cares about. It does not limit what you can fix: a fix inside a subgraph needs no permission a top-level fix would not need.
+`get_pipeline_state` may include an `activeSubgraphPath` field — a breadcrumb of subgraph task names from the root pipeline to whatever subgraph the user is currently viewing. Treat it as a hint about which part of the pipeline the user cares about, and as the destination for anything you add without a stated location (pass that subgraph task's `$id` as `inSubgraphTaskId`). It does not limit what you can fix: a fix inside a subgraph needs no permission a top-level fix would not need.
 
 ## Looking inside a subgraph
 
@@ -76,7 +76,7 @@ The `$id`s you read from `get_subgraph_state` are valid mutation targets. Every 
 
 `add_task`, `add_input` and `add_output` take no entity `$id`, so they have nothing to resolve: they always add to the top-level pipeline. If clearing an issue inside a subgraph would need a new task or port in that subgraph, report that rather than adding it at the top level, where it cannot be connected to anything inside.
 
-Two structural limits remain: `connect_nodes` needs both endpoints in the same graph (to route a value across a subgraph boundary, wire it to that subgraph task's own ports in the parent), and `create_subgraph` cannot group tasks that live at different levels.
+Two structural limits remain: `connect_nodes` needs both endpoints in the same graph (to route a value through a subgraph boundary, add an input or output inside the subgraph with `inSubgraphTaskId` and wire the resulting port in the parent), and `create_subgraph` cannot group tasks that live at different levels.
 
 ## Validation across subgraphs
 

--- a/src/agent/toolBridgeApi.ts
+++ b/src/agent/toolBridgeApi.ts
@@ -126,6 +126,7 @@ export interface ToolBridgeApi {
   addTask(args: {
     name: string;
     componentRef: ComponentReference;
+    inSubgraphTaskId?: string;
   }): Promise<BridgeResult & { taskId?: string; name?: string }>;
   deleteTask(entityId: string): Promise<BridgeResult>;
   renameTask(entityId: string, newName: string): Promise<BridgeResult>;
@@ -136,6 +137,7 @@ export interface ToolBridgeApi {
     description?: string;
     defaultValue?: string;
     optional?: boolean;
+    inSubgraphTaskId?: string;
   }): Promise<BridgeResult & { inputId?: string; name?: string }>;
   deleteInput(entityId: string): Promise<BridgeResult>;
   renameInput(entityId: string, newName: string): Promise<BridgeResult>;
@@ -144,6 +146,7 @@ export interface ToolBridgeApi {
     name: string;
     type?: string;
     description?: string;
+    inSubgraphTaskId?: string;
   }): Promise<BridgeResult & { outputId?: string; name?: string }>;
   deleteOutput(entityId: string): Promise<BridgeResult>;
   renameOutput(entityId: string, newName: string): Promise<BridgeResult>;

--- a/src/agent/tools/csomTools.ts
+++ b/src/agent/tools/csomTools.ts
@@ -129,7 +129,7 @@ export function createCsomTools(bridge: ToolBridgeApi) {
   const addTask = tool({
     name: "add_task",
     description:
-      "Add a new task node to the pipeline. Pass the full componentRef from a search_components result (with `url` and/or `spec`).",
+      "Add a new task node. Pass the full componentRef from a search_components result (with `url` and/or `spec`). Adds to the top-level pipeline unless inSubgraphTaskId names a subgraph to add it inside.",
     parameters: z.object({
       name: z.string().describe("Human-readable task name"),
       componentRef: z
@@ -180,12 +180,20 @@ export function createCsomTools(bridge: ToolBridgeApi) {
         .describe(
           "Component reference from search_components — must include url and/or spec.",
         ),
+      inSubgraphTaskId: z
+        .string()
+        .nullable()
+        .optional()
+        .describe(
+          '$id of a subgraph task to add this inside. Omit for the top-level pipeline. Use it when the user means a specific subgraph — e.g. they are viewing one (see activeSubgraphPath in get_pipeline_state) and say "add X here".',
+        ),
     }),
-    execute: async ({ name, componentRef }) =>
+    execute: async ({ name, componentRef, inSubgraphTaskId }) =>
       asJson(
         await bridge.addTask({
           name,
           componentRef: dropNulls(componentRef) as ComponentReference,
+          inSubgraphTaskId: inSubgraphTaskId ?? undefined,
         }),
       ),
   });
@@ -212,7 +220,8 @@ export function createCsomTools(bridge: ToolBridgeApi) {
 
   const addInput = tool({
     name: "add_input",
-    description: "Add a pipeline-level input.",
+    description:
+      "Add a graph-level input. Adds to the top-level pipeline unless inSubgraphTaskId names a subgraph to add it inside — a subgraph input becomes an input port on that subgraph task.",
     parameters: z.object({
       name: z.string().describe("Input name"),
       type: z
@@ -223,8 +232,22 @@ export function createCsomTools(bridge: ToolBridgeApi) {
       description: z.string().nullable().optional(),
       defaultValue: z.string().nullable().optional().describe("Default value"),
       optional: z.boolean().nullable().optional(),
+      inSubgraphTaskId: z
+        .string()
+        .nullable()
+        .optional()
+        .describe(
+          '$id of a subgraph task to add this inside. Omit for the top-level pipeline. Use it when the user means a specific subgraph — e.g. they are viewing one (see activeSubgraphPath in get_pipeline_state) and say "add X here".',
+        ),
     }),
-    execute: async ({ name, type, description, defaultValue, optional }) =>
+    execute: async ({
+      name,
+      type,
+      description,
+      defaultValue,
+      optional,
+      inSubgraphTaskId,
+    }) =>
       asJson(
         await bridge.addInput({
           name,
@@ -232,6 +255,7 @@ export function createCsomTools(bridge: ToolBridgeApi) {
           description: description ?? undefined,
           defaultValue: defaultValue ?? undefined,
           optional: optional ?? undefined,
+          inSubgraphTaskId: inSubgraphTaskId ?? undefined,
         }),
       ),
   });
@@ -260,18 +284,27 @@ export function createCsomTools(bridge: ToolBridgeApi) {
 
   const addOutput = tool({
     name: "add_output",
-    description: "Add a pipeline-level output.",
+    description:
+      "Add a graph-level output. Adds to the top-level pipeline unless inSubgraphTaskId names a subgraph to add it inside — a subgraph output becomes an output port on that subgraph task.",
     parameters: z.object({
       name: z.string().describe("Output name"),
       type: z.string().nullable().optional().describe("Type"),
       description: z.string().nullable().optional(),
+      inSubgraphTaskId: z
+        .string()
+        .nullable()
+        .optional()
+        .describe(
+          '$id of a subgraph task to add this inside. Omit for the top-level pipeline. Use it when the user means a specific subgraph — e.g. they are viewing one (see activeSubgraphPath in get_pipeline_state) and say "add X here".',
+        ),
     }),
-    execute: async ({ name, type, description }) =>
+    execute: async ({ name, type, description, inSubgraphTaskId }) =>
       asJson(
         await bridge.addOutput({
           name,
           type: type ?? undefined,
           description: description ?? undefined,
+          inSubgraphTaskId: inSubgraphTaskId ?? undefined,
         }),
       ),
   });

--- a/src/agent/tools/csomTools.ts
+++ b/src/agent/tools/csomTools.ts
@@ -185,7 +185,7 @@ export function createCsomTools(bridge: ToolBridgeApi) {
         .nullable()
         .optional()
         .describe(
-          '$id of a subgraph task to add this inside. Omit for the top-level pipeline. Use it when the user means a specific subgraph — e.g. they are viewing one (see activeSubgraphPath in get_pipeline_state) and say "add X here".',
+          "$id of a subgraph task to add this inside. Omit for the top-level pipeline. When the user means the subgraph they are viewing, pass activeSubgraphTaskId from get_pipeline_state verbatim — a name from activeSubgraphPath is not an $id.",
         ),
     }),
     execute: async ({ name, componentRef, inSubgraphTaskId }) =>
@@ -237,7 +237,7 @@ export function createCsomTools(bridge: ToolBridgeApi) {
         .nullable()
         .optional()
         .describe(
-          '$id of a subgraph task to add this inside. Omit for the top-level pipeline. Use it when the user means a specific subgraph — e.g. they are viewing one (see activeSubgraphPath in get_pipeline_state) and say "add X here".',
+          "$id of a subgraph task to add this inside. Omit for the top-level pipeline. When the user means the subgraph they are viewing, pass activeSubgraphTaskId from get_pipeline_state verbatim — a name from activeSubgraphPath is not an $id.",
         ),
     }),
     execute: async ({
@@ -295,7 +295,7 @@ export function createCsomTools(bridge: ToolBridgeApi) {
         .nullable()
         .optional()
         .describe(
-          '$id of a subgraph task to add this inside. Omit for the top-level pipeline. Use it when the user means a specific subgraph — e.g. they are viewing one (see activeSubgraphPath in get_pipeline_state) and say "add X here".',
+          "$id of a subgraph task to add this inside. Omit for the top-level pipeline. When the user means the subgraph they are viewing, pass activeSubgraphTaskId from get_pipeline_state verbatim — a name from activeSubgraphPath is not an $id.",
         ),
     }),
     execute: async ({ name, type, description, inSubgraphTaskId }) =>

--- a/src/routes/v2/pages/Editor/components/AiChat/toolBridge.test.ts
+++ b/src/routes/v2/pages/Editor/components/AiChat/toolBridge.test.ts
@@ -97,6 +97,7 @@ function makeBridge() {
   const bridge = createEditorToolBridge({
     getSpec: () => spec,
     getActiveSubgraphPath: () => [],
+    getActiveSubgraphTaskId: () => undefined,
     undo,
   });
   return { bridge, undo, spec };
@@ -172,6 +173,7 @@ function makeNestedBridge(extraInnerTasks?: Record<string, unknown>) {
   const bridge = createEditorToolBridge({
     getSpec: () => spec,
     getActiveSubgraphPath: () => [],
+    getActiveSubgraphTaskId: () => undefined,
     undo,
   });
   const preprocess = spec.tasks.find((t) => t.name === "Preprocess");
@@ -192,6 +194,7 @@ function makeEmptyBridge() {
   const bridge = createEditorToolBridge({
     getSpec: () => null,
     getActiveSubgraphPath: () => [],
+    getActiveSubgraphTaskId: () => undefined,
     undo,
   });
   return { bridge, undo };
@@ -210,6 +213,7 @@ function makeBackendBridge(
   const bridge = createEditorToolBridge({
     getSpec: () => spec,
     getActiveSubgraphPath: () => [],
+    getActiveSubgraphTaskId: () => undefined,
     undo,
     getBackendUrl: () => TEST_BACKEND_URL,
     getAuthToken: () => overrides.authToken,
@@ -231,12 +235,13 @@ describe("createEditorToolBridge", () => {
   });
 
   describe("getPipelineState", () => {
-    it("returns the serialized spec with the active subgraph path", async () => {
+    it("returns the serialized spec with the active subgraph path and task id", async () => {
       const spec = buildSpec();
       const undo = new RecordingUndo();
       const bridge = createEditorToolBridge({
         getSpec: () => spec,
         getActiveSubgraphPath: () => ["preprocess"],
+        getActiveSubgraphTaskId: () => "task-preprocess",
         undo,
       });
 
@@ -244,6 +249,22 @@ describe("createEditorToolBridge", () => {
       expect(state.name).toBe("Pipe");
       expect(state.tasks).toHaveLength(1);
       expect(state.activeSubgraphPath).toEqual(["preprocess"]);
+      expect(state.activeSubgraphTaskId).toBe("task-preprocess");
+    });
+
+    it("omits the active subgraph task id at the top level", async () => {
+      const spec = buildSpec();
+      const undo = new RecordingUndo();
+      const bridge = createEditorToolBridge({
+        getSpec: () => spec,
+        getActiveSubgraphPath: () => [],
+        getActiveSubgraphTaskId: () => undefined,
+        undo,
+      });
+
+      const state = await bridge.getPipelineState();
+      expect(state.activeSubgraphPath).toBeUndefined();
+      expect(state.activeSubgraphTaskId).toBeUndefined();
     });
   });
 
@@ -417,6 +438,7 @@ describe("createEditorToolBridge", () => {
       const bridge = createEditorToolBridge({
         getSpec: () => spec,
         getActiveSubgraphPath: () => [],
+        getActiveSubgraphTaskId: () => undefined,
         undo,
       });
 
@@ -863,6 +885,7 @@ describe("createEditorToolBridge", () => {
       const bridge = createEditorToolBridge({
         getSpec: () => spec,
         getActiveSubgraphPath: () => [],
+        getActiveSubgraphTaskId: () => undefined,
         undo,
       });
 
@@ -877,6 +900,7 @@ describe("createEditorToolBridge", () => {
       const bridge = createEditorToolBridge({
         getSpec: () => spec,
         getActiveSubgraphPath: () => [],
+        getActiveSubgraphTaskId: () => undefined,
         undo,
       });
 

--- a/src/routes/v2/pages/Editor/components/AiChat/toolBridge.test.ts
+++ b/src/routes/v2/pages/Editor/components/AiChat/toolBridge.test.ts
@@ -748,6 +748,101 @@ describe("createEditorToolBridge", () => {
     });
   });
 
+  describe("adding into a subgraph", () => {
+    it("addTask puts the task inside the named subgraph", async () => {
+      const { bridge, spec, inner } = makeNestedBridge();
+
+      const result = await bridge.addTask({
+        name: "Dedupe",
+        componentRef: containerComponent("Dedupe", "dedupe:1", "path", "table"),
+        inSubgraphTaskId: taskId(spec, "Preprocess"),
+      });
+
+      expect(result.success).toBe(true);
+      expect(inner.tasks.map((t) => t.name).sort()).toEqual([
+        "Dedupe",
+        "DropNulls",
+      ]);
+      expect(spec.tasks.map((t) => t.name)).toEqual(["Preprocess", "Train"]);
+    });
+
+    it("addInput inside a subgraph becomes an input port on the subgraph task", async () => {
+      const { bridge, spec, inner } = makeNestedBridge();
+      const preprocessId = taskId(spec, "Preprocess");
+
+      const result = await bridge.addInput({
+        name: "threshold",
+        type: "Integer",
+        inSubgraphTaskId: preprocessId,
+      });
+
+      expect(result.success).toBe(true);
+      expect(inner.inputs.map((i) => i.name)).toContain("threshold");
+      expect(spec.inputs.map((i) => i.name)).toEqual(["raw_path"]);
+      expect(
+        spec.tasks
+          .find((t) => t.$id === preprocessId)
+          ?.resolvedComponentSpec?.inputs?.map((i) => i.name),
+      ).toContain("threshold");
+    });
+
+    it("addOutput inside a subgraph becomes an output port on the subgraph task", async () => {
+      const { bridge, spec, inner } = makeNestedBridge();
+      const preprocessId = taskId(spec, "Preprocess");
+
+      const result = await bridge.addOutput({
+        name: "report",
+        inSubgraphTaskId: preprocessId,
+      });
+
+      expect(result.success).toBe(true);
+      expect(inner.outputs.map((o) => o.name)).toContain("report");
+      expect(
+        spec.tasks
+          .find((t) => t.$id === preprocessId)
+          ?.resolvedComponentSpec?.outputs?.map((o) => o.name),
+      ).toContain("report");
+    });
+
+    it("adds to the top level when inSubgraphTaskId is omitted", async () => {
+      const { bridge, spec, inner } = makeNestedBridge();
+
+      const result = await bridge.addInput({ name: "extra" });
+
+      expect(result).toMatchObject({ success: true, name: "extra" });
+      expect(spec.inputs.map((i) => i.name)).toEqual(["raw_path", "extra"]);
+      expect(inner.inputs.map((i) => i.name)).toEqual(["path"]);
+    });
+
+    it("refuses a destination that is not a subgraph", async () => {
+      const { bridge, spec } = makeNestedBridge();
+
+      const result = await bridge.addTask({
+        name: "Dedupe",
+        componentRef: containerComponent("Dedupe", "dedupe:1", "path", "table"),
+        inSubgraphTaskId: taskId(spec, "Train"),
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Task "Train" is not a subgraph');
+    });
+
+    it("refuses an unknown destination id", async () => {
+      const { bridge, spec } = makeNestedBridge();
+
+      const result = await bridge.addOutput({
+        name: "report",
+        inSubgraphTaskId: "nope",
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe(
+        'No task with $id "nope" exists in this pipeline.',
+      );
+      expect(spec.outputs).toHaveLength(0);
+    });
+  });
+
   describe("validatePipeline", () => {
     it("reports valid: true on a clean spec", async () => {
       const spec = new ComponentSpec({ $id: "spec_1", name: "Pipe" });

--- a/src/routes/v2/pages/Editor/components/AiChat/toolBridge.test.ts
+++ b/src/routes/v2/pages/Editor/components/AiChat/toolBridge.test.ts
@@ -12,6 +12,7 @@ import { IncrementingIdGenerator } from "@/models/componentSpec/factories/idGene
 import { YamlDeserializer } from "@/models/componentSpec/serialization/yamlDeserializer";
 import { ONBOARDING_MY_RUN_COUNT_KEY } from "@/providers/OnboardingProvider/onboardingQueryKeys";
 import type { UndoGroupable } from "@/routes/v2/shared/nodes/types";
+import { hydrateComponentReference } from "@/services/componentService";
 
 vi.mock("@/services/componentService", () => ({
   hydrateComponentReference: vi.fn(async (ref) => ref),
@@ -298,6 +299,33 @@ describe("createEditorToolBridge", () => {
       const added = spec.tasks.find((t) => t.$id === result.taskId);
       expect(added?.name).toBe("MyLoader");
       expect(undo.labels.filter((l) => l === "Add task")).toHaveLength(1);
+    });
+
+    it("addTask refuses when another pipeline is opened while the component loads", async () => {
+      const original = buildSpec();
+      const opened = new ComponentSpec({ $id: "spec_2", name: "Other" });
+      let current: ComponentSpec = original;
+      const bridge = createEditorToolBridge({
+        getSpec: () => current,
+        getActiveSubgraphPath: () => [],
+        getActiveSubgraphTaskId: () => undefined,
+        undo: new RecordingUndo(),
+      });
+
+      vi.mocked(hydrateComponentReference).mockImplementationOnce(async () => {
+        current = opened;
+        return null;
+      });
+
+      const result = await bridge.addTask({
+        name: "Dedupe",
+        componentRef: containerComponent("Dedupe", "dedupe:1", "path", "table"),
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('changed to "Other"');
+      expect(opened.tasks).toHaveLength(0);
+      expect(original.tasks.map((t) => t.name)).toEqual(["Transform"]);
     });
 
     it("deleteTask reports an unknown id rather than a bare failure", async () => {

--- a/src/routes/v2/pages/Editor/components/AiChat/toolBridge/csomBridge.ts
+++ b/src/routes/v2/pages/Editor/components/AiChat/toolBridge/csomBridge.ts
@@ -58,6 +58,7 @@ import {
   explainNotASubgraph,
   resolveArgumentValue,
   resolveConnectable,
+  resolveDestination,
   resolveTarget,
 } from "./mutationTarget";
 
@@ -111,8 +112,16 @@ export function createCsomBridgeHandlers(deps: CsomBridgeDeps): CsomHandlers {
       return { success: true };
     },
 
-    async addTask({ name, componentRef }) {
-      const spec = requireSpec(deps);
+    async addTask({ name, componentRef, inSubgraphTaskId }) {
+      const destination = resolveDestination(
+        requireSpec(deps),
+        inSubgraphTaskId,
+      );
+      if (!destination.ok) {
+        return { success: false, error: destination.error };
+      }
+      const { spec } = destination;
+
       const hydrated =
         (await hydrateComponentReference(componentRef)) ?? componentRef;
       const task = addTask(
@@ -154,8 +163,23 @@ export function createCsomBridgeHandlers(deps: CsomBridgeDeps): CsomHandlers {
       );
     },
 
-    async addInput({ name, type, description, defaultValue, optional }) {
-      const spec = requireSpec(deps);
+    async addInput({
+      name,
+      type,
+      description,
+      defaultValue,
+      optional,
+      inSubgraphTaskId,
+    }) {
+      const destination = resolveDestination(
+        requireSpec(deps),
+        inSubgraphTaskId,
+      );
+      if (!destination.ok) {
+        return { success: false, error: destination.error };
+      }
+      const { spec } = destination;
+
       const input = addInput(deps.undo, spec, computeNextPosition(spec), name);
       if (type) setInputType(deps.undo, spec, input.$id, type);
       if (description)
@@ -201,8 +225,16 @@ export function createCsomBridgeHandlers(deps: CsomBridgeDeps): CsomHandlers {
       );
     },
 
-    async addOutput({ name, type, description }) {
-      const spec = requireSpec(deps);
+    async addOutput({ name, type, description, inSubgraphTaskId }) {
+      const destination = resolveDestination(
+        requireSpec(deps),
+        inSubgraphTaskId,
+      );
+      if (!destination.ok) {
+        return { success: false, error: destination.error };
+      }
+      const { spec } = destination;
+
       const output = addOutput(
         deps.undo,
         spec,

--- a/src/routes/v2/pages/Editor/components/AiChat/toolBridge/csomBridge.ts
+++ b/src/routes/v2/pages/Editor/components/AiChat/toolBridge/csomBridge.ts
@@ -117,13 +117,21 @@ export function createCsomBridgeHandlers(deps: CsomBridgeDeps): CsomHandlers {
       // Hydration fetches over the network; resolving the destination before it
       // would hand us a subgraph spec the user could detach (undo, navigation,
       // a reload) while we wait, and the task would land in an orphaned tree.
+      // `getSpec` reads whichever pipeline is open now, though, so the root has
+      // to be pinned across the fetch or the add follows the user into another
+      // pipeline.
+      const rootAtCallTime = requireSpec(deps);
       const hydrated =
         (await hydrateComponentReference(componentRef)) ?? componentRef;
+      const root = requireSpec(deps);
+      if (root !== rootAtCallTime) {
+        return {
+          success: false,
+          error: `Nothing was added — the open pipeline changed to "${root.name}" while the component was loading. Check with the user before retrying.`,
+        };
+      }
 
-      const destination = resolveDestination(
-        requireSpec(deps),
-        inSubgraphTaskId,
-      );
+      const destination = resolveDestination(root, inSubgraphTaskId);
       if (!destination.ok) {
         return { success: false, error: destination.error };
       }

--- a/src/routes/v2/pages/Editor/components/AiChat/toolBridge/csomBridge.ts
+++ b/src/routes/v2/pages/Editor/components/AiChat/toolBridge/csomBridge.ts
@@ -97,6 +97,7 @@ export function createCsomBridgeHandlers(deps: CsomBridgeDeps): CsomHandlers {
     async getPipelineState() {
       return serializeSpecForAi(requireSpec(deps), {
         activeSubgraphPath: deps.getActiveSubgraphPath(),
+        activeSubgraphTaskId: deps.getActiveSubgraphTaskId(),
       });
     },
 
@@ -113,6 +114,12 @@ export function createCsomBridgeHandlers(deps: CsomBridgeDeps): CsomHandlers {
     },
 
     async addTask({ name, componentRef, inSubgraphTaskId }) {
+      // Hydration fetches over the network; resolving the destination before it
+      // would hand us a subgraph spec the user could detach (undo, navigation,
+      // a reload) while we wait, and the task would land in an orphaned tree.
+      const hydrated =
+        (await hydrateComponentReference(componentRef)) ?? componentRef;
+
       const destination = resolveDestination(
         requireSpec(deps),
         inSubgraphTaskId,
@@ -122,8 +129,6 @@ export function createCsomBridgeHandlers(deps: CsomBridgeDeps): CsomHandlers {
       }
       const { spec } = destination;
 
-      const hydrated =
-        (await hydrateComponentReference(componentRef)) ?? componentRef;
       const task = addTask(
         deps.undo,
         spec,

--- a/src/routes/v2/pages/Editor/components/AiChat/toolBridge/mutationTarget.ts
+++ b/src/routes/v2/pages/Editor/components/AiChat/toolBridge/mutationTarget.ts
@@ -107,6 +107,34 @@ export function resolveConnectable(
 }
 
 /**
+ * Resolves where a newly created entity belongs. `undefined` means the
+ * top-level pipeline; otherwise the `$id` must name a subgraph task, whose
+ * inner spec becomes the destination.
+ */
+export function resolveDestination(
+  root: ComponentSpec,
+  subgraphTaskId: string | undefined,
+): { ok: true; spec: ComponentSpec } | { ok: false; error: string } {
+  if (!subgraphTaskId) {
+    return { ok: true, spec: root };
+  }
+
+  const target = resolveTarget(root, subgraphTaskId, "task");
+  if (!target.ok) return target;
+
+  const { location } = target;
+  const subgraphSpec = location.entity.subgraphSpec;
+  if (!subgraphSpec) {
+    return {
+      ok: false,
+      error: `Task "${location.entity.name}" is not a subgraph, so nothing can be added inside it. Omit inSubgraphTaskId to add to the top-level pipeline instead.`,
+    };
+  }
+
+  return { ok: true, spec: subgraphSpec };
+}
+
+/**
  * `explainRefusal` names the causes that are knowable before the mutation runs
  * — a rename that would collide, an unpack of something that is not a subgraph.
  * The generic message below is the branch we genuinely cannot explain, so it

--- a/src/routes/v2/pages/RunView/toolBridge/runViewToolBridge.ts
+++ b/src/routes/v2/pages/RunView/toolBridge/runViewToolBridge.ts
@@ -50,6 +50,7 @@ function createReadOnlyCsomHandlers(deps: BridgeDeps): ReadOnlyCsomHandlers {
     async getPipelineState() {
       return serializeSpecForAi(requireSpec(deps), {
         activeSubgraphPath: deps.getActiveSubgraphPath(),
+        activeSubgraphTaskId: deps.getActiveSubgraphTaskId(),
       });
     },
 

--- a/src/routes/v2/shared/components/AiChat/AiChatContent.tsx
+++ b/src/routes/v2/shared/components/AiChat/AiChatContent.tsx
@@ -92,6 +92,7 @@ export const AiChatContent = observer(function AiChatContent({
       getSpec: () => navigation.rootSpec,
       getActiveSubgraphPath: () =>
         navigation.navigationPath.slice(1).map((e) => e.displayName),
+      getActiveSubgraphTaskId: () => navigation.parentContext?.taskId,
       getBackendUrl: () => backendUrlRef.current,
       getAuthToken: () => authTokenRef.current,
       queryClient,

--- a/src/routes/v2/shared/components/AiChat/serializeSpecForAi.ts
+++ b/src/routes/v2/shared/components/AiChat/serializeSpecForAi.ts
@@ -10,6 +10,10 @@
  * separate bridge call. Edits land in whichever spec owns the `$id` they
  * name, so the breadcrumb tells the model where the user is looking
  * rather than where an edit will go.
+ *
+ * `activeSubgraphTaskId` accompanies it because the breadcrumb is made of
+ * display names, which are unique only within one graph — the model cannot
+ * turn a name in it back into the `$id` that `inSubgraphTaskId` needs.
  */
 import type {
   Binding,
@@ -65,10 +69,12 @@ export interface AiSpec {
   tasks: AiTaskSpec[];
   bindings: AiBindingSpec[];
   activeSubgraphPath?: string[];
+  activeSubgraphTaskId?: string;
 }
 
 export interface SerializeSpecOptions {
   activeSubgraphPath?: string[];
+  activeSubgraphTaskId?: string;
 }
 
 function pickDefined<T extends object>(obj: T): T {
@@ -146,8 +152,9 @@ function serializeComponentRef(ref: ComponentReference): AiComponentRef {
 
 export function serializeSpecForAi(
   spec: ComponentSpec,
-  { activeSubgraphPath = [] }: SerializeSpecOptions = {},
+  { activeSubgraphPath = [], activeSubgraphTaskId }: SerializeSpecOptions = {},
 ): AiSpec {
+  const insideSubgraph = activeSubgraphPath.length > 0;
   return pickDefined({
     name: spec.name,
     description: spec.description || undefined,
@@ -155,7 +162,7 @@ export function serializeSpecForAi(
     outputs: spec.outputs.map(serializeOutput),
     tasks: spec.tasks.map(serializeTask),
     bindings: spec.bindings.map(serializeBinding),
-    activeSubgraphPath:
-      activeSubgraphPath.length > 0 ? activeSubgraphPath : undefined,
+    activeSubgraphPath: insideSubgraph ? activeSubgraphPath : undefined,
+    activeSubgraphTaskId: insideSubgraph ? activeSubgraphTaskId : undefined,
   });
 }

--- a/src/routes/v2/shared/components/AiChat/toolBridge/subgraphBridge.test.ts
+++ b/src/routes/v2/shared/components/AiChat/toolBridge/subgraphBridge.test.ts
@@ -91,6 +91,7 @@ function makeDeps(spec: ComponentSpec): BridgeDeps {
   return {
     getSpec: () => spec,
     getActiveSubgraphPath: () => [],
+    getActiveSubgraphTaskId: () => undefined,
   };
 }
 
@@ -188,6 +189,7 @@ describe("createSubgraphBridgeHandlers", () => {
     const { getSubgraphState } = createSubgraphBridgeHandlers({
       getSpec: () => null,
       getActiveSubgraphPath: () => [],
+      getActiveSubgraphTaskId: () => undefined,
     });
 
     await expect(getSubgraphState("task_1")).rejects.toThrow(

--- a/src/routes/v2/shared/components/AiChat/toolBridge/utils.ts
+++ b/src/routes/v2/shared/components/AiChat/toolBridge/utils.ts
@@ -27,6 +27,7 @@ const POSITION_OFFSET = 200;
 export interface BridgeDeps {
   getSpec: () => ComponentSpec | null;
   getActiveSubgraphPath: () => string[];
+  getActiveSubgraphTaskId: () => string | undefined;
   getBackendUrl?: () => string;
   getAuthToken?: () => string | undefined;
   queryClient?: QueryClient;


### PR DESCRIPTION
## Description

The PR below this one made the assistant change existing things wherever they
live. Creating something new still only worked at the top level, which left one
job impossible: getting a value into or out of a subgraph. That needs a new port
on the subgraph itself, and there was no way to ask for one.

Adding a step, an input, or an output can now target a subgraph. Ask for
something without saying where and nothing changes — it goes to the top level as
before. Name a subgraph, or open one and say "add a filter step here", and it
goes inside that one instead. An input added inside a subgraph shows up as a new
input port on that subgraph step, which is how you feed a value into it.

If you name something that isn't a subgraph, it says so and tells you how to add
at the top level instead, rather than failing quietly.

**Getting a value in or out now finishes the job.** A port on the boundary is
only a third of the work — it also has to be wired to the step inside the
subgraph that uses the value, and to whatever feeds it in the parent. Asked for
this, the assistant used to create the port and stop, leaving a value that
reaches nothing and two fresh validation errors where there had been none. It
now does all three, so "feed this into \<subgraph>" is a single request that
ends with a working pipeline.

Two smaller corrections in the same area. Asked to fix a problem while you
happen to be looking at a subgraph, it no longer drops the fix into that
subgraph — repairs land on whatever they're repairing, wherever that lives. And
it now gets the subgraph you're viewing handed to it directly rather than
matching on its name, which was ambiguous whenever two subgraphs at different
levels shared a name.



![image.png](https://app.graphite.com/user-attachments/assets/77d77d64-1b0a-4921-aae6-1f4a5f4ea2d2.png)



## Related Issue and Pull requests

Stacked on #2683 → #2687 → #2686 → #2685 → #2655.

Re-cut alongside #2683 — see that PR for why. This one is now purely the new
capability: it adds to the PR below rather than rewriting it.

## Type of Change

- [x] New feature

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

1. Open a pipeline with a subgraph. Ask the chat: "add a \<component> inside
\<subgraph name>". Open the subgraph and confirm it's there, and that it did
not also appear at the top level.
2. Open a subgraph, then say "add an input called threshold here" — it should go
into the subgraph you're looking at, not the top level.
3. Go back up: that subgraph step should now have a `threshold` input port on it.
4. Ask for the whole route in one go — "feed \<some top-level value> into
\<subgraph name> so \<inner step> can use it". It should end with the port
wired on both sides: connected inside the subgraph to the step that uses it,
and connected in the parent to the value you named. Ask it to validate
afterwards — there should be no new errors, and in particular no unconnected
port left behind.
5. Same again with an output — it should appear as an output port on the subgraph
step, and the route out should get wired end to end the same way.
6. Ask for something with no location at all ("add a \<component>") while looking
at the top level — it should go to the top level, as before.
7. Ask it to add something "inside" a step that isn't a subgraph — it should
explain that step isn't a subgraph rather than silently doing something else.
8. Open a pipeline with a validation problem on a top-level step, then open a
subgraph before asking the chat to fix it. The fix should land on the top-level
step, not inside the subgraph you happen to be looking at.
9. Undo (Cmd/Ctrl+Z) after a nested add, and confirm the pipeline still saves.

## Additional Comments

The earlier version of this PR also returned the subgraph trail on every single
edit so the assistant could quote it back. That's been dropped: the assistant
already knows which subgraph it targeted, because it passed the id, so the extra
field was duplicating information it had. It's still told to name the subgraph it
changed in its reply — the canvas doesn't move, so you need to be told where to
look.

