### PR TITLE
fix: Make AI chat chips work for steps inside subgraphs

### DIFF
--- a/src/models/componentSpec/queries/locateEntity.ts
+++ b/src/models/componentSpec/queries/locateEntity.ts
@@ -10,6 +10,8 @@ type LocatedEntity =
   | { kind: "output"; entity: Output }
   | { kind: "binding"; entity: Binding };
 
+export type LocatedEntityKind = LocatedEntity["kind"];
+
 /**
  * Structurally matches the editor's `ParentContext`, so a location can be
  * handed straight to the I/O actions that propagate port renames and deletes

--- a/src/routes/v2/shared/components/AiChat/AiChatStoreContext.tsx
+++ b/src/routes/v2/shared/components/AiChat/AiChatStoreContext.tsx
@@ -11,6 +11,9 @@ import { AiChatStore } from "./aiChatStore";
 
 const AiChatStoreCtx = createRequiredContext<AiChatStore>("AiChatStoreContext");
 
+const AiChatModeCtx =
+  createRequiredContext<AgentContext["mode"]>("AiChatModeContext");
+
 interface AiChatStoreProviderProps {
   // Page-owned factory that spawns the worker for this AI chat.
   createWorker: () => Worker;
@@ -48,10 +51,18 @@ export function AiChatStoreProvider({
   }, [store]);
 
   return (
-    <AiChatStoreCtx.Provider value={store}>{children}</AiChatStoreCtx.Provider>
+    <AiChatModeCtx.Provider value={context.mode}>
+      <AiChatStoreCtx.Provider value={store}>
+        {children}
+      </AiChatStoreCtx.Provider>
+    </AiChatModeCtx.Provider>
   );
 }
 
 export function useAiChatStore(): AiChatStore {
   return useRequiredContext(AiChatStoreCtx);
+}
+
+export function useAiChatMode(): AgentContext["mode"] {
+  return useRequiredContext(AiChatModeCtx);
 }

--- a/src/routes/v2/shared/components/AiChat/components/ChatEntityChip.tsx
+++ b/src/routes/v2/shared/components/AiChat/components/ChatEntityChip.tsx
@@ -25,6 +25,7 @@ export const ChatEntityChip = forwardRef<
       draggable={draggable}
       className={cn(
         "inline-flex items-center gap-1 rounded-md border bg-background px-1.5 py-0.5 text-xs font-medium text-foreground hover:bg-accent transition-colors align-middle",
+        "disabled:cursor-default disabled:hover:bg-background",
         draggable ? "cursor-grab" : "cursor-pointer",
         className,
       )}

--- a/src/routes/v2/shared/components/AiChat/components/EntityChip.test.tsx
+++ b/src/routes/v2/shared/components/AiChat/components/EntityChip.test.tsx
@@ -1,0 +1,179 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ComponentSpec } from "@/models/componentSpec";
+import { IncrementingIdGenerator } from "@/models/componentSpec/factories/idGenerator";
+import { YamlDeserializer } from "@/models/componentSpec/serialization/yamlDeserializer";
+
+import { EntityChip } from "./EntityChip";
+
+const mocks = vi.hoisted(() => ({
+  navigateToEntity: vi.fn(),
+  navigation: {
+    rootSpec: null as ComponentSpec | null,
+    navigationPath: [],
+  } as {
+    rootSpec: ComponentSpec | null;
+    navigationPath: { displayName: string }[];
+  },
+  mode: "editor" as "editor" | "runView",
+}));
+
+vi.mock("@/routes/v2/shared/store/SharedStoreContext", () => ({
+  useSharedStores: () => ({ navigation: mocks.navigation }),
+}));
+
+vi.mock("@/routes/v2/shared/store/useFocusActions", () => ({
+  useFocusActions: () => ({ navigateToEntity: mocks.navigateToEntity }),
+}));
+
+vi.mock("@/routes/v2/shared/components/AiChat/AiChatStoreContext", () => ({
+  useAiChatMode: () => mocks.mode,
+}));
+
+const containerComponent = (name: string) => ({
+  name,
+  spec: {
+    name,
+    inputs: [{ name: "path", type: "String" }],
+    outputs: [{ name: "table", type: "String" }],
+    implementation: { container: { image: `${name}:1` } },
+  },
+});
+
+const pipelineYaml = {
+  name: "RootPipeline",
+  implementation: {
+    graph: {
+      tasks: {
+        Preprocess: {
+          componentRef: {
+            name: "Preprocess",
+            spec: {
+              name: "Preprocess",
+              implementation: {
+                graph: {
+                  tasks: {
+                    Normalize: {
+                      componentRef: {
+                        name: "Normalize",
+                        spec: {
+                          name: "Normalize",
+                          implementation: {
+                            graph: {
+                              tasks: {
+                                ScaleColumns: {
+                                  componentRef:
+                                    containerComponent("ScaleColumns"),
+                                },
+                              },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        Train: { componentRef: containerComponent("Train") },
+      },
+    },
+  },
+};
+
+function taskIdByPath(spec: ComponentSpec, ...names: string[]): string {
+  let current = spec;
+  for (const name of names.slice(0, -1)) {
+    const task = current.tasks.find((t) => t.name === name);
+    if (!task?.subgraphSpec) throw new Error(`No subgraph named ${name}`);
+    current = task.subgraphSpec;
+  }
+  const leaf = names[names.length - 1];
+  const task = current.tasks.find((t) => t.name === leaf);
+  if (!task) throw new Error(`No task named ${leaf}`);
+  return task.$id;
+}
+
+describe("EntityChip", () => {
+  let spec: ComponentSpec;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    spec = new YamlDeserializer(new IncrementingIdGenerator()).deserialize(
+      pipelineYaml,
+    );
+    mocks.navigation.rootSpec = spec;
+    mocks.navigation.navigationPath = [{ displayName: "RootPipeline" }];
+    mocks.mode = "editor";
+  });
+
+  afterEach(cleanup);
+
+  it("navigates to a top-level entity with just the root name", async () => {
+    const taskId = taskIdByPath(spec, "Train");
+    render(<EntityChip entityId={taskId} label="Train" />);
+
+    await userEvent.click(screen.getByRole("button"));
+
+    expect(mocks.navigateToEntity).toHaveBeenCalledWith(
+      ["RootPipeline"],
+      taskId,
+      "task",
+    );
+  });
+
+  it("prefixes the root name onto the subgraph chain for a nested entity", async () => {
+    const taskId = taskIdByPath(
+      spec,
+      "Preprocess",
+      "Normalize",
+      "ScaleColumns",
+    );
+    render(<EntityChip entityId={taskId} label="ScaleColumns" />);
+
+    await userEvent.click(screen.getByRole("button"));
+
+    expect(mocks.navigateToEntity).toHaveBeenCalledWith(
+      ["RootPipeline", "Preprocess", "Normalize"],
+      taskId,
+      "task",
+    );
+  });
+
+  it("disables the chip for an entity that is not in the pipeline", () => {
+    render(<EntityChip entityId="no-such-id" label="Ghost" />);
+
+    expect(screen.getByRole("button")).toBeDisabled();
+    expect(mocks.navigateToEntity).not.toHaveBeenCalled();
+  });
+
+  it("disables a chip pointing into another subgraph while in RunView", () => {
+    mocks.mode = "runView";
+    const taskId = taskIdByPath(spec, "Preprocess", "Normalize");
+    render(<EntityChip entityId={taskId} label="Normalize" />);
+
+    expect(screen.getByRole("button")).toBeDisabled();
+  });
+
+  it("still navigates within the graph on screen while in RunView", async () => {
+    mocks.mode = "runView";
+    mocks.navigation.navigationPath = [
+      { displayName: "RootPipeline" },
+      { displayName: "Preprocess" },
+    ];
+    const taskId = taskIdByPath(spec, "Preprocess", "Normalize");
+    render(<EntityChip entityId={taskId} label="Normalize" />);
+
+    await userEvent.click(screen.getByRole("button"));
+
+    expect(mocks.navigateToEntity).toHaveBeenCalledWith(
+      ["RootPipeline", "Preprocess"],
+      taskId,
+      "task",
+    );
+  });
+});

--- a/src/routes/v2/shared/components/AiChat/components/EntityChip.tsx
+++ b/src/routes/v2/shared/components/AiChat/components/EntityChip.tsx
@@ -2,24 +2,31 @@ import { observer } from "mobx-react-lite";
 
 import { type IconName } from "@/components/ui/icon";
 import type { ComponentSpec } from "@/models/componentSpec";
-import type { NodeEntityType } from "@/routes/v2/shared/store/editorStore";
+import type { LocatedEntityKind } from "@/models/componentSpec/queries/locateEntity";
+import { locateEntity } from "@/models/componentSpec/queries/locateEntity";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 import { useFocusActions } from "@/routes/v2/shared/store/useFocusActions";
 
 import { ChatEntityChip } from "./ChatEntityChip";
 
-type EntityKind = "task" | "input" | "output" | "unknown";
+type ChipEntityKind = Exclude<LocatedEntityKind, "binding">;
 
-const ENTITY_ICON: Record<EntityKind, IconName> = {
+const ENTITY_ICON: Record<ChipEntityKind, IconName> = {
   task: "SquareFunction",
   input: "ArrowRightToLine",
   output: "ArrowLeftFromLine",
-  unknown: "CircleQuestionMark",
 };
+
+const UNKNOWN_ICON: IconName = "CircleQuestionMark";
 
 interface EntityChipProps {
   entityId: string;
   label: string;
+}
+
+interface NavigableEntity {
+  type: ChipEntityKind;
+  navigationPath: string[];
 }
 
 export const EntityChip = observer(function EntityChip({
@@ -28,32 +35,40 @@ export const EntityChip = observer(function EntityChip({
 }: EntityChipProps) {
   const { navigation } = useSharedStores();
   const { navigateToEntity } = useFocusActions();
-  const rootSpec = navigation.rootSpec;
 
-  const kind = resolveEntityKind(rootSpec, entityId);
+  const target = resolveNavigableEntity(navigation.rootSpec, entityId);
 
   function handleClick() {
-    if (!rootSpec || kind === "unknown") return;
-    const nodeType: NodeEntityType = kind;
-    navigateToEntity([], entityId, nodeType);
+    if (!target) return;
+    navigateToEntity(target.navigationPath, entityId, target.type);
   }
 
   return (
     <ChatEntityChip
-      icon={ENTITY_ICON[kind]}
+      icon={target ? ENTITY_ICON[target.type] : UNKNOWN_ICON}
       label={label}
       onClick={handleClick}
     />
   );
 });
 
-function resolveEntityKind(
+/**
+ * Entities inside a subgraph need the navigation path to their owning spec, not
+ * just their `$id` — `navigateToPath` expects the root pipeline name followed by
+ * the chain of subgraph task names. Bindings have no node to focus, so they are
+ * not navigable.
+ */
+function resolveNavigableEntity(
   rootSpec: ComponentSpec | null,
   entityId: string,
-): EntityKind {
-  if (!rootSpec) return "unknown";
-  if (rootSpec.tasks.some((t) => t.$id === entityId)) return "task";
-  if (rootSpec.inputs.some((i) => i.$id === entityId)) return "input";
-  if (rootSpec.outputs.some((o) => o.$id === entityId)) return "output";
-  return "unknown";
+): NavigableEntity | undefined {
+  if (!rootSpec) return undefined;
+
+  const location = locateEntity(rootSpec, entityId);
+  if (!location || location.kind === "binding") return undefined;
+
+  return {
+    type: location.kind,
+    navigationPath: [rootSpec.name, ...location.subgraphPath],
+  };
 }

