### PR TITLE
fix: Artifact Preview blocked by CORS

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ArtifactPreviewContent.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ArtifactPreviewContent.tsx
@@ -63,6 +63,7 @@ interface PreviewContentProps {
   type: string;
   name: string;
   isFullscreen: boolean;
+  totalSize?: number;
 }
 
 export const PreviewContent = ({
@@ -70,6 +71,7 @@ export const PreviewContent = ({
   type,
   name,
   isFullscreen,
+  totalSize,
 }: PreviewContentProps) => {
   const { backendUrl } = useBackend();
 
@@ -106,7 +108,11 @@ export const PreviewContent = ({
       );
     case "apacheparquet":
       return (
-        <ParquetVisualizer signedUrl={signedUrl} isFullscreen={isFullscreen} />
+        <ParquetVisualizer
+          signedUrl={signedUrl}
+          isFullscreen={isFullscreen}
+          byteLength={totalSize}
+        />
       );
     case "jsonobject":
     case "jsonarray":

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ArtifactVisualizer.test.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ArtifactVisualizer.test.tsx
@@ -108,8 +108,18 @@ vi.mock("./UrlVisualizer", () => ({
 }));
 
 vi.mock("./ParquetVisualizer", () => ({
-  default: ({ signedUrl }: { signedUrl: string }) => (
-    <div data-testid="parquet-visualizer" data-signed-url={signedUrl} />
+  default: ({
+    signedUrl,
+    byteLength,
+  }: {
+    signedUrl: string;
+    byteLength?: number;
+  }) => (
+    <div
+      data-testid="parquet-visualizer"
+      data-signed-url={signedUrl}
+      data-byte-length={byteLength}
+    />
   ),
 }));
 
@@ -353,7 +363,7 @@ describe("ArtifactVisualizer", () => {
       });
     });
 
-    it("renders ParquetVisualizer for apacheparquet type", async () => {
+    it("renders ParquetVisualizer for apacheparquet type with the reported size", async () => {
       renderWithQuery(
         <ArtifactVisualizer
           artifact={makeArtifact()}
@@ -365,7 +375,28 @@ describe("ArtifactVisualizer", () => {
       await userEvent.click(screen.getByText("Preview"));
 
       await waitFor(() => {
-        expect(screen.getByTestId("parquet-visualizer")).toBeInTheDocument();
+        expect(screen.getByTestId("parquet-visualizer")).toHaveAttribute(
+          "data-byte-length",
+          "1024",
+        );
+      });
+    });
+
+    it("renders ParquetVisualizer without a size when the artifact reports none", async () => {
+      renderWithQuery(
+        <ArtifactVisualizer
+          artifact={makeArtifact({ artifact_data: undefined })}
+          name="data"
+          type="Apache Parquet"
+        />,
+      );
+
+      await userEvent.click(screen.getByText("Preview"));
+
+      await waitFor(() => {
+        expect(screen.getByTestId("parquet-visualizer")).not.toHaveAttribute(
+          "data-byte-length",
+        );
       });
     });
   });

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ArtifactVisualizer.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ArtifactVisualizer.tsx
@@ -197,6 +197,7 @@ const ArtifactVisualizer = ({
                 artifactId={artifact.id}
                 type={normalizedType}
                 isFullscreen={isFullscreen}
+                totalSize={artifactData?.total_size}
               />
             </SuspenseWrapper>
           )}

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ParquetVisualizer.test.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ParquetVisualizer.test.tsx
@@ -6,7 +6,6 @@ import { ErrorBoundary } from "react-error-boundary";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import useToastNotification from "@/hooks/useToastNotification";
-import { ArtifactFetchError } from "@/services/executionService";
 
 import { PARQUET_PREVIEW_ROWS } from "./parquetUtils";
 import ParquetVisualizer from "./ParquetVisualizer";
@@ -22,7 +21,6 @@ vi.mock("hyparquet", () => ({
   parquetMetadata: vi.fn(),
   parquetMetadataAsync: vi.fn(),
   asyncBufferFromUrl: vi.fn(),
-  byteLengthFromUrl: vi.fn(),
   cachedAsyncBuffer: vi.fn((buffer) => buffer),
   toJson: vi.fn((value) => value),
 }));
@@ -94,7 +92,6 @@ const {
   parquetMetadata,
   parquetMetadataAsync,
   asyncBufferFromUrl,
-  byteLengthFromUrl,
 } = await import("hyparquet");
 const { downloadStringAsFile } = await import("@/utils/URL");
 
@@ -176,14 +173,72 @@ beforeEach(() => {
   vi.mocked(parquetMetadataAsync).mockReset();
   vi.mocked(parquetReadObjects).mockReset();
   vi.mocked(downloadStringAsFile).mockReset();
-  vi.mocked(byteLengthFromUrl).mockResolvedValue(1024);
+  mockRangeProbe(1024);
   vi.mocked(asyncBufferFromUrl).mockResolvedValue({
     byteLength: 1024,
     slice: vi.fn(),
   } as unknown as Awaited<ReturnType<typeof asyncBufferFromUrl>>);
 });
 
+/** A `Range: bytes=0-0` probe answered with the total size, as object stores do. */
+const mockRangeProbe = (totalSize: number) =>
+  vi.spyOn(globalThis, "fetch").mockResolvedValue({
+    ok: true,
+    status: 206,
+    headers: new Headers({ "Content-Range": `bytes 0-0/${totalSize}` }),
+  } as unknown as Response);
+
 describe("ParquetVisualizer", () => {
+  it("opens the file at the reported size without any size request", async () => {
+    const fetchSpy = mockRangeProbe(1024);
+    mockDataset(SCHEMA, 2);
+
+    renderWithSuspense(
+      <ParquetVisualizer
+        signedUrl="https://storage.example.com/sized.parquet"
+        isFullscreen={false}
+        byteLength={9446073}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("table-visualizer")).toBeInTheDocument(),
+    );
+
+    expect(vi.mocked(asyncBufferFromUrl)).toHaveBeenCalledWith(
+      expect.objectContaining({ byteLength: 9446073 }),
+    );
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("probes the size with a ranged GET, never a HEAD, when none is reported", async () => {
+    const fetchSpy = mockRangeProbe(9446073);
+    mockDataset(SCHEMA, 2);
+
+    renderWithSuspense(
+      <ParquetVisualizer
+        signedUrl="https://storage.example.com/unsized.parquet"
+        isFullscreen={false}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("table-visualizer")).toBeInTheDocument(),
+    );
+
+    expect(vi.mocked(asyncBufferFromUrl)).toHaveBeenCalledWith(
+      expect.objectContaining({ byteLength: 9446073 }),
+    );
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://storage.example.com/unsized.parquet",
+      expect.objectContaining({ headers: { Range: "bytes=0-0" } }),
+    );
+    const methods = fetchSpy.mock.calls.map(([, init]) =>
+      (init?.method ?? "GET").toUpperCase(),
+    );
+    expect(methods).not.toContain("HEAD");
+  });
+
   it("reads via range requests, parses, and renders TableVisualizer with stats", async () => {
     mockDataset(SCHEMA, 2);
 
@@ -381,6 +436,10 @@ describe("ParquetVisualizer", () => {
     expect(screen.queryByRole("button", { name: "Load max" })).toBeNull();
   });
 
+  /**
+   * A host that ignores `Range` and returns the whole object: the size probe
+   * sees 200 with no `Content-Range`, which is the no-range-support signal.
+   */
   const mockFullDownload = (contentLength: string | null) =>
     vi.spyOn(globalThis, "fetch").mockResolvedValue({
       ok: true,
@@ -390,10 +449,6 @@ describe("ParquetVisualizer", () => {
     } as unknown as Response);
 
   it("falls back to a full download when range requests are unavailable", async () => {
-    // Simulate a CORS/network failure on the range path (not an HTTP error).
-    vi.mocked(byteLengthFromUrl).mockRejectedValue(
-      new TypeError("Failed to fetch"),
-    );
     mockFullDownload(String(1024));
     vi.mocked(parquetMetadata).mockReturnValue({
       schema: SCHEMA,
@@ -418,9 +473,6 @@ describe("ParquetVisualizer", () => {
   });
 
   it("errors instead of downloading a huge file when range requests are unavailable", async () => {
-    vi.mocked(byteLengthFromUrl).mockRejectedValue(
-      new TypeError("Failed to fetch"),
-    );
     mockFullDownload(String(200 * 1024 * 1024));
 
     renderWithSuspense(
@@ -437,10 +489,6 @@ describe("ParquetVisualizer", () => {
   });
 
   it("errors instead of downloading when Content-Length is absent", async () => {
-    vi.mocked(byteLengthFromUrl).mockRejectedValue(
-      new TypeError("Failed to fetch"),
-    );
-
     mockFullDownload(null);
 
     renderWithSuspense(
@@ -514,9 +562,11 @@ describe("ParquetVisualizer", () => {
   });
 
   it("surfaces artifact failures to the error boundary", async () => {
-    vi.mocked(byteLengthFromUrl).mockRejectedValue(
-      new ArtifactFetchError(500, "Server Error", "Failed to fetch artifact."),
-    );
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: "Server Error",
+    } as unknown as Response);
 
     renderWithSuspense(
       <ParquetVisualizer

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ParquetVisualizer.test.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ParquetVisualizer.test.tsx
@@ -163,6 +163,14 @@ const mockWideDataset = (columnCount: number, numRows: number) => {
   );
 };
 
+/** A `Range: bytes=0-0` probe answered with the total size, as object stores do. */
+const mockRangeProbe = (totalSize: number) =>
+  vi.spyOn(globalThis, "fetch").mockResolvedValue({
+    ok: true,
+    status: 206,
+    headers: new Headers({ "Content-Range": `bytes 0-0/${totalSize}` }),
+  } as unknown as Response);
+
 beforeEach(() => {
   queryClient.clear();
   lastDownloadFull = undefined;
@@ -179,14 +187,6 @@ beforeEach(() => {
     slice: vi.fn(),
   } as unknown as Awaited<ReturnType<typeof asyncBufferFromUrl>>);
 });
-
-/** A `Range: bytes=0-0` probe answered with the total size, as object stores do. */
-const mockRangeProbe = (totalSize: number) =>
-  vi.spyOn(globalThis, "fetch").mockResolvedValue({
-    ok: true,
-    status: 206,
-    headers: new Headers({ "Content-Range": `bytes 0-0/${totalSize}` }),
-  } as unknown as Response);
 
 describe("ParquetVisualizer", () => {
   it("opens the file at the reported size without any size request", async () => {

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ParquetVisualizer.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ParquetVisualizer.tsx
@@ -27,6 +27,7 @@ import {
 interface ParquetVisualizerProps {
   signedUrl: string;
   isFullscreen: boolean;
+  byteLength?: number;
 }
 
 interface ParquetBase {
@@ -41,11 +42,12 @@ interface ParquetBase {
 const ParquetVisualizer = ({
   signedUrl,
   isFullscreen,
+  byteLength,
 }: ParquetVisualizerProps) => {
   const { data: base } = useSuspenseQuery<ParquetBase>({
     queryKey: ["artifact-parquet", signedUrl],
     queryFn: async () => {
-      const opened = await openParquet(signedUrl);
+      const opened = await openParquet(signedUrl, byteLength);
       const columnCount = countColumns(opened.metadata);
       const { columns, rows } = await readParquetPreview(
         opened,

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/parquetUtils.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/parquetUtils.ts
@@ -1,7 +1,6 @@
 import {
   type AsyncBuffer,
   asyncBufferFromUrl,
-  byteLengthFromUrl,
   cachedAsyncBuffer,
   type FileMetaData,
   parquetMetadata,
@@ -33,17 +32,18 @@ export interface OpenedParquet {
   metadata: FileMetaData;
 }
 
-export async function openParquet(signedUrl: string): Promise<OpenedParquet> {
+export async function openParquet(
+  signedUrl: string,
+  byteLength?: number,
+): Promise<OpenedParquet> {
   try {
-    const byteLength = await byteLengthFromUrl(
-      signedUrl,
-      undefined,
-      fetchArtifactForHyparquet,
-    );
     const source = cachedAsyncBuffer(
       await asyncBufferFromUrl({
         url: signedUrl,
-        byteLength,
+        byteLength:
+          typeof byteLength === "number" && byteLength > 0
+            ? byteLength
+            : await byteLengthFromRangedGet(signedUrl),
         fetch: fetchArtifactForHyparquet,
       }),
     );
@@ -51,26 +51,47 @@ export async function openParquet(signedUrl: string): Promise<OpenedParquet> {
     return { source, metadata };
   } catch (error) {
     if (error instanceof ArtifactFetchError) throw error;
-
-    const response = await fetchArtifactOrThrow(signedUrl);
-    const contentLengthHeader = response.headers.get("Content-Length");
-    const contentLength = contentLengthHeader
-      ? Number(contentLengthHeader)
-      : NaN;
-    if (
-      !Number.isFinite(contentLength) ||
-      contentLength > MAX_VISUALIZABLE_SIZE_BYTES
-    ) {
-      throw new ArtifactFetchError(
-        413,
-        "Payload Too Large",
-        "This parquet file is too large to preview without range-request support.",
-      );
-    }
-
-    const source = await response.arrayBuffer();
-    return { source, metadata: parquetMetadata(source) };
+    return openByFullDownload(signedUrl);
   }
+}
+
+/**
+ * Signed object-store URLs reject HEAD (the method is part of the signature),
+ * and a bucket's CORS policy need not allow it either, so a blocked HEAD
+ * surfaces as an opaque network error rather than a 403 the caller could fall
+ * back from. A ranged GET is signed, CORS-safelisted, and reports the total
+ * size in `Content-Range`.
+ */
+async function byteLengthFromRangedGet(url: string): Promise<number> {
+  const controller = new AbortController();
+  const response = await fetchArtifactOrThrow(url, {
+    headers: { Range: "bytes=0-0" },
+    signal: controller.signal,
+  });
+  const totalSize = response.headers
+    .get("Content-Range")
+    ?.match(/\/(\d+)$/)?.[1];
+  controller.abort();
+
+  if (response.status !== 206 || !totalSize) {
+    throw new Error("Artifact host does not support range requests.");
+  }
+  return Number(totalSize);
+}
+
+async function openByFullDownload(signedUrl: string): Promise<OpenedParquet> {
+  const response = await fetchArtifactOrThrow(signedUrl);
+  const contentLength = Number(response.headers.get("Content-Length"));
+  if (!contentLength || contentLength > MAX_VISUALIZABLE_SIZE_BYTES) {
+    throw new ArtifactFetchError(
+      413,
+      "Payload Too Large",
+      "This parquet file is too large to preview without range-request support.",
+    );
+  }
+
+  const source = await response.arrayBuffer();
+  return { source, metadata: parquetMetadata(source) };
 }
 
 export async function readParquetRows(

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/parquetUtils.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/parquetUtils.ts
@@ -12,10 +12,7 @@ import {
 
 import { ArtifactFetchError } from "@/services/executionService";
 
-import {
-  fetchArtifactForHyparquet,
-  fetchArtifactOrThrow,
-} from "./useArtifactFetch";
+import { fetchArtifactOrThrow } from "./useArtifactFetch";
 import {
   type ArtifactCell,
   type ArtifactColumn,
@@ -44,7 +41,7 @@ export async function openParquet(
           typeof byteLength === "number" && byteLength > 0
             ? byteLength
             : await byteLengthFromRangedGet(signedUrl),
-        fetch: fetchArtifactForHyparquet,
+        fetch: fetchArtifactOrThrow,
       }),
     );
     const metadata = await parquetMetadataAsync(source);
@@ -56,11 +53,12 @@ export async function openParquet(
 }
 
 /**
- * Signed object-store URLs reject HEAD (the method is part of the signature),
+ * Signed object-store URLs reject HEAD — the method is part of the signature —
  * and a bucket's CORS policy need not allow it either, so a blocked HEAD
  * surfaces as an opaque network error rather than a 403 the caller could fall
- * back from. A ranged GET is signed, CORS-safelisted, and reports the total
- * size in `Content-Range`.
+ * back from. A ranged GET is signed and needs no preflight, but reading the
+ * total size back requires the bucket to expose `Content-Range`; where it does
+ * not, this throws and the caller downloads the whole object instead.
  */
 async function byteLengthFromRangedGet(url: string): Promise<number> {
   const controller = new AbortController();

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/useArtifactFetch.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/useArtifactFetch.tsx
@@ -15,22 +15,6 @@ export const fetchArtifactOrThrow: typeof fetch = async (input, init) => {
   return response;
 };
 
-export const fetchArtifactForHyparquet: typeof fetch = async (input, init) => {
-  const response = await fetch(input, init);
-  if (response.ok) return response;
-
-  const method = (init?.method ?? "GET").toUpperCase();
-  if (method === "HEAD" && response.status === 403) {
-    return response;
-  }
-
-  throw new ArtifactFetchError(
-    response.status,
-    response.statusText,
-    "Failed to fetch artifact.",
-  );
-};
-
 export function useArtifactFetch<T>(
   queryKey: string,
   signedUrl: string,

--- a/src/routes/PipelineRun/ArtifactPreview.test.tsx
+++ b/src/routes/PipelineRun/ArtifactPreview.test.tsx
@@ -58,11 +58,13 @@ vi.mock(
         artifactId,
         name,
         isFullscreen,
+        totalSize,
       }: {
         type: string;
         artifactId: string;
         name: string;
         isFullscreen: boolean;
+        totalSize?: number;
       }) => (
         <div
           data-testid="preview-content"
@@ -70,6 +72,7 @@ vi.mock(
           data-artifact-id={artifactId}
           data-name={name}
           data-fullscreen={isFullscreen}
+          data-total-size={totalSize}
         />
       ),
     };
@@ -114,6 +117,7 @@ describe("ArtifactPreviewPage", () => {
       expect(preview).toHaveAttribute("data-artifact-id", "abc");
       expect(preview).toHaveAttribute("data-name", "output");
       expect(preview).toHaveAttribute("data-fullscreen", "true");
+      expect(preview).toHaveAttribute("data-total-size", "100");
     });
   });
 

--- a/src/routes/PipelineRun/ArtifactPreview.tsx
+++ b/src/routes/PipelineRun/ArtifactPreview.tsx
@@ -137,6 +137,7 @@ const ArtifactPreviewBody = ({
           artifactId={artifactId}
           type={normalizedType}
           isFullscreen={true}
+          totalSize={artifactData?.total_size}
         />
       </div>
     </div>

--- a/src/routes/v2/pages/CompareView/components/ArtifactComparisonDialog.test.tsx
+++ b/src/routes/v2/pages/CompareView/components/ArtifactComparisonDialog.test.tsx
@@ -1,0 +1,82 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { ArtifactNodeResponse } from "@/api/types.gen";
+
+import { ArtifactComparisonDialog } from "./ArtifactComparisonDialog";
+
+vi.mock(
+  "@/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/ArtifactPreviewContent",
+  () => ({
+    PreviewContent: ({
+      artifactId,
+      totalSize,
+    }: {
+      artifactId: string;
+      totalSize?: number;
+    }) => (
+      <div
+        data-testid="preview-content"
+        data-artifact-id={artifactId}
+        data-total-size={totalSize}
+      />
+    ),
+    PreviewSkeleton: () => null,
+  }),
+);
+
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } },
+});
+
+const artifact = (
+  id: string,
+  artifactData?: ArtifactNodeResponse["artifact_data"],
+): ArtifactNodeResponse => ({ id, artifact_data: artifactData });
+
+const renderDialog = (
+  artifactA: ArtifactNodeResponse,
+  artifactB: ArtifactNodeResponse,
+) =>
+  render(
+    <QueryClientProvider client={queryClient}>
+      <ArtifactComparisonDialog
+        open
+        onOpenChange={() => {}}
+        name="table"
+        labelA="run-a"
+        labelB="run-b"
+        artifactA={artifactA}
+        artifactB={artifactB}
+        typeA="Apache Parquet"
+        typeB="Apache Parquet"
+      />
+    </QueryClientProvider>,
+  );
+
+describe("ArtifactComparisonDialog", () => {
+  it("passes each side's reported size to its preview", () => {
+    renderDialog(
+      artifact("a1", { total_size: 1024, is_dir: false }),
+      artifact("b1", { total_size: 9446073, is_dir: false }),
+    );
+
+    const [paneA, paneB] = screen.getAllByTestId("preview-content");
+    expect(paneA).toHaveAttribute("data-artifact-id", "a1");
+    expect(paneA).toHaveAttribute("data-total-size", "1024");
+    expect(paneB).toHaveAttribute("data-artifact-id", "b1");
+    expect(paneB).toHaveAttribute("data-total-size", "9446073");
+  });
+
+  it("omits the size when a side reports no artifact data", () => {
+    renderDialog(
+      artifact("a1"),
+      artifact("b1", { total_size: 1024, is_dir: false }),
+    );
+
+    const [paneA, paneB] = screen.getAllByTestId("preview-content");
+    expect(paneA).not.toHaveAttribute("data-total-size");
+    expect(paneB).toHaveAttribute("data-total-size", "1024");
+  });
+});

--- a/src/routes/v2/pages/CompareView/components/ArtifactComparisonDialog.tsx
+++ b/src/routes/v2/pages/CompareView/components/ArtifactComparisonDialog.tsx
@@ -89,6 +89,7 @@ function ComparisonPane({
               artifactId={artifact.id}
               type={normalizedType}
               isFullscreen
+              totalSize={artifact.artifact_data?.total_size}
             />
           </SuspenseWrapper>
         )}


### PR DESCRIPTION
## Description

Parquet artifacts were reporting "Too large to preview without range-request support" even when well under the preview limits.

The size lookup was the problem, not the file. `openParquet` called hyparquet's `byteLengthFromUrl`, which starts with a `HEAD` request. That `HEAD` cannot succeed against a signed object-store URL:

- The HTTP method is part of the signature, so a URL signed for `GET` returns `403` for `HEAD`.
- A bucket's CORS policy need not allow `HEAD` at all, in which case the browser blocks the response and `fetch` rejects with an opaque `TypeError` — there is no `Response` object.

hyparquet's own fallback to a ranged `GET` only triggers on an HTTP `403` *response* ([utils.js#L144](https://github.com/hyparam/hyparquet/blob/master/src/utils.js#L144)), and our `HEAD && 403` passthrough in `useArtifactFetch` needs a response to inspect. When the `HEAD` is blocked by CORS there is nothing for either to check, so the range path was never attempted. Every read then fell through to the whole-file download branch, which fails the 50 MB gate and raises the "too large" error.

So the message was literally true — range requests were unavailable and the download would have been large — but the stated cause was misleading, and the `MAX_PREVIEW_CELLS` render cap was never reached because the file never opened.

### Fix

The artifact's size is already in the payload. `artifact_data.total_size` is a required field that `IOCell` reads for its own size gate, so there is no reason to ask the network for it:

- `openParquet(signedUrl, byteLength?)` passes a supplied size straight into `asyncBufferFromUrl({ url, byteLength })`. The first request becomes the footer read.
- `PreviewContent` takes `byteLength` and feeds it to `ParquetVisualizer` at all three call sites (task preview dialog, shareable artifact page, run comparison). The translation from the API's `artifact_data.total_size` happens once, at each call site.
- `byteLengthFromUrl` is gone. Nothing issues a `HEAD` anymore, so the `HEAD`/403 passthrough goes with it — that left `fetchArtifactForHyparquet` byte-identical to `fetchArtifactOrThrow`, so it is deleted and the one caller uses `fetchArtifactOrThrow`.

Where a size isn't available, it is derived from a `Range: bytes=0-0` request reading `Content-Range` — the same information `HEAD` was providing, but over a request the signature and CORS both permit. The shareable-artifact route renders `PreviewContent` without requiring `artifact_data`, so this path is reachable and previously depended on `HEAD`.

The whole-file download is kept as a last resort for hosts that genuinely ignore `Range`. It still enforces the 50 MB cap. The message it raises is now just "This parquet file is too large to preview." — it used to blame missing range-request support, which is wrong whenever we got here because a ranged open failed for some other reason.

No backend or bucket change is required **for the common path**, which reads only the response body of a ranged `GET` and never `Content-Range`. That depends on nothing beyond `Access-Control-Allow-Origin` on a `GET`, which is already in place.

The size probe is the exception, and worth being precise about. `Range` is a safelisted *request* header and needs no preflight, but `Content-Range` is not a safelisted *response* header — reading it cross-origin requires `Access-Control-Expose-Headers: Content-Range` on the bucket. Where that is missing, the probe throws and we fall through to the whole-file download, i.e. exactly the behaviour we have today. So the probe is strictly better than the `HEAD` it replaces, but it is not unconditionally CORS-clean, and on a bucket that does not expose the header the "too large" message can still appear for a sizeless artifact over 50 MB. Exposing that one header on the bucket would close the gap.

## Related Issue and Pull requests

Follow-up to #2557 (range-backed parquet reads) and #2593 (preview cell budget).

## Type of Change

- [x] Bug fix

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

1. Open a run with a parquet output larger than 50 MB and click **Preview**.
2. The table renders with schema, row count and column count, instead of "Too large to preview".
3. **Load more** / **Load max** page in further rows up to the cell budget.
4. In devtools → Network, confirm there is no `HEAD` request for the artifact and that reads are `206 Partial Content`.
5. Repeat via the shareable preview link (the fullscreen expand icon, or cmd/ctrl+click) and via artifact comparison in the run compare view.

Regression coverage: 2471 unit tests pass.

In `ParquetVisualizer.test.tsx`, two tests assert that a supplied size issues no size request, and that an absent size is resolved with a ranged `GET` and never a `HEAD`. The three "range requests unavailable" tests now simulate the real signature — a `200` with no `Content-Range` — rather than mocking a rejection from the deleted function.

Those cover `openParquet` once the size reaches it, but not the seam the bug actually lived in: the size never arriving. Deleting `totalSize` from all three call sites — a full revert of the fix — left the suite green. So each call site now asserts the size reaches the visualizer: `ArtifactVisualizer.test.tsx` for the task preview dialog, `ArtifactPreview.test.tsx` for the shareable page, and a new `ArtifactComparisonDialog.test.tsx` for run comparison. That same deletion now fails four tests across the three files.

## Additional Comments

Worth a reviewer's eye: this trusts `total_size` to equal the signed object's exact byte length. That holds for a single-file artifact, and it is the same value `IOCell` already trusts for its size gate. If it were ever off, the footer read lands at the wrong offset — under 50 MB the download fallback silently recovers, above it the "too large" message returns.

`is_dir` is intentionally left unguarded: a signed URL for a directory fails on the `GET` regardless, now surfacing a clearer 404 than before.
