### PR TITLE
refactor: Find pipeline entities inside nested subgraphs

### DIFF
--- a/src/models/componentSpec/__tests__/queries/locateEntity.test.ts
+++ b/src/models/componentSpec/__tests__/queries/locateEntity.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from "vitest";
+
+import type { ComponentSpec } from "@/models/componentSpec";
+import { Binding } from "@/models/componentSpec/entities/binding";
+import { IncrementingIdGenerator } from "@/models/componentSpec/factories/idGenerator";
+import {
+  locatedEntityName,
+  locateEntity,
+} from "@/models/componentSpec/queries/locateEntity";
+import { YamlDeserializer } from "@/models/componentSpec/serialization/yamlDeserializer";
+
+const containerComponent = (name: string, image: string) => ({
+  name,
+  spec: {
+    name,
+    inputs: [{ name: "path", type: "String" }],
+    outputs: [{ name: "table", type: "String" }],
+    implementation: { container: { image } },
+  },
+});
+
+const pipelineYaml = {
+  name: "RootPipeline",
+  inputs: [{ name: "raw_path", type: "String" }],
+  outputs: [{ name: "model", type: "String" }],
+  implementation: {
+    graph: {
+      tasks: {
+        Preprocess: {
+          componentRef: {
+            name: "Preprocess",
+            spec: {
+              name: "Preprocess",
+              inputs: [{ name: "path", type: "String" }],
+              outputs: [{ name: "table", type: "String" }],
+              implementation: {
+                graph: {
+                  tasks: {
+                    Normalize: {
+                      componentRef: {
+                        name: "Normalize",
+                        spec: {
+                          name: "Normalize",
+                          inputs: [{ name: "path", type: "String" }],
+                          outputs: [{ name: "table", type: "String" }],
+                          implementation: {
+                            graph: {
+                              tasks: {
+                                ScaleColumns: {
+                                  componentRef: containerComponent(
+                                    "ScaleColumns",
+                                    "scale:1",
+                                  ),
+                                },
+                              },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        Train: { componentRef: containerComponent("Train", "train:1") },
+      },
+    },
+  },
+};
+
+function deserialize(): ComponentSpec {
+  return new YamlDeserializer(new IncrementingIdGenerator()).deserialize(
+    pipelineYaml,
+  );
+}
+
+function subgraphOf(spec: ComponentSpec, taskName: string): ComponentSpec {
+  const task = spec.tasks.find((t) => t.name === taskName);
+  if (!task?.subgraphSpec) throw new Error(`${taskName} is not a subgraph`);
+  return task.subgraphSpec;
+}
+
+describe("locateEntity", () => {
+  it("locates a root task with an empty subgraph path", () => {
+    const spec = deserialize();
+    const train = spec.tasks.find((t) => t.name === "Train");
+
+    const location = locateEntity(spec, train!.$id);
+
+    expect(location).toMatchObject({ kind: "task", subgraphPath: [] });
+    expect(locatedEntityName(location!)).toBe("Train");
+    expect(location?.spec).toBe(spec);
+    expect(location?.entity).toBe(train);
+  });
+
+  it("returns the owning spec and path for a task one level down", () => {
+    const spec = deserialize();
+    const preprocess = subgraphOf(spec, "Preprocess");
+    const normalize = preprocess.tasks.find((t) => t.name === "Normalize");
+
+    const location = locateEntity(spec, normalize!.$id);
+
+    expect(location?.subgraphPath).toEqual(["Preprocess"]);
+    expect(location?.spec).toBe(preprocess);
+  });
+
+  it("builds the full path for a deeply nested task", () => {
+    const spec = deserialize();
+    const normalizeSpec = subgraphOf(
+      subgraphOf(spec, "Preprocess"),
+      "Normalize",
+    );
+    const scale = normalizeSpec.tasks.find((t) => t.name === "ScaleColumns");
+
+    const location = locateEntity(spec, scale!.$id);
+
+    expect(location).toMatchObject({
+      kind: "task",
+      subgraphPath: ["Preprocess", "Normalize"],
+    });
+    expect(locatedEntityName(location!)).toBe("ScaleColumns");
+    expect(location?.spec).toBe(normalizeSpec);
+  });
+
+  it("distinguishes inputs, outputs and bindings from tasks", () => {
+    const spec = deserialize();
+    spec.addBinding(
+      new Binding({
+        $id: "bind_1",
+        sourceEntityId: spec.inputs[0].$id,
+        sourcePortName: "raw_path",
+        targetEntityId: spec.tasks[0].$id,
+        targetPortName: "path",
+      }),
+    );
+
+    const input = locateEntity(spec, spec.inputs[0].$id);
+    const output = locateEntity(spec, spec.outputs[0].$id);
+    const binding = locateEntity(spec, "bind_1");
+
+    expect(input?.kind).toBe("input");
+    expect(locatedEntityName(input!)).toBe("raw_path");
+    expect(output?.kind).toBe("output");
+    expect(locatedEntityName(output!)).toBe("model");
+    expect(binding?.kind).toBe("binding");
+    expect(locatedEntityName(binding!)).toBeUndefined();
+  });
+
+  it("finds an input declared inside a subgraph", () => {
+    const spec = deserialize();
+    const preprocess = subgraphOf(spec, "Preprocess");
+
+    const location = locateEntity(spec, preprocess.inputs[0].$id);
+
+    expect(location).toMatchObject({
+      kind: "input",
+      subgraphPath: ["Preprocess"],
+    });
+    expect(locatedEntityName(location!)).toBe("path");
+  });
+
+  it("returns undefined for an unknown id", () => {
+    expect(locateEntity(deserialize(), "nope")).toBeUndefined();
+  });
+
+  describe("parentContext", () => {
+    it("is absent for an entity in the spec that was passed in", () => {
+      const spec = deserialize();
+
+      const location = locateEntity(spec, spec.tasks[0].$id);
+
+      expect(location?.parentContext).toBeUndefined();
+    });
+
+    it("names the immediate owning spec and subgraph task one level down", () => {
+      const spec = deserialize();
+      const preprocessTask = spec.tasks.find((t) => t.name === "Preprocess");
+      const normalize = subgraphOf(spec, "Preprocess").tasks[0];
+
+      const location = locateEntity(spec, normalize.$id);
+
+      expect(location?.parentContext?.parentSpec).toBe(spec);
+      expect(location?.parentContext?.taskId).toBe(preprocessTask?.$id);
+    });
+
+    it("names the immediate parent rather than the root for a deep entity", () => {
+      const spec = deserialize();
+      const preprocess = subgraphOf(spec, "Preprocess");
+      const normalizeTask = preprocess.tasks.find(
+        (t) => t.name === "Normalize",
+      );
+      const scale = subgraphOf(preprocess, "Normalize").tasks[0];
+
+      const location = locateEntity(spec, scale.$id);
+
+      expect(location?.parentContext?.parentSpec).toBe(preprocess);
+      expect(location?.parentContext?.taskId).toBe(normalizeTask?.$id);
+    });
+  });
+});

--- a/src/models/componentSpec/__tests__/queries/locateEntity.test.ts
+++ b/src/models/componentSpec/__tests__/queries/locateEntity.test.ts
@@ -89,7 +89,7 @@ describe("locateEntity", () => {
 
     const location = locateEntity(spec, train!.$id);
 
-    expect(location).toMatchObject({ kind: "task", subgraphPath: [] });
+    expect(location).toMatchObject({ kind: "task", subgraphTaskNames: [] });
     expect(locatedEntityName(location!)).toBe("Train");
     expect(location?.spec).toBe(spec);
     expect(location?.entity).toBe(train);
@@ -102,7 +102,7 @@ describe("locateEntity", () => {
 
     const location = locateEntity(spec, normalize!.$id);
 
-    expect(location?.subgraphPath).toEqual(["Preprocess"]);
+    expect(location?.subgraphTaskNames).toEqual(["Preprocess"]);
     expect(location?.spec).toBe(preprocess);
   });
 
@@ -118,7 +118,7 @@ describe("locateEntity", () => {
 
     expect(location).toMatchObject({
       kind: "task",
-      subgraphPath: ["Preprocess", "Normalize"],
+      subgraphTaskNames: ["Preprocess", "Normalize"],
     });
     expect(locatedEntityName(location!)).toBe("ScaleColumns");
     expect(location?.spec).toBe(normalizeSpec);
@@ -156,7 +156,7 @@ describe("locateEntity", () => {
 
     expect(location).toMatchObject({
       kind: "input",
-      subgraphPath: ["Preprocess"],
+      subgraphTaskNames: ["Preprocess"],
     });
     expect(locatedEntityName(location!)).toBe("path");
   });

--- a/src/models/componentSpec/queries/findTaskById.ts
+++ b/src/models/componentSpec/queries/findTaskById.ts
@@ -1,21 +1,11 @@
 import type { ComponentSpec } from "../entities/componentSpec";
 import type { Task } from "../entities/task";
+import { locateEntity } from "./locateEntity";
 
 export function findTaskById(
   spec: ComponentSpec,
   entityId: string,
 ): Task | undefined {
-  for (const task of spec.tasks) {
-    if (task.$id === entityId) {
-      return task;
-    }
-
-    const nested =
-      task.subgraphSpec && findTaskById(task.subgraphSpec, entityId);
-    if (nested) {
-      return nested;
-    }
-  }
-
-  return undefined;
+  const location = locateEntity(spec, entityId);
+  return location?.kind === "task" ? location.entity : undefined;
 }

--- a/src/models/componentSpec/queries/locateEntity.ts
+++ b/src/models/componentSpec/queries/locateEntity.ts
@@ -22,14 +22,17 @@ interface EntityParentContext {
 
 export type EntityLocation = LocatedEntity & {
   spec: ComponentSpec;
-  subgraphPath: string[];
+  subgraphTaskNames: string[];
   parentContext?: EntityParentContext;
 };
 
 /**
- * Finds which spec in the tree owns `entityId`. `subgraphPath` is the chain of
- * subgraph task names leading to it, so an empty path means the entity lives in
- * the spec that was passed in, and `parentContext` is absent only in that case.
+ * Finds which spec in the tree owns `entityId`. `subgraphTaskNames` is the chain
+ * of subgraph task names leading to it, so an empty chain means the entity lives
+ * in the spec that was passed in, and `parentContext` is absent only in that
+ * case. The root is not a segment — deliberately unlike
+ * `ComponentValidationIssue.subgraphPath`, which is prefixed with `"root"`;
+ * hence the different field name.
  *
  * Entity `$id`s are unique across the whole document (`generateUniqueId`
  * combines a module-level counter with a timestamp), so a match at any depth is
@@ -41,7 +44,7 @@ export function locateEntity(
 ): EntityLocation | undefined {
   const found = findInSpec(spec, entityId);
   if (found) {
-    return { ...found, spec, subgraphPath: [] };
+    return { ...found, spec, subgraphTaskNames: [] };
   }
 
   for (const task of spec.tasks) {
@@ -50,7 +53,7 @@ export function locateEntity(
     if (nested) {
       return {
         ...nested,
-        subgraphPath: [task.name, ...nested.subgraphPath],
+        subgraphTaskNames: [task.name, ...nested.subgraphTaskNames],
         parentContext: nested.parentContext ?? {
           parentSpec: spec,
           taskId: task.$id,

--- a/src/models/componentSpec/queries/locateEntity.ts
+++ b/src/models/componentSpec/queries/locateEntity.ts
@@ -1,0 +1,88 @@
+import type { Binding } from "../entities/binding";
+import type { ComponentSpec } from "../entities/componentSpec";
+import type { Input } from "../entities/input";
+import type { Output } from "../entities/output";
+import type { Task } from "../entities/task";
+
+type LocatedEntity =
+  | { kind: "task"; entity: Task }
+  | { kind: "input"; entity: Input }
+  | { kind: "output"; entity: Output }
+  | { kind: "binding"; entity: Binding };
+
+/**
+ * Structurally matches the editor's `ParentContext`, so a location can be
+ * handed straight to the I/O actions that propagate port renames and deletes
+ * up to the owning subgraph task.
+ */
+interface EntityParentContext {
+  parentSpec: ComponentSpec;
+  taskId: string;
+}
+
+export type EntityLocation = LocatedEntity & {
+  spec: ComponentSpec;
+  subgraphPath: string[];
+  parentContext?: EntityParentContext;
+};
+
+/**
+ * Finds which spec in the tree owns `entityId`. `subgraphPath` is the chain of
+ * subgraph task names leading to it, so an empty path means the entity lives in
+ * the spec that was passed in, and `parentContext` is absent only in that case.
+ *
+ * Entity `$id`s are unique across the whole document (`generateUniqueId`
+ * combines a module-level counter with a timestamp), so a match at any depth is
+ * unambiguous.
+ */
+export function locateEntity(
+  spec: ComponentSpec,
+  entityId: string,
+): EntityLocation | undefined {
+  const found = findInSpec(spec, entityId);
+  if (found) {
+    return { ...found, spec, subgraphPath: [] };
+  }
+
+  for (const task of spec.tasks) {
+    if (!task.subgraphSpec) continue;
+    const nested = locateEntity(task.subgraphSpec, entityId);
+    if (nested) {
+      return {
+        ...nested,
+        subgraphPath: [task.name, ...nested.subgraphPath],
+        parentContext: nested.parentContext ?? {
+          parentSpec: spec,
+          taskId: task.$id,
+        },
+      };
+    }
+  }
+
+  return undefined;
+}
+
+export function locatedEntityName(
+  location: EntityLocation,
+): string | undefined {
+  return location.kind === "binding" ? undefined : location.entity.name;
+}
+
+function findInSpec(
+  spec: ComponentSpec,
+  entityId: string,
+): LocatedEntity | undefined {
+  const task = spec.tasks.find((t) => t.$id === entityId);
+  if (task) return { kind: "task", entity: task };
+
+  const input = spec.inputs.find((i) => i.$id === entityId);
+  if (input) return { kind: "input", entity: input };
+
+  const output = spec.outputs.find((o) => o.$id === entityId);
+  if (output) return { kind: "output", entity: output };
+
+  const binding = spec.bindings.find((b) => b.$id === entityId);
+  if (binding) return { kind: "binding", entity: binding };
+
+  return undefined;
+}


### PR DESCRIPTION
## Description

Groundwork for the three PRs above this one. No behaviour change on its own.

A pipeline can contain subgraphs, and those subgraphs can contain more subgraphs.
Several parts of the app need to answer the same question about an entity —
"which graph does this thing actually live in, and how do I get to it?" — and
each was answering it separately, or not at all.

This adds one shared helper that answers it: given the pipeline and an entity's
id, it reports the graph that owns the entity, the trail of subgraph names
leading down to it, and the subgraph step directly above it. Ids are unique
across the whole pipeline, so there's no ambiguity about which match is meant.
The existing "find a task by id" helper now uses it instead of walking the tree
itself.

Nothing consumes the parent-step part yet — the PRs above do. It's returned here
because it falls out of the same walk, and it's covered by the tests.

## Related Issue and Pull requests

Stacked on #2655. The rest of the stack builds on this.

## Type of Change

- [x] Improvement

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

Nothing to click through — this is internal plumbing with no user-visible effect.
Unit tests cover finding entities at the top level, one level down, and several
levels down, plus the parent-step reporting.

## Additional Comments

Split out of the AI subgraph work so the shared piece can be reviewed on its own
rather than buried in a larger diff.
