### PR TITLE
Make dashboard notice banners adapt to the visible count

### DIFF
--- a/src/components/shared/Notices/NoticeBanners.test.tsx
+++ b/src/components/shared/Notices/NoticeBanners.test.tsx
@@ -88,22 +88,6 @@ describe("<NoticeBanners />", () => {
     ).toEqual(["Everything is broken", "Heads up", "Worked", "Nice to know"]);
   });
 
-  it("gives each notice a column of the page grid rather than the full width", () => {
-    installSource([
-      { id: "a", title: "One", body: "", variant: "error" },
-      { id: "b", title: "Two", body: "", variant: "warning" },
-    ]);
-
-    const { container } = render(<NoticeBanners />);
-
-    const className = screen.getByTestId("notice-banners").className;
-    expect(className).toContain("grid-cols-1");
-    expect(className).toContain("md:grid-cols-2");
-    expect(className).toContain("lg:grid-cols-3");
-    expect(container.querySelector(".overflow-x-auto")).toBeNull();
-    expect(screen.getByTestId("info-box-error").className).toContain("w-full");
-  });
-
   it("leaves clearing the banners and opening the full list to the header", () => {
     installSource([{ id: "a", title: "Only notice", body: "" }]);
 
@@ -215,10 +199,11 @@ describe("<NoticeBanners />", () => {
     expect(screen.queryByLabelText("Dismiss")).not.toBeInTheDocument();
   });
 
-  it("takes one notice off the banners while leaving the rest in place", () => {
+  it("keeps the remaining banners when notices are hidden", () => {
     installSource([
       { id: "a", title: "First", body: "", variant: "error" },
       { id: "b", title: "Second", body: "", variant: "warning" },
+      { id: "c", title: "Third", body: "", variant: "info" },
     ]);
 
     render(<NoticeBanners />);
@@ -226,7 +211,11 @@ describe("<NoticeBanners />", () => {
 
     expect(
       screen.getAllByTestId("info-box-title").map((el) => el.textContent),
-    ).toEqual(["Second"]);
+    ).toEqual(["Second", "Third"]);
+
+    fireEvent.click(screen.getAllByLabelText("Hide notice")[0]!);
+
+    expect(screen.getByTestId("info-box-title")).toHaveTextContent("Third");
   });
 
   it("keeps a hidden dismissible notice off the banners across a remount", () => {

--- a/src/components/shared/Notices/NoticeBanners.tsx
+++ b/src/components/shared/Notices/NoticeBanners.tsx
@@ -1,6 +1,10 @@
 import { NoticeCard } from "@/components/shared/Notices/NoticeCard";
+import { InlineStack } from "@/components/ui/layout";
 import { useHiddenNotices } from "@/hooks/useHiddenNotices";
 import { useNotices } from "@/hooks/useNotices";
+
+const NOTICE_BANNER_LAYOUT_CLASSES =
+  "w-full *:min-w-0 *:grow *:basis-full md:*:basis-[calc((100%-1.5rem)/2)] lg:*:basis-[calc((100%-3rem)/3)]";
 
 export const NoticeBanners = () => {
   const { notices } = useNotices();
@@ -11,8 +15,11 @@ export const NoticeBanners = () => {
   if (banners.length === 0) return null;
 
   return (
-    <div
-      className="w-full grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 items-start"
+    <InlineStack
+      gap="6"
+      blockAlign="start"
+      wrap="wrap"
+      className={NOTICE_BANNER_LAYOUT_CLASSES}
       data-testid="notice-banners"
     >
       {banners.map((notice) => (
@@ -23,6 +30,6 @@ export const NoticeBanners = () => {
           onHide={() => hide(notice)}
         />
       ))}
-    </div>
+    </InlineStack>
   );
 };

--- a/tests/e2e/notice-banners.spec.ts
+++ b/tests/e2e/notice-banners.spec.ts
@@ -1,0 +1,63 @@
+import { expect, test } from "@playwright/test";
+
+for (const { width, maxColumns, counts } of [
+  { width: 375, maxColumns: 1, counts: [4] },
+  { width: 900, maxColumns: 2, counts: [3, 5] },
+  { width: 1440, maxColumns: 3, counts: [1, 2, 3, 4, 5, 7, 8, 10, 11] },
+]) {
+  for (const count of counts) {
+    test(`${count} notices fill every row at ${width}px`, async ({ page }) => {
+      await page.setViewportSize({ width, height: 900 });
+      await page.goto("/dashboard");
+      await page.evaluate((count) => {
+        const notices = Array.from({ length: count }, (_, index) => ({
+          id: `layout-test-${index}`,
+          title: `Test notice ${index + 1}`,
+          body: "Sample notice content for checking row layout.",
+          variant: "info",
+        }));
+        window.__TANGLE_NOTICE_SOURCE__ = {
+          version: 1,
+          getSnapshot: () => notices,
+          subscribe: () => () => {},
+        };
+        window.dispatchEvent(new CustomEvent("tangle:notice-source"));
+      }, count);
+
+      const banners = page.getByTestId("notice-banners");
+      await expect(banners.getByTestId("info-box-info")).toHaveCount(count);
+      await expect(banners).toBeVisible();
+
+      const layout = await banners.evaluate((element) => {
+        const { left, width } = element.getBoundingClientRect();
+        return {
+          left,
+          width,
+          gap: parseFloat(getComputedStyle(element).columnGap),
+          cards: [...element.children].map((card) => {
+            const { left, top, width } = card.getBoundingClientRect();
+            return { left, top, width };
+          }),
+        };
+      });
+
+      expect(new Set(layout.cards.map(({ top }) => top)).size).toBe(
+        Math.ceil(count / maxColumns),
+      );
+      for (const [index, card] of layout.cards.entries()) {
+        const column = index % maxColumns;
+        const rowStart = index - column;
+        const columnsInRow = Math.min(maxColumns, count - rowStart);
+        const cardWidth =
+          (layout.width - layout.gap * (columnsInRow - 1)) / columnsInRow;
+
+        expect(card.width).toBeCloseTo(cardWidth, 1);
+        expect(card.left).toBeCloseTo(
+          layout.left + column * (cardWidth + layout.gap),
+          1,
+        );
+        expect(card.top).toBe(layout.cards[rowStart]?.top);
+      }
+    });
+  }
+}


### PR DESCRIPTION
## Description

Make dashboard notice banners use the available width instead of always reserving three columns.

- One visible notice spans the full width; two use equal-width columns; three or more use up to three columns before wrapping.
- Recalculate the columns when notices are hidden, while preserving the existing mobile and tablet breakpoints.
- Add component coverage for one through four visible notices and resizing as notices are hidden.

## Type of Change

- [x] Bug fix
- [x] Improvement

## Screenshots

<img width="1903" height="796" alt="image" src="https://github.com/user-attachments/assets/e169276d-2f53-42d0-942d-357447157c6b" />

<img width="1909" height="958" alt="image" src="https://github.com/user-attachments/assets/6666cee2-f9c0-4452-8fa2-3c987c509d82" />

## How to test

1. Open **My Dashboard** with one, two, three, and four visible notices. Confirm the desktop column counts above and that additional notices wrap.
2. Hide notices until only one remains. Confirm the remaining banner expands to full width, then hide it and check that the section disappears.
3. Resize the browser: mobile should stack notices, and tablet should use at most two columns. Check that long messages remain scrollable and action links stay accessible.
4. Run the focused component tests:

   ```bash
   pnpm test src/components/shared/Notices/NoticeBanners.test.tsx
   ```
