### PR TITLE
refactor: Resolve AI mutation targets and explain refusals

### DIFF
--- a/src/models/componentSpec/queries/locateEntity.ts
+++ b/src/models/componentSpec/queries/locateEntity.ts
@@ -28,6 +28,18 @@ export type EntityLocation = LocatedEntity & {
   parentContext?: EntityParentContext;
 };
 
+export type EntityLocationOf<K extends LocatedEntityKind> = Extract<
+  EntityLocation,
+  { kind: K }
+>;
+
+export function isLocationOfKind<K extends LocatedEntityKind>(
+  location: EntityLocation,
+  kind: K,
+): location is EntityLocationOf<K> {
+  return location.kind === kind;
+}
+
 /**
  * Finds which spec in the tree owns `entityId`. `subgraphTaskNames` is the chain
  * of subgraph task names leading to it, so an empty chain means the entity lives

--- a/src/routes/v2/pages/Editor/components/AiChat/toolBridge/mutationTarget.test.ts
+++ b/src/routes/v2/pages/Editor/components/AiChat/toolBridge/mutationTarget.test.ts
@@ -1,0 +1,380 @@
+import { describe, expect, it } from "vitest";
+
+import type { ComponentSpec } from "@/models/componentSpec";
+import { Binding } from "@/models/componentSpec/entities/binding";
+import { IncrementingIdGenerator } from "@/models/componentSpec/factories/idGenerator";
+import type { EntityLocationOf } from "@/models/componentSpec/queries/locateEntity";
+import { locateEntity } from "@/models/componentSpec/queries/locateEntity";
+import { YamlDeserializer } from "@/models/componentSpec/serialization/yamlDeserializer";
+
+import {
+  applyToTarget,
+  describeEntityLocation,
+  explainNameCollision,
+  explainNotASubgraph,
+  resolveArgumentValue,
+  resolveConnectable,
+  resolveTarget,
+} from "./mutationTarget";
+
+const container = (name: string, inputs: string[], outputs: string[]) => ({
+  name,
+  spec: {
+    name,
+    inputs: inputs.map((n) => ({ name: n, type: "String" })),
+    outputs: outputs.map((n) => ({ name: n, type: "String" })),
+    implementation: { container: { image: `${name.toLowerCase()}:1` } },
+  },
+});
+
+const pipelineYaml = {
+  name: "RootPipeline",
+  inputs: [{ name: "raw_path", type: "String" }],
+  outputs: [{ name: "model", type: "String" }],
+  implementation: {
+    graph: {
+      tasks: {
+        Train: { componentRef: container("Train", ["path"], ["model"]) },
+        Preprocess: {
+          componentRef: {
+            name: "Preprocess",
+            spec: {
+              name: "Preprocess",
+              inputs: [{ name: "path", type: "String" }],
+              outputs: [{ name: "table", type: "String" }],
+              implementation: {
+                graph: {
+                  tasks: {
+                    DropNulls: {
+                      componentRef: container("DropNulls", ["path"], ["table"]),
+                    },
+                    Normalize: {
+                      componentRef: container(
+                        "Normalize",
+                        ["table"],
+                        ["table"],
+                      ),
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+function deserialize(): ComponentSpec {
+  return new YamlDeserializer(new IncrementingIdGenerator()).deserialize(
+    pipelineYaml,
+  );
+}
+
+function subgraphOf(spec: ComponentSpec, taskName: string): ComponentSpec {
+  const task = spec.tasks.find((t) => t.name === taskName);
+  if (!task?.subgraphSpec) throw new Error(`${taskName} is not a subgraph`);
+  return task.subgraphSpec;
+}
+
+function idOf(spec: ComponentSpec, taskName: string): string {
+  const task = spec.tasks.find((t) => t.name === taskName);
+  if (!task) throw new Error(`no task ${taskName}`);
+  return task.$id;
+}
+
+function taskLocation(
+  root: ComponentSpec,
+  entityId: string,
+): EntityLocationOf<"task"> {
+  const resolved = resolveTarget(root, entityId, "task");
+  if (!resolved.ok) throw new Error(resolved.error);
+  return resolved.location;
+}
+
+describe("describeEntityLocation", () => {
+  it("names the top-level pipeline for a root entity", () => {
+    const spec = deserialize();
+    const id = idOf(spec, "Train");
+
+    expect(describeEntityLocation(locateEntity(spec, id)!, id)).toBe(
+      'task "Train" in the top-level pipeline',
+    );
+  });
+
+  it("names the subgraph chain for a nested entity", () => {
+    const spec = deserialize();
+    const id = idOf(subgraphOf(spec, "Preprocess"), "DropNulls");
+
+    expect(describeEntityLocation(locateEntity(spec, id)!, id)).toBe(
+      'task "DropNulls" inside subgraph "Preprocess"',
+    );
+  });
+});
+
+describe("resolveTarget", () => {
+  it("resolves a nested entity to the spec that owns it", () => {
+    const spec = deserialize();
+    const preprocess = subgraphOf(spec, "Preprocess");
+
+    const resolved = resolveTarget(spec, idOf(preprocess, "DropNulls"), "task");
+
+    expect(resolved.ok).toBe(true);
+    if (!resolved.ok) return;
+    expect(resolved.location.spec).toBe(preprocess);
+    expect(resolved.location.entity.name).toBe("DropNulls");
+  });
+
+  it("reports an id that exists nowhere", () => {
+    const resolved = resolveTarget(deserialize(), "nope", "task");
+
+    expect(resolved).toEqual({
+      ok: false,
+      error: 'No task with $id "nope" exists in this pipeline.',
+    });
+  });
+
+  it("reports an id that names a different kind of entity", () => {
+    const spec = deserialize();
+    const inputId = spec.inputs[0].$id;
+
+    const resolved = resolveTarget(spec, inputId, "task");
+
+    expect(resolved.ok).toBe(false);
+    if (resolved.ok) return;
+    expect(resolved.error).toBe(
+      `$id "${inputId}" refers to input "raw_path", not a task.`,
+    );
+  });
+});
+
+describe("resolveConnectable", () => {
+  it("accepts tasks and ports", () => {
+    const spec = deserialize();
+
+    expect(resolveConnectable(spec, idOf(spec, "Train")).ok).toBe(true);
+    expect(resolveConnectable(spec, spec.inputs[0].$id).ok).toBe(true);
+    expect(resolveConnectable(spec, spec.outputs[0].$id).ok).toBe(true);
+  });
+
+  it("rejects an existing connection, which is not an endpoint", () => {
+    const spec = deserialize();
+    spec.addBinding(
+      new Binding({
+        $id: "bind_1",
+        sourceEntityId: spec.inputs[0].$id,
+        sourcePortName: "raw_path",
+        targetEntityId: idOf(spec, "Train"),
+        targetPortName: "path",
+      }),
+    );
+
+    const resolved = resolveConnectable(spec, "bind_1");
+
+    expect(resolved).toEqual({
+      ok: false,
+      error:
+        '$id "bind_1" refers to an existing connection, not a task or port that can be connected.',
+    });
+  });
+});
+
+describe("applyToTarget", () => {
+  it("hands the owning spec to the mutation and reports success", () => {
+    const spec = deserialize();
+    const preprocess = subgraphOf(spec, "Preprocess");
+    const id = idOf(preprocess, "DropNulls");
+
+    const seen: ComponentSpec[] = [];
+    const result = applyToTarget(spec, id, "task", (location) => {
+      seen.push(location.spec);
+      return true;
+    });
+
+    expect(result).toEqual({ success: true });
+    expect(seen).toEqual([preprocess]);
+  });
+
+  it("names the entity and its subgraph when the mutation refuses", () => {
+    const spec = deserialize();
+    const id = idOf(subgraphOf(spec, "Preprocess"), "DropNulls");
+
+    const result = applyToTarget(spec, id, "task", () => false);
+
+    expect(result).toEqual({
+      success: false,
+      error:
+        'The requested change to task "DropNulls" inside subgraph "Preprocess" could not be applied.',
+    });
+  });
+
+  it("prefers an explained refusal and never runs the mutation", () => {
+    const spec = deserialize();
+    let ran = false;
+
+    const result = applyToTarget(
+      spec,
+      idOf(spec, "Train"),
+      "task",
+      () => {
+        ran = true;
+        return true;
+      },
+      () => "Because I said so.",
+    );
+
+    expect(result).toEqual({ success: false, error: "Because I said so." });
+    expect(ran).toBe(false);
+  });
+});
+
+describe("explainNameCollision", () => {
+  it("explains a name already taken in the same graph", () => {
+    const spec = deserialize();
+    const id = idOf(spec, "Train");
+
+    const message = explainNameCollision(
+      spec.tasks,
+      id,
+      "Preprocess",
+      locateEntity(spec, id)!,
+    );
+
+    expect(message).toBe(
+      'Cannot rename task "Train" in the top-level pipeline to "Preprocess" — that name is already taken in that graph. Pick a different name.',
+    );
+  });
+
+  it("allows a free name, and allows an entity to keep its own", () => {
+    const spec = deserialize();
+    const id = idOf(spec, "Train");
+    const location = locateEntity(spec, id)!;
+
+    expect(
+      explainNameCollision(spec.tasks, id, "Retrain", location),
+    ).toBeUndefined();
+    expect(
+      explainNameCollision(spec.tasks, id, "Train", location),
+    ).toBeUndefined();
+  });
+
+  it("ignores a same name in a different graph", () => {
+    const spec = deserialize();
+    const preprocess = subgraphOf(spec, "Preprocess");
+    const id = idOf(preprocess, "DropNulls");
+
+    expect(
+      explainNameCollision(
+        preprocess.tasks,
+        id,
+        "Train",
+        locateEntity(spec, id)!,
+      ),
+    ).toBeUndefined();
+  });
+});
+
+describe("explainNotASubgraph", () => {
+  it("passes a real subgraph", () => {
+    const spec = deserialize();
+    const id = idOf(spec, "Preprocess");
+
+    expect(explainNotASubgraph(taskLocation(spec, id), id)).toBeUndefined();
+  });
+
+  it("explains a container task that has nothing to unpack", () => {
+    const spec = deserialize();
+    const id = idOf(spec, "Train");
+
+    expect(explainNotASubgraph(taskLocation(spec, id), id)).toBe(
+      'task "Train" in the top-level pipeline is not a subgraph, so there is nothing to unpack.',
+    );
+  });
+});
+
+describe("resolveArgumentValue", () => {
+  it("passes a plain value through untouched", () => {
+    const spec = deserialize();
+    const location = taskLocation(spec, idOf(spec, "Train"));
+
+    expect(resolveArgumentValue(location, "some/path.csv")).toEqual({
+      ok: true,
+      value: "some/path.csv",
+    });
+  });
+
+  it("accepts a graph input from the same graph", () => {
+    const spec = deserialize();
+    const location = taskLocation(spec, idOf(spec, "Train"));
+    const value = { graphInput: { inputName: "raw_path" } };
+
+    expect(resolveArgumentValue(location, value)).toEqual({ ok: true, value });
+  });
+
+  it("refuses a graph input that lives in the parent graph", () => {
+    const spec = deserialize();
+    const preprocess = subgraphOf(spec, "Preprocess");
+    const location = taskLocation(spec, idOf(preprocess, "DropNulls"));
+
+    const resolved = resolveArgumentValue(location, {
+      graphInput: { inputName: "raw_path" },
+    });
+
+    expect(resolved.ok).toBe(false);
+    if (resolved.ok) return;
+    expect(resolved.error).toContain(
+      'Subgraph "Preprocess" has no input named "raw_path"',
+    );
+    expect(resolved.error).toContain("cannot be referenced across a subgraph");
+  });
+
+  it("refuses a task output produced in another graph", () => {
+    const spec = deserialize();
+    const preprocess = subgraphOf(spec, "Preprocess");
+    const location = taskLocation(spec, idOf(preprocess, "Normalize"));
+
+    const resolved = resolveArgumentValue(location, {
+      taskOutput: { taskId: "Train", outputName: "model" },
+    });
+
+    expect(resolved.ok).toBe(false);
+    if (resolved.ok) return;
+    expect(resolved.error).toContain(
+      'Subgraph "Preprocess" has no task "Train"',
+    );
+  });
+
+  it("normalizes a task output referenced by $id to the task name", () => {
+    const spec = deserialize();
+    const preprocess = subgraphOf(spec, "Preprocess");
+    const location = taskLocation(spec, idOf(preprocess, "Normalize"));
+
+    const resolved = resolveArgumentValue(location, {
+      taskOutput: {
+        taskId: idOf(preprocess, "DropNulls"),
+        outputName: "table",
+      },
+    });
+
+    expect(resolved).toEqual({
+      ok: true,
+      value: { taskOutput: { taskId: "DropNulls", outputName: "table" } },
+    });
+  });
+
+  it("refuses an output the source task does not have", () => {
+    const spec = deserialize();
+    const preprocess = subgraphOf(spec, "Preprocess");
+    const location = taskLocation(spec, idOf(preprocess, "Normalize"));
+
+    const resolved = resolveArgumentValue(location, {
+      taskOutput: { taskId: "DropNulls", outputName: "nope" },
+    });
+
+    expect(resolved).toEqual({
+      ok: false,
+      error: 'Task "DropNulls" has no output named "nope".',
+    });
+  });
+});

--- a/src/routes/v2/pages/Editor/components/AiChat/toolBridge/mutationTarget.ts
+++ b/src/routes/v2/pages/Editor/components/AiChat/toolBridge/mutationTarget.ts
@@ -1,0 +1,229 @@
+/**
+ * Resolves which spec in the tree a CSOM mutation should be applied to.
+ *
+ * The agent addresses entities by `$id` alone, with no indication of depth, so
+ * every mutating handler resolves the owning spec here rather than assuming the
+ * root. Failures come back as prose naming the entity and its subgraph: without
+ * that the model gets the same bare `{ success: false }` for "no such entity" as
+ * for "that entity is a task, not an input", and cannot tell the user which.
+ */
+import type { ArgumentType, ComponentSpec } from "@/models/componentSpec";
+import type {
+  EntityLocation,
+  EntityLocationOf,
+  LocatedEntityKind,
+} from "@/models/componentSpec/queries/locateEntity";
+import {
+  isLocationOfKind,
+  locatedEntityName,
+  locateEntity,
+} from "@/models/componentSpec/queries/locateEntity";
+import {
+  isGraphInputArgument,
+  isTaskOutputArgument,
+} from "@/utils/componentSpec";
+
+const EXPECTED_LABEL: Record<LocatedEntityKind, string> = {
+  task: "a task",
+  input: "an input",
+  output: "an output",
+  binding: "a binding",
+};
+
+export interface MutationResult {
+  success: boolean;
+  error?: string;
+}
+
+type TargetResolution<K extends LocatedEntityKind> =
+  { ok: true; location: EntityLocationOf<K> } | { ok: false; error: string };
+
+function describeEntity(location: EntityLocation, entityId: string): string {
+  const name = locatedEntityName(location);
+  const label = name ? `"${name}"` : `$id "${entityId}"`;
+  return `${location.kind} ${label}`;
+}
+
+export function describeEntityLocation(
+  location: EntityLocation,
+  entityId: string,
+): string {
+  const entity = describeEntity(location, entityId);
+  if (location.subgraphTaskNames.length === 0) {
+    return `${entity} in the top-level pipeline`;
+  }
+  return `${entity} inside subgraph "${location.subgraphTaskNames.join(" > ")}"`;
+}
+
+export function resolveTarget<K extends LocatedEntityKind>(
+  root: ComponentSpec,
+  entityId: string,
+  expected: K,
+): TargetResolution<K> {
+  const location = locateEntity(root, entityId);
+
+  if (!location) {
+    return {
+      ok: false,
+      error: `No ${expected} with $id "${entityId}" exists in this pipeline.`,
+    };
+  }
+
+  if (!isLocationOfKind(location, expected)) {
+    return {
+      ok: false,
+      error: `$id "${entityId}" refers to ${describeEntity(location, entityId)}, not ${EXPECTED_LABEL[expected]}.`,
+    };
+  }
+
+  return { ok: true, location };
+}
+
+/**
+ * Connection endpoints can be tasks, graph inputs or graph outputs, so they are
+ * resolved by exclusion rather than against a single expected kind.
+ */
+export function resolveConnectable(
+  root: ComponentSpec,
+  entityId: string,
+): { ok: true; location: EntityLocation } | { ok: false; error: string } {
+  const location = locateEntity(root, entityId);
+
+  if (!location) {
+    return {
+      ok: false,
+      error: `No entity with $id "${entityId}" exists in this pipeline.`,
+    };
+  }
+
+  if (location.kind === "binding") {
+    return {
+      ok: false,
+      error: `$id "${entityId}" refers to an existing connection, not a task or port that can be connected.`,
+    };
+  }
+
+  return { ok: true, location };
+}
+
+/**
+ * `explainRefusal` names the causes that are knowable before the mutation runs
+ * — a rename that would collide, an unpack of something that is not a subgraph.
+ * The generic message below is the branch we genuinely cannot explain, so it
+ * should stay rare rather than being the default answer.
+ */
+export function applyToTarget<K extends LocatedEntityKind>(
+  root: ComponentSpec,
+  entityId: string,
+  expected: K,
+  apply: (location: EntityLocationOf<K>) => boolean,
+  explainRefusal?: (location: EntityLocationOf<K>) => string | undefined,
+): MutationResult {
+  const target = resolveTarget(root, entityId, expected);
+  if (!target.ok) {
+    return { success: false, error: target.error };
+  }
+
+  const { location } = target;
+  const refusal = explainRefusal?.(location);
+  if (refusal) {
+    return { success: false, error: refusal };
+  }
+
+  if (!apply(location)) {
+    return {
+      success: false,
+      error: `The requested change to ${describeEntityLocation(location, entityId)} could not be applied.`,
+    };
+  }
+
+  return { success: true };
+}
+
+/**
+ * Renames fail for exactly one reason once the entity has been resolved by
+ * `$id`: another entity of the same kind in that graph already holds the name.
+ */
+export function explainNameCollision(
+  siblings: readonly { $id: string; name: string }[],
+  entityId: string,
+  newName: string,
+  location: EntityLocation,
+): string | undefined {
+  const taken = siblings.some((s) => s.name === newName && s.$id !== entityId);
+  if (!taken) return undefined;
+
+  return `Cannot rename ${describeEntityLocation(location, entityId)} to "${newName}" — that name is already taken in that graph. Pick a different name.`;
+}
+
+export function explainNotASubgraph(
+  location: EntityLocationOf<"task">,
+  entityId: string,
+): string | undefined {
+  if (location.entity.subgraphSpec) return undefined;
+
+  return `${describeEntityLocation(location, entityId)} is not a subgraph, so there is nothing to unpack.`;
+}
+
+/**
+ * An argument that references a graph input or another task's output only
+ * serializes if the referent lives in the same graph as the task being written
+ * to — the pipeline format has no way to express a reference across a subgraph
+ * boundary, so writing one produces YAML that fails to load.
+ *
+ * `taskOutput.taskId` is a task **name** in the stored format, but every prompt
+ * tells the model to address entities by `$id`, so both are accepted here and
+ * normalized to the name.
+ */
+export function resolveArgumentValue(
+  location: EntityLocationOf<"task">,
+  value: ArgumentType,
+): { ok: true; value: ArgumentType } | { ok: false; error: string } {
+  const { spec } = location;
+
+  if (isGraphInputArgument(value)) {
+    const { inputName } = value.graphInput;
+    if (!spec.inputs.some((i) => i.name === inputName)) {
+      return {
+        ok: false,
+        error: `${describeGraph(location)} has no input named "${inputName}", so ${location.entity.name} cannot read from it. A value cannot be referenced across a subgraph boundary — add an input to that graph and wire it through instead.`,
+      };
+    }
+    return { ok: true, value };
+  }
+
+  if (isTaskOutputArgument(value)) {
+    const { taskId, outputName } = value.taskOutput;
+    const source = spec.tasks.find(
+      (t) => t.$id === taskId || t.name === taskId,
+    );
+    if (!source) {
+      return {
+        ok: false,
+        error: `${describeGraph(location)} has no task "${taskId}", so ${location.entity.name} cannot read its output. A value cannot be referenced across a subgraph boundary — route it through that subgraph's own inputs and outputs instead.`,
+      };
+    }
+    const hasOutput = source.resolvedComponentSpec?.outputs?.some(
+      (o) => o.name === outputName,
+    );
+    if (!hasOutput) {
+      return {
+        ok: false,
+        error: `Task "${source.name}" has no output named "${outputName}".`,
+      };
+    }
+    return {
+      ok: true,
+      value: { taskOutput: { ...value.taskOutput, taskId: source.name } },
+    };
+  }
+
+  return { ok: true, value };
+}
+
+function describeGraph(location: EntityLocation): string {
+  if (location.subgraphTaskNames.length === 0) {
+    return "The top-level pipeline";
+  }
+  return `Subgraph "${location.subgraphTaskNames.join(" > ")}"`;
+}


