### PR TITLE
fix: Artifact Preview Table Cell Value Rendering

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ParquetVisualizer.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ParquetVisualizer.tsx
@@ -18,7 +18,11 @@ import {
 } from "./parquetUtils";
 import TableVisualizer from "./TableVisualizer";
 import { fetchArtifactOrThrow } from "./useArtifactFetch";
-import { type ArtifactColumn, getPreviewRowLimit } from "./utils";
+import {
+  type ArtifactCell,
+  type ArtifactColumn,
+  getPreviewRowLimit,
+} from "./utils";
 
 interface ParquetVisualizerProps {
   signedUrl: string;
@@ -28,7 +32,7 @@ interface ParquetVisualizerProps {
 interface ParquetBase {
   opened: OpenedParquet;
   columns: ArtifactColumn[];
-  initialRows: string[][];
+  initialRows: ArtifactCell[][];
   totalRows: number;
   columnCount: number;
   schemaJson: unknown;

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/TableVisualizer.test.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/TableVisualizer.test.tsx
@@ -32,6 +32,26 @@ describe("TableVisualizer", () => {
     expect(screen.getByText("row-2")).toBeInTheDocument();
   });
 
+  it("renders object cells as JSON instead of [object Object]", () => {
+    render(
+      <TableVisualizer
+        data={{
+          columns: [{ name: "config" }],
+          rows: [[{ locale: "en", limit: 3 }]],
+          hasMore: false,
+        }}
+        isFullscreen={false}
+        totalRows={1}
+        columnCount={1}
+      />,
+    );
+
+    const cell = screen.getByText('{"locale":"en","limit":3}');
+    expect(cell).toBeInTheDocument();
+    expect(cell).toHaveAttribute("title", '{"locale":"en","limit":3}');
+    expect(screen.queryByText("[object Object]")).not.toBeInTheDocument();
+  });
+
   it("says 'Showing all N rows' when hasMore is false", () => {
     const data = makeData(5);
     render(

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/TableVisualizer.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/TableVisualizer.tsx
@@ -15,7 +15,12 @@ import { Paragraph, Text } from "@/components/ui/typography";
 import useToastNotification from "@/hooks/useToastNotification";
 import { downloadBlobAsFile } from "@/utils/URL";
 
-import { type ArtifactColumn, type ArtifactTableData } from "./utils";
+import {
+  type ArtifactCell,
+  type ArtifactColumn,
+  type ArtifactTableData,
+  formatCellValue,
+} from "./utils";
 
 /**
  * The full dataset usually lives behind a cross-origin signed URL, where the
@@ -145,7 +150,7 @@ export default TableVisualizer;
 
 interface ArtifactTableProps {
   columns: ArtifactColumn[];
-  rows: string[][];
+  rows: ArtifactCell[][];
 }
 
 const ArtifactTable = ({ columns, rows }: ArtifactTableProps) => (
@@ -175,15 +180,14 @@ const ArtifactTable = ({ columns, rows }: ArtifactTableProps) => (
     <TableBody>
       {rows.map((row, i) => (
         <TableRow key={i}>
-          {row.map((cell, j) => (
-            <TableCell
-              key={j}
-              className="font-mono text-xs"
-              title={String(cell)}
-            >
-              {String(cell)}
-            </TableCell>
-          ))}
+          {row.map((cell, j) => {
+            const text = formatCellValue(cell);
+            return (
+              <TableCell key={j} className="font-mono text-xs" title={text}>
+                {text}
+              </TableCell>
+            );
+          })}
         </TableRow>
       ))}
     </TableBody>

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/parquetUtils.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/parquetUtils.ts
@@ -17,7 +17,11 @@ import {
   fetchArtifactForHyparquet,
   fetchArtifactOrThrow,
 } from "./useArtifactFetch";
-import { type ArtifactColumn, MAX_VISUALIZABLE_SIZE_BYTES } from "./utils";
+import {
+  type ArtifactCell,
+  type ArtifactColumn,
+  MAX_VISUALIZABLE_SIZE_BYTES,
+} from "./utils";
 
 export const PARQUET_PREVIEW_ROWS = 100;
 export const PARQUET_LOAD_MORE_ROWS = 100;
@@ -74,22 +78,20 @@ export async function readParquetRows(
   columns: ArtifactColumn[],
   rowStart: number,
   rowEnd: number,
-): Promise<string[][]> {
+): Promise<ArtifactCell[][]> {
   const objects = await parquetReadObjects({
     file: source,
     metadata,
     rowStart,
     rowEnd,
   });
-  return objects.map((obj) =>
-    columns.map((col) => obj[col.name]),
-  ) as string[][];
+  return objects.map((obj) => columns.map((col) => obj[col.name]));
 }
 
 export async function readParquetPreview(
   opened: OpenedParquet,
   previewRows: number,
-): Promise<{ columns: ArtifactColumn[]; rows: string[][] }> {
+): Promise<{ columns: ArtifactColumn[]; rows: ArtifactCell[][] }> {
   const objects = await parquetReadObjects({
     file: opened.source,
     metadata: opened.metadata,
@@ -98,9 +100,7 @@ export async function readParquetPreview(
   if (objects.length === 0) return { columns: [], rows: [] };
 
   const columns = buildColumns(opened.metadata.schema, objects[0]);
-  const rows = objects.map((obj) =>
-    columns.map((col) => obj[col.name]),
-  ) as string[][];
+  const rows = objects.map((obj) => columns.map((col) => obj[col.name]));
   return { columns, rows };
 }
 

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/utils.test.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/utils.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  formatCellValue,
   getPreviewRowLimit,
   MAX_PREVIEW_CELLS,
   MAX_PREVIEW_ROWS,
@@ -94,6 +95,43 @@ describe("parseCsv", () => {
       ["line1\nline2", "x"],
       ["y", "z"],
     ]);
+  });
+});
+
+describe("formatCellValue", () => {
+  it("serializes objects and arrays as JSON", () => {
+    expect(formatCellValue({ locale: "en", limit: 3 })).toBe(
+      '{"locale":"en","limit":3}',
+    );
+    expect(formatCellValue([1, "two", null])).toBe('[1,"two",null]');
+    expect(formatCellValue({ nested: { a: [true] } })).toBe(
+      '{"nested":{"a":[true]}}',
+    );
+  });
+
+  it("serializes bigints nested in objects", () => {
+    expect(formatCellValue({ count: 9007199254740993n })).toBe(
+      '{"count":"9007199254740993"}',
+    );
+  });
+
+  it("renders nullish cells as empty", () => {
+    expect(formatCellValue(null)).toBe("");
+    expect(formatCellValue(undefined)).toBe("");
+  });
+
+  it("renders dates as ISO strings", () => {
+    expect(formatCellValue(new Date("2026-01-02T03:04:05.000Z"))).toBe(
+      "2026-01-02T03:04:05.000Z",
+    );
+  });
+
+  it("stringifies primitives", () => {
+    expect(formatCellValue("red shoes")).toBe("red shoes");
+    expect(formatCellValue(42)).toBe("42");
+    expect(formatCellValue(0)).toBe("0");
+    expect(formatCellValue(false)).toBe("false");
+    expect(formatCellValue(123n)).toBe("123");
   });
 });
 

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/utils.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/utils.ts
@@ -6,18 +6,31 @@ export type ArtifactColumn = {
   nullable?: boolean;
 };
 
+export type ArtifactCell = unknown;
+
 export type ArtifactTableData = {
   columns: ArtifactColumn[];
-  rows: string[][];
+  rows: ArtifactCell[][];
   hasMore: boolean;
 };
 
 export type ParsedArtifact = {
   columns: ArtifactColumn[];
-  rows: string[][];
+  rows: ArtifactCell[][];
   truncated: boolean;
   totalRows: number;
 };
+
+export function formatCellValue(value: ArtifactCell): string {
+  if (value === null || value === undefined) return "";
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === "object") {
+    return JSON.stringify(value, (_key, nested) =>
+      typeof nested === "bigint" ? nested.toString() : nested,
+    );
+  }
+  return String(value);
+}
 
 export const MAX_VISUALIZABLE_SIZE_BYTES = 50 * 1024 * 1024; // 50 MB
 


### PR DESCRIPTION
## Description

Fixes a bug where objects inside a tabulated artifact cell in the preview would render as [object Object] rather than a stringified version of their value.

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

![image.png](https://app.graphite.com/user-attachments/assets/47a09d35-492f-42b5-b492-513b4a7ebd27.png)





<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

Run a pipeline with JSON inside a table and view artifact preview.

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->