--- a/src/routes/v2/shared/components/AiChat/components/EntityChip.tsx
+++ b/src/routes/v2/shared/components/AiChat/components/EntityChip.tsx
@@ -4,6 +4,8 @@ import { type IconName } from "@/components/ui/icon";
 import type { ComponentSpec } from "@/models/componentSpec";
 import type { LocatedEntityKind } from "@/models/componentSpec/queries/locateEntity";
 import { locateEntity } from "@/models/componentSpec/queries/locateEntity";
+import { useAiChatMode } from "@/routes/v2/shared/components/AiChat/AiChatStoreContext";
+import type { NavigationStore } from "@/routes/v2/shared/store/navigationStore";
 import { useSharedStores } from "@/routes/v2/shared/store/SharedStoreContext";
 import { useFocusActions } from "@/routes/v2/shared/store/useFocusActions";
 
@@ -35,8 +37,13 @@ export const EntityChip = observer(function EntityChip({
 }: EntityChipProps) {
   const { navigation } = useSharedStores();
   const { navigateToEntity } = useFocusActions();
+  const mode = useAiChatMode();
 
-  const target = resolveNavigableEntity(navigation.rootSpec, entityId);
+  const located = resolveNavigableEntity(navigation.rootSpec, entityId);
+  const target =
+    located && canNavigateTo(mode, navigation, located.navigationPath)
+      ? located
+      : undefined;
 
   function handleClick() {
     if (!target) return;
@@ -45,8 +52,9 @@ export const EntityChip = observer(function EntityChip({
 
   return (
     <ChatEntityChip
-      icon={target ? ENTITY_ICON[target.type] : UNKNOWN_ICON}
+      icon={located ? ENTITY_ICON[located.type] : UNKNOWN_ICON}
       label={label}
+      disabled={!target}
       onClick={handleClick}
     />
   );
@@ -69,6 +77,29 @@ function resolveNavigableEntity(
 
   return {
     type: location.kind,
-    navigationPath: [rootSpec.name, ...location.subgraphPath],
+    navigationPath: [rootSpec.name, ...location.subgraphTaskNames],
   };
+}
+
+/**
+ * In RunView the canvas spec and the execution scope are kept in step by
+ * `useRunViewSubgraphUrlSync`, which can only resolve a child execution id when
+ * the path deepens one level from wherever it already is. A chip jumping two
+ * levels down, or sideways into a sibling subgraph, would move the canvas while
+ * `ExecutionDataProvider` stayed scoped to the old subgraph, leaving task
+ * statuses and artifacts wrong or missing. Until that hook can rebuild the whole
+ * segment chain, RunView chips only navigate within the graph already on screen.
+ */
+function canNavigateTo(
+  mode: "editor" | "runView",
+  navigation: NavigationStore,
+  targetPath: string[],
+): boolean {
+  if (mode === "editor") return true;
+
+  const currentPath = navigation.navigationPath.map((e) => e.displayName);
+  return (
+    currentPath.length === targetPath.length &&
+    currentPath.every((name, index) => name === targetPath[index])
+  );
 }


### PR DESCRIPTION
## Description

When the AI assistant mentions a step, input, or output in its reply, the UI turns
it into a clickable chip that jumps you to it on the canvas.

#2655 gave the assistant the ability to look inside subgraphs, so it started
mentioning nested steps — and the chips broke for them. The chip only ever looked
at the top level of the pipeline, so anything inside a subgraph rendered as a grey
question mark and did nothing when clicked.

Chips now find the entity wherever it lives and remember the route to it, so
clicking one opens the subgraph it's in and selects it. A chip that can't take
you anywhere — a connection, or something that no longer exists — is now
visibly inert rather than looking clickable and doing nothing on click.

**One limit in run view.** Chips there only jump within the graph you're
already looking at. Run view keeps the canvas and the run's data in step by
following one subgraph at a time, so a chip that jumped two levels down, or
sideways into a different subgraph, would show you one subgraph's canvas
alongside another subgraph's step statuses and artifacts. Those chips are inert
for now rather than wrong; the fix belongs in the run view sync and is flagged
as a follow-up. Chips in the editor are unrestricted.

## Related Issue and Pull requests

Stacked on the resolver PR below, which is stacked on #2655.

This was originally bundled into the AI editing PR. It's pulled out because it's a
plain UI bug with nothing to do with editing, and can merge on its own.

## Type of Change

- [x] Bug fix

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

1. Open a pipeline that has a subgraph with a few steps inside it.
2. Ask the AI chat something that makes it mention a step inside that subgraph —
   e.g. "what's inside \<subgraph name>?" or "explain what \<nested step> does".
3. The chips in its reply should show the right icon (step / input / output),
   not a question mark.
4. Click one — it should open that subgraph and select the step.
5. Check chips for top-level steps still work exactly as before.
6. Ask something that makes it mention a connection — that chip should look
   plainly unclickable, and be skipped by tab rather than focusable.
7. Open a run of the same pipeline and ask the chat about a step inside a
   subgraph. From the top level, that chip should be inert. Open the subgraph
   from the canvas and ask again — chips for steps in that graph should work.

## Additional Comments

Nested subgraphs work too — the chip carries the full route down, not just one
level.