### PR DESCRIPTION
## Description

Split out of the PR above it.

That PR reroutes the AI assistant's edit tools so they act on the graph that
actually owns the thing you named, instead of always the top level. Underneath
that sits a layer answering a narrower question: given the pipeline and an
entity's id, which graph owns it, is it the kind of thing the caller expected,
and — when the answer is no — what do you tell the user?

That layer is this PR. It's three things:

- **Resolve.** Find the entity, confirm it's the kind asked for, hand back the
graph that owns it. Connection endpoints resolve slightly differently, since
they can be a step or a port but not an existing connection.
- **Describe.** Turn a location into a phrase — "step `DropNulls` inside
subgraph `Preprocess`" — so every failure can say where it was looking.
- **Explain.** Three cases where the reason for a refusal is knowable up front:
a rename onto a name already taken in that graph, unpacking something that
isn't a subgraph, and a value referencing something that lives in a different
graph (which can't be written down in the pipeline format at all).

Nothing consumes it yet — the PR above swaps its handlers onto it. Same shape as
the resolver PR further down the stack, and split for the same reason: it can be
read on its own in one sitting.

## Related Issue and Pull requests

Stacked on #2686 → #2685 → #2655.

Carved out of #2683 after review, which is down from +999 to +744 as a result.

## Type of Change

- [x] Improvement

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

Nothing to click through — no caller reaches this code until the PR above.
21 unit tests cover it: resolving at the top level and inside a nested subgraph,
each failure message, and the three explained refusals.

## Additional Comments

The two type helpers added to `locateEntity` are here rather than in #2685
because they exist to narrow a location to an expected kind, which is this
layer's job and has no consumer in #2685.

The ratio of message text to logic is high on purpose — explaining refusals in
words the assistant can pass on is the point of the work, not a side effect of
it